### PR TITLE
Fixes anchored state mismatch for field generators on delta

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -324,7 +324,6 @@
 	},
 /obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -62655,18 +62654,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/field/generator{
-	anchored = 1
-	},
+/obj/machinery/field/generator/anchored,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "clT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/field/generator{
-	anchored = 1
-	},
+/obj/machinery/field/generator/anchored,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "clU" = (
@@ -68613,18 +68608,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/field/generator{
-	anchored = 1
-	},
+/obj/machinery/field/generator/anchored,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cxB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/field/generator{
-	anchored = 1
-	},
+/obj/machinery/field/generator/anchored,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cxD" = (
@@ -92691,8 +92682,7 @@
 	pixel_y = 9
 	},
 /obj/item/storage/box/monkeycubes{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/item/storage/pill_bottle/mutadone{
 	pixel_x = -8;
@@ -96403,7 +96393,6 @@
 /area/medical/chemistry)
 "dAV" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/disposalpipe/segment{
@@ -98978,7 +98967,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -112688,7 +112676,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
-	icon_state = "trimline_warn_fill";
 	dir = 8
 	},
 /obj/structure/cable,
@@ -114786,8 +114773,7 @@
 	icon_state = "plant-21"
 	},
 /obj/structure/sign/warning/bodysposal{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -115403,9 +115389,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Chemistry APC";
-	pixel_x = 0;
 	pixel_y = -23
 	},
 /obj/structure/cable,

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -59,6 +59,10 @@ field_generator power level display
 	fields = list()
 	connected_gens = list()
 
+/obj/machinery/field/generator/anchored/Initialize()
+	. = ..()
+	setAnchored(TRUE)
+
 /obj/machinery/field/generator/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/empprotection, EMP_PROTECT_SELF | EMP_PROTECT_WIRES)
@@ -84,6 +88,12 @@ field_generator power level display
 	else
 		to_chat(user, "<span class='warning'>[src] needs to be firmly secured to the floor first!</span>")
 
+/obj/machinery/field/generator/setAnchored(anchorvalue)
+	. = ..()
+	if(active)
+		turn_off()
+	state = anchorvalue ? FG_SECURED : FG_UNSECURED
+
 /obj/machinery/field/generator/can_be_unfasten_wrench(mob/user, silent)
 	if(active)
 		if(!silent)
@@ -96,14 +106,6 @@ field_generator power level display
 		return FAILED_UNFASTEN
 
 	return ..()
-
-/obj/machinery/field/generator/default_unfasten_wrench(mob/user, obj/item/I, time = 20)
-	. = ..()
-	if(. == SUCCESSFUL_UNFASTEN)
-		if(anchored)
-			state = FG_SECURED
-		else
-			state = FG_UNSECURED
 
 /obj/machinery/field/generator/wrench_act(mob/living/user, obj/item/I)
 	..()
@@ -145,8 +147,7 @@ field_generator power level display
 
 /obj/machinery/field/generator/attack_animal(mob/living/simple_animal/M)
 	if(M.environment_smash & ENVIRONMENT_SMASH_RWALLS && active == FG_OFFLINE && state != FG_UNSECURED)
-		state = FG_UNSECURED
-		anchored = FALSE
+		setAnchored(FALSE)
 		M.visible_message("<span class='warning'>[M] rips [src] free from its moorings!</span>")
 	else
 		..()


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed the field generators in Delta's Singulo area being anchored but not secured.
fix: Fixed field generators continuing to function after being uprooted by a mob.
/:cl:
Fixes #52042