### PR TITLE
Combine RDS quirk with schizophrenia

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -185,6 +185,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_DWARF				"dwarf"
 #define TRAIT_SILENT_FOOTSTEPS	"silent_footsteps" //makes your footsteps completely silent
 #define TRAIT_NICE_SHOT			"nice_shot" //hnnnnnnnggggg..... you're pretty good....
+#define TRAIT_NO_HALLUCINATION  "no_hallucination" /// when present, the mob does not hallucinate, even if they would otherwise.
 
 //non-mob traits
 #define TRAIT_PARALYSIS				"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it

--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -5,6 +5,8 @@
 /datum/brain_trauma/mild
 
 /datum/brain_trauma/mild/hallucinations
+	// Has a special interaction with /datum/reagent/toxin/mindbreaker
+	// If this trauma is present, the toxin becomes beneficial
 	name = "Hallucinations"
 	desc = "Patient suffers constant hallucinations."
 	scan_desc = "schizophrenia"

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -75,6 +75,22 @@
 	. = ..()
 	REMOVE_TRAIT(owner, TRAIT_SOOTHED_THROAT, "[STATUS_EFFECT_TRAIT]_[id]")
 
+
+/datum/status_effect/hallucination_suppression
+	id = "hallucination_supression"
+	duration = 11 SECONDS  /// default cigarette drag time + 1 second
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = null
+
+/datum/status_effect/hallucination_suppression/on_apply()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_NO_HALLUCINATION, "[STATUS_EFFECT_TRAIT]_[id]")
+
+/datum/status_effect/hallucination_suppression/on_remove()
+	. = ..()
+	REMOVE_TRAIT(owner, TRAIT_NO_HALLUCINATION, "[STATUS_EFFECT_TRAIT]_[id]")
+
+
 /datum/status_effect/bounty
 	id = "bounty"
 	status_type = STATUS_EFFECT_UNIQUE

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -415,30 +415,47 @@
 	hardcore_value = 4
 
 /datum/quirk/insanity
-	name = "Reality Dissociation Syndrome"
+	name = "Reality Dissociation Syndrome"  // also known as permament schitzophrenia
 	desc = "You suffer from a severe disorder that causes very vivid hallucinations. Mindbreaker toxin can suppress its effects, and you are immune to mindbreaker's hallucinogenic properties. <b>This is not a license to grief.</b>"
 	value = -2
-	//no mob trait because it's handled uniquely
-	gain_text = "<span class='userdanger'>...</span>"
-	lose_text = "<span class='notice'>You feel in tune with the world again.</span>"
-	medical_record_text = "Patient suffers from acute Reality Dissociation Syndrome and experiences vivid hallucinations."
+	//no mob trait because it's handled by the gaining/losing of the trauma
+	gain_text = null
+	lose_text = null
+	medical_record_text = "Patient suffers from acute schizophrenia and experiences vivid hallucinations."
 	hardcore_value = 6
+	var/datum/brain_trauma/mild/hallucinations/trauma
+	var/where_pack  /// where the emergency Leary's are
+	var/where_lighter /// where the lighter for smoking your Leary's is
 
-/datum/quirk/insanity/on_process()
-	if(quirk_holder.reagents.has_reagent(/datum/reagent/toxin/mindbreaker, needs_metabolizing = TRUE))
-		quirk_holder.hallucination = 0
-		return
-	if(prob(2)) //we'll all be mad soon enough
-		madness()
+/datum/quirk/insanity/add()
+	trauma = new()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(trauma, TRAUMA_RESILIENCE_ABSOLUTE)
 
-/datum/quirk/insanity/proc/madness()
-	quirk_holder.hallucination += rand(10, 25)
+/datum/quirk/insanity/remove()
+	qdel(trauma)
+
+/datum/quirk/insanity/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+
+	var/list/slots = list(
+		"in your left pocket" = ITEM_SLOT_LPOCKET,
+		"in your right pocket" = ITEM_SLOT_RPOCKET,
+		"in your backpack" = ITEM_SLOT_BACKPACK
+	)
+	var/learys = new /obj/item/storage/fancy/cigarettes/cigpack_mindbreaker(get_turf(H))
+	var/lighter = new /obj/item/lighter/greyscale(get_turf(H))
+
+	where_pack = H.equip_in_one_of_slots(learys, slots, FALSE) || "at your feet"
+	where_lighter = H.equip_in_one_of_slots(lighter, slots, FALSE) || "at your feet"
 
 /datum/quirk/insanity/post_add() //I don't /think/ we'll need this but for newbies who think "roleplay as insane" = "license to kill" it's probably a good thing to have
 	if(!quirk_holder.mind || quirk_holder.mind.special_role)
 		return
 	to_chat(quirk_holder, "<span class='big bold info'>Please note that your dissociation syndrome does NOT give you the right to attack people or otherwise cause any interference to \
 	the round. You are not an antagonist, and the rules will treat you the same as other crewmembers.</span>")
+
+	to_chat(quirk_holder, "<span class='boldnotice'>There is a packet of Leary's Delight [where_pack], and a lighter [where_lighter], which can keep the visions at bay. Make good use of them, they're technically illegal.</span>")
 
 /datum/quirk/social_anxiety
 	name = "Social Anxiety"

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -31,6 +31,10 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 
 	hallucination--
 
+	// Hallucination stat continues to tick down, but actual effects are supressed
+	if(HAS_TRAIT(src, TRAIT_NO_HALLUCINATION))
+		return
+
 	if(world.time < next_hallucination)
 		return
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -263,7 +263,7 @@
 	return(istype(src.wear_mask, /obj/item/clothing/mask/muzzle))
 
 /mob/living/carbon/hallucinating()
-	if(hallucination)
+	if(hallucination && !HAS_TRAIT(src, TRAIT_NO_HALLUCINATION))
 		return TRUE
 	else
 		return FALSE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -711,7 +711,7 @@
 		var/status = ""
 		var/brutedamage = LB.brute_dam
 		var/burndamage = LB.burn_dam
-		if(hallucination)
+		if(hallucinating())
 			if(prob(30))
 				brutedamage += rand(30,40)
 			if(prob(30))

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -34,6 +34,8 @@
 			if(filterToxins && !HAS_TRAIT(owner, TRAIT_TOXINLOVER))
 				//handle liver toxin filtration
 				for(var/datum/reagent/toxin/T in C.reagents.reagent_list)
+					if(!T.liver_filter(C, src))
+						continue
 					var/thisamount = C.reagents.get_reagent_amount(T.type)
 					if (thisamount && thisamount <= toxTolerance)
 						C.reagents.remove_reagent(T.type, 1)


### PR DESCRIPTION
During a hardmode character playthrough, I noticed that being an RDS
sufferer, even when swigging mindbreaker, hallucinations still occured,
because the mindbreaker was adding its own hallucination stacks.

I decided to combine RDS with the hallucinations (schizophrenia) brain
trauma, since they overlap essentially in function (both having
constant, or occasional hallucinations).

Mindbreaker toxin now checks for the presence of the hallucination brain
trauma, and supresses all hallucinations if it is present (so no changes
need to be made to the trauma itself, the TRAIT_NO_HALLUCINATE is a
different way of supressing hallucinations).

During testing, I discovered that "mindbreaker cigarettes" were
completely ineffectual in preventing hallucinations when a person had a
functional liver, as the small doses of  mindbreaker (and the lipocide)
were being filtered out by the liver's action.

`/datum/reagent/toxin` now has a new proc to allow a reagent to skip
being filtered by the liver if it is actually beneficial (or I suppose,
if someone wants to make a reagent, parented under
`/datum/reagent/toxin` that the liver ignores).

The Leary's Delight cigarettes were a fun discovery, so all RDS
sufferers now spawn with a pack.

:cl: coiax
tweak: Reality Dissociation Syndrome is now mechanically the same as the
brain trauma schizophrenia.
fix: Mindbreaker no longer causes hallucinations if a person has Reality
Dissociation Syndrome or schizophrenia.
balance: Mindbreaker is metabolized slower if it is applying a
beneficial effect (if the patient has RDS or schizophrenia), and is not
filtered by the liver when acting beneficially.
add: RDS quirk holders now spawn with a packet of Leary's Delight,
for non-sufferers, "mindbreaker rollies", but for an RDS sufferer, a
temporary reprieve from hallucinations. Be sparing, you can't buy them
in any vendor on the station.
/:cl: