### PR TITLE
[READY] Vendors can tip on people thrown at them extra hard, lets you set ejection speed on disposal outlets

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -120,6 +120,12 @@
 #define SHOES_TIED 1
 #define SHOES_KNOTTED 2
 
+//how fast a disposal machinery thing is ejecting things
+#define EJECT_SPEED_SLOW 	1
+#define EJECT_SPEED_MED		2
+#define EJECT_SPEED_FAST	4
+#define EJECT_SPEED_YEET	6
+
 //Cache of bloody footprint images
 //Key:
 //"entered-[blood_state]-[dir_of_image]"

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -366,6 +366,7 @@
 			user.adjustBruteLoss(30)
 			playsound(user, 'sound/effects/blobattack.ogg', 60, TRUE)
 			playsound(user, 'sound/effects/splat.ogg', 70, TRUE)
+			playsound(user, 'sound/effects/crack2.ogg', 70, TRUE)
 			user.emote("scream")
 			user.gain_trauma(/datum/brain_trauma/severe/paralysis/paraplegic) // oopsie indeed!
 			shake_camera(user, 7, 7)
@@ -434,13 +435,13 @@
 		W.obj_destruction()
 		user.adjustStaminaLoss(10 * speed)
 		user.Paralyze(30)
-		user.visible_message("<span class='danger'>[user] slams into [W] and shatters it, shredding [user.p_them()]self with glass!</span>", "<span class='userdanger'>You slam into [W] and shatter it, shredding yourself with glass!</span>")
+		user.visible_message("<span class='danger'>[user] smacks into [W] and shatters it, shredding [user.p_them()]self with glass!</span>", "<span class='userdanger'>You smacks into [W] and shatter it, shredding yourself with glass!</span>")
 
 	else
-		user.visible_message("<span class='danger'>[user] slams into [W] like a bug, then slowly slides off it!</span>", "<span class='userdanger'>You slam into [W] like a bug, then slowly slide off it!</span>")
+		user.visible_message("<span class='danger'>[user] smacks into [W] like a bug!</span>", "<span class='userdanger'>You smacks into [W] like a bug!</span>")
 		user.Paralyze(10)
 		user.Knockdown(30)
-		W.take_damage(20 * speed)
+		W.take_damage(30 * speed)
 		user.adjustStaminaLoss(10 * speed)
 		user.adjustBruteLoss(5 * speed)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -574,7 +574,7 @@
 	if(impact_signal & COMPONENT_MOVABLE_IMPACT_FLIP_HITPUSH)
 		hitpush = FALSE // hacky, tie this to something else or a proper workaround later
 
-	if(impact_signal & ~COMPONENT_MOVABLE_IMPACT_NEVERMIND) // in case a signal interceptor broke or deleted the thing before we could process our hit
+	if(!(impact_signal && (impact_signal & COMPONENT_MOVABLE_IMPACT_NEVERMIND))) // in case a signal interceptor broke or deleted the thing before we could process our hit
 		return hit_atom.hitby(src, throwingdatum=throwingdatum, hitpush=hitpush)
 
 /atom/movable/hitby(atom/movable/AM, skipcatch, hitpush = TRUE, blocked, datum/thrownthing/throwingdatum)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -166,6 +166,10 @@
 		var/power_throw = 0
 		if(HAS_TRAIT(src, TRAIT_HULK))
 			power_throw++
+		if(HAS_TRAIT(src, TRAIT_DWARF))
+			power_throw--
+		if(HAS_TRAIT(thrown_thing, TRAIT_DWARF))
+			power_throw++
 		if(pulling && grab_state >= GRAB_NECK)
 			power_throw++
 		visible_message("<span class='danger'>[src] throws [thrown_thing][power_throw ? " really hard!" : "."]</span>", \

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -13,6 +13,10 @@
 	var/obj/structure/disposalconstruct/stored
 	var/start_eject = 0
 	var/eject_range = 2
+	/// how fast we're spitting fir- atoms
+	var/eject_speed = EJECT_SPEED_MED
+	/// if we've been emagged or not, duh
+	var/emagged = FALSE
 
 /obj/structure/disposaloutlet/Initialize(mapload, obj/structure/disposalconstruct/make_from)
 	. = ..()
@@ -61,7 +65,7 @@
 		var/atom/movable/AM = A
 		AM.forceMove(T)
 		AM.pipe_eject(dir)
-		AM.throw_at(target, eject_range, 1)
+		AM.throw_at(target, eject_range, eject_speed)
 
 	H.vent_gas(T)
 	qdel(H)
@@ -80,3 +84,39 @@
 		stored = null
 		qdel(src)
 	return TRUE
+
+/obj/structure/disposaloutlet/examine(mob/user)
+	. = ..()
+	switch(eject_speed)
+		if(EJECT_SPEED_SLOW)
+			. += "<span class='info'>An LED image of a turtle is displayed on the side of the outlet.</span>"
+		if(EJECT_SPEED_MED)
+			. += "<span class='info'>An LED image of a bumblebee is displayed on the side of the outlet.</span>"
+		if(EJECT_SPEED_FAST)
+			. += "<span class='info'>An LED image of a speeding bullet is displayed on the side of the outlet.</span>"
+		if(EJECT_SPEED_YEET)
+			. += "<span class='info'>An LED image of a grawlix is displayed on the side of the outlet.</span>"
+
+/obj/structure/disposaloutlet/multitool_act(mob/living/user, obj/item/I)
+	. = ..()
+	to_chat(user, "<span class='notice'>You adjust the ejection force on \the [src].</span>")
+	switch(eject_speed)
+		if(EJECT_SPEED_SLOW)
+			eject_speed = EJECT_SPEED_MED
+		if(EJECT_SPEED_MED)
+			eject_speed = EJECT_SPEED_FAST
+		if(EJECT_SPEED_FAST)
+			if(emagged)
+				eject_speed = EJECT_SPEED_YEET
+			else
+				eject_speed = EJECT_SPEED_SLOW
+		if(EJECT_SPEED_YEET)
+			eject_speed = EJECT_SPEED_SLOW
+	return TRUE
+
+/obj/structure/disposaloutlet/emag_act(mob/user, obj/item/card/emag/E)
+	. = ..()
+	if(emagged)
+		return
+	to_chat(user, "<span class='notice'>You silently disable the sanity checking on \the [src]'s ejection force.</span>")
+	emagged = TRUE

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -15,8 +15,6 @@
 	var/eject_range = 2
 	/// how fast we're spitting fir- atoms
 	var/eject_speed = EJECT_SPEED_MED
-	/// if we've been emagged or not, duh
-	var/emagged = FALSE
 
 /obj/structure/disposaloutlet/Initialize(mapload, obj/structure/disposalconstruct/make_from)
 	. = ..()
@@ -106,7 +104,7 @@
 		if(EJECT_SPEED_MED)
 			eject_speed = EJECT_SPEED_FAST
 		if(EJECT_SPEED_FAST)
-			if(emagged)
+			if(obj_flags & EMAGGED)
 				eject_speed = EJECT_SPEED_YEET
 			else
 				eject_speed = EJECT_SPEED_SLOW
@@ -116,7 +114,7 @@
 
 /obj/structure/disposaloutlet/emag_act(mob/user, obj/item/card/emag/E)
 	. = ..()
-	if(emagged)
+	if(obj_flags & EMAGGED)
 		return
 	to_chat(user, "<span class='notice'>You silently disable the sanity checking on \the [src]'s ejection force.</span>")
-	emagged = TRUE
+	obj_flags |= EMAGGED

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -962,6 +962,14 @@ GLOBAL_LIST_EMPTY(vending_products)
 /obj/machinery/vending/onTransitZ()
 	return
 
+/obj/machinery/vending/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
+	. = ..()
+	var/mob/living/L = AM
+	if(tilted || !istype(L) || !prob(25 * (throwingdatum.speed - L.throw_speed))) // hulk throw = +25%, neckgrab throw = +25%
+		return
+
+	tilt(L)
+
 /obj/machinery/vending/custom
 	name = "Custom Vendor"
 	icon_state = "robotics"

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -965,7 +965,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 /obj/machinery/vending/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	. = ..()
 	var/mob/living/L = AM
-	if(tilted || !istype(L) || !prob(25 * (throwingdatum.speed - L.throw_speed))) // hulk throw = +25%, neckgrab throw = +25%
+	if(tilted || !istype(L) || !prob(20 * (throwingdatum.speed - L.throw_speed))) // hulk throw = +20%, neckgrab throw = +20%
 		return
 
 	tilt(L)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR gives people who are thrown extra hard into vending machines a chance to be crushed by said vending machine. Being thrown extra hard means being thrown at a speed higher than your normal throw_speed (for carbons, 2). Here's a quick list of throw_speed mods for carbons.

- Thrown by a hulk: +1 speed
- Throwing a dwarf: +1 speed
- Thrown from a neckgrab: +1 speed
- Thrown by a dwarf: -1 speed

Each extra throw_speed adds 20% to your chance to get squished, so being thrown by a hulk gives you a 20% chance, being neckthrown by a hulk gives you a 40% chance, and being a dwarf thrown by a hulk who has you in a neckgrab gives you a 60% chance. This PR also lets you use a multitool on a disposal outlet to change the eject speed between 1/2/4 rather than just 1. If you emag it, you can crank it up to 6! Fun!

There's other things that can throw you faster like baseball bats (40% of the time you launch at 4 speed) and cartoonish sneezing (random from 1-4 speed), so experiment! 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds more ways to use the environment to your advantage in a battle, gives hulk a small yet flavorful buff that isn't just "click to smash thing"
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
add: Throwing people really hard into vending machines is not advised if you don't want to clean them up afterwards. Things are considered thrown really hard if: You're throwing them as a hulk, the person you're throwing is a dwarf, and/or if you're throwing someone from a neckgrab
add: You can now adjust the speed disposal outlets eject contents at with a multitool, and emag the disposal outlet to amp the speed up even further!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
