### PR TITLE
speedpatch for survival medipens

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -215,7 +215,7 @@
 
 /obj/item/reagent_containers/hypospray/medipen/survival
 	name = "survival emergency medipen"
-	desc = "A medipen for surviving in harsh environments, heals most common damage sources. WARNING: May cause organ damage."
+	desc = "A medipen for surviving in harsh environments. Heals most common damage types. WARNING: May cause organ damage."
 	icon_state = "stimpen"
 	inhand_icon_state = "stimpen"
 	volume = 30
@@ -229,14 +229,12 @@
 			return
 		to_chat(user,"<span class='notice'>You start manually releasing the low-pressure gauge...</span>")
 		if(do_mob(user, M ,10 SECONDS))
-			amount_per_transfer_from_this = initial(amount_per_transfer_from_this)
 			return ..()
-	amount_per_transfer_from_this = initial(amount_per_transfer_from_this)
 	return ..()
 
 /obj/item/reagent_containers/hypospray/medipen/survival/luxury
 	name = "luxury medipen"
-	desc = "Cutting edge bluespace technology allowed Nanotrasen to compact 62u of chems into a single medipen. Contains rare and powerful chemicals used to aid in the exploration of very inhospitable enviroments. WARNING: CONTAINS PENTHRITE, DO NOT MIX WITH EPINEPHRINE OR ATROPINE. CONTAINS MORPHINE, DO NOT INJECT MULTIPLE PENS IN RAPID SUCCESSION."
+	desc = "Cutting edge bluespace technology allowed Nanotrasen to compact 62u of chemicals into a single medipen. Contains rare and powerful chemicals used to aid in the exploration of very inhospitable enviroments. WARNING: CONTAINS PENTHRITE, DO NOT MIX WITH EPINEPHRINE OR ATROPINE. CONTAINS MORPHINE, DO NOT INJECT MULTIPLE PENS IN RAPID SUCCESSION."
 	icon_state = "luxpen"
 	inhand_icon_state = "atropen"
 	volume = 62

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -215,7 +215,7 @@
 
 /obj/item/reagent_containers/hypospray/medipen/survival
 	name = "survival emergency medipen"
-	desc = "A medipen for surviving in the harsh environments, heals most common damage sources. WARNING: May cause organ damage."
+	desc = "A medipen for surviving in harsh environments, heals most common damage sources. WARNING: May cause organ damage."
 	icon_state = "stimpen"
 	inhand_icon_state = "stimpen"
 	volume = 30
@@ -229,19 +229,19 @@
 			return
 		to_chat(user,"<span class='notice'>You start manually releasing the low-pressure gauge...</span>")
 		if(do_mob(user, M ,10 SECONDS))
-			amount_per_transfer_from_this = initial(amount_per_transfer_from_this) * 0.5
+			amount_per_transfer_from_this = initial(amount_per_transfer_from_this)
 			return ..()
 	amount_per_transfer_from_this = initial(amount_per_transfer_from_this)
 	return ..()
 
 /obj/item/reagent_containers/hypospray/medipen/survival/luxury
 	name = "luxury medipen"
-	desc = "Cutting edge bluespace technology allowed Nanotrasen to compact 60u of volume into a single medipen. Contains rare and powerful chemicals used to aid in exploration of very hard enviroments. WARNING: DO NOT MIX WITH EPINEPHRINE OR ATROPINE."
+	desc = "Cutting edge bluespace technology allowed Nanotrasen to compact 62u of chems into a single medipen. Contains rare and powerful chemicals used to aid in the exploration of very inhospitable enviroments. WARNING: CONTAINS PENTHRITE, DO NOT MIX WITH EPINEPHRINE OR ATROPINE. CONTAINS MORPHINE, DO NOT INJECT MULTIPLE PENS IN RAPID SUCCESSION."
 	icon_state = "luxpen"
 	inhand_icon_state = "atropen"
-	volume = 60
-	amount_per_transfer_from_this = 60
-	list_reagents = list(/datum/reagent/medicine/salbutamol = 10, /datum/reagent/medicine/c2/penthrite = 10, /datum/reagent/medicine/oxandrolone = 10, /datum/reagent/medicine/sal_acid = 10 ,/datum/reagent/medicine/omnizine = 10 ,/datum/reagent/medicine/leporazine = 10)
+	volume = 62
+	amount_per_transfer_from_this = 62
+	list_reagents = list(/datum/reagent/medicine/salbutamol = 10, /datum/reagent/medicine/c2/penthrite = 10, /datum/reagent/medicine/oxandrolone = 10, /datum/reagent/medicine/sal_acid = 10 ,/datum/reagent/medicine/omnizine = 10 ,/datum/reagent/medicine/leporazine = 10,/datum/reagent/medicine/morphine = 2)
 
 /obj/item/reagent_containers/hypospray/medipen/atropine
 	name = "atropine autoinjector"


### PR DESCRIPTION
## About The Pull Request

Adds 2u of morphine to luxury survival medipens.

Removes the 0.5x chem transfer penalty for using survival medipens in a non-low pressure environment. 

Changes some text to fix grammar issues and update warning labels and such.

## Why It's Good For The Game

The damage slowdown immunity that survival medipens used to provide with their morphine is _probably_ important for luxury medipens to have. The presence of morphine in luxury medipens also discourages double-penning. If double-penning is intentional, I could replace that morphine with muscle stimulant or something.

You're already spending 10 seconds standing still in order to use the pen, halving the amount of chems that come out of the pen after that incredibly long timer (that you can't double-up on with the same pen) finishes is a bit TOO punishing. Plus, you can still get the rest of the chems out of the pen, you just have to wait ANOTHER 10 seconds to do so, which is just tedium at that point.

## Changelog
:cl:
balance: Adds 2u of morphine to luxury survival medipens.
balance: Removes the 0.5x chem transfer penalty for using survival medipens in a non-low pressure environment. 
tweak: Changes some survival medipen-related text to fix grammar issues and update warning labels and such.
/:cl:
