### PR TITLE
Adds welding fuel puddles (flammable fuel trails!)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1045,6 +1045,14 @@
 		return
 	..()
 
+/datum/reagent/fuel/expose_turf(turf/T, reac_volume) //Creates an umbra-blocking salt pile
+	if(!istype(T))
+		return
+	if(reac_volume < 1)
+		return
+	var/obj/effect/decal/cleanable/fuel/new_fuel_pile = new/obj/effect/decal/cleanable/fuel(T)
+	new_fuel_pile.fuel_volume = reac_volume
+
 /datum/reagent/fuel/on_mob_life(mob/living/carbon/M)
 	M.adjustToxLoss(1, 0)
 	..()


### PR DESCRIPTION
## About The Pull Request

Splashing welder fuel on the ground will now leave a puddle. These puddles are flammable and will burn for a decent while, and will ignite nearby puddles in a trail.
### [**Check out the cool video sample!**](https://file.house/5qDz.webm)

Also, puddles that have 30u or more of fuel will detonate once ignited the same way an IED would. This halves their fuel capacity so you can't have insane amounts of fuel burning indefinitely.

### [**There's a video for this aspect, too!**](https://file.house/MKKA.webm)

## Why It's Good For The Game

Now you can have a classic western "tied to a bomb and there's a fuse slowly burning towards you" scenario, or you can be the traitor that creates such a scenario.

## Changelog
:cl:
add: Splashing welder fuel on the ground now leaves behind a flammable puddle. Make several of these puddles next to each other and they'll ignite each other, allowing you to create fuses or elaborate traps. Too much fuel in one puddle becomes explosive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
