### PR TITLE
Fixes sheets of glass / other materials that don't have a valid false wall type being consumed without doing anything when you try to construct a false wall with them

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -166,6 +166,10 @@
 		if(S.sheettype != "runed")
 			var/M = S.sheettype
 			if(state == GIRDER_DISPLACED)
+				var/falsewall_type = text2path("/obj/structure/falsewall/[M]")
+				if(!falsewall_type)
+					to_chat(user, "<span class='warning'>You can't seem to figure out how to make a false wall with [S]!</span>")
+					return
 				if(S.get_amount() < 2)
 					to_chat(user, "<span class='warning'>You need at least two sheets to create a false wall!</span>")
 					return
@@ -174,8 +178,7 @@
 						return
 					S.use(2)
 					to_chat(user, "<span class='notice'>You create a false wall. Push on it to open or close the passage.</span>")
-					var/F = text2path("/obj/structure/falsewall/[M]")
-					var/obj/structure/FW = new F (loc)
+					var/obj/structure/falsewall/FW = new falsewall_type (loc)
 					transfer_fingerprints_to(FW)
 					qdel(src)
 			else


### PR DESCRIPTION
:cl: ShizCalev
fix:  Fixed sheets of glass / other materials that don't have a valid false wall type being consumed without doing anything when you try to construct a false wall with them.
/:cl:
