### PR TITLE
Borgs and AIs now start with their borgHUDs/siliconHUDs on by default

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -34,7 +34,7 @@
 	var/hackedcheck[1]
 	var/devillawcheck[5]
 
-	var/sensors_on = 0
+	var/sensors_on = 1 //are our HUDs on?
 	var/med_hud = DATA_HUD_MEDICAL_ADVANCED //Determines the med hud to use
 	var/sec_hud = DATA_HUD_SECURITY_ADVANCED //Determines the sec hud to use
 	var/d_hud = DATA_HUD_DIAGNOSTIC_BASIC //Determines the diag hud to use
@@ -57,6 +57,7 @@
 		diag_hud.add_to_hud(src)
 	diag_hud_set_status()
 	diag_hud_set_health()
+	add_sensors()
 
 /mob/living/silicon/med_hud_set_health()
 	return //we use a different hud

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -34,7 +34,7 @@
 	var/hackedcheck[1]
 	var/devillawcheck[5]
 
-	var/sensors_on = 1 //are our HUDs on?
+	var/sensors_on = TRUE //are our HUDs on?
 	var/med_hud = DATA_HUD_MEDICAL_ADVANCED //Determines the med hud to use
 	var/sec_hud = DATA_HUD_SECURITY_ADVANCED //Determines the sec hud to use
 	var/d_hud = DATA_HUD_DIAGNOSTIC_BASIC //Determines the diag hud to use

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -33,8 +33,9 @@
 	var/ioncheck[1]
 	var/hackedcheck[1]
 	var/devillawcheck[5]
-
-	var/sensors_on = TRUE //are our HUDs on?
+	
+	///Are our siliconHUDs on? TRUE for yes, FALSE for no.
+	var/sensors_on = TRUE
 	var/med_hud = DATA_HUD_MEDICAL_ADVANCED //Determines the med hud to use
 	var/sec_hud = DATA_HUD_SECURITY_ADVANCED //Determines the sec hud to use
 	var/d_hud = DATA_HUD_DIAGNOSTIC_BASIC //Determines the diag hud to use


### PR DESCRIPTION
## About The Pull Request

see title

## Why It's Good For The Game

pushing this button at roundstart every round is mildly annoying, and many new silicon players don't even know that it exists

## Changelog
:cl: ATHATH
tweak: Borgs and AIs now start with their borgHUDs/siliconHUDs on by default.
/:cl: