### PR TITLE
Quirk waits for client before setting preferences

### DIFF
--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -35,10 +35,13 @@
 		RegisterSignal(quirk_holder, COMSIG_MOB_LOGIN, .proc/on_quirk_holder_first_login)
 
 
-/*
- * Clear signal and run post_add to set client preferences.
- * For when the client has not attached at time of gaining the perk.
- */
+/**
+  * On client connection set quirk preferences.
+  *
+  * Run post_add to set the client preferences for the quirk.
+  * Clear the attached signal for login.
+  * Used when the quirk has been gained and no client is attached to the mob.
+  */
 /datum/quirk/proc/on_quirk_holder_first_login(mob/living/source)
 		UnregisterSignal(source, COMSIG_MOB_LOGIN)
 		post_add()

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -35,7 +35,7 @@
 		RegisterSignal(quirk_holder, COMSIG_MOB_LOGIN, .proc/on_quirk_holder_first_login)
 
 
-///Description of what this proc does here.
+/// Run post spawn text and client preferences
 /datum/quirk/proc/on_quirk_holder_first_login(mob/living/source)
 		UnregisterSignal(source, COMSIG_MOB_LOGIN)
 		post_add()

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -35,7 +35,10 @@
 		RegisterSignal(quirk_holder, COMSIG_MOB_LOGIN, .proc/on_quirk_holder_first_login)
 
 
-/// Run post spawn text and client preferences
+/*
+ * Clear signal and run post_add to set client preferences.
+ * For when the client has not attached at time of gaining the perk.
+ */
 /datum/quirk/proc/on_quirk_holder_first_login(mob/living/source)
 		UnregisterSignal(source, COMSIG_MOB_LOGIN)
 		post_add()

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -12,6 +12,7 @@
 	var/mob_trait //if applicable, apply and remove this mob trait
 	///Amount of points this trait is worth towards the hardcore character mode; minus points implies a positive quirk, positive means its hard. This is used to pick the quirks assigned to a hardcore character. 0 means its not available to hardcore draws.
 	var/hardcore_value = 0
+	var/post_add_ran = FALSE /// Tracks if the post_add was run on the quirk on process tick
 	var/mob/living/quirk_holder
 
 /datum/quirk/New(mob/living/quirk_mob, spawn_effects)
@@ -29,7 +30,6 @@
 	add()
 	if(spawn_effects)
 		on_spawn()
-		addtimer(CALLBACK(src, .proc/post_add), 30)
 
 /datum/quirk/Destroy()
 	STOP_PROCESSING(SSquirks, src)
@@ -65,6 +65,9 @@
 		return
 	if(quirk_holder.stat == DEAD)
 		return
+	if(!post_add_ran)
+		post_add()
+		post_add_ran = TRUE
 	on_process()
 
 /**

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -1,5 +1,3 @@
-#define QUIRK_POST_ADD_RAN (1<<0)
-
 //every quirk in this folder should be coded around being applied on spawn
 //these are NOT "mob quirks" like GOTTAGOFAST, but exist as a medium to apply them and other different effects
 /datum/quirk
@@ -14,7 +12,6 @@
 	var/mob_trait //if applicable, apply and remove this mob trait
 	///Amount of points this trait is worth towards the hardcore character mode; minus points implies a positive quirk, positive means its hard. This is used to pick the quirks assigned to a hardcore character. 0 means its not available to hardcore draws.
 	var/hardcore_value = 0
-	var/quirk_flags = NONE /// bitflag to track that post_add was run
 	var/mob/living/quirk_holder
 
 /datum/quirk/New(mob/living/quirk_mob, spawn_effects)
@@ -32,8 +29,10 @@
 	add()
 	if(spawn_effects)
 		on_spawn()
+	RegisterSignal(quirk_holder, COMSIG_MOB_LOGIN, .proc/post_add)
 
 /datum/quirk/Destroy()
+	UnregisterSignal(quirk_holder, COMSIG_MOB_LOGIN)
 	STOP_PROCESSING(SSquirks, src)
 	remove()
 	if(quirk_holder)
@@ -67,11 +66,6 @@
 		return
 	if(quirk_holder.stat == DEAD)
 		return
-	// post_add is used to get settings from the client prefs
-	// validate that a client is attached before running
-	if(!(quirk_flags & QUIRK_POST_ADD_RAN) && quirk_holder.client)
-		post_add()
-		quirk_flags |= QUIRK_POST_ADD_RAN
 	on_process()
 
 /**
@@ -161,5 +155,3 @@ Use this as a guideline
 //If you don't need any special effects like spawning glasses, then you don't need an add()
 
 */
-
-#undef QUIRK_POST_ADD_RAN

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -65,9 +65,13 @@
 		return
 	if(quirk_holder.stat == DEAD)
 		return
+	// post_add is used to get settings from the client prefs
+	// validate that a client is attached before running
 	if(!post_add_ran)
-		post_add()
-		post_add_ran = TRUE
+		var/mob/user = quirk_holder
+		if(user && user.client)
+			post_add()
+			post_add_ran = TRUE
 	on_process()
 
 /**

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -29,7 +29,16 @@
 	add()
 	if(spawn_effects)
 		on_spawn()
-	RegisterSignal(quirk_holder, COMSIG_MOB_LOGIN, .proc/post_add)
+	if(quirk_holder.client)
+		post_add()
+	else
+		RegisterSignal(quirk_holder, COMSIG_MOB_LOGIN, .proc/on_quirk_holder_first_login)
+
+
+///Description of what this proc does here.
+/datum/quirk/proc/on_quirk_holder_first_login(mob/living/source)
+		UnregisterSignal(source, COMSIG_MOB_LOGIN)
+		post_add()
 
 /datum/quirk/Destroy()
 	STOP_PROCESSING(SSquirks, src)

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -1,3 +1,5 @@
+#define QUIRK_POST_ADD_RAN (1<<0)
+
 //every quirk in this folder should be coded around being applied on spawn
 //these are NOT "mob quirks" like GOTTAGOFAST, but exist as a medium to apply them and other different effects
 /datum/quirk
@@ -12,7 +14,7 @@
 	var/mob_trait //if applicable, apply and remove this mob trait
 	///Amount of points this trait is worth towards the hardcore character mode; minus points implies a positive quirk, positive means its hard. This is used to pick the quirks assigned to a hardcore character. 0 means its not available to hardcore draws.
 	var/hardcore_value = 0
-	var/post_add_ran = FALSE /// Tracks if the post_add was run on the quirk on process tick
+	var/quirk_flags = NONE /// bitflag to track that post_add was run
 	var/mob/living/quirk_holder
 
 /datum/quirk/New(mob/living/quirk_mob, spawn_effects)
@@ -67,11 +69,9 @@
 		return
 	// post_add is used to get settings from the client prefs
 	// validate that a client is attached before running
-	if(!post_add_ran)
-		var/mob/user = quirk_holder
-		if(user && user.client)
-			post_add()
-			post_add_ran = TRUE
+	if(!(quirk_flags & QUIRK_POST_ADD_RAN) && quirk_holder.client)
+		post_add()
+		quirk_flags |= QUIRK_POST_ADD_RAN
 	on_process()
 
 /**
@@ -161,3 +161,5 @@ Use this as a guideline
 //If you don't need any special effects like spawning glasses, then you don't need an add()
 
 */
+
+#undef QUIRK_POST_ADD_RAN

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -32,7 +32,6 @@
 	RegisterSignal(quirk_holder, COMSIG_MOB_LOGIN, .proc/post_add)
 
 /datum/quirk/Destroy()
-	UnregisterSignal(quirk_holder, COMSIG_MOB_LOGIN)
 	STOP_PROCESSING(SSquirks, src)
 	remove()
 	if(quirk_holder)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Quirks used a timer to run post_add to set the client preferences.
We will now validate that we have a client before applying preferences.

This was not an issue on local servers but it can happen on the live servers more often.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Should solve the random phobia when spawn takes longer then normal.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Quirks settings trigger after spawn now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
