### PR TITLE
Fixes ice demon teleport runtime

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice demon.dm
@@ -57,6 +57,8 @@
 		if(isclosedturf(T))
 			continue
 		possible_ends |= T
+	if(!possible_ends.len)
+		return ..()
 	var/turf/end = pick(possible_ends)
 	do_teleport(src, end, 0,  channel=TELEPORT_CHANNEL_BLUESPACE, forced = TRUE)
 	SLEEP_CHECK_DEATH(8)


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed a scenario where ice demons wouldn't fire at you if they were unsuccessful in finding a spot to teleport to.
/:cl:
