### PR TITLE
Fixes Infinite Loop in Bubblegum Hallucination

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -319,7 +319,11 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 
 /datum/hallucination/oh_yeah/proc/bubble_attack(turf/landing)
 	var/charged = FALSE //only get hit once
-	while(get_turf(bubblegum) != landing && target && target.stat != DEAD)
+	while(get_turf(bubblegum) != landing && target?.stat != DEAD)
+		if(!landing)
+			break
+		if((get_turf(bubblegum)).loc.z != landing.loc.z)
+			break
 		bubblegum.forceMove(get_step_towards(bubblegum, landing))
 		bubblegum.setDir(get_dir(bubblegum, landing))
 		target.playsound_local(get_turf(bubblegum), 'sound/effects/meteorimpact.ogg', 150, 1)


### PR DESCRIPTION
## About The Pull Request

Fixes an infinite loop in the Bubblegum hallucination that occurred when transferring z-levels. 

## Why It's Good For The Game

infinite loops are bad, infinite camera shake is sickening 

## Changelog
:cl: Melbert
fix: Fixes an infinite loop / infinite camera shake in the Bubblegum hallucination
/:cl:

