### PR TITLE
bababooey emote now causes you to slowly lose your braincells

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -516,6 +516,7 @@
 /datum/emote/living/bababooey/get_sound(mob/living/user)
 	if(isliving(user))
 		var/mob/living/L = user
+		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
 				return 'sound/voice/human/ffff.ogg'
@@ -534,6 +535,7 @@
 /datum/emote/living/babafooey/get_sound(mob/living/user)
 	if(isliving(user))
 		var/mob/living/L = user
+		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
 				return 'sound/voice/human/ffff.ogg'
@@ -552,6 +554,7 @@
 /datum/emote/living/fafafooey/get_sound(mob/living/user)
 	if(isliving(user))
 		var/mob/living/L = user
+		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
 				return 'sound/voice/human/ffff.ogg'
@@ -572,6 +575,7 @@
 /datum/emote/living/fafafoggy/get_sound(mob/living/user)
 	if(isliving(user))
 		var/mob/living/L = user
+		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
 				return 'sound/voice/human/ffff.ogg'
@@ -592,6 +596,7 @@
 /datum/emote/living/hohohoy/get_sound(mob/living/user)
 	if(isliving(user))
 		var/mob/living/L = user
+		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
 				return 'sound/voice/human/ffff.ogg'
@@ -609,5 +614,6 @@
 /datum/emote/living/ffff/get_sound(mob/living/user)
 	if(isliving(user))
 		var/mob/living/L = user
+		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
 		if(!L.mind || !L.mind.miming)
 			return 'sound/voice/human/ffff.ogg'

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -517,6 +517,8 @@
 	if(isliving(user))
 		var/mob/living/L = user
 		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+		if(rand(0,1) == 1)
+			to_chat(user, "<span class='danger'>You feel your braincells dying</span>")
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
 				return 'sound/voice/human/ffff.ogg'
@@ -536,6 +538,8 @@
 	if(isliving(user))
 		var/mob/living/L = user
 		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+		if(rand(0,1) == 1)
+			to_chat(user, "<span class='danger'>You feel your braincells dying</span>")
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
 				return 'sound/voice/human/ffff.ogg'
@@ -555,6 +559,8 @@
 	if(isliving(user))
 		var/mob/living/L = user
 		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+		if(rand(0,1) == 1)
+			to_chat(user, "<span class='danger'>You feel your braincells dying</span>")
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
 				return 'sound/voice/human/ffff.ogg'
@@ -576,6 +582,8 @@
 	if(isliving(user))
 		var/mob/living/L = user
 		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+		if(rand(0,1) == 1)
+			to_chat(user, "<span class='danger'>You feel your braincells dying</span>")
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
 				return 'sound/voice/human/ffff.ogg'
@@ -597,6 +605,8 @@
 	if(isliving(user))
 		var/mob/living/L = user
 		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+		if(rand(0,1) == 1)
+			to_chat(user, "<span class='danger'>You feel your braincells dying</span>")
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
 				return 'sound/voice/human/ffff.ogg'
@@ -615,5 +625,7 @@
 	if(isliving(user))
 		var/mob/living/L = user
 		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+		if(rand(0,1) == 1)
+			to_chat(user, "<span class='danger'>You feel your braincells dying</span>")
 		if(!L.mind || !L.mind.miming)
 			return 'sound/voice/human/ffff.ogg'

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -517,7 +517,7 @@
 	if(isliving(user))
 		var/mob/living/L = user
 		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
-		if(rand(0,1) == 1)
+		if(prob(50))
 			to_chat(user, "<span class='danger'>You feel your braincells dying</span>")
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
@@ -538,7 +538,7 @@
 	if(isliving(user))
 		var/mob/living/L = user
 		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
-		if(rand(0,1) == 1)
+		if(prob(50))
 			to_chat(user, "<span class='danger'>You feel your braincells dying</span>")
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
@@ -559,7 +559,7 @@
 	if(isliving(user))
 		var/mob/living/L = user
 		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
-		if(rand(0,1) == 1)
+		if(prob(50))
 			to_chat(user, "<span class='danger'>You feel your braincells dying</span>")
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
@@ -582,7 +582,7 @@
 	if(isliving(user))
 		var/mob/living/L = user
 		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
-		if(rand(0,1) == 1)
+		if(prob(50))
 			to_chat(user, "<span class='danger'>You feel your braincells dying</span>")
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
@@ -605,7 +605,7 @@
 	if(isliving(user))
 		var/mob/living/L = user
 		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
-		if(rand(0,1) == 1)
+		if(prob(50))
 			to_chat(user, "<span class='danger'>You feel your braincells dying</span>")
 		if(!L.mind || !L.mind.miming)
 			if(user.is_muzzled())
@@ -625,7 +625,7 @@
 	if(isliving(user))
 		var/mob/living/L = user
 		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
-		if(rand(0,1) == 1)
+		if(prob(50))
 			to_chat(user, "<span class='danger'>You feel your braincells dying</span>")
 		if(!L.mind || !L.mind.miming)
 			return 'sound/voice/human/ffff.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Using bababooey and its variants will cause you 5 brain damage per use and has 50% chance of displaying warning about your braincells dying.
## Why It's Good For The Game
balances emote

## Changelog
:cl:
add: bababooey now deals brain damage when used.
/:cl: