### PR TITLE
Revenants can now hear again (Fixes #52325)

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -49,7 +49,7 @@
 	move_resist = MOVE_FORCE_OVERPOWERING
 	mob_size = MOB_SIZE_TINY
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
-	flags_1 = RAD_NO_CONTAMINATE_1
+	flags_1 |= RAD_NO_CONTAMINATE_1
 	speed = 1
 	unique_name = TRUE
 	hud_possible = list(ANTAG_HUD)

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -49,7 +49,6 @@
 	move_resist = MOVE_FORCE_OVERPOWERING
 	mob_size = MOB_SIZE_TINY
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
-	flags_1 |= RAD_NO_CONTAMINATE_1
 	speed = 1
 	unique_name = TRUE
 	hud_possible = list(ANTAG_HUD)
@@ -73,6 +72,7 @@
 
 /mob/living/simple_animal/revenant/Initialize(mapload)
 	. = ..()
+	flags_1 |= RAD_NO_CONTAMINATE_1
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
 	ADD_TRAIT(src, TRAIT_SIXTHSENSE, INNATE_TRAIT)
 	AddSpell(new /obj/effect/proc_holder/spell/targeted/night_vision/revenant(null))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #52325 

Revenants were deaf.

All mobs have a flags_1 value of HEAR_1.

Revenants overwrote flags_1 instead of adding a new flag to it after #52091

Change this. Now Revenants inheret the HEAR_1 flag from mobs appropriately.

![image](https://user-images.githubusercontent.com/24975989/87892130-2d93ea00-ca34-11ea-952d-c1bd67850ddc.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Deaf revenants are bad, sad and mad question mark?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Revenants are no longer deaf.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
