### PR TITLE
Meta metal wood bar tables what

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -287,7 +287,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aaM" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aaN" = (
@@ -32794,12 +32794,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "byB" = (
-/obj/structure/table/wood/bar,
 /obj/item/clothing/mask/cigarette/cigar,
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "byC" = (
@@ -74831,7 +74831,6 @@
 /area/crew_quarters/toilet/auxiliary)
 "pEK" = (
 /obj/structure/table/reinforced,
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -75764,6 +75763,14 @@
 /obj/item/reagent_containers/food/snacks/grown/banana,
 /turf/open/floor/grass,
 /area/medical/virology)
+"qUk" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "qUR" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
@@ -77289,11 +77296,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "tyf" = (
-/obj/structure/table/wood/bar,
 /obj/item/clothing/head/fedora,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "tyz" = (
@@ -77507,6 +77514,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "tQf" = (
@@ -114443,7 +114451,7 @@ bWO
 bYg
 bWT
 caM
-tYS
+qUk
 bST
 dDr
 cgq

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -31436,10 +31436,6 @@
 /area/crew_quarters/bar)
 "buS" = (
 /obj/machinery/computer/arcade,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
@@ -32838,9 +32834,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "byH" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Did you know that bar wooden tables are made out of metal?
Replaced some tables in the bar with a valid type.

Also botany got some lights.
And other fixes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Crazy tables are bad for sanity.
Also plants need light to grow I guess.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Meta bar tables are not that metal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
