### PR TITLE
Supermatter slivers thrown by bombs / mass drivers will now consume a mob if they're hit by it.

### DIFF
--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -149,16 +149,38 @@
 		qdel(W)
 		qdel(src)
 
+/obj/item/hemostat/supermatter_sliver/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	if(!isliving(hit_atom))
+		return ..()
+	var/mob/living/victim = hit_atom
+	if(victim.incorporeal_move || victim.status_flags & GODMODE) //try to keep this in sync with supermatter's consume fail conditions
+		return ..()
+	if(throwingdatum?.thrower)
+		var/mob/user = throwingdatum.thrower
+		log_combat(throwingdatum?.thrower, hit_atom, "consumed", src)
+		message_admins("[src] has consumed [key_name_admin(victim)] [ADMIN_JMP(src)], thrown by [key_name_admin(user)].")
+		investigate_log("has consumed [key_name(victim)], thrown by [key_name(user)]", INVESTIGATE_SUPERMATTER)
+	else
+		message_admins("[src] has consumed [key_name_admin(victim)] [ADMIN_JMP(src)] via throw impact.")
+		investigate_log("has consumed [key_name(victim)] via throw impact.", INVESTIGATE_SUPERMATTER)
+	victim.visible_message("<span class='danger'>As [victim] is hit by [src], both flash into dust and silence fills the room...</span>",\
+		"<span class='userdanger'>You're hit by [src] and everything suddenly goes silent.\n[src] flashes into dust, and soon as you can register this, you do as well.</span>",\
+		"<span class='hear'>Everything suddenly goes silent.</span>")
+	victim.dust()
+	radiation_pulse(src, 500, 2)
+	playsound(src, 'sound/effects/supermatter.ogg', 50, TRUE)
+	qdel(src)
+
 /obj/item/nuke_core/supermatter_sliver/pickup(mob/living/user)
 	..()
-	if(!iscarbon(user))
+	if(!isliving(user) || user.status_flags & GODMODE) //try to keep this in sync with supermatter's consume fail conditions
 		return FALSE
 	var/mob/ded = user
 	user.visible_message("<span class='danger'>[ded] reaches out and tries to pick up [src]. [ded.p_their()] body starts to glow and bursts into flames before flashing into dust!</span>",\
 			"<span class='userdanger'>You reach for [src] with your hands. That was dumb.</span>",\
 			"<span class='hear'>Everything suddenly goes silent.</span>")
 	radiation_pulse(user, 500, 2)
-	playsound(get_turf(user), 'sound/effects/supermatter.ogg', 50, TRUE)
+	playsound(src, 'sound/effects/supermatter.ogg', 50, TRUE)
 	ded.dust()
 
 /obj/item/nuke_core_container/supermatter
@@ -225,10 +247,7 @@
 	return ..()
 
 /obj/item/hemostat/supermatter/update_icon_state()
-	if(sliver)
-		icon_state = "supermatter_tongs_loaded"
-	else
-		icon_state = "supermatter_tongs"
+	icon_state = "supermatter_tongs[sliver ? "loaded" : null]"
 
 /obj/item/hemostat/supermatter/afterattack(atom/O, mob/user, proximity)
 	. = ..()
@@ -243,18 +262,25 @@
 		visible_message("<span class='notice'>\The [sliver] falls out of \the [src] as it hits the ground.</span>")
 		sliver = null
 		update_icon()
-	..()
+	return ..()
 
 /obj/item/hemostat/supermatter/proc/Consume(atom/movable/AM, mob/user)
 	if(ismob(AM))
-		var/mob/victim = AM
+		if(!isliving(AM))
+			return
+		var/mob/living/victim = AM
+		if(victim.incorporeal_move || victim.status_flags & GODMODE) //try to keep this in sync with supermatter's consume fail conditions
+			return
 		victim.dust()
 		message_admins("[src] has consumed [key_name_admin(victim)] [ADMIN_JMP(src)].")
-		investigate_log("has consumed [key_name(victim)].", "supermatter")
+		investigate_log("has consumed [key_name(victim)].", INVESTIGATE_SUPERMATTER)
+	else if(istype(AM, /obj/singularity))
+		return
 	else
-		investigate_log("has consumed [AM].", "supermatter")
+		investigate_log("has consumed [AM].", INVESTIGATE_SUPERMATTER)
 		qdel(AM)
 	if (user)
+		log_combat(user, AM, "consumed", sliver, "via [src]")
 		user.visible_message("<span class='danger'>As [user] touches [AM] with \the [src], both flash into dust and silence fills the room...</span>",\
 			"<span class='userdanger'>You touch [AM] with [src], and everything suddenly goes silent.\n[AM] and [sliver] flash into dust, and soon as you can register this, you do as well.</span>",\
 			"<span class='hear'>Everything suddenly goes silent.</span>")

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -840,7 +840,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	dust_mob(user, cause = "hand")
 
 /obj/machinery/power/supermatter_crystal/proc/dust_mob(mob/living/nom, vis_msg, mob_msg, cause)
-	if(nom.incorporeal_move || nom.status_flags & GODMODE)
+	if(nom.incorporeal_move || nom.status_flags & GODMODE) //try to keep supermatter sliver's + hemostat's dust conditions in sync with this too
 		return
 	if(!vis_msg)
 		vis_msg = "<span class='danger'>[nom] reaches out and touches [src], inducing a resonance... [nom.p_their()] body starts to glow and burst into flames before flashing into dust!</span>"


### PR DESCRIPTION
:cl: ShizCalev
fix: Supermatter slivers thrown by bombs / mass drivers will now consume a mob if they're hit by it.
fix: Fixed an exploit allowing jaunting mobs to consume supermatter slivers on the ground.
fix: Fixed simple animals (ie gorillas) not being consumed by supermatter slivers after picking them up.
fix: Fixed an exploit allowing you to kill jaunting mobs with supermatter slivers held by tongs.
/:cl:

Fixes #49357