### PR TITLE
[ready?] Disallows pacifists from using the HONK Punching Glove, but adds a non-lethal toggle.

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -479,7 +479,7 @@
 		return
 
 	if(can_toggle_lethal)
-		return "[..()] </span>&nbsp; <a href='?src=[REF(src)];lethalPunch=1'>[harmful?"Punch":"Pat"] mode</a>"
+		return "[..()] &nbsp; <a href='?src=[REF(src)];lethalPunch=1'>[harmful?"Punch":"Pat"] mode</a>"
 	else
 		return
 

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -466,7 +466,7 @@
 	harmful = TRUE
 	diags_first = TRUE
 	var/punch_damage = 35 ///damage done by the glove on contact
-	var/can_toggle_lethal = TRUE ///TRUE - can toggled between lethal and non lethal || FALSE - cannot toggle
+	var/can_toggle_lethal = TRUE ///TRUE - can toggled between lethal and non lethal || FALSE - cannot toggle 
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/punching_glove/can_attach(obj/mecha/combat/honker/M)
 	if(..())
@@ -481,7 +481,8 @@
 	if(can_toggle_lethal)
 		return "[..()] &nbsp; <a href='?src=[REF(src)];lethalPunch=1'>[harmful?"Punch":"Pat"] mode</a>"
 	else
-		return
+		return ..()
+
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/punching_glove/Topic(href, href_list)
 	..()

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -463,6 +463,7 @@
 	fire_sound = 'sound/items/bikehorn.ogg'
 	projectiles = 10
 	projectile_energy_cost = 500
+	harmful = TRUE
 	diags_first = TRUE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/punching_glove/can_attach(obj/mecha/combat/honker/M)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -465,12 +465,32 @@
 	projectile_energy_cost = 500
 	harmful = TRUE
 	diags_first = TRUE
+	var/punch_damage = 35 ///damage done by the glove on contact
+	var/can_toggle_lethal = TRUE ///TRUE - can toggled between lethal and non lethal || FALSE - cannot toggle
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/punching_glove/can_attach(obj/mecha/combat/honker/M)
 	if(..())
 		if(istype(M))
 			return 1
 	return 0
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/punching_glove/get_equip_info()
+	if(!chassis)
+		return
+
+	if(can_toggle_lethal)
+		return "[..()] </span>&nbsp; <a href='?src=[REF(src)];lethalPunch=1'>[harmful?"Punch":"Pat"] mode</a>"
+	else
+		return
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/punching_glove/Topic(href, href_list)
+	..()
+	if(href_list["lethalPunch"])
+		harmful = !harmful
+		if(harmful)
+			chassis?.occupant_message("<span class='warning'>Lethal Fisting Enabled.</span>")
+		else
+			chassis?.occupant_message("<span class='warning'>Lethal Fisting Disabled.</span>")
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/punching_glove/action(target)
 	. = ..()
@@ -480,6 +500,12 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/punching_glove/proj_init(obj/item/punching_glove/PG)
 	if(!istype(PG))
 		return
+
+	if(harmful)
+		PG.throwforce = punch_damage
+	else
+		PG.throwforce = 0
+
 	 //has to be low sleep or it looks weird, the beam doesn't exist for very long so it's a non-issue
 	chassis.Beam(PG, icon_state = "chain", time = missile_range * 20, maxdistance = missile_range + 2, beam_sleep_time = 1)
 
@@ -493,5 +519,5 @@
 	if(!..())
 		if(ismovable(hit_atom))
 			var/atom/movable/AM = hit_atom
-			AM.safe_throw_at(get_edge_target_turf(AM,get_dir(src, AM)), 7, 2)
+			AM.safe_throw_at(get_edge_target_turf(AM,get_dir(src, AM)), clamp(throwforce/5, 2, 20), 2) //Throws them equal to damage/5, with a min range of 2 and max range of 20
 		qdel(src)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -465,8 +465,10 @@
 	projectile_energy_cost = 500
 	harmful = TRUE
 	diags_first = TRUE
-	var/punch_damage = 35 ///damage done by the glove on contact
-	var/can_toggle_lethal = TRUE ///TRUE - can toggled between lethal and non lethal || FALSE - cannot toggle 
+	/// Damage done by the glove on contact. Also used to determine throw distance (damage / 5)
+	var/punch_damage = 35 
+	/// TRUE - Can toggle between lethal and non-lethal || FALSE - Cannot toggle
+	var/can_toggle_lethal = TRUE 
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/punching_glove/can_attach(obj/mecha/combat/honker/M)
 	if(..())
@@ -482,7 +484,6 @@
 		return "[..()] &nbsp; <a href='?src=[REF(src)];lethalPunch=1'>[harmful?"Punch":"Pat"] mode</a>"
 	else
 		return ..()
-
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/punching_glove/Topic(href, href_list)
 	..()
@@ -520,5 +521,5 @@
 	if(!..())
 		if(ismovable(hit_atom))
 			var/atom/movable/AM = hit_atom
-			AM.safe_throw_at(get_edge_target_turf(AM,get_dir(src, AM)), clamp(throwforce/5, 2, 20), 2) //Throws them equal to damage/5, with a min range of 2 and max range of 20
+			AM.safe_throw_at(get_edge_target_turf(AM,get_dir(src, AM)), clamp(round(throwforce/5), 2, 20), 2) //Throws them equal to damage/5, with a min range of 2 and max range of 20
 		qdel(src)


### PR DESCRIPTION
## About The Pull Request

Now that the HONK can break people's ribs and bones, I figured I should do something about this.

Previously, the HONK Punching Glove equipment wasn't marked as harmful, meaning pacifists could use it do deal 35 damage + stunlock (+break ribs and bones now). I removed that, because it's an exploit to get around pacifism to kill people. 

Now, the punching glove has a toggle between lethal and non-lethal punching, and the distance it throws you scales on the punching damage. Also included some vars for admin editing, for fun. 

Yes, i'm aware the you can still 'damage' people if you hit people into solid walls. It's much less damage though, so i'm not too concerned.
## Why It's Good For The Game

Removing an exploit to get around pacifism is good.
I thought people would complain if I made it harmful and left it at that, so I decided a toggle would be the best of both worlds - this way, pacifist clowns can still push people around and prank them, but they won't break ribs. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Melbert
add: Allows the HONK Oingo-Boingo Punch-Face to toggle between lethal and non-lethal modes. 
tweak: The HONK Oingo-Boingo Punch-Face's throw distance now scales on how much damage it deals. By default, it's the same distance as before.
fix: Pacifists can no longer use the HONK Oingo-Boingo Punch-Face to damage people.
admin: Admins can now edit the damage of the HONK Oingo-Boingo Punch-Face. Honk.
/:cl: