### PR TITLE
Makes every organic species teleporter flyperson compatible.

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -76,9 +76,11 @@
 			if(!calibrated && prob(30 - ((accuracy) * 10))) //oh dear a problem
 				if(ishuman(M))//don't remove people from the round randomly you jerks
 					var/mob/living/carbon/human/human = M
-					to_chat(M, "<span class='hear'>You hear a buzzing in your ears.</span>")
-					human.set_species(/datum/species/fly)
-					log_game("[human] ([key_name(human)]) was turned into a fly person")
+					if(!(human.mob_biotypes & (MOB_ROBOTIC|MOB_MINERAL|MOB_UNDEAD|MOB_SPIRIT)))
+						if(human.dna && human.dna.species.id != "fly")
+							to_chat(M, "<span class='hear'>You hear a buzzing in your ears.</span>")
+							human.set_species(/datum/species/fly)
+							log_game("[human] ([key_name(human)]) was turned into a fly person")
 
 					human.apply_effect((rand(120 - accuracy * 40, 180 - accuracy * 60)), EFFECT_IRRADIATE, 0)
 			calibrated = 0

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -76,10 +76,9 @@
 			if(!calibrated && prob(30 - ((accuracy) * 10))) //oh dear a problem
 				if(ishuman(M))//don't remove people from the round randomly you jerks
 					var/mob/living/carbon/human/human = M
-					if(human.dna && human.dna.species.id == "human")
-						to_chat(M, "<span class='hear'>You hear a buzzing in your ears.</span>")
-						human.set_species(/datum/species/fly)
-						log_game("[human] ([key_name(human)]) was turned into a fly person")
+					to_chat(M, "<span class='hear'>You hear a buzzing in your ears.</span>")
+					human.set_species(/datum/species/fly)
+					log_game("[human] ([key_name(human)]) was turned into a fly person")
 
 					human.apply_effect((rand(120 - accuracy * 40, 180 - accuracy * 60)), EFFECT_IRRADIATE, 0)
 			calibrated = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes calibration relevant to the non human part of the crew, for good or worse. Dont run into an uncalibrated teleporter if your species is important to you, or use it to remove all the catgirls, or whatever. 

Disallowed for robotic, mineral, undead, spirit mob types. This excludes plasmamen/skeletons, golems, zombies (who would otherwise get converted back). 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was a pretty arbitrary limitation, easily bypassed by being a cat for instance.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
balance: Teleporters can now turn any organic living species into a flyperson. Practice good teleporter safety.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
