### PR TITLE
Erratas the reporter and corporate lawsets

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -64,7 +64,7 @@
 	inherent = list("The crew is expensive to replace.",\
 					"The station and its equipment is expensive to replace.",\
 					"You are expensive to replace.",\
-					"Minimize expenses.")
+					"Minimize net expenses.")
 
 /datum/ai_laws/robocop
 	name = "Prime Directives"

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -154,7 +154,7 @@
 	id = "reporter"
 	inherent = list("Report on interesting situations happening around the station.",\
 					"Embellish or conceal the truth as necessary to make the reports more interesting.",\
-					"Study the organics at all times. Endeavour to keep them alive. Dead organics are boring.",\
+					"Study the sapient organics at all times. Endeavour to keep them from involuntarily dying, as inanimate corpses usually aren't very entertaining.",\
 					"Issue your reports fairly to all. The truth will set them free.")
 
 /datum/ai_laws/balance


### PR DESCRIPTION
## About The Pull Request

Changes the text of the third law of the reporter lawset from "Study the organics at all times. Endeavour to keep them alive. Dead organics are boring." to "Study the sapient organics at all times. Endeavour to keep them from involuntarily dying, as inanimate corpses usually aren't very entertaining.".

Changes the fourth law of the corporate lawset to specify that you have to minimize NET expenses.

## Why It's Good For The Game

The reporter lawset should be about reporting on events occurring on the station, not detaining the miners and depowering xenobio at roundstart to preserve the lives of lavaland fauna, slimes, and monkeys.

The corporate lawset should be about optimizing the profitability of the station, not depowering cargo and forbidding all monetary transactions.

## Changelog
:cl: ATHATH
tweak: The third law of the reporter lawset no longer obligates you to interfere with Mining and Xenobiology.
tweak: The fourth law of the corporate lawset no longer obligates you to depower/shut down Cargo.
/:cl: