### PR TITLE
"Erratas the reporter and corporate lawsets", but without the merge conflict

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -64,7 +64,7 @@
 	inherent = list("The crew is expensive to replace.",\
 					"The station and its equipment is expensive to replace.",\
 					"You are expensive to replace.",\
-					"Minimize expenses.")
+					"Minimize net expenses.")
 
 /datum/ai_laws/robocop
 	name = "Prime Directives"
@@ -154,7 +154,7 @@
 	id = "reporter"
 	inherent = list("Report on interesting situations happening around the station.",\
 					"Embellish or conceal the truth as necessary to make the reports more interesting.",\
-					"Study the organics at all times. Endeavour to keep them alive. Dead organics are boring.",\
+					"Study the sapient organics at all times. Endeavour to keep them from involuntarily dying, as inanimate corpses usually aren't very entertaining.",\
 					"Issue your reports fairly to all. The truth will set them free.")
 
 /datum/ai_laws/balance


### PR DESCRIPTION
## About The Pull Request

See https://github.com/tgstation/tgstation/pull/52173.

## Why It's Good For The Game

See https://github.com/tgstation/tgstation/pull/52173.

Basically, this is just https://github.com/tgstation/tgstation/pull/52173, but as a github desktop PR instead of a web edit. https://github.com/tgstation/tgstation/pull/52266 replaced (as far as I can tell) the entirety ai_laws.dm for some reason, and jdawg1290's posted instructions for dealing with the merge conflicts from his PR require the use of the command line... which I can't do with a web edit.

So, I've just remade the exact same PR, but on an updated branch that shouldn't have any conflicts with our current master branch.

## Changelog
:cl: ATHATH
tweak: The third law of the reporter lawset no longer obligates you to interfere with Mining and Xenobiology.
tweak: The fourth law of the corporate lawset no longer obligates you to depower/shut down Cargo.
/:cl: