### PR TITLE
BLOB: Makes placing Resource and Factory Blobs require a blob_allowed area

### DIFF
--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -92,13 +92,13 @@
 		to_chat(src, "<span class='warning'>Unable to use this blob, find a normal one.</span>")
 		return
 	if(needsNode)
-		if(nodes_required && !(locate(/obj/structure/blob/node) in orange(3, T)) && !(locate(/obj/structure/blob/core) in orange(4, T)))
-			to_chat(src, "<span class='warning'>You need to place this blob closer to a node or core!</span>")
-			return //handholdotron 2000
 		var/area/A = get_area(src)
 		if(!A.blob_allowed) //factory and resource blobs must be legit
 			to_chat(src, "<span class='warning'>This type of blob must be placed on the station!</span>")
 			return
+		if(nodes_required && !(locate(/obj/structure/blob/node) in orange(3, T)) && !(locate(/obj/structure/blob/core) in orange(4, T)))
+			to_chat(src, "<span class='warning'>You need to place this blob closer to a node or core!</span>")
+			return //handholdotron 2000
 	if(minSeparation)
 		for(var/obj/structure/blob/L in orange(minSeparation, T))
 			if(L.type == blobstrain)

--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -81,7 +81,7 @@
 		if(chosen_node)
 			forceMove(chosen_node.loc)
 
-/mob/camera/blob/proc/createSpecial(price, blobstrain, nearEquals, needsNode, turf/T)
+/mob/camera/blob/proc/createSpecial(price, blobstrain, minSeparation, needsNode, turf/T)
 	if(!T)
 		T = get_turf(src)
 	var/obj/structure/blob/B = (locate(/obj/structure/blob) in T)
@@ -91,14 +91,18 @@
 	if(!istype(B, /obj/structure/blob/normal))
 		to_chat(src, "<span class='warning'>Unable to use this blob, find a normal one.</span>")
 		return
-	if(needsNode && nodes_required)
-		if(!(locate(/obj/structure/blob/node) in orange(3, T)) && !(locate(/obj/structure/blob/core) in orange(4, T)))
+	if(needsNode)
+		if(nodes_required && !(locate(/obj/structure/blob/node) in orange(3, T)) && !(locate(/obj/structure/blob/core) in orange(4, T)))
 			to_chat(src, "<span class='warning'>You need to place this blob closer to a node or core!</span>")
 			return //handholdotron 2000
-	if(nearEquals)
-		for(var/obj/structure/blob/L in orange(nearEquals, T))
+		var/area/A = get_area(src)
+		if(!A.blob_allowed) //factory and resource blobs must be legit
+			to_chat(src, "<span class='warning'>This type of blob must be placed on the station!</span>")
+			return
+	if(minSeparation)
+		for(var/obj/structure/blob/L in orange(minSeparation, T))
 			if(L.type == blobstrain)
-				to_chat(src, "<span class='warning'>There is a similar blob nearby, move more than [nearEquals] tiles away from it!</span>")
+				to_chat(src, "<span class='warning'>There is a similar blob nearby, move more than [minSeparation] tiles away from it!</span>")
 				return
 	if(!can_buy(price))
 		return
@@ -133,25 +137,25 @@
 		to_chat(src, "<span class='warning'>You secrete a reflective ooze over the shield blob, allowing it to reflect projectiles at the cost of reduced integrity.</span>")
 		S.change_to(/obj/structure/blob/shield/reflective, src)
 	else
-		createSpecial(15, /obj/structure/blob/shield, 0, 0, T)
+		createSpecial(15, /obj/structure/blob/shield, 0, FALSE, T)
 
 /mob/camera/blob/verb/create_resource()
 	set category = "Blob"
 	set name = "Create Resource Blob (40)"
 	set desc = "Create a resource tower which will generate resources for you."
-	createSpecial(40, /obj/structure/blob/resource, 4, 1)
+	createSpecial(40, /obj/structure/blob/resource, 4, TRUE)
 
 /mob/camera/blob/verb/create_node()
 	set category = "Blob"
 	set name = "Create Node Blob (50)"
 	set desc = "Create a node, which will power nearby factory and resource blobs."
-	createSpecial(50, /obj/structure/blob/node, 5, 0)
+	createSpecial(50, /obj/structure/blob/node, 5, FALSE)
 
 /mob/camera/blob/verb/create_factory()
 	set category = "Blob"
 	set name = "Create Factory Blob (60)"
 	set desc = "Create a spore tower that will spawn spores to harass your enemies."
-	createSpecial(60, /obj/structure/blob/factory, 7, 1)
+	createSpecial(60, /obj/structure/blob/factory, 7, TRUE)
 
 /mob/camera/blob/verb/create_blobbernaut()
 	set category = "Blob"


### PR DESCRIPTION
## About The Pull Request

Adds a check for `blob_allowed = TRUE` on the area of the overmind's camera location when trying to place a Resource Blob or a Factory Blob plus a little refactoring.

## Why It's Good For The Game

Hopefully this will discourage blobs from venturing off far from where they need to be while not punishing them too much for thinking outside the box. I passed on a few ideas before settling on this solution like heavily decreasing resource gain or dealing damage over time while the blob core is not on a legit blob, so let me know what you think.

Could be a solution to #52067 

## Changelog
:cl:
balance: Resource and Factory Blobs can only be placed on station where they count towards critical mass.
/:cl: