### PR TITLE
Fixes completing a bounty and not getting paid.

### DIFF
--- a/code/game/machinery/civilian_bountys.dm
+++ b/code/game/machinery/civilian_bountys.dm
@@ -78,7 +78,7 @@
 		return FALSE
 	var/datum/bounty/curr_bounty = inserted_scan_id.registered_account.civilian_bounty
 	var/active_stack = 0
-	if(!SSeconomy.get_dep_account(inserted_scan_id.registered_account.account_job.paycheck_department).has_money(curr_bounty.reward))
+	if(!(SSeconomy.get_dep_account(inserted_scan_id.registered_account.account_job.paycheck_department).has_money(curr_bounty.reward)))
 		playsound(loc, 'sound/machines/synth_no.ogg', 50 , TRUE)
 		stop_sending("Not enough funds to submit bounty at this time, please try again later.")
 		return FALSE

--- a/code/game/machinery/civilian_bountys.dm
+++ b/code/game/machinery/civilian_bountys.dm
@@ -78,6 +78,10 @@
 		return FALSE
 	var/datum/bounty/curr_bounty = inserted_scan_id.registered_account.civilian_bounty
 	var/active_stack = 0
+	if(!SSeconomy.get_dep_account(inserted_scan_id.registered_account.account_job.paycheck_department).has_money(curr_bounty.reward))
+		playsound(loc, 'sound/machines/synth_no.ogg', 50 , TRUE)
+		stop_sending("Not enough funds to submit bounty at this time, please try again later.")
+		return FALSE
 	for(var/atom/movable/AM in get_turf(pad))
 		if(AM == pad)
 			continue

--- a/code/game/machinery/civilian_bountys.dm
+++ b/code/game/machinery/civilian_bountys.dm
@@ -79,7 +79,7 @@
 	var/datum/bounty/curr_bounty = inserted_scan_id.registered_account.civilian_bounty
 	var/active_stack = 0
 	var/datum/bank_account/dept_account = SSeconomy.get_dep_account(inserted_scan_id.registered_account.account_job.paycheck_department)
-	if(!dept_account.has_money(curr_bounty.reward) || !dept_account)
+	if(!dept_account?.has_money(curr_bounty.reward))
 		playsound(loc, 'sound/machines/synth_no.ogg', 50 , TRUE)
 		stop_sending("Not enough funds to submit bounty at this time, please try again later.")
 		return FALSE

--- a/code/game/machinery/civilian_bountys.dm
+++ b/code/game/machinery/civilian_bountys.dm
@@ -78,7 +78,8 @@
 		return FALSE
 	var/datum/bounty/curr_bounty = inserted_scan_id.registered_account.civilian_bounty
 	var/active_stack = 0
-	if(!(SSeconomy.get_dep_account(inserted_scan_id.registered_account.account_job.paycheck_department).has_money(curr_bounty.reward)))
+	var/datum/bank_account/dept_account = SSeconomy.get_dep_account(inserted_scan_id.registered_account.account_job.paycheck_department)
+	if(!dept_account.has_money(curr_bounty.reward) || !dept_account)
 		playsound(loc, 'sound/machines/synth_no.ogg', 50 , TRUE)
 		stop_sending("Not enough funds to submit bounty at this time, please try again later.")
 		return FALSE
@@ -96,7 +97,7 @@
 		stop_sending()
 	if(curr_bounty.can_claim())
 		//Pay for the bounty with the ID's department funds.
-		inserted_scan_id.registered_account.transfer_money(SSeconomy.get_dep_account(inserted_scan_id.registered_account.account_job.paycheck_department), curr_bounty.reward)
+		inserted_scan_id.registered_account.transfer_money(dept_account, curr_bounty.reward)
 		status_report += "Bounty Completed! [curr_bounty.reward] credits have been paid out. "
 		inserted_scan_id.registered_account.reset_bounty()
 	pad.visible_message("<span class='notice'>[pad] activates!</span>")

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -153,19 +153,6 @@
 	required_count = 8
 	wanted_types = list(/obj/item/kirbyplants)
 
-/datum/bounty/item/assistant/earmuffs
-	name = "Earmuffs"
-	description = "Central Command is getting tired of your station's messages. They've ordered that you ship some earmuffs to lessen the annoyance."
-	reward = 1000
-	wanted_types = list(/obj/item/clothing/ears/earmuffs)
-
-/datum/bounty/item/assistant/handcuffs
-	name = "Handcuffs"
-	description = "A large influx of escaped convicts have arrived at Central Command. Now is the perfect time to ship out spare handcuffs (or restraints)."
-	reward = 1000
-	required_count = 5
-	wanted_types = list(/obj/item/restraints/handcuffs)
-
 /datum/bounty/item/assistant/monkey_cubes
 	name = "Monkey Cubes"
 	description = "Due to a recent genetics accident, Central Command is in serious need of monkeys. Your mission is to ship monkey cubes."

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -386,11 +386,13 @@
 	pad.icon_state = pad.warmup_state
 	sending_timer = addtimer(CALLBACK(src,.proc/send),warmup_time, TIMER_STOPPABLE)
 
-/obj/machinery/computer/piratepad_control/proc/stop_sending()
+/obj/machinery/computer/piratepad_control/proc/stop_sending(var/custom_report)
 	if(!sending)
 		return
 	sending = FALSE
 	status_report = "Ready for delivery."
+	if(custom_report)
+		status_report = custom_report
 	pad.icon_state = pad.idle_state
 	deltimer(sending_timer)
 

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -386,7 +386,7 @@
 	pad.icon_state = pad.warmup_state
 	sending_timer = addtimer(CALLBACK(src,.proc/send),warmup_time, TIMER_STOPPABLE)
 
-/obj/machinery/computer/piratepad_control/proc/stop_sending(var/custom_report)
+/obj/machinery/computer/piratepad_control/proc/stop_sending(custom_report)
 	if(!sending)
 		return
 	sending = FALSE


### PR DESCRIPTION
## About The Pull Request

Fixes #52343, and fixes #52387 by adding a brief visual notification to the UI when you attempt to submit a bounty but the budget account doesn't have the cash, rejecting it and letting you know to attempt to submit it later.

Additionally, this also moves over the handcuff and earmuff bounty fully over to security, from assistant bounties.

## Why It's Good For The Game

Fixes a feedback issue, as well as fixes adjusting two security bounties that didn't get fully moved over, leaving 2 duplicates.

## Changelog
:cl:
fix: Civilian bounty pads, when submitting a bounty that the department can't pay for, will allow you to submit it later.
fix: Fixes 2 duplicate bounties between security/assistants.
/:cl: