### PR TITLE
Fix gib_stack_trace printing to runtime logs

### DIFF
--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -30,6 +30,7 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 		for (var/line in splittext(E.desc, "\n"))
 			if (text2ascii(line) != 32)
 				stack_trace_storage += line
+		return
 
 	var/static/list/error_last_seen = list()
 	var/static/list/error_cooldown = list() /* Error_cooldown items will either be positive(cooldown time) or negative(silenced error)


### PR DESCRIPTION
I forgot a return
fixes #51958 
