### PR TITLE
Adds some user feedback to borgs using modules while buckled to things

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -60,8 +60,12 @@
 		return
 
 	if(W)
-		// buckled cannot prevent machine interlinking but stops arm movement
-		if( buckled || incapacitated())
+		if(incapacitated())
+			return
+
+		//while buckled you can still connect control things, but you can't use your robot arms
+		if(buckled)
+			to_chat(src, "<span class='warning'>You can't use modules while buckled to [buckled]!</span>")
 			return
 
 		if(W == A)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -63,7 +63,7 @@
 		if(incapacitated())
 			return
 
-		//while buckled you can still connect control things, but you can't use your robot arms
+		//while buckled, you can still connect to and control things like doors, but you can't use your modules
 		if(buckled)
 			to_chat(src, "<span class='warning'>You can't use modules while buckled to [buckled]!</span>")
 			return


### PR DESCRIPTION
## About The Pull Request
as demonstrated by #52438 , being buckled to something stops you from using your modules as a cyborg, but it doesn't give you a warning or message, which is kinda misleading/confusing

## Why It's Good For The Game
a little bit more user feedback, makes things more clear

## Changelog
:cl: Melbert
tweak: user feedback for cyborgs trying to use modules while buckled to things
/:cl:
