### PR TITLE
Fixes #51574 - Added a whitespace sanitizing proc

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -85,7 +85,8 @@
 	t = matchMiddle.group[1]
 
 	// Replace any non-space whitespace characters with spaces, and also multiple occurences with just one space
-	t = replacetext(t, regex(@"\s+", "g"), " ")
+	var/static/regex/matchSpacing = new(@"\s+", "g")
+	t = replacetext(t, matchSpacing, " ")
 
 	return t
 

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -79,7 +79,7 @@
   */
 /proc/htmlrendertext(t)
 	// Trim "whitespace" by lazily capturing word characters in the middle
-	var/regex/matchMiddle = new(@"^\s*([\W\w]*?)\s*$")
+	var/static/regex/matchMiddle = new(@"^\s*([\W\w]*?)\s*$")
 	if(matchMiddle.Find(t) == 0)
 		return t
 	t = matchMiddle.group[1]

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -68,6 +68,26 @@
 /proc/adminscrub(t,limit=MAX_MESSAGE_LEN)
 	return copytext((html_encode(strip_html_simple(t))),1,limit)
 
+/**
+  * Perform a whitespace cleanup on the text, similar to what HTML renderers do
+  *
+  * This is useful if you want to better predict how text is going to look like when displaying it to a user
+  * HTML renderers collapse multiple whitespaces into one, trims prepending and appending spaces, among other things. This proc attempts to do the same thing.
+  * HTML5 defines whitespace pretty much exactly like regex defines the \s group, [ \t\r\n\f].
+  * Arguments:
+  * * t - The text to "render"
+  */
+/proc/htmlrendertext(t)
+	// Trim "whitespace" by lazily capturing word characters in the middle
+	var/regex/matchMiddle = new(@"^\s*([\W\w]*?)\s*$")
+	if(matchMiddle.Find(t) == 0)
+		return t
+	t = matchMiddle.group[1]
+
+	// Replace any non-space whitespace characters with spaces, and also multiple occurences with just one space
+	t = replacetext(t, regex(@"\s+", "g"), " ")
+
+	return t
 
 //Returns null if there is any bad text in the string
 /proc/reject_bad_text(text, max_length = 512, ascii_only = TRUE)

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -32,6 +32,10 @@
 	if(speaker == src)
 		return
 
+	// raw_message can contain multiple spaces between words etc which are not seen in chat due to HTML rendering
+	// this means if the teller records a message with e.g. double spaces or tabs, other people will not be able to trigger the sensor since they don't know how to perform the same combination
+	raw_message = htmlrendertext(raw_message)
+
 	if(listening && !radio_freq)
 		record_speech(speaker, raw_message, message_language)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As explained in the issue, people can use multiple consecutive whitespaces to mess with the logic of the voice analyzer. These multiples will not be displayed in the HTML chat since HTML renderers collapse multiple whitespaces into just one regular space.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes exploitable behaviour with the voice analyzer

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed being able to cheese the voice analyzer by using multiple consecutive whitespaces
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
