### PR TITLE
racial dormant mutation changes

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -20,6 +20,7 @@
 #define RACEMUT		/datum/mutation/human/race
 #define BADSIGHT	/datum/mutation/human/nearsight
 #define LASEREYES	/datum/mutation/human/laser_eyes
+#define LASEREYESLESSER	/datum/mutation/human/laser_eyes/lesser
 #define CHAMELEON	/datum/mutation/human/chameleon
 #define WACKY		/datum/mutation/human/wacky
 #define MUT_MUTE	/datum/mutation/human/mute

--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -20,7 +20,6 @@
 #define RACEMUT		/datum/mutation/human/race
 #define BADSIGHT	/datum/mutation/human/nearsight
 #define LASEREYES	/datum/mutation/human/laser_eyes
-#define LASEREYESLESSER	/datum/mutation/human/laser_eyes/lesser
 #define CHAMELEON	/datum/mutation/human/chameleon
 #define WACKY		/datum/mutation/human/wacky
 #define MUT_MUTE	/datum/mutation/human/mute
@@ -56,6 +55,7 @@
 #define SPIDER_WEB	/datum/mutation/human/webbing
 #define MARTYRDOM	/datum/mutation/human/martyrdom
 #define HARS		/datum/mutation/human/headless
+#define FARSIGHT /datum/mutation/human/farsight
 
 #define UI_CHANGED "ui changed"
 #define UE_CHANGED "ue changed"

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -87,7 +87,6 @@
 	difficulty = 16
 	instability = 5
 	conflicts = list(GIGANTISM)
-	locked = TRUE    // Default intert species for now, so locked from regular pool.
 
 /datum/mutation/human/dwarfism/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
@@ -238,6 +237,7 @@
 	quality = POSITIVE
 	text_gain_indication = "<span class='notice'>You feel strong.</span>"
 	difficulty = 16
+	locked = TRUE    // Default inert species for now, so locked from regular pool.
 
 /datum/mutation/human/stimmed
 	name = "Stimmed"

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -77,6 +77,11 @@
 	layer_used = FRONT_MUTATIONS_LAYER
 	limb_req = BODY_ZONE_HEAD
 	instability = 40
+	var/cooldown_mult = 1
+
+/datum/mutation/human/laser_eyes/lesser //moths can roll this as a dormant mutation
+	name = "Lesser Laser Eyes"
+	cooldown_mult = 1.5
 
 /datum/mutation/human/laser_eyes/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
 	..()
@@ -103,7 +108,7 @@
 	if(source.a_intent != INTENT_HARM)
 		return
 	to_chat(source, "<span class='warning'>You shoot with your laser eyes!</span>")
-	source.changeNext_move(CLICK_CD_RANGE)
+	source.changeNext_move(CLICK_CD_RANGE * cooldown_mult)
 	source.newtonian_move(get_dir(target, source))
 	var/obj/projectile/beam/laser_eyes/LE = new(source.loc)
 	LE.firer = source

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -76,6 +76,7 @@
 	text_gain_indication = "<span class='notice'>You feel pressure building up behind your eyes.</span>"
 	layer_used = FRONT_MUTATIONS_LAYER
 	limb_req = BODY_ZONE_HEAD
+	instability = 40
 
 /datum/mutation/human/laser_eyes/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
 	..()

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -59,12 +59,31 @@
 
 ///X-ray Vision lets you see through walls.
 /datum/mutation/human/thermal/x_ray
-	name = "X Ray Vision"
+	name = "X-Ray Vision"
 	desc = "A strange genome that allows the user to see between the spaces of walls." //actual x-ray would mean you'd constantly be blasting rads, wich might be fun for later //hmb
 	text_gain_indication = "<span class='notice'>The walls suddenly disappear!</span>"
 	instability = 35
 	locked = TRUE
 	visionflag = TRAIT_XRAY_VISION
+
+///A mutation that's only found naturally in moths. Gives you a spell that lets you set your vision range.
+/datum/mutation/human/farsight
+	name = "Far Sight"
+	desc = "The user of this genome can see farther than normal."
+	text_gain_indication = "<span class='notice'>You can see the bigger picture now.</span>"
+	instability = 20
+	locked = TRUE
+	power = /obj/effect/proc_holder/spell/targeted/view_range/farsight
+
+/datum/mutation/human/farsight/on_losing(mob/living/carbon/human/owner)
+	if(..())
+		return
+	if(owner.client)
+		owner.client.view_size.resetToDefault()
+
+/obj/effect/proc_holder/spell/targeted/view_range/farsight
+	name = "Far Sight"
+	desc = "Hey, I think I can see my house from here!"
 
 ///Laser Eyes lets you shoot lasers from your eyes!
 /datum/mutation/human/laser_eyes
@@ -76,12 +95,6 @@
 	text_gain_indication = "<span class='notice'>You feel pressure building up behind your eyes.</span>"
 	layer_used = FRONT_MUTATIONS_LAYER
 	limb_req = BODY_ZONE_HEAD
-	instability = 40
-	var/cooldown_mult = 1
-
-/datum/mutation/human/laser_eyes/lesser //moths can roll this as a dormant mutation
-	name = "Lesser Laser Eyes"
-	cooldown_mult = 1.5
 
 /datum/mutation/human/laser_eyes/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
 	..()
@@ -108,7 +121,7 @@
 	if(source.a_intent != INTENT_HARM)
 		return
 	to_chat(source, "<span class='warning'>You shoot with your laser eyes!</span>")
-	source.changeNext_move(CLICK_CD_RANGE * cooldown_mult)
+	source.changeNext_move(CLICK_CD_RANGE)
 	source.newtonian_move(get_dir(target, source))
 	var/obj/projectile/beam/laser_eyes/LE = new(source.loc)
 	LE.firer = source

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -91,7 +91,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	///To use MUTCOLOR with a fixed color that's independent of the mcolor feature in DNA.
 	var/fixed_mut_color = ""
 	///Special mutation that can be found in the genepool exclusively in this species. Dont leave empty or changing species will be a headache
-	var/inert_mutation 	= DWARFISM
+	var/inert_mutation 	= STRONG
 	///Used to set the mob's deathsound upon species change
 	var/deathsound
 	///Sounds to override barefeet walking

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -39,6 +39,7 @@
 	var/static/b2 = 149
 	//this is shit but how do i fix it? no clue.
 	var/drain_time = 0 //used to keep ethereals from spam draining power sources
+	inert_mutation = SHOCKTOUCH
 
 /datum/species/ethereal/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	.=..()

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -20,6 +20,7 @@
 	wings_icon = "Megamoth"
 	has_innate_wings = TRUE
 	payday_modifier = 0.75
+	inert_mutation = LASEREYES //the legacy of the ultra-moths
 
 /datum/species/moth/regenerate_organs(mob/living/carbon/C,datum/species/old_species,replace_current=TRUE,list/excluded_zones)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -20,7 +20,7 @@
 	wings_icon = "Megamoth"
 	has_innate_wings = TRUE
 	payday_modifier = 0.75
-	inert_mutation = LASEREYES //the legacy of the ultra-moths
+	inert_mutation = LASEREYESLESSER //the legacy of the ultra-moths
 
 /datum/species/moth/regenerate_organs(mob/living/carbon/C,datum/species/old_species,replace_current=TRUE,list/excluded_zones)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -20,7 +20,7 @@
 	wings_icon = "Megamoth"
 	has_innate_wings = TRUE
 	payday_modifier = 0.75
-	inert_mutation = LASEREYESLESSER //the legacy of the ultra-moths
+	inert_mutation = FARSIGHT
 
 /datum/species/moth/regenerate_organs(mob/living/carbon/C,datum/species/old_species,replace_current=TRUE,list/excluded_zones)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

strength is now the default racial dormant mutation, not dwarfism. what this effectively means is that lizards can now roll dwarfism as one of their dormant mutations (they couldn't before this PR), but they (and moths and ethereals due to the changes further down the list) now can't roll strength as one of their dormant mutations.

ethereals now have shock touch as a racial dormant mutation (you can still craft it the normal way, of course; I just thought that it was in-flavor for them).

moths now have far sight as their racial dormant mutation. it lets you adjust your vision range.

to be clear, not every moth is going to have far sight as a dormant mutation, just as how not every lizard has firebreath as a dormant mutation. it's just in the pool of possible dormant mutations for them.

## Why It's Good For The Game

it's kind of weird that lizards can't roll dwarfism as one of their dormant mutations, but they CAN roll strength as one of their dormant mutations, even though strength's only purpose is to be a component for a mutation that lizards can't even use.

## Changelog
:cl: ATHATH
balance: Strength is now the default racial dormant mutation, not dwarfism.
balance: Ethereals now have shock touch as a racial dormant mutation (you can still craft it the normal way, of course).
add: The far sight mutation has been added to the game as a moth racial dormant mutation-exclusive mutation. It gives you a button that lets you adjust how far you can see.
/:cl: