### PR TITLE
Adds logging for round end crew credits, and showcases the station value/richest player to roundend stats.

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -467,6 +467,8 @@
 	var/datum/bank_account/mr_moneybags
 	///This is the station's total wealth at the end of the round.
 	var/station_vault = 0
+	///How many players joined the round.
+	var/total_players = GLOB.joined_player_list.len
 	for(var/i in SSeconomy.bank_accounts)
 		if(istype(i, /datum/bank_account/department) || istype(i, /datum/bank_account/remote))
 			continue
@@ -476,8 +478,9 @@
 			mr_moneybags = current_acc
 		if(mr_moneybags.account_balance < current_acc.account_balance)
 			mr_moneybags = current_acc
-	parts += "<div class='panel stationborder'>Overall, there were [station_vault] credits collected by crew this shift.</div>"
-	log_econ("Roundend credit total: [station_vault] credits.")
+	parts += "<div class='panel stationborder'>There were [station_vault] credits collected by crew this shift.</div>"
+	parts += "<div class='panel stationborder'>An average of [station_vault/total_players] credits were collected.</div>"
+	log_econ("Roundend credit total: [station_vault] credits. Average Credits: [station_vault/total_players]")
 	if(mr_moneybags)
 		parts += "<div class='panel clockborder'>The most affulent crew member at shift end was <b>[mr_moneybags.account_holder] with [mr_moneybags.account_balance]</b> cr!</div>"
 	else

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -479,7 +479,7 @@
 	parts += "<div class='panel stationborder'>There were [station_vault] credits collected by crew this shift.</div>"
 	if(total_players > 0)
 		parts += "<div class='panel stationborder'>An average of [station_vault/total_players] credits were collected.</div>"
-	log_econ("Roundend credit total: [station_vault] credits. Average Credits: [station_vault/total_players]")
+		log_econ("Roundend credit total: [station_vault] credits. Average Credits: [station_vault/total_players]")
 	if(mr_moneybags)
 		parts += "<div class='panel clockborder'>The most affulent crew member at shift end was <b>[mr_moneybags.account_holder] with [mr_moneybags.account_balance]</b> cr!</div>"
 	else

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -316,7 +316,7 @@
 	parts += medal_report()
 	//Station Goals
 	parts += goal_report()
-	//Economy
+	//Economy & Money
 	parts += market_report()
 
 	listclearnulls(parts)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -477,7 +477,8 @@
 		if(!mr_moneybags || mr_moneybags.account_balance < current_acc.account_balance)
 			mr_moneybags = current_acc
 	parts += "<div class='panel stationborder'>There were [station_vault] credits collected by crew this shift.</div>"
-	parts += "<div class='panel stationborder'>An average of [station_vault/total_players] credits were collected.</div>"
+	if(total_players > 0)
+		parts += "<div class='panel stationborder'>An average of [station_vault/total_players] credits were collected.</div>"
 	log_econ("Roundend credit total: [station_vault] credits. Average Credits: [station_vault/total_players]")
 	if(mr_moneybags)
 		parts += "<div class='panel clockborder'>The most affulent crew member at shift end was <b>[mr_moneybags.account_holder] with [mr_moneybags.account_balance]</b> cr!</div>"

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -316,6 +316,8 @@
 	parts += medal_report()
 	//Station Goals
 	parts += goal_report()
+	//Economy
+	parts += market_report()
 
 	listclearnulls(parts)
 
@@ -456,6 +458,31 @@
 			var/datum/station_goal/G = V
 			parts += G.get_result()
 		return "<div class='panel stationborder'><ul>[parts.Join()]</ul></div>"
+
+///Generate a report for how much money is on station, as well as the richest crewmember on the station.
+/datum/controller/subsystem/ticker/proc/market_report()
+	var/list/parts = list()
+	parts += "<span class='header'>Station Economic Summary:</span>"
+	///This is the richest account on station at roundend.
+	var/datum/bank_account/mr_moneybags
+	///This is the station's total wealth at the end of the round.
+	var/station_vault = 0
+	for(var/i in SSeconomy.bank_accounts)
+		if(istype(i, /datum/bank_account/department) || istype(i, /datum/bank_account/remote))
+			continue
+		var/datum/bank_account/current_acc = i
+		station_vault += current_acc.account_balance
+		if(!mr_moneybags)
+			mr_moneybags = current_acc
+		if(mr_moneybags.account_balance < current_acc.account_balance)
+			mr_moneybags = current_acc
+	parts += "<div class='panel stationborder'>Overall, there were [station_vault] credits collected by crew this shift.</div>"
+	log_econ("Roundend credit total: [station_vault] credits.")
+	if(mr_moneybags)
+		parts += "<div class='panel clockborder'>The most affulent crew member at shift end was <b>[mr_moneybags.account_holder] with [mr_moneybags.account_balance]</b> cr!</div>"
+	else
+		parts += "div class = panel redborder'>Somehow, nobody made any money this shift! This'll result in some budget cuts...</div>"
+	return parts
 
 /datum/controller/subsystem/ticker/proc/medal_report()
 	if(GLOB.commendations.len)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -472,9 +472,7 @@
 			continue
 		var/datum/bank_account/current_acc = i
 		station_vault += current_acc.account_balance
-		if(!mr_moneybags)
-			mr_moneybags = current_acc
-		if(mr_moneybags.account_balance < current_acc.account_balance)
+		if(!mr_moneybags || mr_moneybags.account_balance < current_acc.account_balance)
 			mr_moneybags = current_acc
 	parts += "<div class='panel stationborder'>Overall, there were [station_vault] credits collected by crew this shift.</div>"
 	log_econ("Roundend credit total: [station_vault] credits.")


### PR DESCRIPTION
## About The Pull Request

Hey you, wanna **FLEX ON SOME NERDS**?
Wanna feel good about making all those credits from those punk ass medical doctors who didn't even **NEED their life savings**?
Need to feel validated about the fact that you are COVERED in HEAD TO TOE in **14 CARAT GOLD**?
Well look no further!
![image](https://user-images.githubusercontent.com/41715314/85680922-bf5c4180-b698-11ea-91d3-4187b9b2adfd.png)

## Why It's Good For The Game

Adds a small, cheap incentive to try and obtain more money than other players on the station, and makes compiling data about the shift easier by just totaling how much money exists in accounts at round-end.

## Changelog
:cl:
add: The richest crew account on station is now showcased on the round-end window! Flex on your coworkers!
code: Economy Logging now totals how much money the crew had at round-end.
/:cl:
