### PR TITLE
Fix DNA Console enzyme/disk ejection bluescreen (Issue #51771)

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -149,11 +149,13 @@
 	// Insert data disk if console disk slot is empty
 	// Swap data disk if there is one already a disk in the console
 	if (istype(I, /obj/item/disk/data)) //INSERT SOME DISKETTES
+		// Insert disk into DNA Console
 		if (!user.transferItemToLoc(I,src))
 			return
+		// If insertion was successful and there's already a diskette in the console, eject the old one.
 		if(diskette)
-			diskette.forceMove(drop_location())
-			diskette = null
+			eject_disk(user)
+		// Set the new diskette.
 		diskette = I
 		to_chat(user, "<span class='notice'>You insert [I].</span>")
 		return
@@ -1978,6 +1980,9 @@
 		return
 
 	to_chat(user, "<span class='notice'>You eject [diskette] from [src].</span>")
+
+	// Reset the state to console storage.
+	tgui_view_state["storageMode"] = "console"
 
 	// If the disk shouldn't pop into the user's hand for any reason, drop it on the console instead.
 	if(!istype(user) || !Adjacent(user) || !user.put_in_active_hand(diskette))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #51771 

When I originally recoded the DNA Consoles in tgui I forgot to reset view state when disks were ejected. This can lead to tgui bluescreens with JS null reference errors.

State is now correctly re-set when ejecting disks.

Disk insertion code has had a minor logic change and will now swap disks in-hand if you insert a disk into a console that already contains a disk.

## Why It's Good For The Game

I feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: DNA Console will no longer bluescreen in certain scenarios when disks are ejected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
