### PR TITLE
Allows miners to use doors and objects in luxury bar shelter

### DIFF
--- a/_maps/templates/shelter_3.dmm
+++ b/_maps/templates/shelter_3.dmm
@@ -70,7 +70,12 @@
 /turf/open/floor/pod/dark,
 /area/survivalpod)
 "m" = (
-/obj/structure/closet/secure_closet/bar,
+/obj/structure/closet/secure_closet/bar{
+	req_access = 0;
+	req_access_txt = 0;
+	req_one_access = 0;
+	req_one_access_txt = "25;48"
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -94,7 +99,10 @@
 /area/survivalpod)
 "p" = (
 /obj/machinery/door/airlock/survival_pod/glass{
-	req_access_txt = "25"
+	req_access = 0;
+	req_access_txt = 0;
+	req_one_access = 0;
+	req_one_access_txt = "25;48"
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/pod/dark,
@@ -129,7 +137,10 @@
 /area/survivalpod)
 "v" = (
 /obj/machinery/door/window/survival_pod{
-	req_access_txt = "25;48"
+	req_access = 0;
+	req_access_txt = 0;
+	req_one_access = 0;
+	req_one_access_txt = "25;48"
 	},
 /turf/open/floor/pod/dark,
 /area/survivalpod)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates the 10k mining point reward bar's require access to allow miners (id 48) to access the left hand bar access door, bar sliding door, and booze cabinet. Previously these doors were only accessible to bartenders (id25) or for some odd reason required both bartender and mining access combined to open (25+48).

![Mining Fix](https://user-images.githubusercontent.com/66910879/86413283-14afd880-bcc1-11ea-8629-b076b6c924b2.png)



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows the player who purchased the bar, to tend the bar.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Disco
fix: Miners can now open doors and cabinets in luxury bar capsules they purchase
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
