### PR TITLE
Gives families cops bowman headset, internals

### DIFF
--- a/code/modules/antagonists/gang/outfits.dm
+++ b/code/modules/antagonists/gang/outfits.dm
@@ -30,9 +30,8 @@
 	/obj/item/storage/box/flashbangs = 1,
 	/obj/item/shield/riot/tele = 1,
 	/obj/item/ammo_box/magazine/m45 = 3,
-	/obj/item/ammo_box/c45 = 2
+	/obj/item/ammo_box/c45 = 2,
 	/obj/item/storage/box/survival/security)
-
 
 /datum/outfit/families_police/beatcop/armored
 	name = "Families: Armored Beat Cop"
@@ -43,7 +42,7 @@
 	/obj/item/storage/box/teargas = 1,
 	/obj/item/storage/box/flashbangs = 1,
 	/obj/item/shield/riot/tele = 1,
-	/obj/item/storage/box/lethalshot = 2
+	/obj/item/storage/box/lethalshot = 2,
 	/obj/item/storage/box/survival/security)
 
 /datum/outfit/families_police/beatcop/swat
@@ -56,7 +55,7 @@
 	/obj/item/storage/box/teargas = 1,
 	/obj/item/storage/box/flashbangs = 1,
 	/obj/item/shield/riot/tele = 1,
-	/obj/item/storage/box/lethalshot = 2
+	/obj/item/storage/box/lethalshot = 2,
 	/obj/item/storage/box/survival/security)
 
 /datum/outfit/families_police/beatcop/fbi
@@ -70,7 +69,7 @@
 	/obj/item/storage/box/flashbangs = 1,
 	/obj/item/shield/riot/tele = 1,
 	/obj/item/ammo_box/magazine/smgm9mm = 3,
-	/obj/item/ammo_box/c9mm = 2
+	/obj/item/ammo_box/c9mm = 2,
 	/obj/item/storage/box/survival/security)
 
 /datum/outfit/families_police/beatcop/military
@@ -83,5 +82,5 @@
 	backpack_contents = list(/obj/item/storage/box/handcuffs = 1,
 	/obj/item/storage/box/teargas = 1,
 	/obj/item/storage/box/flashbangs = 1,
-	/obj/item/shield/riot/tele = 1
+	/obj/item/shield/riot/tele = 1,
 	/obj/item/storage/box/survival/security)

--- a/code/modules/antagonists/gang/outfits.dm
+++ b/code/modules/antagonists/gang/outfits.dm
@@ -18,7 +18,7 @@
 	shoes = /obj/item/clothing/shoes/combat/swat
 	gloves = null
 	glasses = /obj/item/clothing/glasses/hud/spacecop
-	ears = /obj/item/radio/headset/headset_sec
+	ears = /obj/item/radio/headset/headset_sec/alt
 	mask = null
 	head = /obj/item/clothing/head/spacepolice
 	belt = /obj/item/gun/ballistic/automatic/pistol/m1911
@@ -30,7 +30,8 @@
 	/obj/item/storage/box/flashbangs = 1,
 	/obj/item/shield/riot/tele = 1,
 	/obj/item/ammo_box/magazine/m45 = 3,
-	/obj/item/ammo_box/c45 = 2)
+	/obj/item/ammo_box/c45 = 2
+	/obj/item/storage/box/survival/security)
 
 
 /datum/outfit/families_police/beatcop/armored
@@ -42,7 +43,8 @@
 	/obj/item/storage/box/teargas = 1,
 	/obj/item/storage/box/flashbangs = 1,
 	/obj/item/shield/riot/tele = 1,
-	/obj/item/storage/box/lethalshot = 2)
+	/obj/item/storage/box/lethalshot = 2
+	/obj/item/storage/box/survival/security)
 
 /datum/outfit/families_police/beatcop/swat
 	name = "Families: SWAT Beat Cop"
@@ -54,7 +56,8 @@
 	/obj/item/storage/box/teargas = 1,
 	/obj/item/storage/box/flashbangs = 1,
 	/obj/item/shield/riot/tele = 1,
-	/obj/item/storage/box/lethalshot = 2)
+	/obj/item/storage/box/lethalshot = 2
+	/obj/item/storage/box/survival/security)
 
 /datum/outfit/families_police/beatcop/fbi
 	name = "Families: Space FBI Officer"
@@ -67,7 +70,8 @@
 	/obj/item/storage/box/flashbangs = 1,
 	/obj/item/shield/riot/tele = 1,
 	/obj/item/ammo_box/magazine/smgm9mm = 3,
-	/obj/item/ammo_box/c9mm = 2)
+	/obj/item/ammo_box/c9mm = 2
+	/obj/item/storage/box/survival/security)
 
 /datum/outfit/families_police/beatcop/military
 	name = "Families: Space Military"
@@ -79,4 +83,5 @@
 	backpack_contents = list(/obj/item/storage/box/handcuffs = 1,
 	/obj/item/storage/box/teargas = 1,
 	/obj/item/storage/box/flashbangs = 1,
-	/obj/item/shield/riot/tele = 1)
+	/obj/item/shield/riot/tele = 1
+	/obj/item/storage/box/survival/security)


### PR DESCRIPTION
## About The Pull Request

Gives families's cops a bowman headset and some internals.

## Why It's Good For The Game

Due to Families being self antag: The Game, many rounds will have the station being plasmaflooded and bombed. Without internals, the cops just suffocate. Even assistants spawn with this; why not cops?

Bowmans because every cop gets a god damn box of flashbangs. Giving someone flashbangs and not the gear to protect from it is just stupid.

## Changelog
:cl:
balance: Space Cops now come equipped with appropriate environmental protection.
/:cl:
