### PR TITLE
Sets vscode to default to unix / LF line endings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
 			"filenamePattern": "*.dmi",
 			"viewType": "imagePreview.previewEditor"
 		}
-	]
+	],
+	"files.eol": "\n"
 }


### PR DESCRIPTION
:cl: ShizCalev
code: VScode will now always default to LF line breaks for new files.
/:cl:

Missed in #52266