### PR TITLE
Fix missing comma and argument name in ban edit query

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -838,12 +838,12 @@
 	var/datum/db_query/query_edit_ban = SSdbcore.NewQuery({"
 		UPDATE [format_table_name("ban")]
 		SET
-			expiration_time = IF(:duration IS NULL, NULL, bantime + INTERVAL :duration [interval])
+			expiration_time = IF(:duration IS NULL, NULL, bantime + INTERVAL :duration [interval]),
 			applies_to_admins = :applies_to_admins,
 			reason = :reason,
 			ckey = :ckey,
 			ip = INET_ATON(:ip),
-			computerid = :ci
+			computerid = :cid,
 			edits = CONCAT(IFNULL(edits,''), :change_message)
 		WHERE [where]
 	"}, arguments)


### PR DESCRIPTION
![spaceman](https://user-images.githubusercontent.com/4343468/87071771-0e3fd480-c25e-11ea-8dbc-3e7e59b69184.jpg)
