### PR TITLE
Monkey mind mag helmets's sprites don't break on updating their icon_state

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -346,10 +346,12 @@
 	strip_delay = 100
 	var/mob/living/carbon/monkey/magnification = null ///if the helmet is on a valid target (just works like a normal helmet if not (cargo please stop))
 	var/polling = FALSE///if the helmet is currently polling for targets (special code for removal)
+	var/light_colors = 1 ///which icon state color this is (red, blue, yellow)
 
 /obj/item/clothing/head/helmet/monkey_sentience/Initialize()
 	. = ..()
-	icon_state = "[icon_state][rand(1,3)]"
+	light_colors = rand(1,3)
+	icon_state = "[icon_state][light_colors]"
 
 /obj/item/clothing/head/helmet/monkey_sentience/examine(mob/user)
 	. = ..()
@@ -359,6 +361,9 @@
 	. += "<span class='warning'>PRIMAL GENE ACTIVATION</span>"
 	. += "<span class='warning'>GENETIC MAKEUP MASS SUSCEPTIBILITY</span>"
 	. += "<span class='boldnotice'>Ask your CMO if mind magnification is right for you.</span>"
+
+/obj/item/clothing/head/helmet/monkey_sentience/update_icon_state()
+	icon_state = "[initial(icon_state)][light_colors]"
 
 /obj/item/clothing/head/helmet/monkey_sentience/equipped(mob/user, slot)
 	. = ..()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -363,7 +363,8 @@
 	. += "<span class='boldnotice'>Ask your CMO if mind magnification is right for you.</span>"
 
 /obj/item/clothing/head/helmet/monkey_sentience/update_icon_state()
-	icon_state = "[initial(icon_state)][light_colors]"
+	var/lightson = magnification ? "up" : ""
+	icon_state = "[initial(icon_state)][light_colors][lightson]"
 
 /obj/item/clothing/head/helmet/monkey_sentience/equipped(mob/user, slot)
 	. = ..()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -351,7 +351,7 @@
 /obj/item/clothing/head/helmet/monkey_sentience/Initialize()
 	. = ..()
 	light_colors = rand(1,3)
-	icon_state = "[icon_state][light_colors]"
+	update_icon_state()
 
 /obj/item/clothing/head/helmet/monkey_sentience/examine(mob/user)
 	. = ..()
@@ -363,8 +363,7 @@
 	. += "<span class='boldnotice'>Ask your CMO if mind magnification is right for you.</span>"
 
 /obj/item/clothing/head/helmet/monkey_sentience/update_icon_state()
-	var/lightson = magnification ? "up" : ""
-	icon_state = "[initial(icon_state)][light_colors][lightson]"
+	icon_state = "[initial(icon_state)][light_colors][magnification ? "up" : ""]"
 
 /obj/item/clothing/head/helmet/monkey_sentience/equipped(mob/user, slot)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds a special override for update icon that keeps the light color.

## Why It's Good For The Game

ERROR ERROR

## Changelog
:cl:
fix: mind mag helms losing their icon sometimes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
