### PR TITLE
fixed issue with the destructive analyzer

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -60,13 +60,22 @@ Note: Must be placed within 3 tiles of the R&D Console
 /obj/machinery/rnd/destructive_analyzer/proc/reclaim_materials_from(obj/item/thing)
 	. = 0
 	var/datum/component/material_container/storage = linked_console?.linked_lathe?.materials.mat_container
-	if(storage) //Also sends salvaged materials to a linked protolathe, if any.
-		for(var/material in thing.custom_materials)
-			var/can_insert = min((storage.max_amount - storage.total_amount), (min(thing.custom_materials[material]*(decon_mod/10), thing.custom_materials[material])))
-			storage.insert_amount_mat(can_insert, material)
-			. += can_insert
-		if (.)
-			linked_console.linked_lathe.materials.silo_log(src, "reclaimed", 1, "[thing.name]", thing.custom_materials)
+	if(!storage) // If we have no storage drop out
+		return
+	// sends salvaged materials to a linked protolathe, if any.
+	for(var/material in thing.custom_materials)
+		var/can_insert = 0 // the amount of material to insert
+		if(istype(thing, /obj/item/stack/sheet))
+			var/obj/item/stack/sheet/stack = thing
+			if(stack.mats_per_unit)
+				can_insert += stack.mats_per_unit[material]
+			can_insert = min((storage.max_amount - storage.total_amount), (min(can_insert*(decon_mod/10), can_insert)))
+		else
+			can_insert = min((storage.max_amount - storage.total_amount), (min(thing.custom_materials[material]*(decon_mod/10), thing.custom_materials[material])))
+		storage.insert_amount_mat(can_insert, material)
+		. += can_insert
+	if (.)
+		linked_console.linked_lathe.materials.silo_log(src, "reclaimed", 1, "[thing.name]", thing.custom_materials)
 
 /obj/machinery/rnd/destructive_analyzer/proc/destroy_item(obj/item/thing, innermode = FALSE)
 	if(QDELETED(thing) || QDELETED(src) || QDELETED(linked_console))
@@ -87,12 +96,14 @@ Note: Must be placed within 3 tiles of the R&D Console
 	if(istype(thing, /obj/item/stack/sheet))
 		var/obj/item/stack/sheet/S = thing
 		if(S.amount > 1 && !innermode)
-			S.amount--
+			S.use(1, check=FALSE)
 			loaded_item = S
 		else
-			qdel(S)
-	if(thing)
+			qdel(thing)
+			loaded_item = null
+	else
 		qdel(thing)
+		loaded_item = null
 	if (!innermode)
 		update_icon()
 	return TRUE
@@ -124,7 +135,6 @@ Note: Must be placed within 3 tiles of the R&D Console
 		SSblackbox.record_feedback("nested tally", "item_deconstructed", 1, list("[TN.id]", "[loaded_item.type]"))
 		if(destroy_item(loaded_item))
 			linked_console.stored_research.boost_with_path(SSresearch.techweb_node_by_id(TN.id), dpath)
-			loaded_item = null
 
 	else
 		var/list/point_value = techweb_item_point_check(loaded_item)
@@ -144,8 +154,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 		if(destroy_item(loaded_item))
 			linked_console.stored_research.add_point_list(point_value)
 			linked_console.stored_research.deconstructed_items[loaded_type] = point_value
-			loaded_item = null
-	update_icon()
+
 	return TRUE
 
 /obj/machinery/rnd/destructive_analyzer/proc/unload_item()

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -91,7 +91,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 			loaded_item = S
 		else
 			qdel(S)
-	else
+	if(thing)
 		qdel(thing)
 	if (!innermode)
 		update_icon()
@@ -124,6 +124,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 		SSblackbox.record_feedback("nested tally", "item_deconstructed", 1, list("[TN.id]", "[loaded_item.type]"))
 		if(destroy_item(loaded_item))
 			linked_console.stored_research.boost_with_path(SSresearch.techweb_node_by_id(TN.id), dpath)
+			loaded_item = null
 
 	else
 		var/list/point_value = techweb_item_point_check(loaded_item)
@@ -143,6 +144,8 @@ Note: Must be placed within 3 tiles of the R&D Console
 		if(destroy_item(loaded_item))
 			linked_console.stored_research.add_point_list(point_value)
 			linked_console.stored_research.deconstructed_items[loaded_type] = point_value
+			loaded_item = null
+	update_icon()
 	return TRUE
 
 /obj/machinery/rnd/destructive_analyzer/proc/unload_item()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes reclaim mats not updating the device to show that the item was removed, and actually destroys the item.

Fixes #48752

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This was a bad issue that needs fixing not exploiting.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed destructive analyzer item visual not being removed when destroying items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
