### PR TITLE
Resolves Parallax GC Isuses

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -411,6 +411,7 @@
 		loc.handle_atom_del(src)
 	for(var/atom/movable/AM in contents)
 		qdel(AM)
+	LAZYCLEARLIST(client_mobs_in_contents)
 	moveToNullspace()
 	invisibility = INVISIBILITY_ABSTRACT
 	if(pulledby)


### PR DESCRIPTION
all movable atoms keep a `client_mobs_in_contents` list for the sake of allowing parallax to update when said `/atom/movable` moves.

This list is cleared when a client is deleted (as it should be), but it is not removed when the atom itself is deleted.

This results in all mobs having a hard references to themselves, which prevents garbage collection.

This should make `/mob/dead/new_player` successfully garbage collect.

fixes: https://github.com/tgstation/tgstation/issues/51950