### PR TITLE
adds more feedback to borg headlamps

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -526,7 +526,7 @@
 
 //Some sort of magical "modulo" thing which somehow increments lamp power by 2, until it hits the max and resets to 0.
 	lamp_intensity = (lamp_intensity+2) % (lamp_max+2)
-	to_chat(src, "<span class='notice'>[lamp_intensity ? "Headlamp power set to Level [lamp_intensity/2]" : "Headlamp disabled"].</span>")
+	to_chat(src, "<span class='notice'>[lamp_intensity ? "Headlamp power set to level [lamp_intensity/2]. Headlamp power consumption rate is now [DisplayEnergy(clamp((lamp_intensity - 2) * 2,1,cell.charge))]/tick" : "Headlamp disabled"].</span>") //the expression "clamp((lamp_intensity - 2) * 2,1,cell.charge)" is taken from robot/life.dm; update it if the power consumption rate of cyborg headlamps is ever changed
 	update_headlamp()
 
 /mob/living/silicon/robot/proc/update_headlamp(turn_off = 0, cooldown = 100)


### PR DESCRIPTION
## About The Pull Request

Adjusting the intensity setting of your headlamp as a cyborg now tells you its new power consumption rate.

## Why It's Good For The Game

Hopefully, this should help teach newer borgs to KEEP YOUR HEADLAMPS OFF WHEN YOU'RE NOT USING THEM AHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH THIS ANNOYS ME SO GODDAMN MUCH WHEN I OBSERVE BORGS AS A GHOST YOU DON'T NEED TO STAY GLUED TO A CHARGER YOU CAN LIVE A FULLER AND MORE COMPLETE LIFE JUST TURN YOUR LAMP OFF JESUS CHRIST

In all seriousness, this change gives newer borgs some better feedback as to why their cell might be half-drained from what feels like only a few minutes of activity. Letting them see the numbers for themselves will hopefully better impress upon them that headlamps are emergency tools, not something that should be on at max power 24/7 (unless you have a self-recharging cell, of course).

## Changelog
:cl: ATHATH
tweak: Adjusting the intensity setting of your headlamp as a cyborg now tells you its new power consumption rate.
/:cl: