### PR TITLE
Unfucks gun belt icons

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -8,6 +8,7 @@
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "detective"
 	inhand_icon_state = "gun"
+	worn_icon_state = "gun"
 	flags_1 =  CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
 	custom_materials = list(/datum/material/iron=2000)


### PR DESCRIPTION
There might be some stealthy weapon somewhere that you wouldn't want this for, but better to have a majority of shit fixed for now and find that single instance when it pops up, instead of just having everything be a missing texture all together.

:cl: ShizCalev
fix: Wearing a gun on your armor / belt will no longer result in your waist turning purple and black.
/:cl:

Step towards resolving #50947
