### PR TITLE
Occupational Corruption Device

### DIFF
--- a/code/game/objects/items/devices/ocd.dm
+++ b/code/game/objects/items/devices/ocd.dm
@@ -1,0 +1,11 @@
+/obj/item/devices/ocd_device
+	name = "Occupational Corruption Device"
+	desc = "When you need to make the lives of new-hires that much more confusing, think OCD."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "gangtool-white"
+
+/obj/item/devices/ocd_device/attack_self(mob/user)
+    var/datum/round_event/bureaucratic_error/event = new()
+    event.start()
+    deadchat_broadcast("<span class='bold'> An OCD has been activated! </span>")
+    qdel(src)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1924,6 +1924,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/autosurgeon/syndicate/laser_arm
 	restricted_roles = list("Roboticist")
 
+/datum/uplink_item/role_restricted/ocd_device
+	name = "Organic Resources Disturbance Inducer"
+	desc = "A device that raises hell in organic resources indirectly. Single use."
+	cost = 2
+	limited_stock = 1
+	item = /obj/item/devices/ocd_device
+	restricted_roles = list("Head of Personnel", "Quartermaster")
+
 // Pointless
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1033,6 +1033,7 @@
 #include "code\game\objects\items\devices\lightreplacer.dm"
 #include "code\game\objects\items\devices\megaphone.dm"
 #include "code\game\objects\items\devices\multitool.dm"
+#include "code\game\objects\items\devices\ocd.dm"
 #include "code\game\objects\items\devices\paicard.dm"
 #include "code\game\objects\items\devices\pipe_painter.dm"
 #include "code\game\objects\items\devices\polycircuit.dm"


### PR DESCRIPTION
## About The Pull Request

Adds a new traitor item exclusive to Heads of Personnel and Quartermasters that triggers a bureaucratic error

## Why It's Good For The Game

Adds a new method for traitors to cause indirect havoc to the station at large

## Changelog
:cl:
add: Added a new traitor item for HoP and QM, the OCD
/:cl: