### PR TITLE
Arcade Machines now show combos when examine_more is used

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -592,6 +592,15 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	last_three_move = null
 	return ..() //well boys we did it, lists are no more
 
+/obj/machinery/computer/arcade/battle/examine_more(mob/user)
+	to_chat(user, "<span class='notice'>Scribbled on the side of the Arcade Machine you notice some writing...\
+	\nmagical -> >=50 power\
+	\nsmart -> defend, defend, light attack\
+	\nshotgun -> defend, defend, power attack\
+	\nshort temper -> counter, counter, counter\
+	\npoisonous -> light attack, light attack, light attack\
+	\nchonker -> power attack, power attack, power attack</span>")
+	return
 
 /obj/machinery/computer/arcade/battle/emag_act(mob/user)
 	if(obj_flags & EMAGGED)

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -600,7 +600,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	\nshort temper -> counter, counter, counter\
 	\npoisonous -> light attack, light attack, light attack\
 	\nchonker -> power attack, power attack, power attack</span>")
-	return
+	return ..()
 
 /obj/machinery/computer/arcade/battle/emag_act(mob/user)
 	if(obj_flags & EMAGGED)


### PR DESCRIPTION
## About The Pull Request

When examined twice quickly, the Battle Arcade Machines will show the combos in this formatting, "smart -> defend, defend, quick attack"

## Why It's Good For The Game

While Gamers will still have to identify the different types of enemy they are facing, they no longer have to head over to the GitHub page for the Arcade PR to see the combos.
I understand that the combos are fairly simple, but I think it is a very small change that can help players, and make rare use of examine_more!

## Changelog
:cl:
add: When further examining a battle arcade machine it will display all the combos that can be used.
/:cl: