### PR TITLE
Return of modules to AI shell names

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -82,7 +82,7 @@
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
 #define MAX_MESSAGE_LEN			1024
-#define MAX_NAME_LEN			42
+#define MAX_NAME_LEN			38
 #define MAX_BROADCAST_LEN		512
 #define MAX_CHARTER_LEN			80
 

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -82,7 +82,7 @@
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
 #define MAX_MESSAGE_LEN			1024
-#define MAX_NAME_LEN			38
+#define MAX_NAME_LEN			42
 #define MAX_BROADCAST_LEN		512
 #define MAX_CHARTER_LEN			80
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -913,7 +913,7 @@
   * * AI - AI unit that initiated the deployment into the AI shell
   */
 /mob/living/silicon/robot/proc/deploy_init(mob/living/silicon/ai/AI)
-	real_name = "[AI.real_name] Shell-[ident]"
+	real_name = "[AI.real_name] [designation] Shell-[ident]"
 	name = real_name
 	if(!QDELETED(builtInCamera))
 		builtInCamera.c_tag = real_name	//update the camera name too


### PR DESCRIPTION
## About The Pull Request

In march there was a PR to add consistency to the numbers at the end of AI shells, while that PR did service its purpose it also removed the modules from the shell names, which is rather annoying for AIs who are lucky enough to have kind robotocists make them multiple shells, this PR reintroduces that feature

## Why It's Good For The Game

Most AI mains that I have spoken to all generally agree that this is rather annoying and that the ease of being able to see the module name would make the drop down menu for shell picking far easier for identification. 

## Changelog
:cl:
tweak: Reintroduces module type to AI shell name
/:cl:

