### PR TITLE
The mastercrafted armor set now comes with a nobreath mask instead of an oxygen tank

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -364,7 +364,7 @@
 
 /datum/spellbook_entry/item/armor
 	name = "Mastercrafted Armor Set"
-	desc = "An artefact suit of armor that allows you to cast spells while providing more protection against attacks and the void of space. Comes with a magical rebreather that removes your need to breathe without needing an air tank to do so."
+	desc = "An artefact suit of armor that allows you to cast spells while providing more protection against attacks and the void of space. Comes with a magical rebreather that removes your need to breathe without needing an air tank to do so. Also comes with a pair of sandals and enchanted (and, more importantly, insulated) gloves."
 	item_path = /obj/item/clothing/suit/space/hardsuit/wizard
 	category = "Defensive"
 
@@ -426,7 +426,7 @@
 
 /datum/spellbook_entry/item/battlemage
 	name = "Battlemage Armour"
-	desc = "An ensorceled suit of armour, protected by a powerful shield. The shield can completely negate sixteen attacks before being permanently depleted."
+	desc = "An ensorceled suit of armour, protected by a powerful shield. The shield can completely negate sixteen attacks before being permanently depleted. Also comes with a pair of sandals and enchanted (and, more importantly, insulated) gloves."
 	item_path = /obj/item/clothing/suit/space/hardsuit/shielded/wizard
 	limit = 1
 	category = "Defensive"

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -372,7 +372,7 @@
 	. = ..()
 	if(.)
 		new /obj/item/clothing/mask/nobreath(get_turf(user)) //air tanks are for MUGGLES
-		new /obj/item/clothing/shoes/sandal/magic(get_turf(user)) //In case they've lost them.  //how the fuck did you manage to lose ALL of the available sandals on the wizard ship (which is the only place you can buy this item)?!
+		new /obj/item/clothing/shoes/sandal/magic(get_turf(user)) //In case they've lost them.
 		new /obj/item/clothing/gloves/combat/wizard(get_turf(user))//To complete the outfit
 
 /datum/spellbook_entry/item/contract

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -371,8 +371,8 @@
 /datum/spellbook_entry/item/armor/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
 	. = ..()
 	if(.)
-		new /obj/item/tank/internals/oxygen(get_turf(user)) //i need to BREATHE
-		new /obj/item/clothing/shoes/sandal/magic(get_turf(user)) //In case they've lost them.
+		new /obj/item/clothing/mask/nobreath(get_turf(user)) //air tanks are for MUGGLES
+		new /obj/item/clothing/shoes/sandal/magic(get_turf(user)) //In case they've lost them.  //how the fuck did you manage to lose ALL of the available sandals on the wizard ship (which is the only place you can buy this item)?!
 		new /obj/item/clothing/gloves/combat/wizard(get_turf(user))//To complete the outfit
 
 /datum/spellbook_entry/item/contract

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -364,7 +364,7 @@
 
 /datum/spellbook_entry/item/armor
 	name = "Mastercrafted Armor Set"
-	desc = "An artefact suit of armor that allows you to cast spells while providing more protection against attacks and the void of space."
+	desc = "An artefact suit of armor that allows you to cast spells while providing more protection against attacks and the void of space. Comes with a magical rebreather that removes your need to breathe without needing an air tank to do so."
 	item_path = /obj/item/clothing/suit/space/hardsuit/wizard
 	category = "Defensive"
 


### PR DESCRIPTION
## About The Pull Request

Specifically, it now comes with the chilling blue xenobio crossbreed, which is a magical mask that gives you the nobreath trait while you wear it.

This doesn't affect the contents of the internals boxes that wizards spawn with.

This PR also alters the descriptions of the battlemage armour and mastercrafted armor sets to mention that they come with (enchanted) insulated gloves.

## Why It's Good For The Game

A magical mask that removes your need to breathe seems so much more on-theme for a wizard than an ordinary internals mask+oxygen tank combo.

Also, this makes it possible to play plasmaman wizard without using mind transfer or suffocating. Y'know, in case you wanna flex on everyone by playing a race with 1.5x brute and burn damage multipliers and blowing 2 wizard points on this armor set instead of just playing an android or something.

## Changelog
:cl: ATHATH
balance: The mastercrafted armor set (for wizards) now comes with a magical rebreather mask that removes your need to breathe while you wear it instead of a boring old oxygen tank.
tweake: Altered the descriptions of the battlemage armour set and the mastercrafted armor set to mention that they come with (enchanted) insulated gloves.
/:cl: