### PR TITLE
Shows sentient Blob mobs the critical mass progress as a status

### DIFF
--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -34,11 +34,16 @@
 		verbs -= /mob/living/verb/pulled
 	else
 		pass_flags &= ~PASSBLOB
-		
+
 /mob/living/simple_animal/hostile/blob/Destroy()
 	if(overmind)
 		overmind.blob_mobs -= src
 	return ..()
+
+/mob/living/simple_animal/hostile/blob/Stat()
+	..()
+	if(overmind && statpanel("Status"))
+		stat(null, "Blobs to Win: [overmind.blobs_legit.len]/[overmind.blobwincount]")
 
 /mob/living/simple_animal/hostile/blob/blob_act(obj/structure/blob/B)
 	if(stat != DEAD && health < maxHealth)
@@ -128,7 +133,7 @@
 	if(factory && z != factory.z)
 		death()
 	..()
-	
+
 /mob/living/simple_animal/hostile/blob/blobspore/attack_ghost(mob/user)
 	. = ..()
 	if(.)


### PR DESCRIPTION
## About The Pull Request

Next up in my low effort high impact PR series is a copy pasta of some `Stat()` code from the blob overmind into `simple_animal/hostile/blob` to display **Blobs to Win** just like the overmind sees. Now blobbernauts and spores can follow the progress of the blob too.

## Why It's Good For The Game

Lack of access to such basic info seems bad when the overmind has it and can examine any blob to see it as well.

Maybe it is good to encourage the mobs to ask or keep them in the dark? Let me know what you think.

## Changelog
:cl:
add: Blob mobs from an overmind now see critical mass progress as a status.
/:cl:
