### PR TITLE
fixes laserpointer diode runtime

### DIFF
--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -15,7 +15,7 @@
 	var/energy = 10
 	var/max_energy = 10
 	var/effectchance = 30
-	var/recharging = 0
+	var/recharging = FALSE
 	var/recharge_locked = FALSE
 	var/obj/item/stock_parts/micro_laser/diode //used for upgrading!
 
@@ -178,7 +178,7 @@
 	energy -= 1
 	if(energy <= max_energy)
 		if(!recharging)
-			recharging = 1
+			recharging = TRUE
 			START_PROCESSING(SSobj, src)
 		if(energy <= 0)
 			to_chat(user, "<span class='warning'>[src]'s battery is overused, it needs time to recharge!</span>")
@@ -188,10 +188,13 @@
 	icon_state = "pointer"
 
 /obj/item/laser_pointer/process()
+	if(!diode)
+		recharging = FALSE
+		return PROCESS_KILL
 	if(prob(20 + diode.rating*20 - recharge_locked*2)) //t1 is 20, 2 40
 		energy += 1
 		if(energy >= max_energy)
 			energy = max_energy
-			recharging = 0
+			recharging = FALSE
 			recharge_locked = FALSE
-			..()
+			return ..()


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed a minor runtime caused by removing a laser pointer's diode while it's still turned on.
/:cl:
