### PR TITLE
Fixes log_wound runtime

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1291,13 +1291,15 @@
   * * base_roll- Base wounding ability of an attack is a random number from 1 to (dealt_damage ** WOUND_DAMAGE_EXPONENT). This is the number that was rolled in there, before mods
   */
 /proc/log_wound(atom/victim, datum/wound/suffered_wound, dealt_damage, dealt_wound_bonus, dealt_bare_wound_bonus, base_roll)
-	var/message = "has suffered: [suffered_wound] to [suffered_wound.limb.name]" // maybe indicate if it's a promote/demote?
+	if(QDELETED(victim) || !suffered_wound)
+		return
+	var/message = "has suffered: [suffered_wound][suffered_wound.limb ? " to [suffered_wound.limb.name]" : null]"// maybe indicate if it's a promote/demote?
 
 	if(dealt_damage)
 		message += " | Damage: [dealt_damage]"
 		// The base roll is useful since it can show how lucky someone got with the given attack. For example, dealing a cut
 		if(base_roll)
-			message += "(rolled [base_roll]/[dealt_damage ** WOUND_DAMAGE_EXPONENT])"
+			message += " (rolled [base_roll]/[dealt_damage ** WOUND_DAMAGE_EXPONENT])"
 
 	if(dealt_wound_bonus)
 		message += " | WB: [dealt_wound_bonus]"
@@ -1413,7 +1415,7 @@
 /**
   * Used to set something as 'open' if it's being used as a supplypod
   *
-  * Override this if you want an atom to be usable as a supplypod. 
+  * Override this if you want an atom to be usable as a supplypod.
   */
 /atom/proc/setOpened()
 	return
@@ -1421,7 +1423,7 @@
 /**
   * Used to set something as 'closed' if it's being used as a supplypod
   *
-  * Override this if you want an atom to be usable as a supplypod. 
+  * Override this if you want an atom to be usable as a supplypod.
   */
 /atom/proc/setClosed()
 	return


### PR DESCRIPTION
:cl: Ryll/Shaps
fix: Fixed a runtime when log_wound wasn't passed a wound or a victim to apply it to.
/:cl:

Pulled from #51786 to get it merged asap.