### PR TITLE
Adjusts dark mode info span color

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -306,7 +306,7 @@ em						{font-style: normal;	font-weight: bold;}
 .boldannounce			{color: #c51e1e;	font-weight: bold;}
 .greenannounce			{color: #059223;	font-weight: bold;}
 .rose					{color: #ff5050;}
-.info					{color: #6685f5;}
+.info					{color: #9ab0ff;}
 .notice					{color: #6685f5;}
 .tinynotice				{color: #6685f5; font-style: italic;	font-size: 85%;}
 .smallnotice			{color: #6685f5; font-style: italic;	font-size: 90%;}


### PR DESCRIPTION
Makes it a little easier to tell the difference. Made it slightly lighter than notification message, as it is in light mode.
:cl: ShizCalev
fix: Info messages are now slightly brighter than notification messages when using dark mode.
/:cl:

![image](https://user-images.githubusercontent.com/6209658/86507997-62544000-bdaa-11ea-97b6-6d5717134a62.png)

maintenance panel is notification, the screwdriver message is info