### PR TITLE
Fixes railings

### DIFF
--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -67,20 +67,21 @@
 	return TRUE
 
 /obj/structure/railing/CanPass(atom/movable/mover, turf/target)
-	..()
+	. = ..()
 	if(get_dir(loc, target) & dir)
-		var/checking = UNSTOPPABLE | FLYING | FLOATING
-		return !density || mover.movement_type & checking
+		var/checking = FLYING | FLOATING
+		return . || mover.movement_type & checking
 	return TRUE
 
 /obj/structure/railing/corner/CanPass()
 	..()
 	return TRUE
 
-/obj/structure/railing/CheckExit(atom/movable/O, turf/target)
+/obj/structure/railing/CheckExit(atom/movable/mover, turf/target)
 	..()
 	if(get_dir(loc, target) & dir)
-		return FALSE
+		var/checking = UNSTOPPABLE | FLYING | FLOATING
+		return !density || mover.movement_type & checking || mover.move_force >= MOVE_FORCE_EXTREMELY_STRONG
 	return TRUE
 
 /obj/structure/railing/corner/CheckExit()


### PR DESCRIPTION
## About The Pull Request

Fixes railings blocking bullets and immovable rods from a certain direction.
Fixes #52060

## Why It's Good For The Game

Railings shouldn't block bullets and immovable rods.

## Changelog
:cl: Melbert
fix: Fixes railings blocking bullets and immovable rods from a certain direction.
/:cl:
