### PR TITLE
You can now actually sacrifice people who are strapped to sacrificial altars.

### DIFF
--- a/code/game/objects/structures/divine.dm
+++ b/code/game/objects/structures/divine.dm
@@ -1,22 +1,22 @@
 /obj/structure/sacrificealtar
 	name = "sacrificial altar"
-	desc = "An altar designed to perform blood sacrifice for a deity."
+	desc = "An altar designed to perform blood sacrifice for a deity. Alt-click it to sacrifice a buckled creature."
 	icon = 'icons/obj/hand_of_god_structures.dmi'
 	icon_state = "sacrificealtar"
 	anchored = TRUE
 	density = FALSE
 	can_buckle = 1
 
-/obj/structure/sacrificealtar/attack_hand(mob/living/user)
-	. = ..()
-	if(.)
+/obj/structure/sacrificealtar/AltClick(mob/living/user)
+	..()
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
 		return
 	if(!has_buckled_mobs())
 		return
 	var/mob/living/L = locate() in buckled_mobs
 	if(!L)
 		return
-	to_chat(user, "<span class='notice'>You attempt to sacrifice [L] by invoking the sacrificial ritual.</span>")
+	to_chat(user, "<span class='notice'>Invoking the sacred ritual, you sacrifice [L].</span>")
 	L.gib()
 	message_admins("[ADMIN_LOOKUPFLW(user)] has sacrificed [key_name_admin(L)] on the sacrificial altar at [AREACOORD(src)].")
 


### PR DESCRIPTION
## About The Pull Request

To sacrifice someone on a sacrificial altar (such as the ones found in the healing fountain ruin), you must now alt-click the altar, not normal-click it. The default descriptions of sacrificial altars have been updated accordingly.

## Why It's Good For The Game

Before this PR, trying to sacrifice someone strapped to a sacrificial altar would unbuckle them from the altar before the altar would check to see if anyone was strapped to it (and thus eligible for sacrifice).

This is just a bugfix PR, but hey, maybe in a follow-up PR, we can make performing a sacrifice recharge the godblood fountain or aheal you or something.

## Changelog
:cl: ATHATH
fix: To sacrifice someone on a sacrificial altar (such as the ones found in the healing fountain ruin), you must now alt-click the altar, not normal-click it. The default descriptions of sacrificial altars have been updated accordingly.
/:cl: