### PR TITLE
Renames COOLDOWN_CHECK, fixes some light jank

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -63,7 +63,8 @@
 
 #define COOLDOWN_START(cd_source, cd_index, cd_time) (cd_source.cd_index = world.time + cd_time)
 
-#define COOLDOWN_CHECK(cd_source, cd_index) (cd_source.cd_index < world.time)
+//Returns true if the cooldown has run its course, false otherwise
+#define COOLDOWN_FINISHED(cd_source, cd_index) (cd_source.cd_index < world.time)
 
 #define COOLDOWN_RESET(cd_source, cd_index) cd_source.cd_index = 0
 

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -537,7 +537,7 @@
 	if(!isturf(owner.loc)) //Don't let the player use this to escape mechs/welded closets.
 		to_chat(owner, "<span class='warning'>You need more space to activate this implant!</span>")
 		return
-	if(COOLDOWN_CHECK(src, box_cooldown))
+	if(!COOLDOWN_FINISHED(src, box_cooldown))
 		return
 	COOLDOWN_START(src, box_cooldown, 10 SECONDS)
 	var/box = new boxtype(owner.drop_location())

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -51,7 +51,7 @@
 			damage *= 0.75
 
 
-		if(!COOLDOWN_CHECK(src, caltrop_cooldown))
+		if(COOLDOWN_FINISHED(src, caltrop_cooldown))
 			COOLDOWN_START(src, caltrop_cooldown, 1 SECONDS) //cooldown to avoid message spam.
 			var/atom/A = parent
 			if(!H.incapacitated(ignore_restraints = TRUE))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -404,7 +404,7 @@
 /obj/machinery/door/airlock/proc/shock(mob/living/user, prb)
 	if(!istype(user) || !hasPower())		// unpowered, no shock
 		return FALSE
-	if(COOLDOWN_CHECK(src, shockCooldown))
+	if(!COOLDOWN_FINISHED(src, shockCooldown))
 		return FALSE	//Already shocked someone recently?
 	if(!prob(prb))
 		return FALSE //you lucked out, no shock for you


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

COOLDOWN_CHECK  returns true if the cooldown is done, but it was being used as if it returned false when done.

I think this is down to the ambiguous naming, so I've changed it to COOLDOWN_FINISHED instead, and fixed up the uses of it
It doesn't match the timer version, please advise @Rohesie

## Why It's Good For The Game
Makes stealth boxes work, code more clear, all that good stuff.

## Changelog
:cl:
fix: Fixed stealth implants not properly boxing the user, and doors not shocking
refactor: Renamed COOLDOWN_CHECK to COOLDOWN_FINISHED
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
