### PR TITLE
[Ready and tested and microwaved] Rework the battle arcade game in the honor of fallen gamers

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -534,10 +534,12 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 
 /obj/machinery/computer/arcade/battle/proc/gameover_check(mob/user)
 	var/xp_gained = 0
-	if (enemy_hp <= 0)
+	if(enemy_hp <= 0)
 		if(!gameover)
 			if(timer_id)
 				deltimer(timer_id)
+			if(player_hp <= 0)
+				player_hp = 1 //let's just pretend the enemy didn't kill you so not both the player and enemy look dead.
 			gameover = TRUE
 			blocked = FALSE
 			temp = "<br><center><h3>[enemy_name] has fallen! Rejoice!<center><h3>"
@@ -555,9 +557,8 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 				prizevend(user)
 				xp_gained += 50
 			SSblackbox.record_feedback("nested tally", "arcade_results", 1, list("win", (obj_flags & EMAGGED ? "emagged":"normal")))
-			return
 
-	else if (player_hp <= 0)
+	else if(player_hp <= 0)
 		if(timer_id)
 			deltimer(timer_id)
 		gameover = TRUE

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -285,7 +285,6 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 
 		if(finishing_move) //time to bonk that fucker,cuban pete will sometime survive a finishing move.
 			attackamt *= 10
-			finishing_move = FALSE
 
 //light attack suck absolute ass but it doesn't cost any MP so it's pretty good to finish an enemy off
 		if (href_list["attack"])
@@ -378,7 +377,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	if(player_stance == "defend")
 		attack_amount -= 5
 
-///if emagged cuban pete will set up a bomb acting up as a timer.
+///if emagged, cuban pete will set up a bomb acting up as a timer. when it reaches 0 the player fucking dies
 	if(obj_flags & EMAGGED)
 		if(bomb_cooldown == 18)
 			temp += "<br><center><h3>[enemy_name] takes two valve tank and links them together, what's he planning?<center><h3>"
@@ -512,8 +511,9 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			temp += "<br><center><h3>the stinky breath of [enemy_name] hurts you for 3 hp!<center><h3> "
 			player_hp -= 3
 
-	if(pissed_off >= max_passive)
-		temp += "<br><center><h3>You have weakened [enemy_name] enough for them to show their weak point, you will do 10 times as much damage with your attacks next turn!<center><h3> "
+//if all passive's weakpoint have been triggered, set finishing_move to TRUE
+	if(pissed_off >= max_passive && !finishing_move)
+		temp += "<br><center><h3>You have weakened [enemy_name] enough for them to show their weak point, you will do 10 times as much damage with your next attack!<center><h3> "
 		finishing_move = TRUE
 
 	playsound(src, 'sound/arcade/heal.ogg', 50, TRUE, extrarange = -3)

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -170,11 +170,13 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	///weapon wielded by the enemy, the shotgun doesn't count.
 	var/chosen_weapon
 
-	///Player health/attack points
+	///Player health
 	var/player_hp = 85
+	///player magic points
 	var/player_mp = 20
 	///used to remember the last three move of the player before this turn.
 	var/list/last_three_move
+	///if the enemy or player died. basically restart the game when TRUE
 	var/gameover = FALSE
 	///the player cannot make any move while this is set to TRUE. is basically only TRUE during enemy turns.
 	var/blocked = FALSE
@@ -207,6 +209,11 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 
 	if("chonker" in current_enemy_passive)
 		enemy_hp += 20
+
+	if("shotgun" in current_enemy_passive)
+		chosen_weapon = "shotgun"
+	else
+		chosen_weapon = pick(weapons)
 
 	if(player_skill)
 		player_hp += player_skill * 2
@@ -241,7 +248,6 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 
 	enemy_name = ("The " + name_part1 + " " + name_part2)
 	name = (name_action + " " + enemy_name)
-	chosen_weapon = pick(weapons)
 
 	enemy_setup(0) //in the case it's reset we assume the player skill is 0 because the VOID isn't a gamer
 
@@ -393,19 +399,20 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			player_hp -= attack_amount * 1000 //hey it's a maxcap we might as well go all in
 		bomb_cooldown--
 
-//heccing chonker passive, only gives more HP at the start of a new game but has one of the hardest weakpoint to trigger.
-	if("chonker" in current_enemy_passive)
-		if(weakpoint_check("chonker","power_attack","power_attack","power_attack"))
-			temp += "<br><center><h3>After a lot of power attacks you manage to tip over [enemy_name] as they fall over their enormous weight<center><h3> "
-			enemy_hp -= 30
-
 //yeah I used the shotgun as a passive, you know why? because the shotgun gives +5 attack which is pretty good
 	if("shotgun" in current_enemy_passive)
 		if(weakpoint_check("shotgun","defend","defend","power_attack"))
 			temp += "<br><center><h3>You manage to disarm [enemy_name] with a surprise power attack and shoot him with his shotgun until it runs out of ammo! <center><h3> "
 			enemy_hp -= 10
+			chosen_weapon = "empty shotgun"
 		else
 			attack_amount += 5
+
+//heccing chonker passive, only gives more HP at the start of a new game but has one of the hardest weakpoint to trigger.
+	if("chonker" in current_enemy_passive)
+		if(weakpoint_check("chonker","power_attack","power_attack","power_attack"))
+			temp += "<br><center><h3>After a lot of power attacks you manage to tip over [enemy_name] as they fall over their enormous weight<center><h3> "
+			enemy_hp -= 30
 
 //smart passive trait, mainly works in tandem with other traits, makes the enemy unable to be counter_attacked
 	if("smart" in current_enemy_passive)
@@ -522,7 +529,6 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	screen_setup(user)
 	timer_id = null
 	blocked = FALSE
-
 
 
 /obj/machinery/computer/arcade/battle/proc/gameover_check(mob/user)

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -542,7 +542,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	if(length(last_three_move) < 3)
 		return FALSE
 
-	if(last_three_move[1] == first_move && last_three_move[2] == second_move && last_three_move[3] == third_move && passive in current_enemy_passive)
+	if(last_three_move[1] == first_move && last_three_move[2] == second_move && last_three_move[3] == third_move && (passive in current_enemy_passive))
 		current_enemy_passive -= passive
 		pissed_off++
 		return TRUE

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -184,6 +184,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	var/list/weapons = list()
 
 
+///creates the enemy base stats for a new round.
 /obj/machinery/computer/arcade/battle/proc/enemy_setup()
 	player_hp = 85
 	player_mp = 20
@@ -245,7 +246,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	screen_setup(user)
 
 
-///I prefer being able to set up the screen within my own proc instead of relying on ui_interact
+///sets up the main screen for the user
 /obj/machinery/computer/arcade/battle/proc/screen_setup(mob/user)
 	var/dat = "<a href='byond://?src=[REF(src)];close=1'>Close</a>"
 	dat += "<center><h4>[enemy_name]</h4></center>"
@@ -302,7 +303,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 
 		else if(href_list["counter_attack"] && player_mp < 10)
 			temp = "<br><center><h3>you don't have the mp necessary to counter attack and defend yourself instead</h3></center>"
-			href_list[2] = "defend"
+			href_list["counter_attack"] = "defend"
 			player_mp += 10
 			arcade_action(usr,href_list,attackamt)
 			playsound(src, 'sound/arcade/mana.ogg', 50, TRUE, extrarange = -3)
@@ -316,7 +317,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 
 		else if(href_list["power_attack"] && player_mp < 20)
 			temp = "<br><center><h3>You don't have the mp necessary for a power attack and settle for a light attack!</h3></center>"
-			href_list[2] = "attack"
+			href_list["power_attack"] = "attack"
 			enemy_hp -= attackamt
 			arcade_action(usr,href_list,attackamt)
 
@@ -331,6 +332,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			Reset()
 			obj_flags &= ~EMAGGED
 
+		enemy_setup()
 		screen_setup(usr)
 
 
@@ -431,7 +433,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 				player_hp -= attack_amount + 5
 				enemy_stance = "attack"
 			if(!success)
-				added_temp = "the wall and breaking their skull in the process!" //[enemy_name] you have a literal dent in your skull
+				added_temp = "the wall, breaking their skull in the process!" //[enemy_name] you have a literal dent in your skull
 				enemy_hp -= attack_amount
 				enemy_stance = "attack"
 
@@ -468,16 +470,15 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			player_hp -= 10
 			enemy_mp -= 20
 
-		else if(enemy_hp >= 20 && enemy_mp >= 20 && enemy_stance == "defensive")
-			temp += "<br><center><h3>[enemy_name] Blasts you with magic from afar and gets hurt in the process!<center><h3>"
-			enemy_mp -= 20
-			enemy_hp -= 10
-			player_hp -= 25
+		else if(enemy_hp >= 20 && enemy_mp >= 30 && enemy_stance == "defensive")
+			temp += "<br><center><h3>[enemy_name] Blasts you with magic from afar!<center><h3>"
+			enemy_mp -= 30
+			player_hp -= 30
 
 		else if(enemy_hp < 20 && enemy_mp >= 20 && enemy_stance == "defensive") //it's a pretty expensive spell so they can't spam it that much
-			temp += "<br><center><h3>[enemy_name] heal themselves with magic and gain back 10 hp!<center><h3>"
-			enemy_hp += 10
-			enemy_mp -= 20
+			temp += "<br><center><h3>[enemy_name] heal themselves with magic and gain back 20 hp!<center><h3>"
+			enemy_hp += 20
+			enemy_mp -= 30
 		else
 			temp += "<br><center><h3>[enemy_name]'s magical nature lets them get some mp back!<center><h3>"
 			enemy_mp += attack_amount

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -211,8 +211,10 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 
 	if("shotgun" in current_enemy_passive)
 		chosen_weapon = "shotgun"
-	else
+	else if(weapons)
 		chosen_weapon = pick(weapons)
+	else
+		chosen_weapon = "null gun" //if the weapons list is somehow empty, shouldn't happen but runtimes are sneaky bastards.
 
 	if(player_skill)
 		player_hp += player_skill * 2

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -477,7 +477,8 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		if(enemy_stance == "defensive" && enemy_mp < 15)
 			temp += "<br><center><h3>[enemy_name] take some time to get some mp back!<center><h3> "
 			enemy_mp += attack_amount
-		else if (enemy_stance == "defensive" && enemy_mp >= 15)
+
+		else if (enemy_stance == "defensive" && enemy_mp >= 15 && !("magical" in current_enemy_passive))
 			temp += "<br><center><h3>[enemy_name] quickly heal themselves for 5 hp!<center><h3> "
 			enemy_mp -= 15
 			enemy_hp += 5
@@ -490,15 +491,16 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			LAZYREMOVE(current_enemy_passive, "magical")
 			pissed_off++
 
-		else if("smart" in current_enemy_passive && player_stance == "counter_attack" && enemy_mp > 20)
+		else if("smart" in current_enemy_passive && player_stance == "counter_attack" && enemy_mp >= 20)
 			temp += "<br><center><h3>[enemy_name] blasts you with magic from afar for 10 points of damage before you can counter!<center><h3>"
 			player_hp -= 10
 			enemy_mp -= 20
 
-		else if(enemy_hp >= 20 && enemy_mp >= 30 && enemy_stance == "defensive")
+		else if(enemy_hp >= 20 && enemy_mp >= 40 && enemy_stance == "defensive")
 			temp += "<br><center><h3>[enemy_name] Blasts you with magic from afar!<center><h3>"
-			enemy_mp -= 30
+			enemy_mp -= 40
 			player_hp -= 30
+			enemy_stance = "attack"
 
 		else if(enemy_hp < 20 && enemy_mp >= 20 && enemy_stance == "defensive") //it's a pretty expensive spell so they can't spam it that much
 			temp += "<br><center><h3>[enemy_name] heal themselves with magic and gain back 20 hp!<center><h3>"
@@ -555,7 +557,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			SSblackbox.record_feedback("nested tally", "arcade_results", 1, list("win", (obj_flags & EMAGGED ? "emagged":"normal")))
 			return
 
-	if (player_hp <= 0)
+	else if (player_hp <= 0)
 		if(timer_id)
 			deltimer(timer_id)
 		gameover = TRUE

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -364,7 +364,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 
 ///the enemy turn, the enemy's action entirely depend on their current passive and a teensy tiny bit of randomness
 /obj/machinery/computer/arcade/battle/proc/enemy_action(player_stance,mob/user)
-	temp = ""
+	var/list/list_temp = list()
 
 	switch(LAZYLEN(last_three_move)) //we keep the last three action of the player in a list here
 		if(0 to 2)
@@ -385,22 +385,22 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	if(obj_flags & EMAGGED)
 		switch(bomb_cooldown--)
 			if(18)
-				temp += "<br><center><h3>[enemy_name] takes two valve tank and links them together, what's he planning?<center><h3>"
+				list_temp += "<br><center><h3>[enemy_name] takes two valve tank and links them together, what's he planning?<center><h3>"
 			if(15)
-				temp += "<br><center><h3>[enemy_name] adds a remote control to the tan- ho god is that a bomb?<center><h3>"
+				list_temp += "<br><center><h3>[enemy_name] adds a remote control to the tan- ho god is that a bomb?<center><h3>"
 			if(12)
-				temp += "<br><center><h3>[enemy_name] throws the bomb next to you, you'r too scared to pick it up. <center><h3>"
+				list_temp += "<br><center><h3>[enemy_name] throws the bomb next to you, you'r too scared to pick it up. <center><h3>"
 			if(6)
-				temp += "<br><center><h3>[enemy_name]'s hand brushes the remote linked to the bomb, your heart skipped a beat. <center><h3>"
+				list_temp += "<br><center><h3>[enemy_name]'s hand brushes the remote linked to the bomb, your heart skipped a beat. <center><h3>"
 			if(2)
-				temp += "<br><center><h3>[enemy_name] is going to press the button! It's now or never! <center><h3>"
+				list_temp += "<br><center><h3>[enemy_name] is going to press the button! It's now or never! <center><h3>"
 			if(0)
 				player_hp -= attack_amount * 1000 //hey it's a maxcap we might as well go all in
 
 	//yeah I used the shotgun as a passive, you know why? because the shotgun gives +5 attack which is pretty good
 	if(LAZYACCESS(enemy_passive, "shotgun"))
 		if(weakpoint_check("shotgun","defend","defend","power_attack"))
-			temp += "<br><center><h3>You manage to disarm [enemy_name] with a surprise power attack and shoot him with his shotgun until it runs out of ammo! <center><h3> "
+			list_temp += "<br><center><h3>You manage to disarm [enemy_name] with a surprise power attack and shoot him with his shotgun until it runs out of ammo! <center><h3> "
 			enemy_hp -= 10
 			chosen_weapon = "empty shotgun"
 		else
@@ -409,24 +409,24 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	//heccing chonker passive, only gives more HP at the start of a new game but has one of the hardest weakpoint to trigger.
 	if(LAZYACCESS(enemy_passive, "chonker"))
 		if(weakpoint_check("chonker","power_attack","power_attack","power_attack"))
-			temp += "<br><center><h3>After a lot of power attacks you manage to tip over [enemy_name] as they fall over their enormous weight<center><h3> "
+			list_temp += "<br><center><h3>After a lot of power attacks you manage to tip over [enemy_name] as they fall over their enormous weight<center><h3> "
 			enemy_hp -= 30
 
 	//smart passive trait, mainly works in tandem with other traits, makes the enemy unable to be counter_attacked
 	if(LAZYACCESS(enemy_passive, "smart"))
 		if(weakpoint_check("smart","defend","defend","attack"))
-			temp += "<br><center><h3>[enemy_name] is confused by your illogical strategy!<center><h3> "
+			list_temp += "<br><center><h3>[enemy_name] is confused by your illogical strategy!<center><h3> "
 			attack_amount -= 5
 
 		else if(attack_amount >= player_hp)
 			player_hp -= attack_amount
-			temp += "<br><center><h3>[enemy_name] figures out you are really close to death and finishes you off with their [chosen_weapon]!<center><h3>"
+			list_temp += "<br><center><h3>[enemy_name] figures out you are really close to death and finishes you off with their [chosen_weapon]!<center><h3>"
 			enemy_stance = "attack"
 
 		else if(player_stance == "counter_attack")
-			temp += "<br><center><h3>[enemy_name] is not taking your bait. <center><h3> "
+			list_temp += "<br><center><h3>[enemy_name] is not taking your bait. <center><h3> "
 			if(LAZYACCESS(enemy_passive, "short_temper"))
-				temp += "However controlling their hatred of you still takes a toll on their mental and physical health!"
+				list_temp += "However controlling their hatred of you still takes a toll on their mental and physical health!"
 				enemy_hp -= 5
 				enemy_mp -= 5
 			enemy_stance = "defensive"
@@ -434,18 +434,18 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	//short temper passive trait, gets easily baited into being counter attacked but will bypass your counter when low on HP
 	if(LAZYACCESS(enemy_passive, "short_temper"))
 		if(weakpoint_check("short_temper","counter_attack","counter_attack","counter_attack"))
-			temp += "<br><center><h3>[enemy_name] is getting frustrated at all your counter attacks and throws a tantrum!<center><h3>"
+			list_temp += "<br><center><h3>[enemy_name] is getting frustrated at all your counter attacks and throws a tantrum!<center><h3>"
 			enemy_hp -= attack_amount
 
 		else if(player_stance == "counter_attack")
 			if(!(LAZYACCESS(enemy_passive, "smart")) && enemy_hp > 30)
-				temp += "<br><center><h3>[enemy_name] took the bait and allowed you to counter attack for [attack_amount * 2] damage!<center><h3>"
+				list_temp += "<br><center><h3>[enemy_name] took the bait and allowed you to counter attack for [attack_amount * 2] damage!<center><h3>"
 				player_hp -= attack_amount
 				enemy_hp -= attack_amount * 2
 				enemy_stance = "attack"
 
 			else if(enemy_hp <= 30) //will break through the counter when low enough on HP even when smart.
-				temp += "<br><center><h3>[enemy_name] is getting tired of your tricks and breaks through your counter with their [chosen_weapon]!<center><h3>"
+				list_temp += "<br><center><h3>[enemy_name] is getting tired of your tricks and breaks through your counter with their [chosen_weapon]!<center><h3>"
 				player_hp -= attack_amount
 				enemy_stance = "attack"
 
@@ -461,70 +461,71 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 				enemy_hp -= attack_amount
 				enemy_stance = "attack"
 
-			temp += "<br><center><h3>[enemy_name] grits their teeth and charge right into [added_temp]<center><h3>"
+			list_temp += "<br><center><h3>[enemy_name] grits their teeth and charge right into [added_temp]<center><h3>"
 
 	//in the case none of the previous passive triggered, Mainly here to set an enemy stance for passives that needs it like the magical passive.
 	if(!enemy_stance)
 		enemy_stance = pick("attack","defensive")
 		if(enemy_stance == "attack")
 			player_hp -= attack_amount
-			temp += "<br><center><h3>[enemy_name] attacks you for [attack_amount] points of damage with their [chosen_weapon]<center><h3>"
+			list_temp += "<br><center><h3>[enemy_name] attacks you for [attack_amount] points of damage with their [chosen_weapon]<center><h3>"
 			if(player_stance == "counter_attack")
 				enemy_hp -= attack_amount * 2
-				temp += "<br><center><h3>You counter [enemy_name]'s attack and deal [attack_amount * 2] points of damage!<center><h3>"
+				list_temp += "<br><center><h3>You counter [enemy_name]'s attack and deal [attack_amount * 2] points of damage!<center><h3>"
 
 		if(enemy_stance == "defensive" && enemy_mp < 15)
-			temp += "<br><center><h3>[enemy_name] take some time to get some mp back!<center><h3> "
+			list_temp += "<br><center><h3>[enemy_name] take some time to get some mp back!<center><h3> "
 			enemy_mp += attack_amount
 
 		else if (enemy_stance == "defensive" && enemy_mp >= 15 && !(LAZYACCESS(enemy_passive, "magical")))
-			temp += "<br><center><h3>[enemy_name] quickly heal themselves for 5 hp!<center><h3> "
+			list_temp += "<br><center><h3>[enemy_name] quickly heal themselves for 5 hp!<center><h3> "
 			enemy_mp -= 15
 			enemy_hp += 5
 
 	//magical passive trait, recharges MP nearly every turn it's not blasting you with magic.
 	if(LAZYACCESS(enemy_passive, "magical"))
 		if(player_mp >= 50)
-			temp += "<br><center><h3>the huge amount of magical energy you have acumulated throws [enemy_name] off balance!<center><h3>"
+			list_temp += "<br><center><h3>the huge amount of magical energy you have acumulated throws [enemy_name] off balance!<center><h3>"
 			enemy_mp = 0
 			LAZYREMOVE(enemy_passive, "magical")
 			pissed_off++
 
 		else if(LAZYACCESS(enemy_passive, "smart") && player_stance == "counter_attack" && enemy_mp >= 20)
-			temp += "<br><center><h3>[enemy_name] blasts you with magic from afar for 10 points of damage before you can counter!<center><h3>"
+			list_temp += "<br><center><h3>[enemy_name] blasts you with magic from afar for 10 points of damage before you can counter!<center><h3>"
 			player_hp -= 10
 			enemy_mp -= 20
 
 		else if(enemy_hp >= 20 && enemy_mp >= 40 && enemy_stance == "defensive")
-			temp += "<br><center><h3>[enemy_name] Blasts you with magic from afar!<center><h3>"
+			list_temp += "<br><center><h3>[enemy_name] Blasts you with magic from afar!<center><h3>"
 			enemy_mp -= 40
 			player_hp -= 30
 			enemy_stance = "attack"
 
 		else if(enemy_hp < 20 && enemy_mp >= 20 && enemy_stance == "defensive") //it's a pretty expensive spell so they can't spam it that much
-			temp += "<br><center><h3>[enemy_name] heal themselves with magic and gain back 20 hp!<center><h3>"
+			list_temp += "<br><center><h3>[enemy_name] heal themselves with magic and gain back 20 hp!<center><h3>"
 			enemy_hp += 20
 			enemy_mp -= 30
 		else
-			temp += "<br><center><h3>[enemy_name]'s magical nature lets them get some mp back!<center><h3>"
+			list_temp += "<br><center><h3>[enemy_name]'s magical nature lets them get some mp back!<center><h3>"
 			enemy_mp += attack_amount
 
 	//poisonous passive trait, while it's less damage added than the shotgun it acts up even when the enemy doesn't attack at all.
 	if(LAZYACCESS(enemy_passive, "poisonous"))
 		if(weakpoint_check("poisonous","attack","attack","attack"))
-			temp += "<br><center><h3>your flurry of attack throws back the poisonnous gas at [enemy_name] and makes them choke on it!<center><h3> "
+			list_temp += "<br><center><h3>your flurry of attack throws back the poisonnous gas at [enemy_name] and makes them choke on it!<center><h3> "
 			enemy_hp -= 5
 		else
-			temp += "<br><center><h3>the stinky breath of [enemy_name] hurts you for 3 hp!<center><h3> "
+			list_temp += "<br><center><h3>the stinky breath of [enemy_name] hurts you for 3 hp!<center><h3> "
 			player_hp -= 3
 
 	//if all passive's weakpoint have been triggered, set finishing_move to TRUE
 	if(pissed_off >= max_passive && !finishing_move)
-		temp += "<br><center><h3>You have weakened [enemy_name] enough for them to show their weak point, you will do 10 times as much damage with your next attack!<center><h3> "
+		list_temp += "<br><center><h3>You have weakened [enemy_name] enough for them to show their weak point, you will do 10 times as much damage with your next attack!<center><h3> "
 		finishing_move = TRUE
 
 	playsound(src, 'sound/arcade/heal.ogg', 50, TRUE, extrarange = -3)
 
+	temp = list_temp.Join()
 	gameover_check(user)
 	screen_setup(user)
 	blocked = FALSE
@@ -602,7 +603,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	var/gamerSkill = usr.mind?.get_skill_level(/datum/skill/gaming)
 	enemy_setup(gamerSkill)
 	enemy_hp += 100 //extra HP just to make cuban pete even more bullshit
-	player_hp += 15 //the player will also get a few extra HP in order to have a fucking chance
+	player_hp += 30 //the player will also get a few extra HP in order to have a fucking chance
 
 	screen_setup(user)
 	gameover = FALSE

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -291,20 +291,20 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		if(finishing_move) //time to bonk that fucker,cuban pete will sometime survive a finishing move.
 			attackamt *= 10
 
-//light attack suck absolute ass but it doesn't cost any MP so it's pretty good to finish an enemy off
+		//light attack suck absolute ass but it doesn't cost any MP so it's pretty good to finish an enemy off
 		if (href_list["attack"])
 			temp = "<br><center><h3>you do quick jab for [attackamt] of damage!</h3></center>"
 			enemy_hp -= attackamt
 			arcade_action(usr,"attack",attackamt)
 
-//defend lets you gain back MP and take less damage from non magical attack.
+		//defend lets you gain back MP and take less damage from non magical attack.
 		else if(href_list["defend"])
 			temp = "<br><center><h3>you take a defensive stance and gain back 10 mp!</h3></center>"
 			player_mp += 10
 			arcade_action(usr,"defend",attackamt)
 			playsound(src, 'sound/arcade/mana.ogg', 50, TRUE, extrarange = -3)
 
-//mainly used to counter short temper and their absurd damage, will deal twice the damage the player took of a non magical attack.
+		//mainly used to counter short temper and their absurd damage, will deal twice the damage the player took of a non magical attack.
 		else if(href_list["counter_attack"] && player_mp >= 10)
 			temp = "<br><center><h3>you prepare yourself to counter the next attack!</h3></center>"
 			player_mp -= 10
@@ -317,7 +317,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			arcade_action(usr,"defend",attackamt)
 			playsound(src, 'sound/arcade/mana.ogg', 50, TRUE, extrarange = -3)
 
-//power attack deals twice the amount of damage but is really expensive MP wise, mainly used with combos to get weakpoints.
+		//power attack deals twice the amount of damage but is really expensive MP wise, mainly used with combos to get weakpoints.
 		else if (href_list["power_attack"] && player_mp >= 20)
 			temp = "<br><center><h3>You attack [enemy_name] with all your might for [attackamt * 2] damage!</h3></center>"
 			enemy_hp -= attackamt * 2
@@ -440,7 +440,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			enemy_hp -= attack_amount
 
 		else if(player_stance == "counter_attack" && enemy_hp > 30 && !("smart" in current_enemy_passive))
-			temp += "<br><center><h3>[enemy_name] took the bait and allowed you to counter attack!<center><h3>"
+			temp += "<br><center><h3>[enemy_name] took the bait and allowed you to counter attack for [attack_amount * 2] damage!<center><h3>"
 			player_hp -= attack_amount
 			enemy_hp -= attack_amount * 2
 			enemy_stance = "attack"
@@ -458,7 +458,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 				player_hp -= attack_amount + 5
 				enemy_stance = "attack"
 			else
-				added_temp = "the wall, breaking their skull in the process!" //[enemy_name] you have a literal dent in your skull
+				added_temp = "the wall, breaking their skull in the process and losing [attack_amount] hp!" //[enemy_name] you have a literal dent in your skull
 				enemy_hp -= attack_amount
 				enemy_stance = "attack"
 

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -288,7 +288,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		var/attackamt = rand(5,7) + rand(0, gamerSkill)
 
 		if(finishing_move) //time to bonk that fucker,cuban pete will sometime survive a finishing move.
-			attackamt *= 10
+			attackamt *= 100
 
 		//light attack suck absolute ass but it doesn't cost any MP so it's pretty good to finish an enemy off
 		if (href_list["attack"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reworks the battle arcade game in a more interesting, engaging vidya game.
The player will have 4 actions to choose from :

- light attack : just a normal light attack, not that much damage as is.

- defend : gain back some MP and reduce the damage of non magical attack.

- counter attack : if the enemy attacks you next turn with a non magical attack you will deal twice the amount of damage you took to the enemy. Costs 10MP

- power attack : deals twice the amount of damage compared to a light attack.
costs 20MP

and the enemy will have 3 of 6 randomly chosen passive which will dictate its actions

- smart : won't fall for your counter attacks ever but is heavily reliant on other passives.
weakpoint: defend,defend,light attack. Confusion as to why you would ever save up on MP only to use an MP free attack

- magical: constantly regains MP and will often blast you up for a fuckton of damage, also the only passive that doesn't have a weakpoint related to combos.
weakpoint: spam defend until your MP are equal or above 50. Way to flex on the magician

- short temper: short temper will always fall for a counter attack unless they are smart, otherwise they will charge at you for a lot of damage hurting themselves in the process or missing entirely.
weakpoint: (counter attack,counter attack,counter attack). spamming the same bullshit move is the best way of pissing off someone.

- poisonous: will deal 3 damage at the end of their turn no matter what. Pretty straight forward.
weakpoint: light attack light attack, light attack. use your weapon as a fan to make the fucker choke on their own poison

- shotgun: will augment the damage of nearly any attacks used, because the shotgun never miss
weakpoint : defend,defend,power attack. take the guy by surprise with a shove and shoot him with his own shotgun.

- chonker: gives more HP, one of the weakest passive if not for the fact that its weakpoint is expensive to trigger.
weakpoint : power attack,power attack, power attack. Tip them over, cost 60MP which is like 6 turns of defending. You should probably deal with other passive first.

ho right weakpoints. while the three passives may seem overwhelming at first, you CAN disable each passive by triggering their weakpoint, when all weakpoints are triggered, you will be able to do 10 time as much damage next turn, basically finishing most fights in a single bonk. most weakpoints require a certain combo of attack with the exception of the magical passive.

it's all about paying attention to the fight and actually be willing to experiment. It sounds complicated, but really the game is more about figuring the enemy's passive and choosing which one to take out first than just "unga me hit man until man give toy"

Do note this does NOT (yet) apply to the upgraded computer version of the game, which is kind of ironic because I kind of thought of making this PR when I was bored through space playing the vidya game on my space computer

the emag mode gives cuban pete ALL the passive among a special countdown, more HP and giving the player slightly more HP too. When the counter reaches 0 the player will be insta killed, the countdown has been optimised so that you will need to know the exact gaming tactic and a bunch of luck to succeed, the optimised tactic is :
defend 3 times to deactivate the magic passive, use counter attack 3 times to deactive short temper, then use defend two times in a row followed by 3 light attacks to disable both smart and poisonous. Then Finish that off with two defend and 3 power attacks to disable the shotgun and chonker passive.

if you SOMEHOW survived until then, hit him right into his weakpoint and finish him before the counter reaches 0.

in other word, you need to be the ultimate gamer to outgame cuban pete. Or you know, get lucky as fuck.

TODO: 

- [x] give a proper difficulty setting for emags.

- [x] give the G A M I N G skill more things in the game than just more damage.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The battle arcade game sucked, there's no way around it. Like holy shit, boss that heals already aren't too much fun, but when literally every single one of your actions are random as hell and you basically have to roll the dice until you get a few lucky turns, it isn't fun, it's tedious.

This update is trying to make the game more interesting, and actually reward G A M E R S for trying to figure out a game instead of just spamming the same button over and over again until they win.

also my version use timers and not sleep so you know there's that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: NT finally decided to update the arcade battle video game after its terrible space game reviews from syndicate gaming.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
