### PR TITLE
Sorts client playtime panel alphabetically

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1225,7 +1225,9 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	var/list/msg = list()
 	msg += "<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Playtime Report</title></head><body>Playtime:<BR><UL>"
-	for(var/client/C in GLOB.clients)
+	var/list/clients_list_copy = GLOB.clients.Copy()
+	sortList(clients_list_copy)
+	for(var/client/C in clients_list_copy)
 		msg += "<LI> - [key_name_admin(C)]: <A href='?_src_=holder;[HrefToken()];getplaytimewindow=[REF(C.mob)]'>" + C.get_exp_living() + "</a></LI>"
 	msg += "</UL></BODY></HTML>"
 	src << browse(msg.Join(), "window=Player_playtime_check")


### PR DESCRIPTION
:cl: ShizCalev
admin: The client playtime panel is now sorted alphabetically as opposed to the order in which they were added to the list.
/:cl: