### PR TITLE
Fixes handi-capable tackling from beyond the grave

### DIFF
--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -68,7 +68,7 @@
 
 ///See if we can tackle or not. If we can, leap!
 /datum/component/tackler/proc/checkTackle(mob/living/carbon/user, atom/A, params)
-	if(!user.in_throw_mode || user.get_active_held_item() || user.pulling || user.buckled || HAS_TRAIT(user, TRAIT_INCAPACITATED))
+	if(!user.in_throw_mode || user.get_active_held_item() || user.pulling || user.buckled || user.incapacitated())
 		return
 
 	if(!A || !(isturf(A) || isturf(A.loc)))

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -68,7 +68,7 @@
 
 ///See if we can tackle or not. If we can, leap!
 /datum/component/tackler/proc/checkTackle(mob/living/carbon/user, atom/A, params)
-	if(!user.in_throw_mode || user.get_active_held_item() || user.pulling || user.buckling)
+	if(!user.in_throw_mode || user.get_active_held_item() || user.pulling || user.buckled)
 		return
 
 	if(!A || !(isturf(A) || isturf(A.loc)))

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -68,7 +68,7 @@
 
 ///See if we can tackle or not. If we can, leap!
 /datum/component/tackler/proc/checkTackle(mob/living/carbon/user, atom/A, params)
-	if(!user.in_throw_mode || user.get_active_held_item() || user.pulling || user.buckled)
+	if(!user.in_throw_mode || user.get_active_held_item() || user.pulling || user.buckled || HAS_TRAIT(user, TRAIT_INCAPACITATED))
 		return
 
 	if(!A || !(isturf(A) || isturf(A.loc)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #52300 

I mixed up buckling and buckled due to some weird comments (which i fixed a while ago in #49749), which meant that you were only prevented from tackling if something was buckled to you, not if you were buckled to something. Since these vehicles give back your stand flag, being buckled them allowed you to tackle from the grave. This fixes that (and also tackling from chairs and such in general)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
remove exploit
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Corpses buckled to chairs can no longer tackle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
