### PR TITLE
Update the config to allow the widescreen toggle in settings

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -483,7 +483,7 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 ##  15x15 would be the standard square view. 21x15 is what goonstation uses for widescreen.
 ##  Setting this to something different from DEFAULT_VIEW_SQUARE will enable widescreen toggles
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
-DEFAULT_VIEW 15x15
+DEFAULT_VIEW 19x15
 
 ##Default view size, in tiles. Should *always* be square.
 ## The alternative square viewport size if you're using a widescreen view size


### PR DESCRIPTION
## About The Pull Request

Well, all servers use 19x15 nowadays, and it's togglable in player preferences, so why not update the config to make it default? Right now, we're forced to have a square box, and editing this config while also using git can be messy.

Changes nothing on live servers, improves dev lyfe.
