### PR TITLE
Non-chaplains can now use the armaments beacon

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -24,13 +24,6 @@
 	name = "armaments beacon"
 	desc = "Contains a set of armaments for the chaplain."
 
-/obj/item/choice_beacon/holy/canUseBeacon(mob/living/user)
-	if(user.mind && user.mind.holy_role)
-		return ..()
-	else
-		playsound(src, 'sound/machines/buzz-sigh.ogg', 40, TRUE)
-		return FALSE
-
 /obj/item/choice_beacon/holy/generate_display_names()
 	var/static/list/holy_item_list
 	if(!holy_item_list)


### PR DESCRIPTION
## About The Pull Request

This PR removes the holy_role restriction of the armaments beacon.

## Why It's Good For The Game

The curator's hero beacon is already like this.

Chaplain armor looks (and is) badass, and it's a shame that you can't summon it if you're a non-chaplain, even if you're filling in for the chaplain and paid the 550 credits needed (IIRC) to buy this beacon. Like, I don't really see the point of putting this beacon in a vending machine if non-chaplains can't use it anyway.

Also, who knows, we might be able to add an armaments beacon cargo crate (which would probably have to cost considerably more credits than a riot armor crate and a riot helmet crate would, of course) in the future.

## Changelog
:cl: ATHATH
balance: Non-holy people can now use the armaments beacon.
/:cl: