### PR TITLE
Adds paramedic uniforms to medidrobe.

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -52,6 +52,8 @@
 					/obj/item/storage/backpack/medic = 4,
 					/obj/item/storage/backpack/satchel/med = 4,
 					/obj/item/clothing/suit/hooded/wintercoat/medical = 4,
+					/obj/item/clothing/under/rank/medical/paramedic = 4,
+					/obj/item/clothing/under/rank/medical/paramedic/skirt = 4,
 					/obj/item/clothing/under/rank/medical/doctor/nurse = 4,
 					/obj/item/clothing/head/nursehat = 4,
 					/obj/item/clothing/under/rank/medical/doctor/skirt= 4,


### PR DESCRIPTION
## About The Pull Request

It adds both paramedic suit and skirt to the medidrobe, since they were not there until now.

## Why It's Good For The Game

Fixes an oversight in the medidrobe's available uniforms.

## Changelog
:cl: Kathy Ryals
add: Due to some very convincing paramedics, the medidrobe has been updated to include the paramedic jumpsuit and jumpskirt.
/:cl: