### PR TITLE
Gives cyborgs the ability to insert tanks into radiation collectors and canisters by using their crowbar.

### DIFF
--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -53,6 +53,15 @@
 	else if(I.tool_behaviour == TOOL_WRENCH)
 		default_unfasten_wrench(user, I, time = 20)
 		return
+	else if(I.tool_behaviour == TOOL_CROWBAR)
+		if(!contents.len)
+			to_chat(user, "<span class='warn'>The [src] is empty!</span>")
+			return
+		var/obj/item/tank/tank = pick(contents)
+		tank.forceMove(get_turf(src))
+		playsound(user, 'sound/items/crowbar.ogg', 50)
+		update_icon()
+		return
 	else if(user.a_intent != INTENT_HARM)
 		to_chat(user, "<span class='notice'>[I] does not fit into [src].</span>")
 		return

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -86,6 +86,7 @@ As a Cyborg, you are impervious to fires and heat. If you are rogue, you can rel
 As a Cyborg, you are extremely vulnerable to EMPs as EMPs both stun you and damage you. The ion rifle in the armory or a traitor with an EMP kit can kill you in seconds.
 As a Service Cyborg, your spray can knocks people down. However, it is blocked by masks and glasses.
 As an Engineering Cyborg, you can attach air alarm/fire alarm/APC frames to walls by placing them on the floor and using a screwdriver on them.
+As an Engineering Cyborg, you can use your crowbar to insert air tanks into canisters or radiation collectors. You can also use it to pull tanks from a dispenser at random.
 As a Medical Cyborg, you can fully perform surgery and even augment people.
 As a Janitor Cyborg, you are the bane of all slaughter demons and even Bubblegum himself. Cleaning up blood stains will severely gimp them.
 As the Chief Engineer, you can rename areas or create entirely new ones using your station blueprints.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows cyborgs the ability to insert a tank into a radiation collector or canister by using their crowbar. They have to stand two tiles from the target machine with the tank sitting in the middle, and then click on the tank with their crowbar.

To compliment this change, using any crowbar on a tank dispenser will remove one random item from inside (as borgs otherwise have no other way of accessing the tanks save for smashing the dispenser).

Added a tip detailing the above to the tips.txt file.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows for engineer borgs to actually finish engine setup.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Cyborgs can now use their crowbar tool to leverage a tank into a radiation collector or canister, and can also use it to pull a tank at random from a dispenser.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
