### PR TITLE
Removes the pop requirement of the war op challenge beacon, increases the pop requirement of the nuke op game mode to 50

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -3,7 +3,7 @@
 	config_tag = "nuclear"
 	report_type = "nuclear"
 	false_report_weight = 10
-	required_players = 30 // 30 players - 3 players to be the nuke ops = 27 players remaining
+	required_players = 50 // the former threshold for declaring war. if you want to lower this, consider also lowering CHALLENGE_TELECRYSTALS in nuclear_challenge.dm
 	required_enemies = 2
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -3,7 +3,7 @@
 	config_tag = "nuclear"
 	report_type = "nuclear"
 	false_report_weight = 10
-	required_players = 50 // the former threshold for declaring war. if you want to lower this, consider also lowering CHALLENGE_TELECRYSTALS in nuclear_challenge.dm
+	required_players = 50 // Remember the existence of war ops when changing this value. If you want to lower (or raise) this value, consider also lowering (or raising) CHALLENGE_TELECRYSTALS in nuclear_challenge.dm.
 	required_enemies = 2
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,6 +1,5 @@
 #define CHALLENGE_TELECRYSTALS 280
 #define CHALLENGE_TIME_LIMIT 3000
-#define CHALLENGE_MIN_PLAYERS 50
 #define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
 GLOBAL_LIST_EMPTY(jam_on_wardec)
@@ -103,9 +102,6 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 	if(declaring_war)
 		to_chat(user, "<span class='boldwarning'>You are already in the process of declaring war! Make your mind up.</span>")
 		return FALSE
-	if(GLOB.player_list.len < CHALLENGE_MIN_PLAYERS)
-		to_chat(user, "<span class='boldwarning'>The enemy crew is too small to be worth declaring war on.</span>")
-		return FALSE
 	if(!user.onSyndieBase())
 		to_chat(user, "<span class='boldwarning'>You have to be at your base to use this.</span>")
 		return FALSE
@@ -124,5 +120,4 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 
 #undef CHALLENGE_TELECRYSTALS
 #undef CHALLENGE_TIME_LIMIT
-#undef CHALLENGE_MIN_PLAYERS
 #undef CHALLENGE_SHUTTLE_DELAY


### PR DESCRIPTION
## About The Pull Request

The war op challenge beacon can now be used regardless of the pop count of the station.

The pop requirement of the nuclear emergency and clown ops gamemodes have been increased to 50, the previous minimum pop requirement for using the war op challenge beacon.

## Why It's Good For The Game

Blitz ops are a blight upon the nuclear emergency gamemode. Stealth ops are fine if they have a good gimmick (and can sometimes create memorable rounds), and war ops scratch that TDM itch (or, at the very least, allow the people who hate the nuclear emergency game mode to suicide before their rounds/gimmicks get cut short).

Blitz ops, on the other hand, basically just waltz into the station and end the round abruptly with no resistance/challenge (unlike war ops) or novelty (unlike stealth ops) to be had. The only way that blitz ops can lose is if they fuck things up for themselves somehow or don't know how to use their pinpointer tablets.

I believe that many players already know that the blitz op strategy is dishonurubool, and that a common reason for using the blitz op strategy is that they wanted to go war ops, but couldn't due to the low pop count. You can't disable "stealth ops" or "war ops" in your preferences; under the current system, if you like war ops but don't like stealth ops, well, too bad (unless you're willing to change your antag preferences each round based on the population of the server). Now, those filthy blitz ops players will no longer have that excuse- if you're a (member of a) nuke op team, you will now always have the option to go with the strategy you prefer, instead of being forced to either go stealth ops (even if you prefer the mass murder part of playing a nuke op over the planning part) or be dishonorable, rat bastard, cowardly, SONS OF BITCHES and go blitz ops, simply because you rolled nuke op on <50 pop.

An alternative for this change could be to drop the pop requirement of nuclear emergency back down to 30, but scale down the amount of TC you get from declaring war if you did so below 50 pop. We could make the equation be min([server pop]/CHALLENGE_MIN_PLAYERS, 1) * CHALLENGE_TELECRYSTALS, for example. I don't know how well/poorly that would affect the balance of the nuclear emergency gamemode, though.

## Changelog
:cl: ATHATH
balance: The war op challenge beacon can now be used regardless of the pop count of the station.
balance: The pop requirement of the nuclear emergency and clown ops gamemodes have been increased to 50, the previous minimum pop requirement for using the war op challenge beacon.
/:cl: