### PR TITLE
Fixes examine_more runtime

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -597,14 +597,13 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	return ..() //well boys we did it, lists are no more
 
 /obj/machinery/computer/arcade/battle/examine_more(mob/user)
-	to_chat(user, "<span class='notice'>Scribbled on the side of the Arcade Machine you notice some writing...\
-	\nmagical -> >=50 power\
-	\nsmart -> defend, defend, light attack\
-	\nshotgun -> defend, defend, power attack\
-	\nshort temper -> counter, counter, counter\
-	\npoisonous -> light attack, light attack, light attack\
-	\nchonker -> power attack, power attack, power attack</span>")
-	return ..()
+	var/list/msg = list("<span class='notice'><i>You notice some writing scribbled on the side of [src]...</i></span>")
+	msg += "\t<span class='info'>smart -> defend, defend, light attack</span>"
+	msg += "\t<span class='info'>shotgun -> defend, defend, power attack</span>"
+	msg += "\t<span class='info'>short temper -> counter, counter, counter</span>"
+	msg += "\t<span class='info'>poisonous -> light attack, light attack, light attack</span>"
+	msg += "\t<span class='info'>chonker -> power attack, power attack, power attack</span>"
+	return msg
 
 /obj/machinery/computer/arcade/battle/emag_act(mob/user)
 	if(obj_flags & EMAGGED)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -222,6 +222,7 @@
 
 /obj/item/paper/examine_more(mob/user)
 	ui_interact(user)
+	return list("<span class='notice'><i>You try to read [src]...</i></span>")
 
 
 /obj/item/paper/can_interact(mob/user)


### PR DESCRIPTION
expects a list to be returned.

:cl: ShizCalev
fix: Fixed a minor runtime when examining paper twice.
refactor: Cleaned up arcade machine examine-more messages a little.
/:cl:


```
[xxxxxxxxx] Runtime in mob.dm, line 431: Cannot execute null.Join().
verb name: Examine (/mob/verb/examinate)
usr: xxxxxxxxxxxxx
usr.loc: (Cargo Office (165,160,2))
src: xxxxxxxxxxx (/mob/living/carbon/human)
src.loc: the floor (165,160,2) (/turf/open/floor/plasteel)
call stack:
xxxxxxxxxxxxxxxxx (/mob/living/carbon/human): Examine(the paper - Bounties (/obj/item/paper/bounty_printout))
the paper - Bounties (/obj/item/paper/bounty_printout): ShiftClick(xxxxxxx (/mob/living/carbon/human))
xxxxxxxxxxxxxxxxx (/mob/living/carbon/human): ShiftClickOn(the paper - Bounties (/obj/item/paper/bounty_printout))
xxxxxxxxxxxxxxxxx (/mob/living/carbon/human): ClickOn(the paper - Bounties (/obj/item/paper/bounty_printout), "icon-x=9;icon-y=14;left=1;shif...")
the paper - Bounties (/obj/item/paper/bounty_printout): Click(null, "mapwindow.map", "icon-x=9;icon-y=14;left=1;shif...")
the head (/obj/screen/inventory): Click(null, "mapwindow.map", "icon-x=9;icon-y=14;left=1;shif...")
xxxxxxxxx (/client): Click(the head (/obj/screen/inventory), null, "mapwindow.map", "icon-x=9;icon-y=14;left=1;shif...")
```