### PR TITLE
You can now contract viruses from licking wounds

### DIFF
--- a/code/datums/wounds/cuts.dm
+++ b/code/datums/wounds/cuts.dm
@@ -141,6 +141,18 @@
 		to_chat(user, "<span class='warning'>You're already interacting with [victim]!</span>")
 		return
 
+	if(user.is_mouth_covered())
+		to_chat(user, "<span class='warning'>Your mouth is covered, you can't lick [victim]'s wounds!</span>")
+		return
+
+	if(!user.getorganslot(ORGAN_SLOT_TONGUE))
+		to_chat(user, "<span class='warning'>You can't lick wounds without a tongue!</span>") // f in chat
+		return
+
+	// transmission is one way patient -> felinid since google said cat saliva is antiseptic or whatever, and also because felinids are already risking getting beaten for this even without people suspecting they're spreading a deathvirus
+	for(var/datum/disease/D in victim.diseases)
+		user.ForceContractDisease(D)
+
 	user.visible_message("<span class='notice'>[user] begins licking the wounds on [victim]'s [limb.name].</span>", "<span class='notice'>You begin licking the wounds on [victim]'s [limb.name]...</span>", ignored_mobs=victim)
 	to_chat(victim, "<span class='notice'>[user] begins to lick the wounds on your [limb.name].</span")
 	if(!do_after(user, base_treat_time, target=victim, extra_checks = CALLBACK(src, .proc/still_exists)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
[PR Theme](https://www.youtube.com/watch?v=bjXh4w--EY4)

Licking open bleeding wounds, while a natural defense mechanism for many forms of life, is hella nasty on a germ level. You now automatically contract any viruses from the patient who you're treating, though you won't spread whatever diseases you have to other people because of antiseptic in cat tongues or whatever. Honestly felinids are already risking getting beaten for stopping bleeding this way, so I don't think there needs to be an extra reason to immediately kill them because they might be trying to infect you with a super virus

Also adds in checks to make sure your mouth isn't covered and that you do, in fact, have a tongue you can lick with.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
@kriskog told me to, deepens the immersion
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
tweak: Licking wounds on other people will automatically contract any diseases they're carrying. This is a one way transmission vector, you cannot contract disease from a felinid doctor in this way due to the partially antiseptic nature of cat saliva or whatever
tweak: You also cannot lick wounds if your mouth is covered or if you do not, in fact, possess a tongue
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
