### PR TITLE
Slightly tweaks Obsessed Photo Objective + Fixes it

### DIFF
--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -248,7 +248,7 @@
 /datum/objective/polaroid/update_explanation_text()
 	..()
 	if(target && target.current)
-		explanation_text = "Take a photo with [target.name] while they're alive."
+		explanation_text = "Take a photo of [target.name] while they're alive."
 	else
 		explanation_text = "Free Objective"
 
@@ -261,7 +261,7 @@
 		for(var/obj/I in all_items) //Check for wanted items
 			if(istype(I, /obj/item/photo))
 				var/obj/item/photo/P = I
-				if(P.picture.mobs_seen.Find(owner) && P.picture.mobs_seen.Find(target) && !P.picture.dead_seen.Find(target))//you are in the picture, they are but they are not dead.
+				if(P.picture && (target.current in P.picture.mobs_seen) && !(target.current in P.picture.dead_seen)) //Does the picture exist and is the target in it and is the target not dead
 					return TRUE
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Fixes #51525
Probably Fixes #44795 (I couldn't reproduce the heirloom bug, they probably got the wrong item and didn't realize it.)

The check for your target was checking for a mind in a list of mobs. That's been fixed.
Also removes the need for the obsessed to be in the picture. 

## Why It's Good For The Game

This objective has been broken for over a year, I think.
For the tweak: I think it's slightly more thematic if the obsessed person creeps around, taking photos of their obsession through windows from a distance, rather than running up to them and grabbing a selfie.

## Changelog
:cl: Melbert
tweak: Obsession picture objective no longer needs the obsessed themselves to be in the picture.
fix: Obsession picture objective now works properly.
/:cl:

