### PR TITLE
Captains no longer have to turn on all of their headset's non-command/sec channels at roundstart

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -82,7 +82,7 @@
 /obj/item/encryptionkey/heads/captain
 	name = "\proper the captain's encryption key"
 	icon_state = "cap_cypherkey"
-	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_SECURITY = 1, RADIO_CHANNEL_ENGINEERING = 0, RADIO_CHANNEL_SCIENCE = 0, RADIO_CHANNEL_MEDICAL = 0, RADIO_CHANNEL_SUPPLY = 0, RADIO_CHANNEL_SERVICE = 0)
+	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_SECURITY = 1, RADIO_CHANNEL_ENGINEERING = 1, RADIO_CHANNEL_SCIENCE = 1, RADIO_CHANNEL_MEDICAL = 1, RADIO_CHANNEL_SUPPLY = 1, RADIO_CHANNEL_SERVICE = 1)
 
 /obj/item/encryptionkey/heads/rd
 	name = "\proper the research director's encryption key"


### PR DESCRIPTION
## About The Pull Request

This PR makes all of the channels of captain headset encryption keys (such as the ones found in the captain's roundstart headset and the headsets in their locker) default to being turned on, instead of just the command and security channels.

## Why It's Good For The Game

As far as I'm aware, captain headset encryption keys are the ONLY encryption keys in the game that don't start with all of their channels on, and I see no good reason as to WHY this is the case.

This is a pointless, 5 second bit of roundstart tedium for captains that does not improve the game or serve a balance purpose. It's basically just a trap that needlessly punishes new captains that don't know that they don't start the round with all of their headset channels turned on.

Also, calling it now, like 4 different coders are gonna come out of the woodwork and start arguing that this is a CRUCIAL part of the game and that I "might as well give everything to everyone at roundstart" or something. The captain will still have to gear up from his locker at the start of the round; this PR just removes a small, unintuitive (again, NO OTHER HEADSET ENCRYPTION KEY IN THE GAME WORKS THIS WAY) part of that routine that new captains might not even know that they have to do.

I would normally also take this opportunity to make headsets with the ability to start on loud mode start on loud mode by default, but apparently, loud mode is a controversial feature/topic, so I'll just save that for a future PR.

## Changelog
:cl: ATHATH
tweak: Captain headsets (and, by extension, CentCom Commander headsets) now have all of their channels on by default, instead of just their security and command channels.
/:cl: