### PR TITLE
animate_atom_living proc (Staff of Animation) fix

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -336,12 +336,10 @@
 				return
 		else
 			var/obj/O = src
-			if(!isturf(O.loc))
-				O.forceMove(O.loc.drop_location())
 			if(istype(O, /obj/item/gun))
-				new /mob/living/simple_animal/hostile/mimic/copy/ranged(loc, src, owner)
+				new /mob/living/simple_animal/hostile/mimic/copy/ranged(drop_location(), src, owner)
 			else
-				new /mob/living/simple_animal/hostile/mimic/copy(loc, src, owner)
+				new /mob/living/simple_animal/hostile/mimic/copy(drop_location(), src, owner)
 
 	else if(istype(src, /mob/living/simple_animal/hostile/mimic/copy))
 		// Change our allegiance!

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -336,6 +336,8 @@
 				return
 		else
 			var/obj/O = src
+			if(!isturf(O.loc))
+				O.forceMove(O.loc.drop_location())
 			if(istype(O, /obj/item/gun))
 				new /mob/living/simple_animal/hostile/mimic/copy/ranged(loc, src, owner)
 			else


### PR DESCRIPTION
## About The Pull Request

Fixes a bug involving calling the animate atom proc on items in inventories causing strange things to happen. AFAIK it's unreported on the github, I discovered it working on a downstream project and it exists on the lastest build.

## Why It's Good For The Game

Bugs bag.

## Changelog
:cl:  Melbert
fix: Fixed staff of animation being able to spawn animated objects inside containers (ie bags)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
