### PR TITLE
[READY] Addictions: 3 new drugs to show off a fun feature.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -126,6 +126,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_LIMBATTACHMENT 	"limb_attach"
 #define TRAIT_NOLIMBDISABLE		"no_limb_disable"
 #define TRAIT_EASYLIMBDISABLE	"easy_limb_disable"
+#define TRAIT_HARDLIMBDISABLE	"hard_limb_disable"
 #define TRAIT_TOXINLOVER		"toxinlover"
 #define TRAIT_NOBREATH			"no_breath"
 #define TRAIT_ANTIMAGIC			"anti_magic"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -73,8 +73,10 @@
 	var/list/known_skills = list()
 	///What character we spawned in as- either at roundstart or latejoin, so we know for persistent scars if we ended as the same person or not
 	var/mob/original_character
-	///Skill modifier, adjusts how much xp you get/loose from adjust_xp
-	var/experience_modifier = 1
+	///Skill multiplier, adjusts how much xp you get/loose from adjust_xp. Dont override it directly, add your reason to experience_multiplier_reasons and use that as a key to put your value in there.
+	var/experience_multiplier = 1
+	///Skill multiplier list, just slap your multiplier change onto this with the type it is coming from as key.
+	var/list/experience_multiplier_reasons = list()
 
 /datum/mind/New(key)
 	src.key = key
@@ -146,7 +148,10 @@
 /datum/mind/proc/adjust_experience(skill, amt, silent = FALSE, force_old_level = 0)
 	var/datum/skill/S = GetSkillRef(skill)
 	var/old_level = force_old_level ? force_old_level : known_skills[skill][SKILL_LVL] //Get current level of the S skill
-	known_skills[skill][SKILL_EXP] = max(0, known_skills[skill][SKILL_EXP] + amt*experience_modifier) //Update exp. Prevent going below 0
+	experience_multiplier = initial(experience_multiplier)
+	for(var/key in experience_multiplier_reasons)
+		experience_multiplier += experience_multiplier_reasons[key]
+	known_skills[skill][SKILL_EXP] = max(0, known_skills[skill][SKILL_EXP] + amt*experience_multiplier) //Update exp. Prevent going below 0
 	known_skills[skill][SKILL_LVL] = update_skill_level(skill)//Check what the current skill level is based on that skill's exp
 	if(silent)
 		return

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -73,6 +73,8 @@
 	var/list/known_skills = list()
 	///What character we spawned in as- either at roundstart or latejoin, so we know for persistent scars if we ended as the same person or not
 	var/mob/original_character
+	///Skill modifier, adjusts how much xp you get/loose from adjust_xp
+	var/experience_modifier = 1
 
 /datum/mind/New(key)
 	src.key = key
@@ -144,7 +146,7 @@
 /datum/mind/proc/adjust_experience(skill, amt, silent = FALSE, force_old_level = 0)
 	var/datum/skill/S = GetSkillRef(skill)
 	var/old_level = force_old_level ? force_old_level : known_skills[skill][SKILL_LVL] //Get current level of the S skill
-	known_skills[skill][SKILL_EXP] = max(0, known_skills[skill][SKILL_EXP] + amt) //Update exp. Prevent going below 0
+	known_skills[skill][SKILL_EXP] = max(0, known_skills[skill][SKILL_EXP] + amt*experience_modifier) //Update exp. Prevent going below 0
 	known_skills[skill][SKILL_LVL] = update_skill_level(skill)//Check what the current skill level is based on that skill's exp
 	if(silent)
 		return

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -376,15 +376,15 @@
 							log_game("[key_name(C)] has started overdosing on [R.name] at [R.volume] units.")
 					if(R.addiction_threshold)
 						if(R.volume >= R.addiction_threshold && !is_type_in_list(R, cached_addictions))
-							var/datum/reagent/new_reagent = new R.type()
+							var/datum/reagent/new_reagent = new R.addiction_type.type()
 							cached_addictions.Add(new_reagent)
 							log_game("[key_name(C)] has become addicted to [R.name] at [R.volume] units.")
 					if(R.overdosed)
 						need_mob_update += R.overdose_process(C)
-					if(is_type_in_list(R,cached_addictions))
+					if(is_type_in_list(R.addiction_type ,cached_addictions))
 						for(var/addiction in cached_addictions)
 							var/datum/reagent/A = addiction
-							if(istype(R, A))
+							if(istype(R.addiction_type, A))
 								A.addiction_stage = -15 // you're satisfied for a good while.
 				need_mob_update += R.on_mob_life(C)
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -376,15 +376,16 @@
 							log_game("[key_name(C)] has started overdosing on [R.name] at [R.volume] units.")
 					if(R.addiction_threshold)
 						if(R.volume >= R.addiction_threshold && !is_type_in_list(R, cached_addictions))
-							var/datum/reagent/new_reagent = new R.addiction_type.type()
+							var/datum/reagent/new_reagent = new R.addiction_type()
 							cached_addictions.Add(new_reagent)
 							log_game("[key_name(C)] has become addicted to [R.name] at [R.volume] units.")
 					if(R.overdosed)
 						need_mob_update += R.overdose_process(C)
-					if(is_type_in_list(R.addiction_type ,cached_addictions))
+					var/datum/reagent/addiction_type = new R.addiction_type()
+					if(is_type_in_list(addiction_type ,cached_addictions))
 						for(var/addiction in cached_addictions)
 							var/datum/reagent/A = addiction
-							if(istype(R.addiction_type, A))
+							if(istype(addiction_type, A))
 								A.addiction_stage = -15 // you're satisfied for a good while.
 				need_mob_update += R.on_mob_life(C)
 

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -54,7 +54,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/overrides_metab = 0
 	/// above this overdoses happen
 	var/overdose_threshold = 0
-	///Overrides what addiction this chemicals feeds into, allowing you to have multiple chems that treat a single addiction.
+	///allows you to feed an addiction with a class of reagents as opposed to strictly the addicted reagent
 	var/datum/reagent/addiction_type
 	/// above this amount addictions start
 	var/addiction_threshold = 0

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -54,6 +54,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/overrides_metab = 0
 	/// above this overdoses happen
 	var/overdose_threshold = 0
+	///Overrides what addiction this chemicals feeds into, allowing you to have multiple chems that treat a single addiction.
+	var/datum/reagent/addiction_type
 	/// above this amount addictions start
 	var/addiction_threshold = 0
 	/// increases as addiction gets worse
@@ -73,7 +75,10 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 
 /datum/reagent/New()
 	. = ..()
-
+	if(!addiction_type || addiction_type == type)
+		addiction_type = src
+	else
+		addiction_type = new addiction_type()
 	if(material)
 		material = SSmaterials.GetMaterialRef(material)
 

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -54,8 +54,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/overrides_metab = 0
 	/// above this overdoses happen
 	var/overdose_threshold = 0
-	///allows you to feed an addiction with a class of reagents as opposed to strictly the addicted reagent
-	var/datum/reagent/addiction_type
+	///Overrides what addiction this chemicals feeds into, allowing you to have multiple chems that treat a single addiction.
+	var/addiction_type
 	/// above this amount addictions start
 	var/addiction_threshold = 0
 	/// increases as addiction gets worse
@@ -75,10 +75,10 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 
 /datum/reagent/New()
 	. = ..()
-	if(!addiction_type || addiction_type == type)
-		addiction_type = src
-	else
-		addiction_type = new addiction_type()
+
+	if(!addiction_type)
+		addiction_type = type
+
 	if(material)
 		material = SSmaterials.GetMaterialRef(material)
 

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -544,11 +544,11 @@
 	// 5x if you want to OD, you can potentially go higher, but good luck managing the brain damage.
 	living_mind.experience_modifier = max(1,round(volume/3,0.1))
 
-/datum/reagent/drug/maint/powder/on_mob_delete(mob/living/L)
+/datum/reagent/drug/maint/powder/on_mob_end_metabolize(mob/living/M)
 	. = ..()
-	if(!L.mind)
+	if(!M.mind)
 		return
-	var/datum/mind/living_mind = L.mind
+	var/datum/mind/living_mind = M.mind
 	living_mind.experience_modifier = initial(living_mind.experience_modifier)
 
 /datum/reagent/drug/maint/powder/overdose_process(mob/living/M)
@@ -560,7 +560,7 @@
 
 /datum/reagent/drug/maint/sludge
 	name = "Maintanance Sludge"
-	description = "An unknown sludge that you most likely gotten from an assistant, a bored chemist... or cooked yourself. Half refined, it fills your body with itself, making it more resistant to wound, but causes toxins to accumulate."
+	description = "An unknown sludge that you most likely gotten from an assistant, a bored chemist... or cooked yourself. Half refined, it fills your body with itself, making it more resistant to wounds, but causes toxins to accumulate."
 	reagent_state = LIQUID
 	color = "#203d2c"
 	metabolization_rate = 2 * REAGENTS_METABOLISM
@@ -568,7 +568,8 @@
 	addiction_threshold = 10
 	can_synth = TRUE
 
-/datum/reagent/drug/maint/sludge/on_mob_add(mob/living/L)
+/datum/reagent/drug/maint/sludge/on_mob_metabolize(mob/living/L)
+
 	. = ..()
 	ADD_TRAIT(L,TRAIT_HARDLIMBDISABLE,type)
 
@@ -576,9 +577,9 @@
 	. = ..()
 	M.adjustToxLoss(0.5)
 
-/datum/reagent/drug/maint/sludge/on_mob_delete(mob/living/L)
+/datum/reagent/drug/maint/sludge/on_mob_end_metabolize(mob/living/M)
 	. = ..()
-	REMOVE_TRAIT(L,TRAIT_HARDLIMBDISABLE,type)
+	REMOVE_TRAIT(M,TRAIT_HARDLIMBDISABLE,type)
 
 /datum/reagent/drug/maint/sludge/overdose_process(mob/living/M)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -491,3 +491,123 @@
 	if(prob(15))
 		M.adjustToxLoss(2, 0)
 	..()
+
+/datum/reagent/drug/maint
+	name = "Maintanance Drugs"
+	addiction_type = /datum/reagent/drug/maint
+
+/datum/reagent/drug/maint/addiction_act_stage1(mob/living/M)
+	. = ..()
+	M.Jitter(1)
+
+/datum/reagent/drug/maint/addiction_act_stage2(mob/living/M)
+	. = ..()
+	M.Jitter(2)
+	if(prob(15))
+		M.emote(pick("twitch","drool"))
+
+/datum/reagent/drug/maint/addiction_act_stage3(mob/living/M)
+	. = ..()
+	M.Jitter(1)
+	M.adjustToxLoss(2)
+	if(prob(5))
+		M.drop_all_held_items()
+	if(prob(15))
+		M.emote(pick("twitch","drool"))
+
+/datum/reagent/drug/maint/addiction_act_stage4(mob/living/M)
+	. = ..()
+	M.Jitter(2)
+	M.adjustToxLoss(3)
+	if(prob(10))
+		M.drop_all_held_items()
+	if(prob(30))
+		M.emote(pick("twitch","drool"))
+
+/datum/reagent/drug/maint/powder
+	name = "Maintanance Powder"
+	description = "An unknown powder that you most likely gotten from an assistant, a bored chemist... or cooked yourself. It is a refined form of tar that enhances your mental ability, making you learn stuff a lot faster."
+	reagent_state = SOLID
+	color = "#ffffff"
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	overdose_threshold = 15
+	addiction_threshold = 5
+
+/datum/reagent/drug/maint/powder/on_mob_life(mob/living/carbon/M)
+	. = ..()
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN,0.1)
+	if(!M.mind)
+		return
+	var/datum/mind/living_mind = M.mind
+	// 5x if you want to OD, you can potentially go higher, but good luck managing the brain damage.
+	living_mind.experience_modifier = max(1,round(volume/3,0.1))
+
+/datum/reagent/drug/maint/powder/on_mob_delete(mob/living/L)
+	. = ..()
+	if(!L.mind)
+		return
+	var/datum/mind/living_mind = L.mind
+	living_mind.experience_modifier = initial(living_mind.experience_modifier)
+
+/datum/reagent/drug/maint/powder/overdose_process(mob/living/M)
+	. = ..()
+	if(!ishuman(M))
+		return
+	var/mob/living/carbon/human/humie = M
+	humier.adjustOrganLoss(ORGAN_SLOT_BRAIN,3)
+
+/datum/reagent/drug/maint/sludge
+	name = "Maintanance Sludge"
+	description = "An unknown sludge that you most likely gotten from an assistant, a bored chemist... or cooked yourself. Half refined, it fills your body with itself, making it more resistant to wound, but causes toxins to accumulate."
+	reagent_state = LIQUID
+	color = "#203d2c"
+	metabolization_rate = 2 * REAGENTS_METABOLISM
+	overdose_threshold = 25
+	addiction_threshold = 10
+
+/datum/reagent/drug/maint/sludge/on_mob_add(mob/living/L)
+	. = ..()
+	ADD_TRAIT(L,TRAIT_HARDLIMBDISABLE,type)
+
+/datum/reagent/drug/maint/sludge/on_mob_life(mob/living/carbon/M)
+	. = ..()
+	M.adjustToxLoss(1.5)
+
+/datum/reagent/drug/maint/sludge/on_mob_delete(mob/living/L)
+	. = ..()
+	REMOVE_TRAIT(L,TRAIT_HARDLIMBDISABLE,type)
+
+/datum/reagent/drug/maint/sludge/overdose_process(mob/living/M)
+	. = ..()
+	if(!ishuman(M))
+		return
+	var/mob/living/carbon/human/humie = M
+	//You will be vomiting so the damage is really for a few ticks before you flush it out of your system
+	humie.adjustToxLoss(5)
+	humie.vomit()
+
+/datum/reagent/drug/maint/tar
+	name = "Maintanance Tar"
+	description = "An unknown tar that you most likely gotten from an assistant, a bored chemist... or cooked yourself. Raw tar, straight from the floor. It can help you with escaping bad situations at the cost of liver damage."
+	reagent_state = LIQUID
+	color = "#000000"
+	overdose_threshold = 30
+	addiction_threshold = 10
+
+/datum/reagent/drug/maint/tar/on_mob_life(mob/living/carbon/M)
+	. = ..()
+	humie.adjustOrganLoss(ORGAN_SLOT_LIVER,1.5)
+	M.AdjustStun(-10, FALSE)
+	M.AdjustKnockdown(-10, FALSE)
+	M.AdjustUnconscious(-10, FALSE)
+	M.AdjustParalyzed(-10, FALSE)
+	M.AdjustImmobilized(-10, FALSE)
+
+/datum/reagent/drug/maint/tar/overdose_process(mob/living/M)
+	. = ..()
+	humie.adjustOrganLoss(ORGAN_SLOT_LIVER,3)
+	M.AdjustStun(10, FALSE)
+	M.AdjustKnockdown(10, FALSE)
+	M.AdjustUnconscious(10, FALSE)
+	M.AdjustParalyzed(10, FALSE)
+	M.AdjustImmobilized(10, FALSE)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -554,7 +554,7 @@
 	if(!ishuman(M))
 		return
 	var/mob/living/carbon/human/humie = M
-	humier.adjustOrganLoss(ORGAN_SLOT_BRAIN,3)
+	humie.adjustOrganLoss(ORGAN_SLOT_BRAIN,3)
 
 /datum/reagent/drug/maint/sludge
 	name = "Maintanance Sludge"
@@ -596,18 +596,26 @@
 
 /datum/reagent/drug/maint/tar/on_mob_life(mob/living/carbon/M)
 	. = ..()
-	humie.adjustOrganLoss(ORGAN_SLOT_LIVER,1.5)
+
 	M.AdjustStun(-10, FALSE)
 	M.AdjustKnockdown(-10, FALSE)
 	M.AdjustUnconscious(-10, FALSE)
 	M.AdjustParalyzed(-10, FALSE)
 	M.AdjustImmobilized(-10, FALSE)
+	if(!ishuman(M))
+		return
+	var/mob/living/carbon/human/humie = M
+	humie.adjustOrganLoss(ORGAN_SLOT_LIVER,1.5)
 
 /datum/reagent/drug/maint/tar/overdose_process(mob/living/M)
 	. = ..()
-	humie.adjustOrganLoss(ORGAN_SLOT_LIVER,3)
+
 	M.AdjustStun(10, FALSE)
 	M.AdjustKnockdown(10, FALSE)
 	M.AdjustUnconscious(10, FALSE)
 	M.AdjustParalyzed(10, FALSE)
 	M.AdjustImmobilized(10, FALSE)
+	if(!ishuman(M))
+		return
+	var/mob/living/carbon/human/humie = M
+	humie.adjustOrganLoss(ORGAN_SLOT_LIVER,3)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -583,8 +583,10 @@
 		return
 	var/mob/living/carbon/human/carbie = M
 	//You will be vomiting so the damage is really for a few ticks before you flush it out of your system
-	carbie.adjustToxLoss(5)
-	carbie.vomit()
+	carbie.adjustToxLoss(1)
+	if(prob(10))
+		carbie.adjustToxLoss(5)
+		carbie.vomit()
 
 /datum/reagent/drug/maint/tar
 	name = "Maintanance Tar"

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -526,7 +526,7 @@
 		M.emote(pick("twitch","drool"))
 
 /datum/reagent/drug/maint/powder
-	name = "Maintanance Powder"
+	name = "Maintenance Powder"
 	description = "An unknown powder that you most likely gotten from an assistant, a bored chemist... or cooked yourself. It is a refined form of tar that enhances your mental ability, making you learn stuff a lot faster."
 	reagent_state = SOLID
 	color = "#ffffff"
@@ -559,7 +559,7 @@
 	carbie.adjustOrganLoss(ORGAN_SLOT_BRAIN,3)
 
 /datum/reagent/drug/maint/sludge
-	name = "Maintanance Sludge"
+	name = "Maintenance Sludge"
 	description = "An unknown sludge that you most likely gotten from an assistant, a bored chemist... or cooked yourself. Half refined, it fills your body with itself, making it more resistant to wounds, but causes toxins to accumulate."
 	reagent_state = LIQUID
 	color = "#203d2c"
@@ -593,7 +593,7 @@
 		carbie.vomit()
 
 /datum/reagent/drug/maint/tar
-	name = "Maintanance Tar"
+	name = "Maintenance Tar"
 	description = "An unknown tar that you most likely gotten from an assistant, a bored chemist... or cooked yourself. Raw tar, straight from the floor. It can help you with escaping bad situations at the cost of liver damage."
 	reagent_state = LIQUID
 	color = "#000000"

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -493,7 +493,7 @@
 	..()
 
 /datum/reagent/drug/maint
-	name = "Maintanance Drugs"
+	name = "Maintenance Drugs"
 	addiction_type = /datum/reagent/drug/maint
 	can_synth = FALSE
 

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -551,10 +551,10 @@
 
 /datum/reagent/drug/maint/powder/overdose_process(mob/living/M)
 	. = ..()
-	if(!ishuman(M))
+	if(!iscarbon(M))
 		return
-	var/mob/living/carbon/human/humie = M
-	humie.adjustOrganLoss(ORGAN_SLOT_BRAIN,3)
+	var/mob/living/carbon/human/carbie = M
+	carbie.adjustOrganLoss(ORGAN_SLOT_BRAIN,3)
 
 /datum/reagent/drug/maint/sludge
 	name = "Maintanance Sludge"
@@ -579,12 +579,12 @@
 
 /datum/reagent/drug/maint/sludge/overdose_process(mob/living/M)
 	. = ..()
-	if(!ishuman(M))
+	if(!iscarbon(M))
 		return
-	var/mob/living/carbon/human/humie = M
+	var/mob/living/carbon/human/carbie = M
 	//You will be vomiting so the damage is really for a few ticks before you flush it out of your system
-	humie.adjustToxLoss(5)
-	humie.vomit()
+	carbie.adjustToxLoss(5)
+	carbie.vomit()
 
 /datum/reagent/drug/maint/tar
 	name = "Maintanance Tar"
@@ -611,7 +611,7 @@
 	. = ..()
 
 	M.adjustToxLoss(5)
-	if(!ishuman(M))
+	if(!iscarbon(M))
 		return
-	var/mob/living/carbon/human/humie = M
-	humie.adjustOrganLoss(ORGAN_SLOT_LIVER,3)
+	var/mob/living/carbon/human/carbie = M
+	carbie.adjustOrganLoss(ORGAN_SLOT_LIVER,3)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -571,7 +571,7 @@
 
 /datum/reagent/drug/maint/sludge/on_mob_life(mob/living/carbon/M)
 	. = ..()
-	M.adjustToxLoss(1)
+	M.adjustToxLoss(0.5)
 
 /datum/reagent/drug/maint/sludge/on_mob_delete(mob/living/L)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -532,7 +532,7 @@
 	color = "#ffffff"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 15
-	addiction_threshold = 5
+	addiction_threshold = 6
 	can_synth = TRUE
 
 /datum/reagent/drug/maint/powder/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -571,7 +571,7 @@
 
 /datum/reagent/drug/maint/sludge/on_mob_life(mob/living/carbon/M)
 	. = ..()
-	M.adjustToxLoss(1.5)
+	M.adjustToxLoss(1)
 
 /datum/reagent/drug/maint/sludge/on_mob_delete(mob/living/L)
 	. = ..()
@@ -610,11 +610,7 @@
 /datum/reagent/drug/maint/tar/overdose_process(mob/living/M)
 	. = ..()
 
-	M.AdjustStun(10, FALSE)
-	M.AdjustKnockdown(10, FALSE)
-	M.AdjustUnconscious(10, FALSE)
-	M.AdjustParalyzed(10, FALSE)
-	M.AdjustImmobilized(10, FALSE)
+	M.adjustToxLoss(5)
 	if(!ishuman(M))
 		return
 	var/mob/living/carbon/human/humie = M

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -495,6 +495,7 @@
 /datum/reagent/drug/maint
 	name = "Maintanance Drugs"
 	addiction_type = /datum/reagent/drug/maint
+	can_synth = FALSE
 
 /datum/reagent/drug/maint/addiction_act_stage1(mob/living/M)
 	. = ..()
@@ -532,6 +533,7 @@
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 15
 	addiction_threshold = 5
+	can_synth = TRUE
 
 /datum/reagent/drug/maint/powder/on_mob_life(mob/living/carbon/M)
 	. = ..()
@@ -564,6 +566,7 @@
 	metabolization_rate = 2 * REAGENTS_METABOLISM
 	overdose_threshold = 25
 	addiction_threshold = 10
+	can_synth = TRUE
 
 /datum/reagent/drug/maint/sludge/on_mob_add(mob/living/L)
 	. = ..()
@@ -595,6 +598,7 @@
 	color = "#000000"
 	overdose_threshold = 30
 	addiction_threshold = 10
+	can_synth = TRUE
 
 /datum/reagent/drug/maint/tar/on_mob_life(mob/living/carbon/M)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -579,7 +579,7 @@
 	. = ..()
 	if(!iscarbon(M))
 		return
-	var/mob/living/carbon/human/carbie = M
+	var/mob/living/carbon/carbie = M
 	//You will be vomiting so the damage is really for a few ticks before you flush it out of your system
 	carbie.adjustToxLoss(1)
 	if(prob(10))

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -538,25 +538,19 @@
 /datum/reagent/drug/maint/powder/on_mob_life(mob/living/carbon/M)
 	. = ..()
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN,0.1)
-	if(!M.mind)
-		return
-	var/datum/mind/living_mind = M.mind
 	// 5x if you want to OD, you can potentially go higher, but good luck managing the brain damage.
-	living_mind.experience_modifier = max(1,round(volume/3,0.1))
+	var/amt = max(1,round(volume/3,0.1))
+	M?.mind?.experience_multiplier_reasons |= type
+	M?.mind?.experience_multiplier_reasons[type] = amt
 
 /datum/reagent/drug/maint/powder/on_mob_end_metabolize(mob/living/M)
 	. = ..()
-	if(!M.mind)
-		return
-	var/datum/mind/living_mind = M.mind
-	living_mind.experience_modifier = initial(living_mind.experience_modifier)
+	M?.mind?.experience_multiplier_reasons[type] = null
+	M?.mind?.experience_multiplier_reasons -= type
 
 /datum/reagent/drug/maint/powder/overdose_process(mob/living/M)
 	. = ..()
-	if(!iscarbon(M))
-		return
-	var/mob/living/carbon/human/carbie = M
-	carbie.adjustOrganLoss(ORGAN_SLOT_BRAIN,3)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN,3)
 
 /datum/reagent/drug/maint/sludge
 	name = "Maintenance Sludge"
@@ -609,16 +603,10 @@
 	M.AdjustUnconscious(-10, FALSE)
 	M.AdjustParalyzed(-10, FALSE)
 	M.AdjustImmobilized(-10, FALSE)
-	if(!ishuman(M))
-		return
-	var/mob/living/carbon/human/humie = M
-	humie.adjustOrganLoss(ORGAN_SLOT_LIVER,1.5)
+	M.adjustOrganLoss(ORGAN_SLOT_LIVER,1.5)
 
 /datum/reagent/drug/maint/tar/overdose_process(mob/living/M)
 	. = ..()
 
 	M.adjustToxLoss(5)
-	if(!iscarbon(M))
-		return
-	var/mob/living/carbon/human/carbie = M
-	carbie.adjustOrganLoss(ORGAN_SLOT_LIVER,3)
+	M.adjustOrganLoss(ORGAN_SLOT_LIVER,3)

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -8,7 +8,6 @@
 	mix_message = "The mixture violently reacts, leaving behind a few crystalline shards."
 	required_temp = 390
 
-
 /datum/chemical_reaction/krokodil
 	results = list(/datum/reagent/drug/krokodil = 6)
 	required_reagents = list(/datum/reagent/medicine/diphenhydramine = 1, /datum/reagent/medicine/morphine = 1, /datum/reagent/space_cleaner = 1, /datum/reagent/potassium = 1, /datum/reagent/phosphorus = 1, /datum/reagent/fuel = 1)
@@ -37,3 +36,21 @@
 /datum/chemical_reaction/pumpup
 	results = list(/datum/reagent/drug/pumpup = 5)
 	required_reagents = list(/datum/reagent/medicine/epinephrine = 2, /datum/reagent/consumable/coffee = 5)
+
+/datum/chemical_reaction/maint_tar1
+	result = list(/datum/reagent/toxin/acid = 1 ,/datum/reagent/drug/maint/tar = 3)
+	required_reagents = list(/datum/reagent/consumable/tea = 1, /datum/reagent/yuck = 1 , /datum/reagent/fuel = 1)
+
+/datum/chemical_reaction/maint_tar2
+	result = list(/datum/reagent/toxin/acid = 1 ,/datum/reagent/drug/maint/tar = 3)
+	required_reagents = list(/datum/reagent/consumable/tea = 1, /datum/reagent/consumable/enzyme = 3 , /datum/reagent/fuel = 1)
+
+/datum/chemical_reaction/maint_sludge
+	result = list(/datum/reagent/drug/maint/sludge = 1)
+	required_reagents = list(/datum/reagent/drug/maint/tar = 3 , /datum/reagent/toxin/acid/fluacid = 1)
+	required_catalysts = list(/datum/reagent/hydrogen_peroxide = 5)
+
+/datum/chemical_reaction/maint_powder
+	result = list(/datum/reagent/drug/maint/powder = 1)
+	required_reagents = list(/datum/reagent/drug/maint/sludge = 6 , /datum/reagent/toxin/acid/nitracid = 1 , /datum/reagent/consumable/enzyme = 1)
+	required_catalysts = list(/datum/reagent/acetone_oxide = 5)

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -38,19 +38,19 @@
 	required_reagents = list(/datum/reagent/medicine/epinephrine = 2, /datum/reagent/consumable/coffee = 5)
 
 /datum/chemical_reaction/maint_tar1
-	result = list(/datum/reagent/toxin/acid = 1 ,/datum/reagent/drug/maint/tar = 3)
+	results = list(/datum/reagent/toxin/acid = 1 ,/datum/reagent/drug/maint/tar = 3)
 	required_reagents = list(/datum/reagent/consumable/tea = 1, /datum/reagent/yuck = 1 , /datum/reagent/fuel = 1)
 
 /datum/chemical_reaction/maint_tar2
-	result = list(/datum/reagent/toxin/acid = 1 ,/datum/reagent/drug/maint/tar = 3)
+	results = list(/datum/reagent/toxin/acid = 1 ,/datum/reagent/drug/maint/tar = 3)
 	required_reagents = list(/datum/reagent/consumable/tea = 1, /datum/reagent/consumable/enzyme = 3 , /datum/reagent/fuel = 1)
 
 /datum/chemical_reaction/maint_sludge
-	result = list(/datum/reagent/drug/maint/sludge = 1)
+	results = list(/datum/reagent/drug/maint/sludge = 1)
 	required_reagents = list(/datum/reagent/drug/maint/tar = 3 , /datum/reagent/toxin/acid/fluacid = 1)
 	required_catalysts = list(/datum/reagent/hydrogen_peroxide = 5)
 
 /datum/chemical_reaction/maint_powder
-	result = list(/datum/reagent/drug/maint/powder = 1)
+	results = list(/datum/reagent/drug/maint/powder = 1)
 	required_reagents = list(/datum/reagent/drug/maint/sludge = 6 , /datum/reagent/toxin/acid/nitracid = 1 , /datum/reagent/consumable/enzyme = 1)
 	required_catalysts = list(/datum/reagent/acetone_oxide = 5)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -252,6 +252,8 @@
 	// actually roll wounds if applicable
 	if(HAS_TRAIT(owner, TRAIT_EASYLIMBDISABLE))
 		damage *= 1.5
+	if(HAS_TRAIT(owner,TRAIT_HARDLIMBDISABLE))
+		damage *= 0.5
 
 	var/base_roll = rand(1, round(damage ** WOUND_DAMAGE_EXPONENT))
 	var/injury_roll = base_roll


### PR DESCRIPTION
## About The Pull Request

Very simple change, but fucking hell does it increase the amount of variety we can have in reagents. Adds a Addiction_type variable that dictates what addiction the reagent feeds into.

3 new drugs:

Maintanance Tar - a simple drug you can make out of organic slurry/enzyme , welding fuel and tea. Gives you 10% stun resist and causes liver damage
Maintanance Sludge - a more complex drug derived out of maint tar and facid, with  hydrogen peroxide being present. Causes you to be more resistant to wounds, but causes constant toxin damage.
Maintanance Powder- the most refined form of tar, made with sludge , nacid and acetone peroxide. Causes you to get more experience for all the skills you do, the more you snort it the higher the modifier goes. Causes slight brain damage.

All of em have the same addiction stages and all of them have od effects.
## Why It's Good For The Game

I wanted to show off the custom addiction feature and cobby agreed i can link some drugs to it. They are nothing major just a fun thing you can do while in maint.

## Changelog
:cl:
add: Maint Tar a new recipe was found by assistants!...
add: ...Then some Janitor found out how to refine it into Sludge...
add: ...After that the chemist created a purified version of it.
/:cl:

