### PR TITLE
Fixes the "See runechat emotes" pref doing nothing

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -270,7 +270,7 @@
 		return FALSE
 	return TRUE
 
-/mob/runechat_prefs_check(mob/target, message, visible_message_flags = NONE)
+/mob/runechat_prefs_check(mob/target, visible_message_flags = NONE)
 	if(!target.client?.prefs.chat_on_map)
 		return FALSE
 	if(visible_message_flags & EMOTE_MESSAGE && !target.client.prefs.see_rc_emotes)


### PR DESCRIPTION
## About The Pull Request

Fixes #52449 
Sorry for pulling an arsonist firefighter move, fixing my own issue, but I was not counting on the solution being so simple.

Seems I am the only one who noticed/reported/cares about the problem. I bet this is because anyone who would use the pref just has runechat disabled altogether. I may or may not actually end up using it myself, but it should either work when you toggle it or not be there at all.

## Why It's Good For The Game

Preferences not working is bad. Having options to tailor how much floating text is on screen is good.

## Changelog
:cl:
fix: The "See runechat emotes" preference now works as intended.
/:cl: