### PR TITLE
Support fireman carrying people onto morgue trays and other bucklable objects (stasis beds, operating tables, chairs)

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -21,7 +21,7 @@
 				return 1
 
 /atom/movable/attackby(obj/item/W, mob/user, params)
-	if(!can_buckle || !istype(W, /obj/item/riding_offhand))
+	if(!can_buckle || !istype(W, /obj/item/riding_offhand) || !user.Adjacent(src))
 		return ..()
 
 	var/obj/item/riding_offhand/riding_item = W
@@ -29,6 +29,7 @@
 	if(carried_mob == user) //Piggyback user.
 		return
 	user.unbuckle_mob(carried_mob)
+	carried_mob.forceMove(get_turf(src))
 	return mouse_buckle_handling(carried_mob, user)
 
 //literally just the above extension of attack_hand(), but for silicons instead (with an adjacency check, since attack_robot() being called doesn't mean that you're adjacent to something)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -20,6 +20,17 @@
 			if(user_unbuckle_mob(buckled_mobs[1],user))
 				return 1
 
+/atom/movable/attackby(obj/item/W, mob/user, params)
+	if(can_buckle && istype(W, /obj/item/riding_offhand))
+		var/obj/item/riding_offhand/riding_item = W
+		var/mob/living/carried_mob = riding_item.rider
+		if(carried_mob == user) //Piggyback user.
+			return
+		user.unbuckle_mob(carried_mob)
+		return mouse_buckle_handling(carried_mob, user)
+	else
+		return ..()
+
 //literally just the above extension of attack_hand(), but for silicons instead (with an adjacency check, since attack_robot() being called doesn't mean that you're adjacent to something)
 /atom/movable/attack_robot(mob/living/user)
 	. = ..()

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -21,15 +21,15 @@
 				return 1
 
 /atom/movable/attackby(obj/item/W, mob/user, params)
-	if(can_buckle && istype(W, /obj/item/riding_offhand))
-		var/obj/item/riding_offhand/riding_item = W
-		var/mob/living/carried_mob = riding_item.rider
-		if(carried_mob == user) //Piggyback user.
-			return
-		user.unbuckle_mob(carried_mob)
-		return mouse_buckle_handling(carried_mob, user)
-	else
+	if(!can_buckle || !istype(W, /obj/item/riding_offhand))
 		return ..()
+
+	var/obj/item/riding_offhand/riding_item = W
+	var/mob/living/carried_mob = riding_item.rider
+	if(carried_mob == user) //Piggyback user.
+		return
+	user.unbuckle_mob(carried_mob)
+	return mouse_buckle_handling(carried_mob, user)
 
 //literally just the above extension of attack_hand(), but for silicons instead (with an adjacency check, since attack_robot() being called doesn't mean that you're adjacent to something)
 /atom/movable/attack_robot(mob/living/user)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -342,15 +342,15 @@ GLOBAL_LIST_EMPTY(crematoriums)
 		to_chat(user, "<span class='warning'>That's not connected to anything!</span>")
 
 /obj/structure/tray/attackby(obj/P, mob/user, params)
-	if(istype(P, /obj/item/riding_offhand))
-		var/obj/item/riding_offhand/riding_item = P
-		var/mob/living/carried_mob = riding_item.rider
-		if(carried_mob == user) //Piggyback user.
-			return
-		user.unbuckle_mob(carried_mob)
-		MouseDrop_T(carried_mob, user)
-	else
+	if(!istype(P, /obj/item/riding_offhand))
 		return ..()
+
+	var/obj/item/riding_offhand/riding_item = P
+	var/mob/living/carried_mob = riding_item.rider
+	if(carried_mob == user) //Piggyback user.
+		return
+	user.unbuckle_mob(carried_mob)
+	MouseDrop_T(carried_mob, user)
 
 /obj/structure/tray/MouseDrop_T(atom/movable/O as mob|obj, mob/user)
 	if(!ismovable(O) || O.anchored || !Adjacent(user) || !user.Adjacent(O) || O.loc == user)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -341,6 +341,17 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	else
 		to_chat(user, "<span class='warning'>That's not connected to anything!</span>")
 
+/obj/structure/tray/attackby(obj/P, mob/user, params)
+	if(istype(P, /obj/item/riding_offhand))
+		var/obj/item/riding_offhand/riding_item = P
+		var/mob/living/carried_mob = riding_item.rider
+		if(carried_mob == user) //Piggyback user.
+			return
+		user.unbuckle_mob(carried_mob)
+		MouseDrop_T(carried_mob, user)
+	else
+		return ..()
+
 /obj/structure/tray/MouseDrop_T(atom/movable/O as mob|obj, mob/user)
 	if(!ismovable(O) || O.anchored || !Adjacent(user) || !user.Adjacent(O) || O.loc == user)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR lets you click on open trays while fireman carrying on them to place them on it.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Currently, if you are fireman carrying someone, the best course of action is to close the tray if it is open, stand on top of the tile, drop the person, stand out of the way, then close the tray. You might be able to drag and drop their sprite as well, though this is still not as intuitive as simply clicking on the tray.

## Changelog
:cl:
add: You can now place people you are fireman carrying onto morgue trays.
add: You can now place people you are fireman carrying onto objects that buckle players.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
