### PR TITLE
Changes Icebox's Fore Maintenance and Service Hall.

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -13904,6 +13904,7 @@
 /obj/structure/table,
 /obj/item/circuitboard/machine/vendatray,
 /obj/item/circuitboard/machine/vendatray,
+/obj/item/camera,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "aGA" = (
@@ -14558,14 +14559,14 @@
 /area/hallway/primary/central)
 "aHS" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Service Hallway";
-	req_access_txt = "25"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock{
+	name = "Bar Service Hall";
+	req_one_access_txt = "25"
+	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "aHT" = (
@@ -14671,6 +14672,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/trimline/green/line,
+/obj/item/kirbyplants/fullysynthetic,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "aId" = (
@@ -14720,6 +14722,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/white/line,
+/obj/item/kirbyplants/fullysynthetic,
 /turf/open/floor/plasteel/showroomfloor,
 /area/hallway/secondary/service)
 "aIi" = (
@@ -15282,13 +15285,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "aJA" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Kitchen Maintenance";
-	req_access_txt = "28"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Kitchen Service Hall";
+	req_access_txt = "28";
+	req_one_access_txt = null
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/hallway/secondary/service)
 "aJB" = (
@@ -48522,6 +48526,13 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"czy" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "czE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -50451,10 +50462,6 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel,
 /area/medical/virology)
-"cLD" = (
-/obj/structure/fermenting_barrel,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "cMm" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -51123,6 +51130,12 @@
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/lawoffice)
+"dvH" = (
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "dvO" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -51285,17 +51298,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"dKq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "dMb" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -51366,10 +51368,52 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel,
 /area/medical/virology)
+"dRY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/space/basic,
+/area/maintenance/starboard/fore)
+"dSl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Service Hallway East";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/trimline/white/line,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "dUO" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"dWE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
+"dXQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/theatre";
+	dir = 8;
+	name = "Theatre APC";
+	pixel_x = -25
+	},
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
+"dXU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "dYq" = (
 /turf/closed/wall,
 /area/science/nanite)
@@ -51400,6 +51444,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"eic" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "eja" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/nanite_chamber_control{
@@ -51415,13 +51472,6 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel,
 /area/medical/virology)
-"eld" = (
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/fore)
 "epk" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -51440,20 +51490,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"euo" = (
-/obj/structure/frame/computer{
-	anchored = 1;
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"ewS" = (
-/obj/structure/marker_beacon{
-	icon_state = "markerburgundy-on"
-	},
-/obj/structure/fluff/fokoff_sign,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
 "eya" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -51486,6 +51522,17 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"eCX" = (
+/obj/item/chair/plastic{
+	pixel_y = 10
+	},
+/obj/item/chair/plastic{
+	pixel_y = 5
+	},
+/obj/item/chair/plastic,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "eFD" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/disks{
@@ -51555,12 +51602,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"eTb" = (
-/obj/item/clothing/gloves/boxing/green,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/drinks/waterbottle,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "eUr" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "testlab";
@@ -51708,6 +51749,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"ftP" = (
+/obj/structure/window,
+/obj/structure/rack,
+/obj/item/assembly/signaler,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "fvi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -51917,6 +51964,10 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"gcb" = (
+/obj/structure/sign/poster/official/random,
+/turf/closed/wall,
+/area/hallway/secondary/service)
 "gdg" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -51939,20 +51990,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"ghc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "giT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -52242,6 +52279,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
+"hmL" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "hnW" = (
 /obj/effect/spawner/structure/window/reinforced{
 	pixel_w = 1
@@ -52254,6 +52294,10 @@
 	dir = 5
 	},
 /area/science/research)
+"hxh" = (
+/obj/machinery/light/small/broken,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "hxs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52262,17 +52306,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"hza" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "hzQ" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -52523,17 +52556,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"iuZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/structure/table,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
+"itV" = (
+/obj/item/pressure_plate,
+/obj/item/pressure_plate,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ivU" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -52607,16 +52635,6 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"iNM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "iOI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/rack,
@@ -52767,6 +52785,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"jlt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "jly" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -52828,22 +52852,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
-"jtv" = (
-/obj/machinery/light/small/broken,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"jtC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Service Hallway East";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/trimline/white/line,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "juq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -52851,19 +52859,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
-"jvQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "jvR" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -53010,12 +53005,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"jUX" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "jVc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -53150,12 +53139,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
-"klF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
 "klM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -53193,10 +53176,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"ksX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
+"kqx" = (
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on"
+	},
+/obj/structure/fluff/fokoff_sign,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "kul" = (
 /turf/closed/wall,
 /area/engine/engine_smes)
@@ -53221,6 +53207,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"kvA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "kvJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -53591,10 +53583,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"loe" = (
-/obj/item/assembly/mousetrap,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "lqJ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
@@ -53753,9 +53741,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"lOE" = (
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "lOR" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -53881,6 +53866,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"lWk" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "lWA" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -54088,9 +54079,6 @@
 /obj/machinery/vending/modularpc,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"mGL" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "mIq" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -54239,10 +54227,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"mWl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/space/basic,
+"mVA" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"mVI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "mWw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -54276,12 +54270,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/medical/surgery)
-"nbe" = (
-/obj/item/pressure_plate,
-/obj/item/pressure_plate,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "nbA" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -54402,6 +54390,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"nuG" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "nwJ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -54410,6 +54404,17 @@
 /obj/machinery/vending/modularpc,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"nxi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "nxv" = (
 /obj/machinery/power/apc{
 	areastring = "/area/construction";
@@ -54473,13 +54478,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"nEz" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "nEP" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/machinery/light{
@@ -54509,6 +54507,10 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"nLZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "nPP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -54630,10 +54632,7 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"ofz" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+"obc" = (
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "ofT" = (
@@ -54777,6 +54776,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"oMP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "oND" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -54815,12 +54825,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
-"oSg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/fore)
 "oUq" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 8
@@ -54905,18 +54909,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"pag" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"pbZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "peL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/warning/coldtemp{
@@ -55100,6 +55092,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"psr" = (
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "psy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -55427,6 +55422,19 @@
 /obj/machinery/rnd/bepis,
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"qcw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "qcV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -55466,6 +55474,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
+"qjK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qjL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -55483,6 +55499,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"qkJ" = (
+/obj/item/assembly/mousetrap,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qnW" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -55508,12 +55528,6 @@
 /obj/machinery/computer/operating,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"qqu" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "qrH" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
@@ -55584,13 +55598,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/security/detectives_office)
-"qNE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/fore)
 "qQC" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
@@ -55612,9 +55619,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"qWr" = (
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
+"qTW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "rcD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -55633,12 +55644,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"rgz" = (
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "rhl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -55777,16 +55782,6 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"rJq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "rKc" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -55931,6 +55926,20 @@
 "sdX" = (
 /turf/closed/wall,
 /area/quartermaster/office)
+"sec" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "sgR" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/green,
@@ -55989,6 +55998,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"sqP" = (
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/service";
+	dir = 1;
+	name = "Service Hall APC";
+	pixel_y = 23
+	},
+/obj/structure/cable,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "suU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -56142,12 +56161,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"sQV" = (
-/obj/structure/window,
-/obj/structure/rack,
-/obj/item/assembly/signaler,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "sRt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -56385,10 +56398,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"ttX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "tuC" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -56465,14 +56474,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/medical/psychology)
-"tGx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/railing,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "tGE" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
@@ -56486,19 +56487,6 @@
 /obj/item/clothing/suit/hooded/wintercoat,
 /turf/open/floor/plasteel,
 /area/storage/mining)
-"tIg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "tIw" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -56567,17 +56555,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"tQz" = (
-/obj/item/chair/plastic{
-	pixel_y = 10
-	},
-/obj/item/chair/plastic{
-	pixel_y = 5
-	},
-/obj/item/chair/plastic,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "tRv" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
@@ -56595,6 +56572,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"tUt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "tXL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -56782,6 +56769,18 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"uze" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/structure/table,
+/obj/item/toner/large,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "uzl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -56969,6 +56968,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
+"vbr" = (
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "vbw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57074,6 +57080,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
+"vqt" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "vqI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57099,6 +57111,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"vwL" = (
+/obj/structure/sign/painting/library,
+/turf/closed/wall,
+/area/hallway/secondary/service)
 "vwX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -57314,6 +57330,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
+"weo" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "wfU" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 8
@@ -57354,6 +57377,10 @@
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"wnu" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "wph" = (
 /obj/docking_port/stationary{
 	dheight = 4;
@@ -57375,6 +57402,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"wrg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "wtb" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -57431,12 +57468,6 @@
 /obj/structure/railing,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"wCK" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "wFc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -57849,14 +57880,6 @@
 "xwN" = (
 /turf/open/floor/plating,
 /area/engine/engine_smes)
-"xxN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "xzi" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -57925,15 +57948,11 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xIh" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 23
+"xOm" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/obj/structure/cable,
-/turf/open/floor/plastic,
+/turf/open/floor/wood,
 /area/hallway/secondary/service)
 "xQZ" = (
 /obj/structure/chair/stool,
@@ -58118,18 +58137,6 @@
 /obj/structure/sign/warning/electricshock,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"ycm" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/theatre";
-	dir = 8;
-	name = "Theatre APC";
-	pixel_x = -25
-	},
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "ydc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -58150,6 +58157,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
+"ydL" = (
+/obj/item/clothing/gloves/boxing/green,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "yeu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -93564,9 +93577,9 @@ axW
 azo
 aAp
 aBC
-ycm
+dXQ
 aEA
-iuZ
+uze
 aGz
 aIb
 aCr
@@ -93822,8 +93835,8 @@ azf
 aAo
 apX
 aBB
-ksX
-ksX
+nLZ
+nLZ
 aGy
 aIa
 cNE
@@ -94079,8 +94092,8 @@ azh
 gsz
 arj
 cVb
-cVb
-qWr
+vwL
+psr
 aGI
 aId
 bke
@@ -94337,8 +94350,8 @@ azp
 azp
 aCu
 cVb
-xIh
-dKq
+sqP
+oMP
 aIc
 aJC
 aKO
@@ -94593,9 +94606,9 @@ aro
 aro
 aro
 aCv
-cVb
-jUX
-ghc
+vwL
+lWk
+sec
 aIe
 aJC
 aJC
@@ -94850,9 +94863,9 @@ aro
 aro
 aro
 aCv
-cVb
-lOE
-hza
+gcb
+obc
+nxi
 aIe
 aJE
 aKQ
@@ -95108,7 +95121,7 @@ aro
 aro
 aCv
 cVb
-ofz
+xOm
 aGA
 aHS
 aJx
@@ -95365,8 +95378,8 @@ aro
 aro
 aCv
 cVb
-wCK
-hza
+nuG
+nxi
 aHM
 aJm
 aKz
@@ -95622,8 +95635,8 @@ aro
 aro
 aCv
 cVb
-pbZ
-jvQ
+kvA
+eic
 aIe
 aJC
 aKS
@@ -95878,9 +95891,9 @@ azp
 azp
 azp
 aCw
-cVb
-lOE
-rJq
+gcb
+obc
+wrg
 aIg
 aJH
 aKR
@@ -96135,9 +96148,9 @@ arj
 boP
 boP
 boP
-cVb
-qqu
-tIg
+vwL
+vqt
+qcw
 aIe
 aJI
 aJI
@@ -96392,9 +96405,9 @@ arj
 boP
 boP
 boP
-cVb
-mGL
-iNM
+gcb
+hmL
+tUt
 aIh
 aJI
 aKT
@@ -96649,8 +96662,8 @@ alP
 alP
 boP
 boP
-cVb
-mGL
+vwL
+hmL
 aGB
 aIf
 aJA
@@ -96902,13 +96915,13 @@ boP
 boP
 alP
 anf
-nbe
+itV
 alP
 boP
 boP
 cVb
-ttX
-xxN
+mVI
+dWE
 aHY
 aQj
 iNn
@@ -97159,14 +97172,14 @@ boP
 boP
 alO
 anf
-cLD
+wnu
 alO
 boP
 boP
 cVb
-nEz
-iNM
-jtC
+czy
+tUt
+dSl
 aJK
 aKV
 tMl
@@ -97423,7 +97436,7 @@ alP
 alP
 alP
 aGP
-klF
+dXU
 aJI
 aJI
 aJI
@@ -97670,13 +97683,13 @@ arp
 alO
 awD
 anf
-sQV
+ftP
 anf
 anf
 atw
 aBE
 alP
-euo
+weo
 aDX
 alP
 aGH
@@ -97933,8 +97946,8 @@ anf
 anf
 anf
 alP
-rgz
-loe
+mVA
+qkJ
 alP
 aGQ
 aIk
@@ -98963,7 +98976,7 @@ anf
 anf
 aCz
 arr
-tGx
+qjK
 aFr
 aIn
 aIp
@@ -99731,9 +99744,9 @@ awH
 arr
 apE
 anf
-eTb
-mWl
-ewS
+ydL
+dRY
+kqx
 bKs
 bKK
 aIp
@@ -99988,7 +100001,7 @@ aoP
 arr
 apE
 anf
-pag
+dvH
 alP
 alP
 aFo
@@ -100245,7 +100258,7 @@ alP
 arr
 alP
 anf
-jtv
+hxh
 alP
 ayf
 aFm
@@ -100492,7 +100505,7 @@ boP
 boP
 boP
 apC
-tQz
+eCX
 anf
 alP
 atx
@@ -100502,7 +100515,7 @@ auD
 arr
 alP
 aAs
-oSg
+jlt
 alP
 aCG
 aFr
@@ -100758,8 +100771,8 @@ apC
 aoP
 arr
 apE
-eld
-qNE
+vbr
+qTW
 alP
 aCG
 aDZ

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -49516,19 +49516,6 @@
 	},
 /turf/closed/wall,
 /area/engine/engineering)
-"cDV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "cDZ" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -50464,6 +50451,10 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel,
 /area/medical/virology)
+"cLD" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "cMm" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -51009,12 +51000,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
-"cZN" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "dbw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -51109,21 +51094,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"doh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "dov" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/medical/psychology)
-"dps" = (
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/fore)
 "dpI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -51242,12 +51216,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"dDA" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "dEq" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -51317,6 +51285,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"dKq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "dMb" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -51394,17 +51373,6 @@
 "dYq" = (
 /turf/closed/wall,
 /area/science/nanite)
-"ebZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "ecg" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/filled/end{
@@ -51447,6 +51415,13 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel,
 /area/medical/virology)
+"eld" = (
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "epk" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -51465,6 +51440,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"euo" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"ewS" = (
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on"
+	},
+/obj/structure/fluff/fokoff_sign,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "eya" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -51566,6 +51555,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"eTb" = (
+/obj/item/clothing/gloves/boxing/green,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "eUr" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "testlab";
@@ -51783,12 +51778,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"fGK" = (
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "fJT" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -51817,9 +51806,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
-"fNJ" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "fQA" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -51953,6 +51939,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"ghc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "giT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -52262,6 +52262,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"hza" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "hzQ" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -52512,6 +52523,17 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"iuZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/structure/table,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "ivU" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -52585,6 +52607,16 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"iNM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "iOI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/rack,
@@ -52796,6 +52828,22 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"jtv" = (
+/obj/machinery/light/small/broken,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"jtC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Service Hallway East";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/trimline/white/line,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "juq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -52803,6 +52851,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
+"jvQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "jvR" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -52876,18 +52937,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jHT" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/theatre";
-	dir = 8;
-	name = "Theatre APC";
-	pixel_x = -25
-	},
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "jHW" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty{
@@ -52961,6 +53010,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"jUX" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "jVc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -53095,6 +53150,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"klF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "klM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -53132,6 +53193,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"ksX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "kul" = (
 /turf/closed/wall,
 /area/engine/engine_smes)
@@ -53162,12 +53227,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"kwr" = (
-/obj/item/clothing/gloves/boxing/green,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/drinks/waterbottle,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "kwA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -53479,10 +53538,6 @@
 	dir = 8
 	},
 /area/science/research)
-"kXD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/space/basic,
-/area/maintenance/starboard/fore)
 "kZR" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
@@ -53495,9 +53550,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"lbI" = (
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "lcg" = (
 /obj/machinery/light{
 	dir = 4
@@ -53526,20 +53578,6 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
-"liK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "ljx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -53553,6 +53591,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"loe" = (
+/obj/item/assembly/mousetrap,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "lqJ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
@@ -53711,6 +53753,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"lOE" = (
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "lOR" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -53846,10 +53891,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"lZz" = (
-/obj/item/assembly/mousetrap,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "lZG" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -53893,13 +53934,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"mgv" = (
-/obj/structure/frame/computer{
-	anchored = 1;
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "mhs" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -53983,17 +54017,6 @@
 	},
 /turf/closed/wall,
 /area/medical/morgue)
-"mBj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "mBm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54060,18 +54083,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/break_room)
-"mFJ" = (
-/obj/structure/marker_beacon{
-	icon_state = "markerburgundy-on"
-	},
-/obj/structure/fluff/fokoff_sign,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
 "mFY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/vending/modularpc,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"mGL" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "mIq" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -54112,12 +54131,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
-"mLq" = (
-/obj/item/pressure_plate,
-/obj/item/pressure_plate,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "mLY" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -54226,6 +54239,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"mWl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/space/basic,
+/area/maintenance/starboard/fore)
 "mWw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -54259,6 +54276,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/medical/surgery)
+"nbe" = (
+/obj/item/pressure_plate,
+/obj/item/pressure_plate,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "nbA" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -54352,18 +54375,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"nrG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Service Hallway East";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/trimline/white/line,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "nsl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -54439,19 +54450,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"nBr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "nCW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -54475,6 +54473,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"nEz" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "nEP" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/machinery/light{
@@ -54482,29 +54487,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"nFs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/structure/table,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
-"nFC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
-"nFX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/railing,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "nGt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -54527,9 +54509,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"nNE" = (
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "nPP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -54651,6 +54630,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"ofz" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "ofT" = (
 /obj/machinery/computer/bounty,
 /turf/open/floor/plasteel,
@@ -54674,10 +54659,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"olb" = (
-/obj/machinery/light/small/broken,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "olh" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54716,12 +54697,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"opN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/fore)
 "orP" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
@@ -54840,6 +54815,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
+"oSg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "oUq" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 8
@@ -54865,16 +54846,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"oXf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "oXE" = (
 /obj/machinery/door/airlock/maintenance{
 	id_tag = "commissarydoor";
@@ -54934,6 +54905,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"pag" = (
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"pbZ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "peL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/warning/coldtemp{
@@ -55005,12 +54988,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"pgz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
 "pgP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55285,12 +55262,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel,
 /area/medical/medbay/lobby)
-"pFX" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "pHl" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
@@ -55414,12 +55385,6 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/sorting)
-"pWq" = (
-/obj/structure/window,
-/obj/structure/rack,
-/obj/item/assembly/signaler,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "pWN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55543,6 +55508,12 @@
 /obj/machinery/computer/operating,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"qqu" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "qrH" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
@@ -55572,13 +55543,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
-"qwO" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "qyN" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
@@ -55620,6 +55584,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/security/detectives_office)
+"qNE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "qQC" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
@@ -55641,6 +55612,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"qWr" = (
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "rcD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -55659,6 +55633,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"rgz" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "rhl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -55687,16 +55667,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"rlW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "rmX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -55807,6 +55777,16 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"rJq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "rKc" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -55993,14 +55973,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"slE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "slW" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
@@ -56017,29 +55989,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"sub" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 23
-	},
-/obj/structure/cable,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "suU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"suY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/fore)
 "sve" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -56187,6 +56142,12 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"sQV" = (
+/obj/structure/window,
+/obj/structure/rack,
+/obj/item/assembly/signaler,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "sRt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -56424,6 +56385,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"ttX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "tuC" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -56500,6 +56465,14 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/medical/psychology)
+"tGx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "tGE" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
@@ -56513,6 +56486,19 @@
 /obj/item/clothing/suit/hooded/wintercoat,
 /turf/open/floor/plasteel,
 /area/storage/mining)
+"tIg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "tIw" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -56581,6 +56567,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"tQz" = (
+/obj/item/chair/plastic{
+	pixel_y = 10
+	},
+/obj/item/chair/plastic{
+	pixel_y = 5
+	},
+/obj/item/chair/plastic,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "tRv" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
@@ -56598,12 +56595,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"tTs" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "tXL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -57440,12 +57431,12 @@
 /obj/structure/railing,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"wEW" = (
+"wCK" = (
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = 32
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "wFc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -57858,6 +57849,14 @@
 "xwN" = (
 /turf/open/floor/plating,
 /area/engine/engine_smes)
+"xxN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "xzi" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -57894,17 +57893,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
-"xAy" = (
-/obj/item/chair/plastic{
-	pixel_y = 10
-	},
-/obj/item/chair/plastic{
-	pixel_y = 5
-	},
-/obj/item/chair/plastic,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "xCq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall,
@@ -57937,11 +57925,15 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xQP" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+"xIh" = (
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/service";
+	dir = 1;
+	name = "Service Hall APC";
+	pixel_y = 23
 	},
-/turf/open/floor/wood,
+/obj/structure/cable,
+/turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "xQZ" = (
 /obj/structure/chair/stool,
@@ -58126,6 +58118,18 @@
 /obj/structure/sign/warning/electricshock,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"ycm" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/theatre";
+	dir = 8;
+	name = "Theatre APC";
+	pixel_x = -25
+	},
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "ydc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -93560,9 +93564,9 @@ axW
 azo
 aAp
 aBC
-jHT
+ycm
 aEA
-nFs
+iuZ
 aGz
 aIb
 aCr
@@ -93818,8 +93822,8 @@ azf
 aAo
 apX
 aBB
-doh
-doh
+ksX
+ksX
 aGy
 aIa
 cNE
@@ -94076,7 +94080,7 @@ gsz
 arj
 cVb
 cVb
-nNE
+qWr
 aGI
 aId
 bke
@@ -94333,8 +94337,8 @@ azp
 azp
 aCu
 cVb
-sub
-ebZ
+xIh
+dKq
 aIc
 aJC
 aKO
@@ -94590,8 +94594,8 @@ aro
 aro
 aCv
 cVb
-xQP
-liK
+jUX
+ghc
 aIe
 aJC
 aJC
@@ -94847,8 +94851,8 @@ aro
 aro
 aCv
 cVb
-lbI
-mBj
+lOE
+hza
 aIe
 aJE
 aKQ
@@ -95104,7 +95108,7 @@ aro
 aro
 aCv
 cVb
-dDA
+ofz
 aGA
 aHS
 aJx
@@ -95361,8 +95365,8 @@ aro
 aro
 aCv
 cVb
-pFX
-mBj
+wCK
+hza
 aHM
 aJm
 aKz
@@ -95618,8 +95622,8 @@ aro
 aro
 aCv
 cVb
-tTs
-cDV
+pbZ
+jvQ
 aIe
 aJC
 aKS
@@ -95875,8 +95879,8 @@ azp
 azp
 aCw
 cVb
-lbI
-rlW
+lOE
+rJq
 aIg
 aJH
 aKR
@@ -96132,8 +96136,8 @@ boP
 boP
 boP
 cVb
-cZN
-nBr
+qqu
+tIg
 aIe
 aJI
 aJI
@@ -96389,8 +96393,8 @@ boP
 boP
 boP
 cVb
-fNJ
-oXf
+mGL
+iNM
 aIh
 aJI
 aKT
@@ -96640,13 +96644,13 @@ arj
 auB
 auB
 arj
-arj
-arj
-boP
+aUx
+alP
+alP
 boP
 boP
 cVb
-fNJ
+mGL
 aGB
 aIf
 aJA
@@ -96896,15 +96900,15 @@ boP
 boP
 boP
 boP
-boP
-boP
-boP
-boP
+alP
+anf
+nbe
+alP
 boP
 boP
 cVb
-nFC
-slE
+ttX
+xxN
 aHY
 aQj
 iNn
@@ -97153,16 +97157,16 @@ boP
 boP
 boP
 boP
-boP
-boP
-boP
-boP
+alO
+anf
+cLD
+alO
 boP
 boP
 cVb
-qwO
-oXf
-nrG
+nEz
+iNM
+jtC
 aJK
 aKV
 tMl
@@ -97411,15 +97415,15 @@ alO
 alO
 alP
 alP
-alP
-alO
+anf
+auC
 alP
 alP
 alP
 alP
 alP
 aGP
-pgz
+klF
 aJI
 aJI
 aJI
@@ -97666,13 +97670,13 @@ arp
 alO
 awD
 anf
-pWq
+sQV
 anf
-mLq
+anf
 atw
 aBE
 alP
-mgv
+euo
 aDX
 alP
 aGH
@@ -97929,8 +97933,8 @@ anf
 anf
 anf
 alP
-fGK
-lZz
+rgz
+loe
 alP
 aGQ
 aIk
@@ -98959,7 +98963,7 @@ anf
 anf
 aCz
 arr
-nFX
+tGx
 aFr
 aIn
 aIp
@@ -99727,9 +99731,9 @@ awH
 arr
 apE
 anf
-kwr
-kXD
-mFJ
+eTb
+mWl
+ewS
 bKs
 bKK
 aIp
@@ -99984,7 +99988,7 @@ aoP
 arr
 apE
 anf
-wEW
+pag
 alP
 alP
 aFo
@@ -100241,7 +100245,7 @@ alP
 arr
 alP
 anf
-olb
+jtv
 alP
 ayf
 aFm
@@ -100488,7 +100492,7 @@ boP
 boP
 boP
 apC
-xAy
+tQz
 anf
 alP
 atx
@@ -100498,7 +100502,7 @@ auD
 arr
 alP
 aAs
-opN
+oSg
 alP
 aCG
 aFr
@@ -100754,8 +100758,8 @@ apC
 aoP
 arr
 apE
-dps
-suY
+eld
+qNE
 alP
 aCG
 aDZ

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -12127,6 +12127,8 @@
 "aCA" = (
 /obj/structure/cable,
 /obj/structure/railing,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -49514,6 +49516,19 @@
 	},
 /turf/closed/wall,
 /area/engine/engineering)
+"cDV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "cDZ" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -50435,10 +50450,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/medical/break_room)
-"cJz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "cKG" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -50998,6 +51009,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
+"cZN" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "dbw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -51092,10 +51109,21 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"doh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "dov" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/medical/psychology)
+"dps" = (
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "dpI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -51214,6 +51242,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"dDA" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "dEq" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -51283,9 +51317,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"dLO" = (
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "dMb" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -51363,6 +51394,17 @@
 "dYq" = (
 /turf/closed/wall,
 /area/science/nanite)
+"ebZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "ecg" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/filled/end{
@@ -51384,18 +51426,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"eey" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/theatre";
-	dir = 8;
-	name = "Theatre APC";
-	pixel_x = -25
-	},
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "egr" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
@@ -51435,12 +51465,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"euS" = (
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "eya" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -51563,12 +51587,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"eWJ" = (
-/obj/item/pressure_plate,
-/obj/item/pressure_plate,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "fcG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -51701,24 +51719,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"fvx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Service Hallway East";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/trimline/white/line,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
-"fwp" = (
-/obj/structure/window,
-/obj/structure/rack,
-/obj/item/assembly/signaler,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "fxH" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/pinpointer_dispenser,
@@ -51783,6 +51783,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"fGK" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "fJT" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -51811,6 +51817,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
+"fNJ" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "fQA" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -51944,12 +51953,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"giA" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "giT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -52168,12 +52171,6 @@
 "gQb" = (
 /turf/closed/mineral/random/snow/no_caves,
 /area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
-"gRT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/fore)
 "gUV" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -52234,10 +52231,6 @@
 /mob/living/simple_animal/pet/fox/renault,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"hgE" = (
-/obj/machinery/light/small/broken,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "hhs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -52368,16 +52361,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/science/xenobiology)
-"hIL" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 23
-	},
-/obj/structure/cable,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "hIZ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -52594,12 +52577,6 @@
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"iMq" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "iNn" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room"
@@ -52826,12 +52803,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
-"juN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
 "jvR" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -52880,13 +52851,6 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"jCk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/fore)
 "jCq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -52912,6 +52876,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jHT" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/theatre";
+	dir = 8;
+	name = "Theatre APC";
+	pixel_x = -25
+	},
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "jHW" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty{
@@ -53186,6 +53162,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"kwr" = (
+/obj/item/clothing/gloves/boxing/green,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "kwA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -53497,6 +53479,10 @@
 	dir = 8
 	},
 /area/science/research)
+"kXD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/space/basic,
+/area/maintenance/starboard/fore)
 "kZR" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
@@ -53509,6 +53495,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"lbI" = (
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "lcg" = (
 /obj/machinery/light{
 	dir = 4
@@ -53537,6 +53526,20 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"liK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "ljx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -53585,13 +53588,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"lvX" = (
-/obj/structure/frame/computer{
-	anchored = 1;
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "lwr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -53850,6 +53846,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lZz" = (
+/obj/item/assembly/mousetrap,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "lZG" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -53869,16 +53869,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/storage)
-"maY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "mdr" = (
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
@@ -53903,20 +53893,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"mfs" = (
-/obj/structure/disposalpipe/segment{
+"mgv" = (
+/obj/structure/frame/computer{
+	anchored = 1;
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "mhs" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -53969,36 +53952,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"mta" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
-"mtj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
-"mtA" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "mtK" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
@@ -54030,6 +53983,17 @@
 	},
 /turf/closed/wall,
 /area/medical/morgue)
+"mBj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "mBm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54096,6 +54060,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/break_room)
+"mFJ" = (
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on"
+	},
+/obj/structure/fluff/fokoff_sign,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "mFY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/vending/modularpc,
@@ -54141,6 +54112,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
+"mLq" = (
+/obj/item/pressure_plate,
+/obj/item/pressure_plate,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "mLY" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -54375,6 +54352,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"nrG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Service Hallway East";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/trimline/white/line,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "nsl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -54450,6 +54439,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"nBr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "nCW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -54480,6 +54482,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"nFs" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/structure/table,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
+"nFC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
+"nFX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "nGt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -54502,6 +54527,9 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"nNE" = (
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "nPP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -54532,30 +54560,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"nSJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
-"nST" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/space/basic,
-/area/maintenance/starboard/fore)
-"nTN" = (
-/obj/structure/marker_beacon{
-	icon_state = "markerburgundy-on"
-	},
-/obj/structure/fluff/fokoff_sign,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
 "nTU" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
@@ -54647,9 +54651,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"obw" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "ofT" = (
 /obj/machinery/computer/bounty,
 /turf/open/floor/plasteel,
@@ -54673,6 +54674,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"olb" = (
+/obj/machinery/light/small/broken,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "olh" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54711,6 +54716,12 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"opN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "orP" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
@@ -54854,6 +54865,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"oXf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "oXE" = (
 /obj/machinery/door/airlock/maintenance{
 	id_tag = "commissarydoor";
@@ -54913,12 +54934,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"pbd" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "peL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/warning/coldtemp{
@@ -54990,6 +55005,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"pgz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "pgP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55142,12 +55163,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"pxN" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "pxV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -55270,20 +55285,16 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel,
 /area/medical/medbay/lobby)
+"pFX" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "pHl" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
-"pHB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "pIc" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -55311,12 +55322,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"pKy" = (
-/obj/item/clothing/gloves/boxing/green,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/drinks/waterbottle,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "pLn" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -55409,6 +55414,12 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/sorting)
+"pWq" = (
+/obj/structure/window,
+/obj/structure/rack,
+/obj/item/assembly/signaler,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "pWN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55477,17 +55488,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"qem" = (
-/obj/item/chair/plastic{
-	pixel_y = 10
-	},
-/obj/item/chair/plastic{
-	pixel_y = 5
-	},
-/obj/item/chair/plastic,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "qeQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55572,6 +55572,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
+"qwO" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "qyN" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
@@ -55680,6 +55687,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"rlW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "rmX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -55692,14 +55709,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"rsb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "ruy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55984,6 +55993,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"slE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "slW" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
@@ -56000,20 +56017,29 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"stG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"sub" = (
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/service";
+	dir = 1;
+	name = "Service Hall APC";
+	pixel_y = 23
 	},
 /obj/structure/cable,
-/obj/structure/railing,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "suU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"suY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "sve" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -56321,9 +56347,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"tnT" = (
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "tqd" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -56462,17 +56485,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"tDt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "tDw" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -56586,6 +56598,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"tTs" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "tXL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -57090,17 +57108,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"vuZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/structure/table,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "vwX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -57215,10 +57222,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"vLT" = (
-/obj/item/assembly/mousetrap,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "vPt" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -57437,6 +57440,12 @@
 /obj/structure/railing,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wEW" = (
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "wFc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -57506,13 +57515,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"wNp" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "wNY" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -57623,10 +57625,6 @@
 	},
 /turf/closed/wall,
 /area/storage/mining)
-"xaw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "xaZ" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/sign/warning/securearea{
@@ -57896,6 +57894,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
+"xAy" = (
+/obj/item/chair/plastic{
+	pixel_y = 10
+	},
+/obj/item/chair/plastic{
+	pixel_y = 5
+	},
+/obj/item/chair/plastic,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "xCq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall,
@@ -57928,13 +57937,12 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xIf" = (
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+"xQP" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/fore)
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "xQZ" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -58216,12 +58224,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"yjl" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "yjr" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -93558,9 +93560,9 @@ axW
 azo
 aAp
 aBC
-eey
+jHT
 aEA
-vuZ
+nFs
 aGz
 aIb
 aCr
@@ -93816,8 +93818,8 @@ azf
 aAo
 apX
 aBB
-cJz
-cJz
+doh
+doh
 aGy
 aIa
 cNE
@@ -94074,7 +94076,7 @@ gsz
 arj
 cVb
 cVb
-dLO
+nNE
 aGI
 aId
 bke
@@ -94331,8 +94333,8 @@ azp
 azp
 aCu
 cVb
-hIL
-tDt
+sub
+ebZ
 aIc
 aJC
 aKO
@@ -94588,8 +94590,8 @@ aro
 aro
 aCv
 cVb
-mtA
-mfs
+xQP
+liK
 aIe
 aJC
 aJC
@@ -94845,8 +94847,8 @@ aro
 aro
 aCv
 cVb
-tnT
-mta
+lbI
+mBj
 aIe
 aJE
 aKQ
@@ -95102,7 +95104,7 @@ aro
 aro
 aCv
 cVb
-yjl
+dDA
 aGA
 aHS
 aJx
@@ -95359,8 +95361,8 @@ aro
 aro
 aCv
 cVb
-pxN
-mta
+pFX
+mBj
 aHM
 aJm
 aKz
@@ -95616,8 +95618,8 @@ aro
 aro
 aCv
 cVb
-iMq
-mtj
+tTs
+cDV
 aIe
 aJC
 aKS
@@ -95873,8 +95875,8 @@ azp
 azp
 aCw
 cVb
-tnT
-maY
+lbI
+rlW
 aIg
 aJH
 aKR
@@ -96130,8 +96132,8 @@ boP
 boP
 boP
 cVb
-pbd
-nSJ
+cZN
+nBr
 aIe
 aJI
 aJI
@@ -96387,8 +96389,8 @@ boP
 boP
 boP
 cVb
-obw
-pHB
+fNJ
+oXf
 aIh
 aJI
 aKT
@@ -96644,7 +96646,7 @@ boP
 boP
 boP
 cVb
-obw
+fNJ
 aGB
 aIf
 aJA
@@ -96901,8 +96903,8 @@ boP
 boP
 boP
 cVb
-xaw
-rsb
+nFC
+slE
 aHY
 aQj
 iNn
@@ -97158,9 +97160,9 @@ boP
 boP
 boP
 cVb
-wNp
-pHB
-fvx
+qwO
+oXf
+nrG
 aJK
 aKV
 tMl
@@ -97417,7 +97419,7 @@ alP
 alP
 alP
 aGP
-juN
+pgz
 aJI
 aJI
 aJI
@@ -97664,13 +97666,13 @@ arp
 alO
 awD
 anf
-fwp
+pWq
 anf
-eWJ
+mLq
 atw
 aBE
 alP
-lvX
+mgv
 aDX
 alP
 aGH
@@ -97927,8 +97929,8 @@ anf
 anf
 anf
 alP
-euS
-vLT
+fGK
+lZz
 alP
 aGQ
 aIk
@@ -98953,11 +98955,11 @@ apC
 awF
 anf
 anf
-arA
+anf
 anf
 aCz
 arr
-stG
+nFX
 aFr
 aIn
 aIp
@@ -99725,9 +99727,9 @@ awH
 arr
 apE
 anf
-pKy
-nST
-nTN
+kwr
+kXD
+mFJ
 bKs
 bKK
 aIp
@@ -99982,7 +99984,7 @@ aoP
 arr
 apE
 anf
-giA
+wEW
 alP
 alP
 aFo
@@ -100239,7 +100241,7 @@ alP
 arr
 alP
 anf
-hgE
+olb
 alP
 ayf
 aFm
@@ -100486,7 +100488,7 @@ boP
 boP
 boP
 apC
-qem
+xAy
 anf
 alP
 atx
@@ -100496,7 +100498,7 @@ auD
 arr
 alP
 aAs
-gRT
+opN
 alP
 aCG
 aFr
@@ -100752,8 +100754,8 @@ apC
 aoP
 arr
 apE
-xIf
-jCk
+dps
+suY
 alP
 aCG
 aDZ

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -8098,10 +8098,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"asx" = (
-/obj/structure/door_assembly/door_assembly_mai,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "asy" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Firefighting Equipment";
@@ -10878,10 +10874,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/hydroponics/garden)
-"azr" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "azs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -11295,22 +11287,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"aAq" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"aAr" = (
-/obj/structure/closet,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aAs" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aAt" = (
 /obj/machinery/door/poddoor/preopen{
@@ -11772,24 +11754,23 @@
 /area/crew_quarters/toilet)
 "aBB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
-"aBC" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/machinery/bounty_board{
+	dir = 4;
+	pixel_x = 32
 	},
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
+"aBC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"aBD" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "aBE" = (
 /obj/item/clothing/under/misc/mailman,
 /obj/item/clothing/head/mailman,
@@ -12138,28 +12119,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
-"aCx" = (
-/obj/machinery/atmospherics/components/binary/valve,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"aCy" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aCz" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/structure/railing,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCA" = (
-/obj/structure/grille/broken,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/structure/window,
 /obj/structure/cable,
+/obj/structure/railing,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -12736,22 +12703,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"aDV" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"aDW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aDX" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aDY" = (
@@ -12785,18 +12740,18 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aEb" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Theatre Maintenance";
-	req_access_txt = "46"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
+	},
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "aEc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -13032,8 +12987,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "aEB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -13342,10 +13297,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"aFn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aFo" = (
@@ -13934,8 +13885,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "aGz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -13945,8 +13896,14 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/circuitboard/machine/vendatray,
+/obj/item/circuitboard/machine/vendatray,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "aGA" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
@@ -13956,8 +13913,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "aGB" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
@@ -13967,8 +13925,8 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "aGC" = (
 /obj/machinery/button/door{
 	id = "xenobio5";
@@ -14048,8 +14006,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "aGJ" = (
 /obj/structure/bed,
 /obj/effect/spawner/lootdrop/prison_contraband,
@@ -14134,10 +14092,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/hallway/secondary/service)
 "aGQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -14146,6 +14110,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGR" = (
@@ -14590,15 +14557,15 @@
 "aHS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
-	name = "Bar Storage Maintenance";
+	name = "Bar Service Hallway";
 	req_access_txt = "25"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "aHT" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -14651,8 +14618,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/trimline/white/line,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "aHZ" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -14676,40 +14644,41 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/trimline/green/line,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "aIb" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/theatre";
-	dir = 8;
-	name = "Theatre APC";
-	pixel_x = -25
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/rnd/production/techfab/department/service,
+/obj/machinery/camera{
+	c_tag = "Service Hallway West";
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/line,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "aIc" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/bar";
 	name = "Bar APC";
 	pixel_y = -23
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/trimline/green/line,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "aId" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/trimline/green/line,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "aIe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -14722,8 +14691,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/trimline/white/line,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "aIg" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -14747,8 +14717,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/trimline/white/line,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "aIi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -14760,8 +14731,10 @@
 	dir = 4;
 	sortType = 21
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aIk" = (
@@ -15313,8 +15286,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "aJB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -25979,15 +25953,6 @@
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"bjD" = (
-/obj/machinery/door/airlock{
-	name = "Service Hall";
-	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/hallway/secondary/service)
 "bjE" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -26218,14 +26183,19 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bke" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_one_access_txt = "12;25;26;35;28;22;37;46;38;70"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "bkf" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -33808,20 +33778,6 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/miningdock)
-"bBI" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 23
-	},
-/obj/structure/cable,
-/obj/machinery/bounty_board{
-	dir = 8;
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "bBK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -37294,7 +37250,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/transparent/openspace/icemoon,
 /area/icemoon/surface/outdoors)
 "bKt" = (
 /obj/structure/table,
@@ -37442,7 +37398,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/transparent/openspace/icemoon,
 /area/icemoon/surface/outdoors)
 "bKL" = (
 /obj/structure/disposalpipe/segment{
@@ -50479,6 +50435,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/medical/break_room)
+"cJz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "cKG" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -51323,6 +51283,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"dLO" = (
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "dMb" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -51421,6 +51384,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"eey" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/theatre";
+	dir = 8;
+	name = "Theatre APC";
+	pixel_x = -25
+	},
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "egr" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
@@ -51460,6 +51435,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"euS" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "eya" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -51582,6 +51563,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"eWJ" = (
+/obj/item/pressure_plate,
+/obj/item/pressure_plate,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "fcG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -51650,16 +51637,9 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "fnC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "fpR" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -51721,6 +51701,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"fvx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Service Hallway East";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/trimline/white/line,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
+"fwp" = (
+/obj/structure/window,
+/obj/structure/rack,
+/obj/item/assembly/signaler,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "fxH" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/pinpointer_dispenser,
@@ -51946,6 +51944,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"giA" = (
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "giT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -52164,6 +52168,12 @@
 "gQb" = (
 /turf/closed/mineral/random/snow/no_caves,
 /area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
+"gRT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "gUV" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -52224,6 +52234,10 @@
 /mob/living/simple_animal/pet/fox/renault,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"hgE" = (
+/obj/machinery/light/small/broken,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "hhs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -52354,6 +52368,16 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/science/xenobiology)
+"hIL" = (
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/service";
+	dir = 1;
+	name = "Service Hall APC";
+	pixel_y = 23
+	},
+/obj/structure/cable,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "hIZ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -52570,6 +52594,12 @@
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"iMq" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "iNn" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room"
@@ -52796,6 +52826,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
+"juN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "jvR" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -52844,6 +52880,13 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"jCk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "jCq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -53026,14 +53069,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"khb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "khB" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -53351,10 +53386,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "kPd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/obj/machinery/light/small,
+/obj/item/trash/can,
+/mob/living/simple_animal/mouse/white,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "kPH" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -53549,6 +53585,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"lvX" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "lwr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -53826,6 +53869,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/storage)
+"maY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "mdr" = (
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
@@ -53850,6 +53903,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"mfs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "mhs" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -53902,6 +53969,36 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"mta" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
+"mtj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
+"mtA" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "mtK" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
@@ -54435,6 +54532,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nSJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
+"nST" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/space/basic,
+/area/maintenance/starboard/fore)
+"nTN" = (
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on"
+	},
+/obj/structure/fluff/fokoff_sign,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "nTU" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
@@ -54526,6 +54647,9 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"obw" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "ofT" = (
 /obj/machinery/computer/bounty,
 /turf/open/floor/plasteel,
@@ -54789,6 +54913,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"pbd" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "peL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/warning/coldtemp{
@@ -55012,6 +55142,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"pxN" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "pxV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -55138,6 +55274,16 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
+"pHB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "pIc" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -55165,6 +55311,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"pKy" = (
+/obj/item/clothing/gloves/boxing/green,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "pLn" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -55325,6 +55477,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"qem" = (
+/obj/item/chair/plastic{
+	pixel_y = 10
+	},
+/obj/item/chair/plastic{
+	pixel_y = 5
+	},
+/obj/item/chair/plastic,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qeQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55529,6 +55692,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"rsb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "ruy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55829,6 +56000,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"stG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "suU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -55874,12 +56053,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
-"sxs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/table,
-/obj/item/shovel/spade,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "sxQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -56047,10 +56220,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"tal" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/hallway/secondary/service)
 "tav" = (
 /turf/closed/wall,
 /area/vacant_room/commissary)
@@ -56152,6 +56321,9 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"tnT" = (
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "tqd" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -56290,6 +56462,17 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"tDt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "tDw" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -56907,6 +57090,17 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"vuZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/structure/table,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "vwX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -56931,10 +57125,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"vCb" = (
-/obj/machinery/rnd/production/techfab/department/service,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "vCt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -57025,6 +57215,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"vLT" = (
+/obj/item/assembly/mousetrap,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "vPt" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -57187,13 +57381,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"wrp" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "wtb" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -57247,8 +57434,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/closed/wall,
-/area/hallway/secondary/service)
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "wFc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -57318,6 +57506,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"wNp" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "wNY" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -57387,11 +57582,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"wUY" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "wVC" = (
 /turf/closed/wall/r_wall,
 /area/medical/storage)
@@ -57433,6 +57623,10 @@
 	},
 /turf/closed/wall,
 /area/storage/mining)
+"xaw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "xaZ" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/sign/warning/securearea{
@@ -57734,6 +57928,13 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xIf" = (
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "xQZ" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -58015,6 +58216,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"yjl" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "yjr" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -93351,9 +93558,9 @@ axW
 azo
 aAp
 aBC
-aCt
+eey
 aEA
-aCt
+vuZ
 aGz
 aIb
 aCr
@@ -93609,8 +93816,8 @@ azf
 aAo
 apX
 aBB
-aBB
-aBB
+cJz
+cJz
 aGy
 aIa
 cNE
@@ -93865,9 +94072,9 @@ axY
 azh
 gsz
 arj
-boP
-boP
-alP
+cVb
+cVb
+dLO
 aGI
 aId
 bke
@@ -94123,9 +94330,9 @@ azg
 azp
 azp
 aCu
-boP
-alP
-aGH
+cVb
+hIL
+tDt
 aIc
 aJC
 aKO
@@ -94380,9 +94587,9 @@ aro
 aro
 aro
 aCv
-boP
-alP
-aGH
+cVb
+mtA
+mfs
 aIe
 aJC
 aJC
@@ -94637,9 +94844,9 @@ aro
 aro
 aro
 aCv
-boP
-alP
-aGH
+cVb
+tnT
+mta
 aIe
 aJE
 aKQ
@@ -94894,8 +95101,8 @@ aro
 aro
 aro
 aCv
-boP
-alP
+cVb
+yjl
 aGA
 aHS
 aJx
@@ -95151,9 +95358,9 @@ aro
 aro
 aro
 aCv
-boP
-alP
-aGH
+cVb
+pxN
+mta
 aHM
 aJm
 aKz
@@ -95408,9 +95615,9 @@ aro
 aro
 aro
 aCv
-boP
-alP
-aGH
+cVb
+iMq
+mtj
 aIe
 aJC
 aKS
@@ -95665,9 +95872,9 @@ azp
 azp
 azp
 aCw
-boP
-alP
-aGH
+cVb
+tnT
+maY
 aIg
 aJH
 aKR
@@ -95919,12 +96126,12 @@ avD
 awC
 ayb
 arj
-alP
-alP
 boP
 boP
-alP
-aGH
+boP
+cVb
+pbd
+nSJ
 aIe
 aJI
 aJI
@@ -96176,12 +96383,12 @@ avC
 avC
 aya
 arj
-arA
-alP
-alP
-alP
-alP
-aGH
+boP
+boP
+boP
+cVb
+obw
+pHB
 aIh
 aJI
 aKT
@@ -96433,11 +96640,11 @@ auB
 arj
 arj
 arj
-anf
-anf
-anf
-awD
-alP
+boP
+boP
+boP
+cVb
+obw
 aGB
 aIf
 aJA
@@ -96689,13 +96896,13 @@ boP
 boP
 boP
 boP
-alP
-ayf
-aBD
-aCx
-aDV
-alP
-aGH
+boP
+boP
+boP
+boP
+cVb
+xaw
+rsb
 aHY
 aQj
 iNn
@@ -96946,14 +97153,14 @@ boP
 boP
 boP
 boP
-alP
-aAq
-aAq
-aCy
-aCG
-alP
-aGH
-avI
+boP
+boP
+boP
+boP
+cVb
+wNp
+pHB
+fvx
 aJK
 aKV
 tMl
@@ -97203,14 +97410,14 @@ alO
 alP
 alP
 alP
+alO
 alP
 alP
 alP
 alP
-aDW
-aFn
+alP
 aGP
-avI
+juN
 aJI
 aJI
 aJI
@@ -97457,13 +97664,13 @@ arp
 alO
 awD
 anf
+fwp
 anf
-awD
-anf
-aoP
-alP
+eWJ
+atw
 aBE
 alP
+lvX
 aDX
 alP
 aGH
@@ -97717,12 +97924,12 @@ anf
 anf
 aEl
 anf
-cVb
-cVb
-cVb
-cVb
-cVb
-cVb
+anf
+anf
+alP
+euS
+vLT
+alP
 aGQ
 aIk
 aIp
@@ -97972,15 +98179,15 @@ alO
 anf
 auC
 alP
+auD
 anf
 anf
-cVb
-bBI
-wrp
+anf
+atB
 fnC
 kPd
-bjD
-aCl
+alP
+arr
 aDZ
 aIp
 aKH
@@ -98231,13 +98438,13 @@ anf
 alP
 awE
 anf
-cVb
-vCb
-wUY
-khb
-sxs
-tal
-aCI
+anf
+anf
+alP
+alP
+alP
+alP
+aCG
 aIj
 aJB
 aKD
@@ -98488,11 +98695,11 @@ apC
 apC
 alP
 anf
-cVb
-cVb
-cVb
-cVb
-cVb
+anf
+anf
+anf
+anf
+anf
 wBd
 aFm
 aIl
@@ -98745,12 +98952,12 @@ auD
 apC
 awF
 anf
-alP
+anf
 arA
 anf
 aCz
 arr
-awx
+stG
 aFr
 aIn
 aIp
@@ -99260,7 +99467,7 @@ apC
 awG
 arr
 alP
-alP
+atB
 alP
 alP
 alP
@@ -99510,17 +99717,17 @@ aoO
 apB
 aqx
 art
-anf
-anf
+aoP
+atw
 arr
 apC
 awH
 arr
-alP
-aAr
+apE
 anf
-alP
-boP
+pKy
+nST
+nTN
 bKs
 bKK
 aIp
@@ -99766,16 +99973,16 @@ aof
 aof
 aof
 aof
-anf
-aoP
-atw
+atB
+alP
+aty
 arr
 apC
 aoP
 arr
-azr
+apE
 anf
-atw
+giA
 alP
 alP
 aFo
@@ -100024,15 +100231,15 @@ boP
 apC
 aqy
 anf
-anf
+alP
 aty
 arr
 apC
 alP
 arr
 alP
-alP
-alP
+anf
+hgE
 alP
 ayf
 aFm
@@ -100279,7 +100486,7 @@ boP
 boP
 boP
 apC
-anf
+qem
 anf
 alP
 atx
@@ -100289,7 +100496,7 @@ auD
 arr
 alP
 aAs
-anf
+gRT
 alP
 aCG
 aFr
@@ -100537,7 +100744,7 @@ boP
 boP
 apC
 anf
-alP
+anf
 alP
 apE
 auG
@@ -100545,8 +100752,8 @@ apC
 aoP
 arr
 apE
-anf
-anf
+xIf
+jCk
 alP
 aCG
 aDZ
@@ -100795,7 +101002,7 @@ boP
 apC
 arA
 anf
-asx
+alP
 anf
 arr
 alP

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -14109,9 +14109,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -48526,13 +48523,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
-"czy" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "czE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -50659,6 +50649,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"cSk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "cSz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -51079,6 +51073,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"dlp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
+"dlx" = (
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "dni" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -51130,12 +51145,6 @@
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/lawoffice)
-"dvH" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "dvO" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -51272,6 +51281,10 @@
 "dGF" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"dHJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/space/basic,
+/area/maintenance/starboard/fore)
 "dHL" = (
 /obj/machinery/suit_storage_unit/cmo,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -51298,6 +51311,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"dJS" = (
+/obj/structure/sign/poster/official/random,
+/turf/closed/wall,
+/area/hallway/secondary/service)
 "dMb" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -51368,52 +51385,10 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel,
 /area/medical/virology)
-"dRY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/space/basic,
-/area/maintenance/starboard/fore)
-"dSl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Service Hallway East";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/trimline/white/line,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "dUO" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"dWE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
-"dXQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/theatre";
-	dir = 8;
-	name = "Theatre APC";
-	pixel_x = -25
-	},
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
-"dXU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
 "dYq" = (
 /turf/closed/wall,
 /area/science/nanite)
@@ -51444,19 +51419,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"eic" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "eja" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/nanite_chamber_control{
@@ -51506,6 +51468,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"ezU" = (
+/obj/item/clothing/gloves/boxing/green,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "eAi" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap,
@@ -51522,17 +51490,14 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"eCX" = (
-/obj/item/chair/plastic{
-	pixel_y = 10
+"eAT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/chair/plastic{
-	pixel_y = 5
-	},
-/obj/item/chair/plastic,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "eFD" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/disks{
@@ -51749,12 +51714,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"ftP" = (
-/obj/structure/window,
-/obj/structure/rack,
-/obj/item/assembly/signaler,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "fvi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -51803,6 +51762,17 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"fCu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"fDD" = (
+/obj/item/assembly/mousetrap,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "fGg" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -51853,6 +51823,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
+"fPh" = (
+/obj/structure/sign/painting/library,
+/turf/closed/wall,
+/area/hallway/secondary/service)
 "fQA" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -51964,10 +51938,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"gcb" = (
-/obj/structure/sign/poster/official/random,
-/turf/closed/wall,
-/area/hallway/secondary/service)
 "gdg" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -52009,6 +51979,12 @@
 "gjl" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
+"gjD" = (
+/obj/structure/window,
+/obj/structure/rack,
+/obj/item/assembly/signaler,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "gkC" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/stripes/line{
@@ -52041,6 +52017,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"goT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "gpE" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -52208,6 +52197,12 @@
 "gQb" = (
 /turf/closed/mineral/random/snow/no_caves,
 /area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
+"gQz" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "gUV" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -52279,9 +52274,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
-"hmL" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "hnW" = (
 /obj/effect/spawner/structure/window/reinforced{
 	pixel_w = 1
@@ -52294,10 +52286,19 @@
 	dir = 5
 	},
 /area/science/research)
-"hxh" = (
-/obj/machinery/light/small/broken,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+"hxq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "hxs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52511,11 +52512,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"iiv" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/theatre";
+	dir = 8;
+	name = "Theatre APC";
+	pixel_x = -25
+	},
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "ijc" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"ijI" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "ink" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -52556,12 +52575,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"itV" = (
-/obj/item/pressure_plate,
-/obj/item/pressure_plate,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ivU" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -52581,6 +52594,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"iyi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "izT" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -52588,6 +52607,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"izV" = (
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "iBZ" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -52785,12 +52810,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"jlt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/fore)
 "jly" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -53176,13 +53195,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"kqx" = (
-/obj/structure/marker_beacon{
-	icon_state = "markerburgundy-on"
-	},
-/obj/structure/fluff/fokoff_sign,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
 "kul" = (
 /turf/closed/wall,
 /area/engine/engine_smes)
@@ -53207,12 +53219,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"kvA" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "kvJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -53514,6 +53520,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"kWH" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "kXf" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -53707,6 +53719,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
+"lHi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "lHR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -53866,12 +53886,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"lWk" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "lWA" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -54008,6 +54022,9 @@
 	},
 /turf/closed/wall,
 /area/medical/morgue)
+"myW" = (
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "mBm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54038,6 +54055,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"mEX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "mFt" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -54227,16 +54250,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"mVA" = (
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"mVI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "mWw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -54390,12 +54403,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"nuG" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "nwJ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -54404,17 +54411,6 @@
 /obj/machinery/vending/modularpc,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"nxi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "nxv" = (
 /obj/machinery/power/apc{
 	areastring = "/area/construction";
@@ -54507,10 +54503,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"nLZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "nPP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -54632,9 +54624,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"obc" = (
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "ofT" = (
 /obj/machinery/computer/bounty,
 /turf/open/floor/plasteel,
@@ -54776,17 +54765,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"oMP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "oND" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -55092,9 +55070,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"psr" = (
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "psy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -55181,6 +55156,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"pAz" = (
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on"
+	},
+/obj/structure/fluff/fokoff_sign,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "pAR" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -55288,6 +55270,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"pKr" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "pLn" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -55332,6 +55318,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
+"pOR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "pPs" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -55422,19 +55418,6 @@
 /obj/machinery/rnd/bepis,
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"qcw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "qcV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -55474,14 +55457,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
-"qjK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/railing,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "qjL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -55499,10 +55474,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"qkJ" = (
-/obj/item/assembly/mousetrap,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+"qkI" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "qnW" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -55570,6 +55547,9 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"qzO" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "qDH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -55598,6 +55578,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/security/detectives_office)
+"qMc" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/structure/table,
+/obj/item/toner/large,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "qQC" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
@@ -55619,13 +55611,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"qTW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/fore)
 "rcD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -55637,6 +55622,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
+"rfI" = (
+/obj/item/pressure_plate,
+/obj/item/pressure_plate,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "rgu" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -55684,6 +55675,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"rrd" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "ruy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55876,6 +55873,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"rWl" = (
+/obj/item/chair/plastic{
+	pixel_y = 10
+	},
+/obj/item/chair/plastic{
+	pixel_y = 5
+	},
+/obj/item/chair/plastic,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "rWQ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -55926,20 +55934,6 @@
 "sdX" = (
 /turf/closed/wall,
 /area/quartermaster/office)
-"sec" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "sgR" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/green,
@@ -55998,14 +55992,8 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"sqP" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 23
-	},
-/obj/structure/cable,
+"ssv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "suU" = (
@@ -56279,6 +56267,13 @@
 /obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
+"tdZ" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "tgl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -56408,12 +56403,28 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"tve" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "twh" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"twX" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "tyB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -56572,16 +56583,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"tUt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "tXL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -56677,6 +56678,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"uoD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "upN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -56769,18 +56781,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"uze" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/structure/table,
-/obj/item/toner/large,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
 "uzl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -56968,13 +56968,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
-"vbr" = (
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/fore)
 "vbw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57080,12 +57073,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
-"vqt" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "vqI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57111,10 +57098,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"vwL" = (
-/obj/structure/sign/painting/library,
-/turf/closed/wall,
-/area/hallway/secondary/service)
+"vvP" = (
+/obj/machinery/light/small/broken,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "vwX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -57330,19 +57317,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
-"weo" = (
-/obj/structure/frame/computer{
-	anchored = 1;
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "wfU" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"wgt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "whK" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
@@ -57377,10 +57364,16 @@
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
-"wnu" = (
-/obj/structure/fermenting_barrel,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+"wom" = (
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/service";
+	dir = 1;
+	name = "Service Hall APC";
+	pixel_y = 23
+	},
+/obj/structure/cable,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "wph" = (
 /obj/docking_port/stationary{
 	dheight = 4;
@@ -57402,16 +57395,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"wrg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "wtb" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -57737,6 +57720,18 @@
 /obj/item/plunger,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"xfm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Service Hallway East";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/trimline/white/line,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "xfD" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/genetics";
@@ -57948,10 +57943,7 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xOm" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+"xLr" = (
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "xQZ" = (
@@ -58028,6 +58020,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
+"xVA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "xWd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -58041,6 +58044,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"xWM" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "xXe" = (
 /obj/structure/closet/radiation,
 /obj/machinery/airalarm{
@@ -58157,12 +58167,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
-"ydL" = (
-/obj/item/clothing/gloves/boxing/green,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/drinks/waterbottle,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "yeu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -93577,9 +93581,9 @@ axW
 azo
 aAp
 aBC
-dXQ
+iiv
 aEA
-uze
+qMc
 aGz
 aIb
 aCr
@@ -93835,8 +93839,8 @@ azf
 aAo
 apX
 aBB
-nLZ
-nLZ
+ssv
+ssv
 aGy
 aIa
 cNE
@@ -94092,8 +94096,8 @@ azh
 gsz
 arj
 cVb
-vwL
-psr
+fPh
+myW
 aGI
 aId
 bke
@@ -94350,8 +94354,8 @@ azp
 azp
 aCu
 cVb
-sqP
-oMP
+wom
+uoD
 aIc
 aJC
 aKO
@@ -94606,9 +94610,9 @@ aro
 aro
 aro
 aCv
-vwL
-lWk
-sec
+fPh
+kWH
+dlp
 aIe
 aJC
 aJC
@@ -94863,9 +94867,9 @@ aro
 aro
 aro
 aCv
-gcb
-obc
-nxi
+dJS
+xLr
+xVA
 aIe
 aJE
 aKQ
@@ -95121,7 +95125,7 @@ aro
 aro
 aCv
 cVb
-xOm
+gQz
 aGA
 aHS
 aJx
@@ -95378,8 +95382,8 @@ aro
 aro
 aCv
 cVb
-nuG
-nxi
+rrd
+xVA
 aHM
 aJm
 aKz
@@ -95635,8 +95639,8 @@ aro
 aro
 aCv
 cVb
-kvA
-eic
+ijI
+goT
 aIe
 aJC
 aKS
@@ -95891,9 +95895,9 @@ azp
 azp
 azp
 aCw
-gcb
-obc
-wrg
+dJS
+xLr
+tve
 aIg
 aJH
 aKR
@@ -96148,9 +96152,9 @@ arj
 boP
 boP
 boP
-vwL
-vqt
-qcw
+fPh
+qkI
+hxq
 aIe
 aJI
 aJI
@@ -96405,9 +96409,9 @@ arj
 boP
 boP
 boP
-gcb
-hmL
-tUt
+dJS
+qzO
+pOR
 aIh
 aJI
 aKT
@@ -96662,8 +96666,8 @@ alP
 alP
 boP
 boP
-vwL
-hmL
+fPh
+qzO
 aGB
 aIf
 aJA
@@ -96915,13 +96919,13 @@ boP
 boP
 alP
 anf
-itV
+rfI
 alP
 boP
 boP
 cVb
-mVI
-dWE
+cSk
+eAT
 aHY
 aQj
 iNn
@@ -97172,14 +97176,14 @@ boP
 boP
 alO
 anf
-wnu
+pKr
 alO
 boP
 boP
 cVb
-czy
-tUt
-dSl
+xWM
+pOR
+xfm
 aJK
 aKV
 tMl
@@ -97436,7 +97440,7 @@ alP
 alP
 alP
 aGP
-dXU
+iyi
 aJI
 aJI
 aJI
@@ -97683,13 +97687,13 @@ arp
 alO
 awD
 anf
-ftP
+gjD
 anf
 anf
 atw
 aBE
 alP
-weo
+tdZ
 aDX
 alP
 aGH
@@ -97946,8 +97950,8 @@ anf
 anf
 anf
 alP
-mVA
-qkJ
+twX
+fDD
 alP
 aGQ
 aIk
@@ -98206,7 +98210,7 @@ atB
 fnC
 kPd
 alP
-arr
+fCu
 aDZ
 aIp
 aKH
@@ -98976,7 +98980,7 @@ anf
 anf
 aCz
 arr
-qjK
+lHi
 aFr
 aIn
 aIp
@@ -99744,9 +99748,9 @@ awH
 arr
 apE
 anf
-ydL
-dRY
-kqx
+ezU
+dHJ
+pAz
 bKs
 bKK
 aIp
@@ -100001,7 +100005,7 @@ aoP
 arr
 apE
 anf
-dvH
+izV
 alP
 alP
 aFo
@@ -100258,7 +100262,7 @@ alP
 arr
 alP
 anf
-hxh
+vvP
 alP
 ayf
 aFm
@@ -100505,7 +100509,7 @@ boP
 boP
 boP
 apC
-eCX
+rWl
 anf
 alP
 atx
@@ -100515,7 +100519,7 @@ auD
 arr
 alP
 aAs
-jlt
+mEX
 alP
 aCG
 aFr
@@ -100771,8 +100775,8 @@ apC
 aoP
 arr
 apE
-vbr
-qTW
+dlx
+wgt
 alP
 aCG
 aDZ


### PR DESCRIPTION
## About The Pull Request

Icebox suffers from Box's issues regarding it's service hall: It was really just thrown into maintenance with very little consideration. This works the service hall into an actual hallway behind most of the service rooms on icebox, and adds a bit more flavor to the surrounding icebox maint to boot.

The area behind the bar-theater-kitchen has been rolled into one large hallway alongside the service techlathe. 

The area where the old service hall was has been swapped out for 2 new rooms, a small "gamer hut" with an unfinished compuer frame and a civilian modular computer console.

The area to the left of the blast door assembly has been retrofitted into a small gym space.

The weird single window pane queue line has been swapped out for a railing based queue line.

The window hole between hydroponics and the library has been replaced with a "true" hole now.

To best view the changes, go to the "changes" tab for the PR and click MapDiffBot for cleaner screenshots.

## Why It's Good For The Game

Box station's mait was never all that well thought out, and the service hallway in particular has drawn my ire for the last time. This makes the whole zone a bit better laid out, while leaving the maintenance loop around the station intact from the holodeck to the chapel. Plus, now service will have a collective area to meet/congregate/start a book club/club a guy to death with a book that isn't just their backrooms.

## Changelog
:cl:
tweak: Icebox Maintenance, and Icebox Service Hallway have been rearranged to be more spacious.
/:cl:
