### PR TITLE
removes rotatium from the saferChems list of the clogged vents event

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -14,8 +14,8 @@
 	var/randomProbability = 1
 	var/reagentsAmount = 100
 	var/list/saferChems = list(/datum/reagent/water,/datum/reagent/carbon,/datum/reagent/consumable/flour,/datum/reagent/space_cleaner,/datum/reagent/consumable/nutriment,/datum/reagent/consumable/condensedcapsaicin,/datum/reagent/drug/mushroomhallucinogen,/datum/reagent/lube,/datum/reagent/glitter/pink,/datum/reagent/cryptobiolin,
-						 /datum/reagent/toxin/plantbgone,/datum/reagent/blood,/datum/reagent/medicine/C2/multiver,/datum/reagent/drug/space_drugs,/datum/reagent/medicine/morphine,/datum/reagent/water/holywater,/datum/reagent/consumable/ethanol,/datum/reagent/consumable/hot_coco,/datum/reagent/toxin/acid,/datum/reagent/toxin/mindbreaker,/datum/reagent/toxin/rotatium,/datum/reagent/bluespace,
-						 /datum/reagent/pax,/datum/reagent/consumable/laughter,/datum/reagent/concentrated_barbers_aid,/datum/reagent/baldium,/datum/reagent/colorful_reagent,/datum/reagent/peaceborg/confuse,/datum/reagent/peaceborg/tire,/datum/reagent/consumable/sodiumchloride,/datum/reagent/consumable/ethanol/beer,/datum/reagent/hair_dye,/datum/reagent/consumable/sugar,/datum/reagent/glitter/white,/datum/reagent/growthserum)
+						 /datum/reagent/toxin/plantbgone,/datum/reagent/blood,/datum/reagent/medicine/C2/multiver,/datum/reagent/drug/space_drugs,/datum/reagent/medicine/morphine,/datum/reagent/water/holywater,/datum/reagent/consumable/ethanol,/datum/reagent/consumable/hot_coco,/datum/reagent/toxin/acid,/datum/reagent/toxin/mindbreaker,/datum/reagent/bluespace,
+						 /datum/reagent/pax,/datum/reagent/consumable/laughter,/datum/reagent/concentrated_barbers_aid,/datum/reagent/baldium,/datum/reagent/colorful_reagent,/datum/reagent/peaceborg/confuse,/datum/reagent/peaceborg/tire,/datum/reagent/consumable/sodiumchloride,/datum/reagent/consumable/ethanol/beer,/datum/reagent/hair_dye,/datum/reagent/consumable/sugar,/datum/reagent/glitter/white,/datum/reagent/growthserum) //readd rotatium to this list once we figure out how to make it stop crashing peoples' clients
 	//needs to be chemid unit checked at some point
 
 /datum/round_event/vent_clog/announce()


### PR DESCRIPTION
## About The Pull Request

Now, rotatium won't be selected as a chem for foam from the clogged vents event unless the 1%/10%/30% chance for any chem to be selected is rolled (and then rotatium gets chosen from the list of all of the chems in the game that can be chosen).

## Why It's Good For The Game

While I was investigating https://github.com/tgstation/tgstation/issues/51521, I noticed that rotatium was in the saferChems list of the clogged vents event. I like funny rotation chems as much as the next guy, but rotatium can currently crash clients, IIRC. **We can/should readd it to the saferChems list once we figure out how to make it stop doing that.**

## Changelog
:cl: ATHATH
tweak: The odds of rotatium appearing in foam from the clogged vents (aka "backpressure surge") event have been drastically lowered
/:cl: