### PR TITLE
Nanites only attempt to heal traumas up to their ability

### DIFF
--- a/code/modules/research/nanites/nanite_programs/healing.dm
+++ b/code/modules/research/nanites/nanite_programs/healing.dm
@@ -70,14 +70,13 @@
 	rogue_types = list(/datum/nanite_program/brain_decay)
 
 /datum/nanite_program/brain_heal/check_conditions()
-	var/problems = FALSE
+	if(host_mob.getOrganLoss(ORGAN_SLOT_BRAIN) > 0)
+		return ..()	
 	if(iscarbon(host_mob))
 		var/mob/living/carbon/C = host_mob
-		if(length(C.get_traumas()))
-			problems = TRUE
-	if(host_mob.getOrganLoss(ORGAN_SLOT_BRAIN) > 0)
-		problems = TRUE
-	return problems ? ..() : FALSE
+		if ( C.has_trauma_type( resilience = TRAUMA_RESILIENCE_BASIC) )
+			return ..()
+	return FALSE
 
 /datum/nanite_program/brain_heal/active_effect()
 	host_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, -1)
@@ -192,14 +191,13 @@
 	rogue_types = list(/datum/nanite_program/brain_decay, /datum/nanite_program/brain_misfire)
 
 /datum/nanite_program/brain_heal_advanced/check_conditions()
-	var/problems = FALSE
+	if(host_mob.getOrganLoss(ORGAN_SLOT_BRAIN) > 0)
+		return ..()	
 	if(iscarbon(host_mob))
 		var/mob/living/carbon/C = host_mob
-		if(length(C.get_traumas()))
-			problems = TRUE
-	if(host_mob.getOrganLoss(ORGAN_SLOT_BRAIN) > 0)
-		problems = TRUE
-	return problems ? ..() : FALSE
+		if ( C.has_trauma_type( resilience = TRAUMA_RESILIENCE_LOBOTOMY) )
+			return ..()
+	return FALSE
 
 /datum/nanite_program/brain_heal_advanced/active_effect()
 	host_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nanites currently try expend themselves trying to heal traumas they aren't able to heal (even permanent ones).
This changes that so nanites will not try to heal traumas they aren't able to heal.

I am a pretty new coder to DM so please look at the code!

## Why It's Good For The Game

No good reason for why nanites should be spent trying to heal a trauma when it's impossible for it to heal that trauma

## Changelog
:cl:
Nanite Neural Reimaging and Neural Regeneration will only spend themselves when the trauma is curable by the nanites
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
