### PR TITLE
Intercom refactor/code cleanup

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -199,6 +199,8 @@
 
 // /area signals
 
+///from base of area/proc/power_change(): ()
+#define COMSIG_AREA_POWER_CHANGE "area_power_change"
 ///from base of area/Entered(): (atom/movable/M)
 #define COMSIG_AREA_ENTERED "area_entered"
 ///from base of area/Exited(): (atom/movable/M)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -498,11 +498,12 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 /**
   * Called when the area power status changes
   *
-  * Updates the area icon and calls power change on all machinees in the area
+  * Updates the area icon, calls power change on all machinees in the area, and sends the `COMSIG_AREA_POWER_CHANGE` signal.
   */
 /area/proc/power_change()
 	for(var/obj/machinery/M in src)	// for each machine in the area
 		M.power_change()				// reverify power status (to update icons etc.)
+	SEND_SIGNAL(src, COMSIG_AREA_POWER_CHANGE)
 	update_icon()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pretty much what the CL says. 

To briefly go over some of the var removals:
- `number` - completely unused
- `anyai` - not used in any meaningful way
- `ai` - not used in any meaningful way, is a list for some reason, never has anything added or removed from it
- `list_tick` - was used for `process()` but we don't need it anymore
- `unfastended` - this was basically a variable that did the exact same thing as the `unscrewed` variable that radios use, but for some reason was re-declared and renamed

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
code: Removed a handful of unnecessary variables from intercoms.
refactor: Refactored intercom's code so that it doesn't need to process() and constantly check whether it's powered or EMP'd every few seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
