### PR TITLE
Mafia now links the wiki page at the start

### DIFF
--- a/code/modules/mafia/roles.dm
+++ b/code/modules/mafia/roles.dm
@@ -51,7 +51,7 @@
 			to_chat(body,"<span class='danger'>You are a crewmember. Find out and lynch the changelings!</span>")
 		if(MAFIA_TEAM_SOLO)
 			to_chat(body,"<span class='danger'>You are not aligned to town or mafia. Accomplish your own objectives!</span>")
-	to_chat(body, "<b>Be sure to read <a href=\"https://tgstation13.org/wiki/Mafia">the wiki page</a> to learn more, if you have no idea what's going on.</b>")
+	to_chat(body, "<b>Be sure to read <a href=\"https://tgstation13.org/wiki/Mafia\">the wiki page</a> to learn more, if you have no idea what's going on.</b>")
 
 //please take care with this, they can break shit with their equipment unless you specifically disallow them (aka stun at the end of the game)
 /datum/mafia_role/proc/reveal_role(datum/mafia_controller/game, verbose = FALSE)

--- a/code/modules/mafia/roles.dm
+++ b/code/modules/mafia/roles.dm
@@ -51,7 +51,7 @@
 			to_chat(body,"<span class='danger'>You are a crewmember. Find out and lynch the changelings!</span>")
 		if(MAFIA_TEAM_SOLO)
 			to_chat(body,"<span class='danger'>You are not aligned to town or mafia. Accomplish your own objectives!</span>")
-	to_chat(src, "<b>Be sure to read <a href=\"https://tgstation13.org/wiki/Mafia">the wiki page</a> to learn more, if you have no idea what's going on</b>")
+	to_chat(body, "<b>Be sure to read <a href=\"https://tgstation13.org/wiki/Mafia">the wiki page</a> to learn more, if you have no idea what's going on.</b>")
 
 //please take care with this, they can break shit with their equipment unless you specifically disallow them (aka stun at the end of the game)
 /datum/mafia_role/proc/reveal_role(datum/mafia_controller/game, verbose = FALSE)

--- a/code/modules/mafia/roles.dm
+++ b/code/modules/mafia/roles.dm
@@ -51,6 +51,7 @@
 			to_chat(body,"<span class='danger'>You are a crewmember. Find out and lynch the changelings!</span>")
 		if(MAFIA_TEAM_SOLO)
 			to_chat(body,"<span class='danger'>You are not aligned to town or mafia. Accomplish your own objectives!</span>")
+	to_chat(src, "<b>Be sure to read <a href=\"https://tgstation13.org/wiki/Mafia">the wiki page</a> to learn more, if you have no idea what's going on</b>")
 
 //please take care with this, they can break shit with their equipment unless you specifically disallow them (aka stun at the end of the game)
 /datum/mafia_role/proc/reveal_role(datum/mafia_controller/game, verbose = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mafia drops a link to the wiki page, which gives some deeper advice for every role and how the game works... kinda. I think the wiki page isn't perfect

## Why It's Good For The Game

Not everyone played mafia, who knew! Hopefully it'll help reduce randomly clicking buttons because you're confused on what this actually is

## Changelog
:cl:
add: a small wiki link at the start of a mafia game
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
