### PR TITLE
Fixes reagent exposure on transfer.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -449,13 +449,12 @@
   * - show_message: Whether to display anything to mobs when they are exposed.
   */
 /atom/proc/expose_reagents(list/reagents, datum/reagents/source, method=TOUCH, volume_modifier=1, show_message=TRUE)
-	. = SEND_SIGNAL(src, COMSIG_ATOM_EXPOSE_REAGENTS, reagents, source, method, volume_modifier, show_message)
-	if(. & COMPONENT_NO_EXPOSE_REAGENTS)
+	if((. = SEND_SIGNAL(src, COMSIG_ATOM_EXPOSE_REAGENTS, reagents, source, method, volume_modifier, show_message)) & COMPONENT_NO_EXPOSE_REAGENTS)
 		return
 
 	for(var/reagent in reagents)
 		var/datum/reagent/R = reagent
-		. |= R.expose_atom(src, reagents[R] || (R.volume * volume_modifier))
+		. |= R.expose_atom(src, reagents[R])
 
 /// Are you allowed to drop this atom
 /atom/proc/AllowDrop()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -346,10 +346,9 @@
 
 /// Handles exposing an object to reagents.
 /obj/expose_reagents(list/reagents, datum/reagents/source, method=TOUCH, volume_modifier=1, show_message=TRUE)
-	. = ..()
-	if(. & COMPONENT_NO_EXPOSE_REAGENTS)
+	if((. = ..()) & COMPONENT_NO_EXPOSE_REAGENTS)
 		return
 
 	for(var/reagent in reagents)
 		var/datum/reagent/R = reagent
-		R.expose_obj(src, reagents[R] || (R.volume * volume_modifier))
+		. |= R.expose_obj(src, reagents[R])

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -549,10 +549,9 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 /// Handles exposing a turf to reagents.
 /turf/expose_reagents(list/reagents, datum/reagents/source, method=TOUCH, volume_modifier=1, show_message=TRUE)
-	. = ..()
-	if(. & COMPONENT_NO_EXPOSE_REAGENTS)
+	if((. = ..()) & COMPONENT_NO_EXPOSE_REAGENTS)
 		return
 
 	for(var/reagent in reagents)
 		var/datum/reagent/R = reagent
-		. |= R.expose_turf(src, reagents[R] || (R.volume * volume_modifier))
+		. |= R.expose_turf(src, reagents[R])

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -441,8 +441,7 @@
   * If the method is VAPOR it incorporates permiability protection.
   */
 /mob/living/expose_reagents(list/reagents, datum/reagents/source, method=TOUCH, volume_modifier=1, show_message=TRUE)
-	. = ..()
-	if(. & COMPONENT_NO_EXPOSE_REAGENTS)
+	if((. = ..()) & COMPONENT_NO_EXPOSE_REAGENTS)
 		return
 
 	if(method == INGEST)
@@ -451,4 +450,4 @@
 	var/touch_protection = (method == VAPOR) ? get_permeability_protection() : 0
 	for(var/reagent in reagents)
 		var/datum/reagent/R = reagent
-		. |= R.expose_mob(src, method, reagents[R] || (R.volume * volume_modifier), show_message, touch_protection)
+		. |= R.expose_mob(src, method, reagents[R], show_message, touch_protection)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -664,12 +664,15 @@
 	if(isnull(A))
 		return null
 
-	if(!istype(R))
+	if(ispath(R))
 		R = get_reagent(R)
-		if(isnull(R))
-			return null
+	if(isnull(R))
+		return null
 
-	return A.expose_reagents(list(R = R.volume * volume_modifier), src, method, volume_modifier, show_message)
+	// Do not move this inline, BYOND interprets list(R = R.volume * volume_modifier) as list("R" = R.volume * volume_modifier) and you end up passing a string instead of a datum.
+	var/reagent_to_expose = list()
+	reagent_to_expose[R] = R.volume * volume_modifier
+	return A.expose_reagents(reagent_to_expose, src, method, volume_modifier, show_message)
 
 /// Is this holder full or not
 /datum/reagents/proc/holder_full()

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -669,10 +669,8 @@
 	if(isnull(R))
 		return null
 
-	// Do not move this inline, BYOND interprets list(R = R.volume * volume_modifier) as list("R" = R.volume * volume_modifier) and you end up passing a string instead of a datum.
-	var/reagent_to_expose = list()
-	reagent_to_expose[R] = R.volume * volume_modifier
-	return A.expose_reagents(reagent_to_expose, src, method, volume_modifier, show_message)
+	// Yes, we need the parentheses.
+	return A.expose_reagents(list((R) = R.volume * volume_modifier), src, method, volume_modifier, show_message)
 
 /// Is this holder full or not
 /datum/reagents/proc/holder_full()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Did you know that BYOND interprets `list(var = whatever)` as `list("var" = whatever)`? I didn't, and accidentally broke synthflesh, along with every other instance of exposure on transferal. This fixes that and condenses reagent code a bit.

## Why It's Good For The Game

Fixes a bug I made. #51799
Cleans up some code.

## Changelog
:cl:
fix: Synthflesh works again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
