### PR TITLE
Prevent duplicate names for vents and scrubbers in the air alarm

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -41,3 +41,6 @@ GLOBAL_LIST_EMPTY(ai_status_displays)
 
 GLOBAL_LIST_EMPTY(mob_spawners) 		    // All mob_spawn objects
 GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/computer/station_alert
+
+GLOBAL_LIST_EMPTY(air_scrub_names)			// Name list of all air scrubbers
+GLOBAL_LIST_EMPTY(air_vent_names)			// Name list of all air vents

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -612,7 +612,7 @@ Class Procs:
  * Returns (string) The generated name
  */
 /obj/machinery/proc/assign_random_name(len=5)
-	var/new_name = ""
+	var/list/new_name = list()
 	// machine id's should be fun random chars hinting at a larger world
 	for(var/i = 1 to len)
 		switch(rand(1,3))
@@ -622,4 +622,4 @@ Class Procs:
 				new_name += ascii2text(rand(97,122)) // a - z
 			if(3)
 				new_name += ascii2text(rand(48, 57)) // 0 - 9
-	return new_name
+	return new_name.Join()

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -601,3 +601,25 @@ Class Procs:
 
 /obj/machinery/rust_heretic_act()
 	take_damage(500, BRUTE, "melee", 1)
+
+/**
+ * Generate a name devices
+ *
+ * Creates a randomly generated tag or name for devices5
+ * The length of the generated name can be set by passing in an int
+ * args:
+ * * len (int)(Optional) Default=5 The length of the name
+ * Returns (string) The generated name
+ */
+/obj/machinery/proc/assign_random_name(len=5)
+	var/new_name = ""
+	// machine id's should be fun random chars hinting at a larger world
+	for(var/i = 1 to len)
+		switch(rand(1,3))
+			if(1)
+				new_name += ascii2text(rand(65, 90)) // A - Z
+			if(2)
+				new_name += ascii2text(rand(97,122)) // a - z
+			if(3)
+				new_name += ascii2text(rand(48, 57)) // 0 - 9
+	return new_name

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -192,8 +192,6 @@
 
 //all air alarms in area are connected via magic
 /area
-	var/list/air_vent_names = list()
-	var/list/air_scrub_names = list()
 	var/list/air_vent_info = list()
 	var/list/air_scrub_info = list()
 
@@ -296,8 +294,8 @@
 
 	if(!locked || user.has_unlimited_silicon_privilege)
 		data["vents"] = list()
-		for(var/id_tag in A.air_vent_names)
-			var/long_name = A.air_vent_names[id_tag]
+		for(var/id_tag in A.air_vent_info)
+			var/long_name = GLOB.air_vent_names[id_tag]
 			var/list/info = A.air_vent_info[id_tag]
 			if(!info || info["frequency"] != frequency)
 				continue
@@ -315,8 +313,8 @@
 					"intdefault"= (info["internal"] == 0)
 				))
 		data["scrubbers"] = list()
-		for(var/id_tag in A.air_scrub_names)
-			var/long_name = A.air_scrub_names[id_tag]
+		for(var/id_tag in A.air_scrub_info)
+			var/long_name = GLOB.air_scrub_names[id_tag]
 			var/list/info = A.air_scrub_info[id_tag]
 			if(!info || info["frequency"] != frequency)
 				continue
@@ -503,21 +501,21 @@
 	var/area/A = get_area(src)
 	switch(mode)
 		if(AALARM_MODE_SCRUBBING)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"set_filters" = list(/datum/gas/carbon_dioxide),
 					"scrubbing" = 1,
 					"widenet" = 0
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"checks" = 1,
 					"set_external_pressure" = ONE_ATMOSPHERE
 				), signal_source)
 		if(AALARM_MODE_CONTAMINATED)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"set_filters" = list(
@@ -538,34 +536,34 @@
 					"scrubbing" = 1,
 					"widenet" = 1
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"checks" = 1,
 					"set_external_pressure" = ONE_ATMOSPHERE
 				), signal_source)
 		if(AALARM_MODE_VENTING)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"widenet" = 0,
 					"scrubbing" = 0
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"checks" = 1,
 					"set_external_pressure" = ONE_ATMOSPHERE*2
 				), signal_source)
 		if(AALARM_MODE_REFILL)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"set_filters" = list(/datum/gas/carbon_dioxide),
 					"scrubbing" = 1,
 					"widenet" = 0
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"checks" = 1,
@@ -573,43 +571,43 @@
 				), signal_source)
 		if(AALARM_MODE_PANIC,
 			AALARM_MODE_REPLACEMENT)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"widenet" = 1,
 					"scrubbing" = 0
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 0
 				), signal_source)
 		if(AALARM_MODE_SIPHON)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"widenet" = 0,
 					"scrubbing" = 0
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 0
 				), signal_source)
 
 		if(AALARM_MODE_OFF)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 0
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 0
 				), signal_source)
 		if(AALARM_MODE_FLOOD)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 0
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"checks" = 2,

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -192,6 +192,8 @@
 
 //all air alarms in area are connected via magic
 /area
+	var/list/air_vent_ids = list()
+	var/list/air_scrub_ids = list()
 	var/list/air_vent_names = list()
 	var/list/air_scrub_names = list()
 	var/list/air_vent_info = list()

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -192,8 +192,6 @@
 
 //all air alarms in area are connected via magic
 /area
-	var/list/air_vent_ids = list()
-	var/list/air_scrub_ids = list()
 	var/list/air_vent_names = list()
 	var/list/air_scrub_names = list()
 	var/list/air_vent_info = list()
@@ -298,9 +296,7 @@
 
 	if(!locked || user.has_unlimited_silicon_privilege)
 		data["vents"] = list()
-		for(var/id_tag in A.air_vent_ids)
-			if(!id_tag)
-				continue
+		for(var/id_tag in A.air_vent_names)
 			var/long_name = A.air_vent_names[id_tag]
 			var/list/info = A.air_vent_info[id_tag]
 			if(!info || info["frequency"] != frequency)
@@ -319,9 +315,7 @@
 					"intdefault"= (info["internal"] == 0)
 				))
 		data["scrubbers"] = list()
-		for(var/id_tag in A.air_scrub_ids)
-			if(!id_tag)
-				continue
+		for(var/id_tag in A.air_scrub_names)
 			var/long_name = A.air_scrub_names[id_tag]
 			var/list/info = A.air_scrub_info[id_tag]
 			if(!info || info["frequency"] != frequency)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -298,7 +298,9 @@
 
 	if(!locked || user.has_unlimited_silicon_privilege)
 		data["vents"] = list()
-		for(var/id_tag in A.air_vent_names)
+		for(var/id_tag in A.air_vent_ids)
+			if(!id_tag)
+				continue
 			var/long_name = A.air_vent_names[id_tag]
 			var/list/info = A.air_vent_info[id_tag]
 			if(!info || info["frequency"] != frequency)
@@ -317,7 +319,9 @@
 					"intdefault"= (info["internal"] == 0)
 				))
 		data["scrubbers"] = list()
-		for(var/id_tag in A.air_scrub_names)
+		for(var/id_tag in A.air_scrub_ids)
+			if(!id_tag)
+				continue
 			var/long_name = A.air_scrub_names[id_tag]
 			var/list/info = A.air_scrub_info[id_tag]
 			if(!info || info["frequency"] != frequency)

--- a/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
@@ -18,3 +18,25 @@
 /obj/machinery/atmospherics/components/unary/proc/assign_uid_vents()
 	uid = num2text(gl_uid++)
 	return uid
+
+/**
+ * Assign a name to unary devices
+ *
+ * Creates a randomly generated tag for a unary devices based on the passed in name prefix
+ * appending a 5 character random tag to the end.
+ * This makes the devices show up seperatly in air alarms and have a unique name on mouse over.
+ * args:
+ * * proper_name (string) The prefix for the name
+ * Returns (string) The generated name
+ */
+/obj/machinery/atmospherics/components/unary/proc/assign_random_name(proper_name)
+	var/new_name = proper_name
+	for(var/i = 1 to 5)
+		switch(rand(1,3))
+			if(1)
+				new_name += ascii2text(rand(65, 90)) // A - Z
+			if(2)
+				new_name += ascii2text(rand(97,122)) // a - z
+			if(3)
+				new_name += ascii2text(rand(48, 57)) // 0 - 9
+	return new_name

--- a/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
@@ -18,25 +18,3 @@
 /obj/machinery/atmospherics/components/unary/proc/assign_uid_vents()
 	uid = num2text(gl_uid++)
 	return uid
-
-/**
- * Assign a name to unary devices
- *
- * Creates a randomly generated tag for a unary devices based on the passed in name prefix
- * appending a 5 character random tag to the end.
- * This makes the devices show up seperatly in air alarms and have a unique name on mouse over.
- * args:
- * * proper_name (string) The prefix for the name
- * Returns (string) The generated name
- */
-/obj/machinery/atmospherics/components/unary/proc/assign_random_name(proper_name)
-	var/new_name = proper_name
-	for(var/i = 1 to 5)
-		switch(rand(1,3))
-			if(1)
-				new_name += ascii2text(rand(65, 90)) // A - Z
-			if(2)
-				new_name += ascii2text(rand(97,122)) // a - z
-			if(3)
-				new_name += ascii2text(rand(48, 57)) // 0 - 9
-	return new_name

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -159,8 +159,8 @@
 
 	var/area/vent_area = get_area(src)
 	if(!vent_area.air_vent_names[id_tag])
-		// If we do not have a name assign a random tag
-		name = assign_random_name("\improper [vent_area.name] vent pump ")
+		// If we do not have a name, assign one
+		name = "[assign_random_name()] [vent_area.name] vent pump"
 		vent_area.air_vent_names[id_tag] = name
 
 	vent_area.air_vent_info[id_tag] = signal.data

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -43,7 +43,7 @@
 	var/area/vent_area = get_area(src)
 	if(vent_area)
 		vent_area.air_vent_info -= id_tag
-		vent_area.air_vent_names -= id_tag
+		GLOB.air_vent_names -= id_tag
 
 	SSradio.remove_object(src,frequency)
 	radio_connection = null
@@ -158,10 +158,10 @@
 	))
 
 	var/area/vent_area = get_area(src)
-	if(!vent_area.air_vent_names[id_tag])
+	if(!GLOB.air_vent_names[id_tag])
 		// If we do not have a name, assign one
 		name = "[assign_random_name()] [vent_area.name] Vent Pump" // matching case
-		vent_area.air_vent_names[id_tag] = name
+		GLOB.air_vent_names[id_tag] = name
 
 	vent_area.air_vent_info[id_tag] = signal.data
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -42,10 +42,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/Destroy()
 	var/area/vent_area = get_area(src)
 	if(vent_area)
-		for(var/i=vent_area.air_vent_ids.len, i>0, i--)
-			if(vent_area.air_vent_ids[i] == id_tag)
-				vent_area.air_vent_ids[i] = null
-				break
 		vent_area.air_vent_info -= id_tag
 		vent_area.air_vent_names -= id_tag
 
@@ -163,17 +159,8 @@
 
 	var/area/vent_area = get_area(src)
 	if(!vent_area.air_vent_names[id_tag])
-		var/ids_len = vent_area.air_vent_ids.len + 1
-		var/selected_id
-		for(var/i=1, i<ids_len, i++)
-			if(!vent_area.air_vent_ids[i])
-				vent_area.air_vent_ids[i] = id_tag
-				selected_id = i
-				break
-		if(!selected_id)
-			vent_area.air_vent_ids += id_tag
-			selected_id = ids_len
-		name = "\improper [vent_area.name] vent pump #[selected_id]"
+		// If we do not have a name assign a random tag
+		name = assign_random_name("\improper [vent_area.name] vent pump ")
 		vent_area.air_vent_names[id_tag] = name
 
 	vent_area.air_vent_info[id_tag] = signal.data

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -39,18 +39,6 @@
 	if(!id_tag)
 		id_tag = assign_uid_vents()
 
-	var/area/vent_area = get_area(src)
-	var/ids_len = vent_area.air_vent_ids.len + 1
-	var/vent_name = "\improper [vent_area.name] vent pump #"
-	for(var/i=1, i<ids_len, i++)
-		if(!vent_area.air_vent_ids[i])
-			vent_area.air_vent_ids[i] = id_tag
-			vent_area.air_vent_names[id_tag] = "[vent_name][i]"
-			break
-	if(!vent_area.air_vent_names[id_tag])
-		vent_area.air_vent_ids += id_tag
-		vent_area.air_vent_names[id_tag] = "[vent_name][ids_len]"
-
 /obj/machinery/atmospherics/components/unary/vent_pump/Destroy()
 	var/area/vent_area = get_area(src)
 	if(vent_area)
@@ -174,6 +162,20 @@
 	))
 
 	var/area/vent_area = get_area(src)
+	if(!vent_area.air_vent_names[id_tag])
+		var/ids_len = vent_area.air_vent_ids.len + 1
+		var/selected_id
+		for(var/i=1, i<ids_len, i++)
+			if(!vent_area.air_vent_ids[i])
+				vent_area.air_vent_ids[i] = id_tag
+				selected_id = i
+				break
+		if(!selected_id)
+			vent_area.air_vent_ids += id_tag
+			selected_id = ids_len
+		name = "\improper [vent_area.name] vent pump #[selected_id]"
+		vent_area.air_vent_names[id_tag] = name
+
 	vent_area.air_vent_info[id_tag] = signal.data
 
 	radio_connection.post_signal(src, signal, radio_filter_out)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -159,8 +159,21 @@
 
 	var/area/A = get_area(src)
 	if(!A.air_vent_names[id_tag])
-		name = "\improper [A.name] vent pump #[A.air_vent_names.len + 1]"
-		A.air_vent_names[id_tag] = name
+		var/valid_name = TRUE
+		var/vent_number = A.air_vent_names.len + 1
+		while(TRUE)
+			name = "\improper [A.name] vent pump #[vent_number]"
+			for(var/check_id_tag in A.air_vent_names)
+				var/check_name = A.air_vent_names[check_id_tag]
+				if(check_name == name)
+					valid_name = FALSE
+					vent_number += 1
+					break
+			if(valid_name)
+				A.air_vent_names[id_tag] = name
+				break
+			valid_name = TRUE
+
 	A.air_vent_info[id_tag] = signal.data
 
 	radio_connection.post_signal(src, signal, radio_filter_out)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -159,20 +159,17 @@
 
 	var/area/A = get_area(src)
 	if(!A.air_vent_names[id_tag])
-		var/valid_name = TRUE
-		var/vent_number = A.air_vent_names.len + 1
+		var/name_list = list()
+		for(var/id_tag in A.air_vent_names)
+			name_list += A.air_vent_names[id_tag]
+
+		var/vent_number = 1
 		while(TRUE)
 			name = "\improper [A.name] vent pump #[vent_number]"
-			for(var/check_id_tag in A.air_vent_names)
-				var/check_name = A.air_vent_names[check_id_tag]
-				if(check_name == name)
-					valid_name = FALSE
-					vent_number += 1
-					break
-			if(valid_name)
+			if(!(name in name_list))
 				A.air_vent_names[id_tag] = name
 				break
-			valid_name = TRUE
+			vent_number += 1
 
 	A.air_vent_info[id_tag] = signal.data
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -160,7 +160,7 @@
 	var/area/vent_area = get_area(src)
 	if(!vent_area.air_vent_names[id_tag])
 		// If we do not have a name, assign one
-		name = "[assign_random_name()] [vent_area.name] vent pump"
+		name = "[assign_random_name()] [vent_area.name] Vent Pump" // matching case
 		vent_area.air_vent_names[id_tag] = name
 
 	vent_area.air_vent_info[id_tag] = signal.data

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -39,11 +39,27 @@
 	if(!id_tag)
 		id_tag = assign_uid_vents()
 
+	var/area/vent_area = get_area(src)
+	var/ids_len = vent_area.air_vent_ids.len + 1
+	var/vent_name = "\improper [vent_area.name] vent pump #"
+	for(var/i=1, i<ids_len, i++)
+		if(!vent_area.air_vent_ids[i])
+			vent_area.air_vent_ids[i] = id_tag
+			vent_area.air_vent_names[id_tag] = "[vent_name][i]"
+			break
+	if(!vent_area.air_vent_names[id_tag])
+		vent_area.air_vent_ids += id_tag
+		vent_area.air_vent_names[id_tag] = "[vent_name][ids_len]"
+
 /obj/machinery/atmospherics/components/unary/vent_pump/Destroy()
-	var/area/A = get_area(src)
-	if (A)
-		A.air_vent_names -= id_tag
-		A.air_vent_info -= id_tag
+	var/area/vent_area = get_area(src)
+	if(vent_area)
+		for(var/i=vent_area.air_vent_ids.len, i>0, i--)
+			if(vent_area.air_vent_ids[i] == id_tag)
+				vent_area.air_vent_ids[i] = null
+				break
+		vent_area.air_vent_info -= id_tag
+		vent_area.air_vent_names -= id_tag
 
 	SSradio.remove_object(src,frequency)
 	radio_connection = null
@@ -157,21 +173,8 @@
 		"sigtype" = "status"
 	))
 
-	var/area/A = get_area(src)
-	if(!A.air_vent_names[id_tag])
-		var/name_list = list()
-		for(var/id_tag in A.air_vent_names)
-			name_list += A.air_vent_names[id_tag]
-
-		var/vent_number = 1
-		while(TRUE)
-			name = "\improper [A.name] vent pump #[vent_number]"
-			if(!(name in name_list))
-				A.air_vent_names[id_tag] = name
-				break
-			vent_number += 1
-
-	A.air_vent_info[id_tag] = signal.data
+	var/area/vent_area = get_area(src)
+	vent_area.air_vent_info[id_tag] = signal.data
 
 	radio_connection.post_signal(src, signal, radio_filter_out)
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -116,20 +116,17 @@
 
 	var/area/A = get_area(src)
 	if(!A.air_scrub_names[id_tag])
-		var/valid_name = TRUE
-		var/scrubber_number = A.air_scrub_names.len + 1
+		var/name_list = list()
+		for(var/id_tag in A.air_scrub_names)
+			name_list += A.air_scrub_names[id_tag]
+
+		var/scrubber_number = 1
 		while(TRUE)
 			name = "\improper [A.name] air scrubber #[scrubber_number]"
-			for(var/check_id_tag in A.air_scrub_names)
-				var/check_name = A.air_scrub_names[check_id_tag]
-				if(check_name == name)
-					valid_name = FALSE
-					scrubber_number += 1
-					break
-			if(valid_name)
+			if(!(name in name_list))
 				A.air_scrub_names[id_tag] = name
 				break
-			valid_name = TRUE
+			scrubber_number += 1
 
 	A.air_scrub_info[id_tag] = signal.data
 	radio_connection.post_signal(src, signal, radio_filter_out)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -117,7 +117,7 @@
 	var/area/scrub_area = get_area(src)
 	if(!scrub_area.air_scrub_names[id_tag])
 		// If we do not have a name, assign one
-		name = "[assign_random_name()] [scrub_area.name] air scrubber"
+		name = "[assign_random_name()] [scrub_area.name] Air Scrubber" // matching case
 		scrub_area.air_scrub_names[id_tag] = name
 
 	scrub_area.air_scrub_info[id_tag] = signal.data

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -116,8 +116,8 @@
 
 	var/area/scrub_area = get_area(src)
 	if(!scrub_area.air_scrub_names[id_tag])
-		// If we do not have a name assign a random tag
-		name = assign_random_name("\improper [scrub_area.name] air scrubber ")
+		// If we do not have a name, assign one
+		name = "[assign_random_name()] [scrub_area.name] air scrubber"
 		scrub_area.air_scrub_names[id_tag] = name
 
 	scrub_area.air_scrub_info[id_tag] = signal.data

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -34,18 +34,6 @@
 	if(!id_tag)
 		id_tag = assign_uid_vents()
 
-	var/area/scrub_area = get_area(src)
-	var/ids_len = scrub_area.air_scrub_ids.len + 1
-	var/scrub_name = "\improper [scrub_area.name] air scrubber #"
-	for(var/i=1, i<ids_len, i++)
-		if(!scrub_area.air_scrub_ids[i])
-			scrub_area.air_scrub_ids[i] = id_tag
-			scrub_area.air_scrub_names[id_tag] = "[scrub_name][i]"
-			break
-	if(!scrub_area.air_scrub_names[id_tag])
-		scrub_area.air_scrub_ids += id_tag
-		scrub_area.air_scrub_names[id_tag] = "[scrub_name][ids_len]"
-
 	for(var/f in filter_types)
 		if(istext(f))
 			filter_types -= f
@@ -131,6 +119,20 @@
 	))
 
 	var/area/scrub_area = get_area(src)
+	if(!scrub_area.air_scrub_names[id_tag])
+		var/ids_len = scrub_area.air_scrub_ids.len + 1
+		var/selected_id
+		for(var/i=1, i<ids_len, i++)
+			if(!scrub_area.air_scrub_ids[i])
+				scrub_area.air_scrub_ids[i] = id_tag
+				selected_id = i
+				break
+		if(!selected_id)
+			scrub_area.air_scrub_ids += id_tag
+			selected_id = ids_len
+		name = "\improper [scrub_area.name] air scrubber #[selected_id]"
+		scrub_area.air_scrub_names[id_tag] = name
+
 	scrub_area.air_scrub_info[id_tag] = signal.data
 
 	radio_connection.post_signal(src, signal, radio_filter_out)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -116,8 +116,20 @@
 
 	var/area/A = get_area(src)
 	if(!A.air_scrub_names[id_tag])
-		name = "\improper [A.name] air scrubber #[A.air_scrub_names.len + 1]"
-		A.air_scrub_names[id_tag] = name
+		var/valid_name = TRUE
+		var/scrubber_number = A.air_scrub_names.len + 1
+		while(TRUE)
+			name = "\improper [A.name] air scrubber #[scrubber_number]"
+			for(var/check_id_tag in A.air_scrub_names)
+				var/check_name = A.air_scrub_names[check_id_tag]
+				if(check_name == name)
+					valid_name = FALSE
+					scrubber_number += 1
+					break
+			if(valid_name)
+				A.air_scrub_names[id_tag] = name
+				break
+			valid_name = TRUE
 
 	A.air_scrub_info[id_tag] = signal.data
 	radio_connection.post_signal(src, signal, radio_filter_out)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -43,7 +43,7 @@
 	var/area/scrub_area = get_area(src)
 	if(scrub_area)
 		scrub_area.air_scrub_info -= id_tag
-		scrub_area.air_scrub_names -= id_tag
+		GLOB.air_scrub_names -= id_tag
 
 	SSradio.remove_object(src,frequency)
 	radio_connection = null
@@ -115,10 +115,10 @@
 	))
 
 	var/area/scrub_area = get_area(src)
-	if(!scrub_area.air_scrub_names[id_tag])
+	if(!GLOB.air_scrub_names[id_tag])
 		// If we do not have a name, assign one
 		name = "[assign_random_name()] [scrub_area.name] Air Scrubber" // matching case
-		scrub_area.air_scrub_names[id_tag] = name
+		GLOB.air_scrub_names[id_tag] = name
 
 	scrub_area.air_scrub_info[id_tag] = signal.data
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -42,10 +42,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/Destroy()
 	var/area/scrub_area = get_area(src)
 	if(scrub_area)
-		for(var/i=scrub_area.air_scrub_ids.len, i>0, i--)
-			if(scrub_area.air_scrub_ids[i] == id_tag)
-				scrub_area.air_scrub_ids[i] = null
-				break
 		scrub_area.air_scrub_info -= id_tag
 		scrub_area.air_scrub_names -= id_tag
 
@@ -120,17 +116,8 @@
 
 	var/area/scrub_area = get_area(src)
 	if(!scrub_area.air_scrub_names[id_tag])
-		var/ids_len = scrub_area.air_scrub_ids.len + 1
-		var/selected_id
-		for(var/i=1, i<ids_len, i++)
-			if(!scrub_area.air_scrub_ids[i])
-				scrub_area.air_scrub_ids[i] = id_tag
-				selected_id = i
-				break
-		if(!selected_id)
-			scrub_area.air_scrub_ids += id_tag
-			selected_id = ids_len
-		name = "\improper [scrub_area.name] air scrubber #[selected_id]"
+		// If we do not have a name assign a random tag
+		name = assign_random_name("\improper [scrub_area.name] air scrubber ")
 		scrub_area.air_scrub_names[id_tag] = name
 
 	scrub_area.air_scrub_info[id_tag] = signal.data


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It is always a pain adding in a new vent or scrubber to an area and suddenly you have duplicate names.
This prevents duplicate names for vents and scrubbers in an area.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes engineering's life better, duplicate names are bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Prevent duplicate vent and scrubber names in the air alarm interface.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
