### PR TITLE
Fixes another borg runtime + middle click cycling for borgs

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -85,11 +85,6 @@
 				W.afterattack(A, src, 0, params)
 				return
 
-//Middle click cycles through selected modules.
-/mob/living/silicon/robot/MiddleClickOn(atom/A)
-	. = ..()
-	cycle_modules()
-
 //Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks
 // for non-doors/apcs
 /mob/living/silicon/robot/CtrlShiftClickOn(atom/A)

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -313,7 +313,7 @@
   * * module_num - the slot number being selected
   */
 /mob/living/silicon/robot/proc/select_module(module_num)
-	if(!held_items[module_num])
+	if(is_invalid_module_number(module_num) || !held_items[module_num]) //If the slot number is invalid, or there's nothing there, we have nothing to equip
 		return FALSE
 
 	switch(module_num)


### PR DESCRIPTION
## About The Pull Request

legacy code clashed with the refactored code and caused a list out of bounds error

middleClickOn to cycle modules for cyborgs has been borked for over a year and no one ever noticed so i fixed it as well - the proc ended up calling cycle modules twice (once in the super, once in the subtype) which made it go backwards and not work as intended, so i removed the subtype

## Why It's Good For The Game

i swear, this is the last one

## Changelog
:cl: Melbert
fix: Fixes a cyborg runtime error
fix: middle mouse click to cycle modules for cyborgs works properly again
/:cl: