### PR TITLE
Chameleon tie stolen valor fix

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -668,6 +668,7 @@
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/neck
+	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/neck/cloak/skill_reward)
 	chameleon_action.chameleon_name = "Neck Accessory"
 	chameleon_action.initialize_disguises()
 


### PR DESCRIPTION
:cl: ShizCalev
fix: Chameleon ties can no longer disguise as skill capes.
/:cl:

Fixes #51739