### PR TITLE
Nerfed arrest access through SecHUDs & small balance changes

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -11803,7 +11803,7 @@
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes,
 /obj/item/lighter,
-/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "aEp" = (

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -24,7 +24,7 @@
 	use_power = IDLE_POWER_USE				//this turret uses and requires power
 	idle_power_usage = 50		//when inactive, this turret takes up constant 50 Equipment power
 	active_power_usage = 300	//when active, this turret takes up constant 300 Equipment power
-	req_access = list(ACCESS_SEC_DOORS)
+	req_access = list(ACCESS_SECURITY) /// Only people with Security access
 	power_channel = AREA_USAGE_EQUIP	//drains power from the EQUIPMENT channel
 
 	var/base_icon_state = "standard"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -392,7 +392,7 @@
 			else //Implant and standard glasses check access
 				if(H.wear_id)
 					var/list/access = H.wear_id.GetAccess()
-					if(ACCESS_SEC_DOORS in access)
+					if(ACCESS_SECURITY in access)
 						allowed_access = H.get_authentification_name()
 
 			if(!allowed_access)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Arrest option through SecHUDs is now only available to people with Security access (instead of Brig access), restricting it roundstart to Captain, HoS, HoP and Security Officers. Previously, roles such as Lawyer, CMO, Detective, etc; could set arrest status through SecHUDs.

Additionally, Security access is now also required to operate portable turrets (from Brig access).

Changed PubbyStation SecHUDs at Detective's office for sunglasses, for consistency with the other maps.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It seems that #51370 wasn't very popular in the end and the general consensus would be that detectives shouldn't be arresting people. Well, this change makes them unable to arrest people through SecHUDs (they can still see and set arrest status at security consoles). And, consistenly, other roles that aren't supposed to be setting arrest status now they also can't.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Detective gets roundstart normal sunglasses instead of SecHUDs at PubbyStation.
balance: Balanced access to arrest option through SecHUDs, now requiring Security access instead of Brig access.
balance: Balanced access to portable turrets, now requiring Security access instead of Brig access.
fix: fixed a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
