### PR TITLE
Fixes runtime caused by a mob's client disconnecting while jetpacking around

### DIFF
--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -74,7 +74,7 @@
 /obj/item/tank/jetpack/proc/move_react(mob/user)
 	if(!on)//If jet dont work, it dont work
 		return
-	if(!user)//Don't allow jet self using
+	if(!user || !user.client)//Don't allow jet self using
 		return
 	if(!isturf(user.loc))//You can't use jet in nowhere or from mecha/closet
 		return


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed a runtime caused by a mob's client disconnecting while boosting around with a jetpack.
/:cl:
