### PR TITLE
Fixes Blob strain reactive spines analyzer effect description

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/reactive_spines.dm
+++ b/code/modules/antagonists/blob/blobstrains/reactive_spines.dm
@@ -2,7 +2,7 @@
 /datum/blobstrain/reagent/reactive_spines
 	name = "Reactive Spines"
 	description = "will do medium brute damage through armor and bio resistance."
-	effectdesc = "will also react when attacked with close up burn or brute damage, attacking all near the attacked blob."
+	effectdesc = "will also react when attacked with burn or brute damage, attacking everything in melee range."
 	analyzerdescdamage = "Does medium brute damage, ignoring armor and bio resistance."
 	analyzerdesceffect = "When attacked with burn or brute damage it violently lashes out, attacking everything nearby."
 	color = "#9ACD32"

--- a/code/modules/antagonists/blob/blobstrains/reactive_spines.dm
+++ b/code/modules/antagonists/blob/blobstrains/reactive_spines.dm
@@ -4,7 +4,7 @@
 	description = "will do medium brute damage through armor and bio resistance."
 	effectdesc = "will also react when attacked with close up burn or brute damage, attacking all near the attacked blob."
 	analyzerdescdamage = "Does medium brute damage, ignoring armor and bio resistance."
-	analyzerdesceffect = "When attacked with brute damage, will lash out, attacking everything near it."
+	analyzerdesceffect = "When attacked with burn or brute damage it violently lashes out, attacking everything nearby."
 	color = "#9ACD32"
 	complementary_color = "#FFA500"
 	blobbernaut_message = "stabs"
@@ -12,7 +12,7 @@
 	reagent = /datum/reagent/blob/reactive_spines
 
 /datum/blobstrain/reagent/reactive_spines/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
-	if(damage && ((damage_type == BRUTE) || (damage_type == BURN)) && B.obj_integrity - damage > 0) //is there any damage, is it brute, and will we be alive
+	if(damage && ((damage_type == BRUTE) || (damage_type == BURN)) && B.obj_integrity - damage > 0) //is there any damage, is it burn or brute, and will we be alive
 		if(damage_flag == "melee")
 			B.visible_message("<span class='boldwarning'>The blob retaliates, lashing out!</span>")
 		for(var/atom/A in range(1, B))


### PR DESCRIPTION
## About The Pull Request

Reflects the addition of **burn** type damage causing a violent reaction from the blob when analyzed like with science goggles.

## Why It's Good For The Game

- Blob can now damage morale when that brave scientist investigating its strain has to tell assistants to put down the welders.
- Fixes an oversight that should have been caught during review, but I did not get a chance to read the buff PR.