### PR TITLE
Fixes keybind keyUp() not checking for can_use()

### DIFF
--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -88,7 +88,7 @@
 	// can hold different keys and releasing any should be handled by the key binding specifically
 	for (var/kb_name in prefs.key_bindings[_key])
 		var/datum/keybinding/kb = GLOB.keybindings_by_name[kb_name]
-		if(kb.up(src))
+		if(kb.can_use(src) && kb.up(src))
 			break
 	holder?.key_up(_key, src)
 	mob.focus?.key_up(_key, src)


### PR DESCRIPTION
Closes #52467
Fixes #52442

:cl: ShizCalev
fix: Fixed a minor runtime caused by ghosts pressing the lookup / lookdown keybind.
/:cl:
