### PR TITLE
Fixes pellet cloud runtime

### DIFF
--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -284,4 +284,4 @@
 	UnregisterSignal(target, COMSIG_PARENT_QDELETING)
 	targets_hit -= target
 	bodies -= target
-	purple_hearts -= target
+	LAZYREMOVE(purple_hearts, target)


### PR DESCRIPTION
This list is only initialized if the mob that was hit had a client.

`Runtime in pellet_cloud.dm, line 302: type mismatch: null -= the mouse (/mob/living/simple_animal/mouse)`