### PR TITLE
Fix of shuttle posting

### DIFF
--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -164,7 +164,7 @@
 			return
 
 	to_chat(user, "<span class='notice'>The poster falls down!</span>")
-	D.roll_and_drop(temp_loc)
+	D.roll_and_drop(get_turf(user))
 
 // Various possible posters follow
 


### PR DESCRIPTION


## About The Pull Request

Posters being placed during shuttle movement no more end up in wrong place if the shuttle moves before finishing.
fix #51577

## Why It's Good For The Game

Bugs is bad

## Changelog
:cl:
fix: now posting in shuttle propertly fails
/:cl: