### PR TITLE
changes a max to a min in n2o L U N G   C O D E

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -242,7 +242,7 @@
 		if(SA_pp > SA_para_min) // Enough to make us stunned for a bit
 			H.Unconscious(60) // 60 gives them one second to wake up and run away a bit!
 			if(SA_pp > SA_sleep_min) // Enough to make us sleep as well
-				H.Sleeping(max(H.AmountSleeping() + 40, 200))
+				H.Sleeping(min(H.AmountSleeping() + 100, 200))
 		else if(SA_pp > 0.01)	// There is sleeping gas in their lungs, but only a little, so give them a bit of a warning
 			if(prob(20))
 				H.emote(pick("giggle", "laugh"))


### PR DESCRIPTION
## About The Pull Request

This SHOULD fix n2o sometimes knocking people out for literal hours, even after it's disconnected from their internals.

Changing that 40 to a 100 is just to ensure that you definitely won't wake up occasionally while under anaesthetic, as you only take a breath once every 8 seconds under normal conditions, IIRC.

## Why It's Good For The Game

makes breath code less cursed

## Changelog
:cl: ATHATH
fix: Fixed n2o knocking out players for longer than expected.
/:cl: