### PR TITLE
Removes bsql debug config

### DIFF
--- a/code/controllers/configuration/entries/dbconfig.dm
+++ b/code/controllers/configuration/entries/dbconfig.dm
@@ -48,4 +48,3 @@
 	config_entry_value = 50
 	min_val = 1
 
-/datum/config_entry/flag/bsql_debug

--- a/config/dbconfig.txt
+++ b/config/dbconfig.txt
@@ -33,13 +33,10 @@ FEEDBACK_PASSWORD password
 ## Set to 0 for infinite
 ASYNC_QUERY_TIMEOUT 10
 
-## Time in seconds for blocking queries to execute before slow query timeout 
+## Time in seconds for blocking queries to execute before slow query timeout
 ## Set to 0 for infinite
 ## Must be less than or equal to ASYNC_QUERY_TIMEOUT
 BLOCKING_QUERY_TIMEOUT 5
 
 ## The maximum number of additional threads BSQL is allowed to run at once
 BSQL_THREAD_LIMIT 50
-
-## Uncomment to enable verbose BSQL communication logs
-#BSQL_DEBUG


### PR DESCRIPTION
Leftover code does nothing now.

`BSQL_THREAD_LIMIT` is still used at https://github.com/tgstation/tgstation/blob/master/code/controllers/subsystem/dbcore.dm#L84