### PR TITLE
adds wizard only catastrophic objectives (and they roll it instead of steal and escape set)

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -403,6 +403,35 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 				counter++
 	return counter >= 8
 
+//wizard objectives (fairly hard to pull off and stupidly destructive to the station)
+
+/datum/objective/megafauna
+	name = "megafauna"
+	explanation_text = "Ensure a megafauna from the mining area is alive on or near the station at the end of the shift."
+	martyr_compatible = FALSE //while doable will make the objective way easier and instantly end round to finish martyr
+
+/datum/objective/megafauna/check_completion() //get a megafauna from the mining shuttle to the station. good luck!
+	for(var/a in GLOB.mob_living_list)
+		if(!ismegafauna(a))
+			continue
+		var/mob/living/simple_animal/hostile/megafauna/mega = a
+		if(is_station_level(mega.z))
+			return TRUE
+	return FALSE
+
+/datum/objective/disaster
+	name = "disaster"
+	explanation_text = "Create a tesla OR singularity, or something similar and ensure it's still on or near the station at the end of the shift."
+	martyr_compatible = FALSE //while doable will make the objective way easier and instantly end round to finish martyr
+
+/datum/objective/disaster/check_completion() //create something real BAD!
+	for(var/a in GLOB.poi_list)
+		if(istype(a, /obj/singularity))
+			var/obj/singularity/S = a
+			if(is_station_level(S.z))
+				return TRUE
+	return FALSE
+
 /datum/objective/escape
 	name = "escape"
 	explanation_text = "Escape on the shuttle or an escape pod alive and without being in custody."

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -74,10 +74,14 @@
 				objectives += escape_objective
 
 		if(31 to 60)
-			var/datum/objective/steal/steal_objective = new
-			steal_objective.owner = owner
-			steal_objective.find_target()
-			objectives += steal_objective
+			if(prob(50))
+				var/datum/objective/disaster/disaster_objective = new
+				disaster_objective.owner = owner
+				objectives += disaster_objective
+			else
+				var/datum/objective/megafauna/megafauna_objective = new
+				megafauna_objective.owner = owner
+				objectives += megafauna_objective
 
 			if (!(locate(/datum/objective/escape) in objectives))
 				var/datum/objective/escape/escape_objective = new


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
### ideas from this thread, thank you ideas subforum: https://tgstation13.org/phpBB/viewtopic.php?f=9&t=26689


two new objectives for wizards:
1. have a singularity or tesla on the station at the end of the round
yes, technically you can contain both but the wizard is definitely not going to build a containment for no reason to greentext without bloodshed... cmon that's stupid
2. have a megafauna on the station ALIVE at the end of the round
this one is hard as nails as you have to not die doing it (both of these objectives are given with the escape objective) but also keep it alive from people hunting it down

## Why It's Good For The Game

wizard's steal and escape objective encourages turtling in maintenance with say, jaunt, ei nath and some other really safe spell. i'd much rather give the wizard extremely difficult and destructive objectives for him to try out

## Changelog
:cl:
add: Wizard now gets catastrophic objectives
del: Removed the wizard set of objectives that were "steal something and escape"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
