### PR TITLE
[READY]Plant mutation chances at 80+ instability is now a sliding scale.

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -256,8 +256,8 @@
 
 //This is where stability mutations exist now.
 			if(myseed.instability >= 80)
-				var/mutation_chance = 5 + (100 - myseed.instability)
-				mutate(0, 0, 0, 0, 0, 0, 0, mutation_chance, 0) //Exceedingly low odds of gaining a trait.
+				var/mutation_chance = myseed.instability - 75
+				mutate(0, 0, 0, 0, 0, 0, 0, mutation_chance, 0) //Scaling odds of a random trait or chemical
 			if(myseed.instability >= 60)
 				if(prob((myseed.instability)/2) && !self_sustaining && length(myseed.mutatelist)) //Minimum 30%, Maximum 50% chance of mutating every age tick when not on autogrow.
 					mutatespecie()

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -256,7 +256,8 @@
 
 //This is where stability mutations exist now.
 			if(myseed.instability >= 80)
-				mutate(0, 0, 0, 0, 0, 0, 0, 5, 0) //Exceedingly low odds of gaining a trait.
+				var/mutation_chance = 5 + (100 - myseed.instability)
+				mutate(0, 0, 0, 0, 0, 0, 0, mutation_chance, 0) //Exceedingly low odds of gaining a trait.
 			if(myseed.instability >= 60)
 				if(prob((myseed.instability)/2) && !self_sustaining && length(myseed.mutatelist)) //Minimum 30%, Maximum 50% chance of mutating every age tick when not on autogrow.
 					mutatespecie()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

After discussing it with @ArcaneMusic, we agreed that the current chance to get a random trait / chemicals at 80 + instab is wayyyy too low. The chance is now a sliding scale with a 5% chance at 80 instability, going up to 25% at 100 instability.

## Why It's Good For The Game

More opportunities to get cool chemicals and trait as Botanist, without having to rely on cheesing Strange Seeds, or planting a ton of high instability plant to probably only get a couple rolls anyway.

## Changelog
:cl: Kathy Ryals and ArcaneMusic
tweak: Plant mutation chances at 80+ instability is now a sliding scale.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
