### PR TITLE
Mafia Landmarks are cleaned up at the end of the game

### DIFF
--- a/code/modules/mafia/controller.dm
+++ b/code/modules/mafia/controller.dm
@@ -326,6 +326,10 @@
 	QDEL_LIST(all_roles)
 	turn = 0
 	votes = list()
+	//map gen does not deal with landmarks
+	for(var/i in landmarks)
+		qdel(i)
+	qdel(town_center_landmark)
 	phase = MAFIA_PHASE_SETUP
 
 /**

--- a/code/modules/mafia/controller.dm
+++ b/code/modules/mafia/controller.dm
@@ -327,9 +327,8 @@
 	turn = 0
 	votes = list()
 	//map gen does not deal with landmarks
-	for(var/i in landmarks)
-		qdel(i)
-	qdel(town_center_landmark)
+	QDEL_LIST(landmarks)
+	QDEL_NULL(town_center_landmark)
 	phase = MAFIA_PHASE_SETUP
 
 /**
@@ -577,9 +576,6 @@
 				basic_setup()
 			if("nuke")
 				end_game()
-				for(var/i in landmarks)
-					qdel(i)
-				qdel(town_center_landmark)
 				qdel(src)
 			if("next_phase")
 				var/datum/timedevent/timer = SStimer.timer_id_dict[next_phase_timer]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mafia Landmarks would slowly accrue and mafia right now only holds the landmarks it first discovers if it has none, this is bad for two reasons:
1. it's ugly to leave a shit ton of landmarks that slowly build up as the round goes on
2. this makes maps that don't follow the exact same spawns broken, as it will still use the landmark spawns of the first map loaded

## Why It's Good For The Game

See about the pull request section I accidentally justified it there

## Changelog
:cl:
fix: landmark cleanup on mafia
/:cl:
