### PR TITLE
You can now take obligate carnivory grafts from jupiter cups

### DIFF
--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -227,6 +227,7 @@
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/reagent/liquidelectricity, /datum/plant_gene/trait/plant_type/carnivory)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1)
+	graft_gene = /datum/plant_gene/trait/plant_type/carnivory
 
 /obj/item/seeds/chanter/jupitercup/Initialize(mapload,nogenes)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

see title

note that you still can't remove the obligate carnivory trait from a jupiter cup plant, but now (if this PR gets merged) you can copy it onto another plant with a graft

## Why It's Good For The Game

we currently have no way to get the obligate carnivory trait on a non-jupiter cup plant outside of strange seed shenanigans

this trait doesn't have the flag that makes it removable from a plant, but it DOES have the flag that was (back when the plant DNA manipulator was a thing) supposed to let it be extractable, so I think that being unable to copy it using the graft system was unintentional

## Changelog
:cl: ATHATH
add: You can now take obligate carnivory grafts from jupiter cups.
/:cl: