### PR TITLE
your liver tox purging threshold is now dependent on the health of your liver

### DIFF
--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -35,7 +35,7 @@
 				//handle liver toxin filtration
 				for(var/datum/reagent/toxin/T in C.reagents.reagent_list)
 					var/thisamount = C.reagents.get_reagent_amount(T.type)
-					if (thisamount && thisamount <= toxTolerance)
+					if (thisamount && thisamount <= toxTolerance * (maxHealth - damage) / maxHealth ) //toxTolerance is effectively multiplied by the % that your liver's health is at
 						C.reagents.remove_reagent(T.type, 1)
 					else
 						damage += (thisamount*toxLethality)


### PR DESCRIPTION
## About The Pull Request

Changes the tox purging threshold for livers from 3u to 3u * [liver's health]/[liver's max health].

## Why It's Good For The Game

should give liver damage an actual impact other than "it's a bit easier for something to bring your liver to full damage (the only thing you actually care about) now". in short, it makes the health of your liver less binary, but in a subtle way (*glares at stomachs*).

## Changelog
:cl: ATHATH
balance: The tox purging threshold for livers has been changed from 3u to 3u * [liver's health]/[liver's maximum health].
/:cl: