### PR TITLE
Fixes a spear hard del

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -382,6 +382,7 @@
 				L.transferItemToLoc(M, src)
 			else
 				M.forceMove(src)
+	parts_list.Cut()
 
 ///Hook for multiz???
 /atom/proc/update_multiz(prune_on_fail = FALSE)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -449,15 +449,14 @@
 			return
 	..()
 
-
 /obj/item/bombcore/chemical/CheckParts(list/parts_list)
+	..()
 	// Using different grenade casings, causes the payload to have different properties.
-	var/obj/item/stock_parts/matter_bin/MB = locate(/obj/item/stock_parts/matter_bin) in parts_list
+	var/obj/item/stock_parts/matter_bin/MB = locate(/obj/item/stock_parts/matter_bin) in src
 	if(MB)
 		max_beakers += MB.rating	// max beakers = 2-5.
-		parts_list -= MB
 		qdel(MB)
-	for(var/obj/item/grenade/chem_grenade/G in parts_list)
+	for(var/obj/item/grenade/chem_grenade/G in src)
 
 		if(istype(G, /obj/item/grenade/chem_grenade/large))
 			var/obj/item/grenade/chem_grenade/large/LG = G
@@ -471,14 +470,14 @@
 				else
 					S.forceMove(drop_location())
 
-		else if(istype(G, /obj/item/grenade/chem_grenade/cryo))
+		if(istype(G, /obj/item/grenade/chem_grenade/cryo))
 			spread_range -= 1 // Reduced range, but increased density.
 			temp_boost -= 100 // minimum of -150K blast.
 
-		else if(istype(G, /obj/item/grenade/chem_grenade/pyro))
+		if(istype(G, /obj/item/grenade/chem_grenade/pyro))
 			temp_boost += 150 // maximum of +350K blast, which is enough to self ignite. Which means a self igniting bomb can't take advantage of other grenade casing properties. Sorry?
 
-		else if(istype(G, /obj/item/grenade/chem_grenade/adv_release))
+		if(istype(G, /obj/item/grenade/chem_grenade/adv_release))
 			time_release += 50 // A typical bomb, using basic beakers, will explode over 2-4 seconds. Using two will make the reaction last for less time, but it will be more dangerous overall.
 
 		for(var/obj/item/reagent_containers/glass/B in G)
@@ -488,10 +487,9 @@
 			else
 				B.forceMove(drop_location())
 
-		parts_list -= G
 		qdel(G)
 
-	return ..()
+
 
 
 ///Syndicate Detonator (aka the big red button)///

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -449,14 +449,15 @@
 			return
 	..()
 
+
 /obj/item/bombcore/chemical/CheckParts(list/parts_list)
-	..()
 	// Using different grenade casings, causes the payload to have different properties.
-	var/obj/item/stock_parts/matter_bin/MB = locate(/obj/item/stock_parts/matter_bin) in src
+	var/obj/item/stock_parts/matter_bin/MB = locate(/obj/item/stock_parts/matter_bin) in parts_list
 	if(MB)
 		max_beakers += MB.rating	// max beakers = 2-5.
+		parts_list -= MB
 		qdel(MB)
-	for(var/obj/item/grenade/chem_grenade/G in src)
+	for(var/obj/item/grenade/chem_grenade/G in parts_list)
 
 		if(istype(G, /obj/item/grenade/chem_grenade/large))
 			var/obj/item/grenade/chem_grenade/large/LG = G
@@ -470,14 +471,14 @@
 				else
 					S.forceMove(drop_location())
 
-		if(istype(G, /obj/item/grenade/chem_grenade/cryo))
+		else if(istype(G, /obj/item/grenade/chem_grenade/cryo))
 			spread_range -= 1 // Reduced range, but increased density.
 			temp_boost -= 100 // minimum of -150K blast.
 
-		if(istype(G, /obj/item/grenade/chem_grenade/pyro))
+		else if(istype(G, /obj/item/grenade/chem_grenade/pyro))
 			temp_boost += 150 // maximum of +350K blast, which is enough to self ignite. Which means a self igniting bomb can't take advantage of other grenade casing properties. Sorry?
 
-		if(istype(G, /obj/item/grenade/chem_grenade/adv_release))
+		else if(istype(G, /obj/item/grenade/chem_grenade/adv_release))
 			time_release += 50 // A typical bomb, using basic beakers, will explode over 2-4 seconds. Using two will make the reaction last for less time, but it will be more dangerous overall.
 
 		for(var/obj/item/reagent_containers/glass/B in G)
@@ -487,9 +488,10 @@
 			else
 				B.forceMove(drop_location())
 
+		parts_list -= G
 		qdel(G)
 
-
+	return ..()
 
 
 ///Syndicate Detonator (aka the big red button)///

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -38,13 +38,15 @@
 
 /obj/item/spear/CheckParts(list/parts_list)
 	var/obj/item/shard/tip = locate() in parts_list
-	if (istype(tip, /obj/item/shard/plasma))
-		throwforce = 21
-		icon_prefix = "spearplasma"
-		AddComponent(/datum/component/two_handed, force_unwielded=11, force_wielded=19, icon_wielded="[icon_prefix]1")
-	update_icon()
-	qdel(tip)
-	..()
+	if(tip)
+		if (istype(tip, /obj/item/shard/plasma))
+			throwforce = 21
+			icon_prefix = "spearplasma"
+			AddComponent(/datum/component/two_handed, force_unwielded=11, force_wielded=19, icon_wielded="[icon_prefix]1")
+		update_icon()
+		parts_list -= tip
+		qdel(tip)
+	return ..()
 
 /obj/item/spear/explosive
 	name = "explosive lance"


### PR DESCRIPTION
List reference was passed through `parts_list`, `CheckParts` qdeleted some of their contents without removing them from the list, called parent which cycled through the whole list and forcemoved the qdeleted items into things, item got hard deleted due to being referenced by a contents list.

Emptied the `parts_list` at the end of it for good measure.