### PR TITLE
Fixes runtime when doing things with a ballistic gun without a magazine loaded

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -253,7 +253,7 @@
 			if (chambered && !chambered.BB)
 				chambered.forceMove(drop_location())
 				chambered = null
-			var/num_loaded = magazine.attackby(A, user, params, TRUE)
+			var/num_loaded = magazine?.attackby(A, user, params, TRUE)
 			if (num_loaded)
 				to_chat(user, "<span class='notice'>You load [num_loaded] [cartridge_wording]\s into \the [src].</span>")
 				playsound(src, load_sound, load_sound_volume, load_sound_vary)
@@ -410,7 +410,8 @@
 		rounds.Add(chambered)
 		if(drop_all)
 			chambered = null
-	rounds.Add(magazine.ammo_list(drop_all))
+	if(magazine)
+		rounds.Add(magazine.ammo_list(drop_all))
 	return rounds
 
 #define BRAINS_BLOWN_THROW_RANGE 3

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -17,6 +17,8 @@
 	var/recent_spin = 0
 
 /obj/item/gun/ballistic/revolver/chamber_round(spin_cylinder = TRUE)
+	if(!magazine) //if it mag was qdel'd somehow.
+		CRASH("revolver tried to chamber a round without a magazine!")
 	if(spin_cylinder)
 		chambered = magazine.get_round(TRUE)
 	else
@@ -91,14 +93,14 @@
 						)
 
 /obj/item/gun/ballistic/revolver/detective/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
-	if(magazine.caliber != initial(magazine.caliber))
+	if(magazine && magazine.caliber != initial(magazine.caliber))
 		if(prob(70 - (magazine.ammo_count() * 10)))	//minimum probability of 10, maximum of 60
 			playsound(user, fire_sound, fire_sound_volume, vary_fire_sound)
 			to_chat(user, "<span class='userdanger'>[src] blows up in your face!</span>")
 			user.take_bodypart_damage(0,20)
 			user.dropItemToGround(src)
-			return 0
-	..()
+			return FALSE
+	return ..()
 
 /obj/item/gun/ballistic/revolver/detective/screwdriver_act(mob/living/user, obj/item/I)
 	if(..())


### PR DESCRIPTION
missing sanity checks, also fixed a missing return for detective revolver's process_fire()

🆑 ShizCalev
fix: Fixed a runtime caused by eject a chambered round without a magazine inserted.
fix: Added a stack trace if you try to fire a revolver with it's magazine deleted by an admin.
/🆑