### PR TITLE
makes unholy water and eldritch essence use metabolization_rate, like most other chems in the game

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -320,6 +320,7 @@
 	name = "Unholy Water"
 	description = "Something that shouldn't exist on this plane of existence."
 	taste_description = "suffering"
+	metabolization_rate = 2.5 * REAGENTS_METABOLISM  //1u/tick
 
 /datum/reagent/fuel/unholywater/expose_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(method == TOUCH || method == VAPOR)
@@ -344,8 +345,7 @@
 		M.adjustFireLoss(2, 0)
 		M.adjustOxyLoss(2, 0)
 		M.adjustBruteLoss(2, 0)
-	holder.remove_reagent(type, 1)
-	return TRUE
+	..()
 
 /datum/reagent/hellwater			//if someone has this in their system they've really pissed off an eldrich god
 	name = "Hell Water"
@@ -2310,11 +2310,12 @@
 		M.adjustStaminaLoss(-0.25*REM) // the more wounds, the more stamina regen
 	..()
 
-/datum/reagent/eldritch
+/datum/reagent/eldritch //unholy water, but for eldritch cultists. why couldn't they have both just used the same reagent? who knows. maybe nar'sie is considered to be too "mainstream" of a god to worship in the cultist community.
 	name = "Eldritch Essence"
-	description = "Strange liquid that defies the laws of physics"
+	description = "A strange liquid that defies the laws of physics. It re-energizes and heals those who can see beyond this fragile reality, but is incredibly harmful to the closed-minded. It metabolizes very quickly."
 	taste_description = "Ag'hsj'saje'sh"
 	color = "#1f8016"
+	metabolization_rate = 2.5 * REAGENTS_METABOLISM  //1u/tick
 
 /datum/reagent/eldritch/on_mob_life(mob/living/carbon/M)
 	if(IS_HERETIC(M))
@@ -2333,5 +2334,4 @@
 		M.adjustFireLoss(2, FALSE)
 		M.adjustOxyLoss(2, FALSE)
 		M.adjustBruteLoss(2, FALSE)
-	holder.remove_reagent(type, 1)
-	return TRUE
+	..()


### PR DESCRIPTION
## About The Pull Request

See title.

I also changed the description of eldritch essence to make what it actually does more clear.

## Why It's Good For The Game

why the fuck do these two chems directly delete themselves from your bloodstream instead of using the variable that's specifically there for setting how quickly a chem should remove itself from your bloodstream ahhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh

I mean, I know that eldritch essence does it because it just copy+pasted the on_mob_life() effect of unholy water and replaced the blood cultist check with an eldritch cultist one, but still.

## Changelog
:cl: ATHATH
tweak: The description of eldritch essence has been modified to make what it actually does more clear.
tweak: Eldritch essence and unholy water both now actually use the metabolization_rate variable.
/:cl: