### PR TITLE
Fixes hulk arms breaking when punching non walls

### DIFF
--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -39,16 +39,26 @@
 		source.do_attack_animation(target, ATTACK_EFFECT_SMASH)
 		source.changeNext_move(CLICK_CD_MELEE)
 
-		var/obj/item/bodypart/arm = source.hand_bodyparts[source.active_hand_index]
-		switch(arm.brute_dam)
-			if(45 to 50)
-				arm.force_wound_upwards(/datum/wound/brute/bone/critical)
-			if(41 to 45)
-				arm.force_wound_upwards(/datum/wound/brute/bone/severe)
-			if(35 to 41)
-				arm.force_wound_upwards(/datum/wound/brute/bone/moderate)
-
 		return COMPONENT_NO_ATTACK_HAND
+
+
+/**
+  *Checks damage of a hulk's arm and applies bone wounds as necessary.
+  *
+  *Called by specific atoms being attacked, such as walls. If an atom
+  *does not call this proc, than punching that atom will not cause
+  *arm breaking (even if the atom deals recoil damage to hulks).
+  *Arguments:
+  *arg1 is the arm to evaluate damage of and possibly break.
+  */
+/datum/mutation/human/hulk/proc/break_an_arm(obj/item/bodypart/arm)
+	switch(arm.brute_dam)
+		if(45 to 50)
+			arm.force_wound_upwards(/datum/wound/brute/bone/critical)
+		if(41 to 45)
+			arm.force_wound_upwards(/datum/wound/brute/bone/severe)
+		if(35 to 41)
+			arm.force_wound_upwards(/datum/wound/brute/bone/moderate)
 
 /datum/mutation/human/hulk/on_life()
 	if(owner.health < 0)

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -34,8 +34,13 @@
 	explosion_block = 3
 	canSmoothWith = list(/turf/closed/wall/mineral/diamond, /obj/structure/falsewall/diamond)
 
-/turf/closed/wall/mineral/diamond/hulk_recoil(obj/item/bodypart/arm)
+/turf/closed/wall/mineral/diamond/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
 	arm.receive_damage(brute=41, wound_bonus = CANT_WOUND)
+	var/datum/dna/deoxyribonucleicacid = hulkman.dna
+	for(var/datum/mutation/human/hulk/smasher in deoxyribonucleicacid.mutations)
+		if(istype(smasher))
+			smasher.break_an_arm(arm)
+			break
 
 /turf/closed/wall/mineral/bananium
 	name = "bananium wall"
@@ -87,8 +92,13 @@
 	radiate()
 	..()
 
-/turf/closed/wall/mineral/uranium/hulk_recoil(obj/item/bodypart/arm)
+/turf/closed/wall/mineral/uranium/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
 	arm.receive_damage(brute=41, wound_bonus = CANT_WOUND)
+	var/datum/dna/deoxyribonucleicacid = hulkman.dna
+	for(var/datum/mutation/human/hulk/smasher in deoxyribonucleicacid.mutations)
+		if(istype(smasher))
+			smasher.break_an_arm(arm)
+			break
 
 /turf/closed/wall/mineral/plasma
 	name = "plasma wall"
@@ -287,8 +297,13 @@
 	bombcore.detonate()
 	..()
 
-/turf/closed/wall/mineral/plastitanium/hulk_recoil(obj/item/bodypart/arm)
+/turf/closed/wall/mineral/plastitanium/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
 	arm.receive_damage(brute=41, wound_bonus = CANT_WOUND)
+	var/datum/dna/deoxyribonucleicacid = hulkman.dna
+	for(var/datum/mutation/human/hulk/smasher in deoxyribonucleicacid.mutations)
+		if(istype(smasher))
+			smasher.break_an_arm(arm)
+			break
 
 //have to copypaste this code
 /turf/closed/wall/mineral/plastitanium/interior/copyTurf(turf/T)

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -34,12 +34,8 @@
 	explosion_block = 3
 	canSmoothWith = list(/turf/closed/wall/mineral/diamond, /obj/structure/falsewall/diamond)
 
-/turf/closed/wall/mineral/diamond/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
-	arm.receive_damage(brute=41, wound_bonus = CANT_WOUND)
-	var/datum/mutation/human/hulk/smasher = locate(/datum/mutation/human/hulk) in hulkman.dna.mutations
-	if(!smasher)
-		return
-	smasher.break_an_arm(arm)
+/turf/closed/wall/mineral/diamond/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman, var/damage = 41)
+	return ..()
 
 /turf/closed/wall/mineral/bananium
 	name = "bananium wall"
@@ -91,12 +87,8 @@
 	radiate()
 	..()
 
-/turf/closed/wall/mineral/uranium/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
-	arm.receive_damage(brute=41, wound_bonus = CANT_WOUND)
-	var/datum/mutation/human/hulk/smasher = locate(/datum/mutation/human/hulk) in hulkman.dna.mutations
-	if(!smasher)
-		return
-	smasher.break_an_arm(arm)
+/turf/closed/wall/mineral/uranium/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman, var/damage = 41)
+	return ..()
 
 /turf/closed/wall/mineral/plasma
 	name = "plasma wall"
@@ -156,8 +148,8 @@
 			return
 	return ..()
 
-/turf/closed/wall/mineral/wood/hulk_recoil(obj/item/bodypart/arm)
-	return //No recoil damage, wood is weak
+/turf/closed/wall/mineral/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman, var/damage = 0)
+	return ..() //No recoil damage, wood is weak
 
 /turf/closed/wall/mineral/wood/nonmetal
 	desc = "A solidly wooden wall. It's a bit weaker than a wall made with metal."
@@ -187,8 +179,8 @@
 	bullet_sizzle = TRUE
 	bullet_bounce_sound = null
 
-/turf/closed/wall/mineral/snow/hulk_recoil(obj/item/bodypart/arm)
-	return //No recoil damage, snow is weak
+/turf/closed/wall/mineral/snow/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman, var/damage = 0)
+	return ..() //No recoil damage, snow is weak
 
 /turf/closed/wall/mineral/abductor
 	name = "alien wall"
@@ -295,12 +287,8 @@
 	bombcore.detonate()
 	..()
 
-/turf/closed/wall/mineral/plastitanium/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
-	arm.receive_damage(brute=41, wound_bonus = CANT_WOUND)
-	var/datum/mutation/human/hulk/smasher = locate(/datum/mutation/human/hulk) in hulkman.dna.mutations
-	if(!smasher)
-		return
-	smasher.break_an_arm(arm)
+/turf/closed/wall/mineral/plastitanium/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman, var/damage = 41)
+	return ..()
 
 //have to copypaste this code
 /turf/closed/wall/mineral/plastitanium/interior/copyTurf(turf/T)

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -36,11 +36,10 @@
 
 /turf/closed/wall/mineral/diamond/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
 	arm.receive_damage(brute=41, wound_bonus = CANT_WOUND)
-	var/datum/dna/deoxyribonucleicacid = hulkman.dna
-	for(var/datum/mutation/human/hulk/smasher in deoxyribonucleicacid.mutations)
-		if(istype(smasher))
-			smasher.break_an_arm(arm)
-			break
+	var/datum/mutation/human/hulk/smasher = locate(/datum/mutation/human/hulk) in hulkman.dna.mutations
+	if(!smasher)
+		return
+	smasher.break_an_arm(arm)
 
 /turf/closed/wall/mineral/bananium
 	name = "bananium wall"
@@ -94,11 +93,10 @@
 
 /turf/closed/wall/mineral/uranium/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
 	arm.receive_damage(brute=41, wound_bonus = CANT_WOUND)
-	var/datum/dna/deoxyribonucleicacid = hulkman.dna
-	for(var/datum/mutation/human/hulk/smasher in deoxyribonucleicacid.mutations)
-		if(istype(smasher))
-			smasher.break_an_arm(arm)
-			break
+	var/datum/mutation/human/hulk/smasher = locate(/datum/mutation/human/hulk) in hulkman.dna.mutations
+	if(!smasher)
+		return
+	smasher.break_an_arm(arm)
 
 /turf/closed/wall/mineral/plasma
 	name = "plasma wall"
@@ -299,11 +297,10 @@
 
 /turf/closed/wall/mineral/plastitanium/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
 	arm.receive_damage(brute=41, wound_bonus = CANT_WOUND)
-	var/datum/dna/deoxyribonucleicacid = hulkman.dna
-	for(var/datum/mutation/human/hulk/smasher in deoxyribonucleicacid.mutations)
-		if(istype(smasher))
-			smasher.break_an_arm(arm)
-			break
+	var/datum/mutation/human/hulk/smasher = locate(/datum/mutation/human/hulk) in hulkman.dna.mutations
+	if(!smasher)
+		return
+	smasher.break_an_arm(arm)
 
 //have to copypaste this code
 /turf/closed/wall/mineral/plastitanium/interior/copyTurf(turf/T)

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -47,12 +47,8 @@
 		playsound(src, 'sound/effects/bang.ogg', 50, TRUE)
 		to_chat(M, "<span class='warning'>This wall is far too strong for you to destroy.</span>")
 
-/turf/closed/wall/r_wall/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
-	arm.receive_damage(brute=41, wound_bonus = CANT_WOUND)
-	var/datum/mutation/human/hulk/smasher = locate(/datum/mutation/human/hulk) in hulkman.dna.mutations
-	if(!smasher)
-		return
-	smasher.break_an_arm(arm)
+/turf/closed/wall/r_wall/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman, var/damage = 41)
+	return ..()
 
 /turf/closed/wall/r_wall/try_decon(obj/item/W, mob/user, turf/T)
 	//DECONSTRUCTION

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -49,11 +49,10 @@
 
 /turf/closed/wall/r_wall/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
 	arm.receive_damage(brute=41, wound_bonus = CANT_WOUND)
-	var/datum/dna/deoxyribonucleicacid = hulkman.dna
-	for(var/datum/mutation/human/hulk/smasher in deoxyribonucleicacid.mutations)
-		if(istype(smasher))
-			smasher.break_an_arm(arm)
-			break
+	var/datum/mutation/human/hulk/smasher = locate(/datum/mutation/human/hulk) in hulkman.dna.mutations
+	if(!smasher)
+		return
+	smasher.break_an_arm(arm)
 
 /turf/closed/wall/r_wall/try_decon(obj/item/W, mob/user, turf/T)
 	//DECONSTRUCTION

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -47,8 +47,13 @@
 		playsound(src, 'sound/effects/bang.ogg', 50, TRUE)
 		to_chat(M, "<span class='warning'>This wall is far too strong for you to destroy.</span>")
 
-/turf/closed/wall/r_wall/hulk_recoil(obj/item/bodypart/arm)
+/turf/closed/wall/r_wall/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
 	arm.receive_damage(brute=41, wound_bonus = CANT_WOUND)
+	var/datum/dna/deoxyribonucleicacid = hulkman.dna
+	for(var/datum/mutation/human/hulk/smasher in deoxyribonucleicacid.mutations)
+		if(istype(smasher))
+			smasher.break_an_arm(arm)
+			break
 
 /turf/closed/wall/r_wall/try_decon(obj/item/W, mob/user, turf/T)
 	//DECONSTRUCTION

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -158,7 +158,7 @@
 	return TRUE
 
 /**
-  *Deals damage back to the hulk.
+  *Deals damage back to the hulk's arm.
   *
   *When a hulk manages to break a wall using their hulk smash, this deals back damage to the arm used.
   *This is in its own proc just to be easily overridden by other wall types. Default allows for three

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -170,11 +170,10 @@
  */
 /turf/closed/wall/proc/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
 	arm.receive_damage(brute = 20, blocked = 0, wound_bonus = CANT_WOUND)
-	var/datum/dna/deoxyribonucleicacid = hulkman.dna
-	for(var/datum/mutation/human/hulk/smasher in deoxyribonucleicacid.mutations)
-		if(istype(smasher))
-			smasher.break_an_arm(arm)
-			break
+	var/datum/mutation/human/hulk/smasher = locate(/datum/mutation/human/hulk) in hulkman.dna.mutations
+	if(!smasher)
+		return
+	smasher.break_an_arm(arm)
 
 /turf/closed/wall/attack_hand(mob/user)
 	. = ..()

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -146,7 +146,7 @@
 	if(prob(hardness))
 		playsound(src, 'sound/effects/meteorimpact.ogg', 100, TRUE)
 		user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
-		hulk_recoil(arm)
+		hulk_recoil(arm, user)
 		dismantle_wall(1)
 
 	else
@@ -163,12 +163,18 @@
   *When a hulk manages to break a wall using their hulk smash, this deals back damage to the arm used.
   *This is in its own proc just to be easily overridden by other wall types. Default allows for three
   *smashed walls per arm. Also, we use CANT_WOUND here because wounds are random. Wounds are applied
-  *by hulk code based on arm damage and checked after an attack completes.
+  *by hulk code based on arm damage and checked when we call break_an_arm().
   *Arguments:
   **arg1 is the arm to deal damage to.
+  **arg2 is the hulk
  */
-/turf/closed/wall/proc/hulk_recoil(obj/item/bodypart/arm)
+/turf/closed/wall/proc/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
 	arm.receive_damage(brute = 20, blocked = 0, wound_bonus = CANT_WOUND)
+	var/datum/dna/deoxyribonucleicacid = hulkman.dna
+	for(var/datum/mutation/human/hulk/smasher in deoxyribonucleicacid.mutations)
+		if(istype(smasher))
+			smasher.break_an_arm(arm)
+			break
 
 /turf/closed/wall/attack_hand(mob/user)
 	. = ..()

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -168,10 +168,10 @@
   **arg1 is the arm to deal damage to.
   **arg2 is the hulk
  */
-/turf/closed/wall/proc/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman)
-	arm.receive_damage(brute = 20, blocked = 0, wound_bonus = CANT_WOUND)
+/turf/closed/wall/proc/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman, var/damage = 20)
+	arm.receive_damage(brute = damage, blocked = 0, wound_bonus = CANT_WOUND)
 	var/datum/mutation/human/hulk/smasher = locate(/datum/mutation/human/hulk) in hulkman.dna.mutations
-	if(!smasher)
+	if(!smasher || !damage) //sanity check but also snow and wood walls deal no recoil damage, so no arm breaky
 		return
 	smasher.break_an_arm(arm)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Adds a new proc to handle hulk arm breaking based off damage, appropriately called `break_an_arm()`. This is intended to be called by the atom being punched, during the `attack_hulk()` chain. This fixes hulk arm breaking when punching unintended things (like mobs). Additionally, a call to `break_an_arm()` was *intentionally* left out of machine code, meaning that while punching an airlock or prothlathe will deal the same slight damage, it cannot trigger an arm break (even at max arm damage).

- Fixes #52176
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- Fixes the bug listed above.

- Since we can now deal penalty damage without breaking the arm, I can lower the machine punching penalty to be still annoying without actually carrying the same effects that wall punching does. In effect, you can now break as many airlocks as you wish (but if your arm is at max damage, it'll break the first time you successfuly smash a wall).

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Hulk arms no longer break with punching things unintended to break hulk arms
balance: Hulk arms no longer break when punching machines (but still take a small bit of recoil damage).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
