### PR TITLE
buffs the malf AI forceborger, nerfs the gamer arm

### DIFF
--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -7,9 +7,9 @@
 	icon_state = "separator-AO1"
 	layer = ABOVE_ALL_MOB_LAYER // Overhead
 	density = FALSE
-	var/transform_dead = 0
-	var/transform_standing = 0
-	var/cooldown_duration = 600 // 1 minute
+	var/transform_dead = TRUE
+	var/transform_standing = FALSE
+	var/cooldown_duration = 5 SECONDS
 	var/cooldown = 0
 	var/cooldown_timer
 	var/robot_cell_charge = 5000
@@ -84,10 +84,6 @@
 
 	playsound(src.loc, 'sound/items/welder.ogg', 50, TRUE)
 	H.emote("scream") // It is painful
-	H.adjustBruteLoss(max(0, 80 - H.getBruteLoss())) // Hurt the human, don't try to kill them though.
-
-	// Sleep for a couple of ticks to allow the human to see the pain
-	sleep(5)
 
 	use_power(5000) // Use a lot of power.
 	var/mob/living/silicon/robot/R = H.Robotize()
@@ -103,7 +99,6 @@
 
 /obj/machinery/transformer/proc/unlock_new_robot(mob/living/silicon/robot/R)
 	playsound(src.loc, 'sound/machines/ping.ogg', 50, FALSE)
-	sleep(30)
 	if(R)
 		R.SetLockdown(0)
 		R.notify_ai(NEW_BORG)

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -7,8 +7,9 @@
 
 /obj/item/borg/stun
 	name = "electrically-charged arm"
+	desc = "An electrically-charged arm capable of frying electronics."
 	icon_state = "elecarm"
-	var/charge_cost = 30
+	var/charge_cost = 300
 
 /obj/item/borg/stun/attack(mob/living/M, mob/living/user)
 	if(ishuman(M))
@@ -22,15 +23,14 @@
 			return
 
 	user.do_attack_animation(M)
-	M.Paralyze(100)
-	M.apply_effect(EFFECT_STUTTER, 5)
+	M.emp_act(EMP_HEAVY)
 
 	M.visible_message("<span class='danger'>[user] prods [M] with [src]!</span>", \
 					"<span class='userdanger'>[user] prods you with [src]!</span>")
 
 	playsound(loc, 'sound/weapons/egloves.ogg', 50, TRUE, -1)
 
-	log_combat(user, M, "stunned", src, "(INTENT: [uppertext(user.a_intent)])")
+	log_combat(user, M, "EMP'd", src, "(INTENT: [uppertext(user.a_intent)])")
 
 /obj/item/borg/cyborghug
 	name = "hugging module"

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -7,7 +7,7 @@
 
 /obj/item/borg/stun
 	name = "electrically-charged arm"
-	desc = "An electrically-charged arm capable of frying electronics."
+	desc = "An electrically-charged arm capable of emitting a targeted EMP."
 	icon_state = "elecarm"
 	var/charge_cost = 300
 


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/42606352/85825236-554ea580-b747-11ea-8caf-e82550333c5a.png)

Wait, wait, put the pitchforks away, lemme explain the details.

Alright, so, biggest change first:
- **The emagged engiborg's (and mining borg's) electrically-charged arm nows EMPs its targets** (with a heavy EMP effect; I might change it to a light EMP effect if the feedback on/for this PR indicates that I should do so) **instead of hardstunning them.** They're still strong (they silence radios (without the AI needing to cut comms station-wide) and, more importantly, **burn out flashes and drain the charge(s) of ion guns**), but you can't one click win any fight with them anymore.
- The power cost per use of the electrically-charged arm has also been increased from 30 power units to 300 power units.
- PK borg shock hugs have been left intact for now. I might nerf them to at least respect gloves in a future PR, I dunno.

To compensate for this incredible loss of power for malf AIs, the malf AI forceborger has been buffed:
- **The cooldown between forceborgings for the malf AI forceborger has been reduced from 1 minute to 5 seconds.** Gone are the days of having to wait around in front of the forceborger for ages, babysitting your pile of stunned humans.
- **The malf AI forceborger can now forceborg corpses.** This should increase the viabilities (for the purposes of being malf AI minions) of borg modules that can't reliably hardstun (most) flashproof targets (a group of modules that now includes engiborgs and miner borgs).
- I also removed some pretty much pointless sleep()s from the code of the malf AI forceborger, because sleep()s are bad, yo. As a side effect, this means that borgs made by the malf AI forceborger will be locked down for only 5 seconds after being created (instead of 8 seconds), but that shouldn't impact too much.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/42606352/85826366-15d58880-b74a-11ea-94be-9098c2d47e8d.png)


Aight but for real, the stun arm is kind of disgusting. To give you an idea of how disgusting it is, it is a viable (non-war) nuke op strategy to buy a state of the art, military-grade syndicate cyborg, disassemble it, buy two hypnotic flashes to replace its old flashes, reassemble it into a civilian-grade engiborg, emag it, and send it to one click stun the captain and bring them back to the ship. It's one of the few consistently accessible, un-no-sell-able hardstuns left in the game, and it's pretty much only remained the game so long because malf AIs currently kind of need it in order to use their forceborger effectively.

In my experience, the forceborger usually ends up developing a massive queue of people that some poor engiborg has constantly beat with their stun stick while they wait for the incredibly long cooldown of the forceborger to expire. Waiting in this queue (or managing it as that engiborg) is fun for absolutely no one, and it just seems sort of arbitrary.

The forceborger's inability to process corpses makes pretty much all of the borg modules without a way to hardstun through flash protection unviable for malf AI minions, as you need to be able to keep your victims chainstunned (if they're just in crit, they can use the succumb command to spite you) as you drag them all the way to the forceborger to actually borg them.

Also, the forceborger currently has some sleep()s in it, and unga dunga sleep() bad.

By making the changes listed in the About The Pull Request section, I believe that we can solve all of the above problems.

![image](https://user-images.githubusercontent.com/42606352/85827067-10c50900-b74b-11ea-9253-cf95e750952e.png)

## Changelog
:cl: ATHATH
balance: The emagged engiborg's (and mining borg's) electrically-charged arm nows EMPs its targets instead of hardstunning them.
balance: The power cost per use of the electrically-charged arm has also been increased from 30 power units to 300 power units.
balance: The cooldown between forceborgings for the malf AI forceborger has been reduced from 1 minute to 5 seconds.
balance: The malf AI forceborger can now forceborg corpses.
/:cl: