### PR TITLE
fixes engineering goggles glasses overlay colors

### DIFF
--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -12,6 +12,7 @@
 	icon_state = "trayson-meson"
 	inhand_icon_state = "trayson-meson"
 	actions_types = list(/datum/action/item_action/toggle_mode)
+	glass_colour_type = /datum/client_colour/glass_colour/gray
 
 	vision_flags = NONE
 	darkness_view = 2
@@ -43,11 +44,22 @@
 			vision_flags = SEE_TURFS
 			darkness_view = 1
 			lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+			change_glass_color(user, /datum/client_colour/glass_colour/yellow)
 
 		if(MODE_TRAY) //undoes the last mode, meson
 			vision_flags = NONE
 			darkness_view = 2
 			lighting_alpha = null
+			change_glass_color(user, /datum/client_colour/glass_colour/lightblue)
+
+		if(MODE_RAD)
+			change_glass_color(user, /datum/client_colour/glass_colour/lightgreen)
+
+		if(MODE_SHUTTLE)
+			change_glass_color(user, /datum/client_colour/glass_colour/red)
+
+		if(MODE_NONE)
+			change_glass_color(user, initial(glass_colour_type))
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user


### PR DESCRIPTION
:cl: ShizCalev
fix: Engineering scanner goggles are now the correct color when their modes are switched.
/:cl: