### PR TITLE
Improves player immersion in the chemistry design with more interactive visual designs.

### DIFF
--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -27,7 +27,7 @@
 	glasses = /obj/item/clothing/glasses/science
 	belt = /obj/item/pda/chemist
 	ears = /obj/item/radio/headset/headset_med
-	uniform = /obj/item/clothing/under/rank/medical/chemist
+	uniform = /obj/item/clothing/under/costume/maid
 	shoes = /obj/item/clothing/shoes/sneakers/white
 	suit =  /obj/item/clothing/suit/toggle/labcoat/chemist
 	backpack = /obj/item/storage/backpack/chemistry


### PR DESCRIPTION


## About The Pull Request

Maids were once part of an elaborate hierarchy in great houses, where the retinue of servants stretched up to the housekeeper and butler, responsible for female and male employees respectively. The word "maid" itself is short for "maiden", meaning a girl or unmarried young woman or virgin. Domestic workers, particularly those low in the hierarchy, such as maids and footmen, were expected to remain unmarried while in service,[4][5] and even highest-ranking workers such as butlers could be dismissed for marrying.[citation needed]

In Victorian England, all middle-class families would have "help", but for most small households, this would be only one employee, the maid of all work, often known colloquially as "the girl".

Historically many maids suffered from Prepatellar bursitis, an inflammation of the Prepatellar bursa caused by long periods spent on the knees for purposes of scrubbing and fire-lighting, leading to the condition attracting the colloquial name of "Housemaid's Knee".[6]

## Why It's Good For The Game

...wait, what was I saying again?

## Changelog
:cl:
tweak: Our Chemists look like maids. Does BOOMERSTATION's chemists look like maids?
/:cl:
