### PR TITLE
alternative to "Catatonics no longer get split personalities."

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -71,6 +71,9 @@
 		current_backseat = owner_backseat
 		free_backseat = stranger_backseat
 
+	if(!free_backseat.client) //Make sure we never switch to a logged off mob. //code written by/stolen from kriskog
+		return
+	
 	log_game("[key_name(current_backseat)] assumed control of [key_name(owner)] due to [src]. (Original owner: [current_controller == OWNER ? owner.key : current_backseat.key])")
 	to_chat(owner, "<span class='userdanger'>You feel your control being taken away... your other personality is in charge now!</span>")
 	to_chat(current_backseat, "<span class='userdanger'>You manage to take control of your body!</span>")


### PR DESCRIPTION
## About The Pull Request

This PR is an alternative to https://github.com/tgstation/tgstation/pull/52118.

Basically, it contains the "you won't lose control to a catatonic split personality" part of that PR, without making it impossible to uplift catatonics using brain damage/the split personality trauma.

## Why It's Good For The Game

Uplifting monkeymen with a hypertool/brain damage is actually a really fun chaplain gimmick, and I (and probably others) really don't wanna see it go.

The fix part of https://github.com/tgstation/tgstation/pull/52118 is good, though, hence why I've made this PR to add it separately.

## Changelog
:cl: ATHATH (code written by kriskog)
fix: You now cannot lose control to a catatonic split personality.
/:cl: