### PR TITLE
removes the cooldown for bigtext from megaphones, adds a new megaphone suicide

### DIFF
--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -8,14 +8,20 @@
 	righthand_file = 'icons/mob/inhands/misc/megaphone_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
 	siemens_coefficient = 1
+	/// when can we next play megaphone.ogg? note that this DOESN'T affect the text embiggening, just the special megaphone noise that plays
 	var/spamcheck = 0
 	var/list/voicespan = list(SPAN_COMMAND)
 
 /obj/item/megaphone/suicide_act(mob/living/carbon/user)
-	user.visible_message("<span class='suicide'>[user] is uttering [user.p_their()] last words into \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	spamcheck = 0//so they dont have to worry about recharging
-	user.say("AAAAAAAAAAAARGHHHHH", forced="megaphone suicide")//he must have died while coding this
-	return OXYLOSS
+	user.visible_message("<span class='suicide'>[user] is using \the [src] to amplify a very special message! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	user.say(";ONE DAY WHILE ANDY WAS-", forced="megaphone suicide") //WAIT NO DON'T
+	addtimer(CALLBACK(src, .proc/manual_suicide, user), 20) //we'll give you 2 seconds to contemplate your mistake
+	return MANUAL_SUICIDE
+
+/obj/item/megaphone/proc/manual_suicide(mob/living/user) //modeled after/copied from the code for the timer suicide
+	playsound(loc, 'sound/effects/adminhelp.ogg', 100, TRUE) //B A N B O T S
+	user.adjustOxyLoss(200)
+	user.death(0)
 
 /obj/item/megaphone/equipped(mob/M, slot)
 	. = ..()
@@ -35,7 +41,7 @@
 		else
 			playsound(loc, 'sound/items/megaphone.ogg', 100, FALSE, TRUE)
 			spamcheck = world.time + 50
-			speech_args[SPEECH_SPANS] |= voicespan
+		speech_args[SPEECH_SPANS] |= voicespan
 
 /obj/item/megaphone/emag_act(mob/user)
 	if(obj_flags & EMAGGED)

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -14,6 +14,7 @@
 
 /obj/item/megaphone/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] is using \the [src] to amplify a very special message! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	spamcheck = 0 //screw it, you're committing suicide anyway, you can get your special megaphone noise despite it being on cooldown
 	user.say(";ONE DAY WHILE ANDY WAS-", forced="megaphone suicide") //WAIT NO DON'T
 	addtimer(CALLBACK(src, .proc/manual_suicide, user), 20) //we'll give you 2 seconds to contemplate your mistake
 	return MANUAL_SUICIDE

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -8,7 +8,7 @@
 	righthand_file = 'icons/mob/inhands/misc/megaphone_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
 	siemens_coefficient = 1
-	/// when can we next play megaphone.ogg? note that this DOESN'T affect the text embiggening, just the special megaphone noise that plays
+	/// when can we next play 'megaphone.ogg'? note that this DOESN'T affect the text embiggening, just the special megaphone noise that plays
 	var/spamcheck = 0
 	var/list/voicespan = list(SPAN_COMMAND)
 

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -8,7 +8,7 @@
 	righthand_file = 'icons/mob/inhands/misc/megaphone_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
 	siemens_coefficient = 1
-	/// when can we next play 'megaphone.ogg'? note that this DOESN'T affect the text embiggening, just the special megaphone noise that plays
+	/// When can we next play 'megaphone.ogg'? Note that this DOESN'T affect the text embiggening, just the special megaphone noise that plays when you speak into a megaphone.
 	var/spamcheck = 0
 	var/list/voicespan = list(SPAN_COMMAND)
 


### PR DESCRIPTION
## About The Pull Request

The 5 second cooldown that megaphones have now only applies to the 'megaphone.ogg' sound that plays when you use them, not their text embiggening effect.

Replaces the existing megaphone suicide with a better one.

## Why It's Good For The Game

It's kind of dumb that megaphones, which are items that take up space in your backpack and that you have to hold in your hand to use, have this restriction, while command headsets do not. This restriction was put in place back when headsets and megaphones gave you REALLY big text, but since that's been toned down a bit since the good ol' days, I think that this restriction's purpose is no longer relevant. Maybe now QMs and clowns will actually use their megaphones more often.

Also, it's kind of hard to use proper comedic timing as a clown when you have to wait at least 5 seconds between the delivery of each of your lines.

## Changelog
:cl: ATHATH
balance: The 5 second cooldown that megaphones have now only applies to the 'megaphone.ogg' sound that plays when you use them, not their text embiggening effect.
tweak: The old megaphone suicide has been replaced with a better one. Try it!
/:cl: