### PR TITLE
There are now two roundstart cyborg slots, and cyborgs can now latejoin

### DIFF
--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -4,8 +4,8 @@
 	auto_deadmin_role_flags = DEADMIN_POSITION_SILICON
 	department_flag = ENGSEC
 	faction = "Station"
-	total_positions = 0
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#ddffdd"
 	minimal_player_age = 21


### PR DESCRIPTION
## About The Pull Request

There are now two roundstart cyborg slots (instead of one). Should either or both of those slots not start the round filled, players will be allowed to latejoin as cyborgs to fill them. Latejoining cyborgs arrive on the arrivals shuttle, as a human latejoiner would.

HoPs still cannot open more cyborg slots using their console, as that would step on the toes of robotics too much, IMO.

<img width="348" alt="cyborglatejoin1" src="https://user-images.githubusercontent.com/42606352/87900706-c74e9d80-ca1a-11ea-83b1-801edb68de8d.PNG">
<img width="1439" alt="cyborglatejoin2" src="https://user-images.githubusercontent.com/42606352/87900709-c9b0f780-ca1a-11ea-8cdd-afb71e3b7e61.PNG">

## Why It's Good For The Game

Cyborg is one of the more unique roles on the station, and it's a role that plays very differently to other human roles (and, hell, even to its "head of staff" role, the AI), but there is only one roundstart cyborg slot. This makes rolling said roundstart cyborg slot very (and needlessly, IMO) competitive.

"but ATHATH, you can just get borged at robotics"

Yeah, but you could make a "just get a job change to job X at the HoP's office" argument against expanding the capacity of pretty much any other role in the game. Also, according to https://github.com/tgstation/tgstation/issues/51707, you need to be a roundstart cyborg (I predict that latejoiner cyborgs will also count towards this, but I haven't tested that theory yet) in order for your cyborg hours that round to count towards unlocking the AI role, which requires a whopping TEN HOURS of cyborg playtime.

Also, if cyborgs are meant to be the AI's hands, it'd make sense that they'd have two of them, no?

As for allowing cyborgs to latejoin, the only other role that I know of that doesn't permit latejoining is the prisoner role, which is inherently location-dependent and thus shouldn't be allowed to latejoin on the shuttle. I see no reason why a latejoiner who wishes to fill the cyborg role shouldn't be allowed to do that (if there is enough space for them). Also, playing AI can feel somewhat lonely without your cyborg minion(s), especially if there aren't any roboticists to make new cyborgs for you.

"but ATHATH, you should just observe and wait until robotics prints posibrains"

We allow AIs to latejoin, why not cyborgs? Also, it can be hard to tell from just the round time if posibrains have been researched and printed yet. If the roboticists are absent or new that shift and you observed because you wanted to play posiborg, well, now you're stuck as an observer.

Finally, I'd like to mention that Fulpstation currently has two roundstart cyborg slots and allows cyborgs to latejoin, and I've seen no problems arise there due to that. From my experience playing cyborg there, it's quite nice to have more than one other silicon in binary chat to talk to over the course of the entire round, not just its second half.

## Changelog
:cl:
add: There is now a second roundstart cyborg slot.
add: Cyborgs can now latejoin.
/:cl: