### PR TITLE
Fixes wires and extinguisher hard dels

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -37,6 +37,7 @@
 		CRASH("Wire holder is not of the expected type!")
 
 	src.holder = holder
+	RegisterSignal(holder, COMSIG_PARENT_QDELETING, .proc/on_holder_qdel)
 	if(randomize)
 		randomize()
 	else
@@ -58,6 +59,12 @@
 		if(dud in wires)
 			continue
 		wires += dud
+
+
+///Called when holder is qdeleted for us to clean ourselves as not to leave any unlawful references.
+/datum/wires/proc/on_holder_qdel(atom/source, force)
+	qdel(src)
+
 
 /datum/wires/proc/randomize()
 	var/static/list/possible_colors = list(

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -42,6 +42,8 @@
 	dog_fashion = null
 
 /obj/item/extinguisher/proc/refill()
+	if(!chem)
+		return
 	create_reagents(max_water, AMOUNT_VISIBLE)
 	reagents.add_reagent(chem, max_water)
 

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -23,6 +23,12 @@
 	create_reagents(volume, OPENCONTAINER)
 	noz = make_noz()
 
+
+/obj/item/watertank/Destroy()
+	QDEL_NULL(noz)
+	return ..()
+
+
 /obj/item/watertank/ui_action_click(mob/user)
 	toggle_mister(user)
 
@@ -69,10 +75,6 @@
 			var/mob/M = noz.loc
 			M.temporarilyRemoveItemFromInventory(noz, TRUE)
 		noz.forceMove(src)
-
-/obj/item/watertank/Destroy()
-	QDEL_NULL(noz)
-	return ..()
 
 /obj/item/watertank/attack_hand(mob/user)
 	if (user.get_item_by_slot(user.getBackSlot()) == src)
@@ -217,6 +219,7 @@
 	cooling_power = 5
 	w_class = WEIGHT_CLASS_HUGE
 	item_flags = ABSTRACT  // don't put in storage
+	chem = null //holds no chems of its own, it takes from the tank.
 	var/obj/item/watertank/tank
 	var/nozzle_mode = 0
 	var/metal_synthesis_cooldown = 0
@@ -229,6 +232,12 @@
 		return INITIALIZE_HINT_QDEL
 	reagents = tank.reagents
 	max_water = tank.volume
+
+
+/obj/item/extinguisher/mini/nozzle/Destroy()
+	reagents = null //This is a borrowed reference from the tank.
+	tank = null
+	return ..()
 
 
 /obj/item/extinguisher/mini/nozzle/doMove(atom/destination)


### PR DESCRIPTION
* Wire datums were keeping an uncleaned a reference on whatever holder they had, causing them to hard delete.

* Extinguisher nozzle were making their own reagents datum and then using the tank's. Neither were being properly cleaned, so it all hard deleted.