### PR TITLE
Make sure the discordid of a user is always returned as text

### DIFF
--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -82,8 +82,10 @@ SUBSYSTEM_DEF(discord)
 
 // Returns ID from ckey
 /datum/controller/subsystem/discord/proc/lookup_id(lookup_ckey)
+	//We cast the discord ID to varchar to prevent BYOND mangling
+	//it into it's scientific notation
 	var/datum/DBQuery/query_get_discord_id = SSdbcore.NewQuery(
-		"SELECT discord_id FROM [format_table_name("player")] WHERE ckey = :ckey",
+		"SELECT CAST(discord_id AS VARCHAR(25)) FROM [format_table_name("player")] WHERE ckey = :ckey",
 		list("ckey" = lookup_ckey)
 	)
 	if(!query_get_discord_id.Execute())


### PR DESCRIPTION
If it's left as a number, when inserted into text via the [ ] operator
it will get auto converted to scientification notation, which is
unexpected and causes bugs in code that expects the id to be available
for discord API calls
