### PR TITLE
Fixes AI tracking not working near roundstart

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -172,7 +172,7 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 
 
 /datum/cameranet/proc/checkTurfVis(turf/position)
-	var/datum/camerachunk/chunk = chunkGenerated(position.x, position.y, position.z)
+	var/datum/camerachunk/chunk = getCameraChunk(position.x, position.y, position.z)
 	if(chunk)
 		if(chunk.changed)
 			chunk.hasChanged(1) // Update now, no matter if it's visible or not.


### PR DESCRIPTION
:cl:
fix: Fixed an issue that prevented AIs from tracking players in areas they have not yet viewed.
/:cl:

Fixes #51885

Replaces a `chunkGenerated` which only returns a chunk if it has already been generated with `getCameraChunk` which generates a chunk if it doesn't already exist.