### PR TITLE
fix the microwave not turning off when the power was cut off

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -287,8 +287,8 @@
 
 /obj/machinery/microwave/proc/loop(type, time, wait = max(12 - 2 * efficiency, 2)) // standard wait is 10
 	if(machine_stat & (NOPOWER|BROKEN))
-		if(type == MICROWAVE_PRE)
-			pre_fail()
+		pre_fail()
+		eject()
 		return
 	if(!time)
 		switch(type)

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -286,9 +286,8 @@
 	loop(MICROWAVE_MUCK, 4)
 
 /obj/machinery/microwave/proc/loop(type, time, wait = max(12 - 2 * efficiency, 2)) // standard wait is 10
-	if(machine_stat & BROKEN)
-		if(type == MICROWAVE_PRE)
-			pre_fail()
+	if((machine_stat & BROKEN) && type == MICROWAVE_PRE)
+		pre_fail()
 		return
 	if(!time)
 		switch(type)

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -286,9 +286,9 @@
 	loop(MICROWAVE_MUCK, 4)
 
 /obj/machinery/microwave/proc/loop(type, time, wait = max(12 - 2 * efficiency, 2)) // standard wait is 10
-	if(machine_stat & (NOPOWER|BROKEN))
-		pre_fail()
-		eject()
+	if(machine_stat & BROKEN)
+		if(type == MICROWAVE_PRE)
+			pre_fail()
 		return
 	if(!time)
 		switch(type)
@@ -302,6 +302,12 @@
 	time--
 	use_power(500)
 	addtimer(CALLBACK(src, .proc/loop, type, time, wait), wait)
+
+/obj/machinery/microwave/power_change()
+	. = ..()
+	if((machine_stat & NOPOWER) && operating)
+		pre_fail()
+		eject()
 
 /obj/machinery/microwave/proc/loop_finish()
 	operating = FALSE


### PR DESCRIPTION
wzhzhzhz

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes : https://github.com/tgstation/tgstation/issues/51866#issue-646169236

So for some god forsaken reason the microwave would only stop during a power outage if the microwave was already about to fail, but it STILL returned early meaning the microwave  was never told to actually STOP and would never ever turn off unless you unbuilt it.
either way it's fixed now.

## Why It's Good For The Game
wzhzhzhz is good in moderation
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: the microwave will no longer be turned on infinitely when the power is cut off while it's still on
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
