### PR TITLE
Most likely fixes defibrilators not working

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -873,11 +873,8 @@
 		if (BR.organ_flags & ORGAN_FAILING)
 			return DEFIB_FAIL_FAILING_BRAIN
 
-		if (!BR.brainmob)
+		if (BR.suicided || BR.brainmob?.suiciding)
 			return DEFIB_FAIL_NO_INTELLIGENCE
-
-		if (BR.suicided || BR.brainmob.suiciding)
-			return DEFIB_FAIL_SUICIDE
 
 	return DEFIB_POSSIBLE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The old code checked if `BR.suicided || BR.brainmob?.suiciding`.
![image](https://user-images.githubusercontent.com/35135081/84257669-8b92f080-aaca-11ea-826f-3870dfd65888.png)

This means if there is no brainmob, the whole condition becomes false and the mob is considered to have its intelligence.

The new code did not do an equivalent check. If there was no brainmob, then it was considered to not have intelligence. This has been changed. DEFIB_FAIL_SUICIDE can still be returned if the mob's suiciding flag is checked.

Closes #51561
Fixes #51559

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
#51559

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed defibrillators being borked. Sorry!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
