### PR TITLE
Bloodbrothers now cost less threat

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -56,7 +56,7 @@
 	required_candidates = 2
 	weight = 4
 	cost = 15
-	scaling_cost = 15
+	scaling_cost = 10
 	requirements = list(40,30,30,20,20,15,15,15,10,10)
 	antag_cap = list(2,2,2,2,2,2,2,2,2,2)	// Can pick 3 per team, but rare enough it doesn't matter.
 	var/list/datum/team/brother_team/pre_brother_teams = list()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -55,7 +55,7 @@
 	restricted_roles = list("Cyborg", "AI")
 	required_candidates = 2
 	weight = 4
-	cost = 15
+	cost = 10
 	scaling_cost = 10
 	requirements = list(40,30,30,20,20,15,15,15,10,10)
 	antag_cap = list(2,2,2,2,2,2,2,2,2,2)	// Can pick 3 per team, but rare enough it doesn't matter.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Bloodbrothers now cost 10 and scaling 10 threat instead of 15, to put in line with traitors
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bloodbrothers are less threatening to the order of the station than, at least in my opinion, regular traitors. This is because they have no external tools to cause havoc with if they desire to murderbone, and are to some extent suggested to work as a team to accomplish goals instead of go on a rampage. This results in less chaos on the station, despite there being two antags that work in unison. They also have no way of identifying regular traitors either, and this prevents larger cooperation that may be more chaos promoting to the station.

Furthermore, regular traitors have tools to get a companion if they desire such, in the way of hypnoflash, AI upload board and Emag. 

## Changelog
:cl:IradT
balance: Blood brothers now cost 10 threat instead of 15
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
