### PR TITLE
Fixes gun message runtime if the target was qdel'd

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -179,7 +179,7 @@
 
 /obj/item/gun/afterattack(atom/target, mob/living/user, flag, params)
 	. = ..()
-	if(!target)
+	if(QDELETED(target))
 		return
 	if(firing_burst)
 		return


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed a runtime caused by a target being deleted by a gun's projectiles. 
/:cl: