### PR TITLE
Fix the formula used for calculating reagents in a plant.

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -223,7 +223,7 @@
 		CRASH("[T] has no reagents.")
 
 	for(var/rid in reagents_add)
-		var/amount = max(1, round(potency * reagents_add[rid], 1)) //the plant will always have at least 1u of each of the reagents in its reagent production traits
+		var/amount = max(1, round((potency * reagents_add[rid])/2, 1)) //the plant will always have at least 1u of each of the reagents in its reagent production traits
 
 		var/list/data = null
 		if(rid == /datum/reagent/blood) // Hack to make blood in plants always O-


### PR DESCRIPTION
## About The Pull Request
There is currently a very crippling bug in botany that makes it so you can't do somewhat complex plants. Why? Because the maximum amout of chemicals in a potency 100 plant is 50u (as intended), and right now, when harvesting a plant with the following traits :

- 50% Chemical A
- 50% Chemical B

You will get a plant with 
- 50u Chemical A
- 0u Chemical B

Here is the deathnettle, that illustrate this issue perfectly.

![image](https://user-images.githubusercontent.com/65850818/84994900-a78e3600-b14b-11ea-9f5f-e514f4ef8426.png)



Now for my fixed version.

![image](https://user-images.githubusercontent.com/65850818/84995003-c391d780-b14b-11ea-9f6d-6dd508212d05.png)


## Why It's Good For The Game

Bug fix good.

## Changelog
:cl: Kathy Ryals, with help from ArcaneMusic
fix: Fixed a bug with the formula used for calculating reagents in a plant. Plants should now contain the correct proportions of chemicals.
/:cl: