### PR TITLE
Allow Revenants to read deadchat, and fix their Darkmode speech color

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -1,6 +1,6 @@
 //Revenants: based off of wraiths from Goon
 //"Ghosts" that are invisible and move like ghosts, cannot take damage while invisible
-//Don't hear deadchat and are NOT normal ghosts
+//Can hear deadchat, but are NOT normal ghosts and do NOT have x-ray vision
 //Admin-spawn or random event
 
 #define INVISIBILITY_REVENANT 50
@@ -73,6 +73,7 @@
 /mob/living/simple_animal/revenant/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
+	ADD_TRAIT(src, TRAIT_SIXTHSENSE, INNATE_TRAIT)
 	AddSpell(new /obj/effect/proc_holder/spell/targeted/night_vision/revenant(null))
 	AddSpell(new /obj/effect/proc_holder/spell/targeted/telepathy/revenant(null))
 	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/revenant/defile(null))

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -335,9 +335,9 @@ em						{font-style: normal;	font-weight: bold;}
 .purple					{color: #9956d3;}
 .holoparasite			{color: #88809c;}
 
-.revennotice			{color: #1d2953;}
-.revenboldnotice		{color: #1d2953;	font-weight: bold;}
-.revenbignotice			{color: #1d2953;	font-weight: bold;	font-size: 185%;}
+.revennotice			{color: #c099e2;}
+.revenboldnotice		{color: #c099e2;	font-weight: bold;}
+.revenbignotice			{color: #c099e2;	font-weight: bold;	font-size: 185%;}
 .revenminor				{color: #823abb}
 .revenwarning			{color: #760fbb;	font-style: italic;}
 .revendanger			{color: #760fbb;	font-weight: bold;	font-size: 185%;}


### PR DESCRIPTION
## About The Pull Request

Adds TRAIT_SIXTHSENSE to the Revenant mob, and adjusts the Darkmode goonchat CSS so their messages can be read without eyestrain or having to highlight the text like a black color OOC Jannie.

I am just starting to dabble with DM and esoteric as it is I could have overlooked a superior way of adding the dchat ears to the mob other than calling ADD_TRAIT, so please feel free to suggest adjustments and help me improve.

## Why It's Good For The Game

Revenants are basically ghosts that can also grief, so it only makes sense they can commune with the dead. Their flavor text says they have one foot in the realm of the living and one in the next and even the living if near death can hear ghosts, so why not a discount solo antag ghost?

Currently Revenant chat whether overheard by observers or a living target is near impossible to read with Darkmode enabled. 
![image](https://user-images.githubusercontent.com/64715958/85934163-dfa42000-b893-11ea-8d41-ce251231c937.png)


## Changelog
:cl:
tweak: Revenants, being spirits, can now hear ghost gang banter.
fix: Revenant speech color is now readable when using Darkmode.
/:cl:
