### PR TITLE
Proximity monitor related fixes.

### DIFF
--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -9,7 +9,7 @@
 		for (var/obj/machinery/camera/M in src)
 			if(M.isMotion())
 				motioncameras.Add(M)
-				M.area_motion = src
+				M.set_area_motion(src)
 
 //Only need to use one camera
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -95,7 +95,7 @@
 		proximity_monitor = new(src, 1)
 
 /obj/machinery/camera/proc/set_area_motion(area/A)
-	area_motion = src
+	area_motion = A
 	create_prox_monitor()
 
 /obj/machinery/camera/Destroy()

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -79,7 +79,6 @@
 	if (isturf(loc))
 		myarea = get_area(src)
 		LAZYADD(myarea.cameras, src)
-	proximity_monitor = new(src, 1)
 
 	if(mapload && is_station_level(z) && prob(3) && !start_active)
 		toggle_cam()
@@ -90,6 +89,14 @@
 	for(var/i in network)
 		network -= i
 		network += "[idnum][i]"
+
+/obj/machinery/proc/create_prox_monitor()
+	if(!proximity_monitor)
+		proximity_monitor = new(src, 1)
+
+/obj/machinery/camera/proc/set_area_motion(area/A)
+	area_motion = src
+	create_prox_monitor()
 
 /obj/machinery/camera/Destroy()
 	if(can_use())

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -133,8 +133,11 @@
 	if(!assembly.proxy_module)
 		assembly.proxy_module = new(assembly)
 	upgrades |= CAMERA_UPGRADE_MOTION
+	create_prox_monitor()
 
 /obj/machinery/camera/proc/removeMotion()
 	if(name == "motion-sensitive security camera")
 		name = "security camera"
 	upgrades &= ~CAMERA_UPGRADE_MOTION
+	if(!area_motion)
+		QDEL_NULL(proximity_monitor)

--- a/code/game/turfs/open/space/transit.dm
+++ b/code/game/turfs/open/space/transit.dm
@@ -45,6 +45,10 @@
 		var/datum/space_level/D = A
 		if (D.linkage == CROSSLINKED)
 			possible_transtitons += D.z_value
+	if(!length(possible_transtitons)) //No space to throw them to - try throwing them onto mining
+		possible_transtitons = SSmapping.levels_by_trait(ZTRAIT_MINING)
+		if(!length(possible_transtitons)) //Just throw them back on station, if not just runtime.
+			possible_transtitons = SSmapping.levels_by_trait(ZTRAIT_STATION)
 	var/_z = pick(possible_transtitons)
 
 	//now select coordinates for a border turf

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -121,6 +121,8 @@ All ShuttleMove procs go here
 		update_light()
 	if(rotation)
 		shuttleRotate(rotation)
+	if(proximity_monitor)
+		proximity_monitor.HandleMove()
 
 	update_parallax_contents()
 


### PR DESCRIPTION
Cameras don't make prox monitors unless they need them.
Prox monitors move properly with shuttles.
Transit turfs throw onto mining or station if there's no crosslinked space levels. (Icebox)