### PR TITLE
Fixes glowshrooms spreading slower from better production speed

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -68,7 +68,8 @@
 		myseed.adjust_yield(rand(-3,2))
 		myseed.adjust_production(rand(-3,3))
 		myseed.endurance = clamp(myseed.endurance + rand(-3,2), 0, 100) // adjust_endurance has a min value of 10, need to edit directly
-	delay_spread = delay_spread - myseed.production * 100 //So the delay goes DOWN with better stats instead of up. :I
+	if(myseed.production >= 1) //In case production is varedited to -1 or less which would cause unlimited or negative delay.
+		delay_spread = delay_spread - (11 - myseed.production) * 100 //Because lower production speed stat gives faster production speed, which should give faster mushroom spread. Range 200-1100 deciseconds.
 	var/datum/plant_gene/trait/glow/G = myseed.get_gene(/datum/plant_gene/trait/glow)
 	if(ispath(G)) // Seeds were ported to initialize so their genes are still typepaths here, luckily their initializer is smart enough to handle us doing this
 		myseed.genes -= G


### PR DESCRIPTION
## About The Pull Request
This inverts the the effect of production speed on glowshroom spread. Fixes #52076 . 

## Why It's Good For The Game
Glowshrooms, glowcaps and shadowshrooms were broken because the formula made them spread slower with lower (better) production speed. Since they all have max production (1) by default they would barely spread at all. 

Thanks to @kriskog for fixing the unrelated runtimes so I could PR this. 

It's tested. 

**2 minutes (before this change):**
![200708 1640 55 Fixed glowshroom prod 10 2 minutes](https://user-images.githubusercontent.com/46400996/87234632-271dc680-c3d3-11ea-9cbf-d77325f55e08.png)

**2 minutes (after this change):**
![200708 1643 40 Fixed glowshroom prod 1 2 minutes](https://user-images.githubusercontent.com/46400996/87234634-2be27a80-c3d3-11ea-8a57-44c0d3d411f0.png)


## Changelog
:cl: Angust
fix: Glowshrooms now spread properly again.
/:cl: