### PR TITLE
[B R E A T H   C O D E] fixes a copy+paste error made by ghilker

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -298,7 +298,7 @@
 
 	// Freon
 		var/freon_pp = breath.get_breath_partial_pressure(breath_gases[/datum/gas/freon][MOLES])
-		if (prob(nitryl_pp))
+		if (prob(freon_pp))
 			to_chat(H, "<span class='alert'>Your mouth feels like it's burning!</span>")
 		if (freon_pp >40)
 			H.emote("gasp")


### PR DESCRIPTION
## About The Pull Request

Freon's warning message no longer depends on the presence of nitryl in your lungs.

## Why It's Good For The Game

proofread
👏 
your
👏 
code
👏 

jk ghilker we cool

## Changelog
:cl:
fix: Freon's warning message no longer depends on the presence of nitryl in your lungs.
/:cl:
