### PR TITLE
Adds debug logging to crew monitor

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -177,6 +177,10 @@
 	if (CONFIG_GET(flag/log_job_debug))
 		WRITE_LOG(GLOB.world_job_debug_log, "JOB: [text]")
 
+/proc/log_crew_monitor_debug(text)
+	if (CONFIG_GET(flag/log_crew_monitor_debug))
+		WRITE_LOG(GLOB.world_crew_monitor_debug_log, "CMC: [text]")
+
 /* Log to both DD and the logfile. */
 /proc/log_world(text)
 #ifdef USE_CUSTOM_ERROR_HANDLER

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -46,6 +46,8 @@ GLOBAL_VAR(world_shuttle_log)
 GLOBAL_PROTECT(world_shuttle_log)
 GLOBAL_VAR(discord_api_log)
 GLOBAL_PROTECT(discord_api_log)
+GLOBAL_VAR(world_crew_monitor_debug_log)
+GLOBAL_PROTECT(world_crew_monitor_debug_log)
 
 GLOBAL_VAR(demo_log)
 GLOBAL_PROTECT(demo_log)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -96,6 +96,8 @@
 
 /datum/config_entry/flag/log_shuttle // log shuttle related actions, ie shuttle computers, shuttle manipulator, emergency console
 
+/datum/config_entry/flag/log_crew_monitor_debug // log crew monitor traces
+
 /// Whether demos are written, if not set demo SS never initializes
 /datum/config_entry/flag/demos_enabled
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -35,7 +35,7 @@ GLOBAL_VAR(restart_counter)
 
 	make_datum_references_lists()	//initialises global lists for referencing frequently used datums (so that we only ever do it once)
 
-	GLOB.config_error_log = GLOB.world_manifest_log = GLOB.world_pda_log = GLOB.world_job_debug_log = GLOB.sql_error_log = GLOB.world_href_log = GLOB.world_runtime_log = GLOB.world_attack_log = GLOB.world_game_log = GLOB.world_econ_log = GLOB.world_shuttle_log = "data/logs/config_error.[GUID()].log" //temporary file used to record errors with loading config, moved to log directory once logging is set bl
+	GLOB.config_error_log = GLOB.world_manifest_log = GLOB.world_pda_log = GLOB.world_job_debug_log = GLOB.world_crew_monitor_debug_log = GLOB.sql_error_log = GLOB.world_href_log = GLOB.world_runtime_log = GLOB.world_attack_log = GLOB.world_game_log = GLOB.world_econ_log = GLOB.world_shuttle_log = "data/logs/config_error.[GUID()].log" //temporary file used to record errors with loading config, moved to log directory once logging is set bl
 
 	GLOB.revdata = new
 
@@ -148,6 +148,7 @@ GLOBAL_VAR(restart_counter)
 	GLOB.tgui_log = "[GLOB.log_directory]/tgui.log"
 	GLOB.world_shuttle_log = "[GLOB.log_directory]/shuttle.log"
 	GLOB.discord_api_log = "[GLOB.log_directory]/discord_api_log.log"
+	GLOB.world_crew_monitor_debug_log = "[GLOB.log_directory]/crew_monitor.log"
 
 	GLOB.demo_log = "[GLOB.log_directory]/demo.log"
 
@@ -168,6 +169,7 @@ GLOBAL_VAR(restart_counter)
 	start_log(GLOB.tgui_log)
 	start_log(GLOB.world_shuttle_log)
 	start_log(GLOB.discord_api_log)
+	start_log(GLOB.world_crew_monitor_debug_log)
 
 	GLOB.changelog_hash = md5('html/changelog.html') //for telling if the changelog has changed recently
 	if(fexists(GLOB.config_error_log))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the config option LOG_CREW_MONITOR_DEBUG to turn on detailed logging for the crew monitor consoles. Intended as a test merge.

Debugging with an admin shows the issue is `update_data` returning `null`, when I see no reason that should be happening.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Crew monitor console have been broken for a while (#51496). This is something that I have so far been unable to reproduce in a local server. However, it happens nearly every round on the real servers after some time. If test merged, this would hopefully make it easier to narrow down where exactly the code fails.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
server: Added logging for the crew monitor console.
/:cl:

## Example output
```
[2020-06-11 08:02:46.443] Starting up round ID .
 - -------------------------
[2020-06-11 08:04:02.043] CMC: Creating new list of results. 0 nanite sensors, 6 suit sensors
[2020-06-11 08:04:02.043] CMC: Finished checking nanites, checking suit sensors
[2020-06-11 08:04:02.043] CMC: Checking suit sensors for Rowan Richards: Z: 5, U: the shaft miner's jumpsuit, N: 1
[2020-06-11 08:04:02.043] CMC: Checking suit sensors for Sir Honks-a-Lot: Z: 10, U: the clown suit, N: 1
[2020-06-11 08:04:02.043] CMC: Checking suit sensors for Giggles: Z: 3, U: the clown suit, N: 1
[2020-06-11 08:04:02.043] CMC: Checking suit sensors for Butters The Bean: Z: 3, U: the clown suit, N: 1
[2020-06-11 08:04:02.043] CMC: Checking suit sensors for Yobbo: Z: 3, U: the clown suit, N: 1
[2020-06-11 08:04:02.043] CMC: Checking suit sensors for Mothblocks: Z: 2, U: the chief medical officer's jumpskirt, N: 1
[2020-06-11 08:04:02.043] CMC: Checking suit sensors, U.has_sensor == 1, U.sensor_mode == 2
[2020-06-11 08:04:02.043] CMC: ID: Mothblocks's ID Card (Chief Medical Officer)
[2020-06-11 08:04:02.043] CMC: Result: {"name":"Mothblocks","assignment":"Chief Medical Officer","ijob":20,"life_status":1,"oxydam":0,"toxdam":0,"burndam":0,"brutedam":7,"area":null,"pos_x":null,"pos_y":null,"can_track":0}
[2020-06-11 08:04:02.043] CMC: Final results: /list
[2020-06-11 08:04:02.522] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:03.423] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:04.323] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:05.223] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:06.123] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:06.261] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:06.511] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:07.023] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:07.962] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:08.326] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:08.473] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:08.831] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:09.750] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:09.924] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:10.643] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:11.324] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:11.542] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:11.624] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:11.924] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:12.324] CMC: Creating new list of results. 0 nanite sensors, 6 suit sensors
[2020-06-11 08:04:12.324] CMC: Finished checking nanites, checking suit sensors
[2020-06-11 08:04:12.324] CMC: Checking suit sensors for Rowan Richards: Z: 5, U: the shaft miner's jumpsuit, N: 1
[2020-06-11 08:04:12.324] CMC: Checking suit sensors for Sir Honks-a-Lot: Z: 10, U: the clown suit, N: 1
[2020-06-11 08:04:12.324] CMC: Checking suit sensors for Giggles: Z: 3, U: the clown suit, N: 1
[2020-06-11 08:04:12.324] CMC: Checking suit sensors for Butters The Bean: Z: 3, U: the clown suit, N: 1
[2020-06-11 08:04:12.324] CMC: Checking suit sensors for Yobbo: Z: 3, U: the clown suit, N: 1
[2020-06-11 08:04:12.324] CMC: Checking suit sensors for Mothblocks: Z: 2, U: the chief medical officer's jumpskirt, N: 1
[2020-06-11 08:04:12.324] CMC: Checking suit sensors, U.has_sensor == 1, U.sensor_mode == 2
[2020-06-11 08:04:12.324] CMC: ID: Mothblocks's ID Card (Chief Medical Officer)
[2020-06-11 08:04:12.324] CMC: Result: {"name":"Mothblocks","assignment":"Chief Medical Officer","ijob":20,"life_status":1,"oxydam":0,"toxdam":0,"burndam":0,"brutedam":20,"area":null,"pos_x":null,"pos_y":null,"can_track":0}
[2020-06-11 08:04:12.324] CMC: Final results: /list
[2020-06-11 08:04:12.443] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:13.344] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:14.243] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:15.143] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:16.043] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:16.943] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:17.845] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:18.757] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:19.644] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:20.557] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:21.456] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:22.357] CMC: Creating new list of results. 0 nanite sensors, 6 suit sensors
[2020-06-11 08:04:22.357] CMC: Finished checking nanites, checking suit sensors
[2020-06-11 08:04:22.357] CMC: Checking suit sensors for Rowan Richards: Z: 5, U: the shaft miner's jumpsuit, N: 1
[2020-06-11 08:04:22.357] CMC: Checking suit sensors for Sir Honks-a-Lot: Z: 10, U: the clown suit, N: 1
[2020-06-11 08:04:22.357] CMC: Checking suit sensors for Giggles: Z: 3, U: the clown suit, N: 1
[2020-06-11 08:04:22.357] CMC: Checking suit sensors for Butters The Bean: Z: 3, U: the clown suit, N: 1
[2020-06-11 08:04:22.357] CMC: Checking suit sensors for Yobbo: Z: 3, U: the clown suit, N: 1
[2020-06-11 08:04:22.357] CMC: Checking suit sensors for Mothblocks: Z: 2, U: the chief medical officer's jumpskirt, N: 1
[2020-06-11 08:04:22.357] CMC: Checking suit sensors, U.has_sensor == 1, U.sensor_mode == 2
[2020-06-11 08:04:22.357] CMC: ID: Mothblocks's ID Card (Chief Medical Officer)
[2020-06-11 08:04:22.357] CMC: Result: {"name":"Mothblocks","assignment":"Chief Medical Officer","ijob":20,"life_status":1,"oxydam":0,"toxdam":0,"burndam":0,"brutedam":20,"area":null,"pos_x":null,"pos_y":null,"can_track":0}
[2020-06-11 08:04:22.357] CMC: Final results: /list
[2020-06-11 08:04:23.256] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:24.156] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:25.056] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:25.956] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:26.856] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:27.758] CMC: Retrieving cached result for 2: /list
[2020-06-11 08:04:28.656] CMC: Retrieving cached result for 2: /list
```

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
