### PR TITLE
Fixes attacking cameras with a peice of paper not giving notifications if there's a dead AI somewhere

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -322,7 +322,7 @@
 			if(isAI(O))
 				var/mob/living/silicon/ai/AI = O
 				if(AI.control_disabled || (AI.stat == DEAD))
-					return
+					continue
 				if(U.name == "Unknown")
 					to_chat(AI, "<span class='name'>[U]</span> holds <a href='?_src_=usr;show_paper=1;'>\a [itemname]</a> up to one of your cameras ...")
 				else


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed showing a piece of paper to a camera not working if there was an AI that had died or has remote access disabled.
/:cl:
