### PR TITLE
monkey caps drop on the floor if no ghosts got polled 

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -378,8 +378,9 @@
 	polling = FALSE
 	if(!candidates.len)
 		magnification = null
-		visible_message("<span class='notice'>[src] falls silent. Maybe you should try again later?</span>")
+		visible_message("<span class='notice'>[src] falls silent and drops on the floor. Maybe you should try again later?</span>")
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 30, TRUE)
+		user.dropItemToGround(src)
 	var/mob/picked = pick(candidates)
 	magnification.key = picked.key
 	playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, FALSE)


### PR DESCRIPTION
:cl:
tweak: monkey caps drop on the floor if no ghosts got polled 
/:cl:

its dumb that you have to remove and put cap again to try poll again and it gives less confusion if the monkey is sentient or not