### PR TITLE
Remove Uncessary Lighting Vars

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -55,7 +55,6 @@ SUBSYSTEM_DEF(lighting)
 		var/datum/lighting_corner/C = queue[i]
 
 		C.update_objects()
-		C.needs_update = FALSE
 		if(init_tick_checks)
 			CHECK_TICK
 		else if (MC_TICK_CHECK)
@@ -76,7 +75,6 @@ SUBSYSTEM_DEF(lighting)
 			continue
 
 		O.update()
-		O.needs_update = FALSE
 		if(init_tick_checks)
 			CHECK_TICK
 		else if (MC_TICK_CHECK)

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -118,8 +118,9 @@ GLOBAL_LIST_INIT(LIGHTING_CORNER_DIAGONAL, list(NORTHEAST, SOUTHEAST, SOUTHWEST,
 
 	for (var/TT in masters)
 		var/turf/T = TT
-		if (T.lighting_object)
-			SSlighting.objects_queue[T.lighting_object] = TRUE
+		var/atom/movable/lighting_object/lo = T.lighting_object
+		if (lo)
+			SSlighting.objects_queue[lo] = TRUE
 
 
 /datum/lighting_corner/dummy/New()

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -10,15 +10,12 @@ GLOBAL_LIST_INIT(LIGHTING_CORNER_DIAGONAL, list(NORTHEAST, SOUTHEAST, SOUTHWEST,
 	var/list/datum/light_source/affecting // Light sources affecting us.
 	var/active                            = FALSE  // TRUE if one of our masters has dynamic lighting.
 
-	var/x     = 0
-	var/y     = 0
-	var/z     = 0
+	var/x
+	var/y
 
 	var/lum_r = 0
 	var/lum_g = 0
 	var/lum_b = 0
-
-	var/needs_update = FALSE
 
 	var/cache_r  = LIGHTING_SOFT_THRESHOLD
 	var/cache_g  = LIGHTING_SOFT_THRESHOLD
@@ -29,7 +26,6 @@ GLOBAL_LIST_INIT(LIGHTING_CORNER_DIAGONAL, list(NORTHEAST, SOUTHEAST, SOUTHWEST,
 	. = ..()
 	masters = list()
 	masters[new_turf] = turn(diagonal, 180)
-	z = new_turf.z
 
 	var/vertical   = diagonal & ~(diagonal - 1) // The horizontal directions (4 and 8) are bigger than the vertical ones (1 and 2), so we can reliably say the lsb is the horizontal direction.
 	var/horizontal = diagonal & ~vertical       // Now that we know the horizontal one we can get the vertical one.
@@ -94,9 +90,7 @@ GLOBAL_LIST_INIT(LIGHTING_CORNER_DIAGONAL, list(NORTHEAST, SOUTHEAST, SOUTHWEST,
 	lum_g += delta_g
 	lum_b += delta_b
 
-	if (!needs_update)
-		needs_update = TRUE
-		SSlighting.corners_queue += src
+	SSlighting.corners_queue[src] = TRUE
 
 /datum/lighting_corner/proc/update_objects()
 	// Cache these values ahead of time so 4 individual lighting objects don't all calculate them individually.
@@ -124,9 +118,8 @@ GLOBAL_LIST_INIT(LIGHTING_CORNER_DIAGONAL, list(NORTHEAST, SOUTHEAST, SOUTHWEST,
 
 	for (var/TT in masters)
 		var/turf/T = TT
-		if (T.lighting_object && !T.lighting_object.needs_update)
-			T.lighting_object.needs_update = TRUE
-			SSlighting.objects_queue += T.lighting_object
+		if (T.lighting_object)
+			SSlighting.objects_queue[T.lighting_object] = TRUE
 
 
 /datum/lighting_corner/dummy/New()

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -18,7 +18,7 @@
 	//is totally unsuitable for this object, as we are always changing it's colour manually
 	color = LIGHTING_BASE_MATRIX
 
-	var/turf/myturf = loc
+	var/turf/myturf = get_turf(src)
 	if (myturf.lighting_object)
 		qdel(myturf.lighting_object, force = TRUE)
 	myturf.lighting_object = src

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -11,9 +11,6 @@
 	layer            = LIGHTING_LAYER
 	invisibility     = INVISIBILITY_LIGHTING
 
-	var/needs_update = FALSE
-	var/turf/myturf
-
 /atom/movable/lighting_object/Initialize(mapload)
 	. = ..()
 	verbs.Cut()
@@ -21,7 +18,7 @@
 	//is totally unsuitable for this object, as we are always changing it's colour manually
 	color = LIGHTING_BASE_MATRIX
 
-	myturf = loc
+	var/turf/myturf = loc
 	if (myturf.lighting_object)
 		qdel(myturf.lighting_object, force = TRUE)
 	myturf.lighting_object = src
@@ -30,20 +27,15 @@
 	for(var/turf/open/space/S in RANGE_TURFS(1, src)) //RANGE_TURFS is in code\__HELPERS\game.dm
 		S.update_starlight()
 
-	needs_update = TRUE
-	SSlighting.objects_queue += src
+	SSlighting.objects_queue[src] = TRUE
 
 /atom/movable/lighting_object/Destroy(var/force)
 	if (force)
 		SSlighting.objects_queue -= src
-		if (loc != myturf)
-			var/turf/oldturf = get_turf(myturf)
-			var/turf/newturf = get_turf(loc)
-			stack_trace("A lighting object was qdeleted with a different loc then it is suppose to have ([COORD(oldturf)] -> [COORD(newturf)])")
+		var/turf/myturf = get_turf(src)
 		if (isturf(myturf))
 			myturf.lighting_object = null
 			myturf.luminosity = 1
-		myturf = null
 
 		return ..()
 
@@ -51,15 +43,6 @@
 		return QDEL_HINT_LETMELIVE
 
 /atom/movable/lighting_object/proc/update()
-	if (loc != myturf)
-		if (loc)
-			var/turf/oldturf = get_turf(myturf)
-			var/turf/newturf = get_turf(loc)
-			warning("A lighting object realised it's loc had changed in update() ([myturf]\[[myturf ? myturf.type : "null"]]([COORD(oldturf)]) -> [loc]\[[ loc ? loc.type : "null"]]([COORD(newturf)]))!")
-
-		qdel(src, TRUE)
-		return
-
 	// To the future coder who sees this and thinks
 	// "Why didn't he just use a loop?"
 	// Well my man, it's because the loop performed like shit.
@@ -71,6 +54,7 @@
 	// See LIGHTING_CORNER_DIAGONAL in lighting_corner.dm for why these values are what they are.
 	var/static/datum/lighting_corner/dummy/dummy_lighting_corner = new
 
+	var/turf/myturf = get_turf(src)
 	var/list/corners = myturf.corners
 	var/datum/lighting_corner/cr = dummy_lighting_corner
 	var/datum/lighting_corner/cg = dummy_lighting_corner


### PR DESCRIPTION
- Removed needs_update from corners and objects in favor of associated lists in the subsystem.
- Removed useless corner.z var
- Removed myturf from objects in favor of get_turf()

Cutting down on the penalty for modified datum vars

:cl:
refactor: Further reduced the memory footprint of the lighting system.
/:cl: