### PR TITLE
Improves Alien Hivemind: Grant the Queen BIG VOICE, and remind Larva how to use it

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien_say.dm
+++ b/code/modules/mob/living/carbon/alien/alien_say.dm
@@ -1,11 +1,14 @@
-/mob/living/proc/alien_talk(message, shown_name = real_name)
+/mob/living/proc/alien_talk(message, shown_name = real_name, big_voice = FALSE)
 	src.log_talk(message, LOG_SAY)
 	message = trim(message)
 	if(!message)
 		return
 
 	var/message_a = say_quote(message)
-	var/rendered = "<i><span class='alien'>Hivemind, <span class='name'>[shown_name]</span> <span class='message'>[message_a]</span></span></i>"
+	var/hivemind_spans = "alien"
+	if(big_voice)
+		hivemind_spans += " big"
+	var/rendered = "<i><span class='[hivemind_spans]'>Hivemind, <span class='name'>[shown_name]</span> <span class='message'>[message_a]</span></span></i>"
 	for(var/mob/S in GLOB.player_list)
 		if(!S.stat && S.hivecheck())
 			to_chat(S, rendered)
@@ -14,8 +17,7 @@
 			to_chat(S, "[link] [rendered]")
 
 /mob/living/carbon/alien/humanoid/royal/queen/alien_talk(message, shown_name = name)
-	shown_name = "<FONT size = 3>[shown_name]</FONT>"
-	..(message, shown_name)
+	..(message, shown_name, TRUE)
 
 /mob/living/carbon/hivecheck()
 	var/obj/item/organ/alien/hivenode/N = getorgan(/obj/item/organ/alien/hivenode)

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -40,8 +40,7 @@
 	. = ..()
 	if(!. || !client)
 		return FALSE
-	to_chat(src, "<b>You are the alien larva. Hide from danger until you can evolve.</b>")
-	to_chat(src, "<b>Use say :a to communicate with the hivemind.</b>")
+	to_chat(src, "<b>You are an alien larva. Hide from danger until you can evolve.<br>Use say :a to communicate with the hivemind.</b>")
 
 /mob/living/carbon/alien/larva/adjustPlasma(amount)
 	if(stat != DEAD && amount > 0)

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -36,6 +36,13 @@
 	if(statpanel("Status"))
 		stat(null, "Progress: [amount_grown]/[max_grown]")
 
+/mob/living/carbon/alien/larva/Login()
+	. = ..()
+	if(!. || !client)
+		return FALSE
+	to_chat(src, "<b>You are the alien larva. Hide from danger until you can evolve.</b>")
+	to_chat(src, "<b>Use say :a to communicate with the hivemind.</b>")
+
 /mob/living/carbon/alien/larva/adjustPlasma(amount)
 	if(stat != DEAD && amount > 0)
 		amount_grown = min(amount_grown + 1, max_grown)


### PR DESCRIPTION
## About The Pull Request

Reminds spawning alien larva about the say channel for hivemind with the new login text:
```
You are an alien larva. Hide from danger until you can evolve.
Use say :a to communicate with the hivemind.
```
..and grants the Alien Queen the **big voice** (over hivemind only) she has always deserved instead of the slightly larger name size she currently gets:
![image](https://user-images.githubusercontent.com/64715958/86312958-c7f0d280-bbd8-11ea-9323-97f914a2f37d.png)

## Why It's Good For The Game

This brings the Alien Queen role more inline with the Blob Overmind in terms of aiding the coordination of your spawn, and might make becoming an egg factory just a little less tedious.

Hopefully adding that little bit of text to the larva spawn greatly decreases the chances of 2 larva appearing for an infestation event and one of them being unable to respond back to questions over hivemind like "solo beno?" or "any other larva out there?" since you already get a condensed wiki entry in your chat log when you go to actually evolve why not a small reminder of the special say command that only appears in the actual wiki buried in the middle of the [guide page](https://tgstation13.org/wiki/Xenomorph)?

## Changelog
:cl:
add: New alien larva spawn tips!
tweak: Alien Queens are now easier to distinguish over hivemind communication similar to a Blob Overmind.
/:cl: