### PR TITLE
Miner to cook : Miner changes continue!

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -13,7 +13,7 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
-	var/loot = rand(1,22)
+	var/loot = rand(1,21)
 	switch(loot)
 		if(1)
 			new /obj/item/shared_storage/red(src)
@@ -57,17 +57,15 @@
 		if(16)
 			new /obj/item/immortality_talisman(src)
 		if(17)
-			new /obj/item/gun/magic/hook(src)
-		if(18)
 			new /obj/item/voodoo(src)
-		if(19)
+		if(18)
 			new /obj/item/book/granter/spell/summonitem(src)
-		if(20)
+		if(19)
 			new /obj/item/book_of_babel(src)
-		if(21)
+		if(20)
 			new /obj/item/borg/upgrade/modkit/lifesteal(src)
 			new /obj/item/bedsheet/cult(src)
-		if(22)
+		if(21)
 			new /obj/item/clothing/neck/necklace/memento_mori(src)
 
 //KA modkit design discs

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2004,3 +2004,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	limited_stock = 1
 	cant_discount = TRUE
 	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/badass/meathook
+	name = "Butcher's Meat Hook"
+	desc = "A brutal cleaver on a long chain, it allows you to pull people to your location."
+	item = /obj/item/gun/magic/hook
+	cost = 11
+	restricted_roles = list("Cook")

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2005,7 +2005,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cant_discount = TRUE
 	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/badass/meathook
+/datum/uplink_item/role_restricted/meathook
 	name = "Butcher's Meat Hook"
 	desc = "A brutal cleaver on a long chain, it allows you to pull people to your location."
 	item = /obj/item/gun/magic/hook


### PR DESCRIPTION
## About The Pull Request

Miners can no longer get meat hook from necropolis chest, it was moved to being a cook traitor item that costs 11tc. You know it is literally called meat hook, it is thematically better as a chef weapon.
## Why It's Good For The Game

Why? just why? Who the fuck would give miners a weapon that is completely useless against lavaland mobs, but is incredibly good at killing people.


## Changelog
:cl:
balance: Meat hook is now a 11tc cook traitor item. It can no longer be  aquired from necropolis chests. sorry miners!
/:cl:
