### PR TITLE
look_up tweak and look_down verb

### DIFF
--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -29,5 +29,21 @@
 
 /datum/keybinding/living/look_up/up(client/user)
 	var/mob/living/L = user.mob
-	L.stop_look_up()
+	L.end_look_up()
+	return TRUE
+
+/datum/keybinding/living/look_down
+	hotkey_keys = list(";")
+	name = "look down"
+	full_name = "Look Down"
+	description = "Look down at the previous z-level.  Only works if directly above open space."
+
+/datum/keybinding/living/look_down/down(client/user)
+	var/mob/living/L = user.mob
+	L.look_down()
+	return TRUE
+
+/datum/keybinding/living/look_down/up(client/user)
+	var/mob/living/L = user.mob
+	L.end_look_down()
 	return TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1514,7 +1514,7 @@
 
 ///Checks if the user is incapacitated or on cooldown.
 /mob/living/proc/can_look_up()
-	return !((next_move > world.time) || incapacitated(ignore_restraints = TRUE))
+	return !(incapacitated(ignore_restraints = TRUE))
 
 /**
  * look_up Changes the perspective of the mob to any openspace turf above the mob
@@ -1526,25 +1526,74 @@
 
 	if(client.perspective != MOB_PERSPECTIVE) //We are already looking up.
 		stop_look_up()
-		return
 	if(!can_look_up())
 		return
 	var/turf/ceiling = get_step_multiz(src, UP)
 	if(!ceiling) //We are at the highest z-level.
 		to_chat(src, "<span class='warning'>You can't see through the ceiling above you.</span>")
 		return
-	else if(!istransparentturf(ceiling)) //There is no turf we can look through above us
-		to_chat(src, "<span class='warning'>You can't see through the floor above you.</span>")
-		return
+	else if(!istransparentturf(ceiling)) //There is no turf we can look through below us
+		var/list/checkturfs = block(locate(x-1,y-1,ceiling.z),locate(x+1,y+1,ceiling.z))-ceiling //Try find hole near of us
+		for(var/turf/checkhole in checkturfs)
+			if(istransparentturf(checkhole))
+				ceiling = get_step_multiz(checkhole, UP)
+				break
+		if(!istransparentturf(ceiling))
+			to_chat(src, "<span class='warning'>You can't see through the floor above you.</span>")
+			return
 
 	changeNext_move(CLICK_CD_LOOK_UP)
 	reset_perspective(ceiling)
 	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, .proc/stop_look_up) //We stop looking up if we move.
+	RegisterSignal(src, COMSIG_MOVABLE_MOVED, .proc/look_up) //We start looking again after we move.
 
 /mob/living/proc/stop_look_up()
 	reset_perspective()
-	UnregisterSignal(src, COMSIG_MOVABLE_PRE_MOVE)
 
+/mob/living/proc/end_look_up()
+	stop_look_up()
+	UnregisterSignal(src, COMSIG_MOVABLE_PRE_MOVE)
+	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
+
+/**
+ * look_down Changes the perspective of the mob to any openspace turf below the mob
+ *
+ * This also checks if an openspace turf is below the mob before looking down or resets the perspective if already looking up
+ *
+ */
+/mob/living/proc/look_down()
+
+	if(client.perspective != MOB_PERSPECTIVE) //We are already looking down.
+		stop_look_down()
+	if(!can_look_up()) //if we cant look up, we cant look down.
+		return
+	var/turf/lower_level = get_step_multiz(src, DOWN)
+	var/turf/floor = get_turf(src)
+	if(!lower_level) //We are at the lowest z-level.
+		to_chat(src, "<span class='warning'>You can't see through the floor below you.</span>")
+		return
+	else if(!istransparentturf(floor)) //There is no turf we can look through below us
+		var/list/checkturfs = block(locate(x-1,y-1,z),locate(x+1,y+1,z))-floor //Try find hole near of us
+		for(var/turf/checkhole in checkturfs)
+			if(istransparentturf(checkhole))
+				lower_level = get_step_multiz(checkhole, DOWN)
+				break
+		if(!istransparentturf(floor))
+			to_chat(src, "<span class='warning'>You can't see through the floor below you.</span>")
+			return
+
+	changeNext_move(CLICK_CD_LOOK_UP)
+	reset_perspective(lower_level)
+	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, .proc/stop_look_down) //We stop looking down if we move.
+	RegisterSignal(src, COMSIG_MOVABLE_MOVED, .proc/look_down) //We start looking again after we move.
+
+/mob/living/proc/stop_look_down()
+	reset_perspective()
+
+/mob/living/proc/end_look_down()
+	stop_look_up()
+	UnregisterSignal(src, COMSIG_MOVABLE_PRE_MOVE)
+	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 
 /mob/living/set_stat(new_stat)
 	. = ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1532,12 +1532,16 @@
 	if(!ceiling) //We are at the highest z-level.
 		to_chat(src, "<span class='warning'>You can't see through the ceiling above you.</span>")
 		return
-	else if(!istransparentturf(ceiling)) //There is no turf we can look through below us
-		var/list/checkturfs = block(locate(x-1,y-1,ceiling.z),locate(x+1,y+1,ceiling.z))-ceiling //Try find hole near of us
-		for(var/turf/checkhole in checkturfs)
-			if(istransparentturf(checkhole))
-				ceiling = get_step_multiz(checkhole, UP)
-				break
+	else if(!istransparentturf(ceiling)) //There is no turf we can look through above us
+		var/turf/front_hole = get_step(ceiling, dir)
+		if(istransparentturf(front_hole) //First check turf in front of us
+			ceiling = front_hole
+		else
+			var/list/checkturfs = block(locate(x-1,y-1,ceiling.z),locate(x+1,y+1,ceiling.z))-ceiling-front_hole //Try find hole near of us
+			for(var/turf/checkhole in checkturfs)
+				if(istransparentturf(checkhole))
+					ceiling = checkhole
+					break
 		if(!istransparentturf(ceiling))
 			to_chat(src, "<span class='warning'>You can't see through the floor above you.</span>")
 			return
@@ -1567,17 +1571,21 @@
 		stop_look_down()
 	if(!can_look_up()) //if we cant look up, we cant look down.
 		return
-	var/turf/lower_level = get_step_multiz(src, DOWN)
 	var/turf/floor = get_turf(src)
+	var/turf/lower_level = get_step_multiz(floor, DOWN)
 	if(!lower_level) //We are at the lowest z-level.
 		to_chat(src, "<span class='warning'>You can't see through the floor below you.</span>")
 		return
 	else if(!istransparentturf(floor)) //There is no turf we can look through below us
-		var/list/checkturfs = block(locate(x-1,y-1,z),locate(x+1,y+1,z))-floor //Try find hole near of us
-		for(var/turf/checkhole in checkturfs)
-			if(istransparentturf(checkhole))
-				lower_level = get_step_multiz(checkhole, DOWN)
-				break
+		var/turf/front_hole = get_step(floor, dir)
+		if(istransparentturf(front_hole) //First check turf in front of us
+			ceiling = front_hole
+		else
+			var/list/checkturfs = block(locate(x-1,y-1,z),locate(x+1,y+1,z))-floor //Try find hole near of us
+			for(var/turf/checkhole in checkturfs)
+				if(istransparentturf(checkhole))
+					lower_level = get_step_multiz(checkhole, DOWN)
+					break
 		if(!istransparentturf(floor))
 			to_chat(src, "<span class='warning'>You can't see through the floor below you.</span>")
 			return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1579,6 +1579,7 @@
 	else if(!istransparentturf(floor)) //There is no turf we can look through below us
 		var/turf/front_hole = get_step(floor, dir)
 		if(istransparentturf(front_hole))
+			floor = front_hole
 			lower_level = front_hole
 		else
 			var/list/checkturfs = block(locate(x-1,y-1,z),locate(x+1,y+1,z))-floor //Try find hole near of us

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1534,7 +1534,7 @@
 		return
 	else if(!istransparentturf(ceiling)) //There is no turf we can look through above us
 		var/turf/front_hole = get_step(ceiling, dir)
-		if(istransparentturf(front_hole) //First check turf in front of us
+		if(istransparentturf(front_hole))
 			ceiling = front_hole
 		else
 			var/list/checkturfs = block(locate(x-1,y-1,ceiling.z),locate(x+1,y+1,ceiling.z))-ceiling-front_hole //Try find hole near of us
@@ -1578,12 +1578,13 @@
 		return
 	else if(!istransparentturf(floor)) //There is no turf we can look through below us
 		var/turf/front_hole = get_step(floor, dir)
-		if(istransparentturf(front_hole) //First check turf in front of us
-			ceiling = front_hole
+		if(istransparentturf(front_hole))
+			lower_level = front_hole
 		else
 			var/list/checkturfs = block(locate(x-1,y-1,z),locate(x+1,y+1,z))-floor //Try find hole near of us
 			for(var/turf/checkhole in checkturfs)
 				if(istransparentturf(checkhole))
+					floor = checkhole
 					lower_level = get_step_multiz(checkhole, DOWN)
 					break
 		if(!istransparentturf(floor))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1580,7 +1580,7 @@
 		var/turf/front_hole = get_step(floor, dir)
 		if(istransparentturf(front_hole))
 			floor = front_hole
-			lower_level = front_hole
+			lower_level = get_step_multiz(front_hole, DOWN)
 		else
 			var/list/checkturfs = block(locate(x-1,y-1,z),locate(x+1,y+1,z))-floor //Try find hole near of us
 			for(var/turf/checkhole in checkturfs)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1589,7 +1589,7 @@
 			floor = front_hole
 			lower_level = get_step_multiz(front_hole, DOWN)
 		else
-			var/list/checkturfs = block(locate(x-1,y-1,z),locate(x+1,y+1,z))-floor-front_hole //Try find hole near of us
+			var/list/checkturfs = block(locate(x-1,y-1,z),locate(x+1,y+1,z))-floor //Try find hole near of us
 			for(var/turf/checkhole in checkturfs)
 				if(istransparentturf(checkhole))
 					floor = checkhole

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1523,11 +1523,16 @@
  *
  */
 /mob/living/proc/look_up()
-
 	if(client.perspective != MOB_PERSPECTIVE) //We are already looking up.
 		stop_look_up()
 	if(!can_look_up())
 		return
+	changeNext_move(CLICK_CD_LOOK_UP)
+	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, .proc/stop_look_up) //We stop looking up if we move.
+	RegisterSignal(src, COMSIG_MOVABLE_MOVED, .proc/start_look_up) //We start looking again after we move.
+	start_look_up()
+
+/mob/living/proc/start_look_up()
 	var/turf/ceiling = get_step_multiz(src, UP)
 	if(!ceiling) //We are at the highest z-level.
 		to_chat(src, "<span class='warning'>You can't see through the ceiling above you.</span>")
@@ -1546,10 +1551,7 @@
 			to_chat(src, "<span class='warning'>You can't see through the floor above you.</span>")
 			return
 
-	changeNext_move(CLICK_CD_LOOK_UP)
 	reset_perspective(ceiling)
-	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, .proc/stop_look_up) //We stop looking up if we move.
-	RegisterSignal(src, COMSIG_MOVABLE_MOVED, .proc/look_up) //We start looking again after we move.
 
 /mob/living/proc/stop_look_up()
 	reset_perspective()
@@ -1566,11 +1568,16 @@
  *
  */
 /mob/living/proc/look_down()
-
 	if(client.perspective != MOB_PERSPECTIVE) //We are already looking down.
 		stop_look_down()
 	if(!can_look_up()) //if we cant look up, we cant look down.
 		return
+	changeNext_move(CLICK_CD_LOOK_UP)
+	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, .proc/stop_look_down) //We stop looking down if we move.
+	RegisterSignal(src, COMSIG_MOVABLE_MOVED, .proc/start_look_down) //We start looking again after we move.
+	start_look_down()
+
+/mob/living/proc/start_look_down()
 	var/turf/floor = get_turf(src)
 	var/turf/lower_level = get_step_multiz(floor, DOWN)
 	if(!lower_level) //We are at the lowest z-level.
@@ -1592,18 +1599,16 @@
 			to_chat(src, "<span class='warning'>You can't see through the floor below you.</span>")
 			return
 
-	changeNext_move(CLICK_CD_LOOK_UP)
 	reset_perspective(lower_level)
-	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, .proc/stop_look_down) //We stop looking down if we move.
-	RegisterSignal(src, COMSIG_MOVABLE_MOVED, .proc/look_down) //We start looking again after we move.
 
 /mob/living/proc/stop_look_down()
 	reset_perspective()
 
 /mob/living/proc/end_look_down()
-	stop_look_up()
+	stop_look_down()
 	UnregisterSignal(src, COMSIG_MOVABLE_PRE_MOVE)
 	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
+
 
 /mob/living/set_stat(new_stat)
 	. = ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1589,7 +1589,7 @@
 			floor = front_hole
 			lower_level = get_step_multiz(front_hole, DOWN)
 		else
-			var/list/checkturfs = block(locate(x-1,y-1,z),locate(x+1,y+1,z))-floor //Try find hole near of us
+			var/list/checkturfs = block(locate(x-1,y-1,z),locate(x+1,y+1,z))-floor-front_hole //Try find hole near of us
 			for(var/turf/checkhole in checkturfs)
 				if(istransparentturf(checkhole))
 					floor = checkhole


### PR DESCRIPTION
## About The Pull Request
Part of #51160
look_down verb allow look down
look_up and look_down verbs don't interrupt by move, until you step under/over transparent turf.

## Why It's Good For The Game

MultiZ is great.

## Changelog
:cl:
add: look_down verb that allow look down
tweak: look_up and look_down verbs don't interrupt by move, until you step under/over transparent turf.
/:cl: