### PR TITLE
Pacifists can now escalate to neck grabs

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -200,7 +200,7 @@
 		to_chat(A, "<span class='danger'>You put [D] into a chokehold!</span>")
 		D.SetSleeping(400)
 		restraining = FALSE
-		if(A.grab_state < GRAB_NECK && !HAS_TRAIT(A, TRAIT_PACIFISM))
+		if(A.grab_state < GRAB_NECK)
 			A.setGrabState(GRAB_NECK)
 	else
 		restraining = FALSE

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -114,7 +114,7 @@
 
 /obj/structure/table/proc/tablepush(mob/living/user, mob/living/pushed_mob)
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
-		to_chat(user, "<span class='danger'>Throwing [pushed_mob] onto the table might hurt them!</span>")
+		to_chat(user, "<span class='danger'>Throwing [pushed_mob] onto \the [src] might hurt them!</span>")
 		return
 	var/added_passtable = FALSE
 	if(!pushed_mob.pass_flags & PASSTABLE)
@@ -137,8 +137,11 @@
 	SEND_SIGNAL(pushed_mob, COMSIG_ADD_MOOD_EVENT, "table", /datum/mood_event/table)
 
 /obj/structure/table/proc/tablelimbsmash(mob/living/user, mob/living/pushed_mob)
-	pushed_mob.Knockdown(30)
 	var/obj/item/bodypart/banged_limb = pushed_mob.get_bodypart(user.zone_selected) || pushed_mob.get_bodypart(BODY_ZONE_HEAD)
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, "<span class='danger'>Smashing [pushed_mob]'s [banged_limb.name] against \the [src] might hurt them!</span>") //gee, who'da thunk it
+		return
+	pushed_mob.Knockdown(30)
 	var/extra_wound = 0
 	if(HAS_TRAIT(user, TRAIT_HULK))
 		extra_wound = 20

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -143,7 +143,7 @@
 		to_chat(user, "<span class='warning'>[src] can't be grabbed more aggressively!</span>")
 		return FALSE
 
-	if(user.grab_state >= GRAB_AGGRESSIVE && HAS_TRAIT(user, TRAIT_PACIFISM))
+	if(user.grab_state >= GRAB_NECK && HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='warning'>You don't want to risk hurting [src]!</span>")
 		return FALSE
 	grippedby(user)
@@ -180,24 +180,29 @@
 		user.setGrabState(user.grab_state + 1)
 		switch(user.grab_state)
 			if(GRAB_AGGRESSIVE)
-				var/add_log = ""
 				if(HAS_TRAIT(user, TRAIT_PACIFISM))
 					visible_message("<span class='danger'>[user] firmly grips [src]!</span>",
 									"<span class='danger'>[user] firmly grips you!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", null, user)
 					to_chat(user, "<span class='danger'>You firmly grip [src]!</span>")
-					add_log = " (pacifist)"
+					log_combat(user, src, "grabbed", addition="aggressive grab (pacifist)")
 				else
 					visible_message("<span class='danger'>[user] grabs [src] aggressively!</span>", \
 									"<span class='userdanger'>[user] grabs you aggressively!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", null, user)
 					to_chat(user, "<span class='danger'>You grab [src] aggressively!</span>")
+					log_combat(user, src, "grabbed", addition="aggressive grab")
 				drop_all_held_items()
 				stop_pulling()
-				log_combat(user, src, "grabbed", addition="aggressive grab[add_log]")
 			if(GRAB_NECK)
-				log_combat(user, src, "grabbed", addition="neck grab")
-				visible_message("<span class='danger'>[user] grabs [src] by the neck!</span>",\
-								"<span class='userdanger'>[user] grabs you by the neck!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", null, user)
-				to_chat(user, "<span class='danger'>You grab [src] by the neck!</span>")
+				if(HAS_TRAIT(user, TRAIT_PACIFISM))
+					visible_message("<span class='danger'>[user] firmly grips [src] by the neck!</span>",\
+									"<span class='userdanger'>[user] firmly grips you by the neck!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", null, user)
+					to_chat(user, "<span class='danger'>You firmly grip [src] by the neck!</span>")
+					log_combat(user, src, "grabbed", addition="neck grab (pacifist)")
+				else
+					visible_message("<span class='danger'>[user] grabs [src] by the neck!</span>",\
+					"<span class='userdanger'>[user] grabs you by the neck!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", null, user)
+					to_chat(user, "<span class='danger'>You grab [src] by the neck!</span>")
+					log_combat(user, src, "grabbed", addition="neck grab")
 				update_mobility() //we fall down
 				if(!buckled && !density)
 					Move(user.loc)


### PR DESCRIPTION
## About The Pull Request

Pacifists can now escalate their grabs to the GRAB_NECK level.

Pacifists still cannot escalate their grabs to the GRAB_KILL level.

Also, some minor tweaks have been made to tablepushing and limbsmashing messages, as well as the behind the scenes logging of aggressive (and neck) grabs.

## Why It's Good For The Game

Unlike the GRAB_KILL grab level, the GRAB_NECK grab level doesn't do any damage, so pacifists should be allowed to escalate to it.

Also, this PR will allow pacifist changelings to use that really bad changeling hivemind interrogation ability that they used to not be able to use (as far as I'm aware, though, pacifists changelings still will not be able to absorb people).

As far as I'm aware, this shouldn't break anything or open up any new ways for pacifists to kill people (I did some codediving to check/confirm this, but feel free to tell me if I've missed anything).

## Changelog
:cl: ATHATH
balance: Pacifists can now escalate to neck grabs. They still cannot escalate to kill grabs.
/:cl: