### PR TITLE
replaces the normal medbot on the library ship with a derelict one

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -122,7 +122,7 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/space/has_grav/powered/authorship)
 "y" = (
-/mob/living/simple_animal/bot/medbot/mysterious,
+/mob/living/simple_animal/bot/medbot/derelict,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/space/has_grav/powered/authorship)
 "z" = (

--- a/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -122,7 +122,7 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/space/has_grav/powered/authorship)
 "y" = (
-/mob/living/simple_animal/bot/medbot,
+/mob/living/simple_animal/bot/medbot/mysterious,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/space/has_grav/powered/authorship)
 "z" = (


### PR DESCRIPTION
## About The Pull Request

Replaces the normal medbot on the library ship space ruin with the currently unused derelict/"Old Medibot" one.

## Why It's Good For The Game

The library ship currently has basically no loot in it, which makes it kind of pointless for most space explorers. It's basically the space equivalent of the sloth ruin (except less obstructive/annoying to encounter). Now there is a special medbot there that you can bring back to Medbay or put on your white ship or whatever, provided that you're willing to drag it behind you all the way to wherever you want to move it to.

## Changelog
:cl: ATHATH
balance: The medbot on the library ship is now special.
/:cl: