### PR TITLE
mobs no longer hard delete by default

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -39,8 +39,8 @@
 	qdel(hud_used)
 	QDEL_LIST(client_colours)
 	ghostize()
-	..()
-	return QDEL_HINT_HARDDEL
+	return ..()
+
 
 /**
   * Intialize a mob

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -19,8 +19,6 @@
   * Ghostizes the client attached to this mob
   *
   * Parent call
-  *
-  * Returns QDEL_HINT_HARDDEL (don't change this)
   */
 /mob/Destroy()//This makes sure that mobs with clients/keys are not just deleted from the game.
 	remove_from_mob_list()


### PR DESCRIPTION
Long ago in #20947 all mobs were made to hard delete by default due to a blob issue.

If this issue is not fixed by now, then it should be, instead of forcing every mob to hard del.