### PR TITLE
Fix medical HUD showing skulls when a player leaves their body for a ghost

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -275,6 +275,8 @@ Works together with spawning an observer, noted above.
 			ghost.key = key
 			if(!can_reenter_corpse)	// Disassociates observer mind from the body mind
 				ghost.mind = null
+			else
+				ghost.mind.current?.med_hud_set_status()
 			return ghost
 
 /*

--- a/code/modules/mob/living/logout.dm
+++ b/code/modules/mob/living/logout.dm
@@ -3,3 +3,4 @@
 	..()
 	if(!key && mind)	//key and mind have become separated.
 		mind.active = 0	//This is to stop say, a mind.transfer_to call on a corpse causing a ghost to re-enter its body.
+	med_hud_set_status()

--- a/code/modules/mob/living/logout.dm
+++ b/code/modules/mob/living/logout.dm
@@ -3,4 +3,3 @@
 	..()
 	if(!key && mind)	//key and mind have become separated.
 		mind.active = 0	//This is to stop say, a mind.transfer_to call on a corpse causing a ghost to re-enter its body.
-	med_hud_set_status()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #51576, but doesn't provide a solution to the problem this was meant to solve of players logging out and being defibrillated while catatonic, I'm not sure how to fix that.

This does NOT mean the Ghost command. This means walking out of your body, where you can still be defibbed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Further fixes medical HUDs showing skulls when a body can be defibrilated.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed ghosting making your body look undefibbable to a medical HUD.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
