### PR TITLE
arcade battle bug fix

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -371,8 +371,10 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		if(0 to 2)
 			LAZYADD(last_three_move, player_stance)
 		if(3)
-			LAZYREMOVE(last_three_move, last_three_move[1])
-			LAZYADD(last_three_move, player_stance)
+			for(var/i = 1; i < LAZYLEN(last_three_move); i++)
+				last_three_move[i] = last_three_move[i + 1]
+			last_three_move[LAZYLEN(last_three_move)] = player_stance
+
 		if(4 to INFINITY)
 			last_three_move = null //this shouldn't even happen but we empty the list if it somehow goes above 3
 

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -371,7 +371,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		if(0 to 2)
 			LAZYADD(last_three_move, player_stance)
 		if(3)
-			for(var/i = 1; i < LAZYLEN(last_three_move); i++)
+			for(var/i in 1 to 2)
 				last_three_move[i] = last_three_move[i + 1]
 			last_three_move[3] = player_stance
 

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -572,7 +572,8 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		if(obj_flags & EMAGGED)
 			user.gib()
 		SSblackbox.record_feedback("nested tally", "arcade_results", 1, list("loss", "hp", (obj_flags & EMAGGED ? "emagged":"normal")))
-		user?.mind?.adjust_experience(/datum/skill/gaming, xp_gained+1)//always gain at least 1 point of XP
+
+	user?.mind?.adjust_experience(/datum/skill/gaming, xp_gained+1)//always gain at least 1 point of XP
 
 
 ///used to check if the last three move of the player are the one we want in the right order and if the passive's weakpoint has been triggered yet

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -372,7 +372,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			LAZYADD(last_three_move, player_stance)
 		if(3)
 			for(var/i = 1; i < LAZYLEN(last_three_move); i++)
-				last_three_move[i] = LAZYACCESS(last_three_move, i + 1)
+				last_three_move[i] = last_three_move[i + 1]
 			last_three_move[LAZYLEN(last_three_move)] = player_stance
 
 		if(4 to INFINITY)
@@ -573,7 +573,8 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			user.gib()
 		SSblackbox.record_feedback("nested tally", "arcade_results", 1, list("loss", "hp", (obj_flags & EMAGGED ? "emagged":"normal")))
 
-	user?.mind?.adjust_experience(/datum/skill/gaming, xp_gained+1)//always gain at least 1 point of XP
+	if(gameover)
+		user?.mind?.adjust_experience(/datum/skill/gaming, xp_gained+1)//always gain at least 1 point of XP
 
 
 ///used to check if the last three move of the player are the one we want in the right order and if the passive's weakpoint has been triggered yet

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -372,7 +372,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			LAZYADD(last_three_move, player_stance)
 		if(3)
 			for(var/i = 1; i < LAZYLEN(last_three_move); i++)
-				last_three_move[i] = last_three_move[i + 1]
+				last_three_move[i] = LAZYACCESS(last_three_move, i + 1)
 			last_three_move[LAZYLEN(last_three_move)] = player_stance
 
 		if(4 to INFINITY)

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -373,7 +373,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		if(3)
 			for(var/i = 1; i < LAZYLEN(last_three_move); i++)
 				last_three_move[i] = last_three_move[i + 1]
-			last_three_move[LAZYLEN(last_three_move)] = player_stance
+			last_three_move[3] = player_stance
 
 		if(4 to INFINITY)
 			last_three_move = null //this shouldn't even happen but we empty the list if it somehow goes above 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
funny how I only noticed this bug after it got merged
anyway the bug is kinda weird, the last three move won't be properly registered if the first and third move is the same as the next input. so the input of A,B,A,A will look like A,B,A instead of B,A,A. but other input combo seem to work correctly.

The main reason I didn't realise that sooner because none of the current weakpoint combo are likely to be affected by this bug because of the way they are configured.  but it's still possible, so I'd rather fix it now than forget about it.

also fixes the game not properly giving you gaming XP when you win, that's a pretty big and obvious bug and I have no excuse here.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugs are bad unless they are moths
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed a bug with the battle arcade game where the combos would sometimes not register correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
