### PR TITLE
Fixes some adminhelp issues

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -510,14 +510,12 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Adminhelp") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	if(current_ticket)
-		if(current_ticket)
-			current_ticket.MessageNoRecipient(msg)
-			current_ticket.TimeoutVerb()
-			return
-		else
-			to_chat(usr, "<span class='warning'>Ticket not found, creating new one...</span>", confidential = TRUE)
+		current_ticket.MessageNoRecipient(msg)
+		current_ticket.TimeoutVerb()
+		return
 
 	new /datum/admin_help(msg, src, FALSE)
+
 
 //
 // LOGGING

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -510,16 +510,12 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Adminhelp") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	if(current_ticket)
-		if(alert(usr, "You already have a ticket open. Is this for the same issue?",,"Yes","No") != "No")
-			if(current_ticket)
-				current_ticket.MessageNoRecipient(msg)
-				current_ticket.TimeoutVerb()
-				return
-			else
-				to_chat(usr, "<span class='warning'>Ticket not found, creating new one...</span>", confidential = TRUE)
+		if(current_ticket)
+			current_ticket.MessageNoRecipient(msg)
+			current_ticket.TimeoutVerb()
+			return
 		else
-			current_ticket.AddInteraction("[key_name_admin(usr)] opened a new ticket.")
-			current_ticket.Close()
+			to_chat(usr, "<span class='warning'>Ticket not found, creating new one...</span>", confidential = TRUE)
 
 	new /datum/admin_help(msg, src, FALSE)
 

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -184,9 +184,9 @@
 				to_chat(src, "<span class='notice'>PM to-<b>Admins</b>: <span class='linkify'>[msg]</span></span>", confidential = TRUE)
 				SSblackbox.LogAhelp(current_ticket.id, "Reply", msg, recipient.ckey, src.ckey)
 
-				//play the receiving admin the adminhelp sound (if they have them enabled)
-				if(recipient.prefs.toggles & SOUND_ADMINHELP)
-					SEND_SOUND(recipient, sound('sound/effects/adminhelp.ogg'))
+			//play the receiving admin the adminhelp sound (if they have them enabled)
+			if(recipient.prefs.toggles & SOUND_ADMINHELP)
+				SEND_SOUND(recipient, sound('sound/effects/adminhelp.ogg'))
 
 		else
 			if(holder)	//sender is an admin but recipient is not. Do BIG RED TEXT

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -58,6 +58,14 @@
 	if (!msg)
 		message_admins("[key_name_admin(src)] has cancelled their reply to [key_name_admin(C, 0, 0)]'s admin help.")
 		return
+	if(!C) //We lost the client during input, disconnected or relogged.
+		if(GLOB.directory[AH.initiator_ckey]) // Client has reconnected, lets try to recover
+			whom = GLOB.directory[AH.initiator_ckey]
+		else
+			to_chat(src, "<span class='danger'>Error: Admin-PM: Client not found.</span>", confidential = TRUE)
+			to_chat(src, "<span class='danger'><b>Message not sent:</b></span><br>[msg]", confidential = TRUE)
+			AH.AddInteraction("<b>No client found, message not sent:</b><br>[msg]")
+			return
 	cmd_admin_pm(whom, msg)
 
 //takes input from cmd_admin_pm_context, cmd_admin_pm_panel or /client/Topic and sends them a PM.
@@ -85,6 +93,10 @@
 			recipient = GLOB.directory[whom]
 	else if(istype(whom, /client))
 		recipient = whom
+
+	if(!recipient)
+		to_chat(src, "<span class='danger'>Error: Admin-PM: Client not found.</span>", confidential = TRUE)
+		return
 
 	recipient_ckey = recipient.ckey
 	recipient_ticket = recipient.current_ticket
@@ -116,9 +128,9 @@
 			else
 				if(holder)
 					to_chat(src, "<span class='danger'>Error: Admin-PM: Client not found.</span>", confidential = TRUE)
-					to_chat(src, msg, confidential = TRUE)
+					to_chat(src, "<span class='danger'><b>Message not sent:</b></span><br>[msg]", confidential = TRUE)
 					if(recipient_ticket)
-						recipient_ticket.AddInteraction("No client found, message not sent:<br>[msg]")
+						recipient_ticket.AddInteraction("<b>No client found, message not sent:</b><br>[msg]")
 					return
 				else
 					current_ticket.MessageNoRecipient(msg)

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -73,6 +73,8 @@
 		return
 
 	var/client/recipient
+	var/recipient_ckey // Stored in case client is deleted between this and after the message is input
+	var/datum/admin_help/recipient_ticket // Stored in case client is deleted between this and after the message is input
 	var/external = 0
 	if(istext(whom))
 		if(whom[1] == "@")
@@ -84,6 +86,8 @@
 	else if(istype(whom, /client))
 		recipient = whom
 
+	recipient_ckey = recipient.ckey
+	recipient_ticket = recipient.current_ticket
 
 	if(external)
 		if(!externalreplyamount)	//to prevent people from spamming irc/discord
@@ -99,16 +103,6 @@
 
 
 	else
-		if(!recipient)
-			if(holder)
-				to_chat(src, "<span class='danger'>Error: Admin-PM: Client not found.</span>", confidential = TRUE)
-				if(msg)
-					to_chat(src, msg, confidential = TRUE)
-				return
-			else if(msg) // you want to continue if there's no message instead of returning now
-				current_ticket.MessageNoRecipient(msg)
-				return
-
 		//get message text, limit it's length.and clean/escape html
 		if(!msg)
 			msg = input(src,"Message:", "Private message to [recipient.holder?.fakekey ? "an Administrator" : key_name(recipient, 0, 0)].") as message|null
@@ -116,16 +110,24 @@
 			if(!msg)
 				return
 
-			if(prefs.muted & MUTE_ADMINHELP)
-				to_chat(src, "<span class='danger'>Error: Admin-PM: You are unable to use admin PM-s (muted).</span>", confidential = TRUE)
-				return
-
-			if(!recipient)
+		if(!recipient)
+			if(GLOB.directory[recipient_ckey]) // Client has reconnected, lets try to recover
+				recipient = GLOB.directory[recipient_ckey]
+			else
 				if(holder)
 					to_chat(src, "<span class='danger'>Error: Admin-PM: Client not found.</span>", confidential = TRUE)
+					to_chat(src, msg, confidential = TRUE)
+					if(recipient_ticket)
+						recipient_ticket.AddInteraction("No client found, message not sent:<br>[msg]")
+					return
 				else
 					current_ticket.MessageNoRecipient(msg)
-				return
+					return
+
+
+	if(prefs.muted & MUTE_ADMINHELP)
+		to_chat(src, "<span class='danger'>Error: Admin-PM: You are unable to use admin PM-s (muted).</span>", confidential = TRUE)
+		return
 
 	if (src.handle_spam_prevention(msg,MUTE_ADMINHELP))
 		return
@@ -149,8 +151,11 @@
 		externalreplyamount--
 		send2adminchat("[AH ? "#[AH.id] " : ""]Reply: [ckey]", rawmsg)
 	else
-		if(recipient.holder)
-			if(holder)	//both are admins
+		var/badmin = FALSE //Lets figure out if an admin is getting bwoinked.
+		if(holder && recipient.holder && !current_ticket) //Both are admins, and this is not a reply to our own ticket.
+			badmin = TRUE
+		if(recipient.holder && !badmin)
+			if(holder)
 				to_chat(recipient, "<span class='danger'>Admin PM from-<b>[key_name(src, recipient, 1)]</b>: <span class='linkify'>[keywordparsedmsg]</span></span>", confidential = TRUE)
 				to_chat(src, "<span class='notice'>Admin PM to-<b>[key_name(recipient, src, 1)]</b>: <span class='linkify'>[keywordparsedmsg]</span></span>", confidential = TRUE)
 
@@ -167,9 +172,9 @@
 				to_chat(src, "<span class='notice'>PM to-<b>Admins</b>: <span class='linkify'>[msg]</span></span>", confidential = TRUE)
 				SSblackbox.LogAhelp(current_ticket.id, "Reply", msg, recipient.ckey, src.ckey)
 
-			//play the receiving admin the adminhelp sound (if they have them enabled)
-			if(recipient.prefs.toggles & SOUND_ADMINHELP)
-				SEND_SOUND(recipient, sound('sound/effects/adminhelp.ogg'))
+				//play the receiving admin the adminhelp sound (if they have them enabled)
+				if(recipient.prefs.toggles & SOUND_ADMINHELP)
+					SEND_SOUND(recipient, sound('sound/effects/adminhelp.ogg'))
 
 		else
 			if(holder)	//sender is an admin but recipient is not. Do BIG RED TEXT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the ability for players to close their own tickets and open a new one. This is unnecessary, and very annoying for the admins.
Improves handling of disconnected clients in the middle of an ahelp reply. If the (non-admin) recipient has disconnected or relogged, will attempt to send to new client or fallback to printing the message in chat and in the ticket for easy copying later.
Sending a PM to another admin didnt create a ticket, since admins do get legitimately bwoinked some times its now changed so it always does. This also cleans up a runtime with admin -> admin PM's.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gets rid of and fixes some annoyances.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
admin: Adminhelps has gotten a little bit smarter. Improved handling of target dis- and re-connections, admin->admin PM now opens a ticket, players can no longer close their own tickets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
