### PR TITLE
large water bottles can now have variable transfer amounts.

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -377,7 +377,8 @@
 	custom_materials = list(/datum/material/plastic=3000)
 	list_reagents = list(/datum/reagent/water = 100)
 	volume = 100
-	amount_per_transfer_from_this = 20
+	amount_per_transfer_from_this = 10
+	possible_transfer_amounts = list(5,10,15,20,25,30,50,100)
 	cap_icon_state = "bottle_cap"
 
 /obj/item/reagent_containers/food/drinks/waterbottle/large/empty


### PR DESCRIPTION
Always irked me that they started on 20 units, and couldn't go to 100; if they're almost identical to large beakers, why have those differences?
:cl:
tweak: Large water bottles (made from plastic) now have the same starting and optional transfer volumes as large beakers.
/:cl: