### PR TITLE
Makes age restricted a flag

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -11,6 +11,7 @@
 #define USES_TGUI				(1<<7)	//put on things that use tgui on ui_interact instead of custom/old UI.
 #define FROZEN					(1<<8)
 #define BLOCK_Z_FALL			(1<<9) // Should this object block z falling?
+#define AGE_RESTRICTED			(1<<10) ///Whether spessmen with an ID with an age below AGE_MINOR (20 by default) can buy this item in a vendor
 
 // If you add new ones, be sure to add them to /obj/Initialize as well for complete mapping support
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -65,8 +65,6 @@
 	var/custom_price
 	///Economy cost of item in premium vendor
 	var/custom_premium_price
-	///Whether spessmen with an ID with an age below AGE_MINOR (20 by default) can buy this item
-	var/age_restricted = FALSE
 
 	//List of datums orbiting this atom
 	var/datum/component/orbiter/orbiters

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -137,7 +137,7 @@
 	spawn_type = /obj/item/clothing/mask/cigarette/space_cigarette
 	var/candy = FALSE //for cigarette overlay
 	custom_price = 75
-	age_restricted = TRUE
+	obj_flags = AGE_RESTRICTED
 	var/spawn_coupon = TRUE
 
 /obj/item/storage/fancy/cigarettes/attack_self(mob/user)
@@ -273,7 +273,7 @@
 	icon_type = "candy cigarette"
 	spawn_type = /obj/item/clothing/mask/cigarette/candy
 	candy = TRUE
-	age_restricted = FALSE
+	obj_flags = NONE
 
 /obj/item/storage/fancy/cigarettes/cigpack_candy/Initialize()
 	. = ..()

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -20,13 +20,16 @@
 	var/const/duration = 13 //Directly relates to the 'knockdown' duration. Lowered by armor (i.e. helmets)
 	isGlass = TRUE
 	foodtype = ALCOHOL
-	age_restricted = TRUE // wrryy can't set an init value to see if foodtype contains ALCOHOL so here we go
+	obj_flags = AGE_RESTRICTED
+
+/obj/item/reagent_containers/food/drinks/bottle/empty
+	obj_flags = NONE
 
 /obj/item/reagent_containers/food/drinks/bottle/update_overlays()
 	. = ..()
 	. += "[initial(icon_state)]shine"
 
-/obj/item/reagent_containers/food/drinks/bottle/small
+/obj/item/reagent_containers/food/drinks/bottle/empty/small
 	name = "small glass bottle"
 	desc = "This blank bottle is unyieldingly anonymous, offering no clues to its contents."
 	icon_state = "glassbottlesmall"
@@ -198,7 +201,7 @@
 	icon_state = "bottleofnothing"
 	list_reagents = list(/datum/reagent/consumable/nothing = 100)
 	foodtype = NONE
-	age_restricted = FALSE
+	obj_flags = NONE
 
 /obj/item/reagent_containers/food/drinks/bottle/patron
 	name = "Wrapp Artiste Patron"
@@ -364,7 +367,7 @@
 	isGlass = FALSE
 	list_reagents = list(/datum/reagent/consumable/orangejuice = 100)
 	foodtype = FRUIT | BREAKFAST
-	age_restricted = FALSE
+	obj_flags = NONE
 
 /obj/item/reagent_containers/food/drinks/bottle/cream
 	name = "milk cream"
@@ -377,7 +380,7 @@
 	isGlass = FALSE
 	list_reagents = list(/datum/reagent/consumable/cream = 100)
 	foodtype = DAIRY
-	age_restricted = FALSE
+	obj_flags = NONE
 
 /obj/item/reagent_containers/food/drinks/bottle/tomatojuice
 	name = "tomato juice"
@@ -390,7 +393,7 @@
 	isGlass = FALSE
 	list_reagents = list(/datum/reagent/consumable/tomatojuice = 100)
 	foodtype = VEGETABLES
-	age_restricted = FALSE
+	obj_flags = NONE
 
 /obj/item/reagent_containers/food/drinks/bottle/limejuice
 	name = "lime juice"
@@ -403,7 +406,7 @@
 	isGlass = FALSE
 	list_reagents = list(/datum/reagent/consumable/limejuice = 100)
 	foodtype = FRUIT
-	age_restricted = FALSE
+	obj_flags = NONE
 
 /obj/item/reagent_containers/food/drinks/bottle/pineapplejuice
 	name = "pineapple juice"
@@ -416,7 +419,7 @@
 	isGlass = FALSE
 	list_reagents = list(/datum/reagent/consumable/pineapplejuice = 100)
 	foodtype = FRUIT | PINEAPPLE
-	age_restricted = FALSE
+	obj_flags = NONE
 
 /obj/item/reagent_containers/food/drinks/bottle/menthol
 	name = "menthol"
@@ -437,7 +440,7 @@
 	isGlass = TRUE
 	list_reagents = list(/datum/reagent/consumable/grenadine = 100)
 	foodtype = FRUIT
-	age_restricted = FALSE
+	obj_flags = NONE
 
 /obj/item/reagent_containers/food/drinks/bottle/applejack
 	name = "Buckin' Bronco's Applejack"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
@@ -58,7 +58,7 @@
 	name = "Trappist Bottle"
 	time = 15
 	reqs = list(
-		/obj/item/reagent_containers/food/drinks/bottle/small = 1,
+		/obj/item/reagent_containers/food/drinks/bottle/empty/small = 1,
 		/datum/reagent/consumable/ethanol/trappist = 50
 	)
 	result = /obj/item/reagent_containers/food/drinks/bottle/trappist

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -320,7 +320,9 @@ GLOBAL_LIST_EMPTY(vending_products)
 		R.max_amount = amount
 		R.custom_price = initial(temp.custom_price)
 		R.custom_premium_price = initial(temp.custom_premium_price)
-		R.age_restricted = initial(temp.age_restricted)
+		if(ispath(temp, /obj))
+			var/obj/temp_obj = temp
+			R.age_restricted = (initial(temp_obj.obj_flags) & AGE_RESTRICTED)
 		recordlist += R
 /**
   * Refill a vending machine from a refill canister

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -33,8 +33,8 @@
 					/obj/item/reagent_containers/food/drinks/bottle/grappa = 5,
 					/obj/item/reagent_containers/food/drinks/bottle/sake = 5,
 					/obj/item/reagent_containers/food/drinks/bottle/applejack = 5,
-					/obj/item/reagent_containers/food/drinks/bottle = 15,
-					/obj/item/reagent_containers/food/drinks/bottle/small = 15
+					/obj/item/reagent_containers/food/drinks/bottle/empty = 15,
+					/obj/item/reagent_containers/food/drinks/bottle/empty/small = 15
 					)
 	contraband = list(/obj/item/reagent_containers/food/drinks/mug/tea = 12,
 					 /obj/item/reagent_containers/food/drinks/bottle/fernet = 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so being age restricted for vending machines is an obj_flag instead of a var on /atom. Also fixes empty glass bottles being age restricted. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Age restriction makes more sense as a flag than a var
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Empty glass bottles are no longer marked as age restricted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
