### PR TITLE
Finally adds a quickdraw hotkey for the suit storage slot

### DIFF
--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -8,7 +8,7 @@
 /datum/keybinding/human/quick_equip
 	hotkey_keys = list("E")
 	name = "quick_equip"
-	full_name = "Quick Equip"
+	full_name = "Quick equip"
 	description = "Quickly puts an item in the best slot available"
 
 /datum/keybinding/human/quick_equip/down(client/user)
@@ -16,27 +16,36 @@
 	H.quick_equip()
 	return TRUE
 
-/datum/keybinding/human/quick_equipbelt
+/datum/keybinding/human/quick_equip_belt
 	hotkey_keys = list("ShiftE")
-	name = "quick_equipbelt"
+	name = "quick_equip_belt"
 	full_name = "Quick equip belt"
 	description = "Put held thing in belt or take out most recent thing from belt"
+	///which slot are we trying to quickdraw from/quicksheathe into?
+	var/slot_type = ITEM_SLOT_BELT
+	///what we should call slot_type in messages (including failure messages)
+	var/slot_item_name = "belt"
 
-/datum/keybinding/human/quick_equipbelt/down(client/user)
+/datum/keybinding/human/quick_equip_belt/down(client/user)
 	var/mob/living/carbon/human/H = user.mob
-	H.smart_equipbelt()
+	H.smart_equip_targeted(slot_type, slot_item_name)
 	return TRUE
 
-/datum/keybinding/human/bag_equip
+/datum/keybinding/human/quick_equip_belt/quick_equip_bag
 	hotkey_keys = list("ShiftB")
-	name = "bag_equip"
-	full_name = "Bag equip"
+	name = "quick_equip_bag"
+	full_name = "Quick equip bag"
 	description = "Put held thing in backpack or take out most recent thing from backpack"
+	slot_type = ITEM_SLOT_BACK
+	slot_item_name = "backpack"
 
-/datum/keybinding/human/bag_equip/down(client/user)
-	var/mob/living/carbon/human/H = user.mob
-	H.smart_equipbag()
-	return TRUE
+/datum/keybinding/human/quick_equip_belt/quick_equip_suit_storage
+	hotkey_keys = list("ShiftQ")
+	name = "quick_equip_suit_storage"
+	full_name = "Quick equip suit storage slot"
+	description = "Put held thing in suit storage slot item or take out most recent thing from suit storage slot item"
+	slot_type = ITEM_SLOT_SUITSTORE
+	slot_item_name = "suit storage slot item"
 
 /datum/keybinding/human/equipment_swap
 	hotkey_keys = list("V")

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -299,64 +299,36 @@
 	for(var/obj/item/I in held_items)
 		qdel(I)
 
-/mob/living/carbon/human/proc/smart_equipbag() // take most recent item out of bag or place held item in bag
+/// take the most recent item out of a slot or place held item in a slot
+
+/mob/living/carbon/human/proc/smart_equip_targeted(slot_type = ITEM_SLOT_BELT, slot_item_name = "belt")
 	if(incapacitated())
 		return
 	var/obj/item/thing = get_active_held_item()
-	var/obj/item/equipped_back = get_item_by_slot(ITEM_SLOT_BACK)
-	if(!equipped_back) // We also let you equip a backpack like this
+	var/obj/item/equipped_item = get_item_by_slot(slot_type)
+	if(!equipped_item) // We also let you equip an item like this
 		if(!thing)
-			to_chat(src, "<span class='warning'>You have no backpack to take something out of!</span>")
+			to_chat(src, "<span class='warning'>You have no [slot_item_name] to take something out of!</span>")
 			return
-		if(equip_to_slot_if_possible(thing, ITEM_SLOT_BACK))
+		if(equip_to_slot_if_possible(thing, slot_type))
 			update_inv_hands()
 		return
-	if(!SEND_SIGNAL(equipped_back, COMSIG_CONTAINS_STORAGE)) // not a storage item
+	if(!SEND_SIGNAL(equipped_item, COMSIG_CONTAINS_STORAGE)) // not a storage item
 		if(!thing)
-			equipped_back.attack_hand(src)
+			equipped_item.attack_hand(src)
 		else
-			to_chat(src, "<span class='warning'>You can't fit anything in!</span>")
+			to_chat(src, "<span class='warning'>You can't fit [thing] into your [equipped_item.name]!</span>")
 		return
-	if(thing) // put thing in backpack
-		if(!SEND_SIGNAL(equipped_back, COMSIG_TRY_STORAGE_INSERT, thing, src))
-			to_chat(src, "<span class='warning'>You can't fit anything in!</span>")
+	if(thing) // put thing in storage item
+		if(!SEND_SIGNAL(equipped_item, COMSIG_TRY_STORAGE_INSERT, thing, src))
+			to_chat(src, "<span class='warning'>You can't fit [thing] into your [equipped_item.name]!</span>")
 		return
-	if(!equipped_back.contents.len) // nothing to take out
-		to_chat(src, "<span class='warning'>There's nothing in your backpack to take out!</span>")
+	if(!equipped_item.contents.len) // nothing to take out
+		to_chat(src, "<span class='warning'>There's nothing in your [equipped_item.name] to take out!</span>")
 		return
-	var/obj/item/stored = equipped_back.contents[equipped_back.contents.len]
+	var/obj/item/stored = equipped_item.contents[equipped_item.contents.len]
 	if(!stored || stored.on_found(src))
 		return
-	stored.attack_hand(src) // take out thing from backpack
+	stored.attack_hand(src) // take out thing from item in storage slot
 	return
 
-/mob/living/carbon/human/proc/smart_equipbelt() // put held thing in belt or take most recent item out of belt
-	if(incapacitated())
-		return
-	var/obj/item/thing = get_active_held_item()
-	var/obj/item/equipped_belt = get_item_by_slot(ITEM_SLOT_BELT)
-	if(!equipped_belt) // We also let you equip a belt like this
-		if(!thing)
-			to_chat(src, "<span class='warning'>You have no belt to take something out of!</span>")
-			return
-		if(equip_to_slot_if_possible(thing, ITEM_SLOT_BELT))
-			update_inv_hands()
-		return
-	if(!SEND_SIGNAL(equipped_belt, COMSIG_CONTAINS_STORAGE)) // not a storage item
-		if(!thing)
-			equipped_belt.attack_hand(src)
-		else
-			to_chat(src, "<span class='warning'>You can't fit anything in!</span>")
-		return
-	if(thing) // put thing in belt
-		if(!SEND_SIGNAL(equipped_belt, COMSIG_TRY_STORAGE_INSERT, thing, src))
-			to_chat(src, "<span class='warning'>You can't fit anything in!</span>")
-		return
-	if(!equipped_belt.contents.len) // nothing to take out
-		to_chat(src, "<span class='warning'>There's nothing in your belt to take out!</span>")
-		return
-	var/obj/item/stored = equipped_belt.contents[equipped_belt.contents.len]
-	if(!stored || stored.on_found(src))
-		return
-	stored.attack_hand(src) // take out thing from belt
-	return


### PR DESCRIPTION
## About The Pull Request

Adds Shift+Q as a hotkey for quickdrawing/quicksheathing to/from your suit storage slot.

Makes some minor grammar/capitalization tweaks.

Condenses the smart_equip procs into a single smart_equip_targeted() proc.

## Why It's Good For The Game

To quote the opening post of the first iteration of this PR, https://github.com/tgstation/tgstation/pull/50317 (which got closed due to a merge conflict and accidentally referred to the new hotkey as being Control+Q instead of Shift+Q):

"It always struck me as really odd that it was often easier/faster to quickdraw something from your backpack than it was to quickdraw something from your suit storage slot, which seems to me to be where you're intended to keep your ranged weaponry as a member of Sec."

This PR makes using the suit storage slot as intended less awkward and clumsy, and will hopefully lead to more people actually storing important guns/items there, where they can be seen by others who examine them.

## Changelog
:cl: ATHATH
add: A new hotkey for quickdrawing/quicksheathing items into/from your suit storage slot has been added! It defaults to Shift+Q.
tweak: Corrects some minor capitalization oddities.
/:cl: