### PR TITLE
Fixed randomized toy crate runtime

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2382,12 +2382,11 @@
 	contains = list()
 	crate_name = "booster pack pack"
 
-/datum/supply_pack/costumes_toys/randomised/tcg/generate()
-	. = ..()
+/datum/supply_pack/costumes_toys/randomised/tcg/fill(obj/structure/closet/crate/C)
 	var/cardpacktype
 	for(var/i in 1 to 10)
 		cardpacktype = pick(subtypesof(/obj/item/cardpack))
-		new cardpacktype(.)
+		new cardpacktype(C)
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Miscellaneous ///////////////////////////////////

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2267,15 +2267,14 @@
 	crate_name = "toy crate"
 	crate_type = /obj/structure/closet/crate/wooden
 
-/datum/supply_pack/costumes_toys/randomised/toys/generate()
-	. = ..()
+/datum/supply_pack/costumes_toys/randomised/toys/fill(obj/structure/closet/crate/C)
 	var/the_toy
 	for(var/i in 1 to num_contained)
 		if(prob(50))
 			the_toy = pickweight(GLOB.arcade_prize_pool)
 		else
 			the_toy = pick(subtypesof(/obj/item/toy/plush))
-		new the_toy(.)
+		new the_toy(C)
 
 /datum/supply_pack/costumes_toys/wizard
 	name = "Wizard Costume Crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Got this runtime on my local server:
```
runtime error: Cannot create objects of type null.
 - proc name: fill (/datum/supply_pack/costumes_toys/randomised/fill)
 -   source file: packs.dm,2295
 -   usr: null
 -   src: Toy Crate (/datum/supply_pack/costumes_toys/randomised/toys)
 -   call stack:
 - Toy Crate (/datum/supply_pack/costumes_toys/randomised/toys): fill(the toy crate (/obj/structure/closet/crate/wooden))
 - Toy Crate (/datum/supply_pack/costumes_toys/randomised/toys): generate(null, null)
 - Toy Crate (/datum/supply_pack/costumes_toys/randomised/toys): generate(null)
 - /datum/round_event/stray_cargo (/datum/round_event/stray_cargo): start()
 - /datum/round_event/stray_cargo (/datum/round_event/stray_cargo): process()
 - Events (/datum/controller/subsystem/events): fire(0)
 - Events (/datum/controller/subsystem/events): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop()
 - Master (/datum/controller/master): StartProcessing(0)
```

The randomized toy crate mistakenly overrides the _generate_ proc instead of the _fill_ proc as it should.

Same goes for the TCG booster pack crate

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less runtimes makes for a happier crew

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
