### PR TITLE
You can now buckle people to operating tables without needing to cuff them first

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -523,8 +523,7 @@
 	buildstack = /obj/item/stack/sheet/mineral/silver
 	smooth = SMOOTH_FALSE
 	can_buckle = 1
-	buckle_lying = -1
-	buckle_requires_restraints = 1
+	buckle_lying = 90
 	var/mob/living/carbon/human/patient = null
 	var/obj/machinery/computer/operating/computer = null
 


### PR DESCRIPTION
## About The Pull Request

See the title.

Also, buckling someone to an optable will now always cause them to lay the right way on the optable. People who are merely resting on the same tile as an optable and are not buckled to it can still face the other way, however (as they could before).

## Why It's Good For The Game

Has THIS ever happened to YOU before?

**Open scene.**
**A DOCTOR is attempting to perform brain surgery on a CLUELESS PATIENT, who is resting on a SURGERY TABLE. The DOCTOR accidentally misclicks and causes the CLUELESS PATIENT to stand upright.**
DOCTOR: "Please rest"
**The room is silent for several seconds. The CLUELESS PATIENT has not returned to a resting position.**
DOCTOR: "Please I need you to rest to continue"
CLUELESS PATIENT: "How do i rest"
DOCTOR: "It's the button by your intent keys"
**The room is silent for several seconds again. The CLUELESS PATIENT has still not returned to a resting position.**
DOCTOR: "It's the button with the word rest on it"
**The room is once again silent. The CLUELESS PATIENT has still not left their upright state.**
DOCTOR: "PLEASE REST FOR THE LOVE OF GOD"
**The CLUELESS PATIENT finally finds the REST KEY, and lays back down on the SURGERY TABLE.**
DOCTOR: "Thanks"
**The DOCTOR immediately misclicks again, causing the CLUELESS PATIENT to once again stand upright.**
**End scene.**

To be clear, yes, I know that you can just grab a non-resting patient and click on the table to try to tableplace them again (to make them rest), but that's a bit slow and awkward. Also, mediborgs cannot do that, and although cyborgs ignore what surfaces their patients are on for the purposes of surgery speeds/success chances, a mediborg might wish to use an optable with a nearby operating computer for either aesthetic reasons or guidance.

Now you can just click+drag someone who's standing on an optable onto the optable, and bam, they'll be buckled to it.

Proof of testing (which included testing buckling and unbuckling myself and others from normal optables and abductor optables):
![image](https://user-images.githubusercontent.com/42606352/87494508-d3022480-c614-11ea-8bf2-a7b34f207a77.png)

## Changelog
:cl: ATHATH
tweak: You can now buckle people to operating tables without needing to cuff them first.
/:cl: