### PR TITLE
[READY] Admin ghosts can now examine_more other ghosts to pull up chat links

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -905,6 +905,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!invisibility)
 		. += "It seems extremely obvious."
 
+/mob/dead/observer/examine_more(mob/user)
+	if(!IsAdminGhost(user, TRUE))
+		return ..()
+	. = list("<span class='notice'><i>You examine [src] closer, and note the following...</i></span>")
+	. += list("\t><span class='admin'>[ADMIN_FULLMONTY(src)]</span>")
+
 /mob/dead/observer/proc/set_invisibility(value)
 	invisibility = value
 	if(!value)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -421,7 +421,7 @@
 			to_chat(user, "<span class='warning'>[affecting] is already in good condition!</span>")
 
 ///Is the passed in mob an admin ghost
-/proc/IsAdminGhost(var/mob/user)
+/proc/IsAdminGhost(var/mob/user, ignore_AI_interact)
 	if(!user)		//Are they a mob? Auto interface updates call this with a null src
 		return
 	if(!user.client) // Do they have a client?
@@ -430,7 +430,7 @@
 		return
 	if(!check_rights_for(user.client, R_ADMIN)) // Are they allowed?
 		return
-	if(!user.client.AI_Interact) // Do they have it enabled?
+	if(!ignore_AI_interact && !user.client.AI_Interact) // Do they have it enabled?
 		return
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Admin ghosts can now examine another ghost twice rapidly to pull up a full monty of their information, as below. It's just one line, so it's hardly obstructive

[![dreamseeker_2020-07-07_22-01-53.png](https://i.imgur.com/3cvHXwGl.jpg)](https://i.imgur.com/3cvHXwG.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Chasing another ghost down trying to right click them to pull up their player panel can be a wild goose chase at times, especially since right click lags you for a split second, and the F6 menu is even slower. This is a nice bit of admin QOL I think people will appreciate.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
admin: As an admin ghost, examining another ghost twice quickly will pull up clickable links to their info in chat
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
