### PR TITLE
Fixes for clown op reinforcements

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -143,11 +143,8 @@
 	antag_datum.send_to_spawnpoint = FALSE
 	antag_datum.nukeop_outfit = outfit
 
-	var/datum/antagonist/nukeop/creator_op = user.has_antag_datum(antag_datum, TRUE)
-	if(creator_op)
-		op_mind.add_antag_datum(antag_datum, creator_op.nuke_team)
-	else
-		op_mind.add_antag_datum(antag_datum)
+	var/datum/antagonist/nukeop/creator_op = user.has_antag_datum(/datum/antagonist/nukeop, TRUE)
+	op_mind.add_antag_datum(antag_datum, creator_op ? creator_op.nuke_team : null)
 	op_mind.special_role = special_role_name
 
 //////CLOWN OP

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -134,15 +134,18 @@
 	var/mob/living/carbon/human/M = new/mob/living/carbon/human(T)
 	C.prefs.copy_to(M)
 	M.key = C.key
+	var/datum/mind/op_mind = M.mind
 
 	var/datum/antagonist/nukeop/new_op = new()
 	new_op.send_to_spawnpoint = FALSE
 	new_op.nukeop_outfit = /datum/outfit/syndicate/no_crystals
 
-	var/datum/antagonist/nukeop/creator_op = user.has_antag_datum(/datum/antagonist/nukeop,TRUE)
+	var/datum/antagonist/nukeop/creator_op = user.has_antag_datum(/datum/antagonist/nukeop, TRUE)
 	if(creator_op)
-		M.mind.add_antag_datum(new_op,creator_op.nuke_team)
-		M.mind.special_role = "Nuclear Operative"
+		op_mind.add_antag_datum(new_op, creator_op.nuke_team)
+	else
+		op_mind.add_antag_datum(new_op)
+	op_mind.special_role = "Nuclear Operative"
 
 //////CLOWN OP
 /obj/item/antag_spawner/nuke_ops/clown
@@ -153,15 +156,18 @@
 	var/mob/living/carbon/human/M = new/mob/living/carbon/human(T)
 	C.prefs.copy_to(M)
 	M.key = C.key
+	var/datum/mind/clown_mind = M.mind
 
-	var/datum/antagonist/nukeop/clownop/new_op = new /datum/antagonist/nukeop/clownop()
+	var/datum/antagonist/nukeop/clownop/new_op = new()
 	new_op.send_to_spawnpoint = FALSE
 	new_op.nukeop_outfit = /datum/outfit/syndicate/clownop/no_crystals
 
-	var/datum/antagonist/nukeop/creator_op = user.has_antag_datum(/datum/antagonist/nukeop/clownop,TRUE)
+	var/datum/antagonist/nukeop/creator_op = user.has_antag_datum(/datum/antagonist/nukeop, TRUE)
 	if(creator_op)
-		M.mind.add_antag_datum(new_op, creator_op.nuke_team)
-		M.mind.special_role = "Clown Operative"
+		clown_mind.add_antag_datum(new_op, creator_op.nuke_team)
+	else
+		clown_mind.add_antag_datum(new_op)
+	clown_mind.special_role = "Clown Operative"
 
 
 //////SYNDICATE BORG

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -146,7 +146,7 @@
 	antag_datum.nukeop_outfit = outfit
 
 	var/datum/antagonist/nukeop/creator_op = user.has_antag_datum(/datum/antagonist/nukeop, TRUE)
-	op_mind.add_antag_datum(antag_datum, creator_op ? creator_op.nuke_team : null)
+	op_mind.add_antag_datum(antag_datum, creator_op ? creator_op.get_team() : null)
 	op_mind.special_role = special_role_name
 
 //////CLOWN OP

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -96,15 +96,18 @@
 ///////////BORGS AND OPERATIVES
 
 
+/**
+ * Device to request reinforcments from ghost pop
+ */
 /obj/item/antag_spawner/nuke_ops
 	name = "syndicate operative teleporter"
 	desc = "A single-use teleporter designed to quickly reinforce operatives in the field."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "locator"
 	var/borg_to_spawn
-	var/special_role_name = "Nuclear Operative"
-	var/datum/outfit/syndicate/no_crystals/outfit = /datum/outfit/syndicate/no_crystals
-	var/datum/antagonist/nukeop/antag_datum = /datum/antagonist/nukeop
+	var/special_role_name = "Nuclear Operative" ///The name of the special role given to the recruit
+	var/datum/outfit/syndicate/outfit = /datum/outfit/syndicate/no_crystals ///The applied outfit
+	var/datum/antagonist/nukeop/antag_datum = /datum/antagonist/nukeop ///The antag datam applied
 
 /obj/item/antag_spawner/nuke_ops/proc/check_usability(mob/user)
 	if(used)
@@ -114,7 +117,6 @@
 		to_chat(user, "<span class='danger'>AUTHENTICATION FAILURE. ACCESS DENIED.</span>")
 		return FALSE
 	return TRUE
-
 
 /obj/item/antag_spawner/nuke_ops/attack_self(mob/user)
 	if(!(check_usability(user)))

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -102,6 +102,9 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "locator"
 	var/borg_to_spawn
+	var/special_role_name = "Nuclear Operative"
+	var/datum/outfit/syndicate/no_crystals/outfit = /datum/outfit/syndicate/no_crystals
+	var/datum/antagonist/nukeop/antag_datum = /datum/antagonist/nukeop
 
 /obj/item/antag_spawner/nuke_ops/proc/check_usability(mob/user)
 	if(used)
@@ -136,39 +139,24 @@
 	M.key = C.key
 	var/datum/mind/op_mind = M.mind
 
-	var/datum/antagonist/nukeop/new_op = new()
-	new_op.send_to_spawnpoint = FALSE
-	new_op.nukeop_outfit = /datum/outfit/syndicate/no_crystals
+	antag_datum = new()
+	antag_datum.send_to_spawnpoint = FALSE
+	antag_datum.nukeop_outfit = outfit
 
-	var/datum/antagonist/nukeop/creator_op = user.has_antag_datum(/datum/antagonist/nukeop, TRUE)
+	var/datum/antagonist/nukeop/creator_op = user.has_antag_datum(antag_datum, TRUE)
 	if(creator_op)
-		op_mind.add_antag_datum(new_op, creator_op.nuke_team)
+		op_mind.add_antag_datum(antag_datum, creator_op.nuke_team)
 	else
-		op_mind.add_antag_datum(new_op)
-	op_mind.special_role = "Nuclear Operative"
+		op_mind.add_antag_datum(antag_datum)
+	op_mind.special_role = special_role_name
 
 //////CLOWN OP
 /obj/item/antag_spawner/nuke_ops/clown
 	name = "clown operative teleporter"
 	desc = "A single-use teleporter designed to quickly reinforce clown operatives in the field."
-
-/obj/item/antag_spawner/nuke_ops/clown/spawn_antag(client/C, turf/T, kind, datum/mind/user)
-	var/mob/living/carbon/human/M = new/mob/living/carbon/human(T)
-	C.prefs.copy_to(M)
-	M.key = C.key
-	var/datum/mind/clown_mind = M.mind
-
-	var/datum/antagonist/nukeop/clownop/new_op = new()
-	new_op.send_to_spawnpoint = FALSE
-	new_op.nukeop_outfit = /datum/outfit/syndicate/clownop/no_crystals
-
-	var/datum/antagonist/nukeop/creator_op = user.has_antag_datum(/datum/antagonist/nukeop, TRUE)
-	if(creator_op)
-		clown_mind.add_antag_datum(new_op, creator_op.nuke_team)
-	else
-		clown_mind.add_antag_datum(new_op)
-	clown_mind.special_role = "Clown Operative"
-
+	special_role_name = "Clown Operative"
+	outfit = /datum/outfit/syndicate/clownop/no_crystals
+	antag_datum = /datum/antagonist/nukeop/clownop
 
 //////SYNDICATE BORG
 /obj/item/antag_spawner/nuke_ops/borg_tele


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Clown op reinforcements did not get the antag datum applied properly.
This fixes some issues and if a team is not found or the user of the reinforcement caller is not on the team it still works properly. 

Fixes #52386

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Clowns can now call for backup.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Clown ops reinforcements spawn properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
