### PR TITLE
Fixes a missing qdel hint

### DIFF
--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -40,7 +40,7 @@
 /turf/closed/wall/Destroy()
 	if(is_station_level(z))
 		GLOB.station_turfs -= src
-	..()
+	return ..()
 
 /turf/closed/wall/examine(mob/user)
 	. += ..()

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -65,7 +65,7 @@
 /turf/open/floor/Destroy()
 	if(is_station_level(z))
 		GLOB.station_turfs -= src
-	..()
+	return ..()
 
 /turf/open/floor/ex_act(severity, target)
 	var/shielded = is_shielded()


### PR DESCRIPTION
`/turf/open/floor/plating/asteroid/basalt/lava_land_surface is not returning a qdel hint. It is being placed in the queue. Further instances of this type will also be queued.`