### PR TITLE
Fixes jaunting mobs being unable to move through bar tables

### DIFF
--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -190,15 +190,15 @@
 	var/boot_dir = 1
 
 /obj/structure/table/wood/bar/Crossed(atom/movable/AM)
-	if(isliving(AM) && !is_barstaff(AM))
+	var/mob/living/M = AM
+	if(istype(M) && !M.incorporeal_move && !is_barstaff(M))
 		// No climbing on the bar please
-		var/mob/living/M = AM
 		var/throwtarget = get_edge_target_turf(src, boot_dir)
 		M.Paralyze(40)
 		M.throw_at(throwtarget, 5, 1)
 		to_chat(M, "<span class='notice'>No climbing on the bar please.</span>")
 	else
-		. = ..()
+		return ..()
 
 /obj/structure/table/wood/bar/proc/is_barstaff(mob/living/user)
 	. = FALSE


### PR DESCRIPTION
Fixes an issue described in #51901
:cl: ShizCalev
fix: Jaunting mobs can now travel over bar tables.
/:cl:

