### PR TITLE
makes drills unable to disembowel conscious targets, buffs diamond drills, gives the reticence a silent drill

### DIFF
--- a/code/game/mecha/combat/reticence.dm
+++ b/code/game/mecha/combat/reticence.dm
@@ -13,7 +13,7 @@
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_THEATRE)
 	add_req_access = 0
 	internal_damage_threshold = 25
-	max_equip = 2
+	max_equip = 3
 	step_energy_drain = 3
 	color = "#87878715"
 	stepsound = null
@@ -23,6 +23,8 @@
 /obj/mecha/combat/reticence/loaded/Initialize()
 	. = ..()
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/silenced
+	ME.attach(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/drill/diamonddrill/mime //for silently disposing of your foes
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/rcd //HAHA IT MAKES WALLS GET IT
 	ME.attach(src)

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -11,7 +11,7 @@
 	icon_state = "mecha_drill"
 	equip_cooldown = 15
 	energy_drain = 10
-	force = 10
+	force = 5 //double this to find the damage dealt by this drill when used by a mech
 	harmful = TRUE
 	tool_behaviour = TOOL_DRILL
 	toolspeed = 0.9
@@ -54,7 +54,7 @@
 					playsound(src,'sound/weapons/drill.ogg',40,TRUE)
 			else if(isobj(target))
 				var/obj/O = target
-				O.take_damage(force, BRUTE, 0, FALSE, get_dir(chassis, target))
+				O.take_damage(force * 2, BRUTE, 0, FALSE, get_dir(chassis, target)) //the force has to be doubled here so that humans don't run around smacking each other with 20 force mech diamond drills
 				if(!silent)
 					playsound(src,'sound/weapons/drill.ogg',40,TRUE)
 			else
@@ -128,7 +128,7 @@
 	else
 		//drill makes a hole
 		var/obj/item/bodypart/target_part = target.get_bodypart(ran_zone(BODY_ZONE_CHEST))
-		target.apply_damage(force, BRUTE, BODY_ZONE_CHEST, target.run_armor_check(target_part, "melee"), wound_bonus = 30) //the high wound_bonus helps give off that "holy shit a mech just drilled into that dude's chest" effect in PvP without affecting PvE balance
+		target.apply_damage(force * 2, BRUTE, BODY_ZONE_CHEST, target.run_armor_check(target_part, "melee"), wound_bonus = 30) //the force has to be doubled here so that humans don't run around smacking each other with 20 force mech diamond drills //the high wound_bonus helps give off that "holy shit a mech just drilled into that dude's chest" effect in PvP without affecting PvE balance
 		//blood splatters
 		var/splatter_dir = get_dir(chassis, target)
 		if(isalien(target))
@@ -147,7 +147,7 @@
 	equip_cooldown = 10
 	drill_delay = 4
 	drill_level = DRILL_HARDENED
-	force = 20
+	force = 10
 	toolspeed = 0.7
 
 /obj/item/mecha_parts/mecha_equipment/drill/diamonddrill/mime

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -11,12 +11,14 @@
 	icon_state = "mecha_drill"
 	equip_cooldown = 15
 	energy_drain = 10
-	force = 15
+	force = 10
 	harmful = TRUE
 	tool_behaviour = TOOL_DRILL
 	toolspeed = 0.9
 	var/drill_delay = 7
 	var/drill_level = DRILL_BASIC
+	/// if TRUE, the drill won't make a distinctive noise when it tries to drill something
+	var/silent = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/drill/Initialize()
 	. = ..()
@@ -41,16 +43,20 @@
 		if(isturf(target))
 			var/turf/T = target
 			T.drill_act(src)
+			if(!silent)
+				playsound(src,'sound/weapons/drill.ogg',40,TRUE)
 			set_ready_state(TRUE)
 			return
 		while(do_after_mecha(target, drill_delay))
 			if(isliving(target))
 				drill_mob(target, chassis.occupant)
-				playsound(src,'sound/weapons/drill.ogg',40,TRUE)
+				if(!silent)
+					playsound(src,'sound/weapons/drill.ogg',40,TRUE)
 			else if(isobj(target))
 				var/obj/O = target
-				O.take_damage(15, BRUTE, 0, FALSE, get_dir(chassis, target))
-				playsound(src,'sound/weapons/drill.ogg',40,TRUE)
+				O.take_damage(force, BRUTE, 0, FALSE, get_dir(chassis, target))
+				if(!silent)
+					playsound(src,'sound/weapons/drill.ogg',40,TRUE)
 			else
 				set_ready_state(TRUE)
 				return
@@ -122,8 +128,7 @@
 	else
 		//drill makes a hole
 		var/obj/item/bodypart/target_part = target.get_bodypart(ran_zone(BODY_ZONE_CHEST))
-		target.apply_damage(10, BRUTE, BODY_ZONE_CHEST, target.run_armor_check(target_part, "melee"))
-
+		target.apply_damage(force, BRUTE, BODY_ZONE_CHEST, target.run_armor_check(target_part, "melee"), wound_bonus = 30) //the high wound_bonus helps give off that "holy shit a mech just drilled into that dude's chest" effect in PvP without affecting PvE balance
 		//blood splatters
 		var/splatter_dir = get_dir(chassis, target)
 		if(isalien(target))
@@ -132,7 +137,7 @@
 			new /obj/effect/temp_visual/dir_setting/bloodsplatter(target.drop_location(), splatter_dir)
 
 		//organs go everywhere
-		if(target_part && prob(10 * drill_level))
+		if(target.stat && target_part && prob(20 * drill_level)) //can't pop out the organs of someone who's still conscious
 			target_part.dismember(BRUTE)
 
 /obj/item/mecha_parts/mecha_equipment/drill/diamonddrill
@@ -142,8 +147,13 @@
 	equip_cooldown = 10
 	drill_delay = 4
 	drill_level = DRILL_HARDENED
-	force = 15
+	force = 20
 	toolspeed = 0.7
+
+/obj/item/mecha_parts/mecha_equipment/drill/diamonddrill/mime
+	name = "silenced, diamond-tipped exosuit drill"
+	desc = "This combat-designed drill comes with sound-dampening technology that makes it eerily quiet. Excellent for body disposal."
+	silent = TRUE
 
 
 /obj/item/mecha_parts/mecha_equipment/mining_scanner


### PR DESCRIPTION
## About The Pull Request

The damage dealt by a drill when used by a mech is now equal to DOUBLE that drill's force (instead of a flat 10 damage), and now uses a wound_bonus of 30.

Drills can no longer disembowel or dismember the limbs off of a conscious victim. To make up for this, the chance for a drill to dismember a limb or disembowel someone has been doubled.

The Reticence now has an extra equipment slot and comes with a silenced, diamond-tipped exosuit drill, a subtype of diamond drills that doesn't make a distinctive drilling noise when it drills something.

Normal drills now have a force of 5, diamond drills now have a force of 10, and mime drills have a force of 10.

## Why It's Good For The Game

RNG chances to basically one-shot people are bad.

The Reticence sorely lacks a way to make sure that its victims stay dead. No matter how much you shoot a victim with your carbine, if they get brought back to Medbay, they can just be tend wounds+defibbed back up to health. This is a pretty big flaw for an assassination mech, and the current best thing to do with your Reticence is to drop the incredibly in-theme mech RCD to make space for a noisy, standard mech drill (or a diamond one, if you can get your hands on one). Perhaps some day after this PR, I'll add a specialized tool for the Reticence that'd cut a dead victim's suit sensors, then give them the chameleon mutation to literally hide them in plain sight... but such a tool would require more testing than I want to do for a 5 AM PR.

## Changelog
:cl: ATHATH
balance: The damage dealt by a drill when used by a mech is now equal to DOUBLE that drill's force (instead of a flat 10 damage), and now uses a wound_bonus of 30.
balanc: Drills can no longer disembowel or dismember the limbs off of a conscious victim. To make up for this, the chance for a drill to dismember a limb or disembowel someone has been doubled.
balance: The Reticence now has an extra equipment slot and comes with a silenced, diamond-tipped exosuit drill, a subtype of diamond drills that doesn't make a distinctive drilling noise when it drills something.
balance: Normal drills now have a force of 5, diamond drills now have a force of 10, and mime drills have a force of 10.
/:cl: