### PR TITLE
Makes pierced reality thingys actually scary.

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -196,13 +196,14 @@
 	else
 		//a very elaborate way to suicide
 		to_chat(human_user,"<span class='userdanger'>Eldritch energy lashes out, piercing your fragile mind, tearing it to pieces!</span>")
+		human_user.ghostize()
 		var/obj/item/bodypart/head/head = locate() in human_user.bodyparts
 		if(head)
 			head.dismember()
 			qdel(head)
 		else
 			human_user.gib()
-		human_user.ghostize()
+
 		var/datum/effect_system/reagents_explosion/explosion = new()
 		explosion.set_up(1, get_turf(human_user), 1, 0)
 		explosion.start()

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -135,7 +135,7 @@
 		var/obj/effect/broken_illusion/what_if_i_had_one_but_got_used = locate() in range(1, chosen_location)
 		if(what_if_i_have_one || what_if_i_had_one_but_got_used) //we dont want to spawn
 			continue
-		var/obj/effect/reality_smash/RS = new/obj/effect/reality_smash(chosen_location.loc)
+		var/obj/effect/reality_smash/RS = new/obj/effect/reality_smash(chosen_location)
 		smashes += RS
 	ReworkNetwork()
 
@@ -171,6 +171,23 @@
 	icon_state = "pierced_illusion"
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
+
+/obj/effect/broken_illusion/attack_tk(mob/user)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/human_user = user
+	if(IS_HERETIC(human_user))
+		to_chat(human_user,"<span class='warning'>You know better than to tempt forces out of your control.!</span>")
+	else
+		//a very elaborate way to suicide
+		to_chat(human_user,"<span class='boldwarning'>Eldritch energy lashes out, piercing your fragile mind, tearing it to pieces!</span>")
+		var/obj/item/bodypart/head/head = human_user.bodyparts
+		human_user.ghostize()
+		qdel(head)
+		human_user.update_body_parts_head_only()
+		var/datum/effect_system/reagents_explosion/explosion = new()
+		explosion.set_up(5 , get_turf(human_user), 0, 0)
+		explosion.start()
 
 /obj/effect/broken_illusion/examine(mob/user)
 	if(!IS_HERETIC(user) && ishuman(user))
@@ -230,7 +247,7 @@
 
 ///Generates random name
 /obj/effect/reality_smash/proc/generate_name()
-	var/static/list/prefix = list("Omniscient","Thundering","Enlightening","Intrusive","Rejectful","Atomized","Subtle","Rising","Lowering","Fleeting","Towering","Blissful")
-	var/static/list/postfix = list("Flaw","Presence","Crack","Heat","Cold","Memory","Reminder","Breeze")
+	var/static/list/prefix = list("Omniscient","Thundering","Enlightening","Intrusive","Rejectful","Atomized","Subtle","Rising","Lowering","Fleeting","Towering","Blissful","Arrogant","Threatening","Peaceful","Aggressive")
+	var/static/list/postfix = list("Flaw","Presence","Crack","Heat","Cold","Memory","Reminder","Breeze","Grasp","Sight","Whisper","Flow","Touch","Veil","Thought","Imperfection","Blemish","Blush")
 
 	name = pick(prefix) + " " + pick(postfix)

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -171,30 +171,6 @@
 	icon_state = "pierced_illusion"
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	///List of possible effects
-	var/static/list/effect_list = list("Heat","Cool","Idle")
-	///The effect we chose
-	var/effect
-
-
-/obj/effect/broken_illusion/Initialize()
-	. = ..()
-	effect = pick(effect_list)
-	if(effect != "Idle")
-		name = effect+"ing "+name
-	START_PROCESSING(SSobj,src)
-
-/obj/effect/broken_illusion/process()
-	switch(effect)
-		if("Heat")
-			change_temp_on_turf(1)
-		if("Cool")
-			change_temp_on_turf(-1)
-
-/obj/effect/broken_illusion/proc/change_temp_on_turf(_temp = 0)
-	var/turf/current_turf = get_turf(src)
-	var/datum/gas_mixture/env = current_turf.return_air()
-	env.temperature += _temp
 
 /obj/effect/broken_illusion/attack_hand(mob/living/user)
 	if(!ishuman(user))

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -221,9 +221,12 @@
 		//a very elaborate way to suicide
 		to_chat(human_user,"<span class='userdanger'>Eldritch energy lashes out, piercing your fragile mind, tearing it to pieces!</span>")
 		var/obj/item/bodypart/head/head = locate() in human_user.bodyparts
+		if(head)
+			head.dismember()
+			qdel(head)
+		else
+			human_user.gib()
 		human_user.ghostize()
-		head.dismember()
-		qdel(head)
 		var/datum/effect_system/reagents_explosion/explosion = new()
 		explosion.set_up(1, get_turf(human_user), 1, 0)
 		explosion.start()


### PR DESCRIPTION
## About The Pull Request

Adds a bunch of interaction for pierced realities to make their presence have bigger impact on the game.
Also fixes a bug with illusions spawning only on a single tile of an area.. oops

Trying to interact with them using TK will cause your head to literally explode in a very flashy manner.

Trying to interact with them using your hand has a 25% chance of dismembering the limb and qdeling it.

## Why It's Good For The Game

Pierced realities are underwhelming in their effect. Currently examining them gives you 10 brain damage, this expands this 'conditional' deadliness onto diffrent aspects of trying to interact with them.

## Changelog
:cl:
add: Otherwordly presence has taken more control over the holes in reality.
fix: Influences now actually spawn randomly on the station.

/:cl:

