### PR TITLE
Zone Targeting Buffs, some energy weapon (and sniper rifle) balance

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -116,7 +116,7 @@
 	name = "scatter laser shell"
 	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package."
 	icon_state = "lshell"
-	projectile_type = /obj/projectile/beam/weak
+	projectile_type = /obj/projectile/beam/scatter
 	pellets = 6
 	variance = 35
 

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -27,8 +27,8 @@
 
 /obj/item/ammo_casing/energy/laser/scatter
 	projectile_type = /obj/projectile/beam/scatter
-	pellets = 5
-	variance = 25
+	pellets = 6
+	variance = 35
 	select_name = "scatter"
 
 /obj/item/ammo_casing/energy/laser/scatter/disabler

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -17,6 +17,10 @@
 
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	var/def_zone = ""	//Aiming at
+	///Whether our shot can deviate from the def_zone we chose
+	var/zone_deviation = TRUE
+	///When there is deviation, the factor by which accuracy is multiplied. Should probably always be at least above 0. Higher is better.
+	var/zone_accuracy_factor = 1
 	var/atom/movable/firer = null//Who shot it
 	var/atom/fired_from = null // the atom that the projectile was fired from (gun, turret)
 	var/suppressed = FALSE	//Attack message
@@ -291,7 +295,8 @@
 			return TRUE
 
 	var/distance = get_dist(T, starting) // Get the distance between the turf shot from and the mob we hit and use that for the calculations.
-	def_zone = ran_zone(def_zone, max(100-(7*distance), 5)) //Lower accurancy/longer range tradeoff. 7 is a balanced number to use.
+	if(def_zone && zone_deviation)
+		def_zone = ran_zone(def_zone, max(100-(7*distance), 5) * zone_accuracy_factor) //Lower accurancy/longer range tradeoff, multiplying the final result by the zone accuracy factor
 
 	if(isturf(A) && hitsound_wall)
 		var/volume = clamp(vol_by_damage() + 20, 0, 100)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -2,6 +2,7 @@
 	name = "laser"
 	icon_state = "laser"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	zone_accuracy_factor = 3
 	damage = 20
 	light_range = 2
 	damage_type = BURN
@@ -65,7 +66,8 @@
 /obj/projectile/beam/scatter
 	name = "laser pellet"
 	icon_state = "scatterlaser"
-	damage = 5
+	zone_accuracy_factor = 1
+	damage = 12.5
 
 /obj/projectile/beam/xray
 	name = "\improper X-ray beam"
@@ -85,9 +87,10 @@
 /obj/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 30
+	damage = 40
 	damage_type = STAMINA
 	flag = "energy"
+	zone_deviation = FALSE
 	hitsound = 'sound/weapons/tap.ogg'
 	eyeblur = 0
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -3,6 +3,7 @@
 /obj/projectile/bullet/p50
 	name =".50 bullet"
 	speed = 0.4
+	zone_deviation = FALSE
 	damage = 70
 	paralyze = 100
 	dismemberment = 50

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -1,6 +1,7 @@
 /obj/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
+	zone_deviation = FALSE
 	damage = 15
 	damage_type = TOX
 	nodamage = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Borrowing a change from here https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10916 but changed so that rather than perfect accuracy into the chest, perfect accuracy is on a per projectile basis with the new var 'zone_deviation'.

Borrowing the zone_accuracy_modifier var from kevin's pr, this lets us make some bullets more accurate over long ranges, which is helpful for shooting for limbs and making limb shooting a more informed decision.

This is also meant to be a soft alternative to https://github.com/tgstation/tgstation/pull/51923 but given that pr it is replacing the gun rather than changing the scatterlaser gun, which I've done here, it probably still can exist on it's own.

**Weapon Balance:**
_**Disablers**_
Disablers have no deviation.
Disablers do 40 damage

_**Lasers**_
Lasers have higher zone accuracy (x3)

_**Scatter Laser/Scatter Laser Shells**_
Now equal to buckshot in damage (12.5 per beam)
Scatter laser shells use the scatterlaser beam instead of weak laser beams (12.5 instead of 15, 75 instead of 90)
Has standard bullet deviation.

_**Ebows**_
No bullet deviation.

_**Sniper Rifles**_
No bullet deviation.

## Why It's Good For The Game

It really annoys me that several weapons quite literally are perfect for limb based attacks but just eat shit when you try because of bullet deviation more or less being nearly impossible to reasonably predict once you hit about 5 tiles. This helps make it significantly more useful for a variety of weapons.

Disablers are kinda shit so hopefully this makes them more useful at actually catching criminals.

Ebows suffered significantly due to bullet deviation.

## Changelog
:cl:
add: Adds ways to determine bullet zone targeting on a per projectile basis.
balance: Rebalances a few energy weapons and adds varying accuracy to a few choice examples.
balances: Buffs lasers, ebows, sniper rifles, disablers.
balances: Nerfs scattershot laser shells to be equal to buckshot, but buffs scattershot laser guns to be equal to buckshot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
