### PR TITLE
Changes the plant reagent formula and makes plant potency, plant reagent % and plant volume interact sanely, unnerfed version.

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -73,10 +73,15 @@
 		var/reag_txt = ""
 		if(seed && P_analyzer.scan_mode == PLANT_SCANMODE_CHEMICALS)
 			msg += "<br><span class='info'>*Plant Reagents:*</span>"
+			var/chem_cap = 0
 			for(var/reagent_id in seed.reagents_add)
 				var/datum/reagent/R  = GLOB.chemical_reagents_list[reagent_id]
 				var/amt = reagents.get_reagent_amount(reagent_id)
-				reag_txt += "\n<span class='info'>- [R.name]: [amt]</span>"
+				chem_cap += seed.reagents_add[reagent_id]
+				if(chem_cap <= 1)
+					reag_txt += "\n<span class='info'>- [R.name]: [amt]</span>"
+				else
+					reag_txt += "\n<span class='warning'>- [R.name]: [amt] (OVER 100% CAPACITY)</span>"
 
 		if(reag_txt)
 			msg += "<br><span class='info'>*---------*</span>"
@@ -163,6 +168,11 @@
 			juice_results[juice_results[i]] = nutriment
 		reagents.del_reagent(/datum/reagent/consumable/nutriment)
 		reagents.del_reagent(/datum/reagent/consumable/nutriment/vitamin)
+
+/obj/item/reagent_containers/food/snacks/grown/proc/provide_volume()
+	if(reagents)
+		return reagents.maximum_volume
+	return FALSE
 
 /*
  * Attack self for growns

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -221,20 +221,22 @@
 /obj/item/seeds/proc/prepare_result(var/obj/item/T)
 	if(!T.reagents)
 		CRASH("[T] has no reagents.")
-
+	var/reagent_max = 0
 	for(var/rid in reagents_add)
-		var/amount = max(1, round(potency * reagents_add[rid], 1)) //the plant will always have at least 1u of each of the reagents in its reagent production traits
-
-		var/list/data = null
-		if(rid == /datum/reagent/blood) // Hack to make blood in plants always O-
-			data = list("blood_type" = "O-")
-		if(rid == /datum/reagent/consumable/nutriment || rid == /datum/reagent/consumable/nutriment/vitamin)
-			// apple tastes of apple.
-			if(istype(T, /obj/item/reagent_containers/food/snacks/grown))
-				var/obj/item/reagent_containers/food/snacks/grown/grown_edible = T
-				data = grown_edible.tastes
-
-		T.reagents.add_reagent(rid, amount, data)
+		reagent_max += reagents_add[rid]
+	if(istype(T, /obj/item/reagent_containers/food/snacks/grown))
+		var/obj/item/reagent_containers/food/snacks/grown/grown_edible = T
+		for(var/rid in reagents_add)
+			var/reagent_overflow_mod = 1
+			if(reagent_max > 1)
+				reagent_overflow_mod = (reagents_add[rid]/ reagent_max)
+			var/amount = max(1, round((grown_edible.provide_volume())*(potency/100) * reagents_add[rid] * reagent_overflow_mod, 1)) //the plant will always have at least 1u of each of the reagents in its reagent production traits
+			var/list/data = null
+			if(rid == /datum/reagent/blood) // Hack to make blood in plants always O-
+				data = list("blood_type" = "O-")
+			if(rid == /datum/reagent/consumable/nutriment || rid == /datum/reagent/consumable/nutriment/vitamin)
+				data = grown_edible.tastes // apple tastes of apple.
+			T.reagents.add_reagent(rid, amount, data)
 
 
 /// Setters procs ///

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -231,7 +231,7 @@
 			reagent_max_volume += reagents_add[rid] * potency
 		for(var/rid in reagents_add)
 			var/reagent_ratio = reagents_add[rid] // Ratio used for calculations, initial behavior is to consider the original ratio
-			if(reagent_max_ratio > 1) // If we're exceeding a total ratio of 1
+			if((reagent_max_ratio > 1 || (reagent_max_volume > edible_max_volume)) // If we're exceeding a total ratio of 1 or we're exceeding the maximum available volume
 				reagent_ratio = (reagents_add[rid]/ reagent_max_ratio) // New ratio proportional to the total ratio
 			var/reagent_volume = potency // Volume amount used for calculations, initial behavior is to consider the amount of chemicals in proportion to potency
 			if(reagent_max_volume > edible_max_volume) // If we're restricted by the maximum volume of chemicals

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -231,8 +231,8 @@
 			reagent_max_volume += reagents_add[rid] * potency
 		for(var/rid in reagents_add)
 			var/reagent_ratio = reagents_add[rid] // Ratio used for calculations, initial behavior is to consider the original ratio
-			if((reagent_max_ratio > 1 || (reagent_max_volume > edible_max_volume)) // If we're exceeding a total ratio of 1 or we're exceeding the maximum available volume
-				reagent_ratio = (reagents_add[rid]/ reagent_max_ratio) // New ratio proportional to the total ratio
+			if((reagent_max_ratio > 1) || (reagent_max_volume > edible_max_volume)) // If we're exceeding a total ratio of 1 or we're exceeding the maximum available volume
+				reagent_ratio = (reagents_add[rid] / reagent_max_ratio) // New ratio proportional to the total ratio
 			var/reagent_volume = potency // Volume amount used for calculations, initial behavior is to consider the amount of chemicals in proportion to potency
 			if(reagent_max_volume > edible_max_volume) // If we're restricted by the maximum volume of chemicals
 				reagent_volume = edible_max_volume // Use maximum volume for calculations


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #51723 
, even if I'm completely based on that proposal.
Refactors the calculation for the ratio of reagents and their volume based on the original code and the PR by @ArcaneMusic .

_Arcane's Proposal (if I understood it correctly):_

- If the total ratio of reagents exceeds 1, calculate the proportional ratio respective to the total ratio (in order to make the sum of all ratios become 1).
- Obtain the volume of the reagent with:
`max(1, round((grown_edible.provide_volume())*(potency/100) * reagents_add[rid] * reagent_overflow_mod, 1))` - This translates to: maximum volume * potency ratio * reagent ratio * overflow modifier - I think in fact this formula has a mistake since you should exchange the original reagent ratio for the modifier, because like this:
    - For a plant with maximum volume of 50, 100 potency, 2 reagents with 0.5 and 0.6 ratio
        - reagent_overflow_mod for the 0.6 ratio = 0.6/1.1 -> 0.5454545
        - 50 * (100/100) * 0.6 * 0.5454545 = 16,363635
    - That's less than the 60% both of the original 100 potency and the new 50 capacity.

As I think most people saw, the problem with that proposal is that it considers the maximum volume for the ratio calculations instead of using the potency (as the original code did).

_My proposal_
- If the total ratio of reagents exceeds 1, calculate the proportional ratio respective to the total ratio (in order to make the sum of all ratios become 1). -> No changes from Arcane's, this solves the problem of having multiple ratios exceeding 100%.
- If the total volume of reagents exceeds the maximum capacity volume, calculate the proportion of the volume with the maximum capacity instead of potency.
    - If we have a plant with 100 potency and some reagent with a ratio of 0.1, we end with 10 units of the reagent since it's not exceeding the maximum capacity.
    - If we have multiple reagents in the same plant, exceeding capacity (but not ratio), like 0.3 and 0.3 (would result in 30+30 units), calculate the proportional ratio and use it with the maximum volume -> 0.3/0.6 -> 0.5 * 50 max capacity = 25 units.
    - If we have both exceeding ratios and capacity, do the same calculations, everything should add up to 1 (ratios) and maximum capacity.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes the issue with exceeding 100% of production ratios and not being able to express all reagents in the product when exceeding maximum capacity, without changing the default behavior when not exceeding the maximum capacity.

P.S: Not sure what's the etiquette for making a PR based on another PR when naming the changelog, if it's needed to mention @ArcaneMusic feel free to say so and I'll amend the changelog.
P.S.S: I'm not adding the tag balance since this doesn't balance anything new, still having vanilla behavior when not exceeding the maximum capacity.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Shadark & ArcaneMusic
tweak: Plants with over 100% reagent genes now split up their reagents between all available chemicals.
fix: Plants now correctly apply percentages of reagents to a plant's overall reagent capacity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->