### PR TITLE
quickly fixes an oopsie I made

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -58,7 +58,8 @@
 		diag_hud.add_to_hud(src)
 	diag_hud_set_status()
 	diag_hud_set_health()
-	add_sensors()
+	if(!ispAI(src)) //pAIs need to purchase their HUDs
+		add_sensors()
 
 /mob/living/silicon/med_hud_set_health()
 	return //we use a different hud


### PR DESCRIPTION
## About The Pull Request

pAIs no longer start with a medHUD, secHUD, and diagHUD turned on as soon as they're downloaded, even if they haven't bought any HUDs yet.

## Why It's Good For The Game

I had forgotten that pAIs were a subtype of silicons when I made my roundstart siliconHUD enabling PR.

And yes, cobby, this is a webedit, but I'm fixing my own mistake(s) here, so I think that this should get a pass.

## Changelog
:cl: ATHATH
fix: pAIs no longer start with a medHUD, secHUD, and diagHUD turned on as soon as they're downloaded, even if they haven't bought any HUDs yet.
/:cl: