### PR TITLE
Painting frames are no longer ERRORs

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -289,7 +289,7 @@
 /obj/structure/sign/painting/update_icon_state()
 	. = ..()
 	if(C && C.generated_icon)
-		icon_state = null
+		icon_state = "frame-overlay"
 	else
 		icon_state = "frame-empty"
 


### PR DESCRIPTION
painting frames don't set their icon state to null anymore

![image](https://user-images.githubusercontent.com/40974010/86041410-74289280-b9fa-11ea-99aa-8fbc10e010fb.png)
