### PR TITLE
Reduces possible cargo express pod spam

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -27,6 +27,7 @@
 
 //INDEXES
 #define COOLDOWN_BORG_SELF_REPAIR	"borg_self_repair"
+#define COOLDOWN_EXPRESSPOD_CONSOLE "expresspod_console"
 
 
 //TIMER COOLDOWN MACROS

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -1,4 +1,4 @@
-#define MAX_EMAG_ROCKETS 8
+#define MAX_EMAG_ROCKETS 5
 #define BEACON_COST 500
 #define SP_LINKED 1
 #define SP_READY 2
@@ -149,6 +149,9 @@
 
 
 		if("add")//Generate Supply Order first
+			if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_EXPRESSPOD_CONSOLE))
+				say("Railgun recalibrating. Stand by.")
+				return
 			var/id = text2path(params["id"])
 			var/datum/supply_pack/pack = SSshuttle.supply_packs[id]
 			if(!istype(pack))
@@ -189,6 +192,7 @@
 						if(empty_turfs && empty_turfs.len)
 							LZ = pick(empty_turfs)
 					if (SO.pack.cost <= points_to_check && LZ)//we need to call the cost check again because of the CHECK_TICK call
+						TIMER_COOLDOWN_START(src, COOLDOWN_EXPRESSPOD_CONSOLE, 5 SECONDS)
 						D.adjust_money(-SO.pack.cost)
 						new /obj/effect/pod_landingzone(LZ, podType, SO)
 						. = TRUE
@@ -202,6 +206,7 @@
 						LAZYADD(empty_turfs, T)
 						CHECK_TICK
 					if(empty_turfs && empty_turfs.len)
+						TIMER_COOLDOWN_START(src, COOLDOWN_EXPRESSPOD_CONSOLE, 10 SECONDS)
 						D.adjust_money(-(SO.pack.cost * (0.72*MAX_EMAG_ROCKETS)))
 
 						SO.generateRequisition(get_turf(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a cooldown to the express supply console to limit the amount of pod spam possible. Sets the cooldown to 5 seconds for non emagged and 10 seconds for emagged. Emagged pod amount down from 8 to 5.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The pod spam has proven to be bad enough to cause severe server impact.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
tweak: Express supply console has had emagged pod amount reduced slightly and now has a cooldown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
