### PR TITLE
Fixes failure message being sent to player when an emagged borg is self destructed

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -453,11 +453,10 @@
 
 /mob/living/silicon/robot/proc/self_destruct()
 	if(emagged)
-		if(mmi)
-			qdel(mmi)
-		explosion(src.loc,1,2,4,flame_range = 2)
+		QDEL_NULL(mmi)
+		explosion(loc,1,2,4,flame_range = 2)
 	else
-		explosion(src.loc,-1,0,2)
+		explosion(loc,-1,0,2)
 	gib()
 
 /mob/living/silicon/robot/proc/UnlinkSelf()


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed "your MMI was unable to receive your mind" being sent to emagged borgs when self_destructed via a robotics console.
/:cl:

Fixes #49155