### PR TITLE
Added chat warning if you try to finish a reinforced girder with regular metal

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -134,34 +134,33 @@
 					var/obj/structure/falsewall/reinforced/FW = new (loc)
 					transfer_fingerprints_to(FW)
 					qdel(src)
+			else if(state == GIRDER_REINF)
+				if(S.get_amount() < 1)
+					return
+				to_chat(user, "<span class='notice'>You start finalizing the reinforced wall...</span>")
+				if(do_after(user, 50*platingmodifier, target = src))
+					if(S.get_amount() < 1)
+						return
+					S.use(1)
+					to_chat(user, "<span class='notice'>You fully reinforce the wall.</span>")
+					var/turf/T = get_turf(src)
+					T.PlaceOnTop(/turf/closed/wall/r_wall)
+					transfer_fingerprints_to(T)
+					qdel(src)
+				return
 			else
-				if(state == GIRDER_REINF)
+				if(S.get_amount() < 1)
+					return
+				to_chat(user, "<span class='notice'>You start reinforcing the girder...</span>")
+				if(do_after(user, 60*platingmodifier, target = src))
 					if(S.get_amount() < 1)
 						return
-					to_chat(user, "<span class='notice'>You start finalizing the reinforced wall...</span>")
-					if(do_after(user, 50*platingmodifier, target = src))
-						if(S.get_amount() < 1)
-							return
-						S.use(1)
-						to_chat(user, "<span class='notice'>You fully reinforce the wall.</span>")
-						var/turf/T = get_turf(src)
-						T.PlaceOnTop(/turf/closed/wall/r_wall)
-						transfer_fingerprints_to(T)
-						qdel(src)
-					return
-				else
-					if(S.get_amount() < 1)
-						return
-					to_chat(user, "<span class='notice'>You start reinforcing the girder...</span>")
-					if(do_after(user, 60*platingmodifier, target = src))
-						if(S.get_amount() < 1)
-							return
-						S.use(1)
-						to_chat(user, "<span class='notice'>You reinforce the girder.</span>")
-						var/obj/structure/girder/reinforced/R = new (loc)
-						transfer_fingerprints_to(R)
-						qdel(src)
-					return
+					S.use(1)
+					to_chat(user, "<span class='notice'>You reinforce the girder.</span>")
+					var/obj/structure/girder/reinforced/R = new (loc)
+					transfer_fingerprints_to(R)
+					qdel(src)
+				return
 
 		if(S.sheettype != "runed")
 			var/M = S.sheettype

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -104,6 +104,9 @@
 					var/obj/structure/falsewall/F = new (loc)
 					transfer_fingerprints_to(F)
 					qdel(src)
+			else if(state == GIRDER_REINF)
+				to_chat(user, "<span class='warning'>You can't finish a reinforced girder with regular metal. You need a plasteel sheet for that.</span>")
+				return
 			else
 				if(S.get_amount() < 2)
 					to_chat(user, "<span class='warning'>You need two sheets of metal to finish a wall!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Previously you could create a wall girder, add plasteel and then finish the girder with a regular metal sheet, turning it into an ordinary non-reinforced wall. Due to this, the previously added plasteel would be sent into bluespace and you would be sad to find out your precious plasteel is gone.

This PR adds a warning if you try to finish a reinforced girder with regular metal, and prevents said action. If you mistakenly reinforce a girder you can always remove the reinforcement using screwdriver + wirecutters.

(I also fixed a nearby if scope not properly utilizing if-else, adding unnecessary indentation)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less sad players is good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Prevent being able to finish a reinforced girder using regular metal, making the added reinforcement disappear.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
