### PR TITLE
Fixes bank cards not giving alerts if a mob is around you that has messages disabled

### DIFF
--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -78,25 +78,29 @@
 				icon_source = id_card.get_cached_flat_icon()
 		var/mob/card_holder = recursive_loc_check(A, /mob)
 		if(ismob(card_holder)) //If on a mob
-			if(card_holder.client && !(card_holder.client.prefs.chat_toggles & CHAT_BANKCARD) && !force)
+			if(!card_holder.client || (!(card_holder.client.prefs.chat_toggles & CHAT_BANKCARD) && !force))
 				return
 
-			card_holder.playsound_local(get_turf(card_holder), 'sound/machines/twobeep_high.ogg', 50, TRUE)
 			if(card_holder.can_hear())
+				card_holder.playsound_local(get_turf(card_holder), 'sound/machines/twobeep_high.ogg', 50, TRUE)
 				to_chat(card_holder, "[icon2html(icon_source, card_holder)] <span class='notice'>[message]</span>")
 		else if(isturf(A.loc)) //If on the ground
-			for(var/mob/M in hearers(1,get_turf(A)))
-				if(M.client && !(M.client.prefs.chat_toggles & CHAT_BANKCARD) && !force)
-					return
-				playsound(A, 'sound/machines/twobeep_high.ogg', 50, TRUE)
-				A.audible_message("[icon2html(icon_source, hearers(A))] <span class='notice'>[message]</span>", null, 1)
-				break
-		else
-			for(var/mob/M in A.loc) //If inside a container with other mobs (e.g. locker)
-				if(M.client && !(M.client.prefs.chat_toggles & CHAT_BANKCARD) && !force)
-					return
-				M.playsound_local(get_turf(M), 'sound/machines/twobeep_high.ogg', 50, TRUE)
+			var/turf/T = A.loc
+			for(var/mob/M in hearers(1,T))
+				if(!M.client || (!(M.client.prefs.chat_toggles & CHAT_BANKCARD) && !force))
+					continue
 				if(M.can_hear())
+					M.playsound_local(T, 'sound/machines/twobeep_high.ogg', 50, TRUE)
+					to_chat(M, "[icon2html(icon_source, M)] <span class='notice'>[message]</span>")
+		else
+			var/atom/sound_atom
+			for(var/mob/M in A.loc) //If inside a container with other mobs (e.g. locker)
+				if(!M.client || (!(M.client.prefs.chat_toggles & CHAT_BANKCARD) && !force))
+					continue
+				if(!sound_atom)
+					sound_atom = A.drop_location() //in case we're inside a bodybag in a crate or something. doing this here to only process it if there's a valid mob who can hear the sound.
+				if(M.can_hear())
+					M.playsound_local(get_turf(sound_atom), 'sound/machines/twobeep_high.ogg', 50, TRUE)
 					to_chat(M, "[icon2html(icon_source, M)] <span class='notice'>[message]</span>")
 
 /datum/bank_account/department


### PR DESCRIPTION
:cl: ShizCalev
fix: Bank cards will now still give you notifications if you're standing next to another player who has them disabled.
/:cl:

Also some minor performance optimizations.