### PR TITLE
Fix donuts having two Initialize overrides

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -20,12 +20,9 @@
 
 /obj/item/reagent_containers/food/snacks/donut/Initialize()
 	. = ..()
+	AddElement(/datum/element/dunkable, 10)
 	if(prob(30))
 		decorate_donut()
-
-/obj/item/reagent_containers/food/snacks/donut/Initialize()
-	. = ..()
-	AddElement(/datum/element/dunkable, 10)
 
 /obj/item/reagent_containers/food/snacks/donut/proc/decorate_donut()
 	if(is_decorated || !decorated_icon)


### PR DESCRIPTION
Donut's initialization was split, one handing dunking and the other
handling sprinkles, so they're now in a single proc definition.