### PR TITLE
fixes an oversight with the wound_bonus of the damage taken from being thrown into a wall

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -93,7 +93,7 @@
 	if(hit_atom.density && isturf(hit_atom))
 		if(hurt)
 			Paralyze(20)
-			take_bodypart_damage(10 + 5 * extra_speed, check_armor = TRUE, wound_bonus = extra_speed)
+			take_bodypart_damage(10 + 5 * extra_speed, check_armor = TRUE, wound_bonus = extra_speed * 5)
 	if(iscarbon(hit_atom) && hit_atom != src)
 		var/mob/living/carbon/victim = hit_atom
 		if(victim.movement_type & FLYING)


### PR DESCRIPTION
## About The Pull Request

increased it from just extra_speed (a value from 0 to 3) to extra_speed * 5

## Why It's Good For The Game

the other take_bodypart_damage() calls in this proc (including the ones for when two people are thrown into each other) all use extra_speed * 5 for their wound_bonuses, so this was almost certainly an oversight

also, most other wound_bonus values are neat multiples of 5, and a wound_bonus of 3 would be incredibly insignificant




tldr; being thrown into a solid metal wall now has the same chance to wound you as being thrown into another (probably squishy and organic) carbon

## Changelog
:cl: ATHATH
fix: The damage taken from being thrown into a wall should now use the same wound_bonus value as the damage you'd take from being thrown into a human would use.
/:cl: