### PR TITLE
Allows multiply tagged tgs4 chat channels with ","

### DIFF
--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -166,7 +166,8 @@ SUBSYSTEM_DEF(discord)
 	var/list/channels_to_use = list()
 	for(var/I in world.TgsChatChannelInfo())
 		var/datum/tgs_chat_channel/channel = I
-		if(channel.tag == channel_tag)
+		var/list/applicable_tags = splittext(channel.tag, ",")
+		if(channel_tag in applicable_tags)
 			channels_to_use += channel
 
 	if(channels_to_use.len)

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -152,7 +152,7 @@ SUBSYSTEM_DEF(discord)
   * Sends a message to TGS chat channels.
   *
   * message - The message to send.
-  * channel_tag - Required. If "", the message with be sent to all connected (Game-type for TGS3) channels. Otherwise, it will be sent to TGS4 channels with that tag.
+  * channel_tag - Required. If "", the message with be sent to all connected (Game-type for TGS3) channels. Otherwise, it will be sent to TGS4 channels with that tag (Delimited by ','s).
   */
 /proc/send2chat(message, channel_tag)
 	if(channel_tag == null || !world.TgsAvailable())


### PR DESCRIPTION
:cl:
server: TGS4 channel tags will now use ',' as a delimiter to indicate multiple tags.
/:cl: