### PR TITLE
Improve bad name sanitisation function

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -135,7 +135,11 @@
 	var/charcount = 0
 	var/char = ""
 
-
+	// This is a sanity short circuit, if the users name is three times the maximum allowable length of name
+	// We bail out on trying to process the name at all, as it could be a bug or malicious input and we dont
+	// Want to iterate all of it.
+	if(t_len > 3 * MAX_NAME_LEN)
+		return
 	for(var/i = 1, i <= t_len, i += length(char))
 		char = t_in[i]
 		switch(text2ascii(char))


### PR DESCRIPTION
This adds a sanity short circuit, such that if the string passed into
the reject bad name function is 3 times the maximum length allowable for
a name, this function will refuse to process it at all, instead of doing
the character by character processing of the entire name before deciding
it's over maximum length.
:cl: oranges
tweak: Where some names might previously have been accepted, they will now be rejected, this should not affect any regular names in use
/:cl:
