### PR TITLE
Xray Mutation can no longer be obtained via combining Thermal and Radioactive.

### DIFF
--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -17,10 +17,12 @@
 	required = "/datum/mutation/human/strong; /datum/mutation/human/radioactive"
 	result = HULK
 
+//Commented in an effort to keep the code for a potential later genetics rework maybe?
+/*
 /datum/generecipe/x_ray
 	required = "/datum/mutation/human/thermal; /datum/mutation/human/radioactive"
 	result = XRAY
-
+*/
 /datum/generecipe/mindread
 	required = "/datum/mutation/human/antenna; /datum/mutation/human/paranoia"
 	result = MINDREAD

--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -17,12 +17,6 @@
 	required = "/datum/mutation/human/strong; /datum/mutation/human/radioactive"
 	result = HULK
 
-//Commented in an effort to keep the code for a potential later genetics rework maybe?
-/*
-/datum/generecipe/x_ray
-	required = "/datum/mutation/human/thermal; /datum/mutation/human/radioactive"
-	result = XRAY
-*/
 /datum/generecipe/mindread
 	required = "/datum/mutation/human/antenna; /datum/mutation/human/paranoia"
 	result = MINDREAD


### PR DESCRIPTION
## About The Pull Request
Removes the Thermal + Radioactive combination, thus making the Xray mutation unobtainable in normal gameplay.

## Why It's Good For The Game

Xray mutation has always been an extremely good mutation, and an amazing powergaming tool. It's existence, combined with the fact that geneticists can find it in under five minutes and will often put it on public console for anyone to grab, is extremely detrimental to the balance of the game, because once everyone on the crew has grabbed the mutation, it becomes basically impossible to do anything stealthy as antagonist, which can lead to shitty situation where said antagonist elects to do nothing all shift, for fear of getting caught.

I believe the fog of war is one of the most important part of any top down game, and the fact that anyone can remove it by simply jabbing themselves with a mutator that spits one out every thirty seconds is detrimental to the overall balance of the game.

Xray eyes can still be implanted via surgery, but those needs ressources, researchs, and another player to actually do the surgery.

I'm hoping that a decrease in the amount of people with access to Xray will lead to antagonists feeling more free to do what they are supposed to do : antagonize the crew (especially true for Manuel).

## Changelog
:cl:
del: The Xray mutation can no longer be obtained via combining radioactive and thermal eyes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
