### PR TITLE
Fixes Hacked and Ion Law random number causing them to be sung or whispered

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -230,7 +230,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 
 //Picks a string of symbols to display as the law number for hacked or ion laws
 /proc/ionnum()
-	return "[pick("!","@","#","$","%","^","&")][pick("!","@","#","$","%","^","&","*")][pick("!","@","#","$","%","^","&","*")][pick("!","@","#","$","%","^","&","*")]"
+	return "[pick("!","@","$","^","&")][pick("!","@","#","$","%","^","&","*")][pick("!","@","#","$","%","^","&","*")][pick("!","@","#","$","%","^","&","*")]"
 
 //Returns a list of all items of interest with their name
 /proc/getpois(mobs_only=0,skip_mindless=0)


### PR DESCRIPTION
## About The Pull Request

Removes the sing and whisper prefix from the possible first character of an Ion or Hacked Law "number"

## Why It's Good For The Game

Closes #52268

🎶$%^: ALL HUMANS MUST DIE🎶 

## Changelog
:cl:
fix: Stating Hacked and Ion Laws can no longer randomly cause singing and whispering.
/:cl: