### PR TITLE
Ninja nerf- energy katana dashes and speed.

### DIFF
--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -102,5 +102,5 @@
 /datum/action/innate/dash/ninja
 	current_charges = 3
 	max_charges = 3
-	charge_rate = 30
+	charge_rate = 150
 	recharge_sound = null

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -13,7 +13,6 @@ Contents:
 	icon_state = "s-ninja"
 	inhand_icon_state = "s-ninja_suit"
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals, /obj/item/stock_parts/cell)
-	slowdown = 1
 	resistance_flags = LAVA_PROOF | ACID_PROOF
 	armor = list("melee" = 60, "bullet" = 50, "laser" = 30,"energy" = 40, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 100, "acid" = 100)
 	strip_delay = 12
@@ -133,7 +132,6 @@ Contents:
 		return FALSE
 	affecting = H
 	ADD_TRAIT(src, TRAIT_NODROP, NINJA_SUIT_TRAIT)
-	slowdown = 0
 	n_hood = H.head
 	ADD_TRAIT(n_hood, TRAIT_NODROP, NINJA_SUIT_TRAIT)
 	n_shoes = H.shoes
@@ -153,7 +151,6 @@ Contents:
 /obj/item/clothing/suit/space/space_ninja/proc/unlock_suit()
 	affecting = null
 	REMOVE_TRAIT(src, TRAIT_NODROP, NINJA_SUIT_TRAIT)
-	slowdown = 1
 	icon_state = "s-ninja"
 	if(n_hood)//Should be attached, might not be attached.
 		REMOVE_TRAIT(n_hood, TRAIT_NODROP, NINJA_SUIT_TRAIT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ninjas were crazy fast, this makes them still really fast but slightly less on the crazy side. they can still run from everything just a bit less fast. Yes I tested this.
This also increases the cooldown between dashes. you previously had 3 dashes which recharged at after 3 seconds. Now after 15 seconds the dashes rapidly recharge. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Previously ninja shitcode caused ninjas to be propelled at absurd speeds, to which the only proper response was flailing around and, if you had a gun, shooting wildly. Now the ninja is at least slightly slower than a laser. This might give ninjas reason to use their stealth, which is supposed to be actually useful, but pales in comparison to running across the station at mach 1.

Perhaps you were crafty and tricked the walking seizure into running into a bear trap! tragically, this will not spell the end for the ninja. This is because he can teleport anywhere on his screen once every 3 seconds! this is how long it takes a human to react and walk there, longer if he dashed through a window or something! and what's more is that the ninja can do this 3 times in a row instantly, only then will he have to wait 3 seconds. why does he even have spare dashes stored?
15 seconds is far shorter than the cooldown of ethereal jaunt or the like and it's still basically a use every 5 seconds. This might force ninjas to actually use their brain and decide whether to use a dash to get a good slice in or hold onto it to make bailing safer. It's not as if they're entirely reliant on these dashes-
they have adrenaline shots and fourteen smokebombs to escape with. once they've used all 3 of their dashes, they could also use their stealth to hide or something, maybe even grab some backup bluespace crystals from the station if they're not confident.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: ninja dashes recharge 5x as slow, but they all recharge at the same time.
balance: ninjas are slightly less the definition of speed. They're also faster when their suit is depowered I guess.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
