### PR TITLE
Decrease blood drunk miner move_force

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -61,6 +61,7 @@ Difficulty: Medium
 	attack_action_types = list(/datum/action/innate/megafauna_attack/dash,
 							   /datum/action/innate/megafauna_attack/kinetic_accelerator,
 							   /datum/action/innate/megafauna_attack/transform_weapon)
+	move_force = MOVE_FORCE_NORMAL //Miner beeing able to just move structures like bolted doors and glass looks kinda strange
 
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Blood drunk miner can no longer move stuff like bolted windows or even doors
EDIT:
Blood drunk miner attacking with this PR merged:
https://streamable.com/a5srhr

Miner attacking without this PR:
https://streamable.com/a2i1t9

As you can see nothing changes how the miner fights (on the station which is already rare enough)
The only thing his PR fixes is this:
https://streamable.com/me1j85

And this only happens if well either some player controlled miner walks into the stuff (which I did for the video)
Or if the miner idles and just walks in random directions occasionally
The only reason why I even discovered this was because someone brought the miner to the station on a lowpop Terry round and it walked around in idle mode for some time and started moving airlocks

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It seems kinda strange that some mad miner would have the force to just move bolted down doors or windows (or structures in general)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Blood drunk miner megafauna can no longer move structures like bolted down doors / windows
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
