### PR TITLE
Fixes hat throwing

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -635,7 +635,7 @@
 	else
 		target_zone = thrower.zone_selected
 
-	var/datum/thrownthing/TT = new(src, target, get_turf(target), get_dir(src, target), range, speed, thrower, diagonals_first, force, gentle, callback, thrower, target_zone)
+	var/datum/thrownthing/TT = new(src, target, get_turf(target), get_dir(src, target), range, speed, thrower, diagonals_first, force, gentle, callback, target_zone)
 
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)


### PR DESCRIPTION
:cl:
fix: Fixed an issue that prevented throwing hats onto heads.
/:cl:
Fixes #52372

`thrower` was being passed twice, preventing `target_zone` from being set properly.
https://github.com/tgstation/tgstation/blob/1f149b702381aa7711a370dfbcf53e2344d6f27e/code/controllers/subsystem/throwing.dm#L68