### PR TITLE
Fixes being able to hide your codex while gathering research points

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_book.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_book.dm
@@ -40,7 +40,7 @@
 /obj/item/forbidden_book/proc/get_power_from_influence(atom/target, mob/user)
 	var/obj/effect/reality_smash/RS = target
 	to_chat(target, "<span class='danger'>You start drawing power from influence...</span>")
-	if(do_after(user,10 SECONDS,FALSE,RS))
+	if(do_after(user,10 SECONDS,TRUE,RS))
 		qdel(RS)
 		charge += 1
 


### PR DESCRIPTION
:cl: ShizCalev
fix: You can no longer hide your codex in your pockets while gathering research points with it from a reality tear. You have to actually hold it for the full duration now.
/:cl: