### PR TITLE
Fixes cyborg cycling (and a runtime with uneq_active)

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -326,6 +326,7 @@
 			if(module_active != held_items[module_num])
 				inv3.icon_state = "[initial(inv3.icon_state)] +a"
 	module_active = held_items[module_num]
+	return TRUE
 
 /**
   * Deselects the module in the slot module_num.
@@ -344,6 +345,7 @@
 			if(module_active == held_items[module_num])
 				inv3.icon_state = initial(inv3.icon_state)
 	module_active = null
+	return TRUE
 
 /**
   * Toggles selection of the module in the slot module_num.

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -246,10 +246,11 @@
 					break
 
 /**
-  * Unequips the active held item.
+  * Unequips the active held item, if there is one.
   */
 /mob/living/silicon/robot/proc/uneq_active()
-	unequip_module_from_slot(module_active, get_selected_module())
+	if(module_active)
+		unequip_module_from_slot(module_active, get_selected_module())
 
 /**
   * Unequips all held items.


### PR DESCRIPTION
## About The Pull Request

Some silly man forgot some `return TRUE` in some procs in his refactor and kinda broke cycling a bit

also fixes a runtime involving calling uneq_active with no active modules - Closes #52431

## Why It's Good For The Game

cyborg mains are outside my house with torches and pitchforks

## Changelog
:cl: Melbert
fix: Fixes cyborg slot cycling (and a runtime)
/:cl:
