### PR TITLE
Add anomaly compressor and two random anomaly core spawn to IceBox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -36136,14 +36136,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bHu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/machinery/research/explosive_compressor,
 /turf/open/floor/plasteel,
@@ -37135,6 +37135,21 @@
 /obj/structure/table/reinforced,
 /obj/machinery/airalarm{
 	pixel_y = 23
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_y = 2
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 9;
+	pixel_y = -2
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -49001,6 +49016,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cBB" = (
@@ -51232,6 +51250,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"dJC" = (
+/obj/structure/table/reinforced,
+/obj/item/raw_anomaly_core/random{
+	pixel_y = -2
+	},
+/obj/item/raw_anomaly_core/random{
+	pixel_y = 11
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "dMb" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -51531,24 +51559,25 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "flc" = (
-/obj/item/assembly/prox_sensor{
-	pixel_x = -4;
-	pixel_y = 1
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = 8;
-	pixel_y = 9
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = 9;
-	pixel_y = -2
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_y = 2
-	},
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
 	pixel_x = 29
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -9;
+	pixel_y = -2
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 9;
+	pixel_y = 2
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = -9
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -53075,26 +53104,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"kwK" = (
-/obj/structure/table/reinforced,
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -9
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -9;
-	pixel_y = -2
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -2;
-	pixel_y = 9
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 9;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "kwT" = (
 /obj/vehicle/ridden/wheelchair{
 	dir = 4
@@ -53965,13 +53974,6 @@
 "mJd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
-	},
-/obj/structure/table,
-/obj/item/raw_anomaly_core/random{
-	pixel_y = -2
-	},
-/obj/item/raw_anomaly_core/random{
-	pixel_y = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -107741,8 +107743,8 @@ bEC
 bJZ
 flc
 vPE
-kwK
 bVt
+dJC
 bQZ
 bTl
 bTl

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -36145,6 +36145,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/research/explosive_compressor,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bHv" = (
@@ -53964,6 +53965,13 @@
 "mJd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/structure/table,
+/obj/item/raw_anomaly_core/random{
+	pixel_y = -2
+	},
+/obj/item/raw_anomaly_core/random{
+	pixel_y = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)


### PR DESCRIPTION
## About The Pull Request

Fix an oversight when the anomaly compression PR got merged. Non ironically asking for a speedy merge if possible, because it sucks having to depend on admins to spawn the compressor on Icebox.

## Why It's Good For The Game

More Icebox Fixes good.

## Changelog
:cl: Kathy Ryals
fix: Nanotrasen finally realized they forgot to ship the mandatory anomaly compressor and two anomaly cores to Icebox.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
