### PR TITLE
Reality_smash refactor, makes them less shitcode by utlizing sight

### DIFF
--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -4,8 +4,8 @@
 
 #define SEE_INVISIBLE_LIVING 25
 
-//#define SEE_INVISIBLE_LEVEL_ONE 35 //currently unused
-//#define INVISIBILITY_LEVEL_ONE 35 //currently unused
+#define SEE_INVISIBLE_LEVEL_ONE 35
+#define INVISIBILITY_LEVEL_ONE 35
 
 //#define SEE_INVISIBLE_LEVEL_TWO 45 //currently unused
 //#define INVISIBILITY_LEVEL_TWO 45 //currently unused

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -124,7 +124,7 @@
 
 	if(mob_override)
 		current = mob_override
-	current.see_invisible = INVISIBILITY_LEVEL_ONE
+	current.see_invisible = SEE_INVISIBLE_LEVEL_ONE
 	add_antag_hud(antag_hud_type, antag_hud_name, current)
 	handle_clown_mutation(current, mob_override ? null : "Knowledge described in the book allowed you to overcome your clownish nature, allowing you to use complex items effectively.")
 	current.faction |= "heretics"

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -33,7 +33,7 @@
 		gain_knowledge(/datum/eldritch_knowledge/spell/basic)
 		gain_knowledge(/datum/eldritch_knowledge/living_heart)
 	current.log_message("has been converted to the cult of the forgotten ones!", LOG_ATTACK, color="#960000")
-	GLOB.reality_smash_track.AddMind(owner)
+	GLOB.reality_smash_track.Generate()
 	START_PROCESSING(SSprocessing,src)
 	if(give_equipment)
 		equip_cultist()
@@ -49,7 +49,7 @@
 		owner.current.visible_message("<span class='deconversion_message'>[owner.current] looks like [owner.current.p_theyve()] just reverted to [owner.current.p_their()] old faith!</span>", null, null, null, owner.current)
 		to_chat(owner.current, "<span class='userdanger'>Your mind begins to flare as the otherwordly knowledge escapes your grasp!</span>")
 		owner.current.log_message("has renounced the cult of the old ones!", LOG_ATTACK, color="#960000")
-	GLOB.reality_smash_track.RemoveMind(owner)
+	GLOB.reality_smash_track.target_amount--
 	STOP_PROCESSING(SSprocessing,src)
 
 	return ..()
@@ -121,8 +121,10 @@
 /datum/antagonist/heretic/apply_innate_effects(mob/living/mob_override)
 	. = ..()
 	var/mob/living/current = owner.current
+
 	if(mob_override)
 		current = mob_override
+	current.see_invisible = INVISIBILITY_LEVEL_ONE
 	add_antag_hud(antag_hud_type, antag_hud_name, current)
 	handle_clown_mutation(current, mob_override ? null : "Knowledge described in the book allowed you to overcome your clownish nature, allowing you to use complex items effectively.")
 	current.faction |= "heretics"
@@ -132,6 +134,7 @@
 	var/mob/living/current = owner.current
 	if(mob_override)
 		current = mob_override
+	current.see_invisible = initial(current.see_invisible)
 	remove_antag_hud(antag_hud_type, antag_hud_name, current)
 	handle_clown_mutation(current, removing = FALSE)
 	current.faction -= "heretics"


### PR DESCRIPTION
## About The Pull Request

Changes how reality_smash 'es work, they no longer track everyone that can see them, but isntead rely on invisibility.

Also makes them actually spawn randomly on the station.

Also adds a fun tk interaction :^)

## Why It's Good For The Game

Code clarity and bugfixing is good

## Changelog
:cl:
fix: Influences now actually spawn randomly, instead of one per area.
code: Influences are less shitcodey
add: New pierced reality tk interaction...
/:cl:

