### PR TITLE
Moves Capitalist and Soviet golem spreading to a subtype

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1247,8 +1247,14 @@
 /mob/living/carbon/human/species/golem/capitalist
 	race = /datum/species/golem/capitalist
 
+/mob/living/carbon/human/species/golem/capitalist/spread
+	race = /datum/species/golem/capitalist/spread
+
 /mob/living/carbon/human/species/golem/soviet
 	race = /datum/species/golem/soviet
+
+/mob/living/carbon/human/species/golem/soviet/spread
+	race = /datum/species/golem/soviet/spread
 
 /mob/living/carbon/human/species/jelly
 	race = /datum/species/jelly

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1057,8 +1057,8 @@
 	action_icon_state = "snowball"
 
 /datum/species/golem/capitalist
-	name = "Capitalist Golem"
-	id = "capitalist golem"
+	name = "Capitalism Golem"
+	id = "capitalism golem"
 	prefix = "Capitalist"
 	attack_verb = "monopolize"
 	limbs_id = "ca_golem"
@@ -1094,7 +1094,9 @@
 	speech_args[SPEECH_MESSAGE] = "Hello, I like money!"
 
 /datum/species/golem/capitalist/spread
-	info_text = "As a <span class='danger'>Capitalist Golem</span>, your fist spreads the powerful industrializing light of capitalism."
+	name = "Tycoon Golem"
+	id = "tycoon golem"
+	info_text = "As a <span class='danger'>Tycoon Golem</span>, your fist spreads the powerful industrializing light of capitalism. Punching any lazy good-for-nothings will instill in them the hard-working ideologies of Capitalism!"
 
 /datum/species/golem/capitalist/spread/spec_unarmedattacked(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	..()
@@ -1106,8 +1108,8 @@
 	target.adjust_nutrition(40)
 
 /datum/species/golem/soviet
-	name = "Soviet Golem"
-	id = "soviet golem"
+	name = "Socialism Golem"
+	id = "socialism golem"
 	prefix = "Comrade"
 	attack_verb = "nationalize"
 	limbs_id = "s_golem"
@@ -1115,7 +1117,7 @@
 	species_traits = list(NOBLOOD,NO_UNDERWEAR,NOEYESPRITES)
 	fixed_mut_color = null
 	inherent_traits = list(TRAIT_NOFLASH, TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOFIRE,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER)
-	info_text = "As a <span class='danger'>Soviet Golem</span>, you must spread the glorious word of Communism."
+	info_text = "As a <span class='danger'>Socialism Golem</span>, you must spread the glorious word of Communism."
 	changesource_flags = MIRROR_BADMIN
 	random_eligible = FALSE
 
@@ -1139,7 +1141,9 @@
 	speech_args[SPEECH_MESSAGE] = "Cyka Blyat"
 
 /datum/species/golem/soviet/spread
-	info_text = "As a <span class='danger'>Soviet Golem</span>, your fist spreads the glorious word of Communism to the non-believers."
+	name = "Tzar Golem"
+	id = "tzar golem"
+	info_text = "As a <span class='danger'>Tzar Golem</span>, your fist spreads the glorious word of Communism to the non-believers. Punching any of the decadent carbon-based pigs will convert them to a glorious Socialism Golem!"
 
 /datum/species/golem/soviet/spread/spec_unarmedattacked(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	..()

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1060,13 +1060,13 @@
 	name = "Capitalist Golem"
 	id = "capitalist golem"
 	prefix = "Capitalist"
-	attack_verb = "monopoliz"
+	attack_verb = "monopolize"
 	limbs_id = "ca_golem"
 	special_names = list("John D. Rockefeller","Rich Uncle Pennybags","Commodore Vanderbilt","Entrepreneur","Mr. Moneybags", "Adam Smith")
 	species_traits = list(NOBLOOD,NO_UNDERWEAR,NOEYESPRITES)
 	fixed_mut_color = null
 	inherent_traits = list(TRAIT_NOFLASH,TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOFIRE,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER)
-	info_text = "As a <span class='danger'>Capitalist Golem</span>, your fist spreads the powerful industrializing light of capitalism."
+	info_text = "As a <span class='danger'>Capitalist Golem</span>, you must spread the powerful industrializing light of capitalism."
 	changesource_flags = MIRROR_BADMIN
 	random_eligible = FALSE
 
@@ -1089,30 +1089,33 @@
 	for(var/obj/effect/proc_holder/spell/aoe_turf/knock/spell in C.mob_spell_list)
 		C.RemoveSpell(spell)
 
-/datum/species/golem/capitalist/spec_unarmedattacked(mob/living/carbon/human/user, mob/living/carbon/human/target)
+/datum/species/golem/capitalist/proc/handle_speech(datum/source, list/speech_args)
+	playsound(source, 'sound/misc/mymoney.ogg', 25, FALSE)
+	speech_args[SPEECH_MESSAGE] = "Hello, I like money!"
+
+/datum/species/golem/capitalist/spread
+	info_text = "As a <span class='danger'>Capitalist Golem</span>, your fist spreads the powerful industrializing light of capitalism."
+
+/datum/species/golem/capitalist/spread/spec_unarmedattacked(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	..()
 	if(isgolem(target))
 		return
 	if(target.nutrition >= NUTRITION_LEVEL_FAT)
-		target.set_species(/datum/species/golem/capitalist)
+		target.set_species(/datum/species/golem/capitalist/spread)
 		return
 	target.adjust_nutrition(40)
-
-/datum/species/golem/capitalist/proc/handle_speech(datum/source, list/speech_args)
-	playsound(source, 'sound/misc/mymoney.ogg', 25, FALSE)
-	speech_args[SPEECH_MESSAGE] = "Hello, I like money!"
 
 /datum/species/golem/soviet
 	name = "Soviet Golem"
 	id = "soviet golem"
 	prefix = "Comrade"
-	attack_verb = "nationaliz"
+	attack_verb = "nationalize"
 	limbs_id = "s_golem"
 	special_names = list("Stalin","Lenin","Trotsky","Marx","Comrade") //comrade comrade
 	species_traits = list(NOBLOOD,NO_UNDERWEAR,NOEYESPRITES)
 	fixed_mut_color = null
 	inherent_traits = list(TRAIT_NOFLASH, TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOFIRE,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER)
-	info_text = "As a <span class='danger'>Soviet Golem</span>, your fist spreads the bright soviet light of communism."
+	info_text = "As a <span class='danger'>Soviet Golem</span>, you must spread the glorious word of Communism."
 	changesource_flags = MIRROR_BADMIN
 	random_eligible = FALSE
 
@@ -1131,18 +1134,21 @@
 		C.RemoveSpell(spell)
 	UnregisterSignal(C, COMSIG_MOB_SAY, .proc/handle_speech)
 
-/datum/species/golem/soviet/spec_unarmedattacked(mob/living/carbon/human/user, mob/living/carbon/human/target)
+/datum/species/golem/soviet/proc/handle_speech(datum/source, list/speech_args)
+	playsound(source, 'sound/misc/Cyka Blyat.ogg', 25, FALSE)
+	speech_args[SPEECH_MESSAGE] = "Cyka Blyat"
+
+/datum/species/golem/soviet/spread
+	info_text = "As a <span class='danger'>Soviet Golem</span>, your fist spreads the glorious word of Communism to the non-believers."
+
+/datum/species/golem/soviet/spread/spec_unarmedattacked(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	..()
 	if(isgolem(target))
 		return
 	if(target.nutrition <= NUTRITION_LEVEL_STARVING)
-		target.set_species(/datum/species/golem/soviet)
+		target.set_species(/datum/species/golem/soviet/spread)
 		return
 	target.adjust_nutrition(-40)
-
-/datum/species/golem/soviet/proc/handle_speech(datum/source, list/speech_args)
-	playsound(source, 'sound/misc/Cyka Blyat.ogg', 25, FALSE)
-	speech_args[SPEECH_MESSAGE] = "Cyka Blyat"
 
 /datum/species/golem/mhydrogen
 	name = "Metallic Hydrogen Golem"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I didn't actually know this because it doesn't seem to be documented anywhere, but Soviet and Capitalist golems can convert carbon/human mobs into other golems of the same type based on their hunger. Soviet golems increase your hunger every time they punch you then, when it's at starving, it turns you into a golem. The opposite is true for Capitalist golems. These are fun variants, but there's no easy way to make them without running the risk of ruining the round since they can replicate. This fixes that - there's a subtype variant that specifically has the spreading behavior, so you can still spawn them in events where you actually want them to create massive armies of golems.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This isn't even documented on the wiki what the fuck also now we can spawn one-off versions of these mobs for giggles without fucking up the entire round. This also opens them up for being made available for players to create instead of admin only.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Introduced a variant of Capitalist and Soviet golems that don't spread when they hit someone at a specific hunger level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
