### PR TITLE
fixes forced dynamic families ruleset

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -95,16 +95,16 @@
 /// By default, a rule is acceptable if it satisfies the threat level/population requirements.
 /// If your rule has extra checks, such as counting security officers, do that in ready() instead
 /datum/dynamic_ruleset/proc/acceptable(population = 0, threat_level = 0)
-	if(minimum_players > population)
-		return FALSE
-	if(maximum_players > 0 && population > maximum_players)
-		return FALSE
-
 	pop_per_requirement = pop_per_requirement > 0 ? pop_per_requirement : mode.pop_per_requirement
 	if(antag_cap.len && requirements.len != antag_cap.len)
 		message_admins("DYNAMIC: requirements and antag_cap lists have different lengths in ruleset [name]. Likely config issue, report this.")
 		log_game("DYNAMIC: requirements and antag_cap lists have different lengths in ruleset [name]. Likely config issue, report this.")
 	indice_pop = min(requirements.len,round(population/pop_per_requirement)+1)
+
+	if(minimum_players > population)
+		return FALSE
+	if(maximum_players > 0 && population > maximum_players)
+		return FALSE
 	return (threat_level >= requirements[indice_pop])
 
 /// Called when a suitable rule is picked during roundstart(). Will some times attempt to scale a rule up when there is threat remaining. Returns the additional threat from scaling up.

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -244,9 +244,10 @@
 			candidates -= player
 
 /datum/dynamic_ruleset/midround/families/acceptable(population = 0, threat_level = 0)
+	. = ..()
 	if(GLOB.deaths_during_shift > round(mode.roundstart_pop_ready / 2))
 		return FALSE
-	return ..()
+
 
 /datum/dynamic_ruleset/midround/families/ready(forced = FALSE)
 	if (required_candidates > living_players.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

indice_pop isn't set by acceptable() if the pop is too low but i still used it anyway, which normally wouldn't be a problem since the ruleset just won't execute when the pop is too low except forced rulesets always execute, so indice_pop wasn't set when i needed to use it. this PR just shuffles acceptable() slightly to always calculate indice_pop even if the ruleset is later found unacceptable. i don't think there are any other rulesets that use indice_pop in their execution, but if there are, this  PR stops this specific error from happening to those too.

## Why It's Good For The Game

state variables should always be set

## Changelog
:cl:
fix: dynamic families rulesets can now be forced and will execute instead of runtiming
/:cl: