### PR TITLE
Fixes buckled mobs sometimes z fighting with what they're buckled too

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -955,7 +955,7 @@
 /mob/post_buckle_mob(mob/living/M)
 	var/height = M.get_mob_buckling_height(src)
 	M.pixel_y = initial(M.pixel_y) + height
-	if(M.layer < layer)
+	if(M.layer <= layer) //make sure they stay above our current layer
 		M.layer = layer + 0.1
 ///Call back post unbuckle from a mob, (reset your visual height here)
 /mob/post_unbuckle_mob(mob/living/M)


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed buckled mobs sometimes appearing over what they're buckled to.
/:cl:

fixes #39087