### PR TITLE
HERETICS : fixes an infinite summons exploit.

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -43,7 +43,6 @@
 			if(living_in_range.stat != DEAD || living_in_range == user) // we only accept corpses, no living beings allowed.
 				continue
 		atoms_in_range += atom_in_range
-	atoms_in_range -= atoms_in_use
 	for(var/X in knowledge)
 		var/datum/eldritch_knowledge/current_eldritch_knowledge = knowledge[X]
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -80,7 +80,7 @@
 		if(current_eldritch_knowledge.on_finished_recipe(user,selected_atoms,loc))
 			current_eldritch_knowledge.cleanup_atoms(selected_atoms)
 
-		listclearnulls()
+		listclearnulls(atoms_in_use)
 
 		for(var/to_disappear in atoms_in_use)
 			var/atom/atom_to_disappear = to_disappear

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -5,6 +5,8 @@
 	icon_state = ""
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	layer = SIGIL_LAYER
+	///Used mainly for summoning ritual to prevent spamming the rune to create millions of monsters.
+	var/list/atoms_in_use = list()
 
 /obj/effect/eldritch/attack_hand(mob/living/user)
 	. = ..()
@@ -15,7 +17,7 @@
 /obj/effect/eldritch/proc/try_activate(mob/living/user)
 	if(!IS_HERETIC(user))
 		return
-	activate(user)
+	INVOKE_ASYNC(src, .proc/activate , user)
 
 /obj/effect/eldritch/attacked_by(obj/item/I, mob/living/user)
 	. = ..()
@@ -39,7 +41,7 @@
 			if(living_in_range.stat != DEAD || living_in_range == user) // we only accept corpses, no living beings allowed.
 				continue
 		atoms_in_range += atom_in_range
-
+	atoms_in_range -= atoms_in_use
 	for(var/X in knowledge)
 		var/datum/eldritch_knowledge/current_eldritch_knowledge = knowledge[X]
 
@@ -70,8 +72,22 @@
 
 		flick("[icon_state]_active",src)
 		playsound(user, 'sound/magic/castsummon.ogg', 75, TRUE)
+		atoms_in_use |= selected_atoms
+		for(var/to_disappear in atoms_in_use)
+			var/atom/atom_to_disappear = to_disappear
+			//temporary so we dont have to deal with the bs of someone picking those up when they may be deleted
+			atom_to_disappear.invisibility = INVISIBILITY_ABSTRACT
 		if(current_eldritch_knowledge.on_finished_recipe(user,selected_atoms,loc))
 			current_eldritch_knowledge.cleanup_atoms(selected_atoms)
+
+		listclearnulls()
+
+		for(var/to_disappear in atoms_in_use)
+			var/atom/atom_to_disappear = to_disappear
+			//we need to reappear the item just in case the ritual didnt consume everything... or something.
+			atom_to_disappear.invisibility = initial(atom_to_disappear.invisibility)
+
+		atoms_in_use = list()
 		return
 	to_chat(user,"<span class='warning'>Your ritual failed! You used either wrong components or are missing something important!</span>")
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -187,8 +187,6 @@
 	var/datum/antagonist/heretic_monster/heretic_monster = summoned.mind.has_antag_datum(/datum/antagonist/heretic_monster)
 	var/datum/antagonist/heretic/master = user.mind.has_antag_datum(/datum/antagonist/heretic)
 	heretic_monster.set_owner(master)
-	//delaying the returning makes the cleanup_atoms break on the rune base, so we are calling it here.
-	//cleanup_atoms(atoms)
 	return TRUE
 
 //Ascension knowledge

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -188,8 +188,8 @@
 	var/datum/antagonist/heretic/master = user.mind.has_antag_datum(/datum/antagonist/heretic)
 	heretic_monster.set_owner(master)
 	//delaying the returning makes the cleanup_atoms break on the rune base, so we are calling it here.
-	cleanup_atoms(atoms)
-	return FALSE
+	//cleanup_atoms(atoms)
+	return TRUE
 
 //Ascension knowledge
 /datum/eldritch_knowledge/final

--- a/code/modules/mob/living/simple_animal/eldritch_demons.dm
+++ b/code/modules/mob/living/simple_animal/eldritch_demons.dm
@@ -16,7 +16,7 @@
 	speed = 0
 	a_intent = INTENT_HARM
 	stop_automated_movement = 1
-	AIStatus = AI_ON
+	AIStatus = AI_OFF
 	attack_sound = 'sound/weapons/punch1.ogg'
 	see_in_dark = 7
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
@@ -37,8 +37,6 @@
 /mob/living/simple_animal/hostile/eldritch/Initialize()
 	. = ..()
 	add_spells()
-	//by default
-	mind.add_antag_datum(/datum/antagonist/heretic_monster)
 
 /**
   * Add_spells


### PR DESCRIPTION
## About The Pull Request

There was an exploit caused by delaying a proc caused by PollGhosts(). Since the inital proc never cleaned up the items you could spawn as many heretics summons as fast as you could click. 

## Why It's Good For The Game

:agony:

## Changelog
:cl:
fix: You can no longer infinitely spawn heretics summons
/:cl:

