### PR TITLE
Adds arguments listing to query error logging

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -338,7 +338,7 @@ Delayed insert mode was removed in mysql 7 and only works with MyISAM type table
 	. = run_query(async)
 	var/timed_out = !. && findtext(last_error, "Operation timed out")
 	if(!. && log_error)
-		log_sql("[last_error] | Query used: [sql]")
+		log_sql("[last_error] | Query used: [sql] | Arguments: [json_encode(arguments)]")
 	if(!async && timed_out)
 		log_query_debug("Query execution started at [start_time]")
 		log_query_debug("Query execution ended at [REALTIMEOFDAY]")


### PR DESCRIPTION
Currently only a parameterized query is logged, but for debugging it's useful to see the arguments used by a query too.