### PR TITLE
Fixes Wrong Garbage Controller Timeouts

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -6,7 +6,7 @@ SUBSYSTEM_DEF(garbage)
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 	init_order = INIT_ORDER_GARBAGE
 
-	var/list/collection_timeout = list(0, 2 MINUTES, 10 SECONDS)	// deciseconds to wait before moving something up in the queue to the next level
+	var/list/collection_timeout = list(2 MINUTES, 10 SECONDS)	// deciseconds to wait before moving something up in the queue to the next level
 
 	//Stat tracking
 	var/delslasttick = 0			// number of del()'s we've done this tick


### PR DESCRIPTION
Noticed this tonight.

There was once 3 collection timeouts when there was the pre-queue; now there's only 2, but there's still 3 timeout levels.

The unintended impacts of this are...well, a LOT of false positives.

Needless to say, unless something garbage collected INSTANTANEOUSLY, it would be marked as a failure.

Likewise, it meant queued hard deletes had to wait a full 2 minutes before they were actually hard deleted instead of just 10 seconds (Oh dear, who knows what problems that's been causing!)

This should all be fixed now.

Less time wasted on false positive GC failures and more time spent on hunting down actual failures.