### PR TITLE
makes decal painter a basic tool

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -49,6 +49,7 @@ GLOBAL_LIST_INIT(trash_loot, list(//junk: useless, very easy to get, or ghetto c
 		/obj/item/reagent_containers/food/snacks/urinalcake = 1,
 
 		/obj/item/airlock_painter = 1,
+		/obj/item/airlock_painter/decal = 1,
 		/obj/item/rack_parts = 1,
 		/obj/item/clothing/mask/breath = 1,
 		/obj/item/shard = 1,

--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -150,7 +150,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "decal_sprayer"
 	inhand_icon_state = "decalsprayer"
-	custom_materials = list(/datum/material/iron=2000, /datum/material/glass=500)
+	custom_materials = list(/datum/material/iron=50, /datum/material/glass=50)
 	var/stored_dir = 2
 	var/stored_color = ""
 	var/stored_decal = "warningline"

--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -176,12 +176,6 @@
 	if(use_paint(user) && isturf(F))
 		F.AddComponent(/datum/component/decal, 'icons/turf/decals.dmi', stored_decal_total, stored_dir, CLEAN_STRONG, color, null, null, alpha)
 
-/obj/item/airlock_painter/decal/attack_self(mob/user)
-	if((ink) && (ink.charges >= 1))
-		to_chat(user, "<span class='notice'>[src] beeps to prevent you from removing the toner until out of charges.</span>")
-		return
-	. = ..()
-
 /obj/item/airlock_painter/decal/AltClick(mob/user)
 	. = ..()
 	ui_interact(user)

--- a/code/modules/research/bepis.dm
+++ b/code/modules/research/bepis.dm
@@ -34,7 +34,6 @@
 	var/positive_cash_offset = 0
 	var/negative_cash_offset = 0
 	var/minor_rewards = list(/obj/item/stack/circuit_stack/full,	//To add a new minor reward, add it here.
-					/obj/item/airlock_painter/decal,
 					/obj/item/pen/survival,
 					/obj/item/circuitboard/machine/sleeper/party,
 					/obj/item/toy/sprayoncan)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -255,6 +255,15 @@
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
+/datum/design/airlock_painter/decal
+	name = "Decal Painter"
+	id = "decal_painter"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/iron = 50, /datum/material/glass = 50)
+	build_path = /obj/item/airlock_painter/decal
+	category = list("initial","Tools","Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+
 /datum/design/emergency_oxygen
 	name = "Emergency Oxygen Tank"
 	id = "emergency_oxygen"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -48,7 +48,7 @@
 	starting_node = TRUE
 	display_name = "Basic Tools"
 	description = "Basic mechanical, electronic, surgical and botanical tools."
-	design_ids = list("screwdriver", "wrench", "wirecutters", "crowbar", "multitool", "welding_tool", "tscanner", "analyzer", "cable_coil", "pipe_painter", "airlock_painter",
+	design_ids = list("screwdriver", "wrench", "wirecutters", "crowbar", "multitool", "welding_tool", "tscanner", "analyzer", "cable_coil", "pipe_painter", "airlock_painter", "decal_painter",
 					"cultivator", "plant_analyzer", "shovel", "spade", "hatchet", "secateurs", "mop", "plunger")
 
 /datum/techweb_node/basic_medical


### PR DESCRIPTION
## About The Pull Request

Makes the Decal Painter into a Basic Tool instead of a BEPIS unlock. It's very meh for a BEPIS unlock, especially for the Scientists that'll be using it. Though, it does have a use that some builders might like. add some pizazz to your rage cage with a couple of warning tiles!

## Why It's Good For The Game

Imagine spending a shiz ton of money on the BEPIS and getting a glorified Airlock Painter but for floors? -or being a Builder and not being able to get the Decal Painter because you're not a millionaire. NO MORE, for you can now print it off for 50 Metal, 50 Glass. It does take Ink Toner, which only gives a few shots. It'd be easier to use Spray Cans or Crowbarring the Floor if you wanted to be a horrible person. Worst Case: The Halls are filled with warning signs, after someone managed to get a million Ink Toner and had a LOT of free time. I'm just trying to cover my bases when I say, "Please oh god please don't say it being a BEPIS Reward is a good thing.", all it being a game luck does is give it to people who aren't looking for it.

## Changelog
:cl:
del: Removed Decal Painter from BEPIS Minor Rewards
add: Added Decal Painter to the Basic Tools Research Node
add: Added Decal Painter to Maintenance Loot alongside the Airlock Painter
/:cl:
