### PR TITLE
Canister frame code and UX improvements

### DIFF
--- a/code/game/machinery/canister_frame.dm
+++ b/code/game/machinery/canister_frame.dm
@@ -8,87 +8,116 @@
 /obj/structure/canister_frame/examine(user)
 	. = ..()
 
-/obj/structure/canister_frame/deconstruct(disassembled = TRUE)
-	if (!(flags_1 & NODECONSTRUCT_1))
-		new /obj/item/stack/sheet/metal(loc, 5)
-	qdel(src)
-
 /obj/structure/canister_frame/machine
 	name = "canister frame"
 	desc = "A frame used to build different kinds of canisters."
 
+	/// The previous canister frame tier path
+	var/obj/structure/canister_frame/machine/prev_tier
+	/// The next canister frame tier path
+	var/obj/structure/canister_frame/machine/next_tier
+	/// The required item for going to next tier. Must be set if next_tier is set.
+	var/obj/item/stack/next_tier_reqitem
+	/// The amount of items required in the stack of the required item. Must be set if next_tier is set.
+	var/next_tier_reqitem_am
+	/// The finished usable canister path
+	var/atom/finished_obj
+
+/obj/structure/canister_frame/machine/deconstruct(disassembled = TRUE)
+	if (!(flags_1 & NODECONSTRUCT_1))
+		// Spawn 5 sheets for the tier 0 frame
+		new /obj/item/stack/sheet/metal(loc, 5)
+
+		// Loop backwards in the tiers and spawn the requirement for each tier
+		var/obj/structure/canister_frame/machine/i_prev = prev_tier
+		while(ispath(i_prev))
+			var/obj/item/stack/prev_tier_reqitem = initial(i_prev.next_tier_reqitem)
+			var/prev_tier_reqitem_am = initial(i_prev.next_tier_reqitem_am)
+			new prev_tier_reqitem(loc, prev_tier_reqitem_am)
+			i_prev = initial(i_prev.prev_tier)
+	qdel(src)
+
 /obj/structure/canister_frame/machine/frame_tier_0
-	name = "Tier 0 canister frame"
+	name = "tier 0 canister frame"
 	icon_state = "frame_0"
 
+	next_tier = /obj/structure/canister_frame/machine/frame_tier_1
+	next_tier_reqitem = /obj/item/stack/sheet/metal
+	next_tier_reqitem_am = 5
+
 /obj/structure/canister_frame/machine/frame_tier_1
-	name = "Tier 1 canister frame"
+	name = "tier 1 canister frame"
 	icon_state = "frame_1"
 
+	prev_tier = /obj/structure/canister_frame/machine/frame_tier_0
+	next_tier = /obj/structure/canister_frame/machine/frame_tier_2
+	next_tier_reqitem = /obj/item/stack/sheet/plasteel
+	next_tier_reqitem_am = 5
+	finished_obj = /obj/machinery/portable_atmospherics/canister/tier_1
 
 /obj/structure/canister_frame/machine/frame_tier_2
-	name = "Tier 2 canister frame"
+	name = "tier 2 canister frame"
 	icon_state = "frame_2"
 
+	prev_tier = /obj/structure/canister_frame/machine/frame_tier_1
+	next_tier = /obj/structure/canister_frame/machine/frame_tier_3
+	next_tier_reqitem = /obj/item/stack/sheet/bluespace_crystal
+	next_tier_reqitem_am = 1
+	finished_obj = /obj/machinery/portable_atmospherics/canister/tier_2
+
 /obj/structure/canister_frame/machine/frame_tier_3
-	name = "Tier 3 canister frame"
+	name = "tier 3 canister frame"
 	icon_state = "frame_3"
 
-///Proc to build the different tiers, if the sheet used is right, it will upgrade the frame or build the respective canister tier
-/obj/structure/canister_frame/machine/frame_tier_0/attackby(obj/item/S, mob/user, params)
-	if (istype(S, /obj/item/stack/sheet/metal))
+	prev_tier = /obj/structure/canister_frame/machine/frame_tier_2
+	finished_obj = /obj/machinery/portable_atmospherics/canister/tier_3
+
+/obj/structure/canister_frame/machine/examine(user)
+	. = ..()
+	. += "<span class='notice'>It can be dismantled by removing the <b>bolts</b>.</span>"
+
+	if(ispath(next_tier))
+		var/item_name = initial(next_tier_reqitem.singular_name)
+		if(!item_name)
+			item_name = initial(next_tier_reqitem.name)
+		if(next_tier_reqitem_am > 1)
+			. += "<span class='notice'>It can be improved using [next_tier_reqitem_am] [item_name]\s.</span>"
+		else
+			. += "<span class='notice'>It can be improved using \a [item_name].</span>"
+
+	if(ispath(finished_obj))
+		. += "<span class='notice'>It can be finished off by <b>screwing</b> it together.</span>"
+
+/obj/structure/canister_frame/machine/attackby(obj/item/S, mob/user, params)
+	if (ispath(next_tier) && istype(S, next_tier_reqitem))
 		var/obj/item/stack/ST = S
-		if (ST.get_amount() < 5)
-			to_chat(user, "<span class='warning'>You need at least five sheets for that!</span>")
-			return
-		if(do_after(user, 15, target = src))
-			new /obj/structure/canister_frame/machine/frame_tier_1(drop_location())
+		var/reqitem_name = ST.singular_name ? ST.singular_name : ST.name
+		to_chat(user, "<span class='notice'>You start adding [next_tier_reqitem_am] [reqitem_name]\s to the frame...</span>")
+		if (ST.use_tool(src, user, 2 SECONDS, amount=next_tier_reqitem_am, volume=50))
+			to_chat(user, "<span class='notice'>You added [next_tier_reqitem_am] [reqitem_name]\s to the frame, turning it into \a [initial(next_tier.name)].</span>")
+			new next_tier(drop_location())
 			qdel(src)
-			ST.use(5)
 		return
 	return ..()
 
-///Proc to build the different tiers, if the sheet used is right, it will upgrade the frame or build the respective canister tier
-/obj/structure/canister_frame/machine/frame_tier_1/attackby(obj/item/S, mob/user, params)
-	if (istype(S, /obj/item/screwdriver))
-		if (do_after(user, 6, target = src))
-			new /obj/machinery/portable_atmospherics/canister/tier_1(drop_location())
+/obj/structure/canister_frame/machine/screwdriver_act(mob/living/user, obj/item/I)
+	. = TRUE
+	if(..())
+		return
+	if(ispath(finished_obj))
+		to_chat(user, "<span class='notice'>You start tightening the screws on \the [src].</span>")
+		if (I.use_tool(src, user, 2 SECONDS, volume=50))
+			to_chat(user, "<span class='notice'>You tighten the last screws on \the [src].</span>")
+			new finished_obj(drop_location())
 			qdel(src)
-	else if (istype(S, /obj/item/stack/sheet/plasteel))
-		var/obj/item/stack/ST = S
-		if (ST.get_amount() < 5)
-			to_chat(user, "<span class='warning'>You need at least five sheets for that!</span>")
-			return
-		if (do_after(user, 15, target = src))
-			new /obj/structure/canister_frame/machine/frame_tier_2(drop_location())
-			qdel(src)
-			ST.use(5)
-	else
-		return ..()
+		return
+	return FALSE
 
-///Proc to build the different tiers, if the sheet used is right, it will upgrade the frame or build the respective canister tier
-/obj/structure/canister_frame/machine/frame_tier_2/attackby(obj/item/S, mob/user, params)
-	if (istype(S, /obj/item/screwdriver))
-		if (do_after(user, 6, target = src))
-			new /obj/machinery/portable_atmospherics/canister/tier_2(drop_location())
-			qdel(src)
-	else if (istype(S, /obj/item/stack/sheet/bluespace_crystal))
-		var/obj/item/stack/ST = S
-		if (ST.get_amount() < 1)
-			to_chat(user, "<span class='warning'>You need at least one bluespace crystal for that!</span>")
-			return
-		if (do_after(user,15, target = src))
-			new /obj/structure/canister_frame/machine/frame_tier_3(drop_location())
-			qdel(src)
-			ST.use(1)
-	else
-		return ..()
-
-///Proc to build the different tiers, if the sheet used is right, it will upgrade the frame or build the respective canister tier
-/obj/structure/canister_frame/machine/frame_tier_3/attackby(obj/item/S, mob/user, params)
-	if (istype(S, /obj/item/screwdriver))
-		if (do_after(user, 6, target = src))
-			new /obj/machinery/portable_atmospherics/canister/tier_3(drop_location())
-			qdel(src)
-	else
-		return ..()
+/obj/structure/canister_frame/machine/wrench_act(mob/living/user, obj/item/I)
+	. = TRUE
+	if(..())
+		return
+	to_chat(user, "<span class='notice'>You start to dismantle \the [src]...</span>")
+	if (I.use_tool(src, user, 2 SECONDS, volume=50))
+		to_chat(user, "<span class='notice'>You dismantle \the [src].</span>")
+		deconstruct()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -356,7 +356,8 @@
 		message_admins("[src] deconstructed by [ADMIN_LOOKUPFLW(user)]")
 		log_game("[src] deconstructed by [key_name(user)]")
 	to_chat(user, "<span class='notice'>You begin cutting \the [src] apart...</span>")
-	if(I.use_tool(src, user, 30, volume=50))
+	if(I.use_tool(src, user, 3 SECONDS, volume=50))
+		to_chat(user, "<span class='notice'>You cut \the [src] apart.</span>")
 		deconstruct(TRUE)
 
 	return TRUE

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -249,13 +249,11 @@
 	release_pressure = ONE_ATMOSPHERE*2
 
 /obj/machinery/portable_atmospherics/canister/tier_1
-	name = "Tier 1 canister"
 	heat_limit = 5000
 	pressure_limit = 50000
 	mode = CANISTER_TIER_1
 
 /obj/machinery/portable_atmospherics/canister/tier_2
-	name = "Tier 2 canister"
 	heat_limit = 500000
 	pressure_limit = 5e6
 	volume = 3000
@@ -265,7 +263,6 @@
 	mode = CANISTER_TIER_2
 
 /obj/machinery/portable_atmospherics/canister/tier_3
-	name = "Tier 3 canister"
 	heat_limit = 1e12
 	pressure_limit = 1e14
 	volume = 5000
@@ -355,10 +352,10 @@
 		return TRUE
 	var/pressure = air_contents.return_pressure()
 	if(pressure > 300)
-		to_chat(user, "<span class='alert'>The [src] meter shows high pressure inside!</span>")
+		to_chat(user, "<span class='alert'>The pressure gauge on \the [src] indicates a high pressure inside... maybe you want to reconsider?</span>")
 		message_admins("[src] deconstructed by [ADMIN_LOOKUPFLW(user)]")
 		log_game("[src] deconstructed by [key_name(user)]")
-	to_chat(user, "<span class='notice'>You begin cutting the[src] apart...</span>")
+	to_chat(user, "<span class='notice'>You begin cutting \the [src] apart...</span>")
 	if(I.use_tool(src, user, 30, volume=50))
 		deconstruct(TRUE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Removed a bunch of duplicated code by making it more OOP.
* Added examine notes about what actions you can do at each stage.
* Fixed names being proper nouns
* Properly utilize the more modern screwdriver_act and use_tool etc procs
* Added being able to deconstruct a frame directly by applying wrench to it

Also did some minor fixes in atmos canister code:
* Removed their tier specific names because the tier number is displayed when examining anyways
* Improved welding act messages abit

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This improves the user experience when dealing with the new canister frames which frankly were somewhat confusing before.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Improved user experience when dealing with canister frames
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
