### PR TITLE
Fix multiple message prefixes being allowed at a time. AKA, you can now start messages with ellipses again.

### DIFF
--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -116,6 +116,10 @@
   */
 /mob/proc/get_message_mods(message, list/mods)
 	for(var/I in 1 to MESSAGE_MODS_LENGTH)
+		// Prevents "...text" from being read as a radio message
+		if (length(message) > 1 && message[2] == message[1])
+			continue
+
 		var/key = message[1]
 		var/chop_to = 2 //By default we just take off the first char
 		if(key == "#" && !mods[WHISPER_MODE])

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -20,6 +20,7 @@
 #include "plantgrowth_tests.dm"
 #include "reagent_id_typos.dm"
 #include "reagent_recipe_collisions.dm"
+#include "say.dm"
 #include "siunit.dm"
 #include "spawn_humans.dm"
 #include "species_whitelists.dm"

--- a/code/modules/unit_tests/say.dm
+++ b/code/modules/unit_tests/say.dm
@@ -1,0 +1,23 @@
+/// Test to verify message mods are parsed correctly
+/datum/unit_test/get_message_mods
+	var/mob/host_mob
+
+/datum/unit_test/get_message_mods/Run()
+	host_mob = allocate(/mob/living/carbon/human)
+
+	test("Hello", "Hello", list())
+	test(";HELP", "HELP", list(MODE_HEADSET = TRUE))
+	test(";%Never gonna give you up", "Never gonna give you up", list(MODE_HEADSET = TRUE, MODE_SING = TRUE))
+	test(".s Gun plz", "Gun plz", list(RADIO_KEY = RADIO_KEY_SECURITY, RADIO_EXTENSION = RADIO_CHANNEL_SECURITY))
+	test("...What", "...What", list())
+
+/datum/unit_test/get_message_mods/proc/test(message, expected_message, list/expected_mods)
+	var/list/mods = list()
+	TEST_ASSERT_EQUAL(host_mob.get_message_mods(message, mods), expected_message, "Chopped message was not what we expected. Message: [message]")
+
+	for (var/mod_key in mods)
+		TEST_ASSERT_EQUAL(mods[mod_key], expected_mods[mod_key], "The value for [mod_key] was not what we expected. Message: [message]")
+		expected_mods -= mod_key
+
+	if (expected_mods.len)
+		Fail("Some message mods were expected, but were not returned by get_message_mods: [json_encode(expected_mods)]. Message: [message]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #52496
Fixes #49198 too, apparently?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Fixed a bug where you could not start messages with an ellipses.
fix: Fixed not being able to sing over comms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
