### PR TITLE
Puts McAirstrikes on hold for a bit

### DIFF
--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -57,6 +57,8 @@
 	..()
 
 /obj/machinery/computer/cargo/express/emag_act(mob/living/user)
+	return ///McAirstrikes will have to wait
+	
 	if(obj_flags & EMAGGED)
 		return
 	if(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Early return on the emag_act.

## Why It's Good For The Game

Steel rain causes massive server lag so I think this being one of the more easy methods to cause station wide explosions probably means it needs to be disabled for a bit so more people don't end up getting banned.

Maybe testmergies iunno, depends on whether people want this feature or not. I like it. But I'd like bombs to be fixed first.

## Changelog
:cl:
tweak: Disables express console airstrikes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
