### PR TITLE
Prevents random events triggering after emergency shuttle departure

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -51,6 +51,8 @@
 		return FALSE
 	if(holidayID && (!SSevents.holidays || !SSevents.holidays[holidayID]))
 		return FALSE
+	if(EMERGENCY_ESCAPED_OR_ENDGAMED)
+		return FALSE
 	return TRUE
 
 /datum/round_event_control/proc/preRunEvent()


### PR DESCRIPTION
## About The Pull Request

Adds an additional check to `canSpawnEvent()` for `EMERGENCY_ESCAPED_OR_ENDGAMED` the idea being to prevent triggering any events especially those which would poll for candidates only for them to have the chance to play for a couple minutes on a mostly abandoned station at best.

Events triggered by admins are not affected.

Another possibly better and for sure higher effort solution would be to flag round_event_control datums which have a ghost_role component and only prevent those from triggering after escape shuttle departure, but I am not sure if that is even necessary. Are there any non ghost_role events which happen post departure that matter?

## Why It's Good For The Game

Being dead while watching the emergency shuttle escaping and getting prompted for mid-round free antag only to know it would be silly to click yes feels bad. Worse is if you do anyway and win the roll then your monkey brain, like mine, regardless of independent outcomes and the fact most people probably clicked no anyway thinks its luck was now spent on something near pointless. 

## Changelog
:cl:
fix: Random events no longer trigger after emergency shuttle departure. No more Sentient Disease spawning right as the round ends.
/:cl:
