### PR TITLE
quickly fixes an oopsie I made v2

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -89,6 +89,9 @@
 /mob/living/silicon/pai/can_buckle()
 	return FALSE
 
+/mob/living/silicon/pai/add_sensors() //pAIs have to buy their HUDs
+	return
+
 /mob/living/silicon/pai/Destroy()
 	QDEL_NULL(internal_instrument)
 	if(cable)


### PR DESCRIPTION
## About The Pull Request

a much better way to do https://github.com/tgstation/tgstation/pull/51630

## Why It's Good For The Game

thanks ShizCalev

## Changelog
:cl: ATHATH
fix: pAIs no longer start with a medHUD, secHUD, and diagHUD turned on as soon as they're downloaded, even if they haven't bought any HUDs yet.
/:cl: