### PR TITLE
Fix ban note expiry time

### DIFF
--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -90,7 +90,7 @@
 		"port" = "[world.port]",
 		"round_id" = GLOB.round_id,
 		"secret" = secret,
-		"expiry" = expiry,
+		"expiry" = expiry || null,
 		"note_severity" = note_severity,
 	))
 	var/pm = "[key_name(usr)] has created a [type][(type == "note" || type == "message" || type == "watchlist entry") ? " for [target_key]" : ""]: [text]"


### PR DESCRIPTION
Expiry time was being inserted as `0000-00-00 00:00:00` when `NULL` was expected for non-expiring notes.