### PR TITLE
[s] Fixes a pair of DoS vectors.

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -173,5 +173,5 @@
 	var/last_asset_job = 0
 	var/last_completed_asset_job = 0
 
-	//rate limiting for the crew manifest
+	/// rate limiting for the crew manifest
 	var/crew_manifest_delay

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -172,3 +172,6 @@
 	/// Last asset send job id.
 	var/last_asset_job = 0
 	var/last_completed_asset_job = 0
+
+	//rate limiting for the crew manifest
+	var/crew_manifest_delay

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -177,9 +177,6 @@
 		AttemptLateSpawn(href_list["SelectedJob"])
 		return
 
-	if(!ready && href_list["preference"])
-		if(client)
-			client.prefs.process_link(src, href_list)
 	else if(!href_list["late_join"])
 		new_player_panel()
 
@@ -458,6 +455,12 @@
 		qdel(src)
 
 /mob/dead/new_player/proc/ViewManifest()
+	if(!client)
+		return
+	if(world.time < client.crew_manifest_delay)
+		return
+	client.crew_manifest_delay = world.time + (1 SECONDS)
+
 	var/dat = "<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'></head><body>"
 	dat += "<h4>Crew Manifest</h4>"
 	dat += GLOB.data_core.get_manifest_html()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -647,6 +647,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "View Crew Manifest"
 	set category = "Ghost"
 
+	if(!client)
+		return
+	if(world.time < client.crew_manifest_delay)
+		return
+	client.crew_manifest_delay = world.time + (1 SECONDS)
+
 	var/dat
 	dat += "<h4>Crew Manifest</h4>"
 	dat += GLOB.data_core.get_manifest_html()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -335,6 +335,12 @@
 	usr << browse(list, "window=laws")
 
 /mob/living/silicon/proc/ai_roster()
+	if(!client)
+		return
+	if(world.time < client.crew_manifest_delay)
+		return
+	client.crew_manifest_delay = world.time + (1 SECONDS)
+
 	var/datum/browser/popup = new(src, "airoster", "Crew Manifest", 387, 420)
 	popup.set_content(GLOB.data_core.get_manifest_html())
 	popup.open()


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/6356337/84463339-6c699f80-ac3f-11ea-8abc-e265cd2f35e7.png)

## About The Pull Request
This PR fixes a pair of major DoS vectors that currently are not being exploited on public servers to my knowledge. I will not publicly explain how these can be exploited for a DoS attack (though maintainers of this codebase are free to DM me, and headcoders are free to ping me in coderbus's headcoder chat or host chat's code channel), but one of the patches involves removing a completely unused topic call that lacks security, and the other involves basic rate limiting. Changelog excluded due to lack of player-facing changes. This has been tested locally under artificial conditions simulating a 50-player server.

This patch likely isn't very urgent at the moment due to a lack of people exploiting the DoS vectors, and I'm unaware if the DoS vectors are present in baycode at the moment, but it'd be worth porting this to other codebases ASAP just in case.