### PR TITLE
CDN asset scaffolding: generated urls.

### DIFF
--- a/code/modules/asset_cache/asset_cache.dm
+++ b/code/modules/asset_cache/asset_cache.dm
@@ -94,6 +94,13 @@ Note: If your code uses output() with assets you will need to call asset_flush o
 			var/list/stacktrace = gib_stack_trace()
 			log_asset("WARNING: dupe asset added to the asset cache: [asset_name] existing asset md5: [OACI.md5] new asset md5:[ACI.md5]\n[stacktrace.Join("\n")]")
 	SSassets.cache[asset_name] = ACI
+	return ACI
+
+/// Returns the url of the asset, currently this is just its name, here to allow further work cdn'ing assets.
+/// 	Can be given an asset as well, this is just a work around for buggy edge cases where two assets may have the same name, doesn't matter now, but it will when the cdn comes.
+/proc/get_asset_url(asset_name, asset = null)
+	var/datum/asset_cache_item/ACI = SSassets.cache[asset_name]
+	return ACI?.url
 
 //Generated names do not include file extention.
 //Used mainly for code that deals with assets in a generic way

--- a/code/modules/asset_cache/asset_cache_item.dm
+++ b/code/modules/asset_cache/asset_cache_item.dm
@@ -5,6 +5,7 @@
 **/
 /datum/asset_cache_item
 	var/name
+	var/url
 	var/md5
 	var/resource
 
@@ -18,4 +19,5 @@
 			CRASH("invalid asset sent to asset cache")
 		debug_world_log("asset cache unexpected success of second fcopy_rsc")
 	src.name = name
+	url = name
 	resource = file

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -16,6 +16,9 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	GLOB.asset_datums[type] = src
 	register()
 
+/datum/asset/proc/get_url_mappings()
+	return list()
+
 /datum/asset/proc/register()
 	return
 
@@ -30,11 +33,19 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 /datum/asset/simple/register()
 	for(var/asset_name in assets)
-		register_asset(asset_name, assets[asset_name])
+		assets[asset_name] = register_asset(asset_name, assets[asset_name])
 
 /datum/asset/simple/send(client)
 	. = send_asset_list(client, assets)
 
+/datum/asset/simple/get_url_mappings()
+	. = list()
+	for (var/asset_name in assets)
+		var/datum/asset_cache_item/ACI = assets[asset_name]
+		if (!ACI)
+			continue
+		.[asset_name] = ACI.url
+	
 
 // For registering or sending multiple others at once
 /datum/asset/group
@@ -50,6 +61,11 @@ GLOBAL_LIST_EMPTY(asset_datums)
 		var/datum/asset/A = get_asset_datum(type)
 		. = A.send(C) || .
 
+/datum/asset/group/get_url_mappings()
+	. = list()
+	for(var/type in children)
+		var/datum/asset/A = get_asset_datum(type)
+		. += A.get_url_mappings()
 
 // spritesheet implementation - coalesces various icons into a single .png file
 // and uses CSS to select icons out of that file - saves on transferring some
@@ -90,6 +106,15 @@ GLOBAL_LIST_EMPTY(asset_datums)
 		all += "[name]_[size_id].png"
 	. = send_asset_list(C, all)
 
+/datum/asset/spritesheet/get_url_mappings()
+	if (!name)
+		return
+	. = list("spritesheet_[name].css" = get_asset_url("spritesheet_[name].css"))
+	for(var/size_id in sizes)
+		.["[name]_[size_id].png"] = get_asset_url("[name]_[size_id].png")
+
+
+
 /datum/asset/spritesheet/proc/ensure_stripped(sizes_to_strip = sizes)
 	for(var/size_id in sizes_to_strip)
 		var/size = sizes[size_id]
@@ -111,7 +136,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	for (var/size_id in sizes)
 		var/size = sizes[size_id]
 		var/icon/tiny = size[SPRSZ_ICON]
-		out += ".[name][size_id]{display:inline-block;width:[tiny.Width()]px;height:[tiny.Height()]px;background:url('[name]_[size_id].png') no-repeat;}"
+		out += ".[name][size_id]{display:inline-block;width:[tiny.Width()]px;height:[tiny.Height()]px;background:url('[get_asset_url("[name]_[size_id].png")]') no-repeat;}"
 
 	for (var/sprite_id in sprites)
 		var/sprite = sprites[sprite_id]
@@ -165,7 +190,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	return {"<link rel="stylesheet" href="[css_filename()]" />"}
 
 /datum/asset/spritesheet/proc/css_filename()
-	return "spritesheet_[name].css"
+	return get_asset_url("spritesheet_[name].css")
 
 /datum/asset/spritesheet/proc/icon_tag(sprite_name)
 	var/sprite = sprites[sprite_name]


### PR DESCRIPTION
The short story is once everything is set to use this to get asset urls we can move over to a push based cdn to serve browser assets.

urls returned from this are currently just in the form of `asset_name` (ie: `common.css`) under the cdn they will look more like `https://tgstation13.download/byond/assets/sha1.ext` (adding the hash to the url will allow us to set longer cache validity times and tell the upstream cdn (cloudflare) not to bother with IF-NOT-MODIFIED checks)

Sprite sheets already use generated urls and are already ready to move to a cdn.