### PR TITLE
you can now store dead mice in your chef's hat as well

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -41,7 +41,8 @@
 /datum/component/storage/concrete/pockets/chefhat/Initialize()
 	. = ..()
 	set_holdable(list(
-		/obj/item/clothing/head/mob_holder
+		/obj/item/clothing/head/mob_holder,
+		/obj/item/reagent_containers/food/snacks/deadmouse
 	))
 
 /datum/component/storage/concrete/pockets/chefhat/can_be_inserted(obj/item/I, stop_messages, mob/M)


### PR DESCRIPTION
## About The Pull Request

Adds dead mice to the list of things that can be stored in a chef's hat.

## Why It's Good For The Game

Linguini was never the same after Remy died.

ArcaneMusic's PR made it so that you can store living mice in a chef's hat, but he didn't add dead mice to the list of things that can fit inside of a chef's hat.

If a living mouse can fit in there, so can a dead one, damnit. What if you just wanna keep your little buddy with you, even while he's taking a big long nap? Get the fuck away from me, psychologist, I'm fine, I'm FINE, PUT THAT SYRINGE GUN AWAY OR SO HELP ME GOD I WILL CQC YOUR ASS INTO NEXT TUESDAY.

## Changelog
:cl: ATHATH
add: You can now store a dead mouse inside of your chef's hat. Y'know, in case the living mouse you keep in there dies.
/:cl: