### PR TITLE
the default chem capacity of most grown plants is now 100u

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -21,6 +21,7 @@
 	var/distill_reagent //If NULL and this object can be distilled, it uses a generic fruit_wine reagent and adjusts its variables.
 	var/wine_flavor //If NULL, this is automatically set to the fruit's flavor. Determines the flavor of the wine if distill_reagent is NULL.
 	var/wine_power = 10 //Determines the boozepwr of the wine if distill_reagent is NULL.
+	volume = 100
 
 /obj/item/reagent_containers/food/snacks/grown/Initialize(mapload, obj/item/seeds/new_seed)
 	. = ..()

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -10,7 +10,7 @@
 
 /obj/item/grown/Initialize(newloc, obj/item/seeds/new_seed)
 	. = ..()
-	create_reagents(50)
+	create_reagents(100)
 
 	if(new_seed)
 		seed = new_seed.Copy()


### PR DESCRIPTION
## About The Pull Request

see title

this doesn't affect omega weed, cherry bombs, or any future plants with their own special capacities, and the densified chemicals trait should still work with this PR

I haven't bothered to check to see if potatoes and apples with the densified chemicals trait can still be eaten in a single bite with this PR, but tbh, I think that being able to eat 200u of chems in a single bite might become a balance concern, and you should still be able to eat them in a single bite without the densified chemicals trait

## Why It's Good For The Game

Apparently, peoples' heads fuckin' explode if the reagent capacity of a plant is 50u instead of a 100u, because they keep thinking that because reagent production traits have a "%" signs in them, that percentage "should" be applied to the chem capacity of a plant, instead of (just) its potency. This PR was made to ease the headaches of those people.

## Changelog
:cl: ATHATH
balance: The default chem capacity of most grown plants is now 100u.
/:cl: