### PR TITLE
Add Operator to AI Law Listing for Toggling HTML Output

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -430,25 +430,31 @@
 	if(!owner)
 		owner = M
 
-/datum/ai_laws/proc/get_law_list(include_zeroth = 0, show_numbers = 1)
+/**
+  * Generates a list of all laws on this datum, including rendered HTML tags if required
+  *
+  * Arguments:
+  * * include_zeroth - Operator that controls if law 0 or law 666 is returned in the set
+  * * show_numbers - Operator that controls if law numbers are prepended to the returned laws
+  * * render_html - Operator controlling if HTML tags are rendered on the returned laws
+  */
+/datum/ai_laws/proc/get_law_list(include_zeroth = FALSE, show_numbers = TRUE, render_html = TRUE)
 	var/list/data = list()
 
-	if (include_zeroth && devillaws && devillaws.len)
-		for(var/i in devillaws)
-			data += "[show_numbers ? "666:" : ""] <font color='#cc5500'>[i]</font>"
+	if (include_zeroth && devillaws)
+		for(var/law in devillaws)
+			data += "[show_numbers ? "666:" : ""] [render_html ? "<font color='#cc5500'>[law]</font>" : law]"
 
 	if (include_zeroth && zeroth)
-		data += "[show_numbers ? "0:" : ""] <font color='#ff0000'><b>[zeroth]</b></font>"
+		data += "[show_numbers ? "0:" : ""] [render_html ? "<font color='#ff0000'><b>[zeroth]</b></font>" : zeroth]"
 
 	for(var/law in hacked)
 		if (length(law) > 0)
-			var/num = ionnum()
-			data += "[show_numbers ? "[num]:" : ""] <font color='#660000'>[law]</font>"
+			data += "[show_numbers ? "[ionnum()]:" : ""] [render_html ? "<font color='#660000'>[law]</font>" : law]"
 
 	for(var/law in ion)
 		if (length(law) > 0)
-			var/num = ionnum()
-			data += "[show_numbers ? "[num]:" : ""] <font color='#547DFE'>[law]</font>"
+			data += "[show_numbers ? "[ionnum()]:" : ""] [render_html ? "<font color='#547DFE'>[law]</font>" : law]"
 
 	var/number = 1
 	for(var/law in inherent)
@@ -458,6 +464,6 @@
 
 	for(var/law in supplied)
 		if (length(law) > 0)
-			data += "[show_numbers ? "[number]:" : ""] <font color='#990099'>[law]</font>"
+			data += "[show_numbers ? "[number]:" : ""] [render_html ? "<font color='#990099'>[law]</font>" : law]"
 			number++
 	return data

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -43,7 +43,7 @@
 		data["restoring"] = restoring
 		data["health"] = (occupier.health + 100) / 2
 		data["isDead"] = occupier.stat == DEAD
-		data["laws"] = occupier.laws.get_law_list(include_zeroth = 1)
+		data["laws"] = occupier.laws.get_law_list(include_zeroth = TRUE, render_html = FALSE)
 
 	return data
 

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -65,7 +65,7 @@
 	var/list/data = list()
 	if(AI)
 		data["name"] = AI.name
-		data["laws"] = AI.laws.get_law_list(include_zeroth = 1)
+		data["laws"] = AI.laws.get_law_list(include_zeroth = TRUE, render_html = FALSE)
 		data["health"] = (AI.health + 100) / 2
 		data["wireless"] = !AI.control_disabled //todo disabled->enabled
 		data["radio"] = AI.radio_enabled

--- a/code/modules/admin/verbs/borgpanel.dm
+++ b/code/modules/admin/verbs/borgpanel.dm
@@ -59,7 +59,7 @@
 		if (locate(upgradetype) in borg)
 			installed = TRUE
 		.["upgrades"] += list(list("name" = initial(upgrade.name), "installed" = installed, "type" = upgradetype))
-	.["laws"] = borg.laws ? borg.laws.get_law_list(include_zeroth = TRUE) : list()
+	.["laws"] = borg.laws ? borg.laws.get_law_list(include_zeroth = TRUE, render_html = FALSE) : list()
 	.["channels"] = list()
 	for (var/k in GLOB.radiochannels)
 		if (k == RADIO_CHANNEL_COMMON)

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -113,7 +113,7 @@
 				data["restoring"] = restoring
 				data["health"] = (AI.health + 100) / 2
 				data["isDead"] = AI.stat == DEAD
-				data["laws"] = AI.laws.get_law_list(include_zeroth = 1)
+				data["laws"] = AI.laws.get_law_list(include_zeroth = TRUE, render_html = FALSE)
 
 	return data
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can see the PR from Wayland-Smithy below which shows before and after shots, this PR accomplishes the same thing except by removing the HTML outright instead of including and later removing it.

This specifically adds an operator to the get_law_list() proc of the AI laws datum which allows for controlling if the laws are rendered as HTML or not. Then I use this operator to ensure HTML does not reach tgui interfaces in the first place.

Closes https://github.com/tgstation/tgstation/pull/51951

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Improves handling of HTML rendering when sending tgui data.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
fix: AI laws no longer include HTML on tgui displays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
