### PR TITLE
Fixes wild instability mutations giving the wrong seeds and other issues..

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -213,7 +213,12 @@
 			t_prod = initial(new_prod.product)
 			if(t_prod)
 				t_prod = new t_prod(output_loc, src)
-				t_prod.seed.instability = instability/2
+				if(t_prod.seed)
+					t_prod.seed = initial(t_prod.seed)
+					t_prod.seed = new t_prod.seed
+					t_prod.seed.instability = instability/2
+					t_amount++
+					continue
 		else
 			t_prod = new product(output_loc, src)
 		if(parent.myseed.plantname != initial(parent.myseed.plantname))

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -216,7 +216,7 @@
 				if(t_prod.seed)
 					t_prod.seed = initial(t_prod.seed)
 					t_prod.seed = new t_prod.seed
-					t_prod.seed.instability = instability/2
+					t_prod.seed.instability = round(instability/2)
 					t_amount++
 					continue
 		else

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -208,7 +208,7 @@
 		product_count = clamp(round(product_count/2),0,5)
 	while(t_amount < product_count)
 		var/obj/item/reagent_containers/food/snacks/grown/t_prod
-		if(instability >= 30 && prob(instability/3) && mutatelist.len)
+		if(instability >= 30 && prob(instability/3) && mutatelist)
 			var/obj/item/seeds/new_prod = pick(mutatelist)
 			t_prod = initial(new_prod.product)
 			if(t_prod)


### PR DESCRIPTION
Turns out I may have ignored the part where the plant's parent seed is what determines several attributes of mutated plants, ya know, like "Name", and "Description", and "The Seed that you get from the produce actually mutating into".
This should have those mutations working as expected.

Additionally, throwing in a .len check on plants with no mutations was resulting in plants being able to be harvested infinitely, which should be fixed.

## About The Pull Request

Fixes a bug that I'm not sure how I actually missed. Tested and verified this time.
Also fixes #52279.

## Why It's Good For The Game

Plants attract bugs, and I tend to hate bugs.

## Changelog
:cl:
fix: early plant mutations from 30+ instability
/:cl: