### PR TITLE
Medbots now know they should be healing other damage types instead of brute

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -255,6 +255,8 @@
 				S.firstaid = firstaid
 				S.robot_arm = robot_arm
 				S.healthanalyzer = healthanalyzer
+				var/obj/item/storage/firstaid/FA = firstaid
+				S.damagetype_healer = initial(FA.damagetype_healed)
 				qdel(src)
 
 

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -113,9 +113,6 @@
 	linked_techweb = SSresearch.science_tech
 	if(damagetype_healer == "all")
 		return
-	var/obj/item/storage/firstaid/FA = firstaid
-	if(initial(FA.damagetype_healed))
-		damagetype_healer = initial(FA.damagetype_healed)
 
 /mob/living/simple_animal/bot/medbot/update_mobility()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

whoever made tablecrafting did not think that you might want to make edits to the newly created object after you made it nor thought that you might want to have a direct reference to the items used to make your item so I have not fixed that bug, although it already existed prior to my PR.

in my testing i was manually setting it to various damage types so I had somehow assumed the medical kit was embedded into the initialize rather than post-new modifications on the bot assembly.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

closes #51588

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Cobby kills medbots!!!
fix: Medbots that are suppose to heal other damage types than brute now actually do so
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
