### PR TITLE
Change pierced reality messages, message order

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -63,6 +63,8 @@
 #define COMSIG_ATOM_ATTACK_ANIMAL "attack_animal"
 ///from base of atom/examine(): (/mob)
 #define COMSIG_PARENT_EXAMINE "atom_examine"
+///from base of /mob/verb/examinate(): (atom/target)
+#define COMSIG_ATOM_POST_EXAMINATE "atom_post_examinate"
 ///from base of atom/get_examine_name(): (/mob, list/overrides)
 #define COMSIG_ATOM_GET_EXAMINE_NAME "atom_examine_name"
 #define COMSIG_PARENT_EXAMINE_MORE "atom_examine_more"                    ///from base of atom/examine_more(): (/mob)

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -166,18 +166,29 @@
 		RS.RemoveMind(M)
 
 /obj/effect/broken_illusion
-	name = "Pierced reality"
+	name = "\proper pierced reality" // That's pierced reality. Not "the" pierced reality
+	desc = "The light tubes flicker like shadows. Dreams ripple behind the surface of bathroom mirrors. I must be careful not to drift from the waking world."
 	icon = 'icons/effects/eldritch.dmi'
 	icon_state = "pierced_illusion"
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
+/obj/effect/broken_illusion/Initialize()
+	. = ..()
+
+	// Brain damage can cause messages, so we want to do the damage after the examine text, so it makes sense
+	RegisterSignal(src, COMSIG_ATOM_POST_EXAMINATE, .proc/brain_melting)
+
 /obj/effect/broken_illusion/examine(mob/user)
+	. = ..()
+
+	if(!IS_HERETIC(user) && ishuman(user))
+		. += "<span class='warning'>Light LEAKS through the CRACKS. My mind is BRIGHTER than it EVER was. THE HIGHER I RISE THE MORE I SEE.</span>"
+
+/obj/effect/broken_illusion/proc/brain_melting(datum/source, mob/user)
 	if(!IS_HERETIC(user) && ishuman(user))
 		var/mob/living/carbon/human/human_user = user
-		to_chat(human_user,"<span class='warning'>Your brain hurts when you look at this!</span>")
-		human_user.adjustOrganLoss(ORGAN_SLOT_BRAIN,10)
-	. = ..()
+		human_user.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
 
 /obj/effect/reality_smash
 	name = "/improper reality smash"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -432,6 +432,7 @@
 
 	to_chat(src, result.Join("\n"))
 	SEND_SIGNAL(src, COMSIG_MOB_EXAMINATE, A)
+	SEND_SIGNAL(A, COMSIG_ATOM_POST_EXAMINATE, src)
 
 /mob/proc/clear_from_recent_examines(atom/A)
 	if(QDELETED(A) || !client)


### PR DESCRIPTION
`pierced reality` now no longer has a capital P, but is considered
a proper noun, so will still be examined as "That's pierced reality."

Added a themed examine description, along with a new brain melting
message.

Used new signal to apply brain damage _after_ examine message has been
sent, rather than before.