### PR TITLE
adds pipelining to cross-server comm messages

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -593,8 +593,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			continue
 		if(target_servers && !(I in target_servers))
 			continue
-		world.Export("[servers[I]]?[list2params(message)]")
-
+		INVOKE_ASYNC(world, /world.proc/Export, "[servers[I]]?[list2params(message)]")
 
 /proc/tgsadminwho()
 	var/list/message = list("Admins: ")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -593,7 +593,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			continue
 		if(target_servers && !(I in target_servers))
 			continue
-		INVOKE_ASYNC(world, /world/proc/Export, "[servers[I]]?[list2params(message)]")
+		INVOKE_ASYNC(world, /world/Export, "[servers[I]]?[list2params(message)]")
 
 /proc/tgsadminwho()
 	var/list/message = list("Admins: ")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -593,7 +593,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			continue
 		if(target_servers && !(I in target_servers))
 			continue
-		INVOKE_ASYNC(world, /world.proc/Export, "[servers[I]]?[list2params(message)]")
+		INVOKE_ASYNC(world, /world/proc/Export, "[servers[I]]?[list2params(message)]")
 
 /proc/tgsadminwho()
 	var/list/message = list("Admins: ")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -605,7 +605,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		message["key"] = comms_key
 	var/list/servers = CONFIG_GET(keyed_list/cross_server)
 	var/server_url = servers[server_name]
-	if (!serverurl)
+	if (!server_url)
 		CRASH("Invalid cross comms config: [server_name]")
 	world.Export("[server_url]?[list2params(message)]")
 	

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -593,7 +593,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			continue
 		if(target_servers && !(I in target_servers))
 			continue
-		INVOKE_ASYNC(world, /world/Export, "[servers[I]]?[list2params(message)]")
+		INVOKE_ASYNC(world, "Export", "[servers[I]]?[list2params(message)]")
 
 /proc/tgsadminwho()
 	var/list/message = list("Admins: ")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -573,10 +573,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		send2adminchat(source,final)
 		send2otherserver(source,final)
 
-//
+/// Sends a message to other servers.
 /proc/send2otherserver(source,msg,type = "Ahelp",target_servers)
-	var/comms_key = CONFIG_GET(string/comms_key)
-	if(!comms_key)
+	if(!CONFIG_GET(string/comms_key))
+		debug_world_log("Server cross-comms message not sent for lack of configured key")
 		return
 
 	var/our_id = CONFIG_GET(string/cross_comms_name)
@@ -584,7 +584,6 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	message["message_sender"] = source
 	message["message"] = msg
 	message["source"] = "([our_id])"
-	message["key"] = comms_key
 	message += type
 
 	var/list/servers = CONFIG_GET(keyed_list/cross_server)
@@ -593,7 +592,23 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			continue
 		if(target_servers && !(I in target_servers))
 			continue
-		INVOKE_ASYNC(world, "Export", "[servers[I]]?[list2params(message)]")
+		world.send_cross_comms(I, message)
+
+/// Sends a message to a given cross comms server by name (by name for security).
+/world/proc/send_cross_comms(server_name, list/message, auth = TRUE)
+	set waitfor = FALSE
+	if (auth)
+		var/comms_key = CONFIG_GET(string/comms_key)
+		if(!comms_key)
+			debug_world_log("Server cross-comms message not sent for lack of configured key")
+			return
+		message["key"] = comms_key
+	var/list/servers = CONFIG_GET(keyed_list/cross_server)
+	var/server_url = servers[server_name]
+	if (!serverurl)
+		CRASH("Invalid cross comms config: [server_name]")
+	world.Export("[server_url]?[list2params(message)]")
+	
 
 /proc/tgsadminwho()
 	var/list/message = list("Admins: ")


### PR DESCRIPTION
One server blocking at the network level should not delay the other servers getting their message.

http://www.byond.com/forum/post/2593106 - related bug report.