### PR TITLE
Paper cash stacks visually with it's value.

### DIFF
--- a/code/game/objects/items/stacks/cash.dm
+++ b/code/game/objects/items/stacks/cash.dm
@@ -20,18 +20,43 @@
 
 /obj/item/stack/spacecash/proc/update_desc()
 	var/total_worth = get_item_credit_value()
-	desc = "It's worth [total_worth] credit[( total_worth > 1 ) ? "s" : ""]"
+	desc = "It's worth [total_worth] credit[( total_worth > 1 ) ? "s" : ""] each."
 
 /obj/item/stack/spacecash/get_item_credit_value()
 	return (amount*value)
 
 /obj/item/stack/spacecash/merge(obj/item/stack/S)
 	. = ..()
+	update_icon_state()
 	update_desc()
 
 /obj/item/stack/spacecash/use(used, transfer = FALSE)
 	. = ..()
+	update_icon_state()
 	update_desc()
+
+/obj/item/stack/spacecash/update_icon_state()
+	. = ..()
+	var/cash_value = get_item_credit_value()
+	switch(cash_value)
+		if(1 to 9)
+			icon_state = "spacecash"
+		if(10 to 19)
+			icon_state = "spacecash10"
+		if(20 to 49)
+			icon_state = "spacecash20"
+		if(50 to 99)
+			icon_state = "spacecash50"
+		if(100 to 199)
+			icon_state = "spacecash100"
+		if(200 to 499)
+			icon_state = "spacecash200"
+		if(500 to 999)
+			icon_state = "spacecash500"
+		if(1000 to 9999)
+			icon_state = "spacecash1000"
+		if(10000 to INFINITY)
+			icon_state = "spacecash10000"
 
 /obj/item/stack/spacecash/c1
 	icon_state = "spacecash"

--- a/code/game/objects/items/stacks/cash.dm
+++ b/code/game/objects/items/stacks/cash.dm
@@ -20,23 +20,20 @@
 
 /obj/item/stack/spacecash/proc/update_desc()
 	var/total_worth = get_item_credit_value()
-	desc = "It's worth [total_worth] credit[( total_worth > 1 ) ? "s" : ""] each."
+	desc = "It's worth [total_worth] credit[( total_worth > 1 ) ? "s" : ""] in total."
 
 /obj/item/stack/spacecash/get_item_credit_value()
 	return (amount*value)
 
 /obj/item/stack/spacecash/merge(obj/item/stack/S)
 	. = ..()
-	update_icon_state()
 	update_desc()
 
 /obj/item/stack/spacecash/use(used, transfer = FALSE)
 	. = ..()
-	update_icon_state()
 	update_desc()
 
 /obj/item/stack/spacecash/update_icon_state()
-	. = ..()
 	var/cash_value = get_item_credit_value()
 	switch(cash_value)
 		if(1 to 9)


### PR DESCRIPTION

## About The Pull Request

![image](https://user-images.githubusercontent.com/41715314/88155107-a7170e00-cbd5-11ea-9f4a-516a159a5568.png)
_The top row is single bills of all the various values, while the bottom row is stacks with the same value, made of multiple smaller bills._
I've changed the update_icon_state proc for paper money, so that multiple bills when combined, will visually display their icon associated with the closest paper bill in value, similar to how holocredits update their icon based on value ranges. If nothing else, it improves the clarity of how much a stack of bills is worth, if you even manage to get enough paper bills.

## Why It's Good For The Game

Resolves #31928 considering that space cash is more of a tertiary source of money in the current system anyway, but at least the visual clarity when using it is improved for player use.

## Changelog
:cl:
fix: Paper cash, when stacked, now displays an icon scaling with it's appropriate value.
/:cl:
