### PR TITLE
Brings burn patches in line with brute patches.

### DIFF
--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -36,7 +36,7 @@
 /obj/item/reagent_containers/pill/patch/aiuri
 	name = "aiuri patch (burn)"
 	desc = "Helps with burn injuries. Does minor eye damage. Diluted with Granibitaluri."
-	list_reagents = list(/datum/reagent/medicine/c2/aiuri = 1, /datum/reagent/medicine/granibitaluri = 9)
+	list_reagents = list(/datum/reagent/medicine/c2/aiuri = 2, /datum/reagent/medicine/granibitaluri = 8)
 	icon_state = "bandaid_burn"
 
 /obj/item/reagent_containers/pill/patch/instabitaluri


### PR DESCRIPTION
## About The Pull Request

Changes burn patches to have 2u of Aiuri instead of 1u - keeping it in line with brute patches having 2u of Libital and 8u of Granibitaluri. The change is extremely minor, but it comes after hearing a couple of other MD mains on the tgstation discord complaining about burn patches basically being worthless - healing 10 burn is exactly what a regenerative mesh does, and the burn patches are nearly (if you don't count the Granibitaluri, they ARE) half as effective as burn patches are.

## Why It's Good For The Game

It increases the usefulness of burn patches. Regenerative meshes carry 15 uses and are extremely common - wasting one or two to heal up a minor amount of burn damage on a limb is no big deal - and this makes the burn patches practically useless, considering that they don't stack and heal burn damage extremely poorly. Hopefully this tiny tweak makes them more useful, instead of being the absolute waste-of-space they are right now.

## Changelog
:cl:
tweak: Increases the amount of Aiuri in burn patches to 2u to match the quantity of Libital in brute patches.
/:cl:
