### PR TITLE
[READY] HERETICS: buffs ash ascension so that it's abilities actually deal damage and not just set on fire

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -407,6 +407,8 @@
 		for(var/turf/T in spiral_range_turfs(_range,centre))
 			new /obj/effect/hotspot(T)
 			T.hotspot_expose(700,50,1)
+			for(var/mob/living/livies in T.contents)
+				livies.adjustFireLoss(10)
 		_range++
 		sleep(3)
 
@@ -454,6 +456,8 @@
 	for(var/turf/T in range(1,current_user))
 		new /obj/effect/hotspot(T)
 		T.hotspot_expose(700,50,1)
+		for(var/mob/living/livies in T.contents)
+			livies.adjustFireLoss(5)
 
 
 /obj/effect/proc_holder/spell/targeted/worm_contract


### PR DESCRIPTION


## About The Pull Request

Makes Oath of fire deal 5 fire damage per second to people near while it is active

Makes Fire cascade deal 10 damage to people hit. Increases the closer you are to the center, and the longer you stay there.

## Why It's Good For The Game

Ash final ascension is incredibly weak and deals little to no damage for how flashy it is.

## Changelog
:cl:
balance: Ash ascension spells now deal actual damage.
/:cl:
