### PR TITLE
Further Helps New Player Mobs GC

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -84,6 +84,8 @@
 	SSticker.minds -= src
 	if(islist(antag_datums))
 		QDEL_LIST(antag_datums)
+	current = null
+	soulOwner = null
 	return ..()
 
 /datum/mind/proc/get_language_holder()


### PR DESCRIPTION
When a new player observes the mind datum is deleted to help the `/mob/dead/new_player` mob GC better.

Unfortunately, the mind datum, itself, holds a reference to the `/mob/dead/new_player` mob, which still prevents garbage collection---furthermore, `/datum/mind`, itself won't GC because it holds a reference to....itself (devils antag is to thank for this one).

Observing causes a failure (but successful GC) because the mind datum gets deleted first---it fails, then gets hard deleted, which clears the reference on `/mob/dead/new_player`, which then allows it to GC.

This won't make `/datum/mind` anywhere close to be ready to be actively garbage collected (and there's only one instance in the entire codebase of deleting a mind, anyway)....and well, mind datums are just as bad if not worse than mobs for GCing, but, this does allow `/datum/mind` to GC in the single instance it *IS* qdeleted.