### PR TITLE
Buffs upgraded cybernetic ears

### DIFF
--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -104,14 +104,14 @@
 /obj/item/organ/ears/cybernetic
 	name = "cybernetic ears"
 	icon_state = "ears-c"
-	desc = "A basic cybernetic ear, designed to mimic the operation of organic ears."
+	desc = "Basic cybernetic ears, designed to mimic the operation of organic ears."
 	damage_multiplier = 0.9
 	organ_flags = ORGAN_SYNTHETIC
 
 /obj/item/organ/ears/cybernetic/upgraded
 	name = "upgraded cybernetic ears"
 	icon_state = "ears-c-u"
-	desc = "An advanced cybernetic ear, surpassing the performance of organic ears. Contains compensators that reduce the impact of sudden, large noises."
+	desc = "Advanced cybernetic ears, surpassing the performance of organic ears. They contain sound compensators that reduce the impact of loud, sudden noises."
 	damage_multiplier = 0.5
 	bang_protect = 1 //We can rebuild him. We have the technology. We can make him better than he was. Better... stronger... GONGer.
 

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -104,18 +104,20 @@
 /obj/item/organ/ears/cybernetic
 	name = "cybernetic ears"
 	icon_state = "ears-c"
-	desc = "a basic cybernetic designed to mimic the operation of ears."
+	desc = "A basic cybernetic ear, designed to mimic the operation of organic ears."
 	damage_multiplier = 0.9
 	organ_flags = ORGAN_SYNTHETIC
 
 /obj/item/organ/ears/cybernetic/upgraded
 	name = "upgraded cybernetic ears"
 	icon_state = "ears-c-u"
-	desc = "an advanced cybernetic ear, surpassing the performance of organic ears"
+	desc = "An advanced cybernetic ear, surpassing the performance of organic ears. Contains compensators that reduce the impact of sudden, large noises."
 	damage_multiplier = 0.5
+	bang_protect = 1 //We can rebuild him. We have the technology. We can make him better than he was. Better... stronger... GONGer.
 
 /obj/item/organ/ears/cybernetic/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
 	damage += 40/severity
+	deaf = max(deaf, 30/severity) //1 minute of deafness if it's a strong EMP effect, 30 seconds of deafness if it's a weak EMP effect


### PR DESCRIPTION
## About The Pull Request

Upgraded cybernetic ears now provide a level of ear protection (the same amount that a bowman headset gives, as far as I can tell).

Being hit by an EMP while you have cybernetic ears will now deafen you for either thirty seconds or a minute, depending on the strength of the EMP.

The descriptions of cybernetic ears and advanced cybernetic ears have been updated.

## Why It's Good For The Game

This PR makes it actually worthwhile to grab upgraded cybernetic ears over normal cybernetic ears. There's also precedent for this kind of thing in the form of welding shield eyes (and, arguably, high-tier cybernetic hearts).

## Changelog
:cl: ATHATH
balance: Upgraded cybernetic ears now protect your ears like a bowman headset would.
balance: Being hit by an EMP while you have cybernetic ears will now deafen you for either thirty seconds or a minute, depending on the strength of the EMP.
tweak: The descriptions of cybernetic ears and advanced cybernetic ears have been updated.
/:cl:
