### PR TITLE
[speedmerge pls????] fixes dynamic to not fail repeatedly

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -286,7 +286,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			configuration = json_decode(file2text(json_file))
 			if(configuration["Dynamic"])
 				for(var/variable in configuration["Dynamic"])
-					if(!(variable in vars) || !vars[variable])
+					if(!(variable in vars) || isnull(vars[variable]))
 						stack_trace("Invalid dynamic configuration variable [variable] in game mode variable changes.")
 						continue
 					vars[variable] = configuration["dynamic"][variable]

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -286,7 +286,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			configuration = json_decode(file2text(json_file))
 			if(configuration["Dynamic"])
 				for(var/variable in configuration["Dynamic"])
-					if(!vars[variable])
+					if(!(variable in vars) || !vars[variable])
 						stack_trace("Invalid dynamic configuration variable [variable] in game mode variable changes.")
 						continue
 					vars[variable] = configuration["dynamic"][variable]
@@ -311,7 +311,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 				continue
 			var/rule_conf = configuration[ruleset.ruletype][ruleset.name]
 			for(var/variable in rule_conf)
-				if(isnull(ruleset.vars[variable]))
+				if(!(variable in ruleset.vars) || isnull(ruleset.vars[variable]))
 					stack_trace("Invalid dynamic configuration variable [variable] in [ruleset.ruletype] [ruleset.name].")
 					continue
 				ruleset.vars[variable] = rule_conf[variable]

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -6,7 +6,6 @@
 			"scaling_cost": 10,
 			"weight": 5,
 			"required_candidates": 1,
-			"high_population_requirement": 10,
 			"minimum_required_age": 0,
 			"requirements": [
 				10,


### PR DESCRIPTION
## About The Pull Request

the PR that removed the high_population_requirement var didn't ~~remove it from a specific config file. i can't blame it since when looking for the crash i saw that fucking var show up in the vsc codebase search like 4 times after knowing that exact name was part of the error before i realized that it was the reason for the entire error in the first place. you're just kind of conditioned to ignore .json files~~ account for the fact that there's a snowflake config file that uses the high_population_requirement var for no real good reason and there's code elsewhere that uses config files to override ruleset vars and this code didn't check if the variable was actually in the vars before seeing if it was null or falsey

## Why It's Good For The Game

#51315 did a fucky wucky

## Changelog
:cl:
fix: dynamic now functions
/:cl:

closes #51497
