### PR TITLE
Necromantic stone and soulstone belt buffs/nerfs/changes

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -330,7 +330,7 @@
 
 /obj/item/storage/belt/soulstone
 	name = "soul stone belt"
-	desc = "Designed for ease of access to the shards during a fight, as to not let a single enemy spirit slip away."
+	desc = "Designed for ease of access to soulstone shards during a fight, so as to not let a single enemy spirit slip away."
 	icon_state = "soulstonebelt"
 	inhand_icon_state = "soulstonebelt"
 	worn_icon_state = "soulstonebelt"
@@ -338,17 +338,17 @@
 /obj/item/storage/belt/soulstone/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 6
+	STR.max_items = 7
 	STR.set_holdable(list(
 		/obj/item/soulstone
 		))
 
 /obj/item/storage/belt/soulstone/full/PopulateContents()
-	for(var/i in 1 to 6)
-		new /obj/item/soulstone(src)
+	for(var/i in 1 to 7)
+		new /obj/item/soulstone/anybody/wizard(src)
 
 /obj/item/storage/belt/soulstone/full/chappy/PopulateContents()
-	for(var/i in 1 to 6)
+	for(var/i in 1 to 7)
 		new /obj/item/soulstone/anybody/chaplain(src)
 
 /obj/item/storage/belt/champion

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -193,7 +193,7 @@
 /////////////////////////////////////////Necromantic Stone///////////////////
 
 /obj/item/necromantic_stone
-	name = "necromantic stone"
+	name = "ancient necromantic stone"
 	desc = "A shard capable of resurrecting humans as skeleton thralls."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "necrostone"
@@ -202,10 +202,25 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
 	var/list/spooky_scaries = list()
-	var/unlimited = 0
+	///if set to TRUE, this stone will have no cap to the amount of thralls it can have active at the same time (the normal cap is 3 thralls at any given time).
+	var/unlimited = FALSE
+	///if set to TRUE, each skeleton raised by this stone will, upon being raised, have its inventory dumped on the ground and be equipped with a set of "roman" gear, including an incredibly powerful claymore
+	var/oldstone = TRUE
 
 /obj/item/necromantic_stone/unlimited
-	unlimited = 1
+	name = "stone of supreme necromancy" //idk it was the best name I could come up with
+	unlimited = TRUE
+	oldstone = TRUE //yeah, I know it inherits this value from ancient necromantic stones, I just did this for clarity
+
+/obj/item/necromantic_stone/unlimited/newstone
+	name = "greater necromantic stone"
+	unlimited = TRUE
+	oldstone = FALSE
+
+/obj/item/necromantic_stone/wizard //this is the necromantic stone that wizards can buy
+	name = "necromantic stone"
+	unlimited = FALSE
+	oldstone = FALSE
 
 /obj/item/necromantic_stone/attack(mob/living/carbon/human/M, mob/living/carbon/human/user)
 	if(!istype(M))
@@ -236,11 +251,12 @@
 	M.revive(full_heal = TRUE, admin_revive = TRUE)
 	spooky_scaries |= M
 	to_chat(M, "<span class='userdanger'>You have been revived by </span><B>[user.real_name]!</B>")
-	to_chat(M, "<span class='userdanger'>[user.p_theyre(TRUE)] your master now, assist [user.p_them()] even if it costs you your new life!</span>")
+	to_chat(M, "<span class='userdanger'>[user.p_theyre(TRUE)] your master now, assist and serve [user.p_them()] as best as you are able to, even if it costs you your new unlife!</span>")
 
-	equip_roman_skeleton(M)
+	if(oldstone)
+		equip_roman_skeleton(M)
 
-	desc = "A shard capable of resurrecting humans as skeleton thralls[unlimited ? "." : ", [spooky_scaries.len]/3 active thralls."]"
+	desc = "A shard capable of resurrecting humans as skeleton thralls[unlimited ? "." : ". Currently has [spooky_scaries.len]/3 active thralls."]"
 
 /obj/item/necromantic_stone/proc/check_spooky()
 	if(unlimited) //no point, the list isn't used.

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -193,7 +193,7 @@
 /////////////////////////////////////////Necromantic Stone///////////////////
 
 /obj/item/necromantic_stone
-	name = "ancient necromantic stone"
+	name = "necromantic stone"
 	desc = "A shard capable of resurrecting humans as skeleton thralls."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "necrostone"
@@ -205,22 +205,22 @@
 	///if set to TRUE, this stone will have no cap to the amount of thralls it can have active at the same time (the normal cap is 3 thralls at any given time).
 	var/unlimited = FALSE
 	///if set to TRUE, each skeleton raised by this stone will, upon being raised, have its inventory dumped on the ground and be equipped with a set of "roman" gear, including an incredibly powerful claymore
-	var/oldstone = TRUE
+	var/oldstone = FALSE
 
 /obj/item/necromantic_stone/unlimited
 	name = "stone of supreme necromancy" //idk it was the best name I could come up with
 	unlimited = TRUE
-	oldstone = TRUE //yeah, I know it inherits this value from ancient necromantic stones, I just did this for clarity
+	oldstone = TRUE
 
-/obj/item/necromantic_stone/unlimited/newstone
+/obj/item/necromantic_stone/greater
 	name = "greater necromantic stone"
 	unlimited = TRUE
 	oldstone = FALSE
 
-/obj/item/necromantic_stone/wizard //this is the necromantic stone that wizards can buy
-	name = "necromantic stone"
+/obj/item/necromantic_stone/oldstone
+	name = "ancient necromantic stone"
 	unlimited = FALSE
-	oldstone = FALSE
+	oldstone = TRUE
 
 /obj/item/necromantic_stone/attack(mob/living/carbon/human/M, mob/living/carbon/human/user)
 	if(!istype(M))

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -26,8 +26,12 @@
 /obj/item/soulstone/anybody
 	usability = TRUE
 
+/obj/item/soulstone/anybody/wizard
+	desc = "An artificial replica of a fragment of the legendary treasure known simply as the 'Soul Stone'."
+
 /obj/item/soulstone/anybody/revolver
 	old_shard = TRUE
+	desc = "What did you THINK was gonna happen?"
 
 /obj/item/soulstone/anybody/purified
 	icon = 'icons/obj/wizard.dmi'

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -329,7 +329,7 @@
 
 /datum/spellbook_entry/item/spellblade
 	name = "Spellblade"
-	desc = "A sword capable of firing blasts of energy that can dismember the limbs they hit with ease. Also serves as a decent melee weapon that ignores most armor."
+	desc = "A sword capable of firing blasts of energy that can dismember the limbs they hit with ease. Also serves as a decent melee weapon that ignores most armor. Holding it gives you a 50% base block chance against melee attacks."
 	item_path = /obj/item/gun/magic/staff/spellblade
 
 /datum/spellbook_entry/item/katana

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -334,7 +334,7 @@
 
 /datum/spellbook_entry/item/katana
 	name = "Katana"
-	desc = "An elegant and intricately crafted weapon, favored by the Fighter/Mage multi-classers of the Astral Plane." //not sure if we can mention the g*th directly, so let's just do it indirectly, just to be safe
+	desc = "An elegant and intricately crafted weapon, favored by the Fighter/Mage multi-classers of the Astral Plane. It deals an incredible amount of damage on each melee hit and can block (at a base 50% block rate) both incoming melee attacks and projectiles." //not sure if we can mention the g*th directly, so let's just do it indirectly, just to be safe
 	item_path = /obj/item/katana
 
 /datum/spellbook_entry/item/scryingorb

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -360,7 +360,7 @@
 /datum/spellbook_entry/item/necrostone
 	name = "Necromantic Stone"
 	desc = "A stone enchanted with the ability to resurrect dead individuals as skeletal thralls for you to command. Can sustain up to three skeleton thralls at any given time."
-	item_path = /obj/item/necromantic_stone/wizard
+	item_path = /obj/item/necromantic_stone
 	category = "Assistance"
 
 /datum/spellbook_entry/item/wands

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -307,17 +307,6 @@
 	desc = "A caprious tool that can fire all sorts of magic without any rhyme or reason. Using it on people you care about is not recommended."
 	item_path = /obj/item/gun/magic/staff/chaos
 
-/datum/spellbook_entry/item/spellblade
-	name = "Spellblade"
-	desc = "A sword capable of firing blasts of energy that can rip targets limb from limb."
-	item_path = /obj/item/gun/magic/staff/spellblade
-	cost = 1
-
-/datum/spellbook_entry/item/katana
-	name = "Katana"
-	desc = "An elegant and intricately crafted weapon, modeled after the primary weapon of legendary Kensei/Mage Boldyris Gait."
-	item_path = /obj/item/katana
-
 /datum/spellbook_entry/item/staffdoor
 	name = "Staff of Door Creation"
 	desc = "A particular staff that can mold solid walls into ornate doors. Useful for getting around in the absence of other transportation. Does not work on glass."
@@ -337,6 +326,17 @@
 	desc = "A staff that shoots lockers. It eats anyone it hits on its way, leaving a welded locker with your victims behind."
 	item_path = /obj/item/gun/magic/staff/locker
 	category = "Defensive"
+
+/datum/spellbook_entry/item/spellblade
+	name = "Spellblade"
+	desc = "A sword capable of firing blasts of energy that can rip targets limb from limb."
+	item_path = /obj/item/gun/magic/staff/spellblade
+	cost = 1
+
+/datum/spellbook_entry/item/katana
+	name = "Katana"
+	desc = "An elegant and intricately crafted weapon, modeled after the primary weapon of legendary Kensai/Mage Boldyris Gait."
+	item_path = /obj/item/katana
 
 /datum/spellbook_entry/item/scryingorb
 	name = "Scrying Orb"

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -329,13 +329,12 @@
 
 /datum/spellbook_entry/item/spellblade
 	name = "Spellblade"
-	desc = "A sword capable of firing blasts of energy that can rip targets limb from limb."
+	desc = "A sword capable of firing blasts of energy that can dismember the limbs they hit with ease. Also serves as a decent melee weapon that ignores most armor."
 	item_path = /obj/item/gun/magic/staff/spellblade
-	cost = 1
 
 /datum/spellbook_entry/item/katana
 	name = "Katana"
-	desc = "An elegant and intricately crafted weapon, modeled after the primary weapon of legendary Kensai/Mage Boldyris Gait."
+	desc = "An elegant and intricately crafted weapon, favored by the Fighter/Mage multi-classers of the Astral Plane." //not sure if we can mention the g*th directly, so let's just do it indirectly, just to be safe
 	item_path = /obj/item/katana
 
 /datum/spellbook_entry/item/scryingorb

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -309,8 +309,14 @@
 
 /datum/spellbook_entry/item/spellblade
 	name = "Spellblade"
-	desc = "A sword capable of firing blasts of energy which rip targets limb from limb."
+	desc = "A sword capable of firing blasts of energy that can rip targets limb from limb."
 	item_path = /obj/item/gun/magic/staff/spellblade
+	cost = 1
+
+/datum/spellbook_entry/item/katana
+	name = "Katana"
+	desc = "An elegant and intricately crafted weapon, modeled after the primary weapon of legendary Kensei/Mage Boldyris Gait."
+	item_path = /obj/item/katana
 
 /datum/spellbook_entry/item/staffdoor
 	name = "Staff of Door Creation"
@@ -339,8 +345,8 @@
 	category = "Defensive"
 
 /datum/spellbook_entry/item/soulstones
-	name = "Six Soul Stone Shards and the spell Artificer"
-	desc = "Soul Stone Shards are ancient tools capable of capturing and harnessing the spirits of the dead and dying. The spell Artificer allows you to create arcane machines for the captured souls to pilot."
+	name = "Six Soulstone Shards, Create Construct Shell, and Create Soulstone Shard"
+	desc = "Soulstone shards are ancient tools capable of capturing and harnessing the spirits of the dead and dying. The spell Create Construct Shell allows you to create arcane machines for the captured souls to pilot, and the spell Create Soulstone Shard allows you to create more shards in case you run out of them."
 	item_path = /obj/item/storage/belt/soulstone/full
 	category = "Assistance"
 
@@ -348,12 +354,13 @@
 	. =..()
 	if(.)
 		user.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/construct(null))
+		user.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/soulstone/noncult/wizard(null))
 	return .
 
 /datum/spellbook_entry/item/necrostone
-	name = "A Necromantic Stone"
-	desc = "A Necromantic stone is able to resurrect three dead individuals as skeletal thralls for you to command."
-	item_path = /obj/item/necromantic_stone
+	name = "Necromantic Stone"
+	desc = "A stone enchanted with the ability to resurrect dead individuals as skeletal thralls for you to command. Can sustain up to three skeleton thralls at any given time."
+	item_path = /obj/item/necromantic_stone/wizard
 	category = "Assistance"
 
 /datum/spellbook_entry/item/wands

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -77,7 +77,6 @@
 /obj/effect/proc_holder/spell/aoe_turf/conjure/soulstone
 	name = "Summon Soulstone"
 	desc = "This spell reaches into Nar'Sie's realm, summoning one of the legendary fragments across time and space."
-
 	school = "conjuration"
 	charge_max = 2400
 	clothes_req = FALSE
@@ -96,6 +95,11 @@
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/soulstone/noncult
 	summon_type = list(/obj/item/soulstone/anybody)
+
+/obj/effect/proc_holder/spell/aoe_turf/conjure/soulstone/noncult/wizard
+	name = "Create Soulstone"
+	desc = "This spell creates an artificial replica of a fragment of the Soul Stone." //fun fact: while the shards are called "soulstone shards", the legendary artifact itself is known as the "Soul Stone"
+	charge_max = 600
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/soulstone/noncult/purified
 	summon_type = list(/obj/item/soulstone/anybody/purified)

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -195,8 +195,8 @@
 	cast_sound = 'sound/magic/summon_karp.ogg'
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/construct
-	name = "Artificer"
-	desc = "This spell conjures a construct which may be controlled by Shades."
+	name = "Create Construct Shell"
+	desc = "This spell creates a construct shell that can be piloted by a shade."
 	school = "conjuration"
 	charge_max = 600
 	clothes_req = FALSE


### PR DESCRIPTION
## About The Pull Request

Necromantic stones no longer dump all of the gear of newly-raised skeletons on the ground, nor do they give them any special roman gear (including the incredibly powerful claymore item). Admins can still spawn in stones that work the old way, though.

Wizards can now buy katanas for 2 wizard points each. They're pretty much just reskins of claymores, except they're bulky instead of box-sized.

Soulstone belts can now hold (and come with) 7 soulstone shards instead of 6. The soulstone shards from soulstone belts can now be used by anyone who gets their hands on them, as they're now "replicas" that aren't under the protection of Nar'Sie.

Purchasing the soulstone belt wizard item now teaches you the Create Soulstone spell (self-explanatory, really) in addition to the "Artificer" spell that it taught you before this PR (and still will after this PR), which has been renamed to "Create Construct Shell" for clarity.

A special descripton has been added for the soulstones produced by the cursed Russian revolver, and the descriptions of some of the entries in the wizard spellbook have been updated.

## Why It's Good For The Game

Necromantic stones are a bit janky to use right now. Often, when you raise someone as a skeleton, they'll have to awkwardly stand next to their old gear pile and reequip everything they just dropped before being fully "ready to serve". Necromantic stones currently are also, uh, really strong, because EACH of your skeleton minions will receive a 40 force(!), no negative wound bonus (!!), one-handed(!!!) claymore with a 50% block chance vs. all attacks (!!!!) that's small enough to fit inside of a backpack. It serves not only as a powerful minionmancy tool, but also as a source for an incredibly powerful weapon that's strong enough to be a wizard item in its own right (we'll get to that later). It's telling that one of the necromantic stone's greatest drawbacks is not its thrall cap, but rather the fact that the crew can get their hands on claymores (and dunk on you with them) if they manage to kill some of your skeletons.

Fortunately, the inventory-stripping and roman outfit-equipping part of necromantic stones was all contained in one proc, so it was quite easy to disable that feature (outside of admin-only alternate necromantic stones). However, the claymores from necromantic stones did serve a niche in the wizard's arsenal, and I felt kind of sad seeing them go... so I added katanas to the wizard's spellbook at a price of 2 wizard points each. They're basically reskinned claymores (they have pretty much the exact same stats, aside from the katanas being bulky items (that can still fit in your back or belt slots, just like claymores) and looking much more look a wizard item (gish gang rise up). Plus, you can make neckbeard jokes with 'em.

As for soulstone belts, it was just kind of annoying/janky that you had to turn people into artificers in order to get more soulstones, even though you could summon a construct SHELL for those soulstones on your own once every minute. Now, if you have just one soulstone left, you won't have to turn that shade who really wanted to be a juggernaut into an artificer so that you won't run out of soulstones. Now, the soulstone belt experience should be a lot smoother, and the soulstone belt shouldn't force you into the artificer spam strategy.

The soulstone belt only holding 6 items for seemingly no reason, despite most other belts in the game holding 7 items, was also mildly triggering my OCD, so I bumped that 6 up to a 7 (and increased the number of soulstones that start in the belt to compensate).

I also didn't really like that the power of the soulstone belt (and its assorted items/abilties) came from Nar'Sie, not the wizard themselves, so I refluffed the wizard soulstones as being imitations of the shards of the Soul Stone artefact.

## Changelog
:cl: ATHATH
balance: Necromantic stones no longer dump all of the gear of newly-raised skeletons on the ground, nor do they give them any special roman gear (including the incredibly powerful claymore item). Admins can still spawn in stones that work the old way, though.
add: Wizards can now buy katanas for 2 wizard points each. They're pretty much just reskins of claymores, except they're bulky instead of box-sized.
balance: Soulstone belts can now hold (and come with) 7 soulstone shards instead of 6. The soulstone shards from soulstone belts can now be used by anyone who gets their hands on them, as they're now "replicas" that aren't under the protection of Nar'Sie.
balance: Purchasing the soulstone belt wizard item now teaches you the Create Soulstone spell (self-explanatory, really) in addition to the "Artificer" spell that it taught you before this PR (and still will after this PR), which has been renamed to "Create Construct Shell" for clarity.
tweak: A special descripton has been added for the soulstones produced by the cursed Russian revolver, and the descriptions of some of the entries in the wizard spellbook have been updated.
/:cl: