### PR TITLE
Fixes a snowflake heart check from the defib hud fix.

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -853,8 +853,8 @@
 	if ((getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE) || (getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE))
 		return DEFIB_FAIL_TISSUE_DAMAGE
 
-	// Plasmamen do not need a heart to live
-	if (!isplasmaman(src))
+	// Only check for a heart if they actually need a heart. Who would've thunk
+	if (needs_heart())
 		var/obj/item/organ/heart = getorgan(/obj/item/organ/heart)
 
 		if (!heart)


### PR DESCRIPTION
Fixes a snowflake plasmamen check added in #51478

## Changelog
:cl: ShizCalev
fix: Defibbing now works properly on ALL species that don't require hearts to survive, as opposed to just plasmamen.
fix: Defibbing now works properly on mobs with the Muscled Veins trait if their heart was removed.
/:cl:
