### PR TITLE
Add chance of loot to roundstart toilets

### DIFF
--- a/code/controllers/subsystem/materials.dm
+++ b/code/controllers/subsystem/materials.dm
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(materials)
 	///List of stackcrafting recipes for materials using rigid materials
 	var/list/rigid_stack_recipes = list(
 		new /datum/stack_recipe("Chair", /obj/structure/chair/greyscale, one_per_turf = TRUE, on_floor = TRUE, applies_mats = TRUE),
-		new /datum/stack_recipe("Toilet", /obj/structure/toilet/greyscale, one_per_turf = TRUE, on_floor = TRUE, applies_mats = TRUE),
+		new /datum/stack_recipe("Toilet", /obj/structure/toilet/greyscale/built, one_per_turf = TRUE, on_floor = TRUE, applies_mats = TRUE),
 		new /datum/stack_recipe("Sink", /obj/structure/sink/greyscale, one_per_turf = TRUE, on_floor = TRUE, applies_mats = TRUE),
 		new /datum/stack_recipe("Floor tile", /obj/item/stack/tile/material, 1, 4, 20, applies_mats = TRUE),
 	)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -147,6 +147,7 @@
 /obj/structure/toilet/secret
 	var/obj/item/secret
 	var/secret_type = null
+	loot_chance = 0  // Don't want RNG to conflict with the mapper's vision
 
 /obj/structure/toilet/secret/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -12,11 +12,29 @@
 	var/buildstacktype = /obj/item/stack/sheet/metal //they're metal now, shut up
 	var/buildstackamount = 1
 
+	// Chance that there's something hanging around in the cistern
+	var/loot_chance = 33
+
 /obj/structure/toilet/Initialize()
 	. = ..()
 	open = round(rand(0, 1))
 	update_icon()
 
+	if(prob(loot_chance))
+		spawn_loot()
+
+/obj/structure/toilet/proc/spawn_loot()
+	var/loot = GLOB.maintenance_loot
+	var/spawn_type = pickweight(loot)
+	while(islist(spawn_type))
+		spawn_type = pickweight(spawn_type)
+
+	var/obj/item/I = new spawn_type(src)
+	// Can't spawn items which we wouldn't accept being hidden in the toilet in the first place
+	if (!istype(I) || (w_items + I.w_class) >= WEIGHT_CLASS_HUGE)
+		qdel(I)
+	else
+		w_items += I.w_class
 
 /obj/structure/toilet/attack_hand(mob/living/user)
 	. = ..()
@@ -141,6 +159,9 @@
 /obj/structure/toilet/greyscale
 	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	buildstacktype = null
+
+/obj/structure/toilet/greyscale/built
+	loot_chance = 0
 
 /obj/structure/urinal
 	name = "urinal"


### PR DESCRIPTION
:cl: coiax
add: Occasionally toilets can have random stuff in the cistern, at the
start of the shift.
/:cl:

Before, if you find an item in a toilet, someone deliberately hid it
there. Now there's a slim chance that maybe that welding torch in the
brig toilet was there through dumb luck, and not an inside job.

Constructed toilets do not come with a chance of maintenance loot.

Sanity checks are present to ensure that something isn't spawned inside
the cistern that you wouldn't be able to put back, and the
`spawn_loot()` proc is seperate, in case for some reason an admin wants
to call it repeatedly. (Did you know you could hide more than one item
in a cistern?)