### PR TITLE
Removes throw_impact from onZImpact

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -100,7 +100,6 @@
 			if(A.layer > highest.layer)
 				highest = A
 	INVOKE_ASYNC(src, .proc/SpinAnimation, 5, 2)
-	throw_impact(highest)
 	return TRUE
 
 //For physical constraints to travelling up/down.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

When I originally added this I wanted this to basically handle hit effects in a general way.
Think, items falling on people's heads
Mobs crashing into each other for knockdown + damage
Throwing people down railings onto people below
Fun, right? 
Unfortunately, throwingdatum is a thing now (well, that's not unfortunate, that's good) and since this isn't an actual throw there isn't a thrownthing datum to be passed, which causes runtimes because.. throw_impact kind of needs it! 
Now I could make a PR to just generate a throwingdatum right then and there to handle it but uh, I feel like it's probably better for people to custom-implement onZImpact anywys, maybe make it return the highest thing hit if necessary to replicate the behavior without another proc. throw_impact was just a lazy thing I threw on for fun and it's no longer necessary, it'll just lead to inconsistency rather than being a good general solution.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: onZImpact no longer does throw_impact. This was broken anyways. Code must now manually handle multiz falling impacts. This fixes runtimes occuring whenever something fell.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
