### PR TITLE
Minor Map Fixes 3- The Revengenancing

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -19040,7 +19040,6 @@
 /area/maintenance/port)
 "bdO" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;5;47"
 	},
 /obj/structure/disposalpipe/segment,
@@ -19950,8 +19949,7 @@
 "bgP" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/end{
-	dir = 8;
-	icon_state = "trimline_end"
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/white,
@@ -20210,8 +20208,7 @@
 "bhn" = (
 /obj/structure/closet/secure_closet/chief_medical,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/cmo";
@@ -21242,12 +21239,10 @@
 /area/medical/medbay/lobby)
 "bjT" = (
 /obj/effect/turf_decal/trimline/blue/corner{
-	dir = 1;
-	icon_state = "trimline_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
-	dir = 1;
-	icon_state = "trimline_corner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
@@ -21260,12 +21255,10 @@
 /area/medical/medbay/lobby)
 "bjU" = (
 /obj/effect/turf_decal/trimline/blue/corner{
-	dir = 4;
-	icon_state = "trimline_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
-	dir = 4;
-	icon_state = "trimline_corner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -21275,13 +21268,11 @@
 "bjV" = (
 /obj/effect/turf_decal/trimline/blue/end,
 /obj/effect/turf_decal/trimline/blue/line{
-	dir = 1;
-	icon_state = "trimline"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/end,
 /obj/effect/turf_decal/trimline/blue/line{
-	dir = 1;
-	icon_state = "trimline"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -22318,12 +22309,10 @@
 /area/crew_quarters/heads/cmo)
 "bmV" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22686,12 +22675,10 @@
 /area/medical/pharmacy)
 "boe" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -22700,8 +22687,7 @@
 /area/medical/medbay/central)
 "bog" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/noticeboard{
 	pixel_y = 27
@@ -22710,16 +22696,14 @@
 /area/medical/medbay)
 "boh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "boj" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -22729,19 +22713,16 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "bom" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/structure/sign/warning/nosmoking/circle{
 	pixel_x = 32
@@ -23088,8 +23069,7 @@
 /area/medical/pharmacy)
 "bpu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -23137,16 +23117,13 @@
 /area/quartermaster/office)
 "bpD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	pixel_x = -30;
@@ -23168,8 +23145,7 @@
 /area/science/genetics)
 "bpF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
@@ -23185,8 +23161,7 @@
 /area/medical/psychology)
 "bpM" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -23485,8 +23460,7 @@
 "bqO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23498,12 +23472,10 @@
 /area/medical/medbay)
 "bqP" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8;
-	icon_state = "trimline_warn_fill"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
@@ -23575,16 +23547,14 @@
 /area/medical/medbay)
 "bqV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4;
-	icon_state = "trimline_warn_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "bqX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -23638,8 +23608,7 @@
 /area/medical/surgery/room_b)
 "brg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -23727,8 +23696,7 @@
 /area/science/genetics)
 "brx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/structure/table,
 /obj/item/book/manual/wiki/medicine,
@@ -24012,12 +23980,10 @@
 /area/medical/medbay/central)
 "bsu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 4
@@ -24059,8 +24025,7 @@
 "bsy" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8;
-	icon_state = "trimline_warn_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -24207,8 +24172,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -24463,8 +24427,7 @@
 /area/science/research)
 "btR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/aft";
@@ -24489,8 +24452,7 @@
 /area/science/research)
 "btV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /obj/machinery/iv_drip,
 /obj/structure/cable,
@@ -24522,19 +24484,16 @@
 /area/medical/medbay/central)
 "btZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bua" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -24597,12 +24556,10 @@
 /area/science/robotics/lab)
 "bul" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8;
-	icon_state = "trimline_warn_fill"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 1
@@ -24642,8 +24599,7 @@
 /area/medical/medbay/aft)
 "bun" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -24662,12 +24618,10 @@
 /area/medical/medbay/aft)
 "buq" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24695,8 +24649,7 @@
 /area/science/genetics)
 "but" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/requests_console{
 	department = "Medbay";
@@ -24724,8 +24677,7 @@
 /area/science/genetics)
 "bux" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/light{
@@ -24746,8 +24698,7 @@
 "buy" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 9
@@ -25073,8 +25024,7 @@
 /area/medical/medbay/aft)
 "bvo" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4;
-	icon_state = "trimline_warn_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -25133,8 +25083,7 @@
 /area/science/research)
 "bvy" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /obj/item/kirbyplants/random,
 /obj/structure/extinguisher_cabinet{
@@ -25429,8 +25378,7 @@
 /area/medical/medbay)
 "bwD" = (
 /obj/effect/turf_decal/trimline/blue/line{
-	dir = 5;
-	icon_state = "trimline"
+	dir = 5
 	},
 /obj/machinery/shower{
 	dir = 4
@@ -25449,8 +25397,7 @@
 /area/medical/medbay/central)
 "bwG" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8;
-	icon_state = "trimline_warn_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -25473,8 +25420,7 @@
 /area/medical/medbay/central)
 "bwI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -25808,8 +25754,7 @@
 /area/crew_quarters/heads/hor)
 "bxR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -25836,8 +25781,7 @@
 /area/medical/medbay/central)
 "bxT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
@@ -25853,8 +25797,7 @@
 /area/medical/medbay/central)
 "bxV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -26349,8 +26292,7 @@
 /area/medical/chemistry)
 "bzd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
@@ -26361,8 +26303,7 @@
 /area/medical/medbay/aft)
 "bzh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -26372,8 +26313,7 @@
 /area/medical/medbay/central)
 "bzl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -26853,8 +26793,7 @@
 /area/medical/medbay/central)
 "bAr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/firealarm{
@@ -26881,8 +26820,7 @@
 /area/medical/medbay/central)
 "bAu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/newscaster{
@@ -27298,8 +27236,7 @@
 /area/quartermaster/miningdock)
 "bBJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
@@ -27309,8 +27246,7 @@
 /area/medical/medbay/aft)
 "bBK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/airalarm{
@@ -27382,8 +27318,7 @@
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -27758,7 +27693,6 @@
 	pixel_y = 1
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 0;
 	pixel_y = 1
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
@@ -27823,8 +27757,7 @@
 "bCS" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/end{
-	dir = 8;
-	icon_state = "trimline_end"
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -27870,8 +27803,7 @@
 /area/medical/medbay/aft)
 "bCV" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -28165,8 +28097,7 @@
 /area/maintenance/aft)
 "bDR" = (
 /obj/effect/turf_decal/trimline/blue/line{
-	dir = 6;
-	icon_state = "trimline"
+	dir = 6
 	},
 /obj/machinery/shower{
 	dir = 4
@@ -28179,8 +28110,7 @@
 /area/medical/medbay/central)
 "bDS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5;
-	icon_state = "trimline_fill"
+	dir = 5
 	},
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -28190,8 +28120,7 @@
 /area/medical/medbay/aft)
 "bDU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/vending/medical{
 	pixel_x = -2
@@ -28336,8 +28265,7 @@
 /area/medical/storage)
 "bEj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/disposal/bin,
 /obj/machinery/light,
@@ -28778,8 +28706,7 @@
 /area/science/storage)
 "bFM" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -28793,8 +28720,7 @@
 "bFN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -29484,8 +29410,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
@@ -29592,8 +29517,7 @@
 /area/medical/cryo)
 "bIq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/extinguisher_cabinet{
@@ -29725,8 +29649,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
@@ -31154,8 +31077,7 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
@@ -31169,12 +31091,10 @@
 /area/medical/virology)
 "bNl" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 10
@@ -31533,8 +31453,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -31738,8 +31657,7 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -31919,8 +31837,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -31954,8 +31871,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -32758,8 +32674,7 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -33144,12 +33059,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
@@ -33189,8 +33102,7 @@
 /area/medical/virology)
 "bSW" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -33202,8 +33114,7 @@
 /area/medical/virology)
 "bSX" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -33754,8 +33665,7 @@
 "bVa" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -34102,8 +34012,7 @@
 	},
 /obj/item/clothing/glasses/science,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -34112,8 +34021,7 @@
 /obj/item/hand_labeler,
 /obj/item/radio/headset/headset_med,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -34447,8 +34355,7 @@
 	},
 /obj/item/storage/box/syringes,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -34460,8 +34367,7 @@
 	},
 /obj/item/pen/red,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -34816,8 +34722,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -35132,8 +35037,7 @@
 "bYX" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -35141,8 +35045,7 @@
 /obj/structure/closet/secure_closet/medical1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -42110,8 +42013,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5;
-	icon_state = "trimline_fill"
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -42393,7 +42295,6 @@
 /area/maintenance/starboard/aft)
 "cTJ" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;5;29;47"
 	},
 /obj/structure/disposalpipe/segment,
@@ -42423,8 +42324,7 @@
 /area/science/xenobiology)
 "cUn" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
@@ -42863,8 +42763,7 @@
 "dAj" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -43042,8 +42941,7 @@
 /area/hallway/primary/fore)
 "dKQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5;
-	icon_state = "trimline_fill"
+	dir = 5
 	},
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
@@ -43099,7 +42997,6 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/white,
@@ -43424,8 +43321,7 @@
 /area/security/prison)
 "ekj" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -43466,8 +43362,7 @@
 /area/medical/morgue)
 "epA" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -43718,12 +43613,10 @@
 /area/crew_quarters/bar)
 "eKp" = (
 /obj/effect/turf_decal/trimline/blue/corner{
-	dir = 8;
-	icon_state = "trimline_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
-	dir = 8;
-	icon_state = "trimline_corner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -43732,8 +43625,7 @@
 /area/medical/medbay/lobby)
 "eLg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
@@ -43891,8 +43783,7 @@
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -43926,8 +43817,7 @@
 "faW" = (
 /obj/machinery/vending/medical,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5;
-	icon_state = "trimline_fill"
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -43963,8 +43853,7 @@
 	pixel_y = 25
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5;
-	icon_state = "trimline_fill"
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -44075,8 +43964,7 @@
 /area/maintenance/port/aft)
 "fkC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -44521,8 +44409,7 @@
 /area/library)
 "fUn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay East";
@@ -44622,8 +44509,7 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/right{
-	dir = 1;
-	icon_state = "sofaend_right"
+	dir = 1
 	},
 /obj/structure/sign/departments/restroom{
 	pixel_y = -32
@@ -44813,8 +44699,7 @@
 /area/security/prison)
 "gvu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4
@@ -44903,8 +44788,7 @@
 "gyK" = (
 /obj/machinery/suit_storage_unit/cmo,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /obj/machinery/light{
 	dir = 8
@@ -45047,8 +44931,7 @@
 /area/science/genetics)
 "gHL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45305,8 +45188,7 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/left{
-	dir = 1;
-	icon_state = "sofaend_left"
+	dir = 1
 	},
 /obj/machinery/airalarm{
 	dir = 1;
@@ -45611,13 +45493,11 @@
 /area/security/prison/safe)
 "hzh" = (
 /obj/effect/turf_decal/trimline/blue/end{
-	dir = 1;
-	icon_state = "trimline_end"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/effect/turf_decal/trimline/blue/end{
-	dir = 1;
-	icon_state = "trimline_end"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/plasteel/white,
@@ -45677,8 +45557,7 @@
 /area/science/nanite)
 "hAY" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -45769,12 +45648,10 @@
 /area/quartermaster/warehouse)
 "hGw" = (
 /obj/vehicle/ridden/wheelchair{
-	dir = 4;
-	icon_state = "wheelchair"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/end{
-	dir = 1;
-	icon_state = "trimline_end_fill"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -46228,12 +46105,10 @@
 /area/maintenance/department/medical/morgue)
 "iqb" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -46277,8 +46152,7 @@
 "iun" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -46490,8 +46364,7 @@
 /area/hallway/secondary/entry)
 "iFq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -46546,16 +46419,14 @@
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "iOm" = (
 /obj/machinery/computer/crew{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -46857,8 +46728,7 @@
 /area/science/research)
 "jsa" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5;
-	icon_state = "trimline_fill"
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -46933,8 +46803,7 @@
 /area/medical/pharmacy)
 "juK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -46946,8 +46815,7 @@
 "jvn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8;
-	icon_state = "trimline_warn_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -47024,12 +46892,10 @@
 /area/engine/gravity_generator)
 "jCi" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8;
-	icon_state = "trimline_warn_fill"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -47059,8 +46925,7 @@
 /area/engine/gravity_generator)
 "jDb" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -47151,8 +47016,7 @@
 /area/science/misc_lab)
 "jIo" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -47380,12 +47244,10 @@
 /area/security/detectives_office)
 "kbq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /obj/structure/cable,
 /obj/structure/cable,
@@ -47412,8 +47274,7 @@
 /area/security/courtroom)
 "kdT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47482,8 +47343,7 @@
 /obj/machinery/light,
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -47524,8 +47384,7 @@
 "kqo" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 23
@@ -47554,7 +47413,6 @@
 /obj/structure/table/glass,
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	icon_state = "left";
 	name = "First-Aid Supplies";
 	red_alert_access = 1;
 	req_access_txt = "5"
@@ -47586,12 +47444,10 @@
 /area/medical/storage)
 "krv" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4;
-	icon_state = "trimline_warn_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -47622,8 +47478,7 @@
 "kuy" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable,
@@ -47700,8 +47555,7 @@
 /area/science/robotics/mechbay)
 "kEg" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -48067,8 +47921,7 @@
 "lkN" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 9
@@ -48154,8 +48007,7 @@
 /area/medical/medbay)
 "lvw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/sign/warning/nosmoking/circle{
@@ -48324,8 +48176,7 @@
 /area/security/prison/safe)
 "lEq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/clothing/neck/stethoscope,
@@ -48401,12 +48252,10 @@
 /area/crew_quarters/dorms)
 "lJw" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8;
-	icon_state = "trimline_warn_fill"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -48452,8 +48301,7 @@
 /area/hallway/secondary/entry)
 "lNL" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -48681,8 +48529,7 @@
 "lZt" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/filled/end{
-	dir = 8;
-	icon_state = "trimline_end_fill"
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/white,
@@ -48876,8 +48723,7 @@
 /area/medical/chemistry)
 "mte" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -48990,8 +48836,7 @@
 /area/engine/engineering)
 "mCi" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -49565,8 +49410,7 @@
 "nAu" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /obj/machinery/light_switch{
 	pixel_x = 28
@@ -49660,8 +49504,7 @@
 /area/science/mixing)
 "nKy" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -49862,8 +49705,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -50244,8 +50086,7 @@
 /area/crew_quarters/heads/hos)
 "oTO" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -50322,12 +50163,10 @@
 /area/space)
 "oYY" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50367,8 +50206,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -50644,8 +50482,7 @@
 /area/security/execution/transfer)
 "pyt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -50670,8 +50507,7 @@
 /area/security/prison/safe)
 "pyL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -50808,12 +50644,10 @@
 /area/medical/cryo)
 "pHX" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -50838,12 +50672,10 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/closet/l3closet,
 /obj/machinery/light,
@@ -50867,12 +50699,10 @@
 /area/maintenance/port/aft)
 "pJG" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4;
-	icon_state = "trimline_warn_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51175,8 +51005,7 @@
 /area/ai_monitored/turret_protected/ai)
 "qbu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -51314,14 +51143,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/cmo{
 	dir = 8;
-	icon_state = "telescreen";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/effect/landmark/start/chief_medical_officer,
 /obj/machinery/button/door{
@@ -51346,8 +51172,7 @@
 /area/medical/cryo)
 "qnm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/item/radio/intercom{
 	pixel_x = 25
@@ -51363,8 +51188,7 @@
 /area/crew_quarters/heads/cmo)
 "qnT" = (
 /obj/vehicle/ridden/wheelchair{
-	dir = 4;
-	icon_state = "wheelchair"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/end,
 /obj/structure/window/reinforced,
@@ -51680,8 +51504,7 @@
 "qWU" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
@@ -51963,8 +51786,7 @@
 "rwY" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -52031,8 +51853,7 @@
 /area/vacant_room/commissary)
 "rFK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -52048,12 +51869,10 @@
 /area/medical/chemistry)
 "rGv" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
@@ -52268,8 +52087,7 @@
 /area/maintenance/starboard/aft)
 "sbe" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/machinery/light{
@@ -52401,7 +52219,6 @@
 /area/medical/medbay/lobby)
 "slk" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;5;47"
 	},
 /obj/structure/disposalpipe/segment,
@@ -52421,8 +52238,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
@@ -52638,12 +52454,10 @@
 /area/hallway/secondary/entry)
 "sIp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4;
-	icon_state = "trimline_warn_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
@@ -52799,8 +52613,7 @@
 	pixel_y = 7
 	},
 /obj/item/storage/box/monkeycubes{
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
@@ -52877,8 +52690,7 @@
 /area/security/prison)
 "tiO" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -53449,11 +53261,9 @@
 /area/security/prison)
 "ubu" = (
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/structure/sink{
-	pixel_x = 0;
 	pixel_y = 20
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -53613,12 +53423,10 @@
 /area/crew_quarters/toilet/locker)
 "uoI" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -53660,8 +53468,7 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -53905,8 +53712,7 @@
 /area/science/mixing/chamber)
 "uTa" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -53934,8 +53740,7 @@
 /area/vacant_room/commissary)
 "uTM" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -54734,8 +54539,7 @@
 "wgb" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54939,12 +54743,10 @@
 /area/hallway/primary/fore)
 "wza" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4;
-	icon_state = "trimline_warn_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -55413,8 +55215,7 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
@@ -55603,8 +55404,7 @@
 "xGS" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -55796,8 +55596,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "xXU" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -55862,12 +55661,10 @@
 /area/security/detectives_office)
 "yaA" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -31501,6 +31501,7 @@
 	name = "Station Intercom (Telecomms)";
 	pixel_y = 26
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bOp" = (
@@ -31607,6 +31608,7 @@
 /area/science/misc_lab)
 "bOC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bOD" = (
@@ -32114,6 +32116,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bPS" = (
@@ -32385,6 +32388,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bQL" = (
@@ -33354,6 +33358,7 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bTJ" = (
@@ -33578,6 +33583,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bUE" = (
@@ -34179,6 +34185,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWu" = (
@@ -34193,6 +34200,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWv" = (
@@ -34202,6 +34210,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWw" = (
@@ -34278,6 +34287,7 @@
 	name = "Telecomms Monitoring APC";
 	pixel_y = 23
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWI" = (
@@ -34309,6 +34319,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bWL" = (
@@ -35001,6 +35012,7 @@
 "bYF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bYG" = (
@@ -44716,6 +44728,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"glP" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/tcommsat/computer)
 "gny" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 10
@@ -83137,7 +83156,7 @@ bNI
 bHE
 bVJ
 bOo
-bOD
+glP
 bQb
 bZv
 bSd

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -24818,23 +24818,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"buH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access";
-	req_access_txt = "47"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "buI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
@@ -48207,8 +48190,9 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/science/nanite";
+	dir = 8;
 	name = "Nanite Lab APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -14643,6 +14643,7 @@
 /area/chapel/main)
 "aQw" = (
 /obj/structure/table/wood,
+/obj/item/storage/book/bible,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aQz" = (
@@ -19949,8 +19950,8 @@
 "bgP" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/end{
-	icon_state = "trimline_end";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_end"
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/white,
@@ -20116,8 +20117,8 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 26;
-	pixel_x = -27
+	pixel_x = -27;
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
@@ -20209,8 +20210,8 @@
 "bhn" = (
 /obj/structure/closet/secure_closet/chief_medical,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/cmo";
@@ -21241,12 +21242,12 @@
 /area/medical/medbay/lobby)
 "bjT" = (
 /obj/effect/turf_decal/trimline/blue/corner{
-	icon_state = "trimline_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
-	icon_state = "trimline_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
@@ -21259,12 +21260,12 @@
 /area/medical/medbay/lobby)
 "bjU" = (
 /obj/effect/turf_decal/trimline/blue/corner{
-	icon_state = "trimline_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
-	icon_state = "trimline_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -21274,13 +21275,13 @@
 "bjV" = (
 /obj/effect/turf_decal/trimline/blue/end,
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline"
 	},
 /obj/effect/turf_decal/trimline/blue/end,
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -22317,12 +22318,12 @@
 /area/crew_quarters/heads/cmo)
 "bmV" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22685,12 +22686,12 @@
 /area/medical/pharmacy)
 "boe" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -22699,8 +22700,8 @@
 /area/medical/medbay/central)
 "bog" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/noticeboard{
 	pixel_y = 27
@@ -22709,16 +22710,16 @@
 /area/medical/medbay)
 "boh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "boj" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -22728,19 +22729,19 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "bom" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/sign/warning/nosmoking/circle{
 	pixel_x = 32
@@ -23087,8 +23088,8 @@
 /area/medical/pharmacy)
 "bpu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -23136,16 +23137,16 @@
 /area/quartermaster/office)
 "bpD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/firealarm{
 	pixel_x = -30;
@@ -23167,8 +23168,8 @@
 /area/science/genetics)
 "bpF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
@@ -23184,8 +23185,8 @@
 /area/medical/psychology)
 "bpM" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -23484,8 +23485,8 @@
 "bqO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23497,12 +23498,12 @@
 /area/medical/medbay)
 "bqP" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
@@ -23574,16 +23575,16 @@
 /area/medical/medbay)
 "bqV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "bqX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -23637,8 +23638,8 @@
 /area/medical/surgery/room_b)
 "brg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -23726,8 +23727,8 @@
 /area/science/genetics)
 "brx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/table,
 /obj/item/book/manual/wiki/medicine,
@@ -24011,12 +24012,12 @@
 /area/medical/medbay/central)
 "bsu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -24058,8 +24059,8 @@
 "bsy" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_warn_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -24206,8 +24207,8 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -24256,6 +24257,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/computer/cargo{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -24459,8 +24463,8 @@
 /area/science/research)
 "btR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/aft";
@@ -24485,8 +24489,8 @@
 /area/science/research)
 "btV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/iv_drip,
 /obj/structure/cable,
@@ -24518,19 +24522,19 @@
 /area/medical/medbay/central)
 "btZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bua" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -24593,12 +24597,12 @@
 /area/science/robotics/lab)
 "bul" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -24638,8 +24642,8 @@
 /area/medical/medbay/aft)
 "bun" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -24658,12 +24662,12 @@
 /area/medical/medbay/aft)
 "buq" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24691,8 +24695,8 @@
 /area/science/genetics)
 "but" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/requests_console{
 	department = "Medbay";
@@ -24720,8 +24724,8 @@
 /area/science/genetics)
 "bux" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/light{
@@ -24742,8 +24746,8 @@
 "buy" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 9
@@ -25069,8 +25073,8 @@
 /area/medical/medbay/aft)
 "bvo" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -25129,8 +25133,8 @@
 /area/science/research)
 "bvy" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /obj/item/kirbyplants/random,
 /obj/structure/extinguisher_cabinet{
@@ -25425,8 +25429,8 @@
 /area/medical/medbay)
 "bwD" = (
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
-	dir = 5
+	dir = 5;
+	icon_state = "trimline"
 	},
 /obj/machinery/shower{
 	dir = 4
@@ -25445,8 +25449,8 @@
 /area/medical/medbay/central)
 "bwG" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_warn_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -25469,8 +25473,8 @@
 /area/medical/medbay/central)
 "bwI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -25804,8 +25808,8 @@
 /area/crew_quarters/heads/hor)
 "bxR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -25832,8 +25836,8 @@
 /area/medical/medbay/central)
 "bxT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
@@ -25849,8 +25853,8 @@
 /area/medical/medbay/central)
 "bxV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -26345,8 +26349,8 @@
 /area/medical/chemistry)
 "bzd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
@@ -26357,8 +26361,8 @@
 /area/medical/medbay/aft)
 "bzh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -26368,8 +26372,8 @@
 /area/medical/medbay/central)
 "bzl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -26849,8 +26853,8 @@
 /area/medical/medbay/central)
 "bAr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/firealarm{
@@ -26877,8 +26881,8 @@
 /area/medical/medbay/central)
 "bAu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/newscaster{
@@ -27294,8 +27298,8 @@
 /area/quartermaster/miningdock)
 "bBJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
@@ -27305,8 +27309,8 @@
 /area/medical/medbay/aft)
 "bBK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/airalarm{
@@ -27378,8 +27382,8 @@
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -27819,8 +27823,8 @@
 "bCS" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/end{
-	icon_state = "trimline_end";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_end"
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -27866,8 +27870,8 @@
 /area/medical/medbay/aft)
 "bCV" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -28161,8 +28165,8 @@
 /area/maintenance/aft)
 "bDR" = (
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline"
 	},
 /obj/machinery/shower{
 	dir = 4
@@ -28175,8 +28179,8 @@
 /area/medical/medbay/central)
 "bDS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 5
+	dir = 5;
+	icon_state = "trimline_fill"
 	},
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -28186,8 +28190,8 @@
 /area/medical/medbay/aft)
 "bDU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/vending/medical{
 	pixel_x = -2
@@ -28332,8 +28336,8 @@
 /area/medical/storage)
 "bEj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/disposal/bin,
 /obj/machinery/light,
@@ -28774,8 +28778,8 @@
 /area/science/storage)
 "bFM" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
@@ -28789,8 +28793,8 @@
 "bFN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -29480,8 +29484,8 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
@@ -29588,8 +29592,8 @@
 /area/medical/cryo)
 "bIq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/extinguisher_cabinet{
@@ -29721,8 +29725,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
@@ -31150,8 +31154,8 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
@@ -31165,12 +31169,12 @@
 /area/medical/virology)
 "bNl" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 10
@@ -31529,8 +31533,8 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -31734,8 +31738,8 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -31915,8 +31919,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -31950,8 +31954,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -32754,8 +32758,8 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -33140,12 +33144,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
@@ -33185,8 +33189,8 @@
 /area/medical/virology)
 "bSW" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -33198,8 +33202,8 @@
 /area/medical/virology)
 "bSX" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -33750,8 +33754,8 @@
 "bVa" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -34098,8 +34102,8 @@
 	},
 /obj/item/clothing/glasses/science,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -34108,8 +34112,8 @@
 /obj/item/hand_labeler,
 /obj/item/radio/headset/headset_med,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -34443,8 +34447,8 @@
 	},
 /obj/item/storage/box/syringes,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -34456,8 +34460,8 @@
 	},
 /obj/item/pen/red,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -34812,8 +34816,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -35128,8 +35132,8 @@
 "bYX" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -35137,8 +35141,8 @@
 /obj/structure/closet/secure_closet/medical1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -42106,8 +42110,8 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 5
+	dir = 5;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -42419,8 +42423,8 @@
 /area/science/xenobiology)
 "cUn" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
@@ -42859,8 +42863,8 @@
 "dAj" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -43038,8 +43042,8 @@
 /area/hallway/primary/fore)
 "dKQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 5
+	dir = 5;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
@@ -43420,8 +43424,8 @@
 /area/security/prison)
 "ekj" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -43462,8 +43466,8 @@
 /area/medical/morgue)
 "epA" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -43714,12 +43718,12 @@
 /area/crew_quarters/bar)
 "eKp" = (
 /obj/effect/turf_decal/trimline/blue/corner{
-	icon_state = "trimline_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
-	icon_state = "trimline_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -43728,8 +43732,8 @@
 /area/medical/medbay/lobby)
 "eLg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
@@ -43887,8 +43891,8 @@
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -43922,8 +43926,8 @@
 "faW" = (
 /obj/machinery/vending/medical,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 5
+	dir = 5;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -43959,8 +43963,8 @@
 	pixel_y = 25
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 5
+	dir = 5;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -44071,8 +44075,8 @@
 /area/maintenance/port/aft)
 "fkC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -44517,8 +44521,8 @@
 /area/library)
 "fUn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay East";
@@ -44618,8 +44622,8 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/right{
-	icon_state = "sofaend_right";
-	dir = 1
+	dir = 1;
+	icon_state = "sofaend_right"
 	},
 /obj/structure/sign/departments/restroom{
 	pixel_y = -32
@@ -44809,8 +44813,8 @@
 /area/security/prison)
 "gvu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -44899,8 +44903,8 @@
 "gyK" = (
 /obj/machinery/suit_storage_unit/cmo,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -45043,8 +45047,8 @@
 /area/science/genetics)
 "gHL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45301,8 +45305,8 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/left{
-	icon_state = "sofaend_left";
-	dir = 1
+	dir = 1;
+	icon_state = "sofaend_left"
 	},
 /obj/machinery/airalarm{
 	dir = 1;
@@ -45607,13 +45611,13 @@
 /area/security/prison/safe)
 "hzh" = (
 /obj/effect/turf_decal/trimline/blue/end{
-	icon_state = "trimline_end";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_end"
 	},
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/effect/turf_decal/trimline/blue/end{
-	icon_state = "trimline_end";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_end"
 	},
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/plasteel/white,
@@ -45673,8 +45677,8 @@
 /area/science/nanite)
 "hAY" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -45765,12 +45769,12 @@
 /area/quartermaster/warehouse)
 "hGw" = (
 /obj/vehicle/ridden/wheelchair{
-	icon_state = "wheelchair";
-	dir = 4
+	dir = 4;
+	icon_state = "wheelchair"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/end{
-	icon_state = "trimline_end_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_end_fill"
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -46224,12 +46228,12 @@
 /area/maintenance/department/medical/morgue)
 "iqb" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -46273,8 +46277,8 @@
 "iun" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -46486,8 +46490,8 @@
 /area/hallway/secondary/entry)
 "iFq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -46542,16 +46546,16 @@
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "iOm" = (
 /obj/machinery/computer/crew{
-	icon_state = "computer";
-	dir = 4
+	dir = 4;
+	icon_state = "computer"
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -46853,8 +46857,8 @@
 /area/science/research)
 "jsa" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 5
+	dir = 5;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -46929,8 +46933,8 @@
 /area/medical/pharmacy)
 "juK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -46942,8 +46946,8 @@
 "jvn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_warn_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -47020,12 +47024,12 @@
 /area/engine/gravity_generator)
 "jCi" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -47055,8 +47059,8 @@
 /area/engine/gravity_generator)
 "jDb" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -47147,8 +47151,8 @@
 /area/science/misc_lab)
 "jIo" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -47376,12 +47380,12 @@
 /area/security/detectives_office)
 "kbq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/structure/cable,
 /obj/structure/cable,
@@ -47408,8 +47412,8 @@
 /area/security/courtroom)
 "kdT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47478,8 +47482,8 @@
 /obj/machinery/light,
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -47520,8 +47524,8 @@
 "kqo" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 23
@@ -47582,12 +47586,12 @@
 /area/medical/storage)
 "krv" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -47618,8 +47622,8 @@
 "kuy" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable,
@@ -47696,8 +47700,8 @@
 /area/science/robotics/mechbay)
 "kEg" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -48063,8 +48067,8 @@
 "lkN" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 9
@@ -48150,8 +48154,8 @@
 /area/medical/medbay)
 "lvw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/sign/warning/nosmoking/circle{
@@ -48320,8 +48324,8 @@
 /area/security/prison/safe)
 "lEq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/clothing/neck/stethoscope,
@@ -48397,12 +48401,12 @@
 /area/crew_quarters/dorms)
 "lJw" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -48448,8 +48452,8 @@
 /area/hallway/secondary/entry)
 "lNL" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -48677,8 +48681,8 @@
 "lZt" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/filled/end{
-	icon_state = "trimline_end_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_end_fill"
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/white,
@@ -48872,8 +48876,8 @@
 /area/medical/chemistry)
 "mte" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -48986,8 +48990,8 @@
 /area/engine/engineering)
 "mCi" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -49561,8 +49565,8 @@
 "nAu" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/light_switch{
 	pixel_x = 28
@@ -49656,8 +49660,8 @@
 /area/science/mixing)
 "nKy" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -49858,8 +49862,8 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -50240,8 +50244,8 @@
 /area/crew_quarters/heads/hos)
 "oTO" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -50318,12 +50322,12 @@
 /area/space)
 "oYY" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50363,8 +50367,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -50640,8 +50644,8 @@
 /area/security/execution/transfer)
 "pyt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -50666,8 +50670,8 @@
 /area/security/prison/safe)
 "pyL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -50804,12 +50808,12 @@
 /area/medical/cryo)
 "pHX" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -50838,8 +50842,8 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/closet/l3closet,
 /obj/machinery/light,
@@ -50863,12 +50867,12 @@
 /area/maintenance/port/aft)
 "pJG" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51171,8 +51175,8 @@
 /area/ai_monitored/turret_protected/ai)
 "qbu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -51310,8 +51314,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/computer/security/telescreen/cmo{
 	dir = 8;
@@ -51342,8 +51346,8 @@
 /area/medical/cryo)
 "qnm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/item/radio/intercom{
 	pixel_x = 25
@@ -51359,8 +51363,8 @@
 /area/crew_quarters/heads/cmo)
 "qnT" = (
 /obj/vehicle/ridden/wheelchair{
-	icon_state = "wheelchair";
-	dir = 4
+	dir = 4;
+	icon_state = "wheelchair"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/end,
 /obj/structure/window/reinforced,
@@ -51676,8 +51680,8 @@
 "qWU" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
@@ -51959,8 +51963,8 @@
 "rwY" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -52027,8 +52031,8 @@
 /area/vacant_room/commissary)
 "rFK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -52044,12 +52048,12 @@
 /area/medical/chemistry)
 "rGv" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
@@ -52264,8 +52268,8 @@
 /area/maintenance/starboard/aft)
 "sbe" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/machinery/light{
@@ -52417,8 +52421,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
@@ -52634,12 +52638,12 @@
 /area/hallway/secondary/entry)
 "sIp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
@@ -52873,8 +52877,8 @@
 /area/security/prison)
 "tiO" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -53609,12 +53613,12 @@
 /area/crew_quarters/toilet/locker)
 "uoI" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -53656,8 +53660,8 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -53901,8 +53905,8 @@
 /area/science/mixing/chamber)
 "uTa" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -53930,8 +53934,8 @@
 /area/vacant_room/commissary)
 "uTM" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -54730,8 +54734,8 @@
 "wgb" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54935,12 +54939,12 @@
 /area/hallway/primary/fore)
 "wza" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -55409,8 +55413,8 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
@@ -55599,8 +55603,8 @@
 "xGS" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -55792,8 +55796,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "xXU" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -55858,12 +55862,12 @@
 /area/security/detectives_office)
 "yaA" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -21298,6 +21298,7 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bjY" = (
@@ -49915,10 +49916,9 @@
 /obj/machinery/cell_charger,
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/lobby";
-	dir = 1;
+	dir = 4;
 	name = "Medbay Lobby APC";
-	pixel_x = 25;
-	pixel_y = 23
+	pixel_x = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -93126,10 +93126,10 @@ aYV
 pLy
 bev
 bfK
+bfK
 bhi
 bhi
-bhi
-bhi
+bfK
 bfK
 eZL
 jrn

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -92637,7 +92637,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "drG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/tile/purple,
@@ -100971,16 +100970,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"dKl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "dKm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -156009,7 +155998,7 @@ dEQ
 dGf
 cXE
 cXE
-dKl
+cXE
 dKT
 dMs
 dNR

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -24668,8 +24668,7 @@
 "bgP" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/end{
-	dir = 8;
-	icon_state = "trimline_end"
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/white,
@@ -24913,8 +24912,7 @@
 "bhn" = (
 /obj/structure/closet/secure_closet/chief_medical,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/cmo";
@@ -24930,14 +24928,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/cmo{
 	dir = 8;
-	icon_state = "telescreen";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/effect/landmark/start/chief_medical_officer,
 /obj/machinery/button/door{
@@ -26123,12 +26118,10 @@
 /area/medical/pharmacy)
 "bjT" = (
 /obj/effect/turf_decal/trimline/blue/corner{
-	dir = 1;
-	icon_state = "trimline_corner"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
-	dir = 1;
-	icon_state = "trimline_corner"
+	dir = 1
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -26136,25 +26129,21 @@
 /area/medical/medbay/lobby)
 "bjU" = (
 /obj/effect/turf_decal/trimline/blue/corner{
-	dir = 4;
-	icon_state = "trimline_corner"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
-	dir = 4;
-	icon_state = "trimline_corner"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "bjV" = (
 /obj/effect/turf_decal/trimline/blue/end,
 /obj/effect/turf_decal/trimline/blue/line{
-	dir = 1;
-	icon_state = "trimline"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/end,
 /obj/effect/turf_decal/trimline/blue/line{
-	dir = 1;
-	icon_state = "trimline"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
@@ -27412,12 +27401,10 @@
 /area/hallway/primary/central)
 "bmV" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27429,8 +27416,7 @@
 "bmW" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28003,12 +27989,10 @@
 /area/medical/pharmacy)
 "boe" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -28017,8 +28001,7 @@
 /area/medical/medbay/central)
 "bog" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/noticeboard{
 	pixel_y = 27
@@ -28027,15 +28010,13 @@
 /area/medical/medbay)
 "boh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "boi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -28043,8 +28024,7 @@
 "boj" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -28052,20 +28032,17 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "bom" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/structure/sign/warning/nosmoking/circle{
 	pixel_x = 32
@@ -28570,8 +28547,7 @@
 /area/medical/pharmacy)
 "bpu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -28618,16 +28594,13 @@
 /area/hallway/primary/central)
 "bpD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	pixel_x = -30;
@@ -28644,8 +28617,7 @@
 /area/science/genetics)
 "bpF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -28662,8 +28634,7 @@
 /area/medical/surgery/room_b)
 "bpM" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -28916,8 +28887,7 @@
 /area/quartermaster/office)
 "bqt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/extinguisher_cabinet{
@@ -29091,8 +29061,7 @@
 "bqO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29106,12 +29075,10 @@
 /area/medical/medbay)
 "bqP" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8;
-	icon_state = "trimline_warn_fill"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -29192,8 +29159,7 @@
 /area/medical/medbay)
 "bqV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4;
-	icon_state = "trimline_warn_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -29204,8 +29170,7 @@
 "bqW" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/structure/cable,
 /obj/structure/cable,
@@ -29217,8 +29182,7 @@
 /area/medical/medbay)
 "bqX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -29294,8 +29258,7 @@
 /area/maintenance/department/medical/morgue)
 "brl" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -29604,12 +29567,10 @@
 /area/crew_quarters/heads/hop)
 "brT" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4;
-	icon_state = "trimline_warn_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29703,12 +29664,10 @@
 /area/quartermaster/miningdock)
 "bse" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8;
-	icon_state = "trimline_warn_fill"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 1
@@ -29851,12 +29810,10 @@
 /area/medical/medbay/central)
 "bsu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 4
@@ -29865,12 +29822,10 @@
 /area/medical/medbay/aft)
 "bsv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29902,8 +29857,7 @@
 "bsy" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8;
-	icon_state = "trimline_warn_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -29929,8 +29883,7 @@
 /area/science/research)
 "bsB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -29946,8 +29899,7 @@
 /area/medical/medbay/aft)
 "bsC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/requests_console{
 	department = "Medbay";
@@ -29967,8 +29919,7 @@
 /area/medical/medbay/aft)
 "bsD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29982,12 +29933,10 @@
 /area/medical/medbay/aft)
 "bsE" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30019,8 +29968,7 @@
 /area/science/genetics)
 "bsI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /obj/item/kirbyplants/random,
 /obj/structure/extinguisher_cabinet{
@@ -30036,8 +29984,7 @@
 /area/medical/medbay/aft)
 "bsJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -30047,8 +29994,7 @@
 /area/medical/medbay/aft)
 "bsK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -30528,8 +30474,7 @@
 /area/science/research)
 "btR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -30556,8 +30501,7 @@
 /area/science/research)
 "btT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/machinery/light{
@@ -30578,8 +30522,7 @@
 /area/science/research)
 "btV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /obj/machinery/iv_drip,
 /obj/structure/cable,
@@ -30622,19 +30565,16 @@
 /area/science/test_area)
 "btZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bua" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -30811,8 +30751,7 @@
 /area/engine/atmos)
 "bux" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/light{
@@ -31200,8 +31139,7 @@
 /area/icemoon/surface/outdoors)
 "bvo" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4;
-	icon_state = "trimline_warn_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/cable,
@@ -31716,8 +31654,7 @@
 /area/medical/chemistry)
 "bwD" = (
 /obj/effect/turf_decal/trimline/blue/line{
-	dir = 5;
-	icon_state = "trimline"
+	dir = 5
 	},
 /obj/machinery/shower{
 	dir = 4
@@ -31739,8 +31676,7 @@
 /area/medical/medbay/central)
 "bwG" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8;
-	icon_state = "trimline_warn_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -31764,8 +31700,7 @@
 /area/medical/medbay/central)
 "bwI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32226,8 +32161,7 @@
 /area/medical/medbay/central)
 "bxT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -32240,8 +32174,7 @@
 /area/medical/medbay/central)
 "bxV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -32769,8 +32702,7 @@
 /area/maintenance/aft)
 "bzh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -33021,8 +32953,7 @@
 "bzO" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 9;
-	pixel_y = 0
+	pixel_x = 9
 	},
 /obj/item/paper_bin{
 	pixel_x = -5;
@@ -33297,8 +33228,7 @@
 /area/medical/medbay/central)
 "bAr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/firealarm{
@@ -33323,8 +33253,7 @@
 /area/medical/medbay/central)
 "bAu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/newscaster{
@@ -33832,8 +33761,7 @@
 /area/quartermaster/miningdock)
 "bBK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/airalarm{
@@ -33910,8 +33838,7 @@
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -34335,7 +34262,6 @@
 	pixel_y = 1
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 0;
 	pixel_y = 1
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
@@ -34418,8 +34344,7 @@
 "bCS" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/end{
-	dir = 8;
-	icon_state = "trimline_end"
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -34742,8 +34667,7 @@
 /area/medical/chemistry)
 "bDF" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -34762,8 +34686,7 @@
 /area/janitor)
 "bDI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -34801,8 +34724,7 @@
 /area/janitor)
 "bDN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/aft";
@@ -34846,8 +34768,7 @@
 /area/medical/chemistry)
 "bDS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5;
-	icon_state = "trimline_fill"
+	dir = 5
 	},
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -34857,8 +34778,7 @@
 /area/medical/medbay/aft)
 "bDU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/vending/medical{
 	pixel_x = -2
@@ -34970,8 +34890,7 @@
 /area/medical/storage)
 "bEj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/disposal/bin,
 /obj/machinery/light,
@@ -35562,8 +35481,7 @@
 /area/medical/medbay/aft)
 "bFM" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -35574,8 +35492,7 @@
 "bFN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -36500,8 +36417,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -36746,8 +36662,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -37484,8 +37399,7 @@
 "bKO" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -37520,8 +37434,7 @@
 /area/medical/break_room)
 "bKR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -38219,8 +38132,7 @@
 "bMJ" = (
 /obj/machinery/vending/medical,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5;
-	icon_state = "trimline_fill"
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -38359,8 +38271,7 @@
 "bNj" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -38374,12 +38285,10 @@
 /area/medical/virology)
 "bNl" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -38924,8 +38833,7 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -39130,8 +39038,7 @@
 "bPr" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -39984,8 +39891,7 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -40364,12 +40270,10 @@
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -40405,15 +40309,13 @@
 /area/medical/virology)
 "bSW" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bSX" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/structure/cable,
 /obj/structure/cable,
@@ -41009,8 +40911,7 @@
 "bVa" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -41366,8 +41267,7 @@
 	},
 /obj/item/clothing/glasses/science,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -41376,8 +41276,7 @@
 /obj/item/hand_labeler,
 /obj/item/radio/headset/headset_med,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -41687,8 +41586,7 @@
 	},
 /obj/item/storage/box/syringes,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -41700,8 +41598,7 @@
 	},
 /obj/item/pen/red,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -42069,8 +41966,7 @@
 /area/maintenance/aft)
 "bYa" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -42086,8 +41982,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -42397,8 +42292,7 @@
 "bYX" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -42406,8 +42300,7 @@
 /obj/structure/closet/secure_closet/medical1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -45524,8 +45417,7 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/left{
-	dir = 1;
-	icon_state = "sofaend_left"
+	dir = 1
 	},
 /obj/machinery/airalarm{
 	dir = 1;
@@ -51025,8 +50917,7 @@
 "cVc" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8;
-	icon_state = "trimline_warn_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -51042,12 +50933,10 @@
 /area/maintenance/starboard/aft)
 "cWz" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -51069,8 +50958,7 @@
 /area/science/genetics)
 "dbw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/structure/table,
 /obj/item/book/manual/wiki/medicine,
@@ -51301,12 +51189,10 @@
 /area/medical/virology)
 "dFo" = (
 /obj/effect/turf_decal/trimline/blue/corner{
-	dir = 8;
-	icon_state = "trimline_corner"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
-	dir = 8;
-	icon_state = "trimline_corner"
+	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -51332,8 +51218,7 @@
 "dHL" = (
 /obj/machinery/suit_storage_unit/cmo,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /obj/machinery/light{
 	dir = 8
@@ -51426,8 +51311,7 @@
 "ecg" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/filled/end{
-	dir = 8;
-	icon_state = "trimline_end_fill"
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/white,
@@ -51486,8 +51370,7 @@
 /area/science/nanite)
 "eya" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -51536,8 +51419,7 @@
 /area/engine/engineering)
 "eIN" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -51549,12 +51431,10 @@
 /area/crew_quarters/dorms)
 "eIZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/structure/cable,
 /obj/structure/cable,
@@ -51567,12 +51447,10 @@
 /area/science/lab)
 "eRH" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51758,8 +51636,7 @@
 "fxY" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -51767,8 +51644,7 @@
 /area/crew_quarters/heads/cmo)
 "fBh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -51778,8 +51654,7 @@
 /area/medical/medbay/aft)
 "fBp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -51837,8 +51712,7 @@
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -51857,8 +51731,7 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -51883,15 +51756,13 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "fUn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay East";
@@ -51907,8 +51778,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -51942,8 +51812,7 @@
 	pixel_y = 25
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5;
-	icon_state = "trimline_fill"
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -51964,11 +51833,9 @@
 /area/maintenance/department/medical/morgue)
 "gdg" = (
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/structure/sink{
-	pixel_x = 0;
 	pixel_y = 20
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -52011,8 +51878,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -52115,8 +51981,7 @@
 /area/science/xenobiology)
 "gGW" = (
 /obj/effect/turf_decal/trimline/blue/line{
-	dir = 6;
-	icon_state = "trimline"
+	dir = 6
 	},
 /obj/machinery/shower{
 	dir = 4
@@ -52208,8 +52073,7 @@
 /area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
 "gUV" = (
 /obj/machinery/computer/crew{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -52233,8 +52097,7 @@
 /area/construction)
 "gZK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4
@@ -52320,8 +52183,7 @@
 /area/science/xenobiology)
 "hAr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -52539,8 +52401,7 @@
 /area/medical/psychology)
 "itm" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -52742,8 +52603,7 @@
 "jib" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -52833,8 +52693,7 @@
 /area/maintenance/starboard/aft)
 "jsH" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -52966,8 +52825,7 @@
 /area/maintenance/department/medical/morgue)
 "jQp" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -53057,8 +52915,7 @@
 /area/medical/chemistry)
 "kcL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -53113,8 +52970,7 @@
 /obj/machinery/light,
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -53178,8 +53034,7 @@
 /area/hallway/primary/central)
 "kqq" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -53203,8 +53058,7 @@
 /area/medical/surgery)
 "kvh" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -53242,12 +53096,10 @@
 /area/science/mixing)
 "kwT" = (
 /obj/vehicle/ridden/wheelchair{
-	dir = 4;
-	icon_state = "wheelchair"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/end{
-	dir = 1;
-	icon_state = "trimline_end_fill"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -53261,8 +53113,7 @@
 /area/medical/medbay/aft)
 "kxj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5;
-	icon_state = "trimline_fill"
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -53306,7 +53157,6 @@
 /obj/structure/table/glass,
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	icon_state = "left";
 	name = "First-Aid Supplies";
 	red_alert_access = 1;
 	req_access_txt = "5"
@@ -53366,8 +53216,7 @@
 	pixel_y = 6
 	},
 /obj/item/folder/white{
-	pixel_x = 2;
-	pixel_y = 0
+	pixel_x = 2
 	},
 /obj/item/storage/pill_bottle/mutadone{
 	pixel_x = 11;
@@ -53628,8 +53477,7 @@
 /area/science/misc_lab)
 "lvw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/sign/warning/nosmoking/circle{
@@ -53656,8 +53504,7 @@
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -53851,8 +53698,7 @@
 /area/storage/mining)
 "lTQ" = (
 /obj/vehicle/ridden/wheelchair{
-	dir = 4;
-	icon_state = "wheelchair"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/end,
 /obj/structure/window/reinforced,
@@ -53971,8 +53817,7 @@
 "mpJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -54045,12 +53890,10 @@
 /area/engine/engineering)
 "mCo" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4;
-	icon_state = "trimline_warn_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -54180,8 +54023,7 @@
 /area/storage/mining)
 "mMH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -54424,8 +54266,7 @@
 "nxD" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -54765,12 +54606,10 @@
 /area/science/nanite)
 "oND" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /obj/structure/cable,
 /obj/structure/cable,
@@ -54855,8 +54694,7 @@
 "oXU" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /obj/machinery/light_switch{
 	pixel_x = 28
@@ -54904,12 +54742,10 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/closet/l3closet,
 /obj/machinery/light,
@@ -54969,13 +54805,11 @@
 /area/security/detectives_office)
 "phz" = (
 /obj/effect/turf_decal/trimline/blue/end{
-	dir = 1;
-	icon_state = "trimline_end"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/effect/turf_decal/trimline/blue/end{
-	dir = 1;
-	icon_state = "trimline_end"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/plasteel/white,
@@ -55091,8 +54925,7 @@
 /area/medical/medbay)
 "pva" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6;
-	icon_state = "trimline_fill"
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -55504,12 +55337,10 @@
 /area/science/genetics)
 "qtX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4;
-	icon_state = "trimline_warn_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -55530,8 +55361,7 @@
 /area/science/xenobiology)
 "qDH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
@@ -55681,12 +55511,10 @@
 /area/medical/morgue)
 "rzu" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8;
-	icon_state = "trimline_warn_fill"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -55756,8 +55584,7 @@
 /area/construction)
 "rLK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/clothing/neck/stethoscope,
@@ -55814,20 +55641,17 @@
 /area/maintenance/port)
 "rTE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8;
-	icon_state = "trimline_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "rVn" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4;
-	icon_state = "trimline_warn_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -55995,8 +55819,7 @@
 /area/hallway/secondary/service)
 "sxQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1;
-	icon_state = "trimline_warn_fill"
+	dir = 1
 	},
 /obj/structure/cable,
 /obj/structure/cable,
@@ -56017,8 +55840,7 @@
 /area/science/xenobiology)
 "sGs" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /obj/item/radio/intercom{
 	pixel_x = 25
@@ -56135,8 +55957,7 @@
 "sVI" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
 /turf/open/floor/plasteel/white,
@@ -56194,8 +56015,7 @@
 	pixel_y = 7
 	},
 /obj/item/storage/box/monkeycubes{
-	pixel_x = -5;
-	pixel_y = 0
+	pixel_x = -5
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
@@ -56513,8 +56333,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5;
-	icon_state = "trimline_fill"
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -56682,8 +56501,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4;
-	icon_state = "trimline_fill"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -56693,8 +56511,7 @@
 /area/chapel/main)
 "uyp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -56745,8 +56562,7 @@
 /area/science/mixing)
 "uGw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5;
-	icon_state = "trimline_fill"
+	dir = 5
 	},
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
@@ -56790,8 +56606,7 @@
 /area/science/research)
 "uJY" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -56820,8 +56635,7 @@
 /area/medical/chemistry)
 "uSc" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/structure/cable,
 /obj/structure/cable,
@@ -56997,8 +56811,7 @@
 /area/science/mixing)
 "vof" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57139,12 +56952,10 @@
 /area/hydroponics/garden)
 "vLr" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8;
-	icon_state = "trimline_warn_fill"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8;
-	icon_state = "trimline_corner_fill"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -57239,8 +57050,7 @@
 /area/medical/cryo)
 "wed" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9;
-	icon_state = "trimline_fill"
+	dir = 9
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -57457,8 +57267,7 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1;
-	icon_state = "trimline_fill"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -57493,12 +57302,10 @@
 /area/medical/medbay/central)
 "wRF" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -57669,12 +57476,10 @@
 /area/science/genetics)
 "xgf" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4;
-	icon_state = "trimline_corner_fill"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 1;
-	icon_state = "trimline_corner_fill"
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -57852,7 +57657,6 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/white,
@@ -58033,8 +57837,7 @@
 /area/medical/surgery)
 "yce" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10;
-	icon_state = "trimline_fill"
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -58120,8 +57923,7 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/right{
-	dir = 1;
-	icon_state = "sofaend_right"
+	dir = 1
 	},
 /obj/structure/sign/departments/restroom{
 	pixel_y = -32

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -8711,16 +8711,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/port/fore)
-"auf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Detective Maintenance";
-	req_access_txt = "4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "aug" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -9176,6 +9166,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Detective Maintenance";
+	req_access_txt = "4"
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "avi" = (
@@ -18002,6 +17996,7 @@
 /area/chapel/main)
 "aQw" = (
 /obj/structure/table/wood,
+/obj/item/storage/book/bible,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aQx" = (
@@ -24673,8 +24668,8 @@
 "bgP" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/end{
-	icon_state = "trimline_end";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_end"
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/white,
@@ -24840,8 +24835,8 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 26;
-	pixel_x = -27
+	pixel_x = -27;
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
@@ -24918,8 +24913,8 @@
 "bhn" = (
 /obj/structure/closet/secure_closet/chief_medical,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/cmo";
@@ -24935,8 +24930,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/computer/security/telescreen/cmo{
 	dir = 8;
@@ -26128,12 +26123,12 @@
 /area/medical/pharmacy)
 "bjT" = (
 /obj/effect/turf_decal/trimline/blue/corner{
-	icon_state = "trimline_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
-	icon_state = "trimline_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -26141,25 +26136,25 @@
 /area/medical/medbay/lobby)
 "bjU" = (
 /obj/effect/turf_decal/trimline/blue/corner{
-	icon_state = "trimline_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
-	icon_state = "trimline_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "bjV" = (
 /obj/effect/turf_decal/trimline/blue/end,
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline"
 	},
 /obj/effect/turf_decal/trimline/blue/end,
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
@@ -27417,12 +27412,12 @@
 /area/hallway/primary/central)
 "bmV" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27434,8 +27429,8 @@
 "bmW" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28008,12 +28003,12 @@
 /area/medical/pharmacy)
 "boe" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -28022,8 +28017,8 @@
 /area/medical/medbay/central)
 "bog" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/noticeboard{
 	pixel_y = 27
@@ -28032,15 +28027,15 @@
 /area/medical/medbay)
 "boh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "boi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -28048,8 +28043,8 @@
 "boj" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -28057,20 +28052,20 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "bom" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/sign/warning/nosmoking/circle{
 	pixel_x = 32
@@ -28575,8 +28570,8 @@
 /area/medical/pharmacy)
 "bpu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -28623,16 +28618,16 @@
 /area/hallway/primary/central)
 "bpD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/firealarm{
 	pixel_x = -30;
@@ -28649,8 +28644,8 @@
 /area/science/genetics)
 "bpF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -28667,8 +28662,8 @@
 /area/medical/surgery/room_b)
 "bpM" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -28921,8 +28916,8 @@
 /area/quartermaster/office)
 "bqt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/extinguisher_cabinet{
@@ -29096,8 +29091,8 @@
 "bqO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29111,12 +29106,12 @@
 /area/medical/medbay)
 "bqP" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -29197,8 +29192,8 @@
 /area/medical/medbay)
 "bqV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -29209,8 +29204,8 @@
 "bqW" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/cable,
 /obj/structure/cable,
@@ -29222,8 +29217,8 @@
 /area/medical/medbay)
 "bqX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -29299,8 +29294,8 @@
 /area/maintenance/department/medical/morgue)
 "brl" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -29609,12 +29604,12 @@
 /area/crew_quarters/heads/hop)
 "brT" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29708,12 +29703,12 @@
 /area/quartermaster/miningdock)
 "bse" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -29856,12 +29851,12 @@
 /area/medical/medbay/central)
 "bsu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -29870,12 +29865,12 @@
 /area/medical/medbay/aft)
 "bsv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29907,8 +29902,8 @@
 "bsy" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_warn_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -29934,8 +29929,8 @@
 /area/science/research)
 "bsB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -29951,8 +29946,8 @@
 /area/medical/medbay/aft)
 "bsC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/requests_console{
 	department = "Medbay";
@@ -29972,8 +29967,8 @@
 /area/medical/medbay/aft)
 "bsD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29987,12 +29982,12 @@
 /area/medical/medbay/aft)
 "bsE" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30024,8 +30019,8 @@
 /area/science/genetics)
 "bsI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /obj/item/kirbyplants/random,
 /obj/structure/extinguisher_cabinet{
@@ -30041,8 +30036,8 @@
 /area/medical/medbay/aft)
 "bsJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -30052,8 +30047,8 @@
 /area/medical/medbay/aft)
 "bsK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -30316,6 +30311,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bts" = (
@@ -30530,8 +30528,8 @@
 /area/science/research)
 "btR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -30558,8 +30556,8 @@
 /area/science/research)
 "btT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/machinery/light{
@@ -30580,8 +30578,8 @@
 /area/science/research)
 "btV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/iv_drip,
 /obj/structure/cable,
@@ -30624,19 +30622,19 @@
 /area/science/test_area)
 "btZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bua" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -30813,8 +30811,8 @@
 /area/engine/atmos)
 "bux" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/light{
@@ -31202,8 +31200,8 @@
 /area/icemoon/surface/outdoors)
 "bvo" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/cable,
@@ -31718,8 +31716,8 @@
 /area/medical/chemistry)
 "bwD" = (
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
-	dir = 5
+	dir = 5;
+	icon_state = "trimline"
 	},
 /obj/machinery/shower{
 	dir = 4
@@ -31741,8 +31739,8 @@
 /area/medical/medbay/central)
 "bwG" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_warn_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -31766,8 +31764,8 @@
 /area/medical/medbay/central)
 "bwI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -31980,9 +31978,6 @@
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "bxi" = (
-/obj/machinery/computer/aifixer{
-	dir = 8
-	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Research Director's Desk";
@@ -31994,6 +31989,9 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/machinery/computer/rdconsole/core{
+	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
@@ -32228,8 +32226,8 @@
 /area/medical/medbay/central)
 "bxT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -32242,8 +32240,8 @@
 /area/medical/medbay/central)
 "bxV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -32771,8 +32769,8 @@
 /area/maintenance/aft)
 "bzh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -33299,8 +33297,8 @@
 /area/medical/medbay/central)
 "bAr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/firealarm{
@@ -33325,8 +33323,8 @@
 /area/medical/medbay/central)
 "bAu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/newscaster{
@@ -33834,8 +33832,8 @@
 /area/quartermaster/miningdock)
 "bBK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/airalarm{
@@ -33912,8 +33910,8 @@
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -34420,8 +34418,8 @@
 "bCS" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/end{
-	icon_state = "trimline_end";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_end"
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -34744,8 +34742,8 @@
 /area/medical/chemistry)
 "bDF" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -34764,8 +34762,8 @@
 /area/janitor)
 "bDI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -34803,8 +34801,8 @@
 /area/janitor)
 "bDN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/aft";
@@ -34848,8 +34846,8 @@
 /area/medical/chemistry)
 "bDS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 5
+	dir = 5;
+	icon_state = "trimline_fill"
 	},
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -34859,8 +34857,8 @@
 /area/medical/medbay/aft)
 "bDU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/vending/medical{
 	pixel_x = -2
@@ -34972,8 +34970,8 @@
 /area/medical/storage)
 "bEj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/disposal/bin,
 /obj/machinery/light,
@@ -35564,8 +35562,8 @@
 /area/medical/medbay/aft)
 "bFM" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -35576,8 +35574,8 @@
 "bFN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -36502,8 +36500,8 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -36748,8 +36746,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -37486,8 +37484,8 @@
 "bKO" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -37522,8 +37520,8 @@
 /area/medical/break_room)
 "bKR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -38221,8 +38219,8 @@
 "bMJ" = (
 /obj/machinery/vending/medical,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 5
+	dir = 5;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -38361,8 +38359,8 @@
 "bNj" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -38376,12 +38374,12 @@
 /area/medical/virology)
 "bNl" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -38926,8 +38924,8 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -39132,8 +39130,8 @@
 "bPr" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -39986,8 +39984,8 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -40366,12 +40364,12 @@
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -40407,15 +40405,15 @@
 /area/medical/virology)
 "bSW" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bSX" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/cable,
 /obj/structure/cable,
@@ -41011,8 +41009,8 @@
 "bVa" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -41368,8 +41366,8 @@
 	},
 /obj/item/clothing/glasses/science,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -41378,8 +41376,8 @@
 /obj/item/hand_labeler,
 /obj/item/radio/headset/headset_med,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -41689,8 +41687,8 @@
 	},
 /obj/item/storage/box/syringes,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -41702,8 +41700,8 @@
 	},
 /obj/item/pen/red,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -42071,8 +42069,8 @@
 /area/maintenance/aft)
 "bYa" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -42088,8 +42086,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -42399,8 +42397,8 @@
 "bYX" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -42408,8 +42406,8 @@
 /obj/structure/closet/secure_closet/medical1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -45526,8 +45524,8 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/left{
-	icon_state = "sofaend_left";
-	dir = 1
+	dir = 1;
+	icon_state = "sofaend_left"
 	},
 /obj/machinery/airalarm{
 	dir = 1;
@@ -51027,8 +51025,8 @@
 "cVc" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -51044,12 +51042,12 @@
 /area/maintenance/starboard/aft)
 "cWz" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -51071,8 +51069,8 @@
 /area/science/genetics)
 "dbw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/table,
 /obj/item/book/manual/wiki/medicine,
@@ -51303,12 +51301,12 @@
 /area/medical/virology)
 "dFo" = (
 /obj/effect/turf_decal/trimline/blue/corner{
-	icon_state = "trimline_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
-	icon_state = "trimline_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -51334,8 +51332,8 @@
 "dHL" = (
 /obj/machinery/suit_storage_unit/cmo,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -51428,8 +51426,8 @@
 "ecg" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/filled/end{
-	icon_state = "trimline_end_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_end_fill"
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/white,
@@ -51488,8 +51486,8 @@
 /area/science/nanite)
 "eya" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -51538,8 +51536,8 @@
 /area/engine/engineering)
 "eIN" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -51551,12 +51549,12 @@
 /area/crew_quarters/dorms)
 "eIZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/cable,
 /obj/structure/cable,
@@ -51569,12 +51567,12 @@
 /area/science/lab)
 "eRH" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51760,8 +51758,8 @@
 "fxY" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -51769,8 +51767,8 @@
 /area/crew_quarters/heads/cmo)
 "fBh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -51780,8 +51778,8 @@
 /area/medical/medbay/aft)
 "fBp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -51839,8 +51837,8 @@
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -51859,8 +51857,8 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -51885,15 +51883,15 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "fUn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay East";
@@ -51909,8 +51907,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -51944,8 +51942,8 @@
 	pixel_y = 25
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 5
+	dir = 5;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -52013,8 +52011,8 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -52117,8 +52115,8 @@
 /area/science/xenobiology)
 "gGW" = (
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline"
 	},
 /obj/machinery/shower{
 	dir = 4
@@ -52210,8 +52208,8 @@
 /area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
 "gUV" = (
 /obj/machinery/computer/crew{
-	icon_state = "computer";
-	dir = 4
+	dir = 4;
+	icon_state = "computer"
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -52235,8 +52233,8 @@
 /area/construction)
 "gZK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -52322,8 +52320,8 @@
 /area/science/xenobiology)
 "hAr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -52541,8 +52539,8 @@
 /area/medical/psychology)
 "itm" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -52613,6 +52611,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"iIX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/vending/wardrobe/det_wardrobe,
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "iNn" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room"
@@ -52739,8 +52742,8 @@
 "jib" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -52830,8 +52833,8 @@
 /area/maintenance/starboard/aft)
 "jsH" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -52963,8 +52966,8 @@
 /area/maintenance/department/medical/morgue)
 "jQp" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -53054,8 +53057,8 @@
 /area/medical/chemistry)
 "kcL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -53110,8 +53113,8 @@
 /obj/machinery/light,
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -53175,8 +53178,8 @@
 /area/hallway/primary/central)
 "kqq" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -53200,8 +53203,8 @@
 /area/medical/surgery)
 "kvh" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -53239,12 +53242,12 @@
 /area/science/mixing)
 "kwT" = (
 /obj/vehicle/ridden/wheelchair{
-	icon_state = "wheelchair";
-	dir = 4
+	dir = 4;
+	icon_state = "wheelchair"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/end{
-	icon_state = "trimline_end_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_end_fill"
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -53258,8 +53261,8 @@
 /area/medical/medbay/aft)
 "kxj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 5
+	dir = 5;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -53625,8 +53628,8 @@
 /area/science/misc_lab)
 "lvw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/sign/warning/nosmoking/circle{
@@ -53653,8 +53656,8 @@
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -53848,8 +53851,8 @@
 /area/storage/mining)
 "lTQ" = (
 /obj/vehicle/ridden/wheelchair{
-	icon_state = "wheelchair";
-	dir = 4
+	dir = 4;
+	icon_state = "wheelchair"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/end,
 /obj/structure/window/reinforced,
@@ -53968,8 +53971,8 @@
 "mpJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -54042,12 +54045,12 @@
 /area/engine/engineering)
 "mCo" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -54177,8 +54180,8 @@
 /area/storage/mining)
 "mMH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -54421,8 +54424,8 @@
 "nxD" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -54762,12 +54765,12 @@
 /area/science/nanite)
 "oND" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/structure/cable,
 /obj/structure/cable,
@@ -54852,8 +54855,8 @@
 "oXU" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/light_switch{
 	pixel_x = 28
@@ -54905,8 +54908,8 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/closet/l3closet,
 /obj/machinery/light,
@@ -54966,13 +54969,13 @@
 /area/security/detectives_office)
 "phz" = (
 /obj/effect/turf_decal/trimline/blue/end{
-	icon_state = "trimline_end";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_end"
 	},
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/effect/turf_decal/trimline/blue/end{
-	icon_state = "trimline_end";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_end"
 	},
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/plasteel/white,
@@ -55088,8 +55091,8 @@
 /area/medical/medbay)
 "pva" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -55501,12 +55504,12 @@
 /area/science/genetics)
 "qtX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -55527,8 +55530,8 @@
 /area/science/xenobiology)
 "qDH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
@@ -55678,12 +55681,12 @@
 /area/medical/morgue)
 "rzu" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -55753,8 +55756,8 @@
 /area/construction)
 "rLK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/clothing/neck/stethoscope,
@@ -55811,20 +55814,20 @@
 /area/maintenance/port)
 "rTE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "rVn" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -55992,8 +55995,8 @@
 /area/hallway/secondary/service)
 "sxQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/structure/cable,
 /obj/structure/cable,
@@ -56014,8 +56017,8 @@
 /area/science/xenobiology)
 "sGs" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /obj/item/radio/intercom{
 	pixel_x = 25
@@ -56132,8 +56135,8 @@
 "sVI" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
 /turf/open/floor/plasteel/white,
@@ -56510,8 +56513,8 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 5
+	dir = 5;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -56679,15 +56682,19 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"uxf" = (
+/obj/structure/altar_of_gods,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "uyp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -56738,8 +56745,8 @@
 /area/science/mixing)
 "uGw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 5
+	dir = 5;
+	icon_state = "trimline_fill"
 	},
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
@@ -56783,8 +56790,8 @@
 /area/science/research)
 "uJY" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -56813,8 +56820,8 @@
 /area/medical/chemistry)
 "uSc" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/cable,
 /obj/structure/cable,
@@ -56990,8 +56997,8 @@
 /area/science/mixing)
 "vof" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57022,8 +57029,8 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "vwX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -57132,12 +57139,12 @@
 /area/hydroponics/garden)
 "vLr" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	icon_state = "trimline_warn_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_warn_fill"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -57232,8 +57239,8 @@
 /area/medical/cryo)
 "wed" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -57450,8 +57457,8 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -57486,12 +57493,12 @@
 /area/medical/medbay/central)
 "wRF" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -57662,12 +57669,12 @@
 /area/science/genetics)
 "xgf" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -58026,8 +58033,8 @@
 /area/medical/surgery)
 "yce" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -58113,8 +58120,8 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/right{
-	icon_state = "sofaend_right";
-	dir = 1
+	dir = 1;
+	icon_state = "sofaend_right"
 	},
 /obj/structure/sign/departments/restroom{
 	pixel_y = -32
@@ -84990,7 +84997,7 @@ qHT
 fBs
 dyN
 wUs
-qHT
+iIX
 vsa
 avh
 awh
@@ -85247,8 +85254,8 @@ apd
 yay
 mSf
 arW
-apd
-auf
+bLE
+pgP
 apd
 awe
 axy
@@ -105053,7 +105060,7 @@ aFz
 aTe
 aML
 aFz
-aFz
+uxf
 aQw
 aRS
 aRS

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -26186,6 +26186,7 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bjY" = (
@@ -54607,14 +54608,13 @@
 	},
 /obj/structure/table,
 /obj/machinery/cell_charger,
+/obj/structure/cable,
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/lobby";
-	dir = 1;
+	dir = 4;
 	name = "Medbay Lobby APC";
-	pixel_x = 25;
-	pixel_y = 23
+	pixel_x = 25
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "olh" = (
@@ -95276,10 +95276,10 @@ aYV
 aYV
 bev
 bfK
+bfK
 bhi
 bhi
-bhi
-bhi
+bfK
 bfK
 fMP
 bpw

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -38713,6 +38713,7 @@
 	name = "Station Intercom (Telecomms)";
 	pixel_y = 26
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bOq" = (
@@ -38801,6 +38802,7 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bOE" = (
@@ -39327,6 +39329,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bPS" = (
@@ -39624,6 +39627,7 @@
 	req_access_txt = "19; 61"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bQL" = (
@@ -40600,6 +40604,7 @@
 "bTI" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bTJ" = (
@@ -40829,6 +40834,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bUz" = (
@@ -41434,6 +41440,7 @@
 /area/science/research)
 "bWs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWt" = (
@@ -41454,12 +41461,14 @@
 	dir = 4
 	},
 /obj/machinery/navbeacon/wayfinding,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWw" = (
@@ -41530,6 +41539,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/tcommsat/computer";
+	dir = 1;
+	name = "Telecomms Monitoring APC";
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWI" = (
@@ -41555,6 +41571,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bWL" = (
@@ -42266,6 +42283,7 @@
 /area/hallway/primary/aft)
 "bYF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bYG" = (
@@ -52059,6 +52077,13 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard)
+"gyr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/tcommsat/computer)
 "gCA" = (
 /obj/machinery/button/door{
 	id = "xenobio8";
@@ -85544,7 +85569,7 @@ bNI
 bUB
 bVJ
 bOl
-bOC
+gyr
 bPQ
 bQK
 bYF

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -53640,8 +53640,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc{
 	areastring = "/area/science/nanite";
+	dir = 8;
 	name = "Nanite Lab APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -21916,7 +21916,7 @@
 "aYY" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=3-Central-Port";
-	location = "2.2-Leaving-Storage"
+	location = "2.1-Leaving-Storage"
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -21978,7 +21978,7 @@
 "aZi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=2.1-Storage";
+	codes_txt = "patrol;next_patrol=2.1-Leaving-Storage";
 	location = "1.5-Fore-Central"
 	},
 /obj/effect/turf_decal/plaque{
@@ -55365,7 +55365,9 @@
 	req_one_access_txt = "29"
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "czi" = (
@@ -76861,7 +76863,7 @@
 	dir = 1
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/medical/virology)
 "svg" = (
 /obj/structure/lattice,
 /obj/structure/girder/reinforced,
@@ -107485,8 +107487,8 @@ car
 car
 car
 cxA
-sVa
 car
+sVa
 cAi
 ctF
 car

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -74913,8 +74913,8 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	acted_explosions = 2;
 	areastring = "/area/medical/chemistry";
+	dir = 8;
 	name = "Chemistry APC";
 	pixel_x = -26
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -42559,6 +42559,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cce" = (
@@ -42568,14 +42571,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ccf" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Center";
-	network = list("ss13","engine");
-	pixel_x = 23
-	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -42589,6 +42584,9 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cch" = (
@@ -43015,6 +43013,11 @@
 	light_color = "#e8eaff"
 	},
 /obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Engineering Center";
+	network = list("ss13","engine");
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cdX" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Another batch of minor map fixes.
Fixes #51851.
Fixes #50256.
Fixes #51692 (thank you TheSmallBlue).
Fixes #50081.
Fixes the Nanite Lab APC on both box and icebox to not be floating, and the Medbay Lobby APC to not be in a window. Also actually connects the TComms on both box and icebox to the power grid, and adds an APC to Icebox TComms control (really, guys?).
Fixes an incorrectly placed fire alarm on Delta's departures hallway, as well as a rogue pipe.
Fixes the Chemistry Factory APC on Meta floating off the wall.
Integrates changes from #51749, thank you @KathyRyals.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less map problems, less pain.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Inept, KathyRyals
fix: A few minor map fixes, hot from the oven.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
