### PR TITLE
Simple mob AI wakes up less

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -227,6 +227,9 @@
 #define AI_OFF		3
 #define AI_Z_OFF	4
 
+//The range at which a mob should wake up if you spawn into the z level near it
+#define MAX_SIMPLEMOB_WAKEUP_RANGE 5
+
 //determines if a mob can smash through it
 #define ENVIRONMENT_SMASH_NONE			0
 #define ENVIRONMENT_SMASH_STRUCTURES	(1<<0) 	//crates, lockers, ect

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1297,8 +1297,8 @@
 				SSmobs.clients_by_zlevel[new_z] += src
 				for (var/I in length(SSidlenpcpool.idle_mobs_by_zlevel[new_z]) to 1 step -1) //Backwards loop because we're removing (guarantees optimal rather than worst-case performance), it's fine to use .len here but doesn't compile on 511
 					var/mob/living/simple_animal/SA = SSidlenpcpool.idle_mobs_by_zlevel[new_z][I]
-					if (SA)
-						SA.toggle_ai(AI_ON) // Guarantees responsiveness for when appearing right next to mobs
+					if (SA && get_dist(get_turf(src), get_turf(SA)) < MAX_SIMPLEMOB_WAKEUP_RANGE)
+						SA.consider_wakeup() // Ask the mob if it wants to turn on it's AI
 					else
 						SSidlenpcpool.idle_mobs_by_zlevel[new_z] -= SA
 


### PR DESCRIPTION
There's no reason to wake every mob on the Z level when we can simply
wake up only those nearest to the mob

In theory we could even not do this at all, but there would be a few
seconds delay before the idle automated actions ran and the AI wokeup
anyway
