### PR TITLE
Fixes bronze golems and bone rattling when dead mobs are around

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -805,7 +805,7 @@
 	last_gong_time = world.time
 	for(var/mob/living/M in get_hearers_in_view(7,H))
 		if(M.stat == DEAD)	//F
-			return
+			continue
 		if(M == H)
 			H.show_message("<span class='narsiesmall'>You cringe with pain as your body rings around you!</span>", MSG_AUDIBLE)
 			H.playsound_local(H, 'sound/effects/gong.ogg', 100, TRUE)
@@ -999,7 +999,7 @@
 		playsound(get_turf(owner),'sound/magic/RATTLEMEBONES.ogg', 100)
 	for(var/mob/living/L in orange(7, get_turf(owner)))
 		if((L.mob_biotypes & MOB_UNDEAD) || isgolem(L) || HAS_TRAIT(L, TRAIT_RESISTCOLD))
-			return //Do not affect our brothers
+			continue //Do not affect our brothers
 
 		to_chat(L, "<span class='cultlarge'>A spine-chilling sound chills you to the bone!</span>")
 		L.apply_status_effect(/datum/status_effect/bonechill)


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed bronze golems' gong ability not working if there was a dead mob on screen.
fix: Fixed bone golems' bonechill ability not working if there was any mobs that were undead, resistant to cold, or also golems on screen.
/:cl:
