### PR TITLE
Fix multitile engine rotating.

### DIFF
--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -24,12 +24,16 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 			var/oldPY = pixel_y
 			pixel_x = oldPY
 			pixel_y = (oldPX*(-1))
-	
-	//rotate the physical bounds and offsets for multitile atoms too. Owerride upper "rotate the pixel offsets" for multitile atoms.
+
+/************************************Base /atom/movable proc************************************/
+
+/atom/movable/shuttleRotate(rotation, params)
+	. = ..()
+	//rotate the physical bounds and offsets for multitile atoms too. Owerride base "rotate the pixel offsets" for multitile atoms.
 	//Owerride non zero bound_x, bound_y, pixel_x, pixel_y to zero. 
 	//Dont take in account starting bound_x, bound_y, pixel_x, pixel_y.
 	//So it can unintentionally shift physical bounds of things that starts with non zero bound_x, bound_y.
-	if(((bound_height != world.icon_size) || (bound_width != world.icon_size)) && (bound_x==0) && (bound_y==0)) //Dont shift things that have non zero bound_x and bound_y, or it move somewhere.
+	if(((bound_height != world.icon_size) || (bound_width != world.icon_size)) && (bound_x==0) && (bound_y==0)) //Dont shift things that have non zero bound_x and bound_y, or it move somewhere. Now it BSA and Gateway.
 		if(dir == 2)
 			pixel_x = 0
 			pixel_y = 0

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -117,3 +117,6 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 	if(dir == 4)
 		pixel_x = -bound_width+32
 		pixel_y = 0
+
+	bound_x = pixel_x
+	bound_y = pixel_y

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -24,6 +24,26 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 			var/oldPY = pixel_y
 			pixel_x = oldPY
 			pixel_y = (oldPX*(-1))
+	
+	//rotate the physical bounds and offsets for multitile atoms too. Owerride upper "rotate the pixel offsets" for multitile atoms.
+	//Owerride non zero bound_x, bound_y, pixel_x, pixel_y to zero. 
+	//Dont take in account starting bound_x, bound_y, pixel_x, pixel_y.
+	//So it can unintentionally shift physical bounds of things that starts with non zero bound_x, bound_y.
+	if(((bound_height != world.icon_size) || (bound_width != world.icon_size)) && (bound_x==0) && (bound_y==0)) //Dont shift things that have non zero bound_x and bound_y, or it move somewhere.
+		if(dir == 2)
+			pixel_x = 0
+			pixel_y = 0
+		if(dir == 8)
+			pixel_x = 0
+			pixel_y = -bound_height+world.icon_size
+		if(dir == 1)
+			pixel_x = -bound_width+world.icon_size
+			pixel_y = -bound_height+world.icon_size
+		if(dir == 4)
+			pixel_x = -bound_width+world.icon_size
+			pixel_y = 0
+		bound_x = pixel_x
+		bound_y = pixel_y
 
 /************************************Turf rotate procs************************************/
 
@@ -101,22 +121,3 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 	. = ..()
 	if(wall_turret_direction && (params & ROTATE_DIR))
 		wall_turret_direction = turn(wall_turret_direction,rotation)
-
-/obj/structure/shuttle/shuttleRotate(rotation, params)
-	setDir(angle2dir(rotation+dir2angle(dir)))
-
-	if(dir == 2)
-		pixel_x = 0
-		pixel_y = 0
-	if(dir == 8)
-		pixel_x = 0
-		pixel_y = -bound_height+32
-	if(dir == 1)
-		pixel_x = -bound_width+32
-		pixel_y = -bound_height+32
-	if(dir == 4)
-		pixel_x = -bound_width+32
-		pixel_y = 0
-
-	bound_x = pixel_x
-	bound_y = pixel_y

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -101,3 +101,19 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 	. = ..()
 	if(wall_turret_direction && (params & ROTATE_DIR))
 		wall_turret_direction = turn(wall_turret_direction,rotation)
+
+/obj/structure/shuttle/shuttleRotate(rotation, params)
+	dir = angle2dir(rotation+dir2angle(dir))
+
+	if(dir == 2)
+		pixel_x = 0
+		pixel_y = 0
+	if(dir == 8)
+		pixel_x = 0
+		pixel_y = -bound_height+32
+	if(dir == 1)
+		pixel_x = -bound_width+32
+		pixel_y = -bound_height+32
+	if(dir == 4)
+		pixel_x = -bound_width+32
+		pixel_y = 0

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -34,19 +34,8 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 	//Dont take in account starting bound_x, bound_y, pixel_x, pixel_y.
 	//So it can unintentionally shift physical bounds of things that starts with non zero bound_x, bound_y.
 	if(((bound_height != world.icon_size) || (bound_width != world.icon_size)) && (bound_x==0) && (bound_y==0)) //Dont shift things that have non zero bound_x and bound_y, or it move somewhere. Now it BSA and Gateway.
-		switch(dir)
-			if(SOUTH)
-				pixel_x = 0
-				pixel_y = 0
-			if(WEST)
-				pixel_x = 0
-				pixel_y = -bound_height+world.icon_size
-			if(NORTH)
-				pixel_x = -bound_width+world.icon_size
-				pixel_y = -bound_height+world.icon_size
-			if(EAST)
-				pixel_x = -bound_width+world.icon_size
-				pixel_y = 0
+		pixel_x = dir & (NORTH|EAST) ? -bound_width+world.icon_size : 0
+		pixel_y = dir & (NORTH|WEST) ? -bound_width+world.icon_size : 0
 		bound_x = pixel_x
 		bound_y = pixel_y
 

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -34,18 +34,19 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 	//Dont take in account starting bound_x, bound_y, pixel_x, pixel_y.
 	//So it can unintentionally shift physical bounds of things that starts with non zero bound_x, bound_y.
 	if(((bound_height != world.icon_size) || (bound_width != world.icon_size)) && (bound_x==0) && (bound_y==0)) //Dont shift things that have non zero bound_x and bound_y, or it move somewhere. Now it BSA and Gateway.
-		if(dir == 2)
-			pixel_x = 0
-			pixel_y = 0
-		if(dir == 8)
-			pixel_x = 0
-			pixel_y = -bound_height+world.icon_size
-		if(dir == 1)
-			pixel_x = -bound_width+world.icon_size
-			pixel_y = -bound_height+world.icon_size
-		if(dir == 4)
-			pixel_x = -bound_width+world.icon_size
-			pixel_y = 0
+		switch(dir)
+			if(SOUTH)
+				pixel_x = 0
+				pixel_y = 0
+			if(WEST)
+				pixel_x = 0
+				pixel_y = -bound_height+world.icon_size
+			if(NORTH)
+				pixel_x = -bound_width+world.icon_size
+				pixel_y = -bound_height+world.icon_size
+			if(EAST)
+				pixel_x = -bound_width+world.icon_size
+				pixel_y = 0
 		bound_x = pixel_x
 		bound_y = pixel_y
 

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -103,7 +103,7 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 		wall_turret_direction = turn(wall_turret_direction,rotation)
 
 /obj/structure/shuttle/shuttleRotate(rotation, params)
-	dir = angle2dir(rotation+dir2angle(dir))
+	setDir(angle2dir(rotation+dir2angle(dir)))
 
 	if(dir == 2)
 		pixel_x = 0


### PR DESCRIPTION
## About The Pull Request

Multitile engines correctly rotates on shuttle rotating.
fix #51892
![image](https://user-images.githubusercontent.com/7734424/88231226-83f36980-cc7c-11ea-8fc9-f9687284e943.png)
![image](https://user-images.githubusercontent.com/7734424/88231235-881f8700-cc7c-11ea-99a4-39e8793d7586.png)

Now it must properly rotate any multitile objects, exept for BSA and Gatewey, it has non zero bound_x.

## Why It's Good For The Game

Bugs is bad

## Changelog
:cl:
fix: Now engines correctly rotate on shuttle rotating.
/:cl:
