### PR TITLE
simplifies fingerprints code to remove a million useless procs and stop creation / deletion of useless extra components

### DIFF
--- a/code/datums/components/forensics.dm
+++ b/code/datums/components/forensics.dm
@@ -34,38 +34,15 @@
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
-/datum/component/forensics/proc/wipe_fingerprints()
-	fingerprints = null
-	return TRUE
-
-/datum/component/forensics/proc/wipe_hiddenprints()
-	return	//no.
-
-/datum/component/forensics/proc/wipe_blood_DNA()
-	blood_DNA = null
-	if(isitem(parent))
-		qdel(parent.GetComponent(/datum/component/decal/blood))
-	return TRUE
-
-/datum/component/forensics/proc/wipe_fibers()
-	fibers = null
-	return TRUE
-
 /datum/component/forensics/proc/clean_act(datum/source, strength)
 	if(strength >= CLEAN_STRENGTH_FINGERPRINTS)
-		wipe_fingerprints()
+		fingerprints = null
 	if(strength >= CLEAN_STRENGTH_BLOOD)
-		wipe_blood_DNA()
+		blood_DNA = null
+		if(isitem(parent))
+			qdel(parent.GetComponent(/datum/component/decal/blood))
 	if(strength >= CLEAN_STRENGTH_FIBERS)
-		wipe_fibers()
-
-/datum/component/forensics/proc/add_fingerprint_list(list/_fingerprints)	//list(text)
-	if(!length(_fingerprints))
-		return
-	LAZYINITLIST(fingerprints)
-	for(var/i in _fingerprints)	//We use an associative list, make sure we don't just merge a non-associative list into ours.
-		fingerprints[i] = i
-	return TRUE
+		fibers = null
 
 /datum/component/forensics/proc/add_fingerprint(mob/living/M, ignoregloves = FALSE)
 	if(!isliving(M))
@@ -89,14 +66,6 @@
 				return
 		var/full_print = md5(H.dna.uni_identity)
 		LAZYSET(fingerprints, full_print, full_print)
-	return TRUE
-
-/datum/component/forensics/proc/add_fiber_list(list/_fibertext)		//list(text)
-	if(!length(_fibertext))
-		return
-	LAZYINITLIST(fibers)
-	for(var/i in _fibertext)	//We use an associative list, make sure we don't just merge a non-associative list into ours.
-		fibers[i] = i
 	return TRUE
 
 /datum/component/forensics/proc/add_fibers(mob/living/carbon/human/M)
@@ -131,14 +100,6 @@
 			LAZYSET(fibers, fibertext, fibertext)
 	return TRUE
 
-/datum/component/forensics/proc/add_hiddenprint_list(list/_hiddenprints)	//list(ckey = text)
-	if(!length(_hiddenprints))
-		return
-	LAZYINITLIST(hiddenprints)
-	for(var/i in _hiddenprints)	//We use an associative list, make sure we don't just merge a non-associative list into ours.
-		hiddenprints[i] = _hiddenprints[i]
-	return TRUE
-
 /datum/component/forensics/proc/add_hiddenprint(mob/M)
 	if(!isliving(M))
 		if(!iscameramob(M))
@@ -165,15 +126,6 @@
 		hiddenprints[M.key] += " Last: [M.real_name]\[[current_time]\][hasgloves]. Ckey: [M.ckey]"	//made sure to be existing by if(!LAZYACCESS);else
 	var/atom/A = parent
 	A.fingerprintslast = M.ckey
-	return TRUE
-
-/datum/component/forensics/proc/add_blood_DNA(list/dna)		//list(dna_enzymes = type)
-	if(!length(dna))
-		return
-	LAZYINITLIST(blood_DNA)
-	for(var/i in dna)
-		blood_DNA[i] = dna[i]
-	check_blood()
 	return TRUE
 
 /datum/component/forensics/proc/check_blood()

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -686,7 +686,7 @@
 	return can_be_inserted(I, silent, M)
 
 /datum/component/storage/proc/show_to_ghost(datum/source, mob/dead/observer/M)
-	return user_show_to_mob(M, TRUE)
+	return show_to(M)
 
 /datum/component/storage/proc/signal_show_attempt(datum/source, mob/showto, force = FALSE)
 	return user_show_to_mob(showto, force)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -386,7 +386,7 @@
 		transfer = min(transfer, S.max_amount - S.amount)
 	if(pulledby)
 		pulledby.start_pulling(S)
-	S.copy_evidences(src)
+	S.copy_evidences_from(src)
 	use(transfer, TRUE)
 	S.add(transfer)
 	return transfer
@@ -437,7 +437,7 @@
 		return FALSE
 	var/obj/item/stack/F = new type(user? user : drop_location(), amount, FALSE)
 	. = F
-	F.copy_evidences(src)
+	F.copy_evidences_from(src)
 	if(user)
 		if(!user.put_in_hands(F, merge_stacks = FALSE))
 			F.forceMove(user.drop_location())
@@ -453,9 +453,9 @@
 	else
 		. = ..()
 
-/obj/item/stack/proc/copy_evidences(obj/item/stack/from)
+/obj/item/stack/proc/copy_evidences_from(obj/item/stack/from)
 	add_blood_DNA(from.return_blood_DNA())
-	transfer_fingerprints_to(from)
+	from.transfer_fingerprints_to(src)
 
 /obj/item/stack/microwave_act(obj/machinery/microwave/M)
 	if(istype(M) && M.dirty < 100)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -455,10 +455,7 @@
 
 /obj/item/stack/proc/copy_evidences(obj/item/stack/from)
 	add_blood_DNA(from.return_blood_DNA())
-	add_fingerprint_list(from.return_fingerprints())
-	add_hiddenprint_list(from.return_hiddenprints())
-	fingerprintslast  = from.fingerprintslast
-	//TODO bloody overlay
+	transfer_fingerprints_to(from)
 
 /obj/item/stack/microwave_act(obj/machinery/microwave/M)
 	if(istype(M) && M.dirty < 100)

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -3,40 +3,32 @@
 /atom/proc/return_fingerprints()
 	var/datum/component/forensics/D = GetComponent(/datum/component/forensics)
 	if(D)
-		. = D.fingerprints
+		return D.fingerprints
 
 /atom/proc/return_hiddenprints()
 	var/datum/component/forensics/D = GetComponent(/datum/component/forensics)
 	if(D)
-		. = D.hiddenprints
+		return D.hiddenprints
 
 /atom/proc/return_blood_DNA()
 	var/datum/component/forensics/D = GetComponent(/datum/component/forensics)
 	if(D)
-		. = D.blood_DNA
+		return D.blood_DNA
 
 /atom/proc/blood_DNA_length()
 	var/datum/component/forensics/D = GetComponent(/datum/component/forensics)
 	if(D)
-		. = length(D.blood_DNA)
+		return length(D.blood_DNA)
 
 /atom/proc/return_fibers()
 	var/datum/component/forensics/D = GetComponent(/datum/component/forensics)
 	if(D)
-		. = D.fibers
-
-/atom/proc/add_fingerprint_list(list/fingerprints)		//ASSOC LIST FINGERPRINT = FINGERPRINT
-	if(length(fingerprints))
-		. = AddComponent(/datum/component/forensics, fingerprints)
+		return D.fibers
 
 //Set ignoregloves to add prints irrespective of the mob having gloves on.
 /atom/proc/add_fingerprint(mob/M, ignoregloves = FALSE)
-	var/datum/component/forensics/D = AddComponent(/datum/component/forensics)
+	var/datum/component/forensics/D = LoadComponent(/datum/component/forensics)
 	. = D.add_fingerprint(M, ignoregloves)
-
-/atom/proc/add_fiber_list(list/fibertext)				//ASSOC LIST FIBERTEXT = FIBERTEXT
-	if(length(fibertext))
-		. = AddComponent(/datum/component/forensics, null, null, null, fibertext)
 
 /atom/proc/add_fibers(mob/living/carbon/human/M)
 	var/old = 0
@@ -50,15 +42,11 @@
 		old = length(M.return_blood_DNA())
 		if(add_blood_DNA(M.return_blood_DNA()) && length(M.return_blood_DNA()) > old)
 			M.bloody_hands--
-	var/datum/component/forensics/D = AddComponent(/datum/component/forensics)
+	var/datum/component/forensics/D = LoadComponent(/datum/component/forensics)
 	. = D.add_fibers(M)
 
-/atom/proc/add_hiddenprint_list(list/hiddenprints)	//NOTE: THIS IS FOR ADMINISTRATION FINGERPRINTS, YOU MUST CUSTOM SET THIS TO INCLUDE CKEY/REAL NAMES! CHECK FORENSICS.DM
-	if(length(hiddenprints))
-		. = AddComponent(/datum/component/forensics, null, hiddenprints)
-
 /atom/proc/add_hiddenprint(mob/M)
-	var/datum/component/forensics/D = AddComponent(/datum/component/forensics)
+	var/datum/component/forensics/D = LoadComponent(/datum/component/forensics)
 	. = D.add_hiddenprint(M)
 
 /atom/proc/add_blood_DNA(list/dna)						//ASSOC LIST DNA = BLOODTYPE
@@ -67,7 +55,9 @@
 /obj/add_blood_DNA(list/dna)
 	. = ..()
 	if(length(dna))
-		. = AddComponent(/datum/component/forensics, null, null, dna)
+		var/datum/component/forensics/D = LoadComponent(/datum/component/forensics)
+		D.blood_DNA = D.blood_DNA | dna //Use of | and |= being different here is INTENTIONAL.
+		D.check_blood()
 
 /obj/item/clothing/gloves/add_blood_DNA(list/blood_dna, list/datum/disease/diseases)
 	. = ..()
@@ -91,12 +81,17 @@
 		var/obj/item/clothing/gloves/G = gloves
 		G.add_blood_DNA(blood_dna)
 	else if(length(blood_dna))
-		AddComponent(/datum/component/forensics, null, null, blood_dna)
+		var/datum/component/forensics/D = LoadComponent(/datum/component/forensics)
+		D.blood_DNA = D.blood_DNA | blood_dna //Use of | and |= being different here is INTENTIONAL.
+		D.check_blood()
 		bloody_hands = rand(2, 4)
 	update_inv_gloves()	//handles bloody hands overlays and updating
 	return TRUE
 
-/atom/proc/transfer_fingerprints_to(atom/A)
-	A.add_fingerprint_list(return_fingerprints())
-	A.add_hiddenprint_list(return_hiddenprints())
+/atom/proc/transfer_fingerprints_to(atom/A) //Use of | and |= being different here is INTENTIONAL.
+	var/datum/component/forensics/AD = A.LoadComponent(/datum/component/forensics)
+	var/datum/component/forensics/D = GetComponent(/datum/component/forensics)
+	AD.fingerprints = AD.fingerprints | D.fingerprints
+	AD.hiddenprints = AD.hiddenprints | D.hiddenprints
 	A.fingerprintslast = fingerprintslast
+	AD.check_blood()

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -89,8 +89,10 @@
 	return TRUE
 
 /atom/proc/transfer_fingerprints_to(atom/A) //Use of | and |= being different here is INTENTIONAL.
-	var/datum/component/forensics/AD = A.LoadComponent(/datum/component/forensics)
 	var/datum/component/forensics/D = GetComponent(/datum/component/forensics)
+	if(!D) // no point transferring fingerprints etc. if we don't even have the fuckin tracker
+		return
+	var/datum/component/forensics/AD = A.LoadComponent(/datum/component/forensics)
 	AD.fingerprints = AD.fingerprints | D.fingerprints
 	AD.hiddenprints = AD.hiddenprints | D.hiddenprints
 	A.fingerprintslast = fingerprintslast


### PR DESCRIPTION
## About The Pull Request

in essence: every time fingerprints were added to an object it instantiated a new forensics component, attached it to the object, did nothing to it, immediately deleted it, and then added the fingerprints to the old forensics component (unless there was no old component, in which case it acted like you'd expect). this was stupid as shit, so i fixed it. (also simplifies code for ghosts viewing storage items)

## Why It's Good For The Game

shitcode is bad

## Changelog
:cl:
refactor: forensics components are no longer instantiated and thrown away immediately every time they're modified. ghost storage item viewing code has been simplified. these (should) have no gameplay effect
/:cl: