### PR TITLE
Removes the pop requirement of the war op challenge beacon, makes declaring war give less TC if you're below 50 pop

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,6 +1,6 @@
 #define CHALLENGE_TELECRYSTALS 280
 #define CHALLENGE_TIME_LIMIT 3000
-#define CHALLENGE_MIN_PLAYERS 50
+#define CHALLENGE_MIN_PLAYERS 50 //if you declare war with fewer than this number of players on the server, you'll get (proportionally) less bonus TC
 #define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
 GLOBAL_LIST_EMPTY(jam_on_wardec)
@@ -75,6 +75,8 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 
 
 	var/tc_to_distribute = CHALLENGE_TELECRYSTALS
+	if(GLOB.player_list.len < CHALLENGE_MIN_PLAYERS) //if there are fewer than 50 players, we give the war ops less bonus TC so that they won't steamroll everyone with the TC needed to take on a 50+ pop station
+		tc_to_distribute *= GLOB.player_list.len/CHALLENGE_MIN_PLAYERS //this will be rounded in the next line anyway
 	var/tc_per_nukie = round(tc_to_distribute / (length(orphans)+length(uplinks)))
 
 	for (var/datum/component/uplink/uplink in uplinks)
@@ -102,9 +104,6 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 /obj/item/nuclear_challenge/proc/check_allowed(mob/living/user)
 	if(declaring_war)
 		to_chat(user, "<span class='boldwarning'>You are already in the process of declaring war! Make your mind up.</span>")
-		return FALSE
-	if(GLOB.player_list.len < CHALLENGE_MIN_PLAYERS)
-		to_chat(user, "<span class='boldwarning'>The enemy crew is too small to be worth declaring war on.</span>")
 		return FALSE
 	if(!user.onSyndieBase())
 		to_chat(user, "<span class='boldwarning'>You have to be at your base to use this.</span>")

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -23,7 +23,10 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		return
 
 	declaring_war = TRUE
-	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew? You have [DisplayTimeText(world.time-SSticker.round_start_time - CHALLENGE_TIME_LIMIT)] to decide", "Declare war?", "Yes", "No")
+	var/quickmaffs = CHALLENGE_TELECRYSTALS
+	if(GLOB.player_list.len < CHALLENGE_MIN_PLAYERS) //if there are fewer than 50 players, we give the war ops less bonus TC so that they won't steamroll everyone with the TC needed to take on a 50+ pop station
+		quickmaffs *= round(GLOB.player_list.len/CHALLENGE_MIN_PLAYERS)
+	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]], which will give you an estimated [quickmaffs] bonus telecrystals. Are you sure you want to alert the enemy crew? You have [DisplayTimeText(world.time-SSticker.round_start_time - CHALLENGE_TIME_LIMIT)] to decide.", "Declare war?", "Yes", "No")
 	declaring_war = FALSE
 
 	if(!check_allowed(user))


### PR DESCRIPTION
## About The Pull Request

You can now declare war as a nuke (or clown) op despite the player count of the server being below 50, but if you do so, you'll receive (CHALLENGE_TELECRYSTALS*GLOB.player_list.len)/CHALLENGE_MIN_PLAYERS bonus TC instead of CHALLENGE_TELECRYSTALS bonus TC.

This does not scale up beyond the old 50 player minimum, so nuke ops that declare war on a 100 pop station still won't receive more bonus TC than nuke ops that declare war on a 70 pop station.

## Why It's Good For The Game

Now you won't be forced into playing either stealth ops or blitz ops if the server's population is below 50. We don't have a special preference for saying "I'd prefer to play nuke op only if the server's population is high enough to declare war", so I felt that this PR was needed.

This PR should cut down on the number of blitz ops that we see, which is a good thing, IMO.

## Changelog
:cl: ATHATH
balance: You can now declare war as a nuclear operative or a clown operative even if the player count of the server is below 50, but doing so will give you proportionally less TC.
/:cl:
