### PR TITLE
Fixes clothing repair not working, adds better pronoun handling

### DIFF
--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -262,3 +262,72 @@
 	if((ITEM_SLOT_ICLOTHING in obscured) && skipface)
 		temp_gender = PLURAL
 	return ..()
+
+
+//clothing need special handling due to pairs of items, ie gloves vs a singular glove, shoes, ect.
+/obj/item/clothing/p_they(capitalized, temp_gender)
+	if(!temp_gender)
+		temp_gender = gender
+	. = "it"
+	if(temp_gender == PLURAL)
+		. = "they"
+	if(capitalized)
+		. = capitalize(.)
+
+/obj/item/clothing/p_their(capitalized, temp_gender)
+	if(!temp_gender)
+		temp_gender = gender
+	. = "its"
+	if(temp_gender == PLURAL)
+		. = "their"
+	if(capitalized)
+		. = capitalize(.)
+
+/obj/item/clothing/p_them(capitalized, temp_gender)
+	if(!temp_gender)
+		temp_gender = gender
+	. = "it"
+	if(temp_gender == PLURAL)
+		. = "them"
+	if(capitalized)
+		. = capitalize(.)
+
+/obj/item/clothing/p_have(temp_gender)
+	if(!temp_gender)
+		temp_gender = gender
+	. = "has"
+	if(temp_gender == PLURAL)
+		. = "have"
+
+/obj/item/clothing/p_are(temp_gender)
+	if(!temp_gender)
+		temp_gender = gender
+	. = "is"
+	if(temp_gender == PLURAL)
+		. = "are"
+
+/obj/item/clothing/p_were(temp_gender)
+	if(!temp_gender)
+		temp_gender = gender
+	. = "was"
+	if(temp_gender == PLURAL)
+		. = "were"
+
+/obj/item/clothing/p_do(temp_gender)
+	if(!temp_gender)
+		temp_gender = gender
+	. = "does"
+	if(temp_gender == PLURAL)
+		. = "do"
+
+/obj/item/clothing/p_s(temp_gender)
+	if(!temp_gender)
+		temp_gender = gender
+	if(temp_gender != PLURAL)
+		. = "s"
+
+/obj/item/clothing/p_es(temp_gender)
+	if(!temp_gender)
+		temp_gender = gender
+	if(temp_gender != PLURAL)
+		. = "es"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -104,7 +104,7 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/heirloom_type
 
-	if(is_species(H, /datum/species/moth) && prob(50))
+	if(ismoth(H) && prob(50))
 		heirloom_type = /obj/item/flashlight/lantern/heirloom_moth
 	else
 		switch(quirk_holder.mind.assigned_role)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -437,11 +437,16 @@ BLIND     // can't see anything
 		body_parts_covered = NONE
 		slot_flags = NONE
 		update_clothes_damaged_state(CLOTHING_SHREDDED)
-		if(ismob(loc))
-			var/mob/M = loc
-			M.visible_message("<span class='danger'>[M]'s [src.name] fall\s off, completely shredded!</span>", "<span class='warning'><b>Your [src.name] fall\s off, completely shredded!</b></span>", vision_distance = COMBAT_MESSAGE_RANGE)
-			M.dropItemToGround(src)
-		name = "shredded [initial(name)]"
+		var/show_message = TRUE
+		if(isliving(loc))
+			var/mob/living/M = loc
+			if(src in M.get_equipped_items(FALSE)) //make sure they were wearing it and not attacking the item in their hands / eating it if they were a moth.
+				M.visible_message("<span class='danger'>[M]'s [src.name] fall\s off, completely shredded!</span>", "<span class='warning'><b>Your [src.name] fall\s off, completely shredded!</b></span>", vision_distance = COMBAT_MESSAGE_RANGE)
+				M.dropItemToGround(src)
+				show_message = FALSE
+		if(show_message)
+			visible_message("<span class='danger'>[src] fall apart, completely shredded!</span>", vision_distance = COMBAT_MESSAGE_RANGE)
+		name = "shredded [initial(name)]" // change the name -after- the message, not before.
 	else
 		..()
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -80,7 +80,7 @@
 	foodtype = CLOTH
 
 /obj/item/clothing/attack(mob/M, mob/user, def_zone)
-	if(user.a_intent != INTENT_HARM && ismoth(M))
+	if(user.a_intent != INTENT_HARM && ismoth(M))// meme
 		var/obj/item/reagent_containers/food/snacks/clothing/clothing_as_food = new
 		clothing_as_food.name = name
 		if(clothing_as_food.attack(M, user, def_zone))
@@ -109,8 +109,7 @@
 
 /// Set the clothing's integrity back to 100%, remove all damage to bodyparts, and generally fix it up
 /obj/item/clothing/proc/repair(mob/user, params)
-	damaged_clothes = CLOTHING_PRISTINE
-	update_clothes_damaged_state()
+	update_clothes_damaged_state(CLOTHING_PRISTINE)
 	obj_integrity = max_integrity
 	name = initial(name) // remove "tattered" or "shredded" if there's a prefix
 	body_parts_covered = initial(body_parts_covered)
@@ -178,7 +177,6 @@
 		obj_destruction((damage_type == BRUTE ? "melee" : "laser")) // melee/laser is good enough since this only procs from direct attacks anyway and not from fire/bombs
 		return
 
-	damaged_clothes = CLOTHING_DAMAGED
 	switch(zones_disabled)
 		if(1)
 			name = "damaged [initial(name)]"
@@ -187,7 +185,7 @@
 		if(3 to INFINITY) // take better care of your shit, dude
 			name = "tattered [initial(name)]"
 
-	update_clothes_damaged_state()
+	update_clothes_damaged_state(CLOTHING_DAMAGED)
 
 /obj/item/clothing/Destroy()
 	user_vars_remembered = null //Oh god somebody put REFERENCES in here? not to worry, we'll clean it up
@@ -343,18 +341,14 @@
 	return .
 
 /obj/item/clothing/obj_break(damage_flag)
-	damaged_clothes = CLOTHING_DAMAGED
-	update_clothes_damaged_state()
+	update_clothes_damaged_state(CLOTHING_DAMAGED)
 	if(ismob(loc)) //It's not important enough to warrant a message if nobody's wearing it
 		var/mob/M = loc
 		to_chat(M, "<span class='warning'>Your [name] starts to fall apart!</span>")
 
 //This mostly exists so subtypes can call appriopriate update icon calls on the wearer.
-/obj/item/clothing/proc/update_clothes_damaged_state(damaging = TRUE)
-	if(damaging)
-		damaged_clothes = 1
-	else
-		damaged_clothes = 0
+/obj/item/clothing/proc/update_clothes_damaged_state(damaged_state = CLOTHING_DAMAGED)
+	damaged_clothes = damaged_state
 
 /obj/item/clothing/update_overlays()
 	. = ..()
@@ -437,11 +431,10 @@ BLIND     // can't see anything
 		addtimer(CALLBACK_NEW(/obj/effect/decal/cleanable/shreds, list(T, name)), 1)
 		deconstruct(FALSE)
 	else if(!(damage_flag in list("acid", "fire")))
-		damaged_clothes = CLOTHING_SHREDDED
 		body_parts_covered = NONE
 		name = "shredded [initial(name)]"
 		slot_flags = NONE
-		update_clothes_damaged_state()
+		update_clothes_damaged_state(CLOTHING_SHREDDED)
 		if(ismob(loc))
 			var/mob/M = loc
 			M.visible_message("<span class='danger'>[M]'s [src.name] falls off, completely shredded!</span>", "<span class='warning'><b>Your [src.name] falls off, completely shredded!</b></span>", vision_distance = COMBAT_MESSAGE_RANGE)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -80,7 +80,10 @@
 	foodtype = CLOTH
 
 /obj/item/clothing/attack(mob/M, mob/user, def_zone)
-	if(user.a_intent != INTENT_HARM && ismoth(M))// meme
+	if(user.a_intent != INTENT_HARM && ismoth(M))
+		if(damaged_clothes == CLOTHING_SHREDDED)
+			to_chat(user, "<span class='notice'>[src] seems pretty torn apart... It probably wouldn't be too tasty.</span>")
+			return
 		var/obj/item/reagent_containers/food/snacks/clothing/clothing_as_food = new
 		clothing_as_food.name = name
 		if(clothing_as_food.attack(M, user, def_zone))
@@ -432,13 +435,13 @@ BLIND     // can't see anything
 		deconstruct(FALSE)
 	else if(!(damage_flag in list("acid", "fire")))
 		body_parts_covered = NONE
-		name = "shredded [initial(name)]"
 		slot_flags = NONE
 		update_clothes_damaged_state(CLOTHING_SHREDDED)
 		if(ismob(loc))
 			var/mob/M = loc
-			M.visible_message("<span class='danger'>[M]'s [src.name] falls off, completely shredded!</span>", "<span class='warning'><b>Your [src.name] falls off, completely shredded!</b></span>", vision_distance = COMBAT_MESSAGE_RANGE)
+			M.visible_message("<span class='danger'>[M]'s [src.name] fall\s off, completely shredded!</span>", "<span class='warning'><b>Your [src.name] fall\s off, completely shredded!</b></span>", vision_distance = COMBAT_MESSAGE_RANGE)
 			M.dropItemToGround(src)
+		name = "shredded [initial(name)]"
 	else
 		..()
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -82,7 +82,7 @@
 /obj/item/clothing/attack(mob/M, mob/user, def_zone)
 	if(user.a_intent != INTENT_HARM && ismoth(M))
 		if(damaged_clothes == CLOTHING_SHREDDED)
-			to_chat(user, "<span class='notice'>[src] seems pretty torn apart... It probably wouldn't be too tasty.</span>")
+			to_chat(user, "<span class='notice'>[src] seem[gender == PLURAL ? "":"s"] pretty torn apart... [gender == PLURAL ? "They" : "It"] probably wouldn't be too tasty.</span>")
 			return
 		var/obj/item/reagent_containers/food/snacks/clothing/clothing_as_food = new
 		clothing_as_food.name = name
@@ -345,9 +345,13 @@
 
 /obj/item/clothing/obj_break(damage_flag)
 	update_clothes_damaged_state(CLOTHING_DAMAGED)
-	if(ismob(loc)) //It's not important enough to warrant a message if nobody's wearing it
-		var/mob/M = loc
-		to_chat(M, "<span class='warning'>Your [name] starts to fall apart!</span>")
+
+	if(isliving(loc)) //It's not important enough to warrant a message if it's not on someone
+		var/mob/living/M = loc
+		if(src in M.get_equipped_items(FALSE))
+			to_chat(M, "<span class='warning'>Your [name] start[gender == PLURAL ? "":"s"] to fall apart!</span>")
+		else
+			to_chat(M, "<span class='warning'>[src] start[gender == PLURAL ? "":"s"] to fall apart!</span>")
 
 //This mostly exists so subtypes can call appriopriate update icon calls on the wearer.
 /obj/item/clothing/proc/update_clothes_damaged_state(damaged_state = CLOTHING_DAMAGED)
@@ -437,15 +441,13 @@ BLIND     // can't see anything
 		body_parts_covered = NONE
 		slot_flags = NONE
 		update_clothes_damaged_state(CLOTHING_SHREDDED)
-		var/show_message = TRUE
 		if(isliving(loc))
 			var/mob/living/M = loc
 			if(src in M.get_equipped_items(FALSE)) //make sure they were wearing it and not attacking the item in their hands / eating it if they were a moth.
-				M.visible_message("<span class='danger'>[M]'s [src.name] fall\s off, completely shredded!</span>", "<span class='warning'><b>Your [src.name] fall\s off, completely shredded!</b></span>", vision_distance = COMBAT_MESSAGE_RANGE)
+				M.visible_message("<span class='danger'>[M]'s [src.name] fall[gender == PLURAL ? "":"s"] off, completely shredded!</span>", "<span class='warning'><b>Your [src.name] fall[gender == PLURAL ? "":"s"] off, completely shredded!</b></span>", vision_distance = COMBAT_MESSAGE_RANGE)
 				M.dropItemToGround(src)
-				show_message = FALSE
-		if(show_message)
-			visible_message("<span class='danger'>[src] fall apart, completely shredded!</span>", vision_distance = COMBAT_MESSAGE_RANGE)
+			else
+				M.visible_message("<span class='danger'>[src] fall[gender == PLURAL ? "":"s"] apart, completely shredded!</span>", vision_distance = COMBAT_MESSAGE_RANGE)
 		name = "shredded [initial(name)]" // change the name -after- the message, not before.
 	else
 		..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -82,7 +82,7 @@
 /obj/item/clothing/attack(mob/M, mob/user, def_zone)
 	if(user.a_intent != INTENT_HARM && ismoth(M))
 		if(damaged_clothes == CLOTHING_SHREDDED)
-			to_chat(user, "<span class='notice'>[src] seem[gender == PLURAL ? "":"s"] pretty torn apart... [gender == PLURAL ? "They" : "It"] probably wouldn't be too tasty.</span>")
+			to_chat(user, "<span class='notice'>[src] seem[p_s()] pretty torn apart... [p_they(TRUE)] probably wouldn't be too tasty.</span>")
 			return
 		var/obj/item/reagent_containers/food/snacks/clothing/clothing_as_food = new
 		clothing_as_food.name = name
@@ -222,7 +222,7 @@
 /obj/item/clothing/examine(mob/user)
 	. = ..()
 	if(damaged_clothes == CLOTHING_SHREDDED)
-		. += "<span class='warning'><b>It is completely shredded and requires mending before it can be worn again!</b></span>"
+		. += "<span class='warning'><b>[p_theyre(TRUE)] completely shredded and require[p_s()] mending before [p_they()] can be worn again!</b></span>"
 		return
 
 	switch (max_heat_protection_temperature)
@@ -349,9 +349,9 @@
 	if(isliving(loc)) //It's not important enough to warrant a message if it's not on someone
 		var/mob/living/M = loc
 		if(src in M.get_equipped_items(FALSE))
-			to_chat(M, "<span class='warning'>Your [name] start[gender == PLURAL ? "":"s"] to fall apart!</span>")
+			to_chat(M, "<span class='warning'>Your [name] start[p_s()] to fall apart!</span>")
 		else
-			to_chat(M, "<span class='warning'>[src] start[gender == PLURAL ? "":"s"] to fall apart!</span>")
+			to_chat(M, "<span class='warning'>[src] start[p_s()] to fall apart!</span>")
 
 //This mostly exists so subtypes can call appriopriate update icon calls on the wearer.
 /obj/item/clothing/proc/update_clothes_damaged_state(damaged_state = CLOTHING_DAMAGED)
@@ -444,10 +444,10 @@ BLIND     // can't see anything
 		if(isliving(loc))
 			var/mob/living/M = loc
 			if(src in M.get_equipped_items(FALSE)) //make sure they were wearing it and not attacking the item in their hands / eating it if they were a moth.
-				M.visible_message("<span class='danger'>[M]'s [src.name] fall[gender == PLURAL ? "":"s"] off, completely shredded!</span>", "<span class='warning'><b>Your [src.name] fall[gender == PLURAL ? "":"s"] off, completely shredded!</b></span>", vision_distance = COMBAT_MESSAGE_RANGE)
+				M.visible_message("<span class='danger'>[M]'s [src.name] fall[p_s()] off, [p_theyre()] completely shredded!</span>", "<span class='warning'><b>Your [src.name] fall[p_s()] off, [p_theyre()] completely shredded!</b></span>", vision_distance = COMBAT_MESSAGE_RANGE)
 				M.dropItemToGround(src)
 			else
-				M.visible_message("<span class='danger'>[src] fall[gender == PLURAL ? "":"s"] apart, completely shredded!</span>", vision_distance = COMBAT_MESSAGE_RANGE)
+				M.visible_message("<span class='danger'>[src] fall[p_s()] apart, completely shredded!</span>", vision_distance = COMBAT_MESSAGE_RANGE)
 		name = "shredded [initial(name)]" // change the name -after- the message, not before.
 	else
 		..()

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -25,7 +25,7 @@
 /obj/item/clothing/glasses/examine(mob/user)
 	. = ..()
 	if(glass_colour_type && ishuman(user))
-		. += "<span class='notice'>Alt-click to toggle its colors.</span>"
+		. += "<span class='notice'>Alt-click to toggle [p_their()] colors.</span>"
 
 /obj/item/clothing/glasses/visor_toggling()
 	..()

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -32,7 +32,7 @@
 		if(HAS_BLOOD_DNA(src))
 			. += mutable_appearance('icons/effects/blood.dmi', "bloodyhands")
 
-/obj/item/clothing/gloves/update_clothes_damaged_state()
+/obj/item/clothing/gloves/update_clothes_damaged_state(damaged_state = CLOTHING_DAMAGED)
 	..()
 	if(ismob(loc))
 		var/mob/M = loc

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -69,7 +69,7 @@
 		if(HAS_BLOOD_DNA(src))
 			. += mutable_appearance('icons/effects/blood.dmi', "helmetblood")
 
-/obj/item/clothing/head/update_clothes_damaged_state()
+/obj/item/clothing/head/update_clothes_damaged_state(damaged_state = CLOTHING_DAMAGED)
 	..()
 	if(ismob(loc))
 		var/mob/M = loc

--- a/code/modules/clothing/masks/_masks.dm
+++ b/code/modules/clothing/masks/_masks.dm
@@ -37,7 +37,7 @@
 			if(HAS_BLOOD_DNA(src))
 				. += mutable_appearance('icons/effects/blood.dmi', "maskblood")
 
-/obj/item/clothing/mask/update_clothes_damaged_state()
+/obj/item/clothing/mask/update_clothes_damaged_state(damaged_state = CLOTHING_DAMAGED)
 	..()
 	if(ismob(loc))
 		var/mob/M = loc

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -94,7 +94,7 @@
 		restore_offsets(user)
 	. = ..()
 
-/obj/item/clothing/shoes/update_clothes_damaged_state()
+/obj/item/clothing/shoes/update_clothes_damaged_state(damaged_state = CLOTHING_DAMAGED)
 	..()
 	if(ismob(loc))
 		var/mob/M = loc

--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -28,7 +28,7 @@
 				if(A.above_suit)
 					. += U.accessory_overlay
 
-/obj/item/clothing/suit/update_clothes_damaged_state()
+/obj/item/clothing/suit/update_clothes_damaged_state(damaged_state = CLOTHING_DAMAGED)
 	..()
 	if(ismob(loc))
 		var/mob/M = loc

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -42,7 +42,7 @@
 	if(!attach_accessory(I, user))
 		return ..()
 
-/obj/item/clothing/under/update_clothes_damaged_state()
+/obj/item/clothing/under/update_clothes_damaged_state(damaged_state = CLOTHING_DAMAGED)
 	..()
 	if(ismob(loc))
 		var/mob/M = loc

--- a/code/modules/ninja/suit/gloves.dm
+++ b/code/modules/ninja/suit/gloves.dm
@@ -78,4 +78,4 @@
 /obj/item/clothing/gloves/space_ninja/examine(mob/user)
 	. = ..()
 	if(HAS_TRAIT_FROM(src, TRAIT_NODROP, NINJA_SUIT_TRAIT))
-		. += "The energy drain mechanism is <B>[candrain?"active":"inactive"]</B>."
+		. += "[p_their(TRUE)] energy drain mechanism is <B>[candrain?"active":"inactive"]</B>."


### PR DESCRIPTION
Fixes #51626
:cl: ShizCalev
fix: Clothing repair now works.
spellcheck: Fixed redundant "shredded x fell apart, completely shredded!" message when damaging clothing in your hands.
spellcheck: Added better pronoun handling for clothing that consist of a pair of items (ie shoes, gloves, ect)
fix: Shredding clothing while holding it will no longer make you drop it.
fix: Shredding clothing while holding it will no longer tell you that it fell off you.
fix: Moths can no longer infinitely eat shredded clothing.
/:cl: