### PR TITLE
Revert "mindshields no longer implant fake memories"

### DIFF
--- a/code/game/gamemodes/gang/gang_things.dm
+++ b/code/game/gamemodes/gang/gang_things.dm
@@ -13,7 +13,7 @@
 /obj/item/gang_induction_package/attack_self(mob/living/user)
 	..()
 	if(HAS_TRAIT(user, TRAIT_MINDSHIELD))
-		to_chat(user, "You attended a seminar on not signing up for a gang, and are not interested.")
+		to_chat(user, "You attended a seminar on not signing up for a gang and are not interested.")
 		return
 	if(user.mind.has_antag_datum(/datum/antagonist/ert/families))
 		to_chat(user, "As a police officer, you can't join this family. However, you pretend to accept it to keep your cover up.")

--- a/code/game/gamemodes/gang/gang_things.dm
+++ b/code/game/gamemodes/gang/gang_things.dm
@@ -13,7 +13,7 @@
 /obj/item/gang_induction_package/attack_self(mob/living/user)
 	..()
 	if(HAS_TRAIT(user, TRAIT_MINDSHIELD))
-		to_chat(user, "Your mind vehemently refuses to accept the family's ideologies.")
+		to_chat(user, "You attended a seminar on not signing up for a gang, and are not interested.")
 		return
 	if(user.mind.has_antag_datum(/datum/antagonist/ert/families))
 		to_chat(user, "As a police officer, you can't join this family. However, you pretend to accept it to keep your cover up.")


### PR DESCRIPTION
Reverts tgstation/tgstation#51248

I disagree with this change as it really does the same thing, but less topical and gang-themed. It doesn't actually make the mindshield implant not brainwash you.

The implant forcing your mind to "vehemently reject" the family is still brainwashing because it's making you disagree with the Family, and it's just less subtle and less funny. 
:cl:
tweak: Members of the crew with mindshields have remembered that anti-gang PSA they watched back in space high school.
/:cl: