### PR TITLE
Fixes space vines/kudzu to no longer spread slower from better production speed

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -22,7 +22,7 @@
 
 	if(turfs.len) //Pick a turf to spawn at if we can
 		var/turf/T = pick(turfs)
-		new /datum/spacevine_controller(T, list(pick(subtypesof(/datum/spacevine_mutation))), rand(10,100), rand(5,10), src) //spawn a controller at turf with randomized stats and a single random mutation
+		new /datum/spacevine_controller(T, list(pick(subtypesof(/datum/spacevine_mutation))), rand(10,100), rand(1,6), src) //spawn a controller at turf with randomized stats and a single random mutation
 
 
 /datum/spacevine_mutation
@@ -396,9 +396,9 @@
 	init_subtypes(/datum/spacevine_mutation/, vine_mutations_list)
 	if(potency != null)
 		mutativeness = potency / 10
-	if(production != null)
-		spread_cap *= production / 5
-		spread_multiplier /= production / 5
+	if(production != null && production <= 10) //Prevents runtime in case production is set to 11.
+		spread_cap *= (11 - production) / 5 //Best production speed of 1 doubles spread_cap to 60 while worst speed of 10 lowers it to 6. Even distribution.
+		spread_multiplier /= (11 - production) / 5
 
 /datum/spacevine_controller/vv_get_dropdown()
 	. = ..()
@@ -446,7 +446,7 @@
 		var/obj/item/seeds/kudzu/KZ = new(S.loc)
 		KZ.mutations |= S.mutations
 		KZ.set_potency(mutativeness * 10)
-		KZ.set_production((spread_cap / initial(spread_cap)) * 5)
+		KZ.set_production(11 - (spread_cap / initial(spread_cap)) * 5) //Reverts spread_cap formula so resulting seed gets original production stat or equivalent back.
 		qdel(src)
 
 /datum/spacevine_controller/process()


### PR DESCRIPTION
## About The Pull Request
This does two main things:
- Inverts space vine spread formulas so they no longer spread slower from better production speed. 
- Buffs space vine random event from having 5-10 production speed to having 1-6. This makes the random event vine unchanged on average. 

Also added a check to prevent runtimes if production speed is changed to be over 10 (such as from egg-plants in downstreams with DNA-manipulator). 

The new formulas have been tested in-game and in spreadsheets. The distribution is identical to before but simply reversed (1 speed is now same as old 10, 5 same as old 6, etc). I've also tested varediting seeds to weird numbers like -11, -1 and 11+ and can't see any weird behaviour or runtimes. Seeds over 10 should simply spread with default rate instead. 

I don't fully understand what spread_multiplier does but I assume it had inverse relationship as well. From testing it all seems to work. 

## Why It's Good For The Game
Years. For years people have assumed this was normal, intended behaviour. But I can't find any code comment implying this inverted relationship is intentional. Production speed stat typically ranges from 1-10 (exception egg-plant with 12), with 1 being the fastest speed and 10 being the slowest . I think it's unintuitive that you must prevent your plant from getting better stats for it to become better. 

What further convinces me this is a bug is that to currently max kudzu you need to add one of the most commonly available reagents in the game, 15u~ blood, to the tray for a few seconds before harvest. But to quickly make production speed faster (lower) you need to add amatoxin, which is much harder to get. 

For years, hundreds of botanists have been tricked into ruining their plants, myself included. This upsets me and my hands are balled. 

**~2 minutes of production speed 1 kudzu before this change**
![200708 1601 48 Fixed kudzu 10 prod 2 minutes](https://user-images.githubusercontent.com/46400996/87026705-659d6080-c1dc-11ea-8c5b-2edb961941ac.png)

**~2 minutes of production speed 1 kudzu after this change**
![200708 1604 35 Fixed kudzu 1 prod 2 minutes](https://user-images.githubusercontent.com/46400996/87026710-66ce8d80-c1dc-11ea-9f92-17d8a0e6eeea.png)

Default stat kudzu with 6 production speed is slightly nerfed (new 6 is same as old 5). 

Most kudzu seen on station will be stronger regardless if this is merged or not, because I plan to paste the 20u blood gamer trick all over the wiki with big red letters. 


## Changelog
:cl: Angust
fix: fixed space vines / kudzu growing slower from better (lower) production speed
balance: random event space vines buffed to have 1-6 production instead of 5-10 to compensate
/:cl: