### PR TITLE
More mulebot fixes

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -460,6 +460,16 @@
 		else
 			holder.icon_state = ""
 
+/mob/living/simple_animal/bot/mulebot/proc/diag_hud_set_mulebotcell()
+	var/image/holder = hud_list[DIAG_BATT_HUD]
+	var/icon/I = icon(icon, icon_state, dir)
+	holder.pixel_y = I.Height() - world.icon_size
+	if(cell)
+		var/chargelvl = (cell.charge/cell.maxcharge)
+		holder.icon_state = "hudbatt[RoundDiagBar(chargelvl)]"
+	else
+		holder.icon_state = "hudnobatt"
+
 /*~~~~~~~~~~~~
 	Airlocks!
 ~~~~~~~~~~~~~*/

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -130,6 +130,7 @@
 	update_mobility()
 	set_light(initial(light_range))
 	update_icon()
+	to_chat(src, "<span class='boldnotice'>You turned on!</span>")
 	diag_hud_set_botstat()
 	return TRUE
 
@@ -138,6 +139,7 @@
 	update_mobility()
 	set_light(0)
 	bot_reset() //Resets an AI's call, should it exist.
+	to_chat(src, "<span class='userdanger'>You turned off!</span>")
 	update_icon()
 
 /mob/living/simple_animal/bot/Initialize()

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -30,6 +30,7 @@
 	bot_type = MULE_BOT
 	model = "MULE"
 	bot_core_type = /obj/machinery/bot_core/mulebot
+	hud_possible = list(DIAG_STAT_HUD, DIAG_BOT_HUD, DIAG_HUD, DIAG_BATT_HUD, DIAG_PATH_HUD = HUD_LIST_LIST) //Diagnostic HUD views
 
 	/// unique identifier in case there are multiple mulebots.
 	var/id
@@ -50,6 +51,7 @@
 	var/report_delivery = TRUE /// true if bot will announce an arrival to a location.
 
 	var/obj/item/stock_parts/cell/cell /// Internal Powercell
+	var/cell_move_power_usage = 1///How much power we use when we move.
 	var/bloodiness = 0 ///If we've run over a mob, how many tiles will we leave tracks on while moving
 	var/num_steps = 0 ///The amount of steps we should take until we rest for a time.
 
@@ -75,6 +77,11 @@
 	D.set_vehicle_dir_layer(NORTH, layer)
 	D.set_vehicle_dir_layer(EAST, layer)
 	D.set_vehicle_dir_layer(WEST, layer)
+	diag_hud_set_mulebotcell()
+
+/mob/living/simple_animal/bot/mulebot/get_movespeed_modifiers()
+	. = ..()
+
 
 /mob/living/simple_animal/bot/mulebot/ComponentInitialize()
 	. = ..()
@@ -86,6 +93,7 @@
 	if(A == cell)
 		turn_off()
 		cell = null
+		diag_hud_set_mulebotcell()
 	return ..()
 
 /mob/living/simple_animal/bot/mulebot/examine(mob/user)
@@ -148,6 +156,7 @@
 		if(!user.transferItemToLoc(I, src))
 			return
 		cell = I
+		diag_hud_set_mulebotcell()
 		visible_message("<span class='notice'>[user] inserts \a [cell] into [src].</span>",
 						"<span class='notice'>You insert [cell] into [src].</span>")
 	else if(I.tool_behaviour == TOOL_CROWBAR && open && user.a_intent != INTENT_HARM)
@@ -162,6 +171,7 @@
 		visible_message("<span class='notice'>[user] crowbars [cell] out from [src].</span>",
 						"<span class='notice'>You pry [cell] out of [src].</span>")
 		cell = null
+		diag_hud_set_mulebotcell()
 	else if(is_wire_tool(I) && open)
 		return attack_hand(user)
 	else if(load && ismob(load))  // chance to knock off rider
@@ -246,7 +256,7 @@
 			data["modeStatus"] = "average"
 		if(BOT_NO_ROUTE)
 			data["modeStatus"] = "bad"
-	data["load"] = load ? load.name : null //IF YOU CHANGE THE NAME OF THIS, UPDATE MULEBOT/PARANORMAL/UI_DATA.
+	data["load"] = get_load_name()
 	data["destination"] = destination ? destination : null
 	data["home"] = home_destination
 	data["destinations"] = GLOB.deliverybeacontags
@@ -358,9 +368,9 @@
 		if(BOT_NO_ROUTE)
 			dat += "<span class='bad'>[mode_name[BOT_NO_ROUTE]]</span>"
 	dat += "</div>"
-
-	dat += "<b>Current Load:</b> [isobserver(load) ? "<i>Unknown</i>" : (load ? load.name : "<i>None</i>")]<BR>"
-	dat += "<b>Destination:</b> [!destination ? "<i>none</i>" : destination]<BR>"
+	var/load_message = get_load_name()
+	dat += "<b>Current Load:</b> <i>[load_message ? load_message : "None"]</i><BR>"
+	dat += "<b>Destination:</b> [!destination ? "<i>None</i>" : destination]<BR>"
 	dat += "<b>Power level:</b> [cell ? cell.percent() : 0]%"
 
 	if(locked && !ai && !isAdminGhostAI(user))
@@ -452,6 +462,10 @@
 	mode = BOT_IDLE
 	update_icon()
 
+///resolves the name to display for the loaded mob. primarily needed for the paranormal subtype since we don't want to show the name of ghosts riding it.
+/mob/living/simple_animal/bot/mulebot/proc/get_load_name()
+	return load ? load.name : null
+
 /mob/living/simple_animal/bot/mulebot/proc/load_mob(mob/living/M)
 	can_buckle = TRUE
 	if(buckle_mob(M))
@@ -492,6 +506,15 @@
 
 	update_icon()
 
+/mob/living/simple_animal/bot/mulebot/Stat()
+	..()
+	if(statpanel("Status"))
+		if(cell)
+			stat("Charge Left:", "[cell.charge]/[cell.maxcharge]")
+		else
+			stat(null, text("No Cell Inserted!"))
+		if(load)
+			stat("Current Load:", get_load_name())
 
 /mob/living/simple_animal/bot/mulebot/call_bot()
 	..()
@@ -502,6 +525,9 @@
 		start()
 
 /mob/living/simple_animal/bot/mulebot/Move(atom/newloc, direct) //handle leaving bloody tracks. can't be done via Moved() since that can end up putting the tracks somewhere BEFORE we get bloody.
+	if(!has_power((client || paicard))) //turn off if we ran out of power.
+		turn_off()
+		return FALSE
 	if(!bloodiness) //important to check this first since Bump() is called in the Move() -> Entered() chain
 		return ..()
 	var/atom/oldLoc = loc
@@ -512,6 +538,15 @@
 	B.add_blood_DNA(return_blood_DNA())
 	B.setDir(direct)
 	bloodiness--
+
+/mob/living/simple_animal/bot/mulebot/Moved() //make sure we always use power after moving.
+	. = ..()
+	if(!cell)
+		return
+	cell.use(cell_move_power_usage)
+	if(cell.charge < cell_move_power_usage) //make sure we have enough power to move again, otherwise turn off.
+		turn_off()
+	diag_hud_set_mulebotcell()
 
 /mob/living/simple_animal/bot/mulebot/handle_automated_action()
 	if(!on)
@@ -551,7 +586,6 @@
 				if(isturf(next))
 					var/oldloc = loc
 					var/moved = step_towards(src, next)	// attempt to move
-					cell.use(1)
 					if(moved && oldloc!=loc)	// successful move
 						blockcount = 0
 						path -= loc
@@ -853,11 +887,10 @@
 	ghost_overlay.pixel_y = 12
 	. += ghost_overlay
 
-/mob/living/simple_animal/bot/mulebot/paranormal/ui_data(mob/user)
-	var/list/data = ..()
-	if(isobserver(load))
-		data["load"] = "Unknown" //don't reveal the name of the ghost to prevent metagaming.
-	return data
+/mob/living/simple_animal/bot/mulebot/paranormal/get_load_name() //Don't reveal the name of ghosts so we can't metagame who died and all that.
+	. = ..()
+	if(. && isobserver(load))
+		return "Unknown"
 
 /mob/living/simple_animal/bot/mulebot/paranormal/proc/ghostmoved()
 	visible_message("<span class='notice'>The ghostly figure vanishes...</span>")

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -79,10 +79,6 @@
 	D.set_vehicle_dir_layer(WEST, layer)
 	diag_hud_set_mulebotcell()
 
-/mob/living/simple_animal/bot/mulebot/get_movespeed_modifiers()
-	. = ..()
-
-
 /mob/living/simple_animal/bot/mulebot/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/ntnet_interface)
@@ -368,6 +364,7 @@
 		if(BOT_NO_ROUTE)
 			dat += "<span class='bad'>[mode_name[BOT_NO_ROUTE]]</span>"
 	dat += "</div>"
+
 	var/load_message = get_load_name()
 	dat += "<b>Current Load:</b> <i>[load_message ? load_message : "None"]</i><BR>"
 	dat += "<b>Destination:</b> [!destination ? "<i>None</i>" : destination]<BR>"


### PR DESCRIPTION
:cl: ShizCalev
fix: Player/pAI controlled MULEbots will now use power when they move.
fix: Player/pAI controlled MULEbots will now turn off properly if they ran out of power while moving.
tweak: MULEbot's power levels now show up on the diagnostic HUD.
tweak: Players controlling a MULEbot will now see their power level and current load on the status panel.
fix: Player controlled bots (ie securitrons, ED209's, MULEbots, ect) will now get a chat notification when they're turned on/off.
/:cl:

Partial fix for #52281 . I'm not that familiar with the speed modification system, so someone else will have to hit that.