### PR TITLE
Engineering sign location fix Meta

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -27405,6 +27405,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/directions/engineering{
+	dir = 4;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "blg" = (
@@ -28076,13 +28080,6 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
-"bmU" = (
-/obj/structure/sign/directions/engineering{
-	dir = 4;
-	pixel_y = 8
-	},
-/turf/closed/wall,
 /area/maintenance/starboard)
 "bmV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -118965,7 +118962,7 @@ aWw
 bhQ
 gjw
 blf
-bmU
+alq
 alq
 alq
 alq


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This moves a sign from on a wall to in the hall shifted on to the wall.

Fixes #51945

Pic because someone cares:
![pic](https://mdb.affectedarc07.co.uk/Files/3234987/890604069/0/after.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mostly closes an issue, and stops you from seeing the sign in Maint.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed the location of an Engineering sign on Meta
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
