### PR TITLE
weakens medipens in outside of lavaland alt to 51706

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1019,13 +1019,19 @@
 
 /datum/reagent/medicine/lavaland_extract
 	name = "Lavaland Extract"
-	description = "An extract of lavaland atmospheric and mineral elements. Heals the user in small doses, but is extremely toxic otherwise."
+	description = "An extract of lavaland atmospheric and mineral elements. Heals the user if exposed to lavaland's microbes, seems to have ill side effects outside of the lavaland zoosphere."
 	color = "#6B372E" //dark and red like lavaland
 	overdose_threshold = 3 //To prevent people stacking massive amounts of a very strong healing reagent
 	can_synth = FALSE
 
 /datum/reagent/medicine/lavaland_extract/on_mob_life(mob/living/carbon/M)
-	M.heal_bodypart_damage(5,5)
+	var/turf/T = get_turf(M)
+	if(is_mining_level(T.z))
+		M.heal_bodypart_damage(5,5)
+	else
+		M.Dizzy(10)
+		if(prob(15))
+			M.vomit()
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1026,7 +1026,7 @@
 
 /datum/reagent/medicine/lavaland_extract/on_mob_life(mob/living/carbon/M)
 	var/turf/T = get_turf(M)
-	if(is_mining_level(T.z))
+	if(!is_station_level(T.z))
 		M.heal_bodypart_damage(5,5)
 	else
 		M.Dizzy(10)
@@ -1037,7 +1037,7 @@
 
 /datum/reagent/medicine/lavaland_extract/overdose_process(mob/living/M)
 	var/turf/T = get_turf(M)
-	if(is_mining_level(T.z))
+	if(!is_station_level(T.z))
 		M.adjustBruteLoss(3*REM, 0, FALSE, BODYPART_ORGANIC)
 		M.adjustFireLoss(3*REM, 0, FALSE, BODYPART_ORGANIC)
 	M.adjustToxLoss(3*REM, 0)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1036,8 +1036,10 @@
 	return TRUE
 
 /datum/reagent/medicine/lavaland_extract/overdose_process(mob/living/M)
-	M.adjustBruteLoss(3*REM, 0, FALSE, BODYPART_ORGANIC)
-	M.adjustFireLoss(3*REM, 0, FALSE, BODYPART_ORGANIC)
+	var/turf/T = get_turf(M)
+	if(is_mining_level(T.z))
+		M.adjustBruteLoss(3*REM, 0, FALSE, BODYPART_ORGANIC)
+		M.adjustFireLoss(3*REM, 0, FALSE, BODYPART_ORGANIC)
 	M.adjustToxLoss(3*REM, 0)
 	..()
 	return TRUE

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -215,7 +215,7 @@
 
 /obj/item/reagent_containers/hypospray/medipen/survival
 	name = "survival medipen"
-	desc = "A medipen for surviving in the harshest of environments, heals and protects from environmental hazards. WARNING: Do not inject more than one pen in quick succession."
+	desc = "A medipen for surviving in the harshest of environments, heals and protects from environmental hazards. WARNING: Do not inject more than one pen in quick succession, the Nanotransen Exotic Medical Research Division is not responsible for any side effects caused by usage in untested enviroments like space stations."
 	icon_state = "stimpen"
 	inhand_icon_state = "stimpen"
 	volume = 60


### PR DESCRIPTION
:cl: MRP agent
balance: survival medipen heals normal on lavaland and less on station +  small side effects
balance: lavaland extract (one of the chem in the medipens) doesnt heal and does dizzyness  
and 15% prob of vomit on station
balance: lavaland extract OD does only 3 tox dmg when on station
/:cl:

- the lavaland extract (one of the healing chem in medipen with biggest healing power) doesnt heal on station and gives you shaky screen with chance of vomiting, making it usable in emergency sitations but not that great in middle of a fight or to spam heal while being beaten by people,
if you syringe it out then you will still get the chance of vomit and lose part of your chem + stun so its fine

- lore 

closes: #51706