### PR TITLE
Speedmerge, voiceless ritual makes the ghouls INVISBLE_ABSTRACT, while they are alive, well and moving

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -83,8 +83,6 @@
 			current_eldritch_knowledge.cleanup_atoms(selected_atoms)
 			is_in_use = FALSE
 
-		listclearnulls(atoms_to_disappear)
-
 		for(var/to_appear in atoms_to_disappear)
 			var/atom/atom_to_appear = to_appear
 			//we need to reappear the item just in case the ritual didnt consume everything... or something.

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -74,7 +74,7 @@
 		flick("[icon_state]_active",src)
 		playsound(user, 'sound/magic/castsummon.ogg', 75, TRUE)
 		//we are doing this since some on_finished_recipe subtract the atoms from selected_atoms making them invisible permanently.
-		var/list/atoms_to_disappear = selected_atoms
+		var/list/atoms_to_disappear = selected_atoms.Copy()
 		for(var/to_disappear in atoms_to_disappear)
 			var/atom/atom_to_disappear = to_disappear
 			//temporary so we dont have to deal with the bs of someone picking those up when they may be deleted

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -73,7 +73,9 @@
 
 		flick("[icon_state]_active",src)
 		playsound(user, 'sound/magic/castsummon.ogg', 75, TRUE)
-		for(var/to_disappear in selected_atoms)
+		//we are doing this since some on_finished_recipe subtract the atoms from selected_atoms making them invisible permanently.
+		var/list/atoms_to_disappear = selected_atoms
+		for(var/to_disappear in atoms_to_disappear)
 			var/atom/atom_to_disappear = to_disappear
 			//temporary so we dont have to deal with the bs of someone picking those up when they may be deleted
 			atom_to_disappear.invisibility = INVISIBILITY_ABSTRACT
@@ -81,12 +83,12 @@
 			current_eldritch_knowledge.cleanup_atoms(selected_atoms)
 			is_in_use = FALSE
 
-		listclearnulls(selected_atoms)
+		listclearnulls(atoms_to_disappear)
 
-		for(var/to_disappear in selected_atoms)
-			var/atom/atom_to_disappear = to_disappear
+		for(var/to_appear in atoms_to_disappear)
+			var/atom/atom_to_appear = to_appear
 			//we need to reappear the item just in case the ritual didnt consume everything... or something.
-			atom_to_disappear.invisibility = initial(atom_to_disappear.invisibility)
+			atom_to_appear.invisibility = initial(atom_to_appear.invisibility)
 
 		return
 	is_in_use = FALSE

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -88,6 +88,7 @@
 	for(var/X in atoms)
 		var/atom/A = X
 		if(!isliving(A))
+			atoms -= A
 			qdel(A)
 	return
 
@@ -211,6 +212,7 @@
 /datum/eldritch_knowledge/final/cleanup_atoms(list/atoms)
 	. = ..()
 	for(var/mob/living/carbon/human/H in atoms)
+		atoms -= H
 		H.gib()
 
 


### PR DESCRIPTION
## About The Pull Request

Simple fix, i didnt consider this to be able to happen, and well it happened. Speedmerge we dont want to have COMPLETELY invisible living MUTE ghouls running around.

## Why It's Good For The Game

Having living, walking players INVISIBLE_ABSTRACT is a bad idea

## Changelog
:cl:
fix: Voiceless dead are now longe INVISIBILITY_ABSTRACT, god i hate bugs
/:cl:

