### PR TITLE
Fixes the nuke lagging the end of the round.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -352,11 +352,6 @@ SUBSYSTEM_DEF(ticker)
 /datum/controller/subsystem/ticker/proc/station_explosion_detonation(atom/bomb)
 	if(bomb)	//BOOM
 		qdel(bomb)
-	for(var/T in GLOB.station_turfs)
-		if(prob(33))
-			SSexplosions.highturf += T
-		else
-			SSexplosions.medturf += T
 
 /datum/controller/subsystem/ticker/proc/create_characters()
 	for(var/i in GLOB.new_player_list)


### PR DESCRIPTION
see title

i remember oranges saying to remove this before but there's just no way to blow up every tile on the station at once performantly