### PR TITLE
Sheetifier and Vend-a-Tray has proper named circuit boards

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -610,8 +610,8 @@
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
 /datum/design/board/sheetifier
-	name = "Machine Design (Sheetifier)"
-	desc = "The circuit board for a Sheetifier."
+	name = "Machine Design (Sheet-meister 2000)"
+	desc = "The circuit board for a Sheet-meister 2000."
 	id = "sheetifier"
 	build_path = /obj/item/circuitboard/machine/sheetifier
 	category = list ("Misc. Machinery")

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -610,14 +610,14 @@
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
 /datum/design/board/sheetifier
-	name = "Sheetifier"
-	desc = "This machine turns weird things into sheets."
+	name = "Machine Design (Sheetifier)"
+	desc = "The circuit board for a Sheetifier."
 	id = "sheetifier"
 	build_path = /obj/item/circuitboard/machine/sheetifier
 	category = list ("Misc. Machinery")
 
 /datum/design/board/vendatray
-	name = "Vend-a-Tray"
+	name = "Machine Design (Vend-a-Tray)"
 	desc = "The circuit board for a Vend-a-Tray."
 	id = "vendatray"
 	build_path = /obj/item/circuitboard/machine/vendatray


### PR DESCRIPTION
## About The Pull Request

Sheetifier and Vend-a-Tray has proper named circuit boards
Fix part of #52461

## Why It's Good For The Game

Proper name is good

## Changelog
:cl:
fix: Sheetifier and Vend-a-Tray has proper named circuit boards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
