### PR TITLE
Makes vend-a-trays usable by bartenders, adds them to a technode.

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -570,4 +570,4 @@
 
 /obj/structure/displaycase/forsale/kitchen
 	desc = "A display case with an ID-card swiper. Use your ID to purchase the contents. Meant for the bartender and chef."
-	req_access = list(ACCESS_KITCHEN)
+	req_one_access = list(ACCESS_KITCHEN, ACCESS_BAR)

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -616,3 +616,9 @@
 	build_path = /obj/item/circuitboard/machine/sheetifier
 	category = list ("Misc. Machinery")
 
+/datum/design/board/vendatray
+	name = "Vend-a-Tray"
+	desc = "The circuit board for a Vend-a-Tray."
+	id = "vendatray"
+	build_path = /obj/item/circuitboard/machine/vendatray
+	category = list ("Misc. Machinery")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -348,7 +348,7 @@
 	display_name = "Electromagnetic Theory"
 	description = "Study into usage of frequencies in the electromagnetic spectrum."
 	prereq_ids = list("base")
-	design_ids = list("holosign", "holosignsec", "holosignengi", "holosignatmos", "inducer", "tray_goggles", "holopad")
+	design_ids = list("holosign", "holosignsec", "holosignengi", "holosignatmos", "inducer", "tray_goggles", "holopad", "vendatray")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION

## About The Pull Request

I totally didn't understand how req_access works, and set vendatrays access to only need kitchen access. HOWEVER, I wasn't aware that bartenders don't have access to the kitchen outside of skeleton crew shifts because I don't have a botnet of 100 players filling rolls on my private server, carrying out my whims.

This changes the roundstart vend-a-trays access requirement to only require either kitchen or bar access to be registered. Regular, existing vend-a-trays will still have no access requirements to them, but the roundstart ones are meant for the chef and the bartender.

Also, I made a board for the vend-a-trays and apparently fell asleep during the whole "Adding it to the techweb so you can actually print new ones" step. Easy fix.

## Why It's Good For The Game

Enables the thing to work as intended by the design of the thing.

## Changelog
:cl:
fix: Vend-a-trays can now be made in the service lathe.
fix: Roundstart Vend-a-trays can now be registered to either chefs or bartenders, respectively.
/:cl: