### PR TITLE
Fixes revenants being unable to use their light breaking / overload ability if there's a single broken / turned off light in the same turf

### DIFF
--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -199,7 +199,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/overload/proc/overload(turf/T, mob/user)
 	for(var/obj/machinery/light/L in T)
 		if(!L.on)
-			return
+			continue
 		L.visible_message("<span class='warning'><b>\The [L] suddenly flares brightly and begins to spark!</span>")
 		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 		s.set_up(4, 0, L)


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed revenant's light overload ability not blowing lights in a square if there was another broken/burnt out/empty light in it.
/:cl: