### PR TITLE
Fixes a scenario where you would be unable to offer someone an item if you already had a pending item offer with someone else standing near you

### DIFF
--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -170,10 +170,10 @@
 					"<span class='notice'>You offer [receiving]</span>", null, 2)
 	for(var/mob/living/carbon/C in orange(1, src))
 		if(!CanReach(C))
-			return
+			continue
 		var/obj/screen/alert/give/G = C.throw_alert("[src]", /obj/screen/alert/give)
 		if(!G)
-			return
+			continue
 		G.setup(C, src, receiving)
 
 /**


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed a scenario where you would be unable to offer someone an item if you already had a pending item offer with someone else standing near you.
/:cl:
