### PR TITLE
[READY]Surgery steps no longer spams the chat of people far away from the surgeon.

### DIFF
--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -180,4 +180,3 @@
 	if(!target_detailed)
 		detailed_mobs -= target //The patient can't see well what's going on, unless it's something like getting cut
 	user.visible_message(detailed_message, self_message, vision_distance = 1, ignored_mobs = target_detailed ? null : target)
-	user.visible_message(vague_message, "", ignored_mobs = detailed_mobs)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -176,5 +176,6 @@
 
 //Replaces visible_message during operations so only people looking over the surgeon can see them.
 /datum/surgery_step/proc/display_results(mob/user, mob/living/carbon/target, self_message, detailed_message, vague_message, target_detailed = FALSE)
-	user.visible_message(detailed_message, self_message, vision_distance = 1, ignored_mobs = target)
-	to_chat(target, vague_message)
+	user.visible_message(detailed_message, self_message, vision_distance = 1, ignored_mobs = target_detailed ? null : target)
+	if(!target_detailed)
+		to_chat(target, vague_message)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -174,9 +174,7 @@
 			chems += chemname
 	return english_list(chems, and_text = require_all_chems ? " and " : " or ")
 
-//Replaces visible_message during operations so only people looking over the surgeon can tell what they're doing, allowing for shenanigans.
+//Replaces visible_message during operations so only people looking over the surgeon can see them.
 /datum/surgery_step/proc/display_results(mob/user, mob/living/carbon/target, self_message, detailed_message, vague_message, target_detailed = FALSE)
-	var/list/detailed_mobs = get_hearers_in_view(1, user) //Only the surgeon and people looking over his shoulder can see the operation clearly
-	if(!target_detailed)
-		detailed_mobs -= target //The patient can't see well what's going on, unless it's something like getting cut
-	user.visible_message(detailed_message, self_message, vision_distance = 1, ignored_mobs = target_detailed ? null : target)
+	user.visible_message(detailed_message, self_message, vision_distance = 1, ignored_mobs = target)
+	to_chat(target, vague_message)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Now only people one tile from the surgeon gets the surgery steps messages.

## Why It's Good For The Game

It's now much MUCH less annoying to work in a crowded medbay.

## Changelog
:cl: Kathy Ryals

tweak: Surgeries now only write to your chat if you're next to the surgeon.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
