### PR TITLE
Add unit tests for some surgeries, adds more APIs for unit tests to call

### DIFF
--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -112,6 +112,7 @@
 	return list()
 
 /mob/living/carbon/get_missing_limbs()
+	RETURN_TYPE(/list)
 	var/list/full = list(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG)
 	for(var/zone in full)
 		if(get_bodypart(zone))

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -2,6 +2,14 @@
 //Keep this sorted alphabetically
 
 #ifdef UNIT_TESTS
+/// Asserts that a condition is true
+/// If the condition is not true, fails the test
+#define TEST_ASSERT(assertion, reason) if (!(assertion)) { return Fail("Assertion failed: [reason || "No reason"]") }
+
+/// Asserts that the two parameters passed are equal, fails otherwise
+/// Optionally allows an additional message in the case of a failure
+#define TEST_ASSERT_EQUAL(a, b, message) if ((a) != (b)) { return Fail("Expected [a] to be equal to [b].[message ? " [message]" : ""]") }
+
 #include "anchored_mobs.dm"
 #include "bespoke_id.dm"
 #include "card_mismatch.dm"
@@ -13,6 +21,10 @@
 #include "spawn_humans.dm"
 #include "species_whitelists.dm"
 #include "subsystem_init.dm"
+#include "surgeries.dm"
 #include "timer_sanity.dm"
 #include "unit_test.dm"
+
+#undef TEST_ASSERT
+#undef TEST_ASSERT_EQUAL
 #endif

--- a/code/modules/unit_tests/surgeries.dm
+++ b/code/modules/unit_tests/surgeries.dm
@@ -60,7 +60,6 @@
 	var/datum/surgery_step/heal/brute/basic/basic_brute_heal = new
 	basic_brute_heal.success(user, patient, BODY_ZONE_CHEST)
 	TEST_ASSERT(patient.getBruteLoss() < 100, "Tending brute wounds didn't lower brute damage ([patient.getBruteLoss()])")
-	TEST_ASSERT(patient.getFireLoss() < 100, "Tending brute wounds lowered burn damage ([patient.getFireLoss()])")
 
 	var/datum/surgery_step/heal/burn/basic/basic_burn_heal = new
 	basic_burn_heal.success(user, patient, BODY_ZONE_CHEST)

--- a/code/modules/unit_tests/surgeries.dm
+++ b/code/modules/unit_tests/surgeries.dm
@@ -1,0 +1,80 @@
+/datum/unit_test/amputation/Run()
+	var/mob/living/carbon/human/patient = allocate(/mob/living/carbon/human)
+	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
+
+	TEST_ASSERT_EQUAL(patient.get_missing_limbs().len, 0, "Patient is somehow missing limbs before surgery")
+
+	var/datum/surgery/amputation/surgery = new(patient, BODY_ZONE_R_ARM, patient.get_bodypart(BODY_ZONE_R_ARM))
+
+	var/datum/surgery_step/sever_limb/sever_limb = new
+	sever_limb.success(user, patient, BODY_ZONE_R_ARM, null, surgery)
+
+	TEST_ASSERT_EQUAL(patient.get_missing_limbs().len, 1, "Patient did not lose any limbs")
+	TEST_ASSERT_EQUAL(patient.get_missing_limbs()[1], BODY_ZONE_R_ARM, "Patient is missing a limb that isn't the one we operated on")
+
+/datum/unit_test/brain_surgery/Run()
+	var/mob/living/carbon/human/patient = allocate(/mob/living/carbon/human)
+	patient.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_SURGERY)
+	patient.setOrganLoss(ORGAN_SLOT_BRAIN, 20)
+
+	TEST_ASSERT(patient.has_trauma_type(), "Patient does not have any traumas, despite being given one")
+
+	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
+
+	var/datum/surgery_step/fix_brain/fix_brain = new
+	fix_brain.success(user, patient)
+
+	TEST_ASSERT(!patient.has_trauma_type(), "Patient kept their brain trauma after brain surgery")
+	TEST_ASSERT(patient.getOrganLoss(ORGAN_SLOT_BRAIN) < 20, "Patient did not heal their brain damage after brain surgery")
+
+/datum/unit_test/multiple_surgeries/Run()
+	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
+	var/mob/living/carbon/human/patient_zero = allocate(/mob/living/carbon/human)
+	var/mob/living/carbon/human/patient_one = allocate(/mob/living/carbon/human)
+
+	var/obj/item/scalpel/scalpel = allocate(/obj/item/scalpel)
+
+	var/datum/surgery_step/incise/surgery_step = new
+	var/datum/surgery/organ_manipulation/surgery_for_zero = new
+
+	INVOKE_ASYNC(surgery_step, /datum/surgery_step/proc/initiate, user, patient_zero, BODY_ZONE_CHEST, scalpel, surgery_for_zero)
+	TEST_ASSERT(surgery_for_zero.step_in_progress, "Surgery on patient zero was not initiated")
+
+	var/datum/surgery/organ_manipulation/surgery_for_one = new
+
+	// Without waiting for the incision to complete, try to start a new surgery
+	TEST_ASSERT(!surgery_step.initiate(user, patient_one, BODY_ZONE_CHEST, scalpel, surgery_for_one), "Was allowed to start a second surgery without the rod of asclepius")
+	TEST_ASSERT(!surgery_for_one.step_in_progress, "Surgery for patient one is somehow in progress, despite not initiating")
+
+	user.apply_status_effect(STATUS_EFFECT_HIPPOCRATIC_OATH)
+	INVOKE_ASYNC(surgery_step, /datum/surgery_step/proc/initiate, user, patient_one, BODY_ZONE_CHEST, scalpel, surgery_for_one)
+	TEST_ASSERT(surgery_for_one.step_in_progress, "Surgery on patient one was not initiated, despite having rod of asclepius")
+
+/datum/unit_test/tend_wounds/Run()
+	var/mob/living/carbon/human/patient = allocate(/mob/living/carbon/human)
+	patient.take_overall_damage(100, 100)
+
+	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
+
+	// Test that tending wounds actually lowers damage
+	var/datum/surgery_step/heal/brute/basic/basic_brute_heal = new
+	basic_brute_heal.success(user, patient, BODY_ZONE_CHEST)
+	TEST_ASSERT(patient.getBruteLoss() < 100, "Tending brute wounds didn't lower brute damage ([patient.getBruteLoss()])")
+	TEST_ASSERT(patient.getFireLoss() < 100, "Tending brute wounds lowered burn damage ([patient.getFireLoss()])")
+
+	var/datum/surgery_step/heal/burn/basic/basic_burn_heal = new
+	basic_burn_heal.success(user, patient, BODY_ZONE_CHEST)
+	TEST_ASSERT(patient.getFireLoss() < 100, "Tending burn wounds didn't lower burn damage ([patient.getFireLoss()])")
+
+	// Test that wearing clothing lowers heal amount
+	var/mob/living/carbon/human/naked_patient = allocate(/mob/living/carbon/human)
+	naked_patient.take_overall_damage(100)
+
+	var/mob/living/carbon/human/clothed_patient = allocate(/mob/living/carbon/human)
+	clothed_patient.equipOutfit(/datum/outfit/job/doctor, TRUE)
+	clothed_patient.take_overall_damage(100)
+
+	basic_brute_heal.success(user, naked_patient, BODY_ZONE_CHEST)
+	basic_brute_heal.success(user, clothed_patient, BODY_ZONE_CHEST)
+
+	TEST_ASSERT(naked_patient.getBruteLoss() < clothed_patient.getBruteLoss(), "Naked patient did not heal more from wounds tending than a clothed patient")

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -25,9 +25,11 @@ GLOBAL_VAR(test_log)
 
 	//internal shit
 	var/succeeded = TRUE
+	var/list/allocated
 	var/list/fail_reasons
 
 /datum/unit_test/New()
+	allocated = new
 	run_loc_bottom_left = locate(1, 1, 1)
 	run_loc_top_right = locate(5, 5, 1)
 
@@ -35,6 +37,7 @@ GLOBAL_VAR(test_log)
 	//clear the test area
 	for(var/atom/movable/AM in block(run_loc_bottom_left, run_loc_top_right))
 		qdel(AM)
+	QDEL_LIST(allocated)
 	return ..()
 
 /datum/unit_test/proc/Run()
@@ -47,6 +50,18 @@ GLOBAL_VAR(test_log)
 		reason = "FORMATTED: [reason != null ? reason : "NULL"]"
 
 	LAZYADD(fail_reasons, reason)
+
+/// Allocates an instance of the provided type, and places it somewhere in an available loc
+/// Instances allocated through this proc will be destroyed when the test is over
+/datum/unit_test/proc/allocate(type, ...)
+	var/list/arguments = args.Copy(2)
+	if (!arguments.len)
+		arguments = list(run_loc_bottom_left)
+	else if (arguments[1] == null)
+		arguments[1] = run_loc_bottom_left
+	var/instance = new type(arglist(arguments))
+	allocated += instance
+	return instance
 
 /proc/RunUnitTests()
 	CHECK_TICK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds unit tests to ensure amputation, brain surgery, and tending wounds all work. Adds a unit test to ensure you cannot commit multiple surgeries without a rod of asclepius.

Adds new APIs for unit tests to call:

`TEST_ASSERT(condition, message)` - Stops and fails the test if the condition is not met.
`TEST_ASSERT_EQUAL(a, b, message)` - Stops and fails the test if a != b.
`allocate(type, ...)` - Allocates an instance of the provided type, and places it somewhere in an available loc. Instances allocated through this proc will be destroyed when the test is over

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ensures https://github.com/tgstation/tgstation/pull/52081 never happens again. We should make sure it is as easy as possible to add new unit tests to the codebase, since it means that you can fix a bug once and ensure it never comes back again. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Added surgery related unit tests and adds TEST_ASSERT, TEST_ASSERT_EQUAL, and allocate to unit tests.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
