### PR TITLE
Makes Rod of Asclepius update health all at once

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -273,32 +273,36 @@
 			//Because a servant of medicines stops at nothing to help others, lets keep them on their toes and give them an additional boost.
 			if(itemUser.health < itemUser.maxHealth)
 				new /obj/effect/temp_visual/heal(get_turf(itemUser), "#375637")
-			itemUser.adjustBruteLoss(-1.5)
-			itemUser.adjustFireLoss(-1.5)
-			itemUser.adjustToxLoss(-1.5, forced = TRUE) //Because Slime People are people too
-			itemUser.adjustOxyLoss(-1.5)
-			itemUser.adjustStaminaLoss(-1.5)
-			itemUser.adjustOrganLoss(ORGAN_SLOT_BRAIN, -1.5)
-			itemUser.adjustCloneLoss(-0.5) //Becasue apparently clone damage is the bastion of all health
+			itemUser.adjustBruteLoss(-5, FALSE)
+			itemUser.adjustFireLoss(-5, FALSE)
+			itemUser.adjustToxLoss(-5, FALSE, TRUE) //Because Slime People are people too
+			itemUser.adjustOxyLoss(-5, FALSE)
+			itemUser.adjustStaminaLoss(-5, FALSE)
+			itemUser.adjustOrganLoss(ORGAN_SLOT_BRAIN, -5)
+			itemUser.adjustCloneLoss(-1.5, FALSE) //Becasue apparently clone damage is the bastion of all health
+			itemUser.updatehealth() //after all healing is done, update health once
 		//Heal all those around you, unbiased
 		for(var/mob/living/L in view(7, owner))
+			if(L == owner)
+				continue
 			if(L.health < L.maxHealth)
 				new /obj/effect/temp_visual/heal(get_turf(L), "#375637")
 			if(iscarbon(L))
-				L.adjustBruteLoss(-3.5)
-				L.adjustFireLoss(-3.5)
-				L.adjustToxLoss(-3.5, forced = TRUE) //Because Slime People are people too
-				L.adjustOxyLoss(-3.5)
-				L.adjustStaminaLoss(-3.5)
+				L.adjustBruteLoss(-3.5, FALSE)
+				L.adjustFireLoss(-3.5, FALSE)
+				L.adjustToxLoss(-3.5, FALSE, TRUE) //Because Slime People are people too
+				L.adjustOxyLoss(-3.5, FALSE)
+				L.adjustStaminaLoss(-3.5, FALSE)
 				L.adjustOrganLoss(ORGAN_SLOT_BRAIN, -3.5)
-				L.adjustCloneLoss(-1) //Becasue apparently clone damage is the bastion of all health
+				L.adjustCloneLoss(-1, FALSE) //Becasue apparently clone damage is the bastion of all health
+				L.updatehealth() //after all healing is done, update health once
 			else if(issilicon(L))
-				L.adjustBruteLoss(-3.5)
-				L.adjustFireLoss(-3.5)
+				L.adjustBruteLoss(-3.5, FALSE)
+				L.adjustFireLoss(-3.5, FALSE)
+				L.updatehealth()
 			else if(isanimal(L))
 				var/mob/living/simple_animal/SM = L
 				SM.adjustHealth(-3.5, forced = TRUE)
-
 /datum/status_effect/hippocratic_oath/proc/consume_owner()
 	owner.visible_message("<span class='notice'>[owner]'s soul is absorbed into the rod, relieving the previous snake of its duty.</span>")
 	var/mob/living/simple_animal/hostile/retaliate/poison/snake/healSnake = new(owner.loc)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -271,8 +271,7 @@
 					itemUser.put_in_hand(newRod, hand, forced = TRUE)
 					to_chat(itemUser, "<span class='notice'>The Rod of Asclepius suddenly grows back out of your arm!</span>")
 			//Because a servant of medicines stops at nothing to help others, lets keep them on their toes and give them an additional boost.
-			if(itemUser.health < itemUser.maxHealth)
-				new /obj/effect/temp_visual/heal(get_turf(itemUser), "#375637")
+			var/last_user_health = itemUser.health
 			itemUser.adjustBruteLoss(-5, FALSE)
 			itemUser.adjustFireLoss(-5, FALSE)
 			itemUser.adjustToxLoss(-5, FALSE, TRUE) //Because Slime People are people too
@@ -280,13 +279,15 @@
 			itemUser.adjustStaminaLoss(-5, FALSE)
 			itemUser.adjustOrganLoss(ORGAN_SLOT_BRAIN, -5)
 			itemUser.adjustCloneLoss(-1.5, FALSE) //Becasue apparently clone damage is the bastion of all health
-			itemUser.updatehealth() //after all healing is done, update health once
+			if(last_user_health < itemUser.health) //if healing is done, update health once and do the effect
+				new /obj/effect/temp_visual/heal(get_turf(itemUser), "#375637")
+				itemUser.updatehealth()
 		//Heal all those around you, unbiased
 		for(var/mob/living/L in view(7, owner))
 			if(L == owner)
 				continue
-			if(L.health < L.maxHealth)
-				new /obj/effect/temp_visual/heal(get_turf(L), "#375637")
+
+			var/last_other_health = L.health
 			if(iscarbon(L))
 				L.adjustBruteLoss(-3.5, FALSE)
 				L.adjustFireLoss(-3.5, FALSE)
@@ -295,14 +296,17 @@
 				L.adjustStaminaLoss(-3.5, FALSE)
 				L.adjustOrganLoss(ORGAN_SLOT_BRAIN, -3.5)
 				L.adjustCloneLoss(-1, FALSE) //Becasue apparently clone damage is the bastion of all health
-				L.updatehealth() //after all healing is done, update health once
 			else if(issilicon(L))
 				L.adjustBruteLoss(-3.5, FALSE)
 				L.adjustFireLoss(-3.5, FALSE)
-				L.updatehealth()
 			else if(isanimal(L))
 				var/mob/living/simple_animal/SM = L
-				SM.adjustHealth(-3.5, forced = TRUE)
+				SM.adjustHealth(-3.5, FALSE, TRUE)
+
+			if(last_other_health < L.health) //if healing is done, update health once and do the effect
+				new /obj/effect/temp_visual/heal(get_turf(L), "#375637")
+				L.updatehealth()
+
 /datum/status_effect/hippocratic_oath/proc/consume_owner()
 	owner.visible_message("<span class='notice'>[owner]'s soul is absorbed into the rod, relieving the previous snake of its duty.</span>")
 	var/mob/living/simple_animal/hostile/retaliate/poison/snake/healSnake = new(owner.loc)


### PR DESCRIPTION
## About The Pull Request

The Rod of Asclepius calls update health 6 times for the user, then 6 times for the user again since they were considered in their own view, every tick (even at full health for now)

it also updates the health of every mob in view 6 times every tick. yikes.

so, this removes 10 of the 12 superfluous update health calls.

Closed cause Shiz is taking over updateHealth stuff and doing a much better job at it

## Why It's Good For The Game

this should also help cut back on update health calls.

## Changelog
:cl: Melbert
code: Rod of Asclepius calls update health all at once, instead of 6 times per mob
/:cl:

