### PR TITLE
pubby  cargo (and nearby) update

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6366,44 +6366,25 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aoE" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/structure/sink/kitchen{
+	pixel_y = 28
 	},
-/obj/machinery/button/door{
-	id = "commissary-bolts";
-	name = "entrance door bolts control";
-	normaldoorcontrol = 1;
-	pixel_y = 24;
-	specialfunctions = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/carpet,
-/area/vacant_room/commissary)
+/obj/effect/decal/cleanable/food/flour,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aoF" = (
 /obj/structure/table,
-/obj/item/storage/crayons,
-/obj/machinery/button/door{
-	id = "commissary-cargo-bolts";
-	name = "cargo door bolts control";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	specialfunctions = 4
-	},
-/obj/machinery/button/door{
-	id = "commissary_2";
-	name = "fore shutters control";
-	pixel_y = 24
-	},
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/food/condiment/rice,
 /obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
+	dir = 1
 	},
-/turf/open/floor/carpet,
-/area/vacant_room/commissary)
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/sugar,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aoG" = (
 /obj/machinery/computer/bounty,
 /obj/effect/turf_decal/tile/brown{
@@ -10543,15 +10524,22 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "axd" = (
-/obj/structure/window{
-	icon_state = "window";
-	dir = 1
+/obj/structure/table,
+/obj/item/kitchen/knife,
+/obj/item/reagent_containers/food/snacks/egg{
+	pixel_x = -11;
+	pixel_y = 12
 	},
-/obj/structure/table/glass,
-/obj/machinery/microwave,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet/cyan,
-/area/quartermaster/storage)
+/obj/item/reagent_containers/food/snacks/egg{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/food/snacks/egg{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "axe" = (
 /obj/machinery/light{
 	dir = 4;
@@ -10571,14 +10559,9 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "axf" = (
-/obj/structure/window{
-	icon_state = "window";
-	dir = 1
-	},
-/obj/structure/table/glass,
-/obj/effect/spawner/lootdrop/donkpockets,
-/turf/open/floor/carpet/cyan,
-/area/quartermaster/storage)
+/obj/effect/decal/cleanable/food/flour,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "axg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/dark,
@@ -10655,18 +10638,14 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "axs" = (
-/obj/structure/window{
-	icon_state = "window";
-	dir = 4
+/obj/item/kitchen/fork,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 7
 	},
-/obj/structure/window{
-	icon_state = "window";
-	dir = 1
-	},
-/obj/structure/table/glass,
-/obj/item/storage/cans/sixsoda,
-/turf/open/floor/carpet/cyan,
-/area/quartermaster/storage)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "axt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11676,12 +11655,36 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "azQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet/cyan,
-/area/quartermaster/storage)
+/obj/structure/closet/crate,
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/seeds/wheat/rice,
+/obj/item/seeds/replicapod,
+/obj/item/seeds/carrot,
+/obj/item/seeds/tomato,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/seeds/tower,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "azR" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/button/door{
+	id = "commissary-bolts";
+	name = "entrance door bolts control";
+	normaldoorcontrol = 1;
+	pixel_y = 24;
+	specialfunctions = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/carpet/cyan,
-/area/quartermaster/storage)
+/area/vacant_room/commissary)
 "azS" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Port Solar Access";
@@ -11691,14 +11694,11 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "azT" = (
-/obj/structure/window{
-	icon_state = "window";
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/snacks/sandwich,
-/turf/open/floor/carpet/cyan,
-/area/quartermaster/storage)
+/turf/open/floor/carpet/black,
+/area/vacant_room/commissary)
 "azU" = (
 /obj/effect/decal/cleanable/plastic,
 /obj/structure/window/reinforced{
@@ -14050,9 +14050,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aFj" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/carpet/cyan,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/vacant_room/commissary)
 "aFk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/lootdrop/minor/bowler_or_that,
@@ -14063,14 +14065,9 @@
 	},
 /area/maintenance/department/security/brig)
 "aFl" = (
-/obj/structure/window{
-	icon_state = "window";
-	dir = 4
-	},
-/obj/structure/table/glass,
-/obj/item/storage/bag/tray,
-/turf/open/floor/carpet/cyan,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet/black,
+/area/vacant_room/commissary)
 "aFm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -14310,22 +14307,29 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aFP" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/floor/carpet/black,
+/area/vacant_room/commissary)
 "aFQ" = (
 /obj/structure/table,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/machinery/light/small{
-	dir = 1
+/obj/item/storage/crayons,
+/obj/machinery/button/door{
+	id = "commissary-cargo-bolts";
+	name = "cargo door bolts control";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	specialfunctions = 4
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/machinery/button/door{
+	id = "commissary_2";
+	name = "fore shutters control";
+	pixel_y = 24
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/carpet/cyan,
+/area/vacant_room/commissary)
 "aFR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/brown,
@@ -15036,17 +15040,12 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aHs" = (
-/obj/structure/closet/crate,
-/obj/item/cultivator,
-/obj/item/shovel/spade,
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/seeds/wheat/rice,
-/obj/item/seeds/replicapod,
-/obj/item/seeds/carrot,
-/obj/item/seeds/tomato,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/carpet/black,
+/area/vacant_room/commissary)
 "aHt" = (
 /obj/effect/decal/cleanable/food/egg_smudge,
 /turf/open/floor/plating,
@@ -15477,8 +15476,12 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aIm" = (
-/obj/machinery/door/airlock/mining/glass,
+/obj/machinery/door/airlock/mining/glass{
+	name = "mining office";
+	req_access_txt = "48"
+	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aIn" = (
@@ -16433,10 +16436,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aKo" = (
-/obj/structure/table,
-/obj/item/kitchen/knife,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/carpet/green,
+/area/vacant_room/commissary)
 "aKp" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -17766,27 +17770,35 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "aNE" = (
-/obj/machinery/computer/security/qm,
-/obj/structure/cable,
-/turf/open/floor/carpet/red,
-/area/quartermaster/qm)
-"aNF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/green,
+/area/vacant_room/commissary)
+"aNF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet/green,
 /area/vacant_room/commissary)
 "aNG" = (
-/obj/structure/table/wood,
-/obj/structure/table/wood,
-/obj/item/phone,
-/turf/open/floor/carpet/red,
-/area/quartermaster/qm)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/vacant_room/commissary)
 "aNH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/structure/cable,
+/obj/item/radio/intercom{
+	pixel_x = -27
+	},
+/obj/structure/table,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/obj/item/stack/package_wrap,
+/turf/open/floor/carpet/black,
 /area/vacant_room/commissary)
 "aNI" = (
 /obj/structure/disposalpipe/segment,
@@ -18086,13 +18098,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aOr" = (
-/obj/structure/chair/sofa/left{
-	icon_state = "sofaend_left";
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/carpet/red,
-/area/quartermaster/qm)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/green,
+/area/vacant_room/commissary)
 "aOs" = (
 /obj/structure/sign/departments/evac,
 /turf/closed/wall,
@@ -18323,8 +18331,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
 /area/vacant_room/commissary)
 "aON" = (
 /obj/machinery/power/apc/auto_name/south,
@@ -18337,13 +18350,21 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aOP" = (
-/turf/open/floor/carpet,
+/obj/structure/table,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/obj/item/paper_bin,
+/turf/open/floor/carpet/black,
 /area/vacant_room/commissary)
 "aOQ" = (
-/obj/structure/table/wood,
-/obj/item/stamp/qm,
-/turf/open/floor/carpet/red,
-/area/quartermaster/qm)
+/obj/machinery/status_display/supply,
+/turf/closed/wall,
+/area/quartermaster/storage)
 "aOR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -18436,10 +18457,12 @@
 	},
 /area/maintenance/department/science)
 "aPb" = (
-/obj/item/kitchen/fork,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /obj/structure/table,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/item/hand_labeler,
+/turf/open/floor/carpet/cyan,
+/area/vacant_room/commissary)
 "aPc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -18496,11 +18519,8 @@
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "aPj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/carpet,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/black,
 /area/vacant_room/commissary)
 "aPk" = (
 /obj/effect/decal/cleanable/robot_debris{
@@ -18818,22 +18838,37 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aPV" = (
-/turf/open/floor/carpet/red,
-/area/quartermaster/qm)
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "commissary_1";
+	name = "aft shutters control";
+	pixel_y = -24
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/obj/item/pen,
+/turf/open/floor/carpet/cyan,
+/area/vacant_room/commissary)
 "aPW" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway Bridge";
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/carpet/red,
-/area/quartermaster/qm)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aPX" = (
-/obj/machinery/airalarm/directional/south,
-/obj/structure/cable,
-/turf/open/floor/carpet/red,
-/area/quartermaster/qm)
+/obj/machinery/status_display/supply,
+/turf/closed/wall,
+/area/quartermaster/office)
 "aPY" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -18860,11 +18895,15 @@
 	},
 /area/maintenance/department/science)
 "aQd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/window{
+	icon_state = "window";
+	dir = 1
 	},
-/turf/open/floor/carpet/orange,
-/area/vacant_room/commissary)
+/obj/structure/table/glass,
+/obj/machinery/microwave,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/carpet/blue,
+/area/quartermaster/storage)
 "aQe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -18905,18 +18944,27 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "aQk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/window{
+	icon_state = "window";
+	dir = 1
 	},
-/turf/open/floor/carpet/orange,
-/area/vacant_room/commissary)
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/donkpockets,
+/turf/open/floor/carpet/blue,
+/area/quartermaster/storage)
 "aQl" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/window{
+	icon_state = "window";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet/orange,
-/area/vacant_room/commissary)
+/obj/structure/window{
+	icon_state = "window";
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/storage/cans/sixsoda,
+/turf/open/floor/carpet/blue,
+/area/quartermaster/storage)
 "aQm" = (
 /obj/structure/cable,
 /obj/effect/spawner/lootdrop/grille_or_trash,
@@ -18927,11 +18975,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aQo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/vacant_room/commissary)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/carpet/blue,
+/area/quartermaster/storage)
 "aQp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -19359,6 +19405,10 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"aRq" = (
+/mob/living/simple_animal/sloth/citrus,
+/turf/open/floor/carpet/blue,
+/area/quartermaster/storage)
 "aRr" = (
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -19410,10 +19460,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "aRA" = (
-/obj/structure/girder,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/window{
+	icon_state = "window";
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/snacks/sandwich,
+/turf/open/floor/carpet/blue,
+/area/quartermaster/storage)
 "aRB" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/neutral{
@@ -19538,17 +19592,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aRK" = (
-/obj/structure/cable,
-/obj/item/radio/intercom{
-	pixel_x = -27
-	},
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/stack/package_wrap,
-/turf/open/floor/carpet,
-/area/vacant_room/commissary)
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/carpet/blue,
+/area/quartermaster/storage)
 "aRL" = (
 /turf/closed/wall,
 /area/hydroponics)
@@ -20038,9 +20084,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aTa" = (
-/obj/machinery/door/airlock/mining/glass,
+/obj/machinery/door/airlock/mining/glass{
+	name = "mining office";
+	req_access_txt = "48"
+	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aTb" = (
@@ -20211,9 +20259,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aTF" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/orange,
-/area/vacant_room/commissary)
+/obj/structure/window{
+	icon_state = "window";
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/storage/bag/tray,
+/turf/open/floor/carpet/blue,
+/area/quartermaster/storage)
 "aTG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -20490,14 +20543,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aUj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/carpet/orange,
-/area/vacant_room/commissary)
+/obj/machinery/status_display/supply,
+/turf/closed/wall,
+/area/quartermaster/miningdock)
 "aUk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20506,17 +20554,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aUl" = (
-/obj/structure/table,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
-	},
-/obj/item/paper_bin,
-/turf/open/floor/carpet,
-/area/vacant_room/commissary)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/carpet/purple,
+/area/quartermaster/qm)
 "aUm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20596,16 +20637,14 @@
 /turf/open/space,
 /area/space/nearstation)
 "aUw" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
-/obj/structure/table,
-/obj/item/hand_labeler,
-/turf/open/floor/carpet,
-/area/vacant_room/commissary)
+/obj/machinery/computer/cargo,
+/turf/open/floor/carpet/purple,
+/area/quartermaster/qm)
 "aUx" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
-/area/vacant_room/commissary)
+/obj/machinery/computer/security/qm,
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/quartermaster/qm)
 "aUy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -21109,12 +21148,16 @@
 /area/quartermaster/qm)
 "aVx" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/carpet/red,
+/obj/structure/table/wood,
+/obj/item/phone,
+/turf/open/floor/carpet/purple,
 /area/quartermaster/qm)
 "aVy" = (
-/obj/machinery/computer/cargo,
-/turf/open/floor/carpet/red,
+/obj/structure/table/wood,
+/obj/item/pen,
+/obj/item/paper_bin,
+/obj/item/hand_labeler,
+/turf/open/floor/carpet/purple,
 /area/quartermaster/qm)
 "aVz" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -21163,7 +21206,7 @@
 	icon_state = "sofaend_right";
 	dir = 1
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/purple,
 /area/quartermaster/qm)
 "aVG" = (
 /obj/structure/disposalpipe/segment{
@@ -21591,18 +21634,13 @@
 /turf/open/floor/grass,
 /area/hallway/primary/central)
 "aWv" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "commissary_1";
-	name = "aft shutters control";
-	pixel_y = -24
+/obj/structure/chair/sofa/left{
+	icon_state = "sofaend_left";
+	dir = 1
 	},
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/obj/item/pen,
-/turf/open/floor/carpet,
-/area/vacant_room/commissary)
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/quartermaster/qm)
 "aWw" = (
 /obj/structure/railing{
 	icon_state = "railing";
@@ -22138,17 +22176,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aXs" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/obj/structure/table/wood,
+/obj/item/stamp/qm,
+/turf/open/floor/carpet/purple,
+/area/quartermaster/qm)
 "aXt" = (
 /obj/structure/table,
 /obj/item/storage/box/shipping,
@@ -23248,13 +23279,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/carpet/purple,
+/area/quartermaster/qm)
 "aZu" = (
 /obj/machinery/vending/custom,
 /obj/machinery/door/window/westright{
@@ -23269,6 +23295,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"aZv" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway Bridge";
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/quartermaster/qm)
+"aZw" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/quartermaster/qm)
 "aZx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -24020,13 +24060,6 @@
 /area/hallway/primary/central)
 "bbE" = (
 /turf/closed/wall,
-/area/quartermaster/qm)
-"bbG" = (
-/obj/structure/table/wood,
-/obj/item/pen,
-/obj/item/paper_bin,
-/obj/item/hand_labeler,
-/turf/open/floor/carpet/red,
 /area/quartermaster/qm)
 "bbI" = (
 /turf/closed/wall,
@@ -97428,7 +97461,7 @@ bfg
 aMc
 aPS
 aMc
-aZt
+aGU
 aAL
 aJZ
 aAL
@@ -97924,10 +97957,10 @@ aIg
 aJf
 aKb
 aLe
-aoE
-aPj
-aRK
-aUw
+azR
+aHs
+aNH
+aPb
 aLe
 aoL
 aBJ
@@ -98181,10 +98214,10 @@ jYe
 aBJ
 aJI
 aMt
-aNF
-aQd
-aTF
-aUx
+azT
+aKo
+aOr
+aPj
 aWB
 atr
 aUo
@@ -98438,10 +98471,10 @@ jYe
 aBJ
 aJI
 aMt
-aNH
-aQk
-aQd
-aUx
+aFj
+aNE
+aKo
+aPj
 aWB
 atr
 aUy
@@ -98695,10 +98728,10 @@ jYe
 aBJ
 bhd
 aMt
+aFl
+aNF
 aOM
-aQl
-aUj
-aOP
+aFP
 aWC
 att
 aUz
@@ -98952,10 +98985,10 @@ jYe
 aBJ
 aJI
 aMt
-aOP
-aQk
-aQk
-aOP
+aFP
+aNE
+aNE
+aFP
 aXg
 aER
 aBJ
@@ -99209,10 +99242,10 @@ hFy
 aJh
 bhe
 aLe
-aoF
-aQo
-aUl
-aWv
+aFQ
+aNG
+aOP
+aPV
 aLe
 aER
 aBJ
@@ -101275,7 +101308,7 @@ bcx
 bcV
 bfB
 aVA
-aLf
+aPX
 aLf
 aDn
 aHf
@@ -101283,9 +101316,9 @@ aLf
 bbE
 aTo
 bwf
-aVx
-bbG
-aPV
+aUl
+aVy
+aZt
 bbE
 aYt
 bjw
@@ -101527,7 +101560,7 @@ acG
 agC
 aje
 aNX
-aXs
+aPW
 bcy
 bfU
 aBw
@@ -101540,9 +101573,9 @@ aIz
 boj
 bpi
 bpZ
-aVy
+aUw
 aVF
-aPW
+aZv
 bbE
 aYt
 bjw
@@ -101797,9 +101830,9 @@ aFS
 aJB
 aLr
 aMx
-aNE
-aOr
-aPX
+aUx
+aWv
+aZw
 bbE
 aYt
 bjw
@@ -102054,9 +102087,9 @@ aIA
 aJC
 aLs
 aMy
-aNG
-aOQ
-aPV
+aVx
+aXs
+aZt
 bbE
 aYt
 bjw
@@ -104087,12 +104120,12 @@ aur
 atn
 aFN
 aGK
-aKo
+axd
 aEj
 aJr
 azW
 aRe
-aRA
+aIp
 aTl
 aLg
 aln
@@ -104599,13 +104632,13 @@ aur
 aur
 aur
 atn
-aFP
+aoE
 aGM
-aFi
+axf
 bfu
 aKn
 aEj
-aHs
+azQ
 aSl
 aGN
 aLg
@@ -104856,9 +104889,9 @@ aur
 aur
 aur
 atn
-aFQ
+aoF
 aOO
-aPb
+axs
 aEj
 aMp
 aEj
@@ -105893,7 +105926,7 @@ aEj
 aSq
 aTg
 aTt
-aLg
+aOQ
 aeH
 aoc
 biH
@@ -106158,9 +106191,9 @@ bjG
 aqJ
 bjG
 bjG
-axd
-azQ
-azQ
+aQd
+aQo
+aQo
 aHD
 aIU
 aKm
@@ -106415,9 +106448,9 @@ aMu
 aqK
 aTm
 aty
-axf
-azR
-aFj
+aQk
+aRq
+aRK
 aHx
 aIW
 aKp
@@ -106672,10 +106705,10 @@ aTm
 aqK
 aTm
 aTm
-axs
-azT
-aFl
-bbI
+aQl
+aRA
+aTF
+aUj
 bdT
 bdT
 bdT
@@ -107189,7 +107222,7 @@ aXC
 aXC
 aXC
 aFR
-aTa
+aIm
 aJg
 aTb
 aLX
@@ -107703,7 +107736,7 @@ bjG
 bjG
 bjG
 aFT
-aIm
+aTa
 aJj
 aKu
 aLZ

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -16,6 +16,13 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"aad" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aae" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -384,15 +391,263 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"aaZ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aba" = (
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall,
+/area/maintenance/department/cargo)
+"abb" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/bookcase/manuals,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abc" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/chair/plastic{
+	icon_state = "plastic_chair";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abd" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abe" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/table,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "abf" = (
 /obj/structure/bed,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"abg" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abh" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abi" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/costume,
+/obj/item/melee/baseball_bat,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abj" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abk" = (
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abl" = (
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abm" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/chair/plastic{
+	icon_state = "plastic_chair";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abo" = (
+/obj/structure/transit_tube/station/reverse{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abp" = (
+/obj/structure/transit_tube/crossing/horizontal,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abq" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space)
+"abr" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/transit_tube/horizontal,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abt" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/transit_tube/crossing/horizontal,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space,
+/area/space/nearstation)
+"abu" = (
+/obj/structure/easel,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abv" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/item/book/manual/wiki/chemistry,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abw" = (
+/obj/structure/closet,
+/obj/item/canvas/twentythree_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/storage/crayons,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abx" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aby" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
 /area/space/nearstation)
+"abz" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abA" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/storage/box/matches,
+/obj/item/toy/crayon/spraycan,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abB" = (
+/obj/structure/table,
+/obj/item/assembly/igniter,
+/obj/item/assembly/igniter,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/stack/pipe_cleaner_coil/random,
+/obj/item/stack/pipe_cleaner_coil/random,
+/obj/item/stack/pipe_cleaner_coil/random,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abC" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 10
+	},
+/obj/item/stack/rods{
+	amount = 25
+	},
+/obj/item/shard{
+	icon_state = "small"
+	},
+/obj/item/light/bulb,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abD" = (
+/obj/structure/transit_tube/horizontal,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
+"abE" = (
+/turf/open/floor/plating,
+/area/quartermaster/storage)
+"abF" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"abG" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"abH" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "abI" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -406,6 +661,28 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"abK" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"abL" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
+	},
+/obj/machinery/camera,
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
+"abM" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
 "abN" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -413,6 +690,73 @@
 "abO" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
+"abP" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"abQ" = (
+/obj/machinery/disposal/delivery_chute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
+"abR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/quartermaster/sorting)
+"abS" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"abT" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"abU" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "abV" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
@@ -421,9 +765,53 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
+"abX" = (
+/obj/item/radio/intercom{
+	pixel_y = 27
+	},
+/obj/machinery/camera,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "abY" = (
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
+"abZ" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aca" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"acb" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "acc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -621,6 +1009,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
+"acx" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/item/stack/wrapping_paper,
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "acy" = (
 /obj/effect/landmark/start/ai,
 /obj/item/radio/intercom{
@@ -654,6 +1051,28 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"acz" = (
+/obj/structure/transit_tube/crossing/horizontal,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
+"acA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "acB" = (
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/circuit,
@@ -696,6 +1115,36 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/plating/airless,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
+"acG" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/item/stack/package_wrap,
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"acH" = (
+/obj/item/storage/box,
+/obj/item/storage/box,
+/obj/item/storage/box,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/structure/table,
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "acI" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -737,6 +1186,12 @@
 "acP" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
+"acQ" = (
+/obj/structure/rack,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/cargo)
 "acR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/dark,
@@ -958,6 +1413,14 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"ady" = (
+/obj/machinery/conveyor{
+	dir = 5;
+	icon_state = "conveyor_map";
+	id = "QMLoad"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "adz" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -1361,6 +1824,13 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"aeH" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "aeI" = (
 /obj/machinery/seed_extractor,
 /obj/machinery/light{
@@ -1868,10 +2338,34 @@
 "afU" = (
 /turf/closed/wall,
 /area/security/execution/transfer)
+"afV" = (
+/obj/structure/transit_tube/curved{
+	icon_state = "curved0";
+	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
+"afW" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "afX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"afY" = (
+/obj/machinery/door/poddoor{
+	id = "QMLoaddoor";
+	name = "supply dock loading door"
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "afZ" = (
 /obj/machinery/vending/sustenance,
 /turf/open/floor/plasteel/dark,
@@ -1945,6 +2439,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"agk" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "agl" = (
 /obj/structure/table/glass,
 /obj/item/restraints/handcuffs,
@@ -1954,6 +2456,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"agm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "agn" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/plasteel/dark,
@@ -2073,6 +2584,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"agC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "agD" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2097,6 +2617,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"agG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "agH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -2192,6 +2720,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"agO" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/plasticflaps,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "agP" = (
 /turf/closed/wall,
 /area/security/main)
@@ -2223,6 +2765,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"agU" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/lootdrop/maintenance/seven,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "agV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
@@ -2269,11 +2818,42 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"ahb" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
+"ahc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "ahd" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"ahe" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "QMLoad"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"ahf" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "31"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
+"ahg" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "ahh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/showcase/cyborg/old{
@@ -2509,6 +3089,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"ahE" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "31"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "ahF" = (
 /obj/machinery/camera{
 	c_tag = "Brig Prison Hallway";
@@ -2910,6 +3500,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"aiI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aiJ" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -3086,6 +3686,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"aje" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "ajf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -3151,6 +3764,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"aji" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "ajj" = (
 /obj/structure/rack,
 /obj/item/storage/box/rubbershot{
@@ -3314,6 +3940,17 @@
 "ajv" = (
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"ajw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "ajx" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "supplybridge"
@@ -3342,16 +3979,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ajA" = (
-/obj/docking_port/stationary{
-	dheight = 1;
-	dir = 8;
-	dwidth = 12;
-	height = 17;
-	id = "syndicate_ne";
-	name = "northeast of station";
-	width = 23
-	},
-/turf/open/space,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/space/basic,
 /area/space/nearstation)
 "ajB" = (
 /obj/item/storage/box/mousetraps,
@@ -3646,6 +4277,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"aki" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "akj" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -4011,6 +4655,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"akS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Office Maintenance";
+	req_access_txt = "50"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
 "akT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -4048,6 +4702,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"akY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "akZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -4073,6 +4737,20 @@
 /obj/item/stack/spacecash/c20,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"ald" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance";
+	req_access_txt = "31"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "ale" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
@@ -4139,6 +4817,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing/cremation)
+"aln" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "alo" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4356,6 +5053,21 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"alN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = 27
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "alO" = (
 /obj/structure/transit_tube/diagonal,
 /obj/structure/lattice,
@@ -4407,6 +5119,22 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/security/processing/cremation)
+"alX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "alY" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/dark,
@@ -4511,6 +5239,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
+"amj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "amk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/southleft{
@@ -4532,6 +5272,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
+"aml" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/delivery_chute{
+	dir = 4
+	},
+/obj/machinery/door/window/westright{
+	name = "Cargo Delivery";
+	icon_state = "right";
+	dir = 4;
+	req_one_access_txt = "31;48"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/structure/plasticflaps,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "amm" = (
 /obj/machinery/light{
 	dir = 8
@@ -4704,6 +5465,16 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"amE" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "amF" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
@@ -4910,6 +5681,14 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"ana" = (
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	icon_state = "conveyor_map_inverted";
+	id = "QMLoad"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "anb" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/light_switch{
@@ -4953,6 +5732,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"anh" = (
+/obj/effect/landmark/start/cargo_technician,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "ani" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -4981,6 +5764,45 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"ann" = (
+/obj/machinery/button/door{
+	id = "QMLoaddoor2";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_x = 24;
+	pixel_y = -8;
+	req_access_txt = "31"
+	},
+/obj/machinery/button/door{
+	id = "QMLoaddoor";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_x = 24;
+	pixel_y = 8;
+	req_access_txt = "31"
+	},
+/obj/machinery/camera{
+	c_tag = "Cargo Supply Dock";
+	dir = 8
+	},
+/obj/machinery/computer/cargo{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"ano" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "anp" = (
 /obj/effect/decal/cleanable/robot_debris{
 	icon_state = "gib6"
@@ -5070,6 +5892,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"anz" = (
+/obj/item/shard,
+/turf/open/space/basic,
+/area/space)
+"anA" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mailroom";
+	req_access_txt = "50"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "anB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -5254,6 +6088,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"anW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
 "anX" = (
 /turf/closed/wall/r_wall,
 /area/teleporter)
@@ -5268,11 +6107,32 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/crew_quarters/dorms)
+"anZ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aoa" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aob" = (
 /obj/structure/closet/emcloset,
 /obj/item/camera,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"aoc" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aod" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -5305,6 +6165,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"aoi" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "aoj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -5387,6 +6253,18 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/main)
+"aou" = (
+/obj/structure/table,
+/obj/item/price_tagger,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aov" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -5473,6 +6351,72 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
+"aoD" = (
+/obj/structure/table,
+/obj/item/storage/box/shipping,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aoE" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/button/door{
+	id = "commissary-bolts";
+	name = "entrance door bolts control";
+	normaldoorcontrol = 1;
+	pixel_y = 24;
+	specialfunctions = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/carpet,
+/area/vacant_room/commissary)
+"aoF" = (
+/obj/structure/table,
+/obj/item/storage/crayons,
+/obj/machinery/button/door{
+	id = "commissary-cargo-bolts";
+	name = "cargo door bolts control";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	specialfunctions = 4
+	},
+/obj/machinery/button/door{
+	id = "commissary_2";
+	name = "fore shutters control";
+	pixel_y = 24
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/carpet,
+/area/vacant_room/commissary)
+"aoG" = (
+/obj/machinery/computer/bounty,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aoH" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -5492,6 +6436,32 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"aoL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aoM" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aoN" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aoO" = (
 /obj/machinery/camera{
 	c_tag = "Brig Gulag Teleporter";
@@ -5515,6 +6485,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"aoQ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aoR" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/clothing/ears/earmuffs,
@@ -5581,6 +6555,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"aoZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "apa" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -5771,6 +6751,23 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
+"aps" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
 "apt" = (
 /obj/structure/chair{
 	dir = 4
@@ -5804,14 +6801,50 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/crew_quarters/dorms)
+"apx" = (
+/obj/machinery/door/poddoor{
+	id = "QMLoaddoor2";
+	name = "supply dock loading door"
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad2"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
+"apy" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad2"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "apz" = (
 /obj/item/target/clown,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"apA" = (
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "apB" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"apC" = (
+/obj/structure/transit_tube/curved/flipped,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
+"apD" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/maintenance/solars/starboard)
 "apE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5833,6 +6866,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"apI" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space,
+/area/maintenance/solars/starboard)
+"apJ" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/maintenance/solars/starboard)
 "apK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -5871,6 +6913,21 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"apN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"apO" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
 "apP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -5903,6 +6960,14 @@
 "apT" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
+"apU" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
+	},
+/obj/structure/plasticflaps,
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
 "apV" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral{
@@ -5918,9 +6983,58 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
+"apW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "apX" = (
 /turf/closed/wall,
 /area/crew_quarters/dorms)
+"apY" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/quartermaster/storage)
+"apZ" = (
+/obj/machinery/door/window/eastleft{
+	dir = 8;
+	icon_state = "right";
+	name = "Incoming Mail";
+	req_access_txt = "50"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/caution/red{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "aqa" = (
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -5929,6 +7043,26 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port)
+"aqb" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aqc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aqd" = (
 /obj/machinery/power/solar{
 	id = "starboardsolar";
@@ -5941,6 +7075,16 @@
 /obj/item/target/alien,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"aqf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aqg" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -5955,6 +7099,30 @@
 /obj/item/clothing/under/color/red,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"aqj" = (
+/obj/machinery/door/poddoor{
+	id = "trash";
+	name = "disposal bay door"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aqk" = (
+/obj/structure/closet/crate,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aql" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aqm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -6155,6 +7323,16 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"aqH" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aqI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -6164,6 +7342,27 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/bridge)
+"aqJ" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
+"aqK" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "aqL" = (
 /obj/machinery/computer/bank_machine,
 /obj/effect/turf_decal/tile/neutral{
@@ -6290,6 +7489,23 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
+"aqW" = (
+/obj/machinery/conveyor{
+	dir = 10;
+	icon_state = "conveyor_map";
+	id = "QMLoad2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
+"aqX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aqY" = (
 /obj/docking_port/stationary{
 	dwidth = 2;
@@ -6305,10 +7521,60 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"ara" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"arb" = (
+/obj/structure/transit_tube,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"arc" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	id = "trash"
+	},
+/obj/machinery/button/massdriver{
+	id = "trash";
+	pixel_x = -28
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "ard" = (
 /obj/item/clothing/head/cone,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"are" = (
+/obj/machinery/button/massdriver{
+	id = "trash";
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"arf" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "garbagestacked";
+	name = "disposal conveyor"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"arg" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"arh" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/xenoblood,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "ari" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -6509,6 +7775,14 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"arG" = (
+/obj/machinery/power/solar{
+	id = "portsolar";
+	name = "Port Solar Array"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/maintenance/solars/starboard)
 "arH" = (
 /obj/machinery/modular_computer/console/preset/command,
 /obj/effect/turf_decal/tile/green{
@@ -6857,6 +8131,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
+"ask" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space,
+/area/maintenance/solars/starboard)
 "asl" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -6887,6 +8166,38 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"asp" = (
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/maintenance/solars/starboard)
+"asq" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"asr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"ass" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"ast" = (
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 8;
+	output_dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "asu" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
@@ -6900,6 +8211,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"asv" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbagestacked"
+	},
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 8;
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "asw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -7076,6 +8399,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/bridge)
+"asP" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbagestacked"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "asQ" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -7126,6 +8456,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"asU" = (
+/obj/machinery/disposal/delivery_chute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/door/window/westleft,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/plasticflaps,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "asV" = (
 /obj/structure/closet/crate/goldcrate,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7217,6 +8565,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
+"ate" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "atf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7312,6 +8669,51 @@
 "atq" = (
 /turf/open/floor/circuit/green,
 /area/maintenance/department/security/brig)
+"atr" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ats" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"att" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"atu" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	freq = 1400;
+	location = "QM #1"
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/mob/living/simple_animal/bot/mulebot{
+	beacon_freq = 1400;
+	home_destination = "QM #1";
+	suffix = "#1"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "atv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -7336,6 +8738,22 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
+"aty" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"atz" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "atA" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 2";
@@ -7348,6 +8766,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"atB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/transit_tube,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "atC" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 3";
@@ -7360,6 +8785,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"atD" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "atE" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/security/glass{
@@ -7754,6 +9189,23 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/department/security/brig)
+"auv" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"auw" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "aux" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -8162,6 +9614,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"avo" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
+	},
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "avp" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -8822,6 +10282,27 @@
 /obj/item/storage/briefcase,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"awF" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Disposal APC";
+	pixel_x = 24
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"awG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Cargo Desk";
+	req_access_txt = "50"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "awH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -8838,6 +10319,23 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
+"awJ" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "qm_warehouse";
+	name = "warehouse shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"awK" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "qm_warehouse";
+	name = "warehouse shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "awL" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -8858,6 +10356,25 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"awM" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	freq = 1400;
+	location = "QM #2"
+	},
+/obj/machinery/camera{
+	c_tag = "Cargo Bay";
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "awN" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -9025,6 +10542,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"axd" = (
+/obj/structure/window{
+	icon_state = "window";
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/machinery/microwave,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/carpet/cyan,
+/area/quartermaster/storage)
 "axe" = (
 /obj/machinery/light{
 	dir = 4;
@@ -9043,6 +10570,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"axf" = (
+/obj/structure/window{
+	icon_state = "window";
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/donkpockets,
+/turf/open/floor/carpet/cyan,
+/area/quartermaster/storage)
 "axg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/dark,
@@ -9118,6 +10654,19 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"axs" = (
+/obj/structure/window{
+	icon_state = "window";
+	dir = 4
+	},
+/obj/structure/window{
+	icon_state = "window";
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/storage/cans/sixsoda,
+/turf/open/floor/carpet/cyan,
+/area/quartermaster/storage)
 "axt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -9172,6 +10721,10 @@
 "axC" = (
 /turf/closed/wall,
 /area/maintenance/solars/port)
+"axD" = (
+/obj/item/stack/spacecash/c500,
+/turf/open/space/basic,
+/area/space)
 "axE" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "prison release";
@@ -9316,6 +10869,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"axY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "axZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -9470,6 +11030,13 @@
 /obj/item/storage/pill_bottle/dice,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"ayp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "ayq" = (
 /obj/structure/table/wood,
 /obj/item/storage/backpack,
@@ -9614,6 +11181,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"ayK" = (
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/plasticflaps,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "ayL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9922,6 +11507,14 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"azw" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
+	},
+/obj/effect/spawner/lootdrop/maintenance/seven,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "azx" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
@@ -9940,6 +11533,13 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"azz" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "azA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -9991,6 +11591,22 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port)
+"azH" = (
+/obj/machinery/recycler,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"azI" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "azJ" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil,
@@ -10000,10 +11616,72 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port)
+"azL" = (
+/obj/machinery/conveyor{
+	dir = 5;
+	icon_state = "conveyor_map";
+	id = "cargo-export"
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	icon_state = "right";
+	name = "cargo export windoor";
+	req_access_txt = "50"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"azM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "azN" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
+"azO" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"azP" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	freq = 1400;
+	location = "QM #3"
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/mob/living/simple_animal/bot/mulebot{
+	home_destination = "QM #2";
+	suffix = "#2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"azQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/carpet/cyan,
+/area/quartermaster/storage)
+"azR" = (
+/turf/open/floor/carpet/cyan,
+/area/quartermaster/storage)
 "azS" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Port Solar Access";
@@ -10012,6 +11690,37 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
+"azT" = (
+/obj/structure/window{
+	icon_state = "window";
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/snacks/sandwich,
+/turf/open/floor/carpet/cyan,
+/area/quartermaster/storage)
+"azU" = (
+/obj/effect/decal/cleanable/plastic,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"azV" = (
+/obj/structure/transit_tube/crossing,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"azW" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"azX" = (
+/obj/structure/chair/plastic{
+	icon_state = "plastic_chair";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "azY" = (
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
@@ -10357,6 +12066,12 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"aAR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "aAS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -10376,6 +12091,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"aAV" = (
+/obj/item/trash/can,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "aAW" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -10396,11 +12118,30 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
+"aAZ" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "garbage";
+	name = "disposal conveyor"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "aBa" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/security/brig)
+"aBb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/toy/sword,
+/obj/item/toy/sword,
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "aBc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -10565,6 +12306,20 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"aBw" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 3
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aBx" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
@@ -10826,6 +12581,28 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"aCa" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "garbage"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
+"aCb" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "aCc" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -11400,6 +13177,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"aDn" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office";
+	req_access_txt = "31"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "aDo" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -11429,6 +13218,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"aDs" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/minor/pirate_or_bandana,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aDt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/grimy,
@@ -11671,6 +13467,14 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"aDT" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/minor/pirate_or_bandana,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aDU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11688,6 +13492,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
+"aDW" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/seven,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aDX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -11771,6 +13582,9 @@
 "aEk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aEl" = (
@@ -12108,6 +13922,15 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
+"aER" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aES" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway Vault";
@@ -12133,12 +13956,24 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
+"aEV" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aEW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aEX" = (
+/obj/structure/closet/crate/internals,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aEY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12188,32 +14023,36 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aFg" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	freq = 1400;
+	location = "QM #4"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aFh" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aFi" = (
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aFj" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/carpet/cyan,
+/area/quartermaster/storage)
 "aFk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/lootdrop/minor/bowler_or_that,
@@ -12223,6 +14062,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"aFl" = (
+/obj/structure/window{
+	icon_state = "window";
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/storage/bag/tray,
+/turf/open/floor/carpet/cyan,
+/area/quartermaster/storage)
 "aFm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -12252,6 +14100,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"aFq" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aFr" = (
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway Entrance";
@@ -12472,11 +14327,29 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aFR" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aFS" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aFT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aFU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -12531,6 +14404,24 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"aFZ" = (
+/obj/machinery/camera,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aGa" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/grimy,
@@ -12784,6 +14675,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aGE" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "aGF" = (
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
@@ -12846,9 +14744,34 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aGP" = (
-/obj/structure/closet/emcloset,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/disposal)
+"aGQ" = (
+/obj/structure/transit_tube/station/flipped{
+	icon_state = "closed_station1";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aGR" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aGS" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aGT" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "aGU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -12858,6 +14781,18 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aGW" = (
+/obj/item/radio/intercom{
+	pixel_x = -27
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "aGX" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -12888,6 +14823,19 @@
 	},
 /turf/open/floor/plating,
 /area/storage/primary)
+"aHa" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "aHb" = (
 /obj/machinery/computer/arcade,
 /obj/effect/turf_decal/tile/neutral{
@@ -12973,6 +14921,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"aHf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/quartermaster/office)
 "aHg" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -13012,6 +14966,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aHi" = (
+/obj/structure/closet/crate/engineering,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aHj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aHk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aHl" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hopqueue";
@@ -13082,6 +15055,27 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"aHv" = (
+/obj/structure/closet/crate,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aHw" = (
+/turf/closed/wall,
+/area/security/checkpoint/supply)
+"aHx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/checkpoint/supply)
+"aHy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/security/checkpoint/supply)
 "aHz" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
@@ -13089,6 +15083,29 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"aHB" = (
+/obj/structure/table,
+/obj/item/stamp{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/stamp/denied{
+	pixel_x = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aHC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -13099,6 +15116,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"aHD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/security/checkpoint/supply)
 "aHE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -13294,6 +15316,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aHX" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/item/dest_tagger,
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "aHY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -13445,6 +15476,30 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
+"aIm" = (
+/obj/machinery/door/airlock/mining/glass,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"aIn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aIo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	icon_state = "pipe11-2";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "aIp" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -13455,6 +15510,142 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"aIr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	icon_state = "pipe11-2";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aIs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	icon_state = "pipe11-2";
+	dir = 8
+	},
+/obj/structure/closet/emcloset,
+/obj/item/radio,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aIt" = (
+/obj/structure/closet/crate/trashcart,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	icon_state = "pipe11-2";
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aIu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	icon_state = "pipe11-2";
+	dir = 8
+	},
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/maintenance/six,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aIv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aIw" = (
+/obj/structure/table,
+/obj/item/pen{
+	layer = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"aIx" = (
+/obj/structure/table,
+/obj/item/paicard,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"aIy" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = 22
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"aIz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aIA" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aIB" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aIC" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -13464,6 +15655,69 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"aID" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aIE" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aIF" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/lizardboots,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aIG" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aIH" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/gloves,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aII" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aIJ" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aIK" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "aIL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -13485,11 +15739,26 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aIO" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "aIP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aIQ" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "aIR" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -13510,6 +15779,17 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aIU" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "aIV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -13517,11 +15797,36 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aIW" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "aIX" = (
 /obj/effect/landmark/observer_start,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aIY" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "aIZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -13579,11 +15884,48 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aJg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "aJh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aJi" = (
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aJj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "aJk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -13595,6 +15937,25 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aJl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	pixel_y = 32
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aJm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -13626,10 +15987,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aJq" = (
+/obj/structure/window/reinforced,
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/crossing,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
+"aJr" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/cobweb,
@@ -13637,20 +16002,11 @@
 	icon_state = "floor6"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
-	},
-/area/maintenance/department/cargo)
-"aJr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/cargo)
 "aJs" = (
@@ -13667,30 +16023,71 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 8
 	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/cable,
 /turf/open/floor/plating{
-	icon_state = "panelscorched"
+	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/cargo)
-"aJv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
+"aJu" = (
+/obj/structure/transit_tube,
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/space/basic,
+/area/space/nearstation)
+"aJv" = (
+/obj/machinery/vending/wallmed/pubby,
+/turf/closed/wall,
+/area/maintenance/disposal)
 "aJw" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/toy/figure/chaplain,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"aJx" = (
+/obj/structure/transit_tube,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aJy" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance/four,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aJz" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aJA" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aJB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/quartermaster/qm)
+"aJC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/quartermaster/qm)
 "aJD" = (
 /obj/structure/chair{
 	dir = 8
@@ -13948,6 +16345,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aKc" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aKd" = (
+/obj/structure/closet/crate/secure/loot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aKe" = (
 /obj/machinery/camera{
 	c_tag = "Dormitories Hallway";
@@ -13994,37 +16401,107 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aKk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/computer/security/mining{
+	icon_state = "computer";
+	dir = 4
 	},
-/obj/effect/decal/cleanable/oil,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"aKn" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
+"aKl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
+"aKm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
+"aKn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aKo" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/obj/structure/table,
+/obj/item/kitchen/knife,
+/turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aKp" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "aKq" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/closet/crate/miningcar,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "aKr" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/toy/figure/curator,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"aKs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"aKt" = (
+/obj/machinery/conveyor/inverted{
+	dir = 5;
+	icon_state = "conveyor_map_inverted";
+	id = "QMLoad2"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
+"aKu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"aKv" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"aKw" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Dock Airlock";
+	req_access_txt = "48"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
+"aKx" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Dock Airlock";
+	req_access_txt = "48"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "aKy" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -14059,6 +16536,14 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"aKC" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "aKD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -14083,6 +16568,17 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"aKF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aKG" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "aKH" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/neutral{
@@ -14172,6 +16668,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
+"aKW" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
+"aKX" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
 "aKY" = (
 /turf/closed/wall/r_wall,
 /area/storage/eva)
@@ -14218,7 +16729,7 @@
 /area/teleporter)
 "aLe" = (
 /turf/closed/wall,
-/area/security/checkpoint/supply)
+/area/vacant_room/commissary)
 "aLf" = (
 /turf/closed/wall,
 /area/quartermaster/office)
@@ -14226,47 +16737,74 @@
 /turf/closed/wall,
 /area/quartermaster/storage)
 "aLh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Warehouse Maintenance";
-	req_access_txt = "31"
-	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"aLi" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"aLj" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aLi" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/obj/item/multitool,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/solars/starboard)
+"aLj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
 "aLk" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aLl" = (
-/obj/item/storage/box/mousetraps,
+/obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aLm" = (
 /turf/closed/wall,
 /area/maintenance/disposal)
 "aLn" = (
-/obj/machinery/door/poddoor{
-	id = "trash";
-	name = "disposal bay door"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/maintenance/solars/starboard)
 "aLo" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/department/science)
+"aLp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aLq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aLr" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/quartermaster/qm)
+"aLs" = (
+/obj/structure/bookcase/manuals,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/quartermaster/qm)
+"aLt" = (
+/obj/structure/bookcase/manuals,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/quartermaster/qm)
 "aLu" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/neutral{
@@ -14425,6 +16963,21 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"aLJ" = (
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "aLK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating{
@@ -14434,6 +16987,48 @@
 "aLL" = (
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"aLM" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/landmark/start/depsec/supply,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
+"aLN" = (
+/obj/machinery/door/window/eastleft{
+	name = "Brig Desk";
+	icon_state = "right";
+	dir = 2;
+	req_access_txt = "1"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
+"aLO" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
+"aLP" = (
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "aLQ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/button/door{
@@ -14507,11 +17102,23 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/teleporter)
+"aLX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "aLY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/teleporter)
+"aLZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "aMa" = (
 /obj/structure/closet/crate,
 /obj/machinery/button/door{
@@ -14540,317 +17147,221 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aMd" = (
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_x = -32
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2;
+	sortType = 1
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 30
-	},
-/obj/machinery/computer/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "aMe" = (
-/obj/machinery/computer/security/mining,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/airlock/engineering{
+	name = "Starboard Solar Access";
+	req_access_txt = "10"
 	},
-/obj/machinery/camera{
-	c_tag = "Cargo Security Post"
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
 "aMf" = (
-/obj/machinery/computer/secure_data,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
 "aMg" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
-	},
-/obj/structure/disposaloutlet{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/quartermaster/sorting)
+/area/maintenance/solars/starboard)
 "aMh" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
-"aMi" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/status_display/supply{
-	pixel_y = 30
-	},
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
-"aMj" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
-"aMk" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
-"aMl" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
-"aMm" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
-	},
-/obj/structure/plasticflaps,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
-"aMn" = (
-/obj/machinery/disposal/delivery_chute{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/quartermaster/sorting)
-"aMo" = (
+/area/maintenance/solars/starboard)
+"aMi" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/maintenance/solars/starboard)
+"aMj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/quartermaster/warehouse)
+/turf/open/space/basic,
+/area/space)
+"aMk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space)
+"aMl" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/maintenance/solars/starboard)
+"aMm" = (
+/obj/structure/lattice/catwalk,
+/obj/item/stack/cable_coil,
+/turf/open/space,
+/area/maintenance/solars/starboard)
+"aMn" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/maintenance/solars/starboard)
+"aMo" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aMp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/cargo)
 "aMq" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aMr" = (
-/obj/structure/closet/crate,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aMs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "aMt" = (
-/obj/structure/closet/cardboard,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissary_2";
+	name = "commissary shutters"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Warehouse"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
+/area/vacant_room/commissary)
 "aMu" = (
-/obj/item/cigbutt/cigarbutt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/conveyor_switch/oneway{
+	id = "QMLoad2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
+/area/quartermaster/storage)
 "aMv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/quartermaster/warehouse";
-	dir = 4;
-	name = "Cargo Warehouse APC";
-	pixel_x = 24
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aMw" = (
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aMx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
+/obj/structure/chair/stool,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/floor/wood,
+/area/quartermaster/qm)
 "aMy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/ash,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/floor/wood,
+/area/quartermaster/qm)
 "aMz" = (
-/obj/structure/grille/broken,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/item/crowbar,
-/obj/machinery/light/small,
+/obj/structure/transit_tube/curved{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/disposal)
 "aMA" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/quartermaster/qm)
 "aMB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/cable,
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science)
+"aMC" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/twenty,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aMD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/window/reinforced,
+/obj/machinery/light/floor,
+/obj/structure/transit_tube/diagonal/crossing,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/disposal)
 "aME" = (
-/obj/machinery/button/massdriver{
-	id = "trash";
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aMF" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "garbagestacked";
-	name = "disposal conveyor"
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/department/science)
 "aMG" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/showcase/cyborg/old,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/department/science)
 "aMH" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/structure/frame/computer,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/department/science)
+"aMI" = (
+/obj/item/rack_parts,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aMJ" = (
+/obj/structure/rack,
+/obj/item/stack/sticky_tape,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aMK" = (
+/obj/structure/rack,
+/obj/item/t_scanner,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aML" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -14859,6 +17370,65 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"aMM" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "cargo-export"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aMN" = (
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
+"aMO" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
+"aMP" = (
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"aMQ" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/structure/frame/computer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aMR" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad2"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
+"aMS" = (
+/obj/effect/landmark/start/shaft_miner,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "aMT" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -15035,10 +17605,40 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"aNk" = (
+/obj/effect/landmark/start/shaft_miner,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"aNl" = (
+/obj/machinery/conveyor{
+	dir = 10;
+	icon_state = "conveyor_map";
+	id = "QMLoad2"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "aNm" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"aNn" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Starboard Solar APC";
+	pixel_x = -25
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
+"aNo" = (
+/obj/structure/chair/stool,
+/obj/item/cigbutt/cigarbutt,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
 "aNp" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots{
@@ -15144,206 +17744,224 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aNB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aNC" = (
+/obj/machinery/power/solar_control{
+	dir = 8;
+	id = "starboardsolar";
+	name = "Starboard Solar Control"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
+"aND" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aNE" = (
+/obj/machinery/computer/security/qm,
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/quartermaster/qm)
+"aNF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/vacant_room/commissary)
+"aNG" = (
+/obj/structure/table/wood,
+/obj/structure/table/wood,
+/obj/item/phone,
+/turf/open/floor/carpet/red,
+/area/quartermaster/qm)
+"aNH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/vacant_room/commissary)
+"aNI" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/wood,
+/area/quartermaster/qm)
+"aNJ" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/structure/closet/crate/secure/loot,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aNK" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aNL" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aNM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aNN" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aNO" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space,
+/area/space/nearstation)
+"aNP" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aNQ" = (
+/obj/item/stack/cable_coil/cut,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/molten_object,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/science)
+"aNR" = (
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aNS" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aNT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aNC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"aNU" = (
+/obj/machinery/mecha_part_fabricator,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aNV" = (
+/obj/item/pipe,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aNW" = (
+/obj/machinery/mech_bay_recharge_port{
+	icon_state = "recharge_port";
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/checkpoint/supply)
-"aND" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/area/maintenance/department/science)
+"aNX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
+"aNY" = (
+/obj/structure/closet/secure_closet/security/cargo,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
-"aNE" = (
-/obj/structure/chair/office{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/landmark/start/depsec/supply,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/firealarm{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"aNF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+"aNZ" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"aNH" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+"aOa" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aNI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light{
+	light_color = "#c9d3e8"
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aNJ" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "packageSort2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aNK" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/storage/box/shipping,
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aNL" = (
-/obj/item/stack/wrapping_paper{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/stack/package_wrap{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aNM" = (
-/obj/item/storage/box,
-/obj/item/storage/box,
-/obj/item/storage/box,
-/obj/item/hand_labeler,
-/obj/item/hand_labeler,
-/obj/structure/table,
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aNN" = (
-/obj/structure/closet/crate/freezer,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
+/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aNO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aNP" = (
-/obj/structure/closet/crate,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aNQ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aNT" = (
-/obj/machinery/mass_driver{
-	dir = 1;
-	id = "trash"
-	},
-/obj/machinery/button/massdriver{
-	id = "trash";
-	pixel_x = -28
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"aNU" = (
-/obj/machinery/mineral/stacking_machine{
-	input_dir = 8;
-	output_dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"aNV" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbagestacked"
-	},
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 8;
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"aNW" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbagestacked"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"aNX" = (
-/obj/machinery/disposal/delivery_chute{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/door/window/westleft,
-/obj/structure/window/reinforced,
+/area/security/checkpoint/supply)
+"aOb" = (
 /obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"aNY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
+"aOc" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
+"aOd" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"aOe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/department/cargo)
 "aOf" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/neutral{
@@ -15385,12 +18003,46 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"aOi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aOj" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/light{
+	light_color = "#c9d3e8"
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "aOk" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"aOl" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Port Aft";
+	dir = 1;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "aOm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/wrench,
@@ -15398,6 +18050,49 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"aOn" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -27
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"aOo" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aOp" = (
+/obj/structure/cable,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aOq" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/transit_tube/curved,
+/turf/open/space/basic,
+/area/space/nearstation)
+"aOr" = (
+/obj/structure/chair/sofa/left{
+	icon_state = "sofaend_left";
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/quartermaster/qm)
 "aOs" = (
 /obj/structure/sign/departments/evac,
 /turf/closed/wall,
@@ -15627,175 +18322,220 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aOO" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
-"aOP" = (
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
-"aOQ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
-"aOR" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Cargo Security Post";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aOS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aOT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aOU" = (
-/obj/structure/chair/stool,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/landmark/start/cargo_technician,
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aOV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aOW" = (
-/obj/machinery/door/window/eastleft{
-	dir = 8;
-	icon_state = "right";
-	name = "Incoming Mail";
-	req_access_txt = "50"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/turf_decal/caution/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aOX" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aOY" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aOZ" = (
-/obj/item/stack/sheet/cardboard,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aPa" = (
-/obj/structure/closet/crate,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aPb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aPc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aPd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aPf" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/shard,
+"aOM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet,
+/area/vacant_room/commissary)
+"aON" = (
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"aPg" = (
+"aOO" = (
+/obj/machinery/reagentgrinder/constructed,
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aOP" = (
+/turf/open/floor/carpet,
+/area/vacant_room/commissary)
+"aOQ" = (
+/obj/structure/table/wood,
+/obj/item/stamp/qm,
+/turf/open/floor/carpet/red,
+/area/quartermaster/qm)
+"aOR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aOS" = (
+/obj/effect/turf_decal/plaque{
+	name = "security borg memorial plaque"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aOT" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
+	},
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
+"aOU" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/airalarm{
+	pixel_y = 22
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
-"aPh" = (
+/area/quartermaster/sorting)
+"aOV" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/status_display/supply{
+	pixel_y = 30
+	},
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
+"aOW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aOX" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
+"aOY" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = 22
+	},
+/turf/open/floor/wood,
+/area/quartermaster/qm)
+"aOZ" = (
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/department/science)
+"aPa" = (
+/mob/living/simple_animal/hostile/hivebot,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/science)
+"aPb" = (
+/obj/item/kitchen/fork,
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aPc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"aPd" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "packageSort2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"aPe" = (
+/obj/structure/closet/supplypod,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aPf" = (
+/mob/living/simple_animal/hostile/hivebot/range,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/science)
+"aPg" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/storage/box/shipping,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"aPh" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
+	},
+/obj/effect/decal/cleanable/molten_object,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aPi" = (
-/obj/machinery/light/small{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/door/airlock{
+	id_tag = "commissary-bolts"
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
+"aPj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/carpet,
+/area/vacant_room/commissary)
+"aPk" = (
+/obj/effect/decal/cleanable/robot_debris{
+	icon_state = "gib3"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aPl" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"aPm" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "aPn" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -15813,6 +18553,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
+"aPp" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aPq" = (
 /obj/machinery/light{
 	dir = 4
@@ -15827,10 +18573,41 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"aPr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"aPs" = (
+/obj/item/stack/wrapping_paper{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/stack/package_wrap{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "aPt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"aPu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aPv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -15838,6 +18615,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"aPw" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "aPx" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -15891,6 +18683,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"aPG" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Mech Bay Maintenance";
+	req_access_txt = "29"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aPH" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/structure/extinguisher_cabinet{
@@ -15997,161 +18800,155 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aPT" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Security Post - Cargo APC";
-	pixel_x = -25
+/obj/machinery/conveyor_switch/oneway{
+	id = "cargo-export"
 	},
-/obj/structure/closet/secure_closet/security/cargo,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
-"aPU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
-"aPV" = (
-/obj/structure/filingcabinet/security,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aPU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
+"aPV" = (
+/turf/open/floor/carpet/red,
+/area/quartermaster/qm)
 "aPW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/quartermaster/office)
+/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway Bridge";
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/quartermaster/qm)
 "aPX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/quartermaster/qm)
 "aPY" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aPZ" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
+/obj/item/banner/cargo,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/quartermaster/qm)
 "aQa" = (
-/obj/structure/disposalpipe/sorting/wrap{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
+/obj/item/stack/cable_coil/cut,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aQb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Mailroom";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "aQc" = (
-/obj/machinery/button/door{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = -24;
-	req_access_txt = "31"
+/obj/item/stack/rods/ten,
+/obj/effect/decal/cleanable/molten_object,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
+/area/maintenance/department/science)
 "aQd" = (
-/obj/item/flashlight,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/carpet/orange,
+/area/vacant_room/commissary)
 "aQe" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aQf" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aQg" = (
-/obj/structure/closet/crate/medical,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aQj" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"aQf" = (
+/obj/structure/mecha_wreckage/clarke,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aQg" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aQh" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/science)
+"aQi" = (
+/mob/living/simple_animal/hostile/hivebot/range,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aQj" = (
+/obj/effect/decal/cleanable/robot_debris{
+	icon_state = "gib6"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aQk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/maintenance/disposal)
-"aQn" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "garbage";
-	name = "disposal conveyor"
+/turf/open/floor/carpet/orange,
+/area/vacant_room/commissary)
+"aQl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet/orange,
+/area/vacant_room/commissary)
+"aQm" = (
+/obj/structure/cable,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aQn" = (
+/obj/item/plunger,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aQo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/vacant_room/commissary)
+"aQp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aQq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"aQo" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "garbage"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"aQp" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aQr" = (
 /obj/structure/chair{
 	dir = 8
@@ -16196,6 +18993,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"aQy" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aQz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -16206,6 +19007,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"aQA" = (
+/obj/structure/cable,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aQB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -16254,6 +19060,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"aQG" = (
+/obj/item/mining_scanner,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aQH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -16453,184 +19264,156 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/eva)
 "aRd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aRe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/sign/departments/cargo{
-	pixel_x = 32
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"aRf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/checkpoint/supply)
-"aRg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Cargo Security Post";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
-"aRh" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light_switch{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aRi" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aRj" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/obj/item/pen,
-/obj/item/paper_bin{
-	layer = 2.9
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aRk" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aRl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/power/apc/highcap/fifteen_k{
-	dir = 4;
-	name = "Delivery Office APC";
-	pixel_x = 24
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aRm" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/food/snacks/donut,
-/obj/item/reagent_containers/food/snacks/donut,
-/obj/item/reagent_containers/food/snacks/donut,
-/obj/item/reagent_containers/food/snacks/donut,
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
-"aRn" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "qm_warehouse";
-	name = "warehouse shutters"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aRo" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "qm_warehouse";
-	name = "warehouse shutters"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aRp" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "qm_warehouse";
-	name = "warehouse shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aRq" = (
-/obj/structure/closet/crate/internals,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"aRs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"aRt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"aRf" = (
+/obj/item/seeds/plump,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aRg" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/space/basic,
+/area/space)
+"aRh" = (
+/obj/machinery/door/airlock/mining/glass{
+	id_tag = "commissary-cargo-bolts";
+	name = "Mailroom";
+	req_access_txt = "50"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/maintenance/disposal)
-"aRu" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
+"aRi" = (
+/obj/effect/decal/cleanable/food/plant_smudge,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aRj" = (
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 4;
+	node1_concentration = 0.8;
+	node2_concentration = 0.2;
+	on = 1;
+	target_pressure = 4500
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
-"aRv" = (
-/obj/item/trash/can,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"aRw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/area/maintenance/department/science)
+"aRk" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aRl" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aRm" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/cargo)
+"aRn" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/chair/plastic{
+	icon_state = "plastic_chair";
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
-"aRy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/stripes/line{
+/area/maintenance/department/science)
+"aRo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
+"aRp" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aRr" = (
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
+"aRs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aRt" = (
+/obj/item/seeds/potato,
+/obj/machinery/light/small/broken{
+	icon_state = "bulb-broken";
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
-"aRz" = (
+/area/maintenance/department/cargo)
+"aRu" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/turf/closed/wall,
+/area/quartermaster/qm)
+"aRv" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aRw" = (
+/obj/structure/table/wood,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aRx" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aRy" = (
+/obj/item/book/manual/wiki/robotics_cyborgs,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aRz" = (
+/obj/machinery/conveyor_switch,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/department/science)
+"aRA" = (
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aRB" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/neutral{
@@ -16754,6 +19537,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"aRK" = (
+/obj/structure/cable,
+/obj/item/radio/intercom{
+	pixel_x = -27
+	},
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/stack/package_wrap,
+/turf/open/floor/carpet,
+/area/vacant_room/commissary)
 "aRL" = (
 /turf/closed/wall,
 /area/hydroponics)
@@ -16878,112 +19673,102 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aSc" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/wrapping,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aSd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
+/obj/effect/decal/cleanable/molten_object,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aSe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westleft{
-	dir = 1;
-	name = "Delivery Desk";
-	req_access_txt = "50"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
+/obj/structure/table_frame,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aSf" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westleft{
-	dir = 1;
-	name = "Delivery Desk";
-	req_access_txt = "50"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
+/obj/item/stack/cable_coil/five,
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aSg" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mailroom";
-	req_access_txt = "50"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
+/obj/structure/table,
+/obj/effect/decal/cleanable/wrapping,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aSh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aSi" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/cargo)
+"aSj" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/quartermaster/sorting)
-"aSi" = (
-/obj/machinery/button/door{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = -24;
-	req_access_txt = "31"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aSj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/maintenance/department/science)
 "aSk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/brown,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aSl" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Cargo Maintenance APC";
-	pixel_x = 24
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
+/obj/item/plant_analyzer,
+/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aSm" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"aSn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"aSo" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Disposal APC";
-	pixel_x = 24
+/obj/structure/sign/poster/contraband/smoke{
+	pixel_x = -32
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/department/science)
+"aSn" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/science)
+"aSo" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aSp" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aSq" = (
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/drinks/bottle{
+	pixel_x = 10;
+	pixel_y = 12
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aSr" = (
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
+"aSs" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aSt" = (
+/obj/item/storage/bag/plants,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aSu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -17019,6 +19804,23 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
+"aSy" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aSz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aSA" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -17160,6 +19962,24 @@
 /obj/item/weldingtool,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"aSS" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aST" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -17167,6 +19987,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"aSU" = (
+/obj/structure/girder,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aSV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -17197,266 +20024,206 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aSY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aSZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aTa" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aTb" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aTc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aTd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aTe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	name = "Emergency Exit";
+	req_access_txt = "0"
 	},
 /turf/open/floor/plating,
-/area/quartermaster/office)
-"aTf" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aTg" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/area/maintenance/disposal)
+"aSZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/office/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aTh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/area/quartermaster/storage)
+"aTa" = (
+/obj/machinery/door/airlock/mining/glass,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/miningdock)
+"aTb" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"aTc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"aTd" = (
+/obj/machinery/plumbing/fermenter,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aTe" = (
+/obj/item/reagent_containers/food/drinks/bottle,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aTf" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aTg" = (
+/obj/item/reagent_containers/food/drinks/bottle/hooch,
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aTh" = (
+/obj/structure/closet/secure_closet/quartermaster,
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/quartermaster/qm)
 "aTi" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_y = 32
-	},
+/obj/structure/transit_tube/horizontal,
 /obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aTj" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aTk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aTk" = (
+/obj/structure/window/reinforced,
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "aTl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/obj/item/stack/ducts,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aTm" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aTn" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "QMLoad"
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aTo" = (
-/obj/machinery/status_display/supply{
-	pixel_y = 30
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "QMLoad"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aTp" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "QMLoad"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aTq" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "QMLoad"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aTr" = (
-/obj/machinery/door/poddoor{
-	id = "QMLoaddoor";
-	name = "supply dock loading door"
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "QMLoad"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aTs" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "QMLoad"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aTv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/structure/transit_tube/crossing,
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
+"aTo" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/quartermaster/qm)
+"aTp" = (
+/obj/machinery/seed_extractor,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"aTq" = (
+/obj/structure/closet,
+/obj/item/weldingtool,
+/obj/item/crowbar,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aTr" = (
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aTs" = (
+/obj/machinery/plumbing/bottler,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aTt" = (
+/obj/machinery/plumbing/synthesizer,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aTu" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aTv" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aTw" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 2
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
+/area/maintenance/department/cargo)
+"aTx" = (
+/obj/machinery/requests_console{
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/quartermaster/qm)
+"aTy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"aTx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"aTy" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Disposal Access";
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/navbeacon/wayfinding/disposals,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "aTz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aTA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light_switch{
+	pixel_x = 24
 	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"aTB" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "qm_warehouse";
+	name = "warehouse shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aTC" = (
+/obj/effect/landmark/start/shaft_miner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"aTD" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood,
+/area/quartermaster/qm)
+"aTE" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"aTB" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"aTF" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/orange,
+/area/vacant_room/commissary)
+"aTG" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
-"aTC" = (
-/obj/machinery/power/solar{
-	id = "portsolar";
-	name = "Port Solar Array"
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard)
-"aTE" = (
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard)
+/area/maintenance/department/cargo)
 "aTH" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -17468,6 +20235,13 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"aTI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aTJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -17509,6 +20283,16 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
+"aTN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aTO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
@@ -17567,6 +20351,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"aTV" = (
+/obj/item/radio/intercom{
+	pixel_x = -27
+	},
+/turf/open/floor/wood,
+/area/quartermaster/qm)
 "aTW" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/plantbgone{
@@ -17632,6 +20422,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/bar)
+"aUc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aUd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -17654,6 +20453,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"aUh" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Maintenance";
+	req_access_txt = "31"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "aUi" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway Cargo";
@@ -17683,13 +20491,13 @@
 /area/hallway/primary/central)
 "aUj" = (
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/carpet/orange,
+/area/vacant_room/commissary)
 "aUk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17698,122 +20506,120 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aUl" = (
-/obj/machinery/door/firedoor,
+/obj/structure/table,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/obj/item/paper_bin,
+/turf/open/floor/carpet,
+/area/vacant_room/commissary)
 "aUm" = (
-/obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
+/turf/closed/wall,
+/area/vacant_room/commissary)
 "aUn" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aUo" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay";
-	req_one_access_txt = "31;48"
+/obj/structure/disposalpipe/sorting/wrap{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/navbeacon/wayfinding/cargo,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/hallway/primary/central)
 "aUp" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aUq" = (
+/obj/structure/sign/warning/nosmoking/circle,
+/turf/closed/wall,
+/area/maintenance/department/science)
+"aUr" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aUs" = (
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aUt" = (
+/obj/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aUu" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aUq" = (
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aUv" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
+"aUw" = (
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/hand_labeler,
+/turf/open/floor/carpet,
+/area/vacant_room/commissary)
+"aUx" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet,
+/area/vacant_room/commissary)
+"aUy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aUr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aUs" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aUt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aUu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aUv" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aUw" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aUx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aUy" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Dock Airlock";
-	req_access_txt = "31"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
+/area/hallway/primary/central)
 "aUz" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/quartermaster/storage)
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aUA" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -17826,17 +20632,39 @@
 /turf/open/space/basic,
 /area/space)
 "aUB" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"aUC" = (
 /obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aUC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aUD" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"aUE" = (
+/obj/machinery/button/door{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access_txt = "31"
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aUF" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/science)
 "aUG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -17847,6 +20675,15 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"aUH" = (
+/obj/effect/turf_decal/plaque{
+	name = "security borg memorial plaque"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aUI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -17876,6 +20713,22 @@
 	dir = 1
 	},
 /area/hallway/primary/central)
+"aUK" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"aUL" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/science)
 "aUM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17959,6 +20812,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"aUV" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/science)
 "aUW" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -18018,6 +20879,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"aVe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aVf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/newscaster{
@@ -18169,166 +21039,197 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aVp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/safe/floor,
+/obj/structure/statue/silver/secborg{
+	anchored = 1
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
+/obj/item/gun/energy/disabler,
+/obj/item/borg/upgrade/disablercooler,
+/obj/item/bodypart/l_arm/robot,
+/obj/item/bodypart/head/robot,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "aVq" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aVr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+	dir = 10
 	},
-/obj/effect/turf_decal/loading_area{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aVs" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "cargodeliver"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aVt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aVu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aVv" = (
-/obj/machinery/light{
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aVr" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/conveyor_switch{
-	id = "cargodeliver"
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aVw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	freq = 1400;
-	location = "QM #1"
+/area/quartermaster/sorting)
+"aVs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/effect/turf_decal/bot,
-/mob/living/simple_animal/bot/mulebot{
-	beacon_freq = 1400;
-	home_destination = "QM #1";
-	suffix = "#1"
+/area/maintenance/department/science)
+"aVt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aVx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/quartermaster/sorting)
+"aVu" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 2
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/science)
+"aVv" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/science)
+"aVw" = (
+/obj/machinery/status_display/supply,
+/turf/closed/wall,
+/area/quartermaster/qm)
+"aVx" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/carpet/red,
+/area/quartermaster/qm)
 "aVy" = (
-/obj/effect/landmark/start/cargo_technician,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/obj/machinery/computer/cargo,
+/turf/open/floor/carpet/red,
+/area/quartermaster/qm)
 "aVz" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aVA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/science)
+"aVA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/quartermaster/storage)
 "aVB" = (
-/obj/machinery/button/door{
-	id = "QMLoaddoor2";
-	layer = 4;
-	name = "Loading Doors";
-	pixel_x = 24;
-	pixel_y = -8;
-	req_access_txt = "31"
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aVC" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "9;55"
 	},
-/obj/machinery/button/door{
-	id = "QMLoaddoor";
-	layer = 4;
-	name = "Loading Doors";
-	pixel_x = 24;
-	pixel_y = 8;
-	req_access_txt = "31"
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Supply Dock";
-	dir = 8
-	},
-/obj/machinery/computer/cargo{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aVE" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aVD" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12; 55"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aVE" = (
+/obj/structure/girder,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aVF" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"aVG" = (
-/obj/structure/easel,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"aVH" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/item/book/manual/wiki/chemistry,
-/obj/machinery/light/small{
+/obj/structure/chair/sofa/right{
+	icon_state = "sofaend_right";
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/floor/carpet/red,
+/area/quartermaster/qm)
+"aVG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aVH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aVI" = (
-/obj/structure/closet,
-/obj/item/canvas/twentythree_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/twentythree_twentythree,
-/obj/item/storage/crayons,
+/obj/structure/plasticflaps,
+/obj/machinery/door/firedoor,
+/obj/machinery/conveyor{
+	id = "cargo-autolathe"
+	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/quartermaster/office)
+"aVJ" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/obj/machinery/conveyor{
+	id = "cargo-autolathe"
+	},
+/obj/machinery/door/window/westleft{
+	dir = 1;
+	icon_state = "right";
+	name = "cargo input/output windoor";
+	req_access_txt = "50"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"aVK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aVL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aVM" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
@@ -18477,6 +21378,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"aWc" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "aWd" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -18537,6 +21453,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"aWk" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aWl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -18650,77 +21573,110 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aWs" = (
-/obj/machinery/computer/cargo/request{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/hallway/primary/central)
 "aWt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
+/obj/structure/railing{
+	icon_state = "railing";
+	dir = 9
+	},
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "aWu" = (
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aWv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 4;
-	output_dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/quartermaster/office)
-"aWw" = (
-/obj/machinery/status_display/supply{
-	dir = 8;
-	layer = 4;
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aWx" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	freq = 1400;
-	location = "QM #2"
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Bay";
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aWy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aWz" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aWA" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aWB" = (
-/obj/machinery/light/small{
+/obj/structure/railing{
+	icon_state = "railing";
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
+/turf/open/floor/grass,
+/area/hallway/primary/central)
+"aWv" = (
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "commissary_1";
+	name = "aft shutters control";
+	pixel_y = -24
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/obj/item/pen,
+/turf/open/floor/carpet,
+/area/vacant_room/commissary)
+"aWw" = (
+/obj/structure/railing{
+	icon_state = "railing";
+	dir = 5
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
+"aWx" = (
+/obj/machinery/conveyor{
+	id = "cargo-autolathe"
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aWy" = (
+/obj/structure/railing{
+	icon_state = "railing";
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
+"aWz" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/requests_console{
+	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"aWA" = (
+/obj/structure/railing{
+	icon_state = "railing";
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
+"aWB" = (
+/obj/structure/table/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissary_1";
+	name = "commissary shutters"
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
+"aWC" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/shipping,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissary_1";
+	name = "commissary shutters"
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
+"aWD" = (
+/obj/structure/railing{
+	icon_state = "railing";
+	dir = 10
+	},
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "aWE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -18736,6 +21692,19 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
+"aWG" = (
+/obj/structure/railing,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
+"aWH" = (
+/obj/structure/railing{
+	icon_state = "railing";
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "aWI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -18766,6 +21735,25 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
+"aWL" = (
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Bridge Starboard Entrance";
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "aWM" = (
 /obj/machinery/washing_machine,
 /obj/structure/sign/plaques/deempisi{
@@ -18916,6 +21904,33 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"aWZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"aXa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aXb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18947,10 +21962,54 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"aXe" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aXf" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aXg" = (
+/obj/structure/table/reinforced,
+/obj/machinery/paystand,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissary_1";
+	name = "commissary shutters"
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "aXh" = (
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"aXi" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aXj" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/door/airlock/security{
+	name = "Security Checkpoint";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "aXk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -19071,44 +22130,108 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aXr" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/computer/cargo/request{
+	icon_state = "computer";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aXs" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aXt" = (
+/obj/structure/table,
+/obj/item/storage/box/shipping,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"aXu" = (
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"aXv" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aXw" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/structure/closet/wardrobe/miner,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"aXx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/quartermaster/qm)
+"aXy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sign/departments/cargo{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aXs" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/westleft{
-	dir = 2;
-	name = "Cargo Desk";
-	req_access_txt = "50"
+"aXz" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aXA" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/space/basic,
+/area/space)
+"aXB" = (
+/obj/structure/sign/departments/evac,
+/turf/closed/wall,
+/area/security/checkpoint/customs)
+"aXC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aXt" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/westleft{
-	dir = 2;
-	name = "Cargo Desk";
-	req_access_txt = "50"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aXv" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Foyer";
+/area/quartermaster/storage)
+"aXD" = (
+/obj/item/banner/cargo,
+/turf/open/floor/wood,
+/area/quartermaster/qm)
+"aXE" = (
+/obj/machinery/computer/shuttle/mining{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown,
@@ -19116,60 +22239,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aXw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	freq = 1400;
-	location = "QM #3"
-	},
-/obj/effect/turf_decal/bot,
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #2";
-	suffix = "#2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aXx" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aXy" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad2"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aXz" = (
-/obj/machinery/door/poddoor{
-	id = "QMLoaddoor2";
-	name = "supply dock loading door"
-	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad2"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aXA" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad2"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aXB" = (
-/obj/structure/sign/departments/evac,
-/turf/closed/wall,
-/area/security/checkpoint/customs)
-"aXC" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/quartermaster/miningdock)
 "aXF" = (
 /obj/structure/chair{
 	dir = 4
@@ -19364,6 +22434,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"aXW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aXX" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom{
@@ -19420,6 +22500,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
+"aYc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aYd" = (
 /obj/machinery/door/airlock{
 	name = "Service Access";
@@ -19562,191 +22652,177 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aYn" = (
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_x = -32
+/obj/machinery/disposal/delivery_chute{
+	dir = 8
 	},
-/obj/machinery/computer/cargo{
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/plasticflaps,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aYo" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
 /obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aYp" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/landmark/start/cargo_technician,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aYq" = (
-/obj/item/stamp{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/stamp/denied{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aYr" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aYs" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aYu" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"aYo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"aYp" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aYq" = (
+/obj/structure/disposalpipe/segment,
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aYr" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aYs" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aYv" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	freq = 1400;
-	location = "QM #4"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aYw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/hallway/primary/central)
+"aYt" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aYu" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aYv" = (
+/obj/effect/decal/cleanable/robot_debris{
+	icon_state = "gib3"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aYw" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "aYx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/obj/structure/transit_tube,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space,
+/area/space/nearstation)
 "aYy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aYz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aYA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aYB" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad2"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aYB" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 24
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aYC" = (
-/obj/structure/grille/broken,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/science)
 "aYD" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/storage/box/matches,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 28
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science)
 "aYE" = (
-/obj/structure/table,
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/pipe_cleaner_coil/random,
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/disposal)
 "aYF" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 10
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/item/stack/rods{
-	amount = 25
+/obj/structure/transit_tube/curved{
+	dir = 1
 	},
-/obj/item/shard{
-	icon_state = "small"
-	},
-/obj/item/light/bulb,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space,
+/area/space/nearstation)
 "aYG" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
@@ -19894,6 +22970,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"aYW" = (
+/obj/structure/cable,
+/obj/structure/transit_tube_pod{
+	dir = 4
+	},
+/obj/structure/transit_tube/station/reverse{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aYX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -20064,125 +23150,125 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/structure/cable,
+/obj/structure/transit_tube/curved/flipped{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"aZj" = (
+/obj/machinery/light{
+	light_color = "#c9d3e8"
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/twelve_gauge{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aZk" = (
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Port Aft";
+	dir = 1;
+	network = list("ss13","engine")
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/power/apc/highcap/fifteen_k{
+	name = "Cargo Bay APC"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aZl" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"aZm" = (
+/obj/effect/turf_decal/plaque{
+	name = "security borg memorial plaque"
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aZn" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aZo" = (
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aZp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/quartermaster/office)
+"aZq" = (
+/obj/structure/cable,
+/obj/machinery/firealarm{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aZr" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aZs" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aZt" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aZj" = (
-/obj/machinery/status_display/supply{
+"aZu" = (
+/obj/machinery/vending/custom,
+/obj/machinery/door/window/westright{
+	name = "Cargo Delivery";
+	icon_state = "right";
 	dir = 4;
-	layer = 4;
-	pixel_x = -32
+	req_one_access_txt = "31;48"
 	},
-/obj/machinery/computer/bounty{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aZk" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aZl" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office";
-	req_access_txt = "31"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aZm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aZn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aZo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"aZp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aZq" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 3
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aZr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aZs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aZt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aZv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"aZw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "aZx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -20573,130 +23659,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bas" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/item/radio/intercom{
-	pixel_y = -26
+"bay" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Cargo Desk";
+	req_access_txt = "50"
 	},
-/obj/item/paper_bin{
-	layer = 2.9
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"bat" = (
-/obj/structure/table,
-/obj/item/clipboard,
-/obj/item/folder/yellow,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"bau" = (
-/obj/machinery/photocopier,
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Cargo Office";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"bav" = (
-/obj/machinery/power/apc{
-	areastring = "/area/quartermaster/office";
-	name = "Cargo Office APC";
-	pixel_x = 1;
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"baw" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"bax" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"baz" = (
+/obj/item/paper_bin,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"baA" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"baB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"baC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	name = "Cargo Bay APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"baD" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"baE" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	sortType = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"baF" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"baG" = (
-/turf/closed/wall,
-/area/maintenance/solars/starboard)
-"baH" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/multitool,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
 "baJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -21036,12 +24009,6 @@
 	icon_state = "carpetsymbol"
 	},
 /area/crew_quarters/bar)
-"bby" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bbz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -21051,117 +24018,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bbA" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Office Maintenance";
-	req_access_txt = "50"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/quartermaster/office)
-"bbB" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 6;
-	pixel_y = -5
-	},
-/obj/item/clothing/under/misc/mailman,
-/obj/item/clothing/head/mailman,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"bbC" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/hand_labeler,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"bbD" = (
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "bbE" = (
 /turf/closed/wall,
 /area/quartermaster/qm)
-"bbF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/quartermaster/qm)
 "bbG" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Quartermaster";
-	req_access_txt = "41"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"bbH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/table/wood,
+/obj/item/pen,
+/obj/item/paper_bin,
+/obj/item/hand_labeler,
+/turf/open/floor/carpet/red,
 /area/quartermaster/qm)
 "bbI" = (
 /turf/closed/wall,
 /area/quartermaster/miningdock)
-"bbJ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bbK" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bbL" = (
-/obj/machinery/power/smes,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
-"bbM" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
-"bbO" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
-"bbP" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space,
-/area/solar/starboard)
 "bbQ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -21341,6 +24210,10 @@
 	icon_state = "carpetsymbol"
 	},
 /area/crew_quarters/bar)
+"bcp" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "bcq" = (
 /obj/item/clothing/glasses/monocle,
 /obj/item/instrument/recorder,
@@ -21426,162 +24299,104 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "bcx" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/cargo)
-"bcy" = (
-/obj/item/chair,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/cargo)
-"bcA" = (
-/obj/structure/closet/secure_closet/quartermaster,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/airalarm{
+/obj/machinery/vending/custom,
+/obj/machinery/door/window/westright{
+	name = "Cargo Delivery";
+	icon_state = "right";
 	dir = 4;
-	pixel_x = -23
+	req_one_access_txt = "31;48"
 	},
-/obj/item/storage/belt/fannypack/yellow,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"bcy" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"bcB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/quartermaster/qm)
+/area/quartermaster/storage)
+"bcz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"bcA" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/cargo_technician,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"bcB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "bcC" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
+/obj/effect/landmark/start/cargo_technician,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"bcD" = (
-/obj/structure/closet/wardrobe/miner,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/area/quartermaster/storage)
 "bcE" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/area/quartermaster/storage)
 "bcF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bcG" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 23
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/area/quartermaster/storage)
 "bcI" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bcJ" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Starboard Solar Access";
-	req_access_txt = "10"
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
-"bcK" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
-"bcL" = (
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
-"bcN" = (
-/obj/machinery/power/solar_control{
-	dir = 8;
-	id = "starboardsolar";
-	name = "Starboard Solar Control"
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"bcO" = (
+/obj/machinery/conveyor_switch{
+	id = "cargo-autolathe"
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
-"bcS" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/starboard)
-"bcT" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/cable_coil,
-/turf/open/space,
-/area/solar/starboard)
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"bcP" = (
+/obj/structure/closet/crate/freezer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "bcV" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard)
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay";
+	req_one_access_txt = "31;48"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "bcX" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -21768,120 +24583,47 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"bdz" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/cargo)
-"bdD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"bdF" = (
-/obj/machinery/power/apc{
-	areastring = "/area/quartermaster/qm";
-	dir = 8;
-	name = "Quartermaster APC";
-	pixel_x = -25
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"bdG" = (
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "bdH" = (
-/obj/machinery/computer/bounty{
-	dir = 8
+/obj/machinery/button/door{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access_txt = "31"
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"bdI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"bdJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"bdM" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/six,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"bdR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/quartermaster/qm)
+"bdS" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"bdI" = (
+/area/quartermaster/storage)
+"bdT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
-"bdJ" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bdK" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/landmark/start/shaft_miner,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bdL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bdM" = (
-/obj/machinery/requests_console{
-	department = "Mining";
-	pixel_x = 32
-	},
-/obj/machinery/computer/security/mining{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bdQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/cargo)
-"bdR" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Starboard Solar APC";
-	pixel_x = -25
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
-"bdS" = (
-/obj/structure/chair/stool,
-/obj/item/cigbutt/cigarbutt,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
 "bdV" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -22262,74 +25004,13 @@
 "beI" = (
 /turf/closed/wall,
 /area/science/robotics/mechbay)
-"beJ" = (
-/obj/machinery/status_display/supply{
-	dir = 4;
-	layer = 4;
-	pixel_x = -32
-	},
-/obj/structure/filingcabinet,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"beK" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/quartermaster,
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"beL" = (
-/obj/machinery/computer/cargo{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"beM" = (
-/obj/machinery/mineral/equipment_vendor,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "beN" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/shaft_miner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"beO" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"beP" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"beR" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"beS" = (
-/obj/item/caution,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "beY" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Central";
@@ -22555,122 +25236,13 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
 "bfB" = (
-/obj/structure/table,
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_x = -30
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/item/paper_bin/carbon{
-	layer = 2.9
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"bfC" = (
-/obj/structure/table,
-/obj/item/clipboard,
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Cargo Quartermaster's Office";
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
-/obj/item/cartridge/quartermaster{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/cartridge/quartermaster,
-/obj/item/cartridge/quartermaster{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/obj/item/coin/silver,
-/obj/item/stamp/qm,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"bfD" = (
-/obj/item/radio/intercom{
-	pixel_y = -35
-	},
-/obj/machinery/computer/security/qm{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"bfE" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/pickaxe{
-	pixel_x = 5
-	},
-/obj/item/shovel{
-	pixel_x = -5
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Mining Dock";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bfF" = (
-/obj/effect/landmark/start/shaft_miner,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bfG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bfH" = (
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bfI" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	req_access_txt = "48"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/machinery/mineral/ore_redemption,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/quartermaster/miningdock)
-"bfJ" = (
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
+/area/quartermaster/storage)
 "bfK" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -22683,25 +25255,38 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"bfM" = (
-/obj/structure/chair{
+"bfR" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/space,
+/area/space/nearstation)
+"bfU" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"bfV" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"bfW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"bfN" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/paperplane,
-/obj/item/trash/chips,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"bfP" = (
-/obj/machinery/power/shieldwallgen,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "bfY" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -23017,27 +25602,24 @@
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
-"bgK" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Mining Dock APC";
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bgL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "bgM" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/area/quartermaster/storage)
+"bgQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Cargo Desk";
+	req_access_txt = "50"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "bgS" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -23230,109 +25812,16 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
-"bhp" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Mech Bay Maintenance";
-	req_access_txt = "29"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"bhq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"bhr" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Mining Maintenance";
-	req_access_txt = "48"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"bhs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "bht" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/machinery/newscaster{
+	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bhu" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bhv" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bhz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"bhB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/quartermaster/storage)
 "bhE" = (
 /obj/machinery/light{
 	dir = 4
@@ -23472,6 +25961,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
+"bia" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "bib" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
@@ -23483,6 +25984,21 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/crew_quarters/lounge)
+"bid" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "bie" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -23633,56 +26149,26 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
-"bix" = (
-/obj/effect/decal/cleanable/robot_debris{
-	icon_state = "gib3"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"biy" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"biz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"biC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/item/shard{
-	icon_state = "small"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "biD" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"biF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+"biG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"biH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "biI" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
@@ -23776,6 +26262,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"biQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "biR" = (
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -23951,33 +26444,37 @@
 "bju" = (
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
-"bjv" = (
-/obj/structure/closet,
-/obj/item/weldingtool,
-/obj/item/crowbar,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "bjw" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
+"bjy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"bjz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"bjA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "bjB" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"bjE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"bjF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+"bjG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "bjI" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood,
@@ -24189,6 +26686,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"bkl" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "bkm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sink{
@@ -24324,6 +26834,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"bkC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "bkD" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
@@ -24343,6 +26860,22 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"bkJ" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "qm_warehouse";
+	name = "warehouse shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"bkM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "bkQ" = (
 /obj/machinery/vending/snack,
 /obj/effect/turf_decal/stripes/line{
@@ -24832,6 +27365,16 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
+"blO" = (
+/obj/structure/table,
+/obj/item/folder/red,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "blP" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/light{
@@ -24851,6 +27394,27 @@
 /obj/machinery/rnd/bepis,
 /turf/open/floor/engine,
 /area/science/explab)
+"blV" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"blW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "blX" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -24931,6 +27495,12 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/storage/emergency/port)
+"bmm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "bmn" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -24942,6 +27512,12 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/port)
+"bmo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "bmp" = (
 /obj/structure/bodycontainer/morgue,
 /obj/machinery/light/small{
@@ -24975,6 +27551,12 @@
 "bmt" = (
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"bmu" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "bmv" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -25044,6 +27626,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"bmE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "bmH" = (
 /obj/machinery/holopad,
 /obj/machinery/navbeacon{
@@ -25205,20 +27793,16 @@
 "bnj" = (
 /turf/closed/wall,
 /area/science/xenobiology)
-"bnl" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+"bnk" = (
+/obj/machinery/computer/cargo,
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"bnn" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/department/cargo)
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "bno" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -25552,6 +28136,16 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"bob" = (
+/obj/machinery/computer/bounty,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "boc" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -25561,6 +28155,16 @@
 "bod" = (
 /turf/closed/wall,
 /area/science/explab)
+"boe" = (
+/obj/structure/filingcabinet,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "bof" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine{
@@ -25573,14 +28177,16 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"bom" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 2
+"boj" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Quartermaster";
+	req_access_txt = "41"
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/cargo)
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "bon" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -26012,6 +28618,13 @@
 /obj/item/relic,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"bpi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood,
+/area/quartermaster/qm)
 "bpn" = (
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -26019,11 +28632,6 @@
 /obj/item/wrench,
 /turf/open/floor/engine,
 /area/science/explab)
-"bpq" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "bpr" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -26161,6 +28769,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"bpK" = (
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/science/robotics/mechbay)
 "bpL" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26319,6 +28931,13 @@
 "bpY" = (
 /turf/closed/wall,
 /area/medical/chemistry)
+"bpZ" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/quartermaster/qm)
 "bqb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -26587,15 +29206,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"bqA" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "9;55"
+"bqy" = (
+/obj/effect/landmark/start/cargo_technician,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "bqC" = (
 /obj/machinery/monkey_recycler,
 /obj/structure/window/reinforced,
@@ -26682,15 +29302,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"bqO" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12; 55"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "bqS" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/entry";
@@ -27269,6 +29880,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"bsc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space)
 "bsd" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -27311,6 +29928,20 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"bsj" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "bsl" = (
 /obj/structure/sign/warning/vacuum/external,
 /obj/effect/spawner/structure/window/reinforced,
@@ -27804,6 +30435,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
+"btk" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "btl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -27814,6 +30459,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/explab)
+"btm" = (
+/obj/machinery/rnd/production/techfab/department/cargo,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "btp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27902,6 +30555,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"btG" = (
+/obj/structure/table,
+/obj/item/export_scanner,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = 22
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"btH" = (
+/turf/closed/wall,
+/area/maintenance/solars/starboard)
+"btJ" = (
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "btK" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -28140,6 +30821,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"buo" = (
+/obj/structure/table,
+/obj/item/lighter/greyscale,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "bup" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/effect/turf_decal/delivery,
@@ -28241,6 +30932,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/explab)
+"buA" = (
+/obj/structure/table,
+/obj/item/storage/briefcase,
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway Bridge";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "buB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -28343,6 +31047,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"buN" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"buO" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "buW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -28869,6 +31591,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"bwf" = (
+/obj/effect/landmark/start/quartermaster,
+/turf/open/floor/wood,
+/area/quartermaster/qm)
 "bwh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/purple,
@@ -29186,6 +31912,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"bwY" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/cargo)
 "bxa" = (
 /obj/structure/table/glass,
 /obj/structure/extinguisher_cabinet{
@@ -45663,10 +48394,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/crew_quarters/bar)
-"coL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/quartermaster/warehouse)
 "coN" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
@@ -47316,14 +50043,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"cvf" = (
-/obj/machinery/recycler,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbage"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "cvg" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -48677,12 +51396,6 @@
 "cCt" = (
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"cCB" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "cCF" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
@@ -48712,10 +51425,6 @@
 /obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"cCT" = (
-/obj/machinery/rnd/production/techfab/department/cargo,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "cCU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/portable_atmospherics/pump,
@@ -48738,23 +51447,6 @@
 /obj/machinery/vending/games,
 /turf/open/floor/plasteel/dark,
 /area/library)
-"cCX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"cCY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"cDa" = (
-/turf/closed/wall,
-/area/quartermaster/warehouse)
 "cDy" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -48930,10 +51622,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"daY" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "dbI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -49089,24 +51777,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"dqY" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "garbage"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"dse" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"dsv" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "dtm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -49216,14 +51886,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dLY" = (
-/obj/structure/table,
-/obj/item/assembly/igniter,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"dMB" = (
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "dMI" = (
 /obj/item/clothing/suit/apron/surgical,
 /turf/open/floor/plating{
@@ -49524,14 +52186,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"eCw" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "eDC" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel,
@@ -49719,10 +52373,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"eZA" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "faA" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/decal/cleanable/dirt,
@@ -49974,12 +52624,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"fwl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "fwr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -49996,11 +52640,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library/artgallery)
-"fwI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "fyO" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -50122,12 +52761,6 @@
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"fNv" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "fPk" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -50248,13 +52881,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"gfi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "gfo" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -50780,17 +53406,6 @@
 "gSH" = (
 /turf/closed/wall,
 /area/lawoffice)
-"gSI" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"gUb" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "gVc" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
@@ -51089,23 +53704,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"hKm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/door/window/westright{
-	name = "Cargo Delivery";
-	req_one_access_txt = "31;48"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "hMa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -51117,10 +53715,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"hOz" = (
-/obj/item/weldingtool,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "hPG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -51556,16 +54150,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/tcommsat/computer)
-"iCe" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 4;
-	node1_concentration = 0.8;
-	node2_concentration = 0.2;
-	on = 1;
-	target_pressure = 4500
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "iCs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -51627,10 +54211,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"iKb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
 "iLl" = (
 /obj/structure/sink{
 	pixel_y = 29
@@ -51689,9 +54269,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"iSi" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/cargo)
 "iSz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -51711,15 +54288,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"iWV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "iYO" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -51969,15 +54537,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"jBh" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "jBn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52198,12 +54757,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"jYA" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/cargo)
 "kbl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -52591,13 +55144,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"kIo" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	layer = 2.9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "kIO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -52623,11 +55169,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
-"kKI" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "kMO" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -54291,13 +56832,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"nZw" = (
-/obj/machinery/door/airlock{
-	name = "Backup Laboratory"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "oag" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -54307,20 +56841,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"obj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 24
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "oex" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -54616,17 +57136,6 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/carpet,
 /area/lawoffice)
-"oCX" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
 "oDP" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -54766,24 +57275,10 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/security/brig)
-"oPy" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	req_access_txt = "48"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "oQp" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"oRX" = (
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "oSa" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 4
@@ -54811,17 +57306,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"oTl" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 28
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "oTp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55118,11 +57602,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"pKd" = (
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "pKg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -55520,11 +57999,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/lobby)
-"qAM" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/cigbutt,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "qBv" = (
 /obj/item/clothing/head/ushanka,
 /turf/open/floor/plating,
@@ -55588,14 +58062,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"qJB" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/department/cargo)
 "qMi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -55731,13 +58197,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"rax" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "garbage"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "reH" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/structure/disposalpipe/segment{
@@ -55914,11 +58373,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"rud" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "rue" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -55950,12 +58404,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"rxa" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "rxQ" = (
 /obj/machinery/door/airlock{
 	id_tag = "PottySci";
@@ -56116,10 +58564,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"rWE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
 "rXT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56326,15 +58770,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"sqQ" = (
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"srZ" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "ssx" = (
 /obj/item/shard,
 /turf/open/floor/plating,
@@ -56348,13 +58783,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"sut" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
 "svK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -56521,16 +58949,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"sQt" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Dock Airlock";
-	req_access_txt = "31"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
 "sQP" = (
 /turf/closed/wall/r_wall,
 /area/space)
@@ -56596,10 +59014,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"sZh" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "sZu" = (
 /obj/item/storage/backpack/satchel/explorer,
 /turf/open/floor/plating,
@@ -56917,10 +59331,6 @@
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"tDn" = (
-/obj/item/wrench,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "tFt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -57833,26 +60243,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"vzP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"vzT" = (
-/obj/structure/table,
-/obj/item/stack/rods{
-	amount = 5;
-	layer = 3.3
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/assembly/prox_sensor{
-	pixel_y = 2
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "vCC" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -58291,15 +60681,6 @@
 /obj/structure/chair,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
-"wAI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "wBb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -58361,13 +60742,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/lobby)
-"wDZ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "wEn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -58468,12 +60842,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"wOf" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "wOF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
@@ -58497,14 +60865,6 @@
 	},
 /turf/closed/wall/mineral/iron,
 /area/library/artgallery)
-"wQU" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/department/cargo)
 "wRk" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -58600,13 +60960,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"xah" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/cargo)
 "xan" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -58620,13 +60973,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
-"xau" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "xaF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/mirror{
@@ -58945,11 +61291,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"xyl" = (
-/obj/structure/table,
-/obj/item/assembly/timer,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "xyB" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
@@ -59148,11 +61489,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"ybX" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "ycr" = (
 /obj/structure/target_stake,
 /obj/item/target/syndicate,
@@ -59203,11 +61539,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"ygZ" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "yhB" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -94569,7 +96900,7 @@ aMb
 aNA
 aOK
 aMb
-aRd
+aXa
 aMb
 sYY
 aUi
@@ -94826,17 +97157,17 @@ aEa
 aJY
 aOL
 aEa
+aXv
 aEa
 aEa
-aEa
-aUj
-aJI
-aDZ
-aHN
-aDZ
-aDZ
-aDZ
-bby
+bcJ
+beN
+aBJ
+awi
+aBJ
+aBJ
+aBJ
+biG
 aDZ
 aDZ
 aDZ
@@ -95078,26 +97409,26 @@ aGU
 ibF
 aJd
 aJZ
-aAL
+agG
 aMc
-aNB
+aOR
 bbz
 aPS
-aRe
-aMc
-mgC
+aXy
+aYs
+aLh
 aUk
 aJZ
-aMc
-aXr
-aMc
-aZi
-aMc
-bbz
+aAL
+aUH
+aAL
+aAL
+aAL
+bfg
 aMc
 aPS
-aAL
-aGU
+aMc
+aZt
 aAL
 aJZ
 aAL
@@ -95337,24 +97668,24 @@ aJe
 aKa
 aLe
 aLe
-aNC
-aRf
+aPi
 aLe
 aLe
-aPW
-aSY
-aUl
-aUs
-aPW
-aLf
-aLf
-aLf
-aLf
-aLf
-aEj
-aEj
-aEj
-aEj
+aLe
+aiI
+aBJ
+aVG
+aKf
+aWt
+aWy
+aWD
+aDZ
+aDZ
+aZq
+bwm
+bwm
+bwm
+bwm
 bgB
 aJI
 aDZ
@@ -95593,25 +97924,25 @@ aIg
 aJf
 aKb
 aLe
-aMd
-aND
-aOO
-aPT
-aRf
-aSc
-xau
-aOT
+aoE
+aPj
+aRK
+aUw
+aLe
+aoL
+aBJ
+aVH
+aOS
+aWu
 aVp
-aWs
-aPW
-aYn
-aZj
-bas
-aLf
-bcx
-bdz
-aFi
-bfu
+aWG
+aOS
+aDZ
+aTv
+bwm
+lWy
+lWy
+aND
 aDZ
 aJI
 bhP
@@ -95849,26 +98180,26 @@ awd
 jYe
 aBJ
 aJI
-aLe
-aMe
-aNE
-aOP
-aPU
-aRg
-aSd
-aTa
-aOT
-aVq
-aWt
-aXs
-aYo
-aVu
-bat
-aLf
-bcy
-qAM
-aEj
-aEj
+aMt
+aNF
+aQd
+aTF
+aUx
+aWB
+atr
+aUo
+aNT
+aOW
+aWw
+aWA
+aWH
+aPR
+aPR
+aZr
+aJA
+aLo
+aMo
+bwm
 bgC
 bhi
 bhQ
@@ -96105,26 +98436,26 @@ aaa
 awd
 jYe
 aBJ
-aJH
-aLe
-aMf
-aNF
-aOQ
-aPV
-aRf
-aSc
-aSZ
-aUm
-aVp
-aWu
-aXt
-aYp
-aPY
-bau
-aLf
-aFi
-aFi
-beI
+aJI
+aMt
+aNH
+aQk
+aQd
+aUx
+aWB
+atr
+aUy
+aJI
+aVK
+aWs
+aZm
+aZn
+aZo
+aWs
+aZs
+bwm
+aLp
+bpK
 beI
 bgD
 bhj
@@ -96362,25 +98693,25 @@ aET
 aET
 jYe
 aBJ
+bhd
+aMt
+aOM
+aQl
+aUj
+aOP
+aWC
+att
+aUz
 aJI
-lAs
-lAs
-iKb
-aOR
-iKb
-lAs
-lAs
-aTb
-aOT
-aVp
-aWu
-aPW
-aYq
-aPY
-bav
+aVK
+aWs
 aLf
-aFi
-jBh
+aLf
+aLf
+aLf
+aLf
+bwm
+aLp
 beI
 bfv
 bgE
@@ -96620,24 +98951,24 @@ aET
 jYe
 aBJ
 aJI
-lAs
-aMg
-aNH
-aOS
-aPX
-aRh
-aSe
-aTc
-aOT
-aVp
-aWu
-aPW
-aYr
-aOV
-baw
-bbA
-rud
-aTv
+aMt
+aOP
+aQk
+aQk
+aOP
+aXg
+aER
+aBJ
+aJI
+aVK
+aWx
+aVI
+aVJ
+aWz
+aGW
+btJ
+bwm
+aLp
 beI
 bfw
 bgF
@@ -96877,24 +99208,24 @@ aET
 hFy
 aJh
 bhe
-lAs
-aMh
-aNI
-fwl
-dMB
-aRi
-aSf
-aTd
-aUn
-aVr
-aWu
-aLf
-aYs
-aZk
-bax
-aLf
-aFi
-cCX
+aLe
+aoF
+aQo
+aUl
+aWv
+aLe
+aER
+aBJ
+aJI
+aVK
+aWs
+aZp
+bcO
+aPY
+aPY
+aIw
+bwm
+aLp
 beI
 bfx
 bgG
@@ -97134,24 +99465,24 @@ aHn
 aIi
 aIN
 aKe
-lAs
-aMi
-aNJ
-fwl
-aPZ
-aRj
-lAs
-aTe
-aUo
-aVs
-aWv
+aLe
+aLe
+aRh
+aUm
+aLe
+aLe
+aFZ
+aBJ
+aJI
+aVK
+aWs
+aZp
+bnk
+aPY
+bkM
+buo
 aLf
-aPW
-aZl
-aPW
-aLf
-aLf
-cCX
+aLp
 beI
 bfy
 bgH
@@ -97392,23 +99723,23 @@ jYe
 aBJ
 aJI
 lAs
-aMj
-aNK
-fwl
-dMB
-dMB
-iKb
-aTf
-aUp
-hKm
-aVt
-aVt
-aVt
-aZm
+aOT
+aWZ
+apW
+azL
+aCa
+aMM
+aBJ
+aJI
+aVK
+aWs
+aZp
+bob
 aPY
-bbB
+bjA
+buA
 aLf
-bdD
+aLp
 beI
 bfz
 bgI
@@ -97649,30 +99980,30 @@ jYe
 aBJ
 aJI
 lAs
-aMk
-aNL
 aOU
-aQa
-aRk
-aSg
-aTg
-aUq
-aVu
-aPY
-aPY
-aPY
-aZn
-aPY
-bbC
+aPc
+aPr
+aYn
+aNX
+aPT
+aBJ
+bhd
+aVL
+aXr
+aZp
+boe
+bmm
+bjA
+aXt
 aLf
-cCX
+aLp
 beI
 bfA
 bgJ
 bhn
 bhV
 beI
-aKq
+hXt
 bkx
 blM
 bmS
@@ -97906,30 +100237,30 @@ coy
 awf
 aJI
 lAs
-aMl
-aNM
-dse
-aQb
-aRl
-aSh
-aTh
-aUr
-aVv
-aWw
-aXv
-aYu
-aOT
-aPY
-bbD
+aOV
+aPd
+aSc
+aYo
+aNX
+aER
+aBJ
+aJI
+aVK
+aWs
+bay
+bqy
+bmo
+bjA
+buN
 aLf
-bdD
+aLp
 beI
 beI
 beI
-bhp
+aPG
 beI
 beI
-bjv
+aTq
 bkx
 blN
 bmT
@@ -98163,30 +100494,30 @@ aDZ
 aJk
 aJH
 lAs
-aMm
-lAs
-aOW
-lAs
-lAs
-lAs
-aSY
-aUs
+aps
+aPg
+aPr
+aVr
+aNX
+aER
+aBJ
+aJI
+aVK
+aWs
+bgQ
+bia
+bmo
+bjA
+buO
 aLf
-aLf
-aLf
-aLf
-aUl
-baz
-aLf
-aLf
-cCY
-rud
-rud
-rud
-bhq
-bcI
-bix
-ygZ
+aLq
+aMq
+aMq
+aMq
+aXz
+aYt
+aYv
+aTu
 bkx
 blM
 bmU
@@ -98420,29 +100751,29 @@ aBI
 awj
 aKf
 lAs
-aMn
-lAs
 aOX
-lAs
-aRm
-aLg
-aTi
-aUt
+aPs
+bcA
+aVt
+aNX
+aER
+aBJ
+aJI
+aVK
+aWs
+bgQ
+bia
+bmo
+bjA
+aIx
+bbE
+bbE
+bbE
 aVw
-aWx
-aXw
-aYv
-aZo
-aTm
 bbE
 bbE
 bbE
-bbE
-bbE
-bbE
-aEj
-aEj
-biy
+aYt
 bjw
 bjw
 bjw
@@ -98676,30 +101007,30 @@ aEd
 aIj
 aJm
 aKg
-cDa
-aMo
-cDa
-cDa
-cDa
-cDa
-aLg
-wDZ
-aUu
-aVx
-aVx
-aVx
-aYw
-aZp
-aZt
-bbF
-bcA
-bdF
-beJ
-bfB
+lAs
+abL
+acx
+ats
+aVt
+aNX
+aSz
+aTv
+aTI
+aWk
+aYq
+awG
+aWc
+aCb
+aHa
+aIy
+bdR
+aTh
+aTx
+aTD
+aTV
+aXD
 bbE
-aZv
-aUC
-biz
+aYt
 bjw
 bky
 blP
@@ -98934,29 +101265,29 @@ aEd
 aJn
 aEd
 aEd
-aMp
-aNN
-aOY
-aQc
-aRn
-aSi
-aTk
-aUv
-aVy
-aWy
-aXx
-aYx
-aZq
-baA
-bbG
-bcB
-bdG
-beK
-bfC
+abM
+aHX
+agm
+acA
+lAs
+aZu
+bcx
+bcV
+bfB
+aVA
+aLf
+aLf
+aDn
+aHf
+aLf
 bbE
-aTx
-aEj
-aTx
+aTo
+bwf
+aVx
+bbG
+aPV
+bbE
+aYt
 bjw
 bkz
 bky
@@ -99191,29 +101522,29 @@ aGF
 aFI
 aKh
 aEd
-aMq
-aNO
-aOZ
-aQd
-aRo
-aSj
-aTl
-aUw
-aTm
-aTm
-aTm
-aYy
-aZo
-baB
-bbH
-bcC
-bdH
-beL
-bfD
+abM
+acG
+agC
+aje
+aNX
+aXs
+bcy
+bfU
+aBw
+aQq
+bkl
+bid
+btk
+blV
+aIz
+boj
+bpi
+bpZ
+aVy
+aVF
+aPW
 bbE
-aTx
-aEj
-aTx
+aYt
 bjw
 bkA
 blR
@@ -99448,29 +101779,29 @@ aIk
 aJo
 aGF
 aEd
-aMr
-aNO
-aPa
-aNO
-aRp
-aSk
-aTm
-aUt
-aVz
-aWz
-aVz
-aYz
-aZo
-baC
-bbI
-bbI
-bdI
-bdI
-bdI
-bbI
-bhr
-bbI
-aTx
+apO
+acH
+agC
+aji
+anA
+biQ
+bcB
+bfV
+bjy
+bcp
+bkC
+bcp
+bcp
+blW
+aFS
+aJB
+aLr
+aMx
+aNE
+aOr
+aPX
+bbE
+aYt
 bjw
 bkB
 blS
@@ -99705,29 +102036,29 @@ aEd
 aEd
 aKi
 aEd
-aMs
-aNO
-aPb
-aQe
-cDa
-cDa
-aTn
-aUx
-aVA
-aTm
-aTm
-aTj
-aZr
-baD
-bbI
-bcD
-bdJ
-beM
-bfE
-bgK
-bhs
-bbI
-aTx
+apU
+lAs
+apZ
+ajw
+anW
+aou
+bcz
+bfW
+bjz
+bjG
+bjG
+aSZ
+bjG
+bmu
+aIA
+aJC
+aLs
+aMy
+aNG
+aOQ
+aPV
+bbE
+aYt
 bjw
 aaj
 aaj
@@ -99962,30 +102293,30 @@ aIl
 aEd
 aKj
 aEd
-aMt
-aNP
-aPb
-aNO
-aNP
-cDa
-aTo
+abQ
+lAs
+agO
+aki
+aNX
+aoD
+aNB
+bmE
+aPp
 aSk
-aTm
-aTm
-aTm
-aYy
-aZs
-baE
-bbJ
-bcE
-bdK
-beN
-bfF
-bgL
-bht
-bbI
-biC
-biz
+blO
+bsj
+btm
+btG
+aIB
+aXx
+aLt
+aMA
+aNI
+aOY
+aPZ
+aRu
+aYr
+aLo
 aaj
 aak
 aam
@@ -100219,30 +102550,30 @@ aEd
 aEd
 aEd
 aEd
-aMu
-aNO
-aPc
-aQf
-aRq
-cDa
-aTp
-aSk
-aTm
-aTm
-cCB
-aYA
-aZt
-aZp
-bbK
+abR
+lAs
+lAs
+akS
+lAs
+aHB
 bcF
-bdL
-beO
-bfG
-bgM
-bhu
-bbI
-aFi
-aTx
+bmE
+aPU
+bht
+aLg
+aLg
+aLg
+aLg
+aLg
+bbE
+bbE
+bbE
+bbE
+bbE
+bbE
+bbE
+bwm
+aLp
 aaj
 aau
 aaC
@@ -100474,32 +102805,32 @@ aGF
 aHq
 aIl
 aEd
-aKk
-aLh
-aMv
-aNQ
-aNO
-aQg
-aNP
-cDa
-aTq
-aSk
-aVB
-aWA
-aXy
-aYB
-cCT
-baF
-bbI
-bcG
-bdM
-beP
-bfH
-bfH
-bhv
-bbI
+afW
+aFi
+aMw
+aFi
+aFi
+aMw
 aEj
-aTx
+aJi
+bcC
+bmE
+aPU
+aUr
+aLg
+bcP
+bdI
+bgM
+aID
+aKc
+aLg
+aMB
+aNJ
+aMo
+aMo
+aRv
+bwm
+aLp
 aal
 aaw
 aan
@@ -100731,32 +103062,32 @@ aEd
 aEd
 aEd
 aEd
-cCX
-cDa
-cDa
-cDa
-coL
-coL
-coL
-cDa
-aTr
-aUy
-aPd
-aUy
-aXz
+aFi
+aEj
+abn
+acQ
+agU
+abs
+aEj
+aoG
+bcp
+bmE
+aPU
+aUE
 aLg
-aLg
-aLg
-bbI
-bbI
-bbI
+bdH
+bdM
 bdI
-bfI
+aIE
 bdI
-bbI
-bbI
-aGP
-aTx
+aLg
+aMC
+lWy
+aOZ
+aNV
+aRy
+bwm
+aLp
 aat
 aay
 aav
@@ -100988,32 +103319,32 @@ aGI
 aHr
 aEd
 aJp
-cCY
-aLi
+aFi
+aUc
+aYz
+aFi
+aFi
 aMw
 aEj
-aaa
-aaa
-aaa
-aLg
-aTs
-aUz
-aPd
-aWB
-aXA
-aLg
-aaa
-aaa
-aaa
-aaa
-aaa
+aJl
+bcE
+aOi
+aQp
+aTm
+aTB
 bdI
-bfJ
+aDs
+aHi
+aIF
 bdI
-aaa
-aEj
-pKd
-aTx
+aLg
+aMF
+aNK
+aPa
+aQa
+aRz
+bwm
+aLp
 aaj
 aaA
 aao
@@ -101245,32 +103576,32 @@ aGJ
 aGJ
 aDl
 aEk
-aEk
-aLj
-aMx
+aOe
+aQg
+aUD
+aTA
+aUD
+akY
 aEj
-aaa
-aaa
-aaa
-aLg
-aTr
-sQt
-aPd
-sQt
-aXz
-aLg
-aaa
-aaa
-aaa
-aaa
-aaa
+aMQ
+bcp
+bdS
+aXC
+aXC
+bkJ
+bdJ
+aDT
+aHj
+aIG
 bdI
-oPy
-bdI
-aaa
-aEj
-aEj
-aTx
+aLg
+aMG
+aNP
+aPe
+aQc
+aSd
+bwm
+aLp
 bjw
 bjw
 aap
@@ -101501,34 +103832,34 @@ aEd
 aEd
 aEd
 aEd
+axY
+aFi
+aVE
 aEj
 aEj
-aKq
-aJs
 aEj
-aaa
-aaa
-aaa
-aaa
-aaa
-aUA
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bfK
-aaa
-aaa
-aaa
+ald
 aEj
-obj
-aLi
+aSS
+bcp
+bmE
+aTm
+aTm
+awJ
+bdI
+bdI
+bdI
+bdI
+aIJ
+aLg
+aMH
+aNQ
+aPf
+aQf
+aNL
+aNS
+aYB
+aUB
 tim
 eXo
 bof
@@ -101756,36 +104087,36 @@ aur
 atn
 aFN
 aGK
-aHs
+aKo
 aEj
-aJq
-aKn
-aKn
-aMy
-aEj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aEj
-aTx
-aFi
+aJr
+azW
+aRe
+aRA
+aTl
+aLg
+aln
+anZ
+aoM
+bcz
+aqk
+bjG
+bjG
+awK
+azM
+aDW
+aHk
+aIH
+bdI
+aLg
+aMG
+aNR
+aPh
+aQh
+aSe
+bwm
+aYC
+aSh
 bjw
 nJI
 bky
@@ -102015,34 +104346,34 @@ aFO
 aGL
 aHt
 aEj
-aJr
+aJt
 aEj
 aLk
-aLk
-aEj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aEj
-aTx
-aEj
+aFi
+aGN
+aLg
+alN
+aTm
+biH
+bcp
+bmE
+aTm
+aTm
+awJ
+bdI
+aXe
+bdI
+aIE
+aKd
+aLg
+aMI
+aNU
+aOZ
+aQi
+aSf
+bwm
+aLp
+bwm
 bjw
 xPa
 boh
@@ -102272,34 +104603,34 @@ aFP
 aGM
 aFi
 bfu
-aJs
-aKo
-aLl
-aMz
+aKn
 aEj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aEj
-aTx
-aFi
+aHs
+aSl
+aGN
+aLg
+alX
+aTm
+biH
+bcp
+bmE
+aTm
+aZj
+aLg
+azO
+aEV
+bdI
+aII
+bdI
+aLg
+aMJ
+aNV
+aOZ
+aQj
+aSg
+bwm
+aLp
+lWy
 bkD
 vxp
 boc
@@ -102526,37 +104857,37 @@ aur
 aur
 atn
 aFQ
+aOO
+aPb
+aEj
+aMp
+aEj
+aRt
+aSt
 aGN
-aGN
-aEj
-aJt
-aFi
-aFi
-aEj
-aEj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aEj
-aTx
-aEj
+aLg
+amj
+aTm
+biH
+apN
+bfV
+bcp
+aZk
+aLg
+bdI
+aEX
+aHv
+aIJ
+aKc
+aLg
+aMK
+aNW
+aPk
+aNL
+aSh
+bwm
+aLp
+bwm
 bjw
 bjw
 bjw
@@ -102786,38 +105117,38 @@ aEj
 aEj
 aEj
 aEj
-aJs
-aKp
-aFi
-aMA
+aMr
 aEj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aEj
-aEj
-aEj
-aEj
-aEj
-aEj
-aEj
-aEj
-oTl
-vzP
-vzP
-iWV
-aFi
-bpq
+aRf
+aRi
+aTp
+aLg
+aml
+aTm
+biH
+bcp
+bmE
+aTm
+aZl
+aLg
+aLg
+aLg
+aHw
+aHw
+aHw
+aHw
+aHw
+aHw
+aHw
+aNS
+bwm
+bwm
+aYD
+aUC
+aUC
+aVe
+lWy
+aVB
 bnj
 brT
 bxF
@@ -103041,41 +105372,41 @@ aEj
 aFf
 hUt
 aFi
-aFi
+aRm
 aFi
 aJs
-aFi
-aFi
-aFi
-aEj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aEl
-bdQ
-beR
+aRw
+aQn
+aTd
+aTr
+aLg
+aeH
+aoa
+biH
+bcp
+bmE
+asq
+atu
+awM
+azP
+aFg
+aHx
+aIK
+aKk
+aLJ
+aWL
+aNY
+aHw
+aXW
+aSj
+aSj
+aTN
+hXt
+bwm
+aVq
 aUC
 aUC
-eCw
-aUC
-aUC
-aZw
-aKq
-aEj
-wAI
-vzP
-vzP
-bqA
+aVC
 brU
 roa
 buK
@@ -103294,37 +105625,37 @@ azF
 aAU
 aBZ
 aDl
-aEk
-aEk
-aEk
-aEk
-aEk
-aEk
-aJv
-aKn
-aKn
-aMB
+aMv
+aPu
+aPu
+aPu
+aPu
+aQe
+aTG
 aEj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aEj
-aTx
-aEj
-aKq
-aEj
-gfi
-aEj
+aRi
+aTe
+aTs
+aLg
+amE
+aTm
+biH
+bcp
+bdS
+aXC
+aXC
+aXC
+aXC
+aFh
+aHy
+aIO
+aKl
+aLM
+aMN
+aNZ
+aHw
+aYc
+bwm
 bkF
 bkF
 bkF
@@ -103551,36 +105882,36 @@ avm
 avm
 atn
 atn
-aEj
-aEj
+aMw
+aQm
 aEj
 aEj
 aHu
 aEj
 aEj
-aKq
 aEj
-aJs
-aEj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aEl
-aTx
-aFi
-aFi
-aEj
-bhz
+aSq
+aTg
+aTt
+aLg
+aeH
+aoc
+biH
+bcp
+aqH
+bcp
+bcp
+bcp
+bcp
+bcp
+aXj
+aIQ
+aIQ
+aIQ
+aIQ
+aOa
+aHw
+aYc
 lEn
 pnU
 pnU
@@ -103805,39 +106136,39 @@ abI
 aaa
 aaa
 aaa
-abI
-abI
-abI
 aEj
-aFg
-aFR
+abh
+aIp
+aMw
+bcI
 aGO
 aFi
 aGO
 aFi
 aFi
-aEj
-aJs
-aEj
-aEj
-aEl
-aEl
-aEl
-aEl
-aEj
-aEj
-aht
-aht
-aEj
-aEl
-aEl
-aEj
-aEj
-aTx
-aFi
-aFi
-aEj
-gfi
+aSi
+aLg
+aLg
+aLg
+aLg
+aeH
+aTm
+aoN
+bjG
+aqJ
+bjG
+bjG
+axd
+azQ
+azQ
+aHD
+aIU
+aKm
+aLN
+aMO
+aOb
+aHw
+aYc
 lEn
 uwb
 bjB
@@ -104062,39 +106393,39 @@ aaa
 aaa
 aaa
 aaa
-aaa
-abI
-aaa
 aEj
-aFh
-aEj
-aGP
+abi
+aIp
+aMw
+aQA
 aEj
 aIp
 aEj
 aEj
 aEj
-aJs
-aFi
-aFi
-aFi
-aFi
-aFi
-aFi
-aUB
-aEl
-aaa
-aaa
-aEl
-aZv
-aUC
-aUC
-aUC
-aZw
-beS
-aFi
-aEj
-gfi
+aTw
+aLg
+abS
+ady
+ahb
+ana
+aTm
+biH
+aMu
+aqK
+aTm
+aty
+axf
+azR
+aFj
+aHx
+aIW
+aKp
+aLO
+aKp
+aOc
+aHw
+aYc
 lEn
 biD
 biD
@@ -104316,42 +106647,42 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aEl
-aFi
-aEj
-aEj
+aEl
+aEl
+aEl
+abj
+aIp
+aqc
+aON
 aEj
 aIq
 aJw
 aKr
 aEj
-aMD
-aPf
-aQj
-aRs
-rud
-aSl
-aTv
-aGO
-aEj
-aEj
-aEj
-aEj
-aTx
-aGO
-bcI
 aFi
-aFi
-aFi
-bfM
-aEj
-bhz
+aLg
+abT
+aeH
+ahc
+bjG
+bjG
+aoQ
+aTm
+aqK
+aTm
+aTm
+axs
+azT
+aFl
+bbI
+bdT
+bdT
+bdT
+bdT
+bdT
+bbI
+aYc
 lEn
 vYN
 vYN
@@ -104572,44 +106903,44 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aEj
-aFj
-aEj
-aEj
+aht
+aad
+aFi
+aaZ
+aFi
+aFi
+aFi
+aqc
+aFi
 aEj
 aEl
 aEj
 aEj
-aLm
-aLm
-aLm
-aQk
-aRt
-aLm
-aLm
-aTw
-aUC
-aVE
-aUC
-aUC
-aUC
-aZw
-aFi
-bcI
-aFi
-aFi
-kIo
-bfN
 aEj
-gfi
-aEj
+aLl
+aLg
+abU
+aeH
+aTm
+aTm
+aTm
+biH
+aKt
+aqW
+aTm
+aTm
+aTm
+aTm
+aFq
+bdT
+aIY
+aKq
+aLP
+aMP
+aOd
+bbI
+aYc
+bwm
 bkF
 bkF
 bkF
@@ -104830,45 +107161,45 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-ahi
-ahi
-ahi
-aaa
-aaa
-aaa
-aaa
-aLn
-aNT
-rax
-aQo
-aPg
-aRu
-srZ
-aLm
-aTx
+aEl
+aEl
+aEl
+aba
 aEj
 aEj
-aEj
-aEj
-aYC
-baG
-baG
-bcJ
-baG
-baG
-aEj
-aEj
-aEj
-bhB
-fwI
-fwI
-bjE
+aqc
+aFi
+aFi
+bwY
+aFi
+aFi
+aFi
+abE
+aLg
+abX
+aeH
+ahe
+aTm
+aTm
+biH
+aMR
+aqX
+asr
+aXC
+aXC
+aXC
+aFR
+aTa
+aJg
+aTb
+aLX
+aTy
+aTE
+aUh
+aYp
+aYr
+aYy
+aYt
 bkF
 bnj
 bnj
@@ -105089,43 +107420,43 @@ aaa
 aaa
 abN
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aLm
-aLm
-aNU
-dqY
-aPh
-aRv
-sZh
-aLm
-aTx
-aEj
-aVF
+aqG
+abb
+abk
 aFi
-aFi
-aFi
-baG
-bbL
-bcK
-bdR
-baG
-bfP
-bfP
+aqf
+aEj
+aEj
+abx
 aEj
 aEj
 aEj
-aKq
-gfi
+aLg
+aLg
+abZ
+aeH
+aTm
+anh
+aTm
+biH
+aMR
+aTm
+aRs
+aTm
+aTm
+aTm
+aXf
+bbI
+aXu
+aTc
+aKs
+aTC
+aOj
+bbI
+bwm
+bwm
+aSU
+aYt
 bkF
 blX
 blX
@@ -105346,43 +107677,43 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aLm
-aME
-aNV
-dqY
-aPh
-aRw
-sqQ
-aLm
-aTy
-aEj
-aEj
-aHu
-aEj
-aEj
-baG
-bbM
-bcL
-bdS
-baG
-kKI
+aqG
+abc
 aFi
-hOz
+aFi
+aqc
 aEj
-oRX
-biF
-bjF
+abu
+aFi
+aFi
+abA
+aEj
+abF
+abH
+aca
+aeH
+aTm
+aTm
+aTm
+aoZ
+apY
+bjG
+bjG
+bjG
+bjG
+bjG
+aFT
+aIm
+aJj
+aKu
+aLZ
+aMS
+aOl
+bbI
+aQy
+aSm
+aYu
+aYt
 bkF
 bnh
 bBU
@@ -105603,43 +107934,43 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aLo
-aMF
-aNW
-dqY
-cvf
-aQn
-sqQ
-aSm
-aTz
+aqG
+abd
+abl
+abo
+aql
 aEj
-aVG
+abv
 aFi
-aFi
-aYD
-baG
-baH
-bcK
-bcN
-baG
-eZA
-tDn
-aFi
-nZw
-aFi
-gfi
-aFi
+abz
+abB
+aEj
+abG
+abK
+acb
+aeH
+abK
+ann
+abK
+aKt
+aNl
+abK
+aRx
+abK
+abK
+abK
+aXi
+bdT
+aXw
+aKv
+aXE
+aNk
+aOn
+bbI
+aQG
+aSn
+aYu
+lWy
 bkF
 bni
 blX
@@ -105860,43 +108191,43 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aLo
-aMG
-aNX
-dqY
-rax
-aRy
-aSn
-aSn
-aTA
-aEj
-aVH
+aqG
+abe
 aFi
-aXC
-aYE
-baG
-rWE
-bbO
-rWE
-baG
-vzT
-gUb
-aFi
+abp
+aqc
 aEj
-gSI
-gfi
-bfM
+abw
+aFi
+abz
+abC
+aEj
+aVA
+aVA
+aVA
+afY
+ahf
+aVA
+ahf
+apx
+aVA
+aVA
+aVA
+aVA
+aVA
+aVA
+aVA
+bbI
+bdT
+aKw
+bdT
+bdT
+bbI
+bbI
+bwm
+aSo
+aYu
+aUn
 bkF
 nWw
 pDf
@@ -106117,43 +108448,43 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aLm
-aMH
-aNY
-aPi
-aQp
-aRz
-daY
-aSo
-aTB
+aqG
+abg
+abm
+abr
+atD
 aEj
-aVI
-aFi
-aXC
-aYF
-baG
-sut
-bcK
-rWE
-baG
-dsv
-dLY
-xyl
 aEj
-aKq
-gfi
-ybX
+aEl
+aEl
+aEl
+aEj
+aaa
+aaa
+aVA
+agk
+ahg
+aVA
+aoi
+apy
+aVA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bdT
+aSr
+bdT
+aaa
+aaa
+aaa
+bwm
+hXt
+aYu
+aUp
 bkF
 bnh
 blX
@@ -106374,6 +108705,26 @@ aaa
 aaa
 aaa
 aaa
+aht
+bQi
+bQi
+abt
+ano
+abI
+bBW
+bBW
+bBW
+bBW
+aaa
+aaa
+aaa
+aVA
+afY
+ahE
+aVA
+ahE
+apx
+aVA
 aaa
 aaa
 aaa
@@ -106381,36 +108732,16 @@ aaa
 aaa
 aaa
 aaa
+bdT
+aKx
+bdT
 aaa
 aaa
 aaa
-aaa
-aLm
-aLm
-aLo
-aLm
-aLo
-aLm
-aLm
-aLm
-aLm
-aEj
-aEj
-aEl
-aEl
-aEl
-baG
-rWE
-oCX
-rWE
-baG
-aEj
-aEj
-aEj
-aEj
-aEj
-bhz
-bfM
+bwm
+bwm
+aYA
+aUn
 bkF
 blX
 blX
@@ -106634,40 +108965,40 @@ aaa
 aaa
 aaa
 aaa
+abD
+aMj
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+bBW
+bBW
+mZE
+mZE
+aUA
 aaa
+mZE
+mZE
+mZE
+bBW
+bBW
+bBW
+bBW
 aaa
-aaa
-abI
-abI
-abI
-aaa
-aaa
-abI
-abI
-abI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bbP
-aaa
-aaa
-aaa
-aaa
+bBW
+bBW
+mZE
+bfK
+mZE
+bBW
+bBW
 aaa
 aht
-aEl
-gfi
-ybX
+rNB
+aYu
+aUp
 bkF
 pDf
 pDf
@@ -106888,43 +109219,43 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abP
 mZE
 aaa
+abD
+aMj
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-bbP
+bBW
+bBW
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+bBW
+bBW
+bBW
+bBW
+aaa
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
 aaa
 aht
-aEl
-gfi
-fNv
+rNB
+aYu
+dmP
 bkF
 bnh
 blX
@@ -107145,43 +109476,43 @@ aaa
 aaa
 aaa
 aaa
+abP
+aht
+aht
+abD
+aMj
 aaa
 aaa
 aaa
 aaa
 aaa
+bBW
 aaa
 aaa
 aaa
 aaa
 aaa
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bbP
-aaa
-aaa
-aaa
-aaa
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
 aaa
 aht
-aEl
-gfi
-bfM
+rNB
+aYu
+aUn
 bkF
 bni
 blX
@@ -107402,43 +109733,43 @@ aaa
 aaa
 aaa
 aaa
+abP
+mZE
+aaa
+abD
+aMj
 aaa
 aaa
 aaa
 aaa
 aaa
+bBW
 aaa
 aaa
 aaa
 aaa
 aaa
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bbP
-aaa
-aaa
-aaa
-aaa
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
 aaa
 aht
-aEl
-gfi
-ybX
+rNB
+aYu
+aUp
 bkF
 kdb
 pDf
@@ -107659,43 +109990,43 @@ aaa
 aaa
 aaa
 aaa
+abP
+mZE
+aaa
+abD
+aMj
 aaa
 aaa
 aaa
 aaa
 aaa
+bBW
 aaa
 aaa
 aaa
 aaa
 aaa
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
 aaa
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bbP
-aaa
-aaa
-abN
-aaa
-aEj
-aEj
-aEj
-bhz
-fNv
+aht
+rNB
+aYu
+dmP
 bkF
 bnh
 blX
@@ -107916,43 +110247,43 @@ aaa
 aaa
 aaa
 aaa
+abP
+mZE
+aaa
+abD
+aMj
 aaa
 aaa
 aaa
 aaa
 aaa
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bbP
-aaa
-aaa
-aaa
-aaa
-aEl
-bnl
-aFi
-gfi
-aFi
+bBW
+bBW
+bBW
+bBW
+bBW
+bwm
+bwm
+bwm
+aYA
+lWy
 bkF
 bni
 blX
@@ -108173,6 +110504,29 @@ aaa
 aaa
 aaa
 aaa
+abP
+aht
+aht
+acz
+aMj
+aaa
+aaa
+aaa
+aaa
+aaa
+bBW
+aaa
+aaa
+aaa
+aaa
+aaa
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
+bBW
 aaa
 aaa
 aaa
@@ -108182,34 +110536,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bcS
-aaa
-aaa
-aaa
-aaa
-aEl
-iCe
-rxa
-gfi
-aFi
+rNB
+aRd
+lWy
+aYu
+lWy
 bkF
 bkF
 bkF
@@ -108430,6 +110761,29 @@ aaa
 aaa
 aaa
 aaa
+abP
+mZE
+aaa
+abD
+aMj
+aaa
+aaa
+aaa
+aaa
+aaa
+bBW
+aaa
+aaa
+aaa
+aaa
+aaa
+bBW
+aaa
+aaa
+bBW
+bBW
+aaa
+bBW
 aaa
 aaa
 aaa
@@ -108439,40 +110793,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bcS
-aaa
-aaa
-aaa
-aaa
-aEl
-wOf
-aFi
-bhB
-fwI
-fwI
-wQU
-xah
-fwI
-fwI
-bqO
+rNB
+aRj
+aSp
+aYu
+rgn
+rgn
+aUL
+aVs
+rgn
+rgn
+aVD
 btB
 btF
 gIC
@@ -108687,6 +111018,11 @@ aaa
 aaa
 aaa
 aaa
+abq
+mZE
+aaa
+abD
+aMj
 aaa
 aaa
 aaa
@@ -108714,21 +111050,16 @@ aaa
 aaa
 aaa
 aaa
-bcS
-aaa
-aaa
-aaa
-aaa
-aEj
-aEj
-aEl
-aEl
-aEj
-jYA
-bnn
-bom
-qJB
-aFi
+rNB
+aRk
+lWy
+aYu
+aUq
+aUF
+aUV
+aVu
+aVz
+lWy
 bkF
 pYj
 faA
@@ -108944,6 +111275,11 @@ aaa
 aaa
 aaa
 aaa
+abP
+mZE
+aaa
+abD
+aMj
 aaa
 aaa
 aaa
@@ -108971,19 +111307,14 @@ aaa
 aaa
 aaa
 aaa
-bcS
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aEj
-aEj
-aEl
-iSi
+bwm
+bwm
+rNB
+aLp
+bwm
+bwm
+rNB
+aVv
 bkF
 bkF
 bkF
@@ -109201,6 +111532,11 @@ aaa
 aaa
 aaa
 aaa
+abP
+mZE
+aaa
+abD
+aMj
 aaa
 aaa
 aaa
@@ -109217,18 +111553,6 @@ aaa
 aaa
 aaa
 aaa
-aby
-aed
-aby
-aby
-aby
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bcS
 aaa
 aaa
 aaa
@@ -109239,6 +111563,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aqG
+aRl
+lWy
+aTf
+aUs
+aKC
 aaa
 aaa
 bkF
@@ -109458,6 +111789,11 @@ aaa
 aaa
 aaa
 aaa
+abP
+mZE
+aaa
+abD
+aMj
 aaa
 aaa
 aaa
@@ -109474,18 +111810,6 @@ aaa
 aaa
 aaa
 aaa
-aby
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bcS
 aaa
 aaa
 aaa
@@ -109496,6 +111820,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aqG
+aRn
+lWy
+aYW
+aUt
+aUK
 aaa
 aaa
 bnd
@@ -109715,6 +112046,11 @@ aaa
 aaa
 aaa
 aaa
+abP
+aht
+aht
+abD
+aMj
 aaa
 aaa
 aaa
@@ -109731,29 +112067,24 @@ aaa
 aaa
 aaa
 aaa
-aby
 aaa
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
 aaa
-bcS
 aaa
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
 aaa
-aby
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aqG
+aRn
+aNP
+aTi
+aUt
+bfR
+aaa
 aaa
 bnd
 qcD
@@ -109972,6 +112303,11 @@ aaa
 aaa
 aaa
 aaa
+abq
+mZE
+aaa
+abD
+aMj
 aaa
 aaa
 aaa
@@ -109988,29 +112324,24 @@ aaa
 aaa
 aaa
 aaa
-aby
-abI
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bcS
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-abI
-aby
+aaa
+aht
+aht
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aqG
+aRp
+aSs
+aZi
+aUu
+bfR
+aaa
 aaa
 bnd
 uPA
@@ -110229,6 +112560,11 @@ aaa
 aaa
 aaa
 aaa
+abP
+mZE
+aaa
+acz
+aMj
 aaa
 aaa
 aaa
@@ -110242,32 +112578,27 @@ aaa
 aaa
 aaa
 aaa
+aht
+bJZ
+bJZ
+bJZ
+aQb
+aSY
+aQb
+aGE
+bJZ
+bJZ
+aOq
+aTn
+aJu
+aJu
+aTn
+aYx
+aYF
+aNO
+aUv
+abI
 aaa
-aaa
-aaa
-aby
-aaa
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTC
-aaa
-bcS
-aaa
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aaa
-aby
 aaa
 bnd
 lGS
@@ -110486,45 +112817,45 @@ aaa
 aaa
 aaa
 aaa
+abP
+mZE
+aaa
+afV
+aMk
+aRg
+aRg
+aRg
+aRg
+aRg
+aRg
+aRg
+aRg
+aRg
+aRg
+aRg
+aRg
+aRg
+apA
+aqb
+ara
+ara
+atz
+aTz
+azU
+aGP
+aGP
+aMD
+aPm
+aRg
+aRg
+aRg
+aRg
+aRg
+aRg
+aRg
+bsc
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aed
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bcS
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aed
 aaa
 bkF
 dmT
@@ -110746,42 +113077,42 @@ aaa
 aaa
 aaa
 aaa
+ajA
+apC
+aTn
+aJu
+aJu
+aJu
+aJu
+aTn
+aJu
+aJu
+aJu
+aJu
+aJu
+aJu
+aJu
+aJq
+aJx
+azV
+arb
+atB
+arb
+azV
+aGQ
+aMz
+aME
+aPw
+bJZ
+bJZ
+bJZ
+aht
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aby
-aaa
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aaa
-bcS
-aaa
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aaa
-aed
 aaa
 bkF
 bkF
@@ -111006,6 +113337,11 @@ aaa
 aaa
 aaa
 aaa
+aht
+aaa
+aaa
+aaa
+aht
 aaa
 aaa
 aaa
@@ -111013,32 +113349,27 @@ aaa
 aaa
 aaa
 aaa
+aqG
+aJy
+aGS
+aJz
+aKF
+aMd
+aMs
+aMs
+aMs
+aNM
+aSy
+aGP
+aGP
+aYw
+aKC
 aaa
 aaa
 aaa
-aby
-abI
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bcS
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-abI
-aby
+aaa
+aaa
+aaa
 aaa
 bkF
 blX
@@ -111261,41 +113592,41 @@ aaa
 aaa
 aaa
 aaa
+mau
+fon
+fon
+fon
+fon
+mau
+fon
+fon
+fon
+aaa
+mau
+aXA
+aaa
+aaa
+aht
+aLm
+aLm
+aLm
+aJv
+ayp
+azX
+aTz
+aIn
+aNN
+aTj
+aTz
+aTz
+aKG
+aKC
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aby
-aaa
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTC
-aaa
-bcS
-aaa
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTC
-aaa
-aby
 aaa
 xKc
 blX
@@ -111519,6 +113850,7 @@ aaa
 aaa
 aaa
 aaa
+axD
 aaa
 aaa
 aaa
@@ -111527,32 +113859,31 @@ aaa
 aaa
 aaa
 aaa
+mau
+aht
+aht
+aht
+aht
+aqj
+arc
+ass
+auv
+ayK
+aAR
+aTz
+aIo
+aOo
+aTz
+aTz
+aTz
+aKG
+aKC
 aaa
 aaa
 aaa
-aby
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bcS
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aby
 aaa
 bkF
 blX
@@ -111766,7 +114097,6 @@ aaa
 aaa
 aaa
 aaa
-ajA
 aaa
 aaa
 aaa
@@ -111786,30 +114116,31 @@ aaa
 aaa
 aaa
 aaa
+fon
 aaa
-aby
 aaa
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
 aaa
-bcS
+aht
+aLm
+aLm
+ast
+auw
+azw
+aAV
+aGR
+aIr
+aOp
+aYE
+aGS
+aTz
+aTk
+aKC
 aaa
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
 aaa
-aby
+aaa
+aaa
+aaa
+aaa
 aaa
 sQP
 lTW
@@ -112042,31 +114373,31 @@ aaa
 aaa
 aaa
 aaa
+fon
+aaa
+anz
+aaa
+aht
+aLm
+are
+asv
+auw
+azz
+aAR
+aGS
+aIs
+btH
+btH
+aMe
+btH
+btH
+aht
 aaa
 aaa
-aby
-abI
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bcS
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-abI
-aby
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -112299,31 +114630,31 @@ aaa
 aaa
 aaa
 aaa
+fon
 aaa
 aaa
-aby
 aaa
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTC
+aht
+aQb
+arf
+asP
+avo
+azH
+aAZ
+aGS
+aIt
+btH
+aKW
+aMf
+aNn
+btH
+aht
 aaa
-bcS
 aaa
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTC
 aaa
-aed
+aaa
+aaa
+aaa
 aed
 aby
 aby
@@ -112556,31 +114887,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aby
-aaa
+fon
 aaa
 aaa
 aaa
+aht
+aQb
+arg
+asU
+auw
+ass
+aBb
+aGS
+aIu
+btH
+aKX
+aRr
+aNo
+btH
+aht
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-bcS
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aby
 aaa
 aaa
 aht
@@ -112812,32 +115143,32 @@ aaa
 aaa
 aaa
 aaa
+aht
+fon
+aht
+aht
+aht
+aht
+aLm
+arh
+ate
+awF
+azI
+aPl
+aGT
+aIv
+btH
+aLi
+aMf
+aNC
+btH
+aht
 aaa
 aaa
 aaa
-aby
 aaa
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
 aaa
-bcS
 aaa
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aaa
-aby
 aaa
 aaa
 aaa
@@ -113070,31 +115401,31 @@ aaa
 aaa
 aaa
 aaa
+fon
 aaa
 aaa
-aby
-abI
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bcS
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-abI
-aby
+aaa
+aht
+aLm
+aLm
+aQb
+aLm
+aQb
+aLm
+aQb
+aQb
+btH
+aRo
+aMg
+aRo
+btH
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -113327,31 +115658,31 @@ aaa
 aaa
 aaa
 aaa
+mau
 aaa
 aaa
-aby
 aaa
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTC
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aLj
+aMf
+aRo
+aht
+aht
 aaa
-bcS
 aaa
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTC
 aaa
-aed
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -113586,7 +115917,6 @@ aaa
 aaa
 aaa
 aaa
-aed
 aaa
 aaa
 aaa
@@ -113597,7 +115927,12 @@ aaa
 aaa
 aaa
 aaa
-bcS
+aaa
+aht
+aRo
+aMh
+aRo
+aht
 aaa
 aaa
 aaa
@@ -113605,10 +115940,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aby
 aaa
 aaa
 aaa
@@ -113843,29 +116174,29 @@ aaa
 aaa
 aaa
 aaa
-aby
 aaa
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
 aaa
-bcS
 aaa
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
-aTC
 aaa
-aby
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aht
+aht
+aMi
+aht
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -114100,31 +116431,31 @@ aaa
 aaa
 aaa
 aaa
-aby
-abI
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bcT
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-bbP
-abI
-aby
 aaa
 aaa
+apD
+aaa
+arG
+arG
+arG
+arG
+arG
+arG
+arG
+arG
+aaa
+aMl
+aaa
+arG
+arG
+arG
+arG
+arG
+arG
+arG
+arG
+aaa
+apD
 aaa
 aaa
 aaa
@@ -114357,31 +116688,31 @@ aaa
 aaa
 aaa
 aaa
-aby
-aaa
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTC
-aaa
-bcS
-aaa
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTC
-aaa
-aby
 aaa
 aaa
+apD
+apJ
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+aMl
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+apJ
+apD
 aaa
 aaa
 aaa
@@ -114614,31 +116945,31 @@ aaa
 aaa
 aaa
 aaa
-abI
 aaa
 aaa
+apD
 aaa
+asp
+asp
+asp
+asp
+asp
+asp
+asp
+arG
 aaa
+aMl
 aaa
+asp
+asp
+asp
+asp
+asp
+asp
+asp
+asp
 aaa
-aaa
-aaa
-aaa
-aaa
-bbP
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abI
-aaa
-aaa
+apD
 aaa
 aaa
 aaa
@@ -114871,31 +117202,31 @@ aaa
 aaa
 aaa
 aaa
-aed
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-cFB
-bbP
-cFB
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aby
 aaa
 aaa
+apI
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aMl
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+abN
+apI
 aaa
 aaa
 aaa
@@ -115130,29 +117461,29 @@ aaa
 aaa
 aaa
 aaa
+apD
 aaa
+arG
+arG
+arG
+arG
+arG
+arG
+arG
+arG
 aaa
+aMl
 aaa
+arG
+arG
+arG
+arG
+arG
+arG
+arG
+arG
 aaa
-aaa
-aaa
-aaa
-abI
-abI
-bcV
-abI
-abI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apI
 aaa
 aaa
 aaa
@@ -115387,29 +117718,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aby
-cFB
-abI
-cFB
-aby
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apD
+apJ
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+aMl
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+apJ
+apD
 aaa
 aaa
 aaa
@@ -115644,29 +117975,29 @@ aaa
 aaa
 aaa
 aaa
+apD
 aaa
+asp
+asp
+asp
+asp
+asp
+asp
+asp
+arG
 aaa
+aMl
 aaa
+asp
+asp
+asp
+asp
+asp
+asp
+asp
+arG
 aaa
-aaa
-aaa
-aaa
-aby
-aby
-aby
-aby
-aby
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apD
 aaa
 aaa
 aaa
@@ -115901,6 +118232,7 @@ aaa
 aaa
 aaa
 aaa
+apD
 aaa
 aaa
 aaa
@@ -115911,6 +118243,7 @@ aaa
 aaa
 aaa
 aaa
+aMl
 aaa
 aaa
 aaa
@@ -115921,9 +118254,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+apD
 aaa
 aaa
 aaa
@@ -116158,29 +118489,29 @@ aaa
 aaa
 aaa
 aaa
+apD
 aaa
+arG
+arG
+arG
+arG
+arG
+arG
+arG
+arG
 aaa
+aMl
 aaa
+arG
+arG
+arG
+arG
+arG
+arG
+arG
+arG
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apD
 aaa
 aaa
 aaa
@@ -116415,29 +118746,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apD
+apJ
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+aMl
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+apJ
+apD
 aaa
 aaa
 aaa
@@ -116672,29 +119003,29 @@ aaa
 aaa
 aaa
 aaa
+apD
 aaa
+asp
+asp
+asp
+asp
+asp
+asp
+asp
+arG
 aaa
+aMl
 aaa
+asp
+asp
+asp
+asp
+asp
+asp
+asp
+arG
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apI
 aaa
 aaa
 aaa
@@ -116929,6 +119260,7 @@ aaa
 aaa
 aaa
 aaa
+apD
 aaa
 aaa
 aaa
@@ -116939,6 +119271,7 @@ aaa
 aaa
 aaa
 aaa
+aMl
 aaa
 aaa
 aaa
@@ -116949,9 +119282,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+apD
 aaa
 aaa
 aaa
@@ -117186,29 +119517,29 @@ aaa
 aaa
 aaa
 aaa
+apD
 aaa
+arG
+arG
+arG
+arG
+arG
+arG
+arG
+arG
 aaa
+aMl
 aaa
+arG
+arG
+arG
+arG
+arG
+arG
+arG
+arG
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apD
 aaa
 aaa
 aaa
@@ -117443,29 +119774,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apD
+apJ
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+aMl
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+apJ
+apD
 aaa
 aaa
 aaa
@@ -117700,29 +120031,29 @@ aaa
 aaa
 aaa
 aaa
+apD
 aaa
+asp
+asp
+asp
+asp
+asp
+asp
+asp
+arG
 aaa
+aMl
 aaa
+asp
+asp
+asp
+asp
+asp
+asp
+asp
+arG
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apI
 aaa
 aaa
 aaa
@@ -117957,6 +120288,7 @@ aaa
 aaa
 aaa
 aaa
+apI
 aaa
 aaa
 aaa
@@ -117967,6 +120299,7 @@ aaa
 aaa
 aaa
 aaa
+aMl
 aaa
 aaa
 aaa
@@ -117977,9 +120310,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+apD
 aaa
 aaa
 aaa
@@ -118214,29 +120545,29 @@ aaa
 aaa
 aaa
 aaa
+apD
 aaa
+arG
+arG
+arG
+arG
+arG
+arG
+arG
+arG
 aaa
+aMl
 aaa
+arG
+arG
+arG
+arG
+arG
+arG
+arG
+arG
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apD
 aaa
 aaa
 aaa
@@ -118471,29 +120802,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apD
+apJ
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+aMm
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+ask
+apJ
+apD
 aaa
 aaa
 aaa
@@ -118728,29 +121059,29 @@ aaa
 aaa
 aaa
 aaa
+apD
 aaa
+asp
+asp
+asp
+asp
+asp
+asp
+asp
+arG
 aaa
+aMl
 aaa
+asp
+asp
+asp
+asp
+asp
+asp
+asp
+arG
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apD
 aaa
 aaa
 aaa
@@ -118985,6 +121316,7 @@ aaa
 aaa
 aaa
 aaa
+apJ
 aaa
 aaa
 aaa
@@ -118995,6 +121327,7 @@ aaa
 aaa
 aaa
 aaa
+ask
 aaa
 aaa
 aaa
@@ -119005,9 +121338,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+apJ
 aaa
 aaa
 aaa
@@ -119242,29 +121573,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apI
+apD
+apD
+apD
+apD
+apD
+apD
+apD
+apD
+apD
+aLn
+ask
+aLn
+apD
+apD
+apD
+apD
+apD
+apD
+apD
+apD
+apD
+apD
 aaa
 aaa
 aaa
@@ -119508,11 +121839,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apJ
+apJ
+aMn
+apJ
+apJ
 aaa
 aaa
 aaa
@@ -119765,11 +122096,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apD
+aLn
+apJ
+aLn
+apD
 aaa
 aaa
 aaa
@@ -120022,11 +122353,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+apD
+apD
+apD
+apD
+apD
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -23235,12 +23235,24 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aZm" = (
-/obj/effect/turf_decal/plaque{
-	name = "security borg memorial plaque"
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Monastery Dining Room";
+	dir = 8;
+	network = list("ss13","monastery")
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/quartermaster/storage)
 "aZn" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -29961,20 +29973,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"bsj" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "bsl" = (
 /obj/structure/sign/warning/vacuum/external,
 /obj/effect/spawner/structure/window/reinforced,
@@ -98481,7 +98479,7 @@ aUy
 aJI
 aVK
 aWs
-aZm
+aOS
 aZn
 aZo
 aWs
@@ -98743,7 +98741,7 @@ aLf
 aLf
 aLf
 aLf
-bwm
+aLf
 aLp
 beI
 bfv
@@ -99000,7 +98998,7 @@ aVJ
 aWz
 aGW
 btJ
-bwm
+aLf
 aLp
 beI
 bfw
@@ -99257,7 +99255,7 @@ bcO
 aPY
 aPY
 aIw
-bwm
+aLf
 aLp
 beI
 bfx
@@ -102337,7 +102335,7 @@ bmE
 aPp
 aSk
 blO
-bsj
+aZm
 btm
 btG
 aIB

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -405,38 +405,24 @@
 /turf/closed/wall,
 /area/maintenance/department/cargo)
 "abb" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/bookcase/manuals,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/lattice,
+/obj/structure/marker_beacon,
+/turf/open/space/basic,
+/area/space/nearstation)
 "abc" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/chair/plastic{
-	icon_state = "plastic_chair";
-	dir = 1
-	},
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "abd" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/five,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "abe" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+/obj/effect/spawner/lootdrop/maintenance/six,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/obj/structure/table,
-/obj/item/flashlight/lamp/green,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "abf" = (
@@ -444,21 +430,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "abg" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/floor,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "abh" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/machinery/space_heater,
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "abi" = (
@@ -473,22 +452,24 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "abk" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
+/turf/closed/wall/mineral/iron,
 /area/maintenance/department/cargo)
 "abl" = (
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/bookcase/random/adult,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "abm" = (
 /obj/structure/window/reinforced{
-	dir = 4
+	dir = 1;
+	pixel_y = 2
 	},
 /obj/structure/chair/plastic{
 	icon_state = "plastic_chair";
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -500,27 +481,37 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "abo" = (
-/obj/structure/transit_tube/station/reverse{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "abp" = (
-/obj/structure/transit_tube/crossing/horizontal,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/table,
+/obj/item/flashlight/lamp/green,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "abq" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space)
-"abr" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/transit_tube/horizontal,
-/obj/structure/cable,
-/obj/structure/cable,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"abr" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "shuttle_dock_shutters";
+	name = "shuttle dock shutters"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "abs" = (
@@ -531,14 +522,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "abt" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
-/obj/structure/transit_tube/crossing/horizontal,
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "abu" = (
 /obj/structure/easel,
 /turf/open/floor/plating,
@@ -607,11 +596,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "abD" = (
-/obj/structure/transit_tube/horizontal,
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/button/door{
+	id = "shuttle_dock_shutters";
+	name = "shuttle dock shutters control";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "abE" = (
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -691,10 +683,12 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "abP" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "abQ" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 8
@@ -802,16 +796,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "acb" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/obj/effect/turf_decal/box,
+/turf/open/space/basic,
+/area/space/nearstation)
 "acc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1052,11 +1041,9 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "acz" = (
-/obj/structure/transit_tube/crossing/horizontal,
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "acA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2339,14 +2326,15 @@
 /turf/closed/wall,
 /area/security/execution/transfer)
 "afV" = (
-/obj/structure/transit_tube/curved{
-	icon_state = "curved0";
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/chair/plastic{
+	icon_state = "plastic_chair";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "afW" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
@@ -5794,15 +5782,15 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ano" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "anp" = (
 /obj/effect/decal/cleanable/robot_debris{
 	icon_state = "gib6"
@@ -7060,10 +7048,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aqg" = (
@@ -7097,10 +7085,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aql" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -8767,13 +8757,13 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "atD" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "atE" = (
@@ -11683,7 +11673,7 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/personal,
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/carpet,
 /area/vacant_room/commissary)
 "azS" = (
 /obj/machinery/door/airlock/engineering{
@@ -14328,7 +14318,7 @@
 	dir = 4;
 	light_color = "#d8b1b1"
 	},
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/carpet,
 /area/vacant_room/commissary)
 "aFR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16800,15 +16790,25 @@
 /turf/open/floor/wood,
 /area/quartermaster/qm)
 "aLs" = (
-/obj/structure/bookcase/manuals,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/quartermaster/qm)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aLt" = (
-/obj/structure/bookcase/manuals,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/quartermaster/qm)
+/obj/machinery/button/door{
+	id = "shuttle_dock_shutters";
+	name = "shuttle dock shutters control";
+	pixel_x = -24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/light/small,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aLu" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/neutral{
@@ -17197,11 +17197,18 @@
 /turf/open/space/basic,
 /area/maintenance/solars/starboard)
 "aMj" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aMk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -17308,11 +17315,11 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aMA" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
+/obj/structure/transit_tube/station/reverse{
+	dir = 1
 	},
-/area/quartermaster/qm)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aMB" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
@@ -18461,7 +18468,7 @@
 /obj/structure/cable,
 /obj/structure/table,
 /obj/item/hand_labeler,
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/carpet,
 /area/vacant_room/commissary)
 "aPc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -18848,7 +18855,7 @@
 	pixel_x = 24
 	},
 /obj/item/pen,
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/carpet,
 /area/vacant_room/commissary)
 "aPW" = (
 /obj/effect/turf_decal/tile/brown{
@@ -18966,8 +18973,7 @@
 /turf/open/floor/carpet/blue,
 /area/quartermaster/storage)
 "aQm" = (
-/obj/structure/cable,
-/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/structure/transit_tube/crossing/horizontal,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aQn" = (
@@ -19054,8 +19060,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aQA" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/transit_tube/horizontal,
 /obj/structure/cable,
-/obj/machinery/light/small,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aQB" = (
@@ -19444,7 +19454,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	light_color = "#e8eaff"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -20598,15 +20609,17 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aUs" = (
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/structure/cable,
+/obj/structure/window/reinforced,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/cargo)
 "aUt" = (
 /obj/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -20616,12 +20629,11 @@
 /area/maintenance/department/science)
 "aUu" = (
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
@@ -23355,6 +23367,14 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"aZB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aZC" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -23639,6 +23659,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"baf" = (
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "bag" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -23655,6 +23684,50 @@
 "bah" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"bai" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"baj" = (
+/obj/machinery/door/airlock/external{
+	name = "Emergency Exit";
+	req_access_txt = "0"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"bak" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"bal" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/quartermaster/qm)
+"bam" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/transit_tube/crossing/horizontal,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space,
+/area/space)
 "ban" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/newscaster{
@@ -23711,6 +23784,44 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bas" = (
+/obj/structure/transit_tube/curved{
+	icon_state = "curved0";
+	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space)
+"bat" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"bau" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"bav" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"baw" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/wood,
+/area/quartermaster/qm)
+"bax" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/quartermaster/qm)
 "bay" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -23722,6 +23833,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"baz" = (
+/obj/machinery/door/airlock/external{
+	name = "Emergency Exit";
+	req_access_txt = "0"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"baA" = (
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/purple,
+/area/quartermaster/qm)
 "baJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -24400,10 +24524,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"bcI" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "bcJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -101316,7 +101436,7 @@ aTo
 bwf
 aUl
 aVy
-aZt
+baA
 bbE
 aYt
 bjw
@@ -102083,7 +102203,7 @@ bjG
 bmu
 aIA
 aJC
-aLs
+bal
 aMy
 aVx
 aXs
@@ -102340,8 +102460,8 @@ btm
 btG
 aIB
 aXx
-aLt
-aMA
+baw
+bax
 aNI
 aOY
 aPZ
@@ -105913,8 +106033,8 @@ avm
 avm
 atn
 atn
-aMw
-aQm
+aqc
+bat
 aEj
 aEj
 aHu
@@ -106168,10 +106288,10 @@ aaa
 aaa
 aaa
 aEj
-abh
+abc
 aIp
-aMw
-bcI
+aqc
+aFi
 aGO
 aFi
 aGO
@@ -106427,8 +106547,8 @@ aaa
 aEj
 abi
 aIp
-aMw
-aQA
+aqc
+bau
 aEj
 aIp
 aEj
@@ -106942,7 +107062,7 @@ aFi
 aFi
 aFi
 aqc
-aFi
+bav
 aEj
 aEl
 aEj
@@ -107451,11 +107571,11 @@ aaa
 aaa
 abN
 aaa
-aqG
-abb
-abk
-aFi
-aqf
+aaa
+aEj
+abd
+abt
+aqc
 aEj
 aEj
 abx
@@ -107708,9 +107828,9 @@ aaa
 aaa
 aaa
 aaa
-aqG
-abc
-aFi
+aaa
+aEl
+abe
 aFi
 aqc
 aEj
@@ -107965,11 +108085,11 @@ aaa
 aaa
 aaa
 aaa
-aqG
-abd
-abl
-abo
-aql
+aaa
+aEl
+abg
+aFi
+aqc
 aEj
 abv
 aFi
@@ -107977,8 +108097,8 @@ abz
 abB
 aEj
 abG
+aRx
 abK
-acb
 aeH
 abK
 ann
@@ -107986,8 +108106,8 @@ abK
 aKt
 aNl
 abK
-aRx
 abK
+aRx
 abK
 abK
 aXi
@@ -108222,11 +108342,11 @@ aaa
 aaa
 aaa
 aaa
-aqG
-abe
-aFi
-abp
-aqc
+aaa
+aEl
+abh
+abD
+atD
 aEj
 abw
 aFi
@@ -108234,7 +108354,7 @@ abz
 abC
 aEj
 aVA
-aVA
+aLg
 aVA
 afY
 ahf
@@ -108244,7 +108364,7 @@ apx
 aVA
 aVA
 aVA
-aVA
+aLg
 aVA
 aVA
 aVA
@@ -108479,11 +108599,11 @@ aaa
 aaa
 aaa
 aaa
-aqG
-abg
-abm
-abr
-atD
+aaa
+aEj
+aEj
+aEj
+aMj
 aEj
 aEj
 aEl
@@ -108736,12 +108856,12 @@ aaa
 aaa
 aaa
 aaa
-aht
-bQi
-bQi
-abt
+aaa
+aaa
+aaa
+abr
 ano
-abI
+abr
 bBW
 bBW
 bBW
@@ -108996,9 +109116,9 @@ aaa
 aaa
 aaa
 aaa
-abD
-aMj
-aaa
+abr
+ano
+abr
 aaa
 aaa
 aaa
@@ -109250,12 +109370,12 @@ aaa
 aaa
 aaa
 aaa
-abP
-mZE
 aaa
-abD
-aMj
 aaa
+aaa
+abr
+ano
+abr
 aaa
 aaa
 aaa
@@ -109507,12 +109627,12 @@ aaa
 aaa
 aaa
 aaa
-abP
-aht
-aht
-abD
-aMj
 aaa
+aaa
+aaa
+abr
+ano
+abr
 aaa
 aaa
 aaa
@@ -109764,12 +109884,12 @@ aaa
 aaa
 aaa
 aaa
-abP
-mZE
 aaa
-abD
-aMj
 aaa
+aaa
+abr
+aqf
+abr
 aaa
 aaa
 aaa
@@ -110021,12 +110141,12 @@ aaa
 aaa
 aaa
 aaa
-abP
-mZE
 aaa
-abD
-aMj
 aaa
+aaa
+abr
+aqc
+abr
 aaa
 aaa
 aaa
@@ -110278,12 +110398,12 @@ aaa
 aaa
 aaa
 aaa
-abP
-mZE
 aaa
-abD
-aMj
 aaa
+aaa
+abr
+aqc
+abr
 aaa
 aaa
 aaa
@@ -110535,12 +110655,12 @@ aaa
 aaa
 aaa
 aaa
-abP
-aht
-aht
-acz
-aMj
 aaa
+aaa
+aaa
+abr
+aqc
+abr
 aaa
 aaa
 aaa
@@ -110792,12 +110912,12 @@ aaa
 aaa
 aaa
 aaa
-abP
-mZE
 aaa
-abD
-aMj
 aaa
+aaa
+abr
+aqc
+abr
 aaa
 aaa
 aaa
@@ -111049,13 +111169,13 @@ aaa
 aaa
 aaa
 aaa
-abq
-mZE
 aaa
-abD
-aMj
-aaa
-aaa
+aht
+abk
+abk
+aql
+abk
+abk
 aaa
 aaa
 aaa
@@ -111306,14 +111426,14 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aqG
+abl
 abP
-mZE
-aaa
-abD
-aMj
-aaa
-aaa
-aaa
+aLs
+aLt
+abk
+aht
 aaa
 aaa
 aaa
@@ -111563,14 +111683,14 @@ aaa
 aaa
 aaa
 aaa
-abP
-mZE
 aaa
-abD
-aMj
-aaa
-aaa
-aaa
+aqG
+abm
+aFi
+aFi
+aZB
+aUK
+aht
 aaa
 aaa
 aaa
@@ -111599,7 +111719,7 @@ aqG
 aRl
 lWy
 aTf
-aUs
+aUu
 aKC
 aaa
 aaa
@@ -111820,39 +111940,39 @@ aaa
 aaa
 aaa
 aaa
-abP
-mZE
-aaa
-abD
-aMj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aqG
+abo
+acz
+aMA
+aZB
+aEl
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aht
+rNB
 aRn
 lWy
 aYW
@@ -112077,43 +112197,43 @@ aaa
 aaa
 aaa
 aaa
-abP
-aht
-aht
-abD
-aMj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aqG
-aRn
+abp
+aFi
+aQm
+aqc
+baj
+cdm
+acb
+cdm
+cdm
+cdm
+cdm
+cdm
+acb
+cdm
+cdm
+cdm
+cdm
+cdm
+acb
+cdm
+cdm
+cdm
+cdm
+cdm
+acb
+cdm
+cdm
+cdm
+cdm
+cdm
+baz
+lWy
 aNP
 aTi
-aUt
+baf
 bfR
 aaa
 aaa
@@ -112334,43 +112454,43 @@ aaa
 aaa
 aaa
 aaa
-abq
-mZE
-aaa
-abD
-aMj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aht
-aht
-aht
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aqG
+abq
+afV
+aQA
+aUs
+aEl
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aht
+cdm
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aht
+rNB
 aRp
 aSs
 aZi
-aUu
+bak
 bfR
 aaa
 aaa
@@ -112591,14 +112711,14 @@ aaa
 aaa
 aaa
 aaa
-abP
-mZE
 aaa
-acz
-aMj
-aaa
-aaa
-aaa
+abb
+bQi
+bQi
+bam
+bai
+aht
+aht
 aaa
 aaa
 aaa
@@ -112848,12 +112968,12 @@ aaa
 aaa
 aaa
 aaa
-abP
-mZE
 aaa
-afV
+aaa
+aaa
+aaa
+bas
 aMk
-aRg
 aRg
 aRg
 aRg
@@ -113108,10 +113228,10 @@ aaa
 aaa
 aaa
 aaa
+aaa
 ajA
 apC
 aTn
-aJu
 aJu
 aJu
 aJu
@@ -113368,8 +113488,8 @@ aaa
 aaa
 aaa
 aaa
-aht
-aaa
+mZE
+oex
 aaa
 aaa
 aht
@@ -113623,8 +113743,8 @@ aaa
 aaa
 aaa
 aaa
+mZE
 mau
-fon
 fon
 fon
 fon
@@ -113881,8 +114001,8 @@ aaa
 aaa
 aaa
 aaa
-axD
 aaa
+axD
 aaa
 aaa
 aaa
@@ -115693,7 +115813,7 @@ mau
 aaa
 aaa
 aaa
-aht
+abb
 aht
 aht
 aht
@@ -115707,7 +115827,7 @@ aLj
 aMf
 aRo
 aht
-aht
+abb
 aaa
 aaa
 aaa


### PR DESCRIPTION
:cl:
add: pubby cargo has been expanded
add: pubby illegal maint distillery/ botany
add: pubby disposal station
add: pubby maint robo
add: pubby commissary room
/:cl:
 
- pubby cargo has always felt super small and caustrophobic now it has a decent sized comparable to the rest of the maps, an export outlet for people to use export scanners etc , a conveyour autolathe input/output to transfer bulk things to the outside and custom vendors because why not
 
- pubby didnt have a commissary room so i added one near cargo
 
- disposal station, reachable only by transit tubes  usefull for a concealed place where do evil things
 
- there was no ghetto robo or ghetto hydro so i added em