### PR TITLE
Add moths to round start races in repository config

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -438,7 +438,7 @@ ROUNDSTART_RACES human
 ## Races that are strictly worse than humans that could probably be turned on without balance concerns
 ROUNDSTART_RACES lizard
 #ROUNDSTART_RACES fly
-#ROUNDSTART_RACES moth
+ROUNDSTART_RACES moth
 ROUNDSTART_RACES plasmaman
 #ROUNDSTART_RACES shadow
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Enables moths as a round start race in the configuration file to match production. Previously, this was commented out.

This doesn't (*shouldn't*) change anything on production, since they have custom configuration files anyway.

~~On a similar note, any reason why the walk speed in the default config is sooo much faster? Seems like something that should be pretty important to making changes.~~ #51934

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/35135081/86113221-d4ace380-ba7d-11ea-8851-ee6d97b12030.png)

Codebase matching production is nice for contributing. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
server: Changed the configuration to enable moths by default, rather than being commented out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
