### PR TITLE
better stack amount varedit handling

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -275,6 +275,17 @@
 				qdel(I)
 		//BubbleWrap END
 
+/obj/item/stack/vv_edit_var(vname, vval)
+	if(vname == NAMEOF(src, amount))
+		add(clamp(vval, 1-amount, max_amount - amount)) //there must always be one.
+		return TRUE
+	else if(vname == NAMEOF(src, max_amount))
+		max_amount = max(vval, 1)
+		add((max_amount < amount) ? (max_amount - amount) : 0) //update icon, weight, ect
+		return TRUE
+	return ..()
+
+
 /obj/item/stack/proc/building_checks(datum/stack_recipe/R, multiplier)
 	if (get_amount() < R.req_amount*multiplier)
 		if (R.req_amount*multiplier>1)


### PR DESCRIPTION
:cl: ShizCalev
admin: Stacks will now update properly when you varedit their amount. It's clamped to max_amount, so make sure to change that too if you want to increase the amount beyond it.
/:cl:
