### PR TITLE
Obsessed can no longer win in mafia if they're dead.

### DIFF
--- a/code/modules/mafia/roles.dm
+++ b/code/modules/mafia/roles.dm
@@ -458,12 +458,14 @@
 	UnregisterSignal(game,COMSIG_MAFIA_SUNDOWN)
 
 /datum/mafia_role/obsessed/proc/check_victory(datum/source,datum/mafia_controller/game,lynch)
+	UnregisterSignal(source,COMSIG_MAFIA_ON_KILL)
+	if(game_status == MAFIA_DEAD)
+		return
 	if(lynch)
 		game.send_message("<span class='big comradio'>!! OBSESSED VICTORY !!</span>")
 		reveal_role(game, FALSE)
 	else
 		to_chat(body, "<span class='userdanger'>You have failed your objective to lynch [obsession.body]!</span>")
-	UnregisterSignal(source,COMSIG_MAFIA_ON_KILL)
 
 /datum/mafia_role/clown
 	name = "Clown"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Obsessed's check victory signal now checks if the obsessed is currently alive.

## Why It's Good For The Game

Cmon, obsessed, that's cheating. You have it easy enough. This is really more of a fix since it's an oversight.

## Changelog
:cl:
fix: Obsessed can't win by lynching their target after they're dead.
/:cl: