### PR TITLE
Lowers the bar for Disk, Please!

### DIFF
--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -36,8 +36,8 @@
 	shooter.apply_status_effect(STATUS_EFFECT_HOLDUP)
 	target.apply_status_effect(STATUS_EFFECT_HELDUP)
 
-	if(target.job == "Captain" && target.stat == CONSCIOUS && is_nuclear_operative(shooter))
-		if(istype(weapon, /obj/item/gun/ballistic/rocketlauncher) && weapon.chambered)
+	if(istype(weapon, /obj/item/gun/ballistic/rocketlauncher) && weapon.chambered)
+		if(target.stat == CONSCIOUS && is_nuclear_operative(shooter) && (locate(/obj/item/disk/nuclear) in target.get_contents()) && shooter.client)
 			shooter.client.give_award(/datum/award/achievement/misc/rocket_holdup, shooter)
 
 	target.do_alert_animation(target)

--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -37,7 +37,7 @@
 	target.apply_status_effect(STATUS_EFFECT_HELDUP)
 
 	if(istype(weapon, /obj/item/gun/ballistic/rocketlauncher) && weapon.chambered)
-		if(target.stat == CONSCIOUS && is_nuclear_operative(shooter) && (locate(/obj/item/disk/nuclear) in target.get_contents()) && shooter.client)
+		if(target.stat == CONSCIOUS && is_nuclear_operative(shooter) && !is_nuclear_operative(target) && (locate(/obj/item/disk/nuclear) in target.get_contents()) && shooter.client)
 			shooter.client.give_award(/datum/award/achievement/misc/rocket_holdup, shooter)
 
 	target.do_alert_animation(target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Back in #48094 I added an achievement, Disk, Please! for:

- Being a Nuke Op
- Having a loaded rocket launcher
- Finding the Captain conscious
- Hold the Captain up

Only now as I'm writing this do I realize I never actually added the damn check to see if they were actually holding the nuke disk, oops! Despite this, a while back atlanta ned told me no one had even gotten this achievement, which is sad. So I've changed the requirements: You now have to hold up any conscious non-nukie who has the disk with the loaded launcher. Sure it's a bit easier to cheese since it need not be the Captain, but this is more interesting anyway.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I wanna see someone get this
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
tweak: The "Disk, Please!" achievement will now be granted to any nuclear operative who holds up any conscious non-nukie holding the disk, rather than needing the Captain. Good luck!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
