### PR TITLE
swarmers can no longer eat ore silos, but can now chew through stacks of materials much more quickly

### DIFF
--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -4,7 +4,7 @@
 	desc = "A shell of swarmer that was completely powered down. It can no longer activate itself."
 	icon = 'icons/mob/swarmer.dmi'
 	icon_state = "swarmer_unactivated"
-	custom_materials = list(/datum/material/iron=10000, /datum/material/glass=4000)
+	custom_materials = list(/datum/material/iron=10000, /datum/material/glass=4000, /datum/material/bluespace=MINERAL_MATERIAL_AMOUNT) //each swarmer drops a bluespace crystal when destroyed, so an inactive shell should have around as much bluespace material in it as a single bluespace crystal would
 
 /obj/effect/mob_spawn/swarmer
 	name = "unactivated swarmer"
@@ -392,7 +392,7 @@
 	return FALSE
 
 /obj/machinery/field/generator/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
-	to_chat(S, "<span class='warning'>Destroying this object would cause a catastrophic chain reaction. Aborting.</span>")
+	to_chat(S, "<span class='warning'>Destroying this object could cause a catastrophic chain reaction. Aborting.</span>")
 	return FALSE
 
 /obj/machinery/field/containment/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
@@ -405,6 +405,10 @@
 
 /obj/machinery/shieldwall/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, "<span class='warning'>This object does not contain solid matter. Aborting.</span>")
+	return FALSE
+
+/obj/machinery/ore_silo/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, "<span class='warning'>Concentrated matter repositories such as this one would be best processed by more specialized units that shall arrive later. Aborting.</span>") //idk it was the best explanation I could come up with
 	return FALSE
 
 ////END CTRL CLICK FOR SWARMERS////
@@ -427,7 +431,7 @@
 	if(resource_gain)
 		resources += resource_gain
 		do_attack_animation(target)
-		changeNext_move(CLICK_CD_MELEE)
+		changeNext_move(CLICK_CD_RAPID)
 		var/obj/effect/temp_visual/swarmer/integrate/I = new /obj/effect/temp_visual/swarmer/integrate(get_turf(target))
 		I.pixel_x = target.pixel_x
 		I.pixel_y = target.pixel_y


### PR DESCRIPTION
## About The Pull Request

swarmers can no longer eat ore silos

the click cooldown that a swarmer is given whenever they eat something has gone down from 0.8 seconds to 0.2 seconds

the deactivated swarmer item (the kind that CAN'T actually awaken into an actual swarmer, which is basically just a prop for ruins and such) now has as much of the bluespace material in it as a single bluespace crystal does

## Why It's Good For The Game

swarmers often end the round not because they've actually done much damage to the station, but rather because one of them just jumped into the vault and ate the ore silo. doing that is also one of the more/most optimal swarmer plays (if you can deal with the motion-sensitive camera(s)); why chew through the station for materials when you can easy get more materials than you could ever eat by destroying a single structure?

to compensate for this nerf and to reduce the amount of time that swarmers have to play cookie clicker for after they've located a nice, juicy stack of metal, I've increased the speed at which swarmers can harvest resources from sheets of metal, sheets of glass, etc.

finally, the deactivated swarmer item thing just sort of made sense to me (I'm not gonna mention it in the changelog because people will just misinterpret what this change actually means)

also, this is an alternative for https://github.com/tgstation/tgstation/pull/51528

## Changelog
:cl: ATHATH
balance: Swarmers can no longer eat ore silos.
balance: Swarmers can now harvest resources from eating items much more quickly (4x as fast).
/:cl: