### PR TITLE
Fix for unbanning panel search

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -593,8 +593,8 @@
 		"}, list(
 			"player_key" = ckey(player_key),
 			"admin_key" = ckey(admin_key),
-			"player_ip" = player_ip,
-			"player_cid" = player_cid,
+			"player_ip" = player_ip || null,
+			"player_cid" = player_cid || null,
 		))
 		if(!query_unban_count_bans.warn_execute())
 			qdel(query_unban_count_bans)
@@ -653,8 +653,8 @@
 		"}, list(
 			"player_key" = ckey(player_key),
 			"admin_key" = ckey(admin_key),
-			"player_ip" = player_ip,
-			"player_cid" = player_cid,
+			"player_ip" = player_ip || null,
+			"player_cid" = player_cid || null,
 			"skip" = bansperpage * page,
 			"take" = bansperpage,
 		))


### PR DESCRIPTION
I tested with general logging on, these parameters were being passed as `''` instead from DM's `""` to `NULL` in sql.

i.e.
```
WHERE	('dave' IS NULL OR ckey = 'dave') AND
	(NULL IS NULL OR a_ckey = NULL) AND
	('' IS NULL OR ip = INET_ATON('')) AND
	('' IS NULL OR computerid = '')
```
Haven't checked if this is happening elsewhere.
@SpaceManiac 