### PR TITLE
Makes Movespeed in Config Consistent with Live

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -45,7 +45,7 @@ WALK_DELAY 4
 ##MULTIPLICATIVE_MOVESPEED /mob/living/carbon/monkey 0
 ##MULTIPLICATIVE_MOVESPEED /mob/living/carbon/alien 0
 ##MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal/slime 0
-MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal 1
+MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal 0
 
 
 ## NAMES ###


### PR DESCRIPTION
Changing this every time you test something with simple mobs is rather annoying and it's going to give someone, one day, the wrong idea of how to properly balance simple mobs, since their delay is different on live than it is locally (as that was happening prior to the run speed being adjusted).

No CL as this is backend.