### PR TITLE
Try to replace light overlay to vis_contents

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -239,7 +239,7 @@
 	var/bulb_emergency_pow_mul = 0.75	// the multiplier for determining the light's power in emergency mode
 	var/bulb_emergency_pow_min = 0.5	// the minimum value for the light's power in emergency mode
 
-	var/mutable_appearance/glowybit		// the light overlay
+	var/obj/effect/overlay/vis/glowybit		// the light overlay
 
 /obj/machinery/light/broken
 	status = LIGHT_BROKEN
@@ -293,8 +293,7 @@
 /obj/machinery/light/Initialize(mapload)
 	. = ..()
 
-	glowybit = mutable_appearance(overlayicon, base_state, layer, LIGHTING_PLANE)
-	vis_contents += glowybit
+	glowybit = SSvis_overlays.add_vis_overlay(src, overlayicon, base_state, layer, LIGHTING_PLANE, dir, alpha = 0, add_appearance_flags = RESET_ALPHA, unique = TRUE)
 
 	if(!mapload) //sync up nightshift lighting for player made lights
 		var/area/A = get_area(src)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -293,7 +293,7 @@
 /obj/machinery/light/Initialize(mapload)
 	. = ..()
 
-	glowybit = mutable_appearance(LIGHTING_PLANE, base_state, layer, EMISSIVE_PLANE)
+	glowybit = mutable_appearance(overlayicon, base_state, layer, LIGHTING_PLANE)
 	vis_contents += glowybit
 
 	if(!mapload) //sync up nightshift lighting for player made lights

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -239,6 +239,8 @@
 	var/bulb_emergency_pow_mul = 0.75	// the multiplier for determining the light's power in emergency mode
 	var/bulb_emergency_pow_min = 0.5	// the minimum value for the light's power in emergency mode
 
+	var/mutable_appearance/glowybit		// the light overlay
+
 /obj/machinery/light/broken
 	status = LIGHT_BROKEN
 	icon_state = "tube-broken"
@@ -312,6 +314,9 @@
 			brightness = 4
 			if(prob(5))
 				break_light_tube(1)
+	glowybit = mutable_appearance(overlayicon, base_state, layer, EMISSIVE_PLANE)
+	vis_contents += glowybit
+
 	addtimer(CALLBACK(src, .proc/update, 0), 1)
 
 /obj/machinery/light/Destroy()
@@ -320,6 +325,8 @@
 		on = FALSE
 //		A.update_lights()
 	QDEL_NULL(cell)
+	vis_contents.Cut()
+	QDEL_NULL(glowybit)
 	return ..()
 
 /obj/machinery/light/update_icon_state()
@@ -340,9 +347,9 @@
 /obj/machinery/light/update_overlays()
 	. = ..()
 	if(on && status == LIGHT_OK)
-		var/mutable_appearance/glowybit = mutable_appearance(overlayicon, base_state, layer, EMISSIVE_PLANE)
 		glowybit.alpha = clamp(light_power*250, 30, 200)
-		. += glowybit
+	else
+		glowybit.alpha = 0
 
 // update the icon_state and luminosity of the light depending on its state
 /obj/machinery/light/proc/update(trigger = TRUE)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -293,7 +293,7 @@
 /obj/machinery/light/Initialize(mapload)
 	. = ..()
 
-	glowybit = SSvis_overlays.add_vis_overlay(src, overlayicon, base_state, layer, LIGHTING_PLANE, dir, alpha = 0, add_appearance_flags = RESET_ALPHA, unique = TRUE)
+	glowybit = SSvis_overlays.add_vis_overlay(src, overlayicon, base_state, layer, plane, dir, alpha = 0, unique = TRUE)
 
 	if(!mapload) //sync up nightshift lighting for player made lights
 		var/area/A = get_area(src)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -293,6 +293,9 @@
 /obj/machinery/light/Initialize(mapload)
 	. = ..()
 
+	glowybit = mutable_appearance(LIGHTING_PLANE, base_state, layer, EMISSIVE_PLANE)
+	vis_contents += glowybit
+
 	if(!mapload) //sync up nightshift lighting for player made lights
 		var/area/A = get_area(src)
 		var/obj/machinery/power/apc/temp_apc = A.get_apc()
@@ -314,9 +317,6 @@
 			brightness = 4
 			if(prob(5))
 				break_light_tube(1)
-	glowybit = mutable_appearance(overlayicon, base_state, layer, EMISSIVE_PLANE)
-	vis_contents += glowybit
-
 	addtimer(CALLBACK(src, .proc/update, 0), 1)
 
 /obj/machinery/light/Destroy()


### PR DESCRIPTION
## About The Pull Request

for #48607, partially because this only for lights.
Try to make light overlays unclickable and less load in case that we dont create new `mutable_appearance` when we on light.

## Why It's Good For The Game

Maybe less load

## Changelog
:cl:
refactor: refactored light overlay to vis_contents in case to make it unclickable and less load
fix: now lihgts has light overlay, again. But now it unclickable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
