### PR TITLE
non-mimes who learn a spell from the guide to dank mimery now also gain the ability to declare a vow of silence

### DIFF
--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -87,5 +87,7 @@
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_chair(null))
 		if (href_list["invisible_box"])
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_box(null))
+	if(!locate(/obj/effect/proc_holder/spell/targeted/mime/speak) in H.mind.spell_list) //if they're not a mime, give them the ability to declare a vow of silence so that they can actually use the mime spell that they just learned
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/mime/speak)
 	to_chat(usr, "<span class='notice'>The book disappears into thin air.</span>")
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request

If you learn a spell from the Guide to Dank Mimery but don't have the ability to declare a vow of silence to actually use it, you'll now gain the ability to declare a vow of silence.

## Why It's Good For The Game

This matches the behavior of the Finger Guns and Invisible Blockade spellbooks.

It's also kinda lame to learn a spell from this book (taken from, say, an SSD mime or a mime who you dunked on at roundstart) and then realize that you can't ever actually cast it, even if you want to pivot into being a mime. This also lines up with oranges's design directive/philosophy (that I really hope I wasn't just misremembering) to tie special abilities to equipment/items instead of to just being a member of a certain job.

## Changelog
:cl:
balance: If you learn a spell from the Guide to Dank Mimery but don't have the ability to declare a vow of silence to actually use it, you'll now gain the ability to declare a vow of silence.
/:cl: