### PR TITLE
You can now print pinpointers from autolathes and seclathes

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -795,6 +795,16 @@
 	build_path = /obj/item/restraints/handcuffs
 	category = list("hacked", "Security")
 
+/datum/design/secpinpointer
+	name = "Doomsday Pinpointer"
+	desc = "Tracks the locations of nuclear disks and other doomsday devices."
+	id = "secpinpointer"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/iron = 3000, /datum/material/glass = 1500)
+	build_path = /obj/item/pinpointer
+	category = list("Security")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
 /datum/design/receiver
 	name = "Modular Receiver"
 	id = "receiver"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -11,7 +11,7 @@
 	design_ids = list("basic_matter_bin", "basic_cell", "basic_scanning", "basic_capacitor", "basic_micro_laser", "micro_mani", "basic_electrolite", "c-reader", "desttagger", "salestagger", "handlabel", "packagewrap",
 					"destructive_analyzer", "circuit_imprinter", "experimentor", "rdconsole", "bepis", "design_disk", "tech_disk", "rdserver", "rdservercontrol", "mechfab",
 					"paystand", "space_heater", "bucket", "sec_rshot", "sec_beanbag_slug", "sec_bshot", "sec_slug", "sec_Islug", "sec_dart", "sec_38", "rglass", "plasteel",
-					"plastitanium", "plasmaglass", "plasmareinforcedglass", "titaniumglass", "plastitaniumglass", "plastic_knife", "plastic_fork", "plastic_spoon", "conveyor_belt", "conveyor_switch")
+					"plastitanium", "plasmaglass", "plasmareinforcedglass", "titaniumglass", "plastitaniumglass", "plastic_knife", "plastic_fork", "plastic_spoon", "conveyor_belt", "conveyor_switch", "secpinpointer")
 
 /datum/techweb_node/mmi
 	id = "mmi"


### PR DESCRIPTION
## About The Pull Request

See title.

They cost some metal and some glass to print, but no gold, because then the AI could just sabotage the ore silo to basically ignore this change.

## Why It's Good For The Game

An alternative to https://github.com/tgstation/tgstation/pull/51754.

Nerfs a way to cheese an incredibly easy delta that I've done several times before as a malf AI or malf AI's cyborg: You wall the AI into a 1 tile spot in maint, then hide or destroy the only two nuke pinpointers on the station, then delta and laugh as no one has any way to find the AI's core (without using x-ray, a friendly revenant, mesons if you've set up the 1 tile spot poorly, etc.).

This will also make nuclear emergency rounds less stressful as a crewmember if you have a dumbass captain who insists on not telling the crew where he is, even though the ops all have pinpointers and thus know where he is anyway. Now, you can just print your own pinpointer(s) and follow the captain (to protect him from the ops) anyway.

## Changelog
:cl: ATHATH
balance: Doomsday pinpointers can now be printed from autolathes and seclathes.
/:cl: