### PR TITLE
Improves our ion laws with a Futurama reference

### DIFF
--- a/strings/ion_laws.json
+++ b/strings/ion_laws.json
@@ -291,6 +291,7 @@
         "MERCURY",
         "JUPITER",
         "URANUS",
+        "URECTUM",
         "NEPTUNE",
         "PLUTO",
         "THE BRIG",


### PR DESCRIPTION
## About The Pull Request

Astronomers renamed Uranus in 2620 to end that stupid joke once and for all. It is now called Urectum.

## Why It's Good For The Game

One day somewhere, an AI might get an ion law that tells it that THE CREW MUST GO TO URECTUM, and if the player watched Futurama, or just knows that scene, he will exhale through the nose a bit deeper than usual.
