### PR TITLE
Smoothing cleanup, variables moved, atom movable three Destroy() merged into one

### DIFF
--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -46,6 +46,11 @@
 #define DEFAULT_UNDERLAY_ICON_STATE 	"plating"
 
 
+#define QUEUE_SMOOTH(thing_to_queue) if(thing_to_queue.smooth) {SSicon_smooth.add_to_queue(thing_to_queue)}
+
+#define QUEUE_SMOOTH_NEIGHBORS(thing_to_queue) for(var/neighbor in orange(1, thing_to_queue)) {var/atom/atom_neighbor = neighbor; QUEUE_SMOOTH(atom_neighbor)}
+
+
 /proc/calculate_adjacencies(atom/A)
 	if(!A.loc)
 		return 0
@@ -100,7 +105,7 @@
 
 	return adjacencies
 
-//do not use, use queue_smooth(atom)
+//do not use, use QUEUE_SMOOTH(atom)
 /proc/smooth_icon(atom/A)
 	if(!A || !A.smooth)
 		return
@@ -299,14 +304,14 @@
 			if(now)
 				smooth_icon(T)
 			else
-				queue_smooth(T)
+				QUEUE_SMOOTH(T)
 		for(var/R in T)
 			var/atom/A = R
 			if(A.smooth)
 				if(now)
 					smooth_icon(A)
 				else
-					queue_smooth(A)
+					QUEUE_SMOOTH(A)
 
 /atom/proc/clear_smooth_overlays()
 	cut_overlay(top_left_corner)
@@ -367,20 +372,6 @@
 			return SOUTHEAST
 		else
 			return 0
-
-//SSicon_smooth
-/proc/queue_smooth_neighbors(atom/A)
-	for(var/V in orange(1,A))
-		var/atom/T = V
-		if(T.smooth)
-			queue_smooth(T)
-
-//SSicon_smooth
-/proc/queue_smooth(atom/A)
-	if(!A.smooth)
-		return
-
-	SSicon_smooth.add_to_queue(A)
 
 
 //Example smooth wall

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -45,14 +45,6 @@
 #define DEFAULT_UNDERLAY_ICON 			'icons/turf/floors.dmi'
 #define DEFAULT_UNDERLAY_ICON_STATE 	"plating"
 
-/atom/var/smooth = SMOOTH_FALSE
-/atom/var/top_left_corner
-/atom/var/top_right_corner
-/atom/var/bottom_left_corner
-/atom/var/bottom_right_corner
-/atom/var/list/canSmoothWith = null // TYPE PATHS I CAN SMOOTH WITH~~~~~ If this is null and atom is smooth, it smooths only with itself
-/atom/movable/var/can_be_unanchored = FALSE
-/turf/var/list/fixed_underlay = null
 
 /proc/calculate_adjacencies(atom/A)
 	if(!A.loc)
@@ -385,12 +377,10 @@
 
 //SSicon_smooth
 /proc/queue_smooth(atom/A)
-	if(!A.smooth || A.smooth & SMOOTH_QUEUED)
+	if(!A.smooth)
 		return
 
-	SSicon_smooth.smooth_queue += A
-	SSicon_smooth.can_fire = 1
-	A.smooth |= SMOOTH_QUEUED
+	SSicon_smooth.add_to_queue(A)
 
 
 //Example smooth wall

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -68,7 +68,7 @@ SUBSYSTEM_DEF(icon_smooth)
 		can_fire = TRUE
 
 /datum/controller/subsystem/icon_smooth/proc/remove_from_queues(atom/thing)
-	thing &= ~SMOOTH_QUEUED
+	thing.smooth &= ~SMOOTH_QUEUED
 	smooth_queue -= thing
 	blueprint_queue -= thing
 	deferred -= thing

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -12,13 +12,15 @@ SUBSYSTEM_DEF(icon_smooth)
 
 /datum/controller/subsystem/icon_smooth/fire()
 	var/list/cached = smooth_queue
-	while(cached.len)
-		var/atom/A = cached[cached.len]
+	while(length(cached))
+		var/atom/smoothing_atom = cached[length(cached)]
 		cached.len--
-		if (A.flags_1 & INITIALIZED_1)
-			smooth_icon(A)
+		if(QDELETED(smoothing_atom) || !(smoothing_atom.smooth & SMOOTH_QUEUED))
+			continue
+		if(smoothing_atom.flags_1 & INITIALIZED_1)
+			smooth_icon(smoothing_atom)
 		else
-			deferred += A
+			deferred += smoothing_atom
 		if (MC_TICK_CHECK)
 			return
 
@@ -27,27 +29,46 @@ SUBSYSTEM_DEF(icon_smooth)
 			smooth_queue = deferred
 			deferred = cached
 		else
-			can_fire = 0
+			can_fire = FALSE
 
 /datum/controller/subsystem/icon_smooth/Initialize()
 	smooth_zlevel(1,TRUE)
 	smooth_zlevel(2,TRUE)
-	var/queue = smooth_queue
+
+	var/list/queue = smooth_queue
 	smooth_queue = list()
-	for(var/V in queue)
-		var/atom/A = V
-		if(!A || A.z <= 2)
+
+	while(length(queue))
+		var/atom/smoothing_atom = queue[length(queue)]
+		queue.len--
+		if(QDELETED(smoothing_atom) || !(smoothing_atom.smooth & SMOOTH_QUEUED) || smoothing_atom.z <= 2)
 			continue
-		smooth_icon(A)
+		smooth_icon(smoothing_atom)
 		CHECK_TICK
+
 	queue = blueprint_queue
 	blueprint_queue = list()
-	var/atom/movable/AM
-	var/turf/T
+
 	for(var/item in queue)
-		AM = item
-		T = AM.loc
-		if(T && AM)
-			T.add_blueprints(AM)
+		var/atom/movable/movable_item = item
+		if(!isturf(movable_item.loc))
+			continue
+		var/turf/item_loc = movable_item.loc
+		item_loc.add_blueprints(movable_item)
 
 	return ..()
+
+
+/datum/controller/subsystem/icon_smooth/proc/add_to_queue(atom/thing)
+	if(thing.smooth & SMOOTH_QUEUED)
+		return
+	thing.smooth |= SMOOTH_QUEUED
+	smooth_queue += thing
+	if(!can_fire)
+		can_fire = TRUE
+
+/datum/controller/subsystem/icon_smooth/proc/remove_from_queues(atom/thing)
+	thing &= ~SMOOTH_QUEUED
+	smooth_queue -= thing
+	blueprint_queue -= thing
+	deferred -= thing

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1308,7 +1308,7 @@
 /proc/log_wound(atom/victim, datum/wound/suffered_wound, dealt_damage, dealt_wound_bonus, dealt_bare_wound_bonus, base_roll)
 	if(QDELETED(victim) || !suffered_wound)
 		return
-		var/message = "has suffered: [suffered_wound][suffered_wound.limb ? " to [suffered_wound.limb.name]" : null]"// maybe indicate if it's a promote/demote?
+	var/message = "has suffered: [suffered_wound][suffered_wound.limb ? " to [suffered_wound.limb.name]" : null]"// maybe indicate if it's a promote/demote?
 
 	if(dealt_damage)
 		message += " | Damage: [dealt_damage]"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -991,7 +991,7 @@
 		flags_1 |= ADMIN_SPAWNED_1
 	. = ..()
 	switch(var_name)
-		if("color")
+		if(NAMEOF(src, color))
 			add_atom_colour(color, ADMIN_COLOUR_PRIORITY)
 
 /**
@@ -1306,13 +1306,15 @@
   * * base_roll- Base wounding ability of an attack is a random number from 1 to (dealt_damage ** WOUND_DAMAGE_EXPONENT). This is the number that was rolled in there, before mods
   */
 /proc/log_wound(atom/victim, datum/wound/suffered_wound, dealt_damage, dealt_wound_bonus, dealt_bare_wound_bonus, base_roll)
-	var/message = "has suffered: [suffered_wound] to [suffered_wound.limb.name]" // maybe indicate if it's a promote/demote?
+	if(QDELETED(victim) || !suffered_wound)
+		return
+		var/message = "has suffered: [suffered_wound][suffered_wound.limb ? " to [suffered_wound.limb.name]" : null]"// maybe indicate if it's a promote/demote?
 
 	if(dealt_damage)
 		message += " | Damage: [dealt_damage]"
 		// The base roll is useful since it can show how lucky someone got with the given attack. For example, dealing a cut
 		if(base_roll)
-			message += "(rolled [base_roll]/[dealt_damage ** WOUND_DAMAGE_EXPONENT])"
+			message += " (rolled [base_roll]/[dealt_damage ** WOUND_DAMAGE_EXPONENT])"
 
 	if(dealt_wound_bonus)
 		message += " | WB: [dealt_wound_bonus]"
@@ -1337,6 +1339,12 @@
 		var/list/arguments = data.Copy()
 		arguments -= "priority"
 		filters += filter(arglist(arguments))
+
+/obj/item/update_filters()
+	. = ..()
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtonIcon()
 
 /atom/movable/proc/get_filter(name)
 	if(filter_data && filter_data[name])

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -167,25 +167,25 @@
 	if((var_name in careful_edits) && (var_value % world.icon_size) != 0)
 		return FALSE
 	switch(var_name)
-		if("x")
+		if(NAMEOF(src, x))
 			var/turf/T = locate(var_value, y, z)
 			if(T)
 				forceMove(T)
 				return TRUE
 			return FALSE
-		if("y")
+		if(NAMEOF(src, y))
 			var/turf/T = locate(x, var_value, z)
 			if(T)
 				forceMove(T)
 				return TRUE
 			return FALSE
-		if("z")
+		if(NAMEOF(src, z))
 			var/turf/T = locate(x, y, var_value)
 			if(T)
 				forceMove(T)
 				return TRUE
 			return FALSE
-		if("loc")
+		if(NAMEOF(src, loc))
 			if(istype(var_value, /atom))
 				forceMove(var_value)
 				return TRUE

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -51,6 +51,8 @@
 	///Internal holder for emissive blocker object, do not use directly use blocks_emissive
 	var/atom/movable/emissive_blocker/em_block
 
+	///Used for the calculate_adjacencies proc for icon smoothing.
+	var/can_be_unanchored = FALSE
 
 /atom/movable/Initialize(mapload)
 	. = ..()
@@ -62,9 +64,46 @@
 			em_block = new(src, render_target)
 			vis_contents += em_block
 
-/atom/movable/Destroy()
+
+/atom/movable/Destroy(force)
+	QDEL_NULL(proximity_monitor)
+	QDEL_NULL(language_holder)
 	QDEL_NULL(em_block)
-	return ..()
+
+	unbuckle_all_mobs(force = TRUE)
+
+	. = ..()
+
+	if(loc)
+		//Restore air flow if we were blocking it (movables with ATMOS_PASS_PROC will need to do this manually if necessary)
+		if(((CanAtmosPass == ATMOS_PASS_DENSITY && density) || CanAtmosPass == ATMOS_PASS_NO) && isturf(loc))
+			CanAtmosPass = ATMOS_PASS_YES
+			air_update_turf(TRUE)
+		loc.handle_atom_del(src)
+
+		// If we have opacity, make sure to tell (potentially) affected light sources.
+		if(opacity && isturf(loc))
+			var/turf/turf_loc = loc
+			var/old_has_opaque_atom = turf_loc.has_opaque_atom
+			turf_loc.recalc_atom_opacity()
+			if(old_has_opaque_atom != turf_loc.has_opaque_atom)
+				turf_loc.reconsider_lights()
+
+	for(var/movable_content in contents)
+		qdel(movable_content)
+
+	LAZYCLEARLIST(client_mobs_in_contents)
+
+	invisibility = INVISIBILITY_ABSTRACT
+	if(pulledby)
+		pulledby.stop_pulling()
+
+	if(orbiting)
+		orbiting.end_orbit(src)
+		orbiting = null
+
+	moveToNullspace()
+
 
 /atom/movable/proc/update_emissive_block()
 	if(blocks_emissive != EMISSIVE_BLOCK_GENERIC)
@@ -127,25 +166,25 @@
 	if((var_name in careful_edits) && (var_value % world.icon_size) != 0)
 		return FALSE
 	switch(var_name)
-		if(NAMEOF(src, x))
+		if("x")
 			var/turf/T = locate(var_value, y, z)
 			if(T)
 				forceMove(T)
 				return TRUE
 			return FALSE
-		if(NAMEOF(src, y))
+		if("y")
 			var/turf/T = locate(x, var_value, z)
 			if(T)
 				forceMove(T)
 				return TRUE
 			return FALSE
-		if(NAMEOF(src, z))
+		if("z")
 			var/turf/T = locate(x, y, var_value)
 			if(T)
 				forceMove(T)
 				return TRUE
 			return FALSE
-		if(NAMEOF(src, loc))
+		if("loc")
 			if(istype(var_value, /atom))
 				forceMove(var_value)
 				return TRUE
@@ -396,30 +435,6 @@
 
 	return TRUE
 
-/atom/movable/Destroy(force)
-	QDEL_NULL(proximity_monitor)
-	QDEL_NULL(language_holder)
-
-	unbuckle_all_mobs(force=1)
-
-	. = ..()
-	if(loc)
-		//Restore air flow if we were blocking it (movables with ATMOS_PASS_PROC will need to do this manually if necessary)
-		if(((CanAtmosPass == ATMOS_PASS_DENSITY && density) || CanAtmosPass == ATMOS_PASS_NO) && isturf(loc))
-			CanAtmosPass = ATMOS_PASS_YES
-			air_update_turf(TRUE)
-		loc.handle_atom_del(src)
-	for(var/atom/movable/AM in contents)
-		qdel(AM)
-	LAZYCLEARLIST(client_mobs_in_contents)
-	moveToNullspace()
-	invisibility = INVISIBILITY_ABSTRACT
-	if(pulledby)
-		pulledby.stop_pulling()
-
-	if(orbiting)
-		orbiting.end_orbit(src)
-		orbiting = null
 
 // Make sure you know what you're doing if you call this, this is intended to only be called by byond directly.
 // You probably want CanPass()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -72,8 +72,6 @@
 
 	unbuckle_all_mobs(force = TRUE)
 
-	. = ..()
-
 	if(loc)
 		//Restore air flow if we were blocking it (movables with ATMOS_PASS_PROC will need to do this manually if necessary)
 		if(((CanAtmosPass == ATMOS_PASS_DENSITY && density) || CanAtmosPass == ATMOS_PASS_NO) && isturf(loc))
@@ -89,18 +87,21 @@
 			if(old_has_opaque_atom != turf_loc.has_opaque_atom)
 				turf_loc.reconsider_lights()
 
-	for(var/movable_content in contents)
-		qdel(movable_content)
-
-	LAZYCLEARLIST(client_mobs_in_contents)
-
 	invisibility = INVISIBILITY_ABSTRACT
+
 	if(pulledby)
 		pulledby.stop_pulling()
 
 	if(orbiting)
 		orbiting.end_orbit(src)
 		orbiting = null
+
+	for(var/movable_content in contents)
+		qdel(movable_content)
+
+	LAZYCLEARLIST(client_mobs_in_contents)
+
+	. = ..()
 
 	moveToNullspace()
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -96,12 +96,12 @@
 		orbiting.end_orbit(src)
 		orbiting = null
 
+	. = ..()
+
 	for(var/movable_content in contents)
 		qdel(movable_content)
 
 	LAZYCLEARLIST(client_mobs_in_contents)
-
-	. = ..()
 
 	moveToNullspace()
 

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -65,11 +65,11 @@
 		smooth = SMOOTH_MORE
 		icon = 'icons/effects/dirt.dmi'
 		icon_state = ""
-		queue_smooth(src)
-	queue_smooth_neighbors(src)
+		QUEUE_SMOOTH(src)
+	QUEUE_SMOOTH_NEIGHBORS(src)
 
 /obj/effect/decal/cleanable/dirt/Destroy()
-	queue_smooth_neighbors(src)
+	QUEUE_SMOOTH_NEIGHBORS(src)
 	return ..()
 
 /obj/effect/decal/cleanable/dirt/dust

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -19,15 +19,15 @@
 		armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	. = ..()
 	if(smooth)
-		queue_smooth(src)
-		queue_smooth_neighbors(src)
+		QUEUE_SMOOTH(src)
+		QUEUE_SMOOTH_NEIGHBORS(src)
 		icon_state = ""
 	GLOB.cameranet.updateVisibility(src)
 
 /obj/structure/Destroy()
 	GLOB.cameranet.updateVisibility(src)
 	if(smooth)
-		queue_smooth_neighbors(src)
+		QUEUE_SMOOTH_NEIGHBORS(src)
 	return ..()
 
 /obj/structure/attack_hand(mob/user)

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -71,7 +71,7 @@
 		if(density)
 			icon_state = initial(icon_state)
 			smooth = SMOOTH_TRUE
-			queue_smooth(src)
+			QUEUE_SMOOTH(src)
 		else
 			icon_state = "fwall_open"
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -32,7 +32,7 @@
 	ratio = CEILING(ratio*4, 1) * 25
 
 	if(smooth)
-		queue_smooth(src)
+		QUEUE_SMOOTH(src)
 
 	if(ratio > 50)
 		return

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -311,7 +311,7 @@
 
 /obj/structure/mineral_door/paperframe/Initialize()
 	. = ..()
-	queue_smooth_neighbors(src)
+	QUEUE_SMOOTH_NEIGHBORS(src)
 
 /obj/structure/mineral_door/paperframe/examine(mob/user)
 	. = ..()
@@ -346,5 +346,5 @@
 	return
 
 /obj/structure/mineral_door/paperframe/Destroy()
-	queue_smooth_neighbors(src)
+	QUEUE_SMOOTH_NEIGHBORS(src)
 	return ..()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -44,8 +44,8 @@
 
 /obj/structure/table/update_icon()
 	if(smooth)
-		queue_smooth(src)
-		queue_smooth_neighbors(src)
+		QUEUE_SMOOTH(src)
+		QUEUE_SMOOTH_NEIGHBORS(src)
 
 /obj/structure/table/narsie_act()
 	var/atom/A = loc

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -305,7 +305,7 @@
 /obj/structure/window/proc/update_nearby_icons()
 	update_icon()
 	if(smooth)
-		queue_smooth_neighbors(src)
+		QUEUE_SMOOTH_NEIGHBORS(src)
 
 //merges adjacent full-tile windows into one
 /obj/structure/window/update_overlays()
@@ -318,7 +318,7 @@
 		ratio = CEILING(ratio*4, 1) * 25
 
 		if(smooth)
-			queue_smooth(src)
+			QUEUE_SMOOTH(src)
 
 		cut_overlay(crack_overlay)
 		if(ratio > 75)
@@ -775,7 +775,7 @@
 		cut_overlay(torn)
 		add_overlay(paper)
 		set_opacity(TRUE)
-	queue_smooth(src)
+	QUEUE_SMOOTH(src)
 
 
 /obj/structure/window/paperframe/attackby(obj/item/W, mob/user)

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -286,7 +286,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		for(var/obj/machinery/door/firedoor/FD in T)
 			FD.CalculateAffectingAreas()
 
-	queue_smooth_neighbors(src)
+	QUEUE_SMOOTH_NEIGHBORS(src)
 
 	HandleTurfChange(src)
 

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -200,8 +200,8 @@
 		clear_smooth_overlays()
 	else
 		smooth = SMOOTH_TRUE
-		queue_smooth_neighbors(src)
-		queue_smooth(src)
+		QUEUE_SMOOTH_NEIGHBORS(src)
+		QUEUE_SMOOTH(src)
 
 /turf/closed/wall/r_wall/update_icon_state()
 	if(d_state != INTACT)

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -200,11 +200,11 @@
 		return 0
 	if(!broken && !burnt)
 		if(smooth)
-			queue_smooth(src)
+			QUEUE_SMOOTH(src)
 	else
 		make_plating()
 		if(smooth)
-			queue_smooth_neighbors(src)
+			QUEUE_SMOOTH_NEIGHBORS(src)
 
 /turf/open/floor/carpet/black
 	icon = 'icons/turf/floors/carpet_black.dmi'

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -1,6 +1,8 @@
 GLOBAL_LIST_EMPTY(station_turfs)
 /turf
 	icon = 'icons/turf/floors.dmi'
+	flags_1 = CAN_BE_DIRTY_1
+	vis_flags = VIS_INHERIT_ID|VIS_INHERIT_PLANE // Important for interaction with and visualization of openspace.
 
 	var/intact = 1
 
@@ -17,8 +19,6 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 	var/blocks_air = FALSE
 
-	flags_1 = CAN_BE_DIRTY_1
-
 	var/list/image/blueprint_data //for the station blueprints, images of objects eg: pipes
 
 	var/explosion_level = 0	//for preventing explosion dodging
@@ -34,7 +34,9 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 	var/tiled_dirt = FALSE // use smooth tiled dirt decal
 
-	vis_flags = VIS_INHERIT_ID|VIS_INHERIT_PLANE	// Important for interaction with and visualization of openspace.
+	///Icon-smoothing variable to map a diagonal wall corner with a fixed underlay.
+	var/list/fixed_underlay = null
+
 
 /turf/vv_edit_var(var_name, new_value)
 	var/static/list/banned_edits = list("x", "y", "z")

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -62,7 +62,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 	levelupdate()
 	if(smooth)
-		queue_smooth(src)
+		QUEUE_SMOOTH(src)
 	visibilityChanged()
 
 	for(var/atom/movable/AM in src)

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -117,7 +117,7 @@
 /turf/open/floor/holofloor/carpet/update_icon()
 	. = ..()
 	if(intact)
-		queue_smooth(src)
+		QUEUE_SMOOTH(src)
 
 /turf/open/floor/holofloor/wood
 	icon_state = "wood"

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -48,15 +48,6 @@
 		else
 			light = new/datum/light_source(src, .)
 
-// If we have opacity, make sure to tell (potentially) affected light sources.
-/atom/movable/Destroy()
-	var/turf/T = loc
-	. = ..()
-	if (opacity && istype(T))
-		var/old_has_opaque_atom = T.has_opaque_atom
-		T.recalc_atom_opacity()
-		if (old_has_opaque_atom != T.has_opaque_atom)
-			T.reconsider_lights()
 
 // Should always be used to change the opacity of an atom.
 // It notifies (potentially) affected light sources so they can update (if needed).

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -523,11 +523,11 @@ Difficulty: Hard
 
 /obj/effect/temp_visual/hierophant/wall/Initialize(mapload, new_caster)
 	. = ..()
-	queue_smooth_neighbors(src)
-	queue_smooth(src)
+	QUEUE_SMOOTH_NEIGHBORS(src)
+	QUEUE_SMOOTH(src)
 
 /obj/effect/temp_visual/hierophant/wall/Destroy()
-	queue_smooth_neighbors(src)
+	QUEUE_SMOOTH_NEIGHBORS(src)
 	return ..()
 
 /obj/effect/temp_visual/hierophant/wall/CanAllowThrough(atom/movable/mover, turf/target)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -314,11 +314,11 @@ While using this makes the system rely on OnFire, it still gives options for tim
 
 /obj/effect/temp_visual/elite_tumor_wall/Initialize(mapload, new_caster)
 	. = ..()
-	queue_smooth_neighbors(src)
-	queue_smooth(src)
+	QUEUE_SMOOTH_NEIGHBORS(src)
+	QUEUE_SMOOTH(src)
 
 /obj/effect/temp_visual/elite_tumor_wall/Destroy()
-	queue_smooth_neighbors(src)
+	QUEUE_SMOOTH_NEIGHBORS(src)
 	activator = null
 	ourelite = null
 	return ..()

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -13,7 +13,7 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 
 	//resmooth if need be.
 	if(smooth && (params & ROTATE_SMOOTH))
-		queue_smooth(src)
+		QUEUE_SMOOTH(src)
 
 	//rotate the pixel offsets too.
 	if((pixel_x || pixel_y) && (params & ROTATE_OFFSET))


### PR DESCRIPTION
Bit of code cleanup mostly

* Moves the smoothing variables to their object definitions, with a little bit of commenting.
* Cleans up a bit of the icon smoothing code to prevent keeping references to qdeleted things.
* Merges the three atom/movable/Destroy proc definitions into a single one for clarity
