### PR TITLE
Bashing borgs to bits no longer makes you bloody

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -691,7 +691,7 @@
 	return list("UNKNOWN DNA" = "X*")
 
 /mob/living/silicon/get_blood_dna_list()
-	return list("MOTOR OIL" = "SAE 5W-30") //just a little flavor text.
+	return
 
 ///to add a mob's dna info into an object's blood_dna list.
 /atom/proc/transfer_mob_blood_dna(mob/living/L)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes: #41439

Beating borgs again and again will cover you and your stuff in red blood decals, despite borgs having oil instead of blood (brain notwithstanding i guess). Scanning the blood will tell you it's actually motor oil, but it still looks like blood and commits the capital sin of small fluff features: being more jarring than interesting.

This only gets rid of the red blood that comes from beating borgs, they still make a mess of oil on the floor when they take heavy damage
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Your clothes and items will no longer be covered in distressingly human looking blood when bashing borgs to bits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
