### PR TITLE
Fixes machinery not sending COMSIG_ATOM_CONTENTS_DEL when an atom inside them is deleted

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -437,6 +437,7 @@ Class Procs:
 		occupant = null
 		update_icon()
 		updateUsrDialog()
+	return ..()
 
 /obj/machinery/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -407,7 +407,7 @@ Class Procs:
 			for(var/obj/item/I in component_parts)
 				I.forceMove(loc)
 			component_parts.Cut()
-	qdel(src)
+	return ..()
 
 /obj/machinery/proc/spawn_frame(disassembled)
 	var/obj/structure/frame/machine/M = new /obj/structure/frame/machine(loc)


### PR DESCRIPTION
🆑 ShizCalev
fix: Fixed machinery not sending the signal for an atom being deleted inside it when an atom was deleted inside it.
fix: Fixed machinery not sending the signal for being deconstructed.
/🆑

https://github.com/tgstation/tgstation/blob/78ab9b1fcbe5df5cbd821607ed6b8d492d5139b3/code/game/atoms.dm#L838-L844