### PR TITLE
Better logging coordinate handling

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -60,11 +60,30 @@
 #define ADMIN_FULLMONTY_NONAME(user) "[ADMIN_QUE(user)] [ADMIN_PP(user)] [ADMIN_VV(user)] [ADMIN_SM(user)] [ADMIN_FLW(user)] [ADMIN_TP(user)] [ADMIN_INDIVIDUALLOG(user)] [ADMIN_SMITE(user)]"
 #define ADMIN_FULLMONTY(user) "[key_name_admin(user)] [ADMIN_FULLMONTY_NONAME(user)]"
 #define ADMIN_JMP(src) "(<a href='?_src_=holder;[HrefToken(TRUE)];adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)"
-#define COORD(src) "[src ? "([src.x],[src.y],[src.z])" : "nonexistent location"]"
-#define AREACOORD(src) "[src ? "[get_area_name(src, TRUE)] ([src.x], [src.y], [src.z])" : "nonexistent location"]"
-#define ADMIN_COORDJMP(src) "[src ? "[COORD(src)] [ADMIN_JMP(src)]" : "nonexistent location"]"
-#define ADMIN_VERBOSEJMP(src) "[src ? "[AREACOORD(src)] [ADMIN_JMP(src)]" : "nonexistent location"]"
+#define COORD(src) "[src ? src.Admin_Coordinates_Readable() : "nonexistent location"]"
+#define AREACOORD(src) "[src ? src.Admin_Coordinates_Readable(TRUE) : "nonexistent location"]"
+#define ADMIN_COORDJMP(src) "[src ? src.Admin_Coordinates_Readable(FALSE, TRUE) : "nonexistent location"]"
+#define ADMIN_VERBOSEJMP(src) "[src ? src.Admin_Coordinates_Readable(TRUE, TRUE) : "nonexistent location"]"
 #define ADMIN_INDIVIDUALLOG(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];individuallog=[REF(user)]'>LOGS</a>)"
+
+/atom/proc/Admin_Coordinates_Readable(area_name, admin_jump_ref)
+	var/turf/T = Safe_COORD_Location()
+	return T ? "[area_name ? "[get_area_name(T, TRUE)] " : " "]([T.x],[T.y],[T.z])[admin_jump_ref ? " [ADMIN_JMP(T)]" : ""]" : "nonexistent location"
+
+/atom/proc/Safe_COORD_Location()
+	var/atom/A = drop_location()
+	if(!A)
+		return //not a valid atom.
+	var/turf/T = get_step(A, 0) //resolve where the thing is.
+	if(!T) //incase it's inside a valid drop container, inside another container. ie if a mech picked up a closet and has it inside it's internal storage.
+		var/atom/last_try = A.loc?.drop_location() //one last try, otherwise fuck it.
+		if(last_try)
+			T = get_step(last_try, 0)
+	return T
+
+/turf/Safe_COORD_Location()
+	return src
+
 
 #define ADMIN_PUNISHMENT_LIGHTNING "Lightning bolt"
 #define ADMIN_PUNISHMENT_BRAINDAMAGE "Brain damage"


### PR DESCRIPTION
:cl: ShizCalev
admin: Fixed logging / admin message coordinate handling for items being held by mobs / in containers / in containers inside other containers giving nullspace / 0,0,0 location references.
/:cl:


Example is with grenades, but it applies to anything that uses `COORD` and `AREACOORD`


**Old**

While being held by a mob:
`ADMIN LOG: shizcalev/(Azerthene Severn)(?) (FLW) at Thunderdome Arena (172, 50, 1) (JMP) has primed a stingbang at Thunderdome Arena (0, 0, 0) (JMP) for detonation.`

While being held by a mob inside a locker
`ADMIN LOG: shizcalev/(Azerthene Severn)(?) (FLW) at Thunderdome Arena (0, 0, 0) (JMP) has primed a stingbang at Thunderdome Arena (0, 0, 0) (JMP) for detonation.`

___________________________________________________________

**New**

While being held by a mob:
`ADMIN LOG: ShizCalev/(Azerthene Severn)(?) (FLW) at Atmospherics (127,92,2) (JMP) has primed a stingbang at Atmospherics (127,92,2) (JMP) for detonation.`

While being held by a mob inside a locker:
`ADMIN LOG: ShizCalev/(Azerthene Severn)(?) (FLW) at Central Primary Hallway (107,141,2) (JMP) has primed a stingbang at Central Primary Hallway (112,141,2) (JMP) for detonation.`

While being held by a mob inside a locker inside a mech:
`ADMIN LOG: ShizCalev/(Azerthene Severn)(?) (FLW) at Bar (133,132,2) (JMP) has primed a stingbang at Bar (133,132,2) (JMP) for detonation.`