### PR TITLE
Reduced radiation contamination spreading and SM abuse

### DIFF
--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -49,4 +49,4 @@ Ask ninjanomnom if they're around
 #define RAD_CONTAMINATION_STR_COEFFICIENT 0.25		// Higher means higher strength scaling contamination strength
 #define RAD_DISTANCE_COEFFICIENT 1					// Lower means further rad spread
 
-#define RAD_HALF_LIFE 90							// The half-life of contaminated objects
+#define RAD_HALF_LIFE 90							// The half-life of contaminated objects in

--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -49,4 +49,6 @@ Ask ninjanomnom if they're around
 #define RAD_CONTAMINATION_STR_COEFFICIENT 0.25		// Higher means higher strength scaling contamination strength
 #define RAD_DISTANCE_COEFFICIENT 1					// Lower means further rad spread
 
-#define RAD_HALF_LIFE 90							// The half-life of contaminated objects in
+#define RAD_HALF_LIFE 90							// The half-life of contaminated objects in Ticks
+// Because of the way half-life works, (RAD_HALF_LIFE*6) ticks and the thing is clean of all contamination
+// its more like (RAD_HALF_LIFE*4) here because we have a lower threshold of RAD_MOB_SAFE

--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -22,6 +22,22 @@
 			continue
 		processing_list += thing.contents
 
+/*
+** Gets the total amount of radioactive contamination an object has including
+** its contents.
+*/
+/proc/get_rad_contamination(atom/location)
+	var/rad_strength = 0
+	for(var/i in get_rad_contents(A)) // Yes it's intentional that you can't detect radioactive things under rad protection. Gives traitors a way to hide their glowing green rocks.
+		var/atom/thing = i
+		if(!thing)
+			continue
+		var/datum/component/radioactive/radiation = thing.GetComponent(/datum/component/radioactive)
+		if(radiation)
+			rad_strength += radiation.strength
+	return rad_strength
+
+
 /proc/radiation_pulse(atom/source, intensity, range_modifier, log=FALSE, can_contaminate=TRUE)
 	if(!SSradiation.can_fire)
 		return

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -1,3 +1,15 @@
+/*
+** Radiation field is a simulation of ionizing radiation.  Basicly, its an
+** invisiable lamp that will kill you and power the station.  While the
+** waves were fine, they added a bit of stress on the servers.  Especialy
+** when a bunch of idiots contaminated themslves or stacked a bunch of
+** urainuam folding chairs.  So instead a field is made using the code
+** from shield gen.  So instead of random datums created and shooting
+** from a source, a field will follow around from this source.
+** putting it all here in the component simplifys things
+*/
+
+
 #define RAD_AMOUNT_LOW 50
 #define RAD_AMOUNT_MEDIUM 200
 #define RAD_AMOUNT_HIGH 500
@@ -6,17 +18,30 @@
 /datum/component/radioactive
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
-	var/source
-
-	var/hl3_release_date //the half-life measured in ticks
-	var/strength
+	/// Is the parrent a source of radiation?
+	/// if so, we never run out of contaimation
+	var/is_source
+	/// How strong it was originaly
+	var/intensity
+	/// How much contaminated material it still has
+	var/remaining_contam
+	/// Higher than 1 makes it drop off faster, 0.5 makes it drop off half etc
+	var/range_modifier
+	/// Whether or not this radiation wave can create contaminated objects
 	var/can_contaminate
+	/// halflife in ticks
+	var/hl3_release_date
+	/// field strengh caculation
+	var/list/field_strength
 
-/datum/component/radioactive/Initialize(_strength=0, _source, _half_life=RAD_HALF_LIFE, _can_contaminate=TRUE)
-	strength = _strength
-	source = _source
+/datum/component/radioactive/Initialize(_intensity=0, _is_source, _half_life=RAD_HALF_LIFE, _can_contaminate=TRUE,_range_modifier=RAD_DISTANCE_COEFFICIENT)
+	intensity = _intensity
+	is_source = _is_source
 	hl3_release_date = _half_life
 	can_contaminate = _can_contaminate
+	range_modifier = _range_modifier
+	remaining_contam = intensity
+	field_strength = caculate_field_range(intensity)
 
 	if(istype(parent, /atom))
 		RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/rad_examine)
@@ -26,27 +51,120 @@
 	else
 		return COMPONENT_INCOMPATIBLE
 
-	if(strength > RAD_MINIMUM_CONTAMINATION)
+	if(intensity > RAD_MINIMUM_CONTAMINATION)
 		SSradiation.warn(src)
 
 	START_PROCESSING(SSradiation, src)
 
+/datum/componnet/proc/caculate_field_range(strength)
+	. = list()
+	var/steps = 1
+	while(strength >  RAD_BACKGROUND_RADIATION)
+		if(steps>1)
+			strength = INVERSE_SQUARE(strength, max(range_modifier*steps, 1), 1)
+		. += strength
+
 /datum/component/radioactive/Destroy()
+
 	STOP_PROCESSING(SSradiation, src)
 	return ..()
 
+// 15 degress radian
+// why not higher?  We might miss tiles on the outer raduis
+// will figure this out after I do some profiling
+#define CIRCLE_INC 0.261799 // 15 degrees radian
+// code copy from line of sight
+// We are basicly drawing a line from the center point to the outer point
+// of where radiation ends
+#define SIGNV(X) (((X)<0)?-1:1)
+#define X1 centerturf.x
+#define Y1 centerturf.y
+#define X2 far_x
+#define Y2 far_y
+#define PX1=16.5
+#define PY1=16.5
+#define PX2=16.5
+#define PY2=16.5
+
+/datum/component/radioactive/proc/create_field()
+	var/ray_strength_precaluated =  caculate_field_range(remaining_contam)
+	var/turf/centerturf = get_turf(parent)
+	var/list/turfs = new/list()
+	var/radius = field_strength.len
+	var/rsq = max_length * (max_length+0.5)
+	var/far_x
+	var/far_y
+	var/far_z = centerturf.z
+	var/turf/T
+	// NOTE, profile this if its better to cache this in a list
+	for(var/rad = 0; r < 2.0; r += CIRCLE_INC)
+		far_x = round(radius*cos(rad) + centerturf.x + 0.5)
+		far_y = round(radius*sin(rad) + centerturf.y + 0.5)
+		T = locate(far_x, far_y, far_z)
+		if(!T || turfs[T])
+			continue  	// If the turf dosn't exist or is free
+		var/rad_blocking = 0
+		var/steps = 1
+		var/ray_strength = ray_strength_precaluated[steps]
+		var/m=(32*(Y2-Y1)+(PY2-PY1))/(32*(X2-X1)+(PX2-PX1))
+		var/b=(Y1+PY1/32-0.015625)-m*(X1+PX1/32-0.015625) //In tiles
+		var/signX = SIGN(X2-X1)
+		var/signY = SIGN(Y2-Y1)
+		if(X1<X2)
+			b+=m
+		while(X1!=X2 || Y1!=Y2)
+			if(round(m*X1+b-Y1))
+				Y1+=signY //Line exits tile vertically
+			else
+				X1+=signX //Line exits tile horizontally
+			T=locate(X1,Y1,Z)
+			ray_strength = ray_strength_precaluated[steps]
+
+		ray_strength = INVERSE_SQUARE(intensity, max(range_modifier*steps, 1), 1)
+	else
+		ray_strength = remaining_contam
+			if(T.opacity)
+				return 0
+
+
+#undef X1
+#undef Y1
+#undef X2
+#undef Y2
+#undef PX1
+#undef PY1
+#undef PX2
+#undef PY2
+#define SIGNV(X) (((X)<0)?-1:1)
+
+
 /datum/component/radioactive/process()
-	if(!prob(50))
-		return
+	var/list/affected_tiles = circlerange(parent, field_strength.len)
+	for(var/turf/T in orange(, parent))
+		affected_tiles[T] = 0
+	var/dist
+	var/dir
+	for(var/turf/K in affected_tiles)
+		dist = get_dist_euclidian (K, parent)
+
+
+	for(var/i in 1 to field_strength.len)
+
+
+
+		get_dist
+		if(isspaceturf(target_tile) && !(locate(/obj/structure/emergency_shield) in target_tile))
+			if(!(machine_stat & BROKEN) || prob(33))
+				deployed_shields += new /obj/structure/emergency_shield(target_tile)
 
 	// Why is strength/4?  So say you are comtaminated with 4000 mev.
 	// Even if you are a few tiles away, even with a *2 to the coefficent you
 	// still get a freaking high dose.  Right next to the guy and your getting most
 	// of it.  But at /4, the contamination you will get will only be 1000
-	// Managable by any of the lower level drugs.  
+	// Managable by any of the lower level drugs.
 	radiation_pulse(parent, strength/4, RAD_DISTANCE_COEFFICIENT*2, FALSE, can_contaminate)
 
-	if(!hl3_release_date)
+	if(is_source || !hl3_release_date)
 		return
 	strength -= strength / hl3_release_date
 	if(strength <= RAD_BACKGROUND_RADIATION)

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -38,7 +38,13 @@
 /datum/component/radioactive/process()
 	if(!prob(50))
 		return
-	radiation_pulse(parent, strength, RAD_DISTANCE_COEFFICIENT*2, FALSE, can_contaminate)
+
+	// Why is strength/4?  So say you are comtaminated with 4000 mev.
+	// Even if you are a few tiles away, even with a *2 to the coefficent you
+	// still get a freaking high dose.  Right next to the guy and your getting most
+	// of it.  But at /4, the contamination you will get will only be 1000
+	// Managable by any of the lower level drugs.  
+	radiation_pulse(parent, strength/4, RAD_DISTANCE_COEFFICIENT*2, FALSE, can_contaminate)
 
 	if(!hl3_release_date)
 		return

--- a/code/datums/radiation_field.dm
+++ b/code/datums/radiation_field.dm
@@ -1,3 +1,13 @@
+/*
+** Radiation field is a simulation of ionizing radiation.  Basicly, its an
+** invisiable lamp that will kill you and power the station.  While the
+** waves were fine, they added a bit of stress on the servers.  Especialy
+** when a bunch of idiots contaminated themslves or stacked a bunch of
+** urainuam folding chairs.  So instead a field is made using the code
+** from shield gen.  So instead of random datums created and shooting
+** from a source, a field will follow around from this source
+*/
+
 /datum/radiation_wave
 	/// The thing that spawned this radiation wave
 	var/source
@@ -98,7 +108,7 @@
 			continue
 		if (thing.rad_insulation != RAD_NO_INSULATION)
 			intensity *= (1-((1-thing.rad_insulation)/width))
-
+// code copyed form line of sight
 /datum/radiation_wave/proc/radiate(list/atoms, strength)
 	var/can_contam = strength >= RAD_MINIMUM_CONTAMINATION
 	var/contamination_strength = (strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -924,8 +924,8 @@
 
 
 ///Proc for being washed by a shower
-/atom/proc/washed(var/atom/washer)
-	. = SEND_SIGNAL(src, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_WEAK)
+/atom/proc/washed(var/atom/washer, clean_mode = CLEAN_WEAK)
+	SEND_SIGNAL(src, COMSIG_COMPONENT_CLEAN_ACT, clean_mode)
 	remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 
 	var/datum/component/radioactive/healthy_green_glow = GetComponent(/datum/component/radioactive)
@@ -934,9 +934,9 @@
 	var/strength = healthy_green_glow.strength
 	if(strength <= RAD_BACKGROUND_RADIATION)
 		qdel(healthy_green_glow)
-		return
-	healthy_green_glow.strength -= max(0, (healthy_green_glow.strength - (RAD_BACKGROUND_RADIATION * 2)) * 0.2)
-
+	else
+		healthy_green_glow.strength -= max(0, (healthy_green_glow.strength - (RAD_BACKGROUND_RADIATION * 2)) * 0.2)
+	return TRUE	// This has to be true for so many updates to work
 
 /**
   * call back when a var is edited on this atom

--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -179,6 +179,7 @@
 		H = user
 		C = H.get_idcard(TRUE)
 
+
 /obj/machinery/medical_kiosk/ui_data(mob/living/carbon/human/user)
 	var/list/data = list()
 	var/patient_name = altPatient.name
@@ -215,8 +216,11 @@
 			blood_warning = " Patient has DANGEROUSLY low blood levels. Seek a blood transfusion, iron supplements, or saline glucose immedietly. Ignoring treatment may lead to death!"
 		blood_status = "Patient blood levels are currently reading [blood_percent]%. Patient has [ blood_type] type blood. [blood_warning]"
 
-	var/rad_value = altPatient.radiation
-	var/rad_status = "Target within normal-low radiation levels."
+	var/rad_sickness_value = altPatient.radiation
+	var/rad_sickness_status = "Target within normal-low radiation levels."
+	var/rad_contamination_value = get_rad_contamination(altPatient)
+	var/rad_contamination_status = "Target clothes and person not radioactive"
+
 	var/trauma_status = "Patient is free of unique brain trauma."
 	var/clone_loss = altPatient.getCloneLoss()
 	var/brain_loss = altPatient.getOrganLoss(ORGAN_SLOT_BRAIN)
@@ -273,12 +277,19 @@
 	else if((brain_loss) >= 1)
 		brain_status = "Mild brain damage detected."  //You may have a miiiild case of severe brain damage.
 
-	if(altPatient.radiation >=1000)  //
-		rad_status = "Patient is suffering from extreme radiation poisoning. Suggested treatment: Isolation of patient, followed by repeated dosages of Pentetic Acid."
-	else if(altPatient.radiation >= 500)
-		rad_status = "Patient is suffering from alarming radiation poisoning. Suggested treatment: Heavy use of showers and decontamination of clothing. Take Pentetic Acid or Potassium Iodine."
-	else if(altPatient.radiation >= 100)
-		rad_status = "Patient has moderate radioactive signatures. Keep under showers until symptoms subside."
+	if(rad_sickness_value >= 100)  //
+		rad_sickness_status = "Patient is suffering from extreme radiation poisoning, high toxen damage expected. Suggested treatment: Repeated dosages of Pentetic Acid or high amounts of Cold Seiver and anti-toxen"
+	else if(rad_sickness_value >= 300)
+		rad_sickness_status = "Patient is suffering from alarming radiation poisoning. Suggested treatment: Take Cold Seiver or Potassium Iodine, watch \his toxen levels."
+	else if(rad_sickness_value >= 100)
+		rad_sickness_status = "Patient has moderate radioactive signatures. Symptoms will subside in a few minutes"
+
+	if(rad_contamination_value >= 800)  //
+		rad_contamination_status = "Patient is wearing extremely radioactive clothing.  Suggested treatment: Isolation of patient and shower, remove all clothing and objects immediatly and place in a washing machine"
+	else if(rad_contamination_value >= 300)
+		rad_contamination_status = "Patient is wearing alarming radioactive clothing. Suggested treatment: Scan for contaminated objects and wash them with soap and water"
+	else if(rad_contamination_value >= 50)
+		rad_contamination_status = "Patient has moderate radioactive clothing.  Maintain a social distance for a few minutes"
 
 	if(pandemonium == TRUE)
 		chaos_modifier = 1
@@ -296,8 +307,10 @@
 	data["brain_health"] = brain_status
 	data["brain_damage"] = brain_loss+(chaos_modifier * (rand(1,30)))
 	data["patient_status"] = patient_status
-	data["rad_value"] = rad_value+(chaos_modifier * (rand(1,500)))
-	data["rad_status"] = rad_status
+	data["rad_sickness_value"] = rad_sickness_value+(chaos_modifier * (rand(1,500)))
+	data["rad_sickness_status"] = rad_sickness_status
+	data["rad_contamination_value"] = rad_contamination_value+(chaos_modifier * (rand(1,500)))
+	data["rad_contamination_status"] = rad_contamination_status
 	data["trauma_status"] = trauma_status
 	data["patient_illness"] = sickness
 	data["illness_info"] = sickness_data

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1117,6 +1117,16 @@
 	icon_state = "service"
 	build_path = /obj/machinery/rnd/production/techfab/department/service
 
+/obj/item/circuitboard/machine/washing_machine
+	name = "Washing Machine (Machine Board)"
+	icon_state = "service"
+	build_path = /obj/machinery/washing_machine
+	req_components = list(
+		/obj/item/stock_parts/matter_bin = 1,
+		/obj/item/stock_parts/manipulator = 1,
+		/obj/item/stack/sheet/beaker = 1)
+	needs_anchored = FALSE
+	
 //Supply
 
 /obj/item/circuitboard/machine/mining_equipment_vendor

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -143,15 +143,8 @@
 		return TRUE
 
 /obj/item/geiger_counter/proc/scan(atom/A, mob/user)
-	var/rad_strength = 0
-	for(var/i in get_rad_contents(A)) // Yes it's intentional that you can't detect radioactive things under rad protection. Gives traitors a way to hide their glowing green rocks.
-		var/atom/thing = i
-		if(!thing)
-			continue
-		var/datum/component/radioactive/radiation = thing.GetComponent(/datum/component/radioactive)
-		if(radiation)
-			rad_strength += radiation.strength
-
+	var/rad_strength = get_rad_contamination(user)
+	
 	if(isliving(A))
 		var/mob/living/M = A
 		if(!M.radiation)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -355,8 +355,9 @@
 			busy = FALSE
 			return 1
 		busy = FALSE
-		SEND_SIGNAL(O, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_STRENGTH_BLOOD)
-		O.acid_level = 0
+		O.washed(src, CLEAN_STRENGTH_BLOOD)
+		O.acid_level = 0	// NOTE: Somone change this to a component, it still dosn't update
+
 		create_reagents(5)
 		reagents.add_reagent(dispensedreagent, 5)
 		reagents.reaction(O, TOUCH)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1122,7 +1122,7 @@
 	for(var/obj/item/I in held_items)
 		I.washed(washer)
 
-	if(back)
+	if(back && back.washed(washer))
 		update_inv_back(0)
 
 	var/list/obscured = check_obscured_slots()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1099,9 +1099,9 @@
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)
 
-/mob/living/carbon/human/washed(var/atom/washer)
-	. = ..()
-	if(wear_suit)
+/mob/living/carbon/human/washed(var/atom/washer, clean_mode = CLEAN_STRENGTH_BLOOD)
+	. = ..(washer, clean_mode)
+	if(wear_suit && wear_suit.washed(washer))
 		update_inv_wear_suit()
 	else if(w_uniform && w_uniform.washed(washer))
 		update_inv_w_uniform()
@@ -1115,7 +1115,7 @@
 	var/list/obscured = check_obscured_slots()
 
 	if(gloves && !(HIDEGLOVES in obscured) && gloves.washed(washer))
-		SEND_SIGNAL(src, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_STRENGTH_BLOOD)
+		SEND_SIGNAL(src, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_STRENGTH_BLOOD)  // WHY!?!?
 
 /mob/living/carbon/human/adjust_nutrition(change) //Honestly FUCK the oldcoders for putting nutrition on /mob someone else can move it up because holy hell I'd have to fix SO many typechecks
 	if(HAS_TRAIT(src, TRAIT_NOHUNGER))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1145,9 +1145,8 @@
 //Mobs on Fire end
 
 //Washing
-/mob/living/washed(var/atom/washer)
-	. = ..()
-	SEND_SIGNAL(src, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_STRENGTH_BLOOD)
+/mob/living/washed(atom/washer, wash_mode = CLEAN_STRENGTH_BLOOD)
+	. = ..(washer, wash_mode)
 
 // used by secbot and monkeys Crossed
 /mob/living/proc/knockOver(var/mob/living/carbon/C)

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -1,6 +1,6 @@
 // stored_energy += (pulse_strength-RAD_COLLECTOR_EFFICIENCY)*RAD_COLLECTOR_COEFFICIENT
 #define RAD_COLLECTOR_EFFICIENCY 80 	// radiation needs to be over this amount to get power
-#define RAD_COLLECTOR_COEFFICIENT 100
+#define RAD_COLLECTOR_COEFFICIENT 150
 #define RAD_COLLECTOR_STORED_OUT 0.04	// (this*100)% of stored power outputted per tick. Doesn't actualy change output total, lower numbers just means collectors output for longer in absence of a source
 #define RAD_COLLECTOR_MINING_CONVERSION_RATE 0.00001 //This is gonna need a lot of tweaking to get right. This is the number used to calculate the conversion of watts to research points per process()
 #define RAD_COLLECTOR_OUTPUT min(stored_energy, (stored_energy*RAD_COLLECTOR_STORED_OUT)+1000) //Produces at least 1000 watts if it has more than that stored

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -238,7 +238,7 @@
 
 /obj/machinery/power/rad_collector/rad_act(pulse_strength)
 	. = ..()
-	if(loaded_tank && active && pulse_strength > RAD_COLLECTOR_EFFICIENCY && largest_rad_pulse > pulse_strength)
+	if(loaded_tank && active && pulse_strength > RAD_COLLECTOR_EFFICIENCY && pulse_strength > largest_rad_pulse)
 		largest_rad_pulse = pulse_strength
 
 /obj/machinery/power/rad_collector/update_overlays()

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -30,6 +30,7 @@
 	var/bitcoinmining = FALSE
 	///research points stored
 	var/stored_research = 0
+	var/largest_rad_pulse = 0
 
 /obj/machinery/power/rad_collector/anchored
 	anchored = TRUE
@@ -47,6 +48,13 @@
 /obj/machinery/power/rad_collector/process()
 	if(!loaded_tank)
 		return
+
+	// we only take the biggest rad pulse and ignore all the
+	// wimpy ones that might exist in the chamber
+	if(active)
+		stored_energy += (largest_rad_pulse-RAD_COLLECTOR_EFFICIENCY)*RAD_COLLECTOR_COEFFICIENT
+	largest_rad_pulse = 0
+
 	if(!bitcoinmining)
 		if(!loaded_tank.air_contents.gases[/datum/gas/plasma])
 			investigate_log("<font color='red'>out of fuel</font>.", INVESTIGATE_SINGULO)
@@ -230,8 +238,8 @@
 
 /obj/machinery/power/rad_collector/rad_act(pulse_strength)
 	. = ..()
-	if(loaded_tank && active && pulse_strength > RAD_COLLECTOR_EFFICIENCY)
-		stored_energy += (pulse_strength-RAD_COLLECTOR_EFFICIENCY)*RAD_COLLECTOR_COEFFICIENT
+	if(loaded_tank && active && pulse_strength > RAD_COLLECTOR_EFFICIENCY && largest_rad_pulse > pulse_strength)
+		largest_rad_pulse = pulse_strength
 
 /obj/machinery/power/rad_collector/update_overlays()
 	. = ..()

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -441,6 +441,13 @@
 	build_path = /obj/item/circuitboard/machine/vendor
 	category = list ("Misc. Machinery")
 
+/datum/design/board/washing_machine
+	name = "Washing Machine (Machine Board)"
+	desc = "The circuit board for a washing machine."
+	id = "washing_machine"
+	build_path = /obj/item/circuitboard/machine/washing_machine
+	category = list ("Misc. Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE | DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/board/ore_redemption
 	name = "Machine Design (Ore Redemption Board)"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -342,7 +342,7 @@
 #include "code\datums\position_point_vector.dm"
 #include "code\datums\profiling.dm"
 #include "code\datums\progressbar.dm"
-#include "code\datums\radiation_wave.dm"
+#include "code\datums\radiation_field.dm"
 #include "code\datums\recipe.dm"
 #include "code\datums\ruins.dm"
 #include "code\datums\saymode.dm"

--- a/tgui/packages/tgui/interfaces/MedicalKiosk.js
+++ b/tgui/packages/tgui/interfaces/MedicalKiosk.js
@@ -247,8 +247,10 @@ const MedicalKioskScanResults3 = (props, context) => {
     clone_health,
     brain_damage,
     brain_health,
-    rad_status,
-    rad_value,
+    rad_contamination_status,
+    rad_contamination_value,
+    rad_sickness_status,
+    rad_sickness_value,
     trauma_status,
   } = data;
   return (
@@ -282,12 +284,21 @@ const MedicalKioskScanResults3 = (props, context) => {
         </LabeledList.Item>
         <LabeledList.Divider />
         <LabeledList.Item
-          label="Radiation Status">
-          {rad_status}
+          label="Radiation Sickness Status">
+          {rad_sickness_status}
         </LabeledList.Item>
         <LabeledList.Item
-          label="Irradiation Percentage">
-          {rad_value}%
+          label="Radiation Sickness Percentage">
+          {rad_sickness_value}%
+        </LabeledList.Item>
+        <LabeledList.Divider />
+        <LabeledList.Item
+          label="Radiation Contamination Status">
+          {rad_contamination_status}
+        </LabeledList.Item>
+        <LabeledList.Item
+          label="Radiation Contamination Percentage">
+          {rad_contamination_value}%
         </LabeledList.Item>
       </LabeledList>
     </Section>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduced the amount of radiation you get from someone who is contaminated by a forth.  So if that CE comes in medical with 2000 mev, at most anyone will get is irradiated by 500.

Oh, and dumping a ton of matter bins in front of the SM for more power, thats fixed to.  Your welcome!

## Why It's Good For The Game
This will stop radiation griefing as well as not dying by just looking at the CE.  Also make the engineers do their job.

## Changelog
:cl:
fix: Reduced the amount of radiation contamination spreading
fix: Fixed the collectors to only eat the highest rad source
add: You can now build washing machines!
tweak: Washing machines now wash contents with bluespace magic!
fix: Sinks and showers properly wash normally and contamination!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
