### PR TITLE
Makes Ash grasp not a downgrade.

### DIFF
--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -41,10 +41,8 @@
 				continue
 			var/obj/effect/proc_holder/spell/targeted/touch/mansus_grasp/MG = X
 			MG.charge_counter = min(round(MG.charge_counter + MG.charge_max * 0.75),MG.charge_max) // refunds 75% of charge.
-	var/atom/throw_target = get_edge_target_turf(C, user.dir)
-	if(!C.anchored)
-		. = TRUE
-		C.throw_at(throw_target, rand(4,8), 14, user)
+
+	C.AdjustUnconscious(3 SECONDS)
 	return
 
 /datum/eldritch_knowledge/ashen_eyes


### PR DESCRIPTION
## About The Pull Request

Ash enhanced mansus grasp will now knock people out for 3 seconds instead of throwing them away.

## Why It's Good For The Game

Throwing people away is uh, counterproductive and makes ash path really bad.

## Changelog
:cl:
balance: Mansus grasp now knocks out people for 3 seconds
/:cl:
