### PR TITLE
Fixes Twitchy Attack Animations

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -767,7 +767,7 @@
 		pixel_x_diff = -8
 
 	animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, time = 2)
-	animate(src, pixel_x = pixel_x - pixel_x_diff, pixel_y = pixel_y - pixel_y_diff, time = 2)
+	animate(pixel_x = pixel_x - pixel_x_diff, pixel_y = pixel_y - pixel_y_diff, time = 2)
 
 /atom/movable/proc/do_item_attack_animation(atom/A, visual_effect_icon, obj/item/used_item)
 	var/image/I


### PR DESCRIPTION
## About The Pull Request

Attack animations have been horrible ever since the swarming component was added. They used to be a very smooth glide to your target and glide back. 

Now, however, whenever you're attacking someone, you look like a twitching lunatic who's just barely flailing at someone; it doesn't look great. Furthermore, things that are swarming don't really have an attack animation at all (at least one that's noticeable).

This was caused by improperly using `animate`.  `animate` is weird in that, successive calls to it just iterates over the previous thing you animated (if you provide an object to the first argument); by supplying `src` as the first argument in the second `animate` call, it creates an entirely new animation, which makes the attack quickly stutter back to the starting position instead of smoothly pushing the attacker back to his original position.

## Why It's Good For The Game

Buttery smooth movement when attacking looks way better,  and is the intended functionality----instead of looking like a flailing idiot.

## Changelog
:cl: Fox McCloud
fix: Fixes attack animations being stuttery and twitchy; they should, once again, be buttery smooth
/:cl:
