### PR TITLE
Novaflower and nettle can now properly burn/stun you

### DIFF
--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -239,7 +239,7 @@
 	. = ..()
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		return TRUE
-	if(isliving(M) && istype(M,/mob/living/carbon))
+	if(iscarbon(M))
 		var/mob/living/carbon/burned = M
 		to_chat(burned, "<span class='danger'>You are lit on fire from the intense heat of the [name]!</span>")
 		burned.adjust_fire_stacks(seed.potency / 20)

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -236,7 +236,7 @@
 	force = round((5 + seed.potency / 5), 1)
 
 /obj/item/grown/novaflower/attack(mob/living/carbon/M, mob/user)
-	if(!..())
+	. = ..()
 		return
 	if(isliving(M))
 		to_chat(M, "<span class='danger'>You are lit on fire from the intense heat of the [name]!</span>")

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -239,13 +239,14 @@
 	. = ..()
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		return TRUE
-	if(iscarbon(M))
-		var/mob/living/carbon/burned = M
-		to_chat(burned, "<span class='danger'>You are lit on fire from the intense heat of the [name]!</span>")
-		burned.adjust_fire_stacks(seed.potency / 20)
-		if(burned.IgniteMob())
-			message_admins("[ADMIN_LOOKUPFLW(user)] set [ADMIN_LOOKUPFLW(burned)] on fire with [src] at [AREACOORD(user)]")
-			log_game("[key_name(user)] set [key_name(burned)] on fire with [src] at [AREACOORD(user)]")
+	if(!iscarbon(M))
+		return
+	var/mob/living/carbon/burned = M
+	to_chat(burned, "<span class='danger'>You are lit on fire from the intense heat of the [name]!</span>")
+	burned.adjust_fire_stacks(seed.potency / 20)
+	if(burned.IgniteMob())
+		message_admins("[ADMIN_LOOKUPFLW(user)] set [ADMIN_LOOKUPFLW(burned)] on fire with [src] at [AREACOORD(user)]")
+		log_game("[key_name(user)] set [key_name(burned)] on fire with [src] at [AREACOORD(user)]")
 
 /obj/item/grown/novaflower/afterattack(atom/A as mob|obj, mob/user,proximity)
 	. = ..()

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -235,22 +235,21 @@
 	..()
 	force = round((5 + seed.potency / 5), 1)
 
-/obj/item/grown/novaflower/attack(mob/living/carbon/M, mob/user)
+/obj/item/grown/novaflower/attack(mob/living/M, mob/user)
 	. = ..()
-	if(isliving(M))
-		if(HAS_TRAIT(user, TRAIT_PACIFISM))
-			return
-		to_chat(M, "<span class='danger'>You are lit on fire from the intense heat of the [name]!</span>")
-		M.adjust_fire_stacks(seed.potency / 20)
-		if(M.IgniteMob())
-			message_admins("[ADMIN_LOOKUPFLW(user)] set [ADMIN_LOOKUPFLW(M)] on fire with [src] at [AREACOORD(user)]")
-			log_game("[key_name(user)] set [key_name(M)] on fire with [src] at [AREACOORD(user)]")
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		return TRUE
+	if(isliving(M) && istype(M,/mob/living/carbon))
+		var/mob/living/carbon/burned = M
+		to_chat(burned, "<span class='danger'>You are lit on fire from the intense heat of the [name]!</span>")
+		burned.adjust_fire_stacks(seed.potency / 20)
+		if(burned.IgniteMob())
+			message_admins("[ADMIN_LOOKUPFLW(user)] set [ADMIN_LOOKUPFLW(burned)] on fire with [src] at [AREACOORD(user)]")
+			log_game("[key_name(user)] set [key_name(burned)] on fire with [src] at [AREACOORD(user)]")
 
 /obj/item/grown/novaflower/afterattack(atom/A as mob|obj, mob/user,proximity)
 	. = ..()
 	if(!proximity)
-		return
-	if(HAS_TRAIT(user, TRAIT_PACIFISM) && ismob(A))
 		return
 	if(force > 0)
 		force -= rand(1, (force / 3) + 1)

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -237,8 +237,9 @@
 
 /obj/item/grown/novaflower/attack(mob/living/carbon/M, mob/user)
 	. = ..()
-		return
 	if(isliving(M))
+		if(HAS_TRAIT(user, TRAIT_PACIFISM))
+			return
 		to_chat(M, "<span class='danger'>You are lit on fire from the intense heat of the [name]!</span>")
 		M.adjust_fire_stacks(seed.potency / 20)
 		if(M.IgniteMob())
@@ -248,6 +249,8 @@
 /obj/item/grown/novaflower/afterattack(atom/A as mob|obj, mob/user,proximity)
 	. = ..()
 	if(!proximity)
+		return
+	if(HAS_TRAIT(user, TRAIT_PACIFISM) && ismob(A))
 		return
 	if(force > 0)
 		force -= rand(1, (force / 3) + 1)

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -109,7 +109,7 @@
 	. = ..()
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		return TRUE
-	if(isliving(M) && istype(M,/mob/living/carbon))
+	if(iscarbon(M))
 		var/mob/living/carbon/target = M
 		to_chat(target, "<span class='danger'>You are stunned by the powerful acid of [src]!</span>")
 		log_combat(user, target, "attacked", src)

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -73,8 +73,6 @@
 	. = ..()
 	if(!proximity)
 		return
-	if(HAS_TRAIT(user, TRAIT_PACIFISM) && ismob(A))
-		return
 	if(force > 0)
 		force -= rand(1, (force / 3) + 1) // When you whack someone with it, leaves fall off
 	else
@@ -107,16 +105,17 @@
 			user.Paralyze(100)
 			to_chat(user, "<span class='userdanger'>You are stunned by [src] as you try picking it up!</span>")
 
-/obj/item/reagent_containers/food/snacks/grown/nettle/death/attack(mob/living/carbon/M, mob/user)
+/obj/item/reagent_containers/food/snacks/grown/nettle/death/attack(mob/living/M, mob/user)
 	. = ..()
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
-		return
-	if(isliving(M) && force > 0)
-		to_chat(M, "<span class='danger'>You are stunned by the powerful acid of [src]!</span>")
-		log_combat(user, M, "attacked", src)
+		return TRUE
+	if(isliving(M) && istype(M,/mob/living/carbon))
+		var/mob/living/carbon/target = M
+		to_chat(target, "<span class='danger'>You are stunned by the powerful acid of [src]!</span>")
+		log_combat(user, target, "attacked", src)
 
-		M.adjust_blurriness(force/7)
+		target.adjust_blurriness(force/7)
 		if(prob(20))
-			M.Unconscious(force / 0.3)
-			M.Paralyze(force / 0.75)
-		M.drop_all_held_items()
+			target.Unconscious(force / 0.3)
+			target.Paralyze(force / 0.75)
+		target.drop_all_held_items()

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -73,6 +73,8 @@
 	. = ..()
 	if(!proximity)
 		return
+	if(HAS_TRAIT(user, TRAIT_PACIFISM) && ismob(A))
+		return
 	if(force > 0)
 		force -= rand(1, (force / 3) + 1) // When you whack someone with it, leaves fall off
 	else
@@ -107,6 +109,8 @@
 
 /obj/item/reagent_containers/food/snacks/grown/nettle/death/attack(mob/living/carbon/M, mob/user)
 	. = ..()
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		return
 	if(isliving(M) && force > 0)
 		to_chat(M, "<span class='danger'>You are stunned by the powerful acid of [src]!</span>")
 		log_combat(user, M, "attacked", src)

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -112,11 +112,11 @@
 	if(!iscarbon(M))
 		return
 	var/mob/living/carbon/target = M
-	to_chat(target, "<span class='danger'>You are stunned by the powerful acid of [src]!</span>")
 	log_combat(user, target, "attacked", src)
 
 	target.adjust_blurriness(force/7)
 	if(prob(20))
+		to_chat(target, "<span class='danger'>You are stunned by the powerful acid of [src]!</span>")
 		target.Unconscious(force / 0.3)
 		target.Paralyze(force / 0.75)
 		target.drop_all_held_items()

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -109,13 +109,14 @@
 	. = ..()
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		return TRUE
-	if(iscarbon(M))
-		var/mob/living/carbon/target = M
-		to_chat(target, "<span class='danger'>You are stunned by the powerful acid of [src]!</span>")
-		log_combat(user, target, "attacked", src)
+	if(!iscarbon(M))
+		return
+	var/mob/living/carbon/target = M
+	to_chat(target, "<span class='danger'>You are stunned by the powerful acid of [src]!</span>")
+	log_combat(user, target, "attacked", src)
 
-		target.adjust_blurriness(force/7)
-		if(prob(20))
-			target.Unconscious(force / 0.3)
-			target.Paralyze(force / 0.75)
+	target.adjust_blurriness(force/7)
+	if(prob(20))
+		target.Unconscious(force / 0.3)
+		target.Paralyze(force / 0.75)
 		target.drop_all_held_items()

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -106,9 +106,8 @@
 			to_chat(user, "<span class='userdanger'>You are stunned by [src] as you try picking it up!</span>")
 
 /obj/item/reagent_containers/food/snacks/grown/nettle/death/attack(mob/living/carbon/M, mob/user)
-	if(!..())
-		return
-	if(isliving(M))
+	. = ..()
+	if(isliving(M) && force > 0)
 		to_chat(M, "<span class='danger'>You are stunned by the powerful acid of [src]!</span>")
 		log_combat(user, M, "attacked", src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/51143#issue-619694704

fixes novaflower and deathnettle no longer having their attack() proc trigger

- what caused the bug?
the answer at its core is simple, the plant would only do their effect if the parent attack proc returned false, which it did not, ever, because it is physically unable to.

- how was the bug fixed?
yeah that's the weird part. You see the attack() proc only triggers when it's on LIVING things, however we need the nettle/novaflower to lose force whenever they attack anything, which is why afterattack is the thing in charge of making them lose force.
why not just move everything to afterattack then? And that is an option, however I settled for another, arguably much shittier solution.
see the ONLY thing in attack proc that can stop you from attacking early is the pacifism trait. and since the only reason you could probably have to not burn/stun someone is being a pacifist, I hardcoded it so it checks for pacifism, and if the guy isn't a pacifist it will stun/burn succesfully.

also you can force people to eat deathnettle on help intent so err, that's a "feature"

the more I'm looking at this the more I realised that yeeting everything into afterattack was the best and simpler fix, but eh.

## Why It's Good For The Game
put witty comment here about bugs being bad here

## Changelog
:cl:
fix: Novaflower and deathnettle will now properly burn/stun their target
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
