### PR TITLE
add_vis_overlay always return overlay

### DIFF
--- a/code/controllers/subsystem/vis_overlays.dm
+++ b/code/controllers/subsystem/vis_overlays.dm
@@ -47,17 +47,18 @@ SUBSYSTEM_DEF(vis_overlays)
 		var/cache_id = "\ref[overlay]@{[world.time]}"
 		unique_vis_overlays += overlay
 		vis_overlay_cache[cache_id] = overlay
-	. = overlay
+		. = overlay
 	thing.vis_contents += overlay
 
 	if(!isatom(thing)) // Automatic rotation is not supported on non atoms
-		return
+		return overlay
 
 	if(!thing.managed_vis_overlays)
 		thing.managed_vis_overlays = list(overlay)
 		RegisterSignal(thing, COMSIG_ATOM_DIR_CHANGE, .proc/rotate_vis_overlay)
 	else
 		thing.managed_vis_overlays += overlay
+	return overlay
 
 /datum/controller/subsystem/vis_overlays/proc/_create_new_vis_overlay(icon, iconstate, layer, plane, dir, alpha, add_appearance_flags)
 	var/obj/effect/overlay/vis/overlay = new

--- a/code/controllers/subsystem/vis_overlays.dm
+++ b/code/controllers/subsystem/vis_overlays.dm
@@ -47,7 +47,7 @@ SUBSYSTEM_DEF(vis_overlays)
 		var/cache_id = "\ref[overlay]@{[world.time]}"
 		unique_vis_overlays += overlay
 		vis_overlay_cache[cache_id] = overlay
-		. = overlay
+	. = overlay
 	thing.vis_contents += overlay
 
 	if(!isatom(thing)) // Automatic rotation is not supported on non atoms


### PR DESCRIPTION
## About The Pull Request

add_vis_overlay always return overlay
@actioninja say me please if i doing something wrong.

## Why It's Good For The Game

add_vis_overlay always return overlay instead of
`"[icon]|[iconstate]|[layer]|[plane]|[dir]|[alpha]|[add_appearance_flags]"`
when overlay not unique

## Changelog

i think so small fix dont need a changelog.
