### PR TITLE
Fixes AI integrity restorer functionality broken in #52265

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -62,9 +62,9 @@
 
 /obj/machinery/computer/aifixer/proc/Fix()
 	use_power(1000)
-	A.adjustOxyLoss(-5, FALSE)
-	A.adjustFireLoss(-5, FALSE)
-	A.adjustBruteLoss(-5, FALSE)
+	occupier.adjustOxyLoss(-5, FALSE)
+	occupier.adjustFireLoss(-5, FALSE)
+	occupier.adjustBruteLoss(-5, FALSE)
 	occupier.updatehealth()
 	if(occupier.health >= 0 && occupier.stat == DEAD)
 		occupier.revive(full_heal = FALSE, admin_revive = FALSE)

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -62,9 +62,9 @@
 
 /obj/machinery/computer/aifixer/proc/Fix()
 	use_power(1000)
-	occupier.adjustOxyLoss(-5, 0, FALSE)
-	occupier.adjustFireLoss(-5, 0, FALSE)
-	occupier.adjustBruteLoss(-5, 0)
+	A.adjustOxyLoss(-5, FALSE)
+	A.adjustFireLoss(-5, FALSE)
+	A.adjustBruteLoss(-5, FALSE)
 	occupier.updatehealth()
 	if(occupier.health >= 0 && occupier.stat == DEAD)
 		occupier.revive(full_heal = FALSE, admin_revive = FALSE)

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -65,6 +65,7 @@
 	occupier.adjustOxyLoss(-5, 0, FALSE)
 	occupier.adjustFireLoss(-5, 0, FALSE)
 	occupier.adjustBruteLoss(-5, 0)
+	occupier.updatehealth()
 	if(occupier.health >= 0 && occupier.stat == DEAD)
 		occupier.revive(full_heal = FALSE, admin_revive = FALSE)
 		if(!occupier.radio_enabled)

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -71,12 +71,17 @@
 		ai_slot.locked = FALSE
 		restoring = FALSE
 		return
-	ai_slot.locked =TRUE
+	ai_slot.locked = TRUE
 	A.adjustOxyLoss(-5, 0, FALSE)
 	A.adjustFireLoss(-5, 0, FALSE)
 	A.adjustBruteLoss(-5, 0)
+
+	// Please don't forget to update health, otherwise the below if statements will probably always fail.
+	A.updatehealth()
+
 	if(A.health >= 0 && A.stat == DEAD)
 		A.revive(full_heal = FALSE, admin_revive = FALSE)
+
 	// Finished restoring
 	if(A.health >= 100)
 		ai_slot.locked = FALSE

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -81,6 +81,7 @@
 
 	if(A.health >= 0 && A.stat == DEAD)
 		A.revive(full_heal = FALSE, admin_revive = FALSE)
+		cardhold.update_icon()
 
 	// Finished restoring
 	if(A.health >= 100)

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -72,9 +72,9 @@
 		restoring = FALSE
 		return
 	ai_slot.locked = TRUE
-	A.adjustOxyLoss(-5, 0, FALSE)
-	A.adjustFireLoss(-5, 0, FALSE)
-	A.adjustBruteLoss(-5, 0)
+	A.adjustOxyLoss(-5, FALSE)
+	A.adjustFireLoss(-5, FALSE)
+	A.adjustBruteLoss(-5, FALSE)
 
 	// Please don't forget to update health, otherwise the below if statements will probably always fail.
 	A.updatehealth()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #52468

#52265 removed the updatehealth() call from the AI integrity restoration process.

Because all restoration logic relies on checking the AI's health state, this completely broke all AI resotration efforts.

![image](https://user-images.githubusercontent.com/24975989/88396766-e5215700-cdba-11ea-90a1-79e91e080c21.png)

This has been re-added and AIs can now be happily restored back to full functionality.

Also updates the AI card icon when the AI is revived, which gives the IntelliCard its happy AI :) face back instead of the bluescreen icon after the AI is revived.

Note: If #52391 gets merged, that PR indirectly fixes this (by refactoring mob/living/proc/heal_overall_damage and using the refactored proc) and thus this should be closed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Forcing admins to revive AIs is bad. I feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: AI integrity restorer program now appropriately restores the integrity of AIs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
