### PR TITLE
Changes the plant reagent formula and makes plant potency, plant reagent % and plant volume interact sanely.

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -169,11 +169,6 @@
 		reagents.del_reagent(/datum/reagent/consumable/nutriment)
 		reagents.del_reagent(/datum/reagent/consumable/nutriment/vitamin)
 
-/obj/item/reagent_containers/food/snacks/grown/proc/provide_volume()
-	if(reagents)
-		return reagents.maximum_volume
-	return FALSE
-
 /*
  * Attack self for growns
  *

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -73,10 +73,15 @@
 		var/reag_txt = ""
 		if(seed && P_analyzer.scan_mode == PLANT_SCANMODE_CHEMICALS)
 			msg += "<br><span class='info'>*Plant Reagents:*</span>"
+			var/chem_cap = 0
 			for(var/reagent_id in seed.reagents_add)
 				var/datum/reagent/R  = GLOB.chemical_reagents_list[reagent_id]
 				var/amt = reagents.get_reagent_amount(reagent_id)
-				reag_txt += "\n<span class='info'>- [R.name]: [amt]</span>"
+				chem_cap += seed.reagents_add[reagent_id]
+				if(chem_cap <= 1)
+					reag_txt += "\n<span class='info'>- [R.name]: [amt]</span>"
+				else
+					reag_txt += "\n<span class='warning'>- [R.name]: [amt] (OVER 100% CAPACITY)</span>"
 
 		if(reag_txt)
 			msg += "<br><span class='info'>*---------*</span>"
@@ -163,6 +168,11 @@
 			juice_results[juice_results[i]] = nutriment
 		reagents.del_reagent(/datum/reagent/consumable/nutriment)
 		reagents.del_reagent(/datum/reagent/consumable/nutriment/vitamin)
+
+/obj/item/reagent_containers/food/snacks/grown/proc/provide_volume()
+	if(reagents)
+		return reagents.maximum_volume
+	return FALSE
 
 /*
  * Attack self for growns

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -78,10 +78,9 @@
 				var/datum/reagent/R  = GLOB.chemical_reagents_list[reagent_id]
 				var/amt = reagents.get_reagent_amount(reagent_id)
 				chem_cap += seed.reagents_add[reagent_id]
-				if(chem_cap <= 1)
-					reag_txt += "\n<span class='info'>- [R.name]: [amt]</span>"
-				else
-					reag_txt += "\n<span class='warning'>- [R.name]: [amt] (OVER 100% CAPACITY)</span>"
+				reag_txt += "\n<span class='info'>- [R.name]: [amt]</span>"
+			if(chem_cap > 1)
+				msg += "<br><span class='warning'>- Reagent Traits Over 100% Production</span></br>"
 
 		if(reag_txt)
 			msg += "<br><span class='info'>*---------*</span>"

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -192,12 +192,21 @@
 
 
 /obj/item/seeds/proc/harvest(mob/user)
+	///Reference to the tray/soil the seeds are planted in.
 	var/obj/machinery/hydroponics/parent = loc //for ease of access
+	///Count used for creating the correct amount of results to the harvest.
 	var/t_amount = 0
+	///List of plants all harvested from the same batch.
 	var/list/result = list()
+	///Tile of the harvester to deposit the growables.
 	var/output_loc = parent.Adjacent(user) ? user.loc : parent.loc //needed for TK
+	///Name of the grown products.
 	var/product_name
-	while(t_amount < getYield())
+	///The Number of products produced by the plant, typically the yield. Modified by Densified Chemicals.
+	var/product_count = getYield()
+	if(get_gene(/datum/plant_gene/trait/maxchem))
+		product_count = clamp(round(product_count/2),0,5)
+	while(t_amount < product_count)
 		var/obj/item/reagent_containers/food/snacks/grown/t_prod = new product(output_loc, src)
 		if(parent.myseed.plantname != initial(parent.myseed.plantname))
 			t_prod.name = lowertext(parent.myseed.plantname)

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -227,11 +227,12 @@
 	if(istype(T, /obj/item/reagent_containers/food/snacks/grown))
 		var/obj/item/reagent_containers/food/snacks/grown/grown_edible = T
 		for(var/rid in reagents_add)
-			var/reagent_overflow_mod = 1
+			var/reagent_overflow_mod = reagents_add[rid]
 			if(reagent_max > 1)
 				reagent_overflow_mod = (reagents_add[rid]/ reagent_max)
-			var/amount = max(1, round((grown_edible.provide_volume())*(potency/100) * reagents_add[rid] * reagent_overflow_mod, 1)) //the plant will always have at least 1u of each of the reagents in its reagent production traits
-			var/list/data = null
+			var/edible_vol = grown_edible.reagents ? grown_edible.reagents.maximum_volume : 0
+			var/amount = max(1, round((edible_vol)*(potency/100) * reagent_overflow_mod, 1)) //the plant will always have at least 1u of each of the reagents in its reagent production traits
+			var/list/data
 			if(rid == /datum/reagent/blood) // Hack to make blood in plants always O-
 				data = list("blood_type" = "O-")
 			if(rid == /datum/reagent/consumable/nutriment || rid == /datum/reagent/consumable/nutriment/vitamin)

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -221,20 +221,22 @@
 /obj/item/seeds/proc/prepare_result(var/obj/item/T)
 	if(!T.reagents)
 		CRASH("[T] has no reagents.")
-
+	var/reagent_max = 0
 	for(var/rid in reagents_add)
-		var/amount = max(1, round(potency * reagents_add[rid], 1)) //the plant will always have at least 1u of each of the reagents in its reagent production traits
-
-		var/list/data = null
-		if(rid == /datum/reagent/blood) // Hack to make blood in plants always O-
-			data = list("blood_type" = "O-")
-		if(rid == /datum/reagent/consumable/nutriment || rid == /datum/reagent/consumable/nutriment/vitamin)
-			// apple tastes of apple.
-			if(istype(T, /obj/item/reagent_containers/food/snacks/grown))
-				var/obj/item/reagent_containers/food/snacks/grown/grown_edible = T
-				data = grown_edible.tastes
-
-		T.reagents.add_reagent(rid, amount, data)
+		reagent_max += reagents_add[rid]
+	if(istype(T, /obj/item/reagent_containers/food/snacks/grown))
+		var/obj/item/reagent_containers/food/snacks/grown/grown_edible = T
+		for(var/rid in reagents_add)
+			var/reagent_overflow_mod = 1
+			if(reagent_max > 1)
+				reagent_overflow_mod = (reagents_add[rid]/ reagent_max)
+			var/amount = max(1, round((grown_edible.provide_volume())*(potency/100) * reagents_add[rid] * reagent_overflow_mod, 1)) //the plant will always have at least 1u of each of the reagents in its reagent production traits
+			var/list/data = null
+			if(rid == /datum/reagent/blood) // Hack to make blood in plants always O-
+				data = list("blood_type" = "O-")
+			if(rid == /datum/reagent/consumable/nutriment || rid == /datum/reagent/consumable/nutriment/vitamin)
+				data = grown_edible.tastes // apple tastes of apple.
+			T.reagents.add_reagent(rid, amount, data)
 
 
 /// Setters procs ///


### PR DESCRIPTION
Alright, so I'll be coming in and editing all of this later so bare with me for grammar and nightcode.

## About The Pull Request

Closes #51720,  but thanks for bringing this to my attention.

How reagents used to work:
You have a plant. The plant has 10 potency, and produces 10% nutriment, with the standard 50 unit reagent capacity. The plant holds 1 unit of nutriment. This is sound. We like this.

You have a plant. The plant has 100 potency, and produces 10% nutriment, with the standard 50 unit reagent capacity. The plant holds 10 unit of nutriment. This is not sound, as 10% of 50 units is 5 units.

You have a plant. The plant has 100 potency, and produces 30% space_drugs, 30% mindbreaker, 15% mercury, 15% lithium, 15% atropine, 15% methamphetamine, 15% bath_salts, 15% crank, 15% krokodil, 15% lipolicide, and 10% nicotine, with 420 unit reagent capacity. The plant holds 190 unit of nutriment. I sit at my desk with my burbon, crying over this tragedy. These are not percents. This is a horror show. The math gremlins tug at the corners of my brain, demanding reason. They find none.

This adjusts the formula used by prepare_result in order to factor in a plant's reagent capacity, chemical traits, and potency in a meaningful way that can be explained uniformly.
**PLANT POTENCY** describes how much of a plant's **Reagent Capacity** is utilized when determining chemical amounts.  So a plant with 50 **Plant Potency** will only utilize 25 units of a standard 50 unit plant (This is the standard amount for most all plants, if you're unaware), And 50 units of the 100 capacity if that plant had Densified Chemicals.

Additionally, if a plant has _more than 100% reagent production,_ their interaction has been changed. Before, reagent chemical percentages were a complete lie. If you had 30% production of a chemical, it was really just 30 chemicals modified by the plant's potency, which while effective for cutting down on plants with too many reagent genes, was also _**NOT HOW PERCENTAGES WORK.**_  Now, percentages above 100% will now respect the percentage total above 100, and going above 100% will instead lower all individual reagents within the plant to compensate, 

**UPDATE 6/30/20:**
This is also going to require a change to densified chemicals, so now DC halves the plant's yield, but still bumps the plant's capacity to 200 units. Ultimately, reagent production is unaffected, but the output of much more powerful utility plants is slowed to compensate.

## Why It's Good For The Game

In the old system, if you have a plant with 50 reagent capacity, 100 potency, and 50% of chem A, and 50% of chem B, it would fill the entire plant with chem A, then ignore all of chem B.
I don't care how much soul it has, how long it's been that way, or how long I have to argue it. 50% of 50 is 25.

Handling of reagents over 100% is a QOL improvement considering that you can't just make a 200 chemical long list of reagents using the DNA manipulator anymore, and APPARENTLY omegaweed and other plants already edge pretty close to 100% as is, so this enables the system to handle them properly without lying about what a percentage is. 

## Changelog
:cl:
tweak: Plants with over 100% reagent genes now split up their reagents between all available chemicals.
fix: Plants now correctly apply percentages of reagents to a plant's overall reagent capacity.
balance: Densified Chemicals now causes plants to produce half the yield, while still produces double capacity plants.
/:cl: