### PR TITLE
Fixes acid/fire/blobs/a few other things touching objects below a tile

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -167,7 +167,7 @@
 	if(!T)
 		return FALSE
 	for(var/atom/movable/AM in T)
-		if(AM.flags_1 & PREVENT_CLICK_UNDER_1 && AM.density && AM.layer > layer)
+		if(AM.flags_1 & PREVENT_CLICK_UNDER_1 && AM.density && (AM.layer > layer || (T.intact && HAS_TRAIT(AM, TRAIT_T_RAY_VISIBLE))))
 			return TRUE
 	return FALSE
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -167,7 +167,7 @@
 	if(!T)
 		return FALSE
 	for(var/atom/movable/AM in T)
-		if(AM.flags_1 & PREVENT_CLICK_UNDER_1 && AM.density && (AM.layer > layer || (T.intact && HAS_TRAIT(AM, TRAIT_T_RAY_VISIBLE))))
+		if(AM.flags_1 & PREVENT_CLICK_UNDER_1 && AM.density && AM.layer > layer)
 			return TRUE
 	return FALSE
 

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -102,6 +102,10 @@
 			step_towards(M,src)
 	for(var/obj/O in range(0,src))
 		if(!O.anchored)
+			if(isturf(O.loc))
+				var/turf/T = O.loc
+				if(T.intact && HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
+					continue
 			var/mob/living/target = locate() in view(4,src)
 			if(target && !target.stat)
 				O.throw_at(target, 5, 10)

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -141,6 +141,10 @@
 	for(var/obj/O in range(0,src))
 		if(O.type == src.type)
 			continue
+		if(isturf(O.loc))
+			var/turf/T = O.loc
+			if(T.intact && HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
+				continue
 		if(lifetime % reagent_divisor)
 			reagents.expose(O, VAPOR, fraction)
 	var/hit = 0

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -232,6 +232,8 @@
 		for(var/atom/movable/AM in T)
 			if(AM.type == src.type)
 				continue
+			if(T.intact && HAS_TRAIT(AM, TRAIT_T_RAY_VISIBLE))
+				continue
 			reagents.expose(AM, TOUCH, fraction)
 
 		reagents.expose(T, TOUCH, fraction)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -67,8 +67,7 @@ GENE SCANNER
 		return
 	var/list/t_ray_images = list()
 	for(var/obj/O in orange(distance, viewer) )
-
-		if(O.invisibility == INVISIBILITY_MAXIMUM || HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
+		if(HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
 			var/image/I = new(loc = get_turf(O))
 			var/mutable_appearance/MA = new(O)
 			MA.alpha = 128

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -91,6 +91,10 @@
 	return TRUE
 
 /obj/blob_act(obj/structure/blob/B)
+	if(isturf(loc))
+		var/turf/T = loc
+		if(T.intact && HAS_TRAIT(src, TRAIT_T_RAY_VISIBLE))
+			return
 	take_damage(400, BRUTE, "melee", 0, get_dir(src, B))
 
 /obj/proc/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, armor_penetration = 0) //used by attack_alien, attack_animal, and attack_slime
@@ -198,6 +202,10 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 
 ///Called when the obj is exposed to fire.
 /obj/fire_act(exposed_temperature, exposed_volume)
+	if(isturf(loc))
+		var/turf/T = loc
+		if(T.intact && HAS_TRAIT(src, TRAIT_T_RAY_VISIBLE))
+			return
 	if(exposed_temperature && !(resistance_flags & FIRE_PROOF))
 		take_damage(clamp(0.02 * exposed_temperature, 0, 20), BURN, "fire", 0)
 	if(!(resistance_flags & ON_FIRE) && (resistance_flags & FLAMMABLE) && !(resistance_flags & FIRE_PROOF))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -389,7 +389,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 /turf/singularity_act()
 	if(intact)
 		for(var/obj/O in contents) //this is for deleting things like wires contained in the turf
-			if(O.invisibility == INVISIBILITY_MAXIMUM)
+			if(HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
 				O.singularity_act()
 	ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 	return(2)
@@ -473,6 +473,8 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		acid_type = /obj/effect/acid/alien
 	var/has_acid_effect = FALSE
 	for(var/obj/O in src)
+		if(intact && HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
+			return
 		if(istype(O, acid_type))
 			var/obj/effect/acid/A = O
 			A.acid_level = min(acid_volume * acidpwr, 12000)//capping acid level to limit power of the acid

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -948,8 +948,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/list/t_ray_images = list()
 	var/static/list/stored_t_ray_images = list()
 	for(var/obj/O in orange(client.view, src) )
-
-		if(O.invisibility == INVISIBILITY_MAXIMUM)
+		if(HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
 			var/image/I = new(loc = get_turf(O))
 			var/mutable_appearance/MA = new(O)
 			MA.alpha = 128


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#49644 refactored layer away, but it also just removed all the checks for "Is this under a turf", so shit like wires would burn.
Fixes #51195
There might be more, I doubt it though, the stuff that got touched was pretty minor.

Oh and you can't use t-ray scanners to see invisible mobs/ai eyes anymore, not sure you could before, but now you extra can't
## Why It's Good For The Game

Turbine wire no burn, BAD.

## Changelog
:cl:
fix: Wires will no longer burn if they're under a tile that's on fire
code: Reinserted some old checks for if something is over/under a tile
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
