### PR TITLE
Cleans up Cybernetic Lung code and fixes minor bug

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -463,8 +463,7 @@
 	desc = "A basic cybernetic version of the lungs found in traditional humanoid entities."
 	icon_state = "lungs-c"
 	organ_flags = ORGAN_SYNTHETIC
-	safe_oxygen_min = 16
-	maxHealth = STANDARD_ORGAN_THRESHOLD*0.5
+	maxHealth = STANDARD_ORGAN_THRESHOLD * 0.5
 
 	var/emp_vulnerability = 80	//Chance of permanent effects if emp-ed.
 
@@ -472,7 +471,6 @@
 	name = "cybernetic lungs"
 	desc = "A cybernetic version of the lungs found in traditional humanoid entities. Allows for greater intakes of oxygen than organic lungs, requiring slightly less pressure."
 	icon_state = "lungs-c-u"
-	organ_flags = ORGAN_SYNTHETIC
 	maxHealth = 1.5 * STANDARD_ORGAN_THRESHOLD
 	safe_oxygen_min = 13
 	emp_vulnerability = 40
@@ -484,6 +482,7 @@
 	safe_toxins_max = 20
 	safe_co2_max = 20
 	maxHealth = 2 * STANDARD_ORGAN_THRESHOLD
+	safe_oxygen_min = 13
 	emp_vulnerability = 20
 
 	cold_level_1_threshold = 200


### PR DESCRIPTION
## About The Pull Request
Discovered some silly code from someone that doesn't even understand parents while I was doing another PR. removed some unnecessary code involving Cybernetic Lungs code and makes tier 3 lungs have the same minimum oxygen requirement as tier 2 lungs

## Why It's Good For The Game

Cleans up code and restores intended functionality to Upgraded Cybernetic Lungs

## Changelog
:cl:
fix: Upgraded Cybernetic Lungs (Tier3) now have improved oxygen absorption, same as Cybernetic Lungs (Tier2)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
