### PR TITLE
Reconstructive surgery for moth wings

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -44,6 +44,7 @@
 		return
 	if(H.dna.features["moth_wings"] != "Burnt Off" && H.bodytemperature >= 800 && H.fire_stacks > 0) //do not go into the extremely hot light. you will not survive
 		to_chat(H, "<span class='danger'>Your precious wings burn to a crisp!</span>")
+		H.dna.features["original_moth_wings"] = H.dna.features["moth_wings"] //Fire apparently destroys DNA, so let's preserve that elsewhere
 		H.dna.features["moth_wings"] = "Burnt Off"
 		if(flying_species) //This is all exclusive to if the person has the effects of a potion of flight
 			if(H.movement_type & FLYING)

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -72,3 +72,12 @@
 		var/datum/gas_mixture/current = H.loc.return_air()
 		if(current && (current.return_pressure() >= ONE_ATMOSPHERE*0.85)) //as long as there's reasonable pressure and no gravity, flight is possible
 			return TRUE
+
+
+/datum/species/moth/spec_fully_heal(mob/living/carbon/human/H)
+	. = ..()
+	if(H.dna.features["original_moth_wings"] != null)
+		H.dna.features["moth_wings"] = H.dna.features["original_moth_wings"]
+	if(H.dna.features["original_moth_wings"] == null && H.dna.features["moth_wings"] == "Burnt Off")
+		H.dna.features["moth_wings"] = "Plain"
+	handle_mutant_bodyparts(H)

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -774,3 +774,10 @@
 	id = "surgery_zombie"
 	surgery = /datum/surgery/advanced/necrotic_revival
 	research_icon_state = "surgery_head"
+
+/datum/design/surgery/wing_reconstruction
+	name = "Wing Reconstruction"
+	desc = "An experimental surgical procedure that reconstructs the damaged wings of moth people. Requires Instabitaluri."
+	id = "surgery_wing_reconstruction"
+	surgery = /datum/surgery/advanced/wing_reconstruction
+	research_icon_state = "surgery_chest"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -103,7 +103,7 @@
 	display_name = "Advanced Surgery"
 	description = "When simple medicine doesn't cut it."
 	prereq_ids = list("imp_wt_surgery")
-	design_ids = list("surgery_lobotomy", "surgery_heal_brute_upgrade_femto", "surgery_heal_burn_upgrade_femto","surgery_heal_combo")
+	design_ids = list("surgery_lobotomy", "surgery_heal_brute_upgrade_femto", "surgery_heal_burn_upgrade_femto","surgery_heal_combo","surgery_wing_reconstruction")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
 	export_price = 4000
 

--- a/code/modules/surgery/advanced/wingreconstruction.dm
+++ b/code/modules/surgery/advanced/wingreconstruction.dm
@@ -9,7 +9,7 @@
 	target_mobtypes = list(/mob/living/carbon/human)
 
 /datum/surgery/advanced/wing_reconstruction/can_start(mob/user, mob/living/carbon/target)
-	return ..() && target.dna.features["moth_wings"] == "Burnt Off"
+	return ..() && target.dna.features["moth_wings"] == "Burnt Off" && ismoth(target)
 
 /datum/surgery_step/wing_reconstruction
 	name = "start wing reconstruction"
@@ -25,13 +25,14 @@
 		"<span class='notice'>[user] begins to perform surgery on [target]'s charred wing membranes.</span>")
 
 /datum/surgery_step/wing_reconstruction/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
-	var/mob/living/carbon/human/H = target
-	display_results(user, target, "<span class='notice'>You succeed in reconstructing [target]'s wings.</span>",
-		"<span class='notice'>[user] successfully reconstructs [target]'s wings!</span>",
-		"<span class='notice'>[user] completes the surgery on [target]'s wings.</span>")
-	if(H.dna.features["original_moth_wings"] != null)
-		H.dna.features["moth_wings"] = H.dna.features["original_moth_wings"]
-	else
-		H.dna.features["moth_wings"] = "Plain"
-	H.update_mutant_bodyparts()
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		display_results(user, target, "<span class='notice'>You succeed in reconstructing [target]'s wings.</span>",
+			"<span class='notice'>[user] successfully reconstructs [target]'s wings!</span>",
+			"<span class='notice'>[user] completes the surgery on [target]'s wings.</span>")
+		if(H.dna.features["original_moth_wings"] != null)
+			H.dna.features["moth_wings"] = H.dna.features["original_moth_wings"]
+		else
+			H.dna.features["moth_wings"] = "Plain"
+		H.update_mutant_bodyparts()
 	return ..()

--- a/code/modules/surgery/advanced/wingreconstruction.dm
+++ b/code/modules/surgery/advanced/wingreconstruction.dm
@@ -11,7 +11,7 @@
 /datum/surgery/advanced/wing_reconstruction/can_start(mob/user, mob/living/carbon/target)
 	if(!..())
 		return FALSE
-	if((target.dna.features["moth_wings"] == "Burnt Off") && target.dna.features["original_moth_wings"] !=null)
+	if(target.dna.features["moth_wings"] == "Burnt Off")
 		return TRUE
 
 /datum/surgery_step/wing_reconstruction
@@ -32,7 +32,9 @@
 	display_results(user, target, "<span class='notice'>You succeed in reconstructing [target]'s wings.</span>",
 		"<span class='notice'>[user] successfully reconstructs [target]'s wings!</span>",
 		"<span class='notice'>[user] completes the surgery on [target]'s wings.</span>")
-	H.dna.features["moth_wings"] = H.dna.features["original_moth_wings"]
-	H.dna.features.Remove("original_moth_wings")
+	if(H.dna.features["original_moth_wings"] != null)
+		H.dna.features["moth_wings"] = H.dna.features["original_moth_wings"]
+	if(H.dna.features["original_moth_wings"] == null)
+		H.dna.features["moth_wings"] = "Plain"
 	H.update_mutant_bodyparts()
 	return ..()

--- a/code/modules/surgery/advanced/wingreconstruction.dm
+++ b/code/modules/surgery/advanced/wingreconstruction.dm
@@ -17,7 +17,6 @@
 	time = 200
 	chems_needed = list(/datum/reagent/medicine/c2/instabitaluri)
 	require_all_chems = FALSE
-	experience_given = MEDICAL_SKILL_ADVANCED
 
 /datum/surgery_step/wing_reconstruction/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, "<span class='notice'>You begin to fix [target]'s charred wing membranes...</span>",

--- a/code/modules/surgery/advanced/wingreconstruction.dm
+++ b/code/modules/surgery/advanced/wingreconstruction.dm
@@ -9,10 +9,7 @@
 	target_mobtypes = list(/mob/living/carbon/human)
 
 /datum/surgery/advanced/wing_reconstruction/can_start(mob/user, mob/living/carbon/target)
-	if(!..())
-		return FALSE
-	if(target.dna.features["moth_wings"] == "Burnt Off")
-		return TRUE
+	return ..() && target.dna.features["moth_wings"] == "Burnt Off"
 
 /datum/surgery_step/wing_reconstruction
 	name = "start wing reconstruction"

--- a/code/modules/surgery/advanced/wingreconstruction.dm
+++ b/code/modules/surgery/advanced/wingreconstruction.dm
@@ -1,0 +1,38 @@
+/datum/surgery/advanced/wing_reconstruction
+	name = "Wing Reconstruction"
+	desc = "An experimental surgical procedure that reconstructs the damaged wings of moth people. Requires Instabitaluri."
+	steps = list(/datum/surgery_step/incise,
+				/datum/surgery_step/retract_skin,
+				/datum/surgery_step/clamp_bleeders,
+				/datum/surgery_step/wing_reconstruction)
+	possible_locs = list(BODY_ZONE_CHEST)
+	target_mobtypes = list(/mob/living/carbon/human)
+
+/datum/surgery/advanced/wing_reconstruction/can_start(mob/user, mob/living/carbon/target)
+	if(!..())
+		return FALSE
+	if((target.dna.features["moth_wings"] == "Burnt Off") && target.dna.features["original_moth_wings"] !=null)
+		return TRUE
+
+/datum/surgery_step/wing_reconstruction
+	name = "start wing reconstruction"
+	implements = list(TOOL_HEMOSTAT = 85, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
+	time = 200
+	chems_needed = list(/datum/reagent/medicine/c2/instabitaluri)
+	require_all_chems = FALSE
+	experience_given = MEDICAL_SKILL_ADVANCED
+
+/datum/surgery_step/wing_reconstruction/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(user, target, "<span class='notice'>You begin to fix [target]'s charred wing membranes...</span>",
+		"<span class='notice'>[user] begins to fix [target]'s charred wing membranes.</span>",
+		"<span class='notice'>[user] begins to perform surgery on [target]'s charred wing membranes.</span>")
+
+/datum/surgery_step/wing_reconstruction/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
+	var/mob/living/carbon/human/H = target
+	display_results(user, target, "<span class='notice'>You succeed in reconstructing [target]'s wings.</span>",
+		"<span class='notice'>[user] successfully reconstructs [target]'s wings!</span>",
+		"<span class='notice'>[user] completes the surgery on [target]'s wings.</span>")
+	H.dna.features["moth_wings"] = H.dna.features["original_moth_wings"]
+	H.dna.features.Remove("original_moth_wings")
+	H.update_mutant_bodyparts()
+	return ..()

--- a/code/modules/surgery/advanced/wingreconstruction.dm
+++ b/code/modules/surgery/advanced/wingreconstruction.dm
@@ -31,7 +31,7 @@
 		"<span class='notice'>[user] completes the surgery on [target]'s wings.</span>")
 	if(H.dna.features["original_moth_wings"] != null)
 		H.dna.features["moth_wings"] = H.dna.features["original_moth_wings"]
-	if(H.dna.features["original_moth_wings"] == null)
+	else
 		H.dna.features["moth_wings"] = "Plain"
 	H.update_mutant_bodyparts()
 	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3024,6 +3024,7 @@
 #include "code\modules\surgery\advanced\necrotic_revival.dm"
 #include "code\modules\surgery\advanced\pacification.dm"
 #include "code\modules\surgery\advanced\viral_bonding.dm"
+#include "code\modules\surgery\advanced\wingreconstruction.dm"
 #include "code\modules\surgery\advanced\bioware\bioware.dm"
 #include "code\modules\surgery\advanced\bioware\bioware_surgery.dm"
 #include "code\modules\surgery\advanced\bioware\cortex_folding.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds a new advanced surgery which allows medbay to repair burned off moth wings with the use of synthflesh. It modifies the relevant tech node and medical designs to include this under the appropriate research. It also slightly modifies the mothmen species, as wings being burned off currently destroys that genetic information.

## Why It's Good For The Game

Currently burned off moth wings are the only mutant body part which cannot be repaired or reattached by medbay. In fact they cannot be restored by any in-game means (including magical healing and aheals) other than variable editing. This is something I have heard requested a number of times, and appears to be a fairly long standing issue.

Moth wings confer minor in game benefits and are part of a character's visual identity. At the price of time (and the cost of synthflesh) players now have the option of having an otherwise permanent injury fixed.

## Changelog
:cl:
add: Added reconstructive surgery for moth wings, requiring synthflesh
bugfix: Magical healing and aheals now restore moth wings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
