### PR TITLE
Prevents some unecessary health updates on breath ticks

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -186,7 +186,7 @@
 
 	else //Enough oxygen
 		failed_last_breath = 0
-		if(health >= crit_threshold)
+		if(health >= crit_threshold && getOxyLoss())
 			adjustOxyLoss(-5)
 		oxygen_used = breath_gases[/datum/gas/oxygen][MOLES]
 		clear_alert("not_enough_oxy")

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -126,7 +126,7 @@
 			H.throw_alert("not_enough_oxy", /obj/screen/alert/not_enough_oxy)
 		else
 			H.failed_last_breath = FALSE
-			if(H.health >= H.crit_threshold)
+			if(H.health >= H.crit_threshold && H.getOxyLoss())
 				H.adjustOxyLoss(-5)
 			gas_breathed = breath_gases[/datum/gas/oxygen][MOLES]
 			H.clear_alert("not_enough_oxy")
@@ -154,7 +154,7 @@
 			H.throw_alert("nitro", /obj/screen/alert/not_enough_nitro)
 		else
 			H.failed_last_breath = FALSE
-			if(H.health >= H.crit_threshold)
+			if(H.health >= H.crit_threshold && H.getOxyLoss())
 				H.adjustOxyLoss(-5)
 			gas_breathed = breath_gases[/datum/gas/nitrogen][MOLES]
 			H.clear_alert("nitro")
@@ -191,7 +191,7 @@
 			H.throw_alert("not_enough_co2", /obj/screen/alert/not_enough_co2)
 		else
 			H.failed_last_breath = FALSE
-			if(H.health >= H.crit_threshold)
+			if(H.health >= H.crit_threshold && H.getOxyLoss())
 				H.adjustOxyLoss(-5)
 			gas_breathed = breath_gases[/datum/gas/carbon_dioxide][MOLES]
 			H.clear_alert("not_enough_co2")
@@ -221,7 +221,7 @@
 			H.throw_alert("not_enough_tox", /obj/screen/alert/not_enough_tox)
 		else
 			H.failed_last_breath = FALSE
-			if(H.health >= H.crit_threshold)
+			if(H.health >= H.crit_threshold && H.getOxyLoss())
 				H.adjustOxyLoss(-5)
 			gas_breathed = breath_gases[/datum/gas/plasma][MOLES]
 			H.clear_alert("not_enough_tox")


### PR DESCRIPTION
## About The Pull Request

Breath ticks in which a mob was in an adequate atmosphere healed the mob for 5 oxygen damage, even if they didn't have any suffocation at all. 

Closed cause Shiz is taking over updateHealth stuff and doing a much better job at it

## Why It's Good For The Game

Minor adjustment, but should overall reduce the amount of times updateHealth is called on mobs. (adjustOxyLoss's default behavior calls updateHealth, so calling it when your health doesn't change is a waste)

## Changelog
:cl: Melbert
code: Prevents some unnecessary updateHealth calls on breath ticks
/:cl:
