### PR TITLE
Scannergates 2.0

### DIFF
--- a/code/__DEFINES/wires.dm
+++ b/code/__DEFINES/wires.dm
@@ -51,4 +51,5 @@
 #define WIRE_PRIZEVEND "Emergency Prize Vend"
 #define WIRE_RESETOWNER "Reset Owner"
 #define WIRE_AGELIMIT "Age Limit"
-
+#define WIRE_PASS "Check Passed"
+#define WIRE_FAIL "Check Failed"

--- a/code/__DEFINES/wires.dm
+++ b/code/__DEFINES/wires.dm
@@ -53,3 +53,4 @@
 #define WIRE_AGELIMIT "Age Limit"
 #define WIRE_PASS "Check Passed"
 #define WIRE_FAIL "Check Failed"
+

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -157,6 +157,7 @@
 			pulse_color(color)
 			return TRUE
 
+
 /datum/wires/proc/attach_assembly(color, obj/item/assembly/S)
 	if(S && istype(S) && S.attachable && !is_attached(color))
 		assemblies[color] = S

--- a/code/datums/wires/scan_gate.dm
+++ b/code/datums/wires/scan_gate.dm
@@ -1,0 +1,31 @@
+/datum/wires/scan_gate
+	holder_type = /obj/machinery/scanner_gate
+	proper_name = "Scanner Gate"
+
+/datum/wires/scan_gate/New(atom/holder)
+	wires = list(
+		WIRE_PASS, WIRE_FAIL, WIRE_DISABLE, WIRE_ACTIVATE, WIRE_DISARM
+	)
+	..()
+
+/datum/wires/scan_gate/on_pulse(wire)
+	var/obj/machinery/scanner_gate/V = holder
+	switch(wire)
+		if(WIRE_PASS)
+			V.green = !V.green
+		if(WIRE_FAIL)
+			V.red = !V.red
+		if(WIRE_DISARM)
+			V.ignore_signals = !V.ignore_signals
+		if(WIRE_DISABLE)
+			V.ignore_signals = TRUE
+		if(WIRE_ACTIVATE)
+			V.ignore_signals = FALSE
+
+/datum/wires/scan_gate/get_status()
+	var/obj/machinery/scanner_gate/V = holder
+	var/list/status = list()
+	status += "The Green light is [V.green ? "blinking" : "off"]."
+	status += "The Red light is [V.red ? "blinking" : "off"]."
+	status += "The Purple light is [V.ignore_signals ? "on" : "off"]."
+	return status

--- a/code/game/machinery/scan_gate.dm
+++ b/code/game/machinery/scan_gate.dm
@@ -181,12 +181,14 @@
 		if(!ignore_signals)
 			color = wires.get_color_of_wire(WIRE_FAIL)
 			var/obj/item/assembly/S = wires.get_attached(color)
-			S.activate()
+			if(istype(S))
+				S.activate()
 	else
 		if(!ignore_signals)
 			color = wires.get_color_of_wire(WIRE_PASS)
 			var/obj/item/assembly/S = wires.get_attached(color)
-			S.activate()
+			if(istype(S))
+				S.activate()
 		set_scanline("scanning", 10)
 
 /obj/machinery/scanner_gate/proc/alarm_beep()

--- a/code/game/machinery/scan_gate.dm
+++ b/code/game/machinery/scan_gate.dm
@@ -166,6 +166,7 @@
 		set_scanline("scanning", 10)
 
 /obj/machinery/scanner_gate/proc/alarm_beep()
+	say("Buzz!")
 	if(next_beep <= world.time)
 		next_beep = world.time + 20
 		playsound(src, 'sound/machines/scanbuzz.ogg', 100, FALSE)

--- a/code/game/machinery/scan_gate.dm
+++ b/code/game/machinery/scan_gate.dm
@@ -63,7 +63,7 @@
 	auto_scan(AM)
 
 /obj/machinery/scanner_gate/proc/auto_scan(atom/movable/AM)
-	if(!(machine_stat & (BROKEN|NOPOWER)) && isliving(AM) & (!panel_open))
+	if(!(machine_stat & (BROKEN|NOPOWER)) && isliving(AM) && !panel_open)
 		perform_scan(AM)
 
 /obj/machinery/scanner_gate/proc/set_scanline(type, duration)

--- a/code/game/machinery/scan_gate.dm
+++ b/code/game/machinery/scan_gate.dm
@@ -52,7 +52,7 @@
 	else
 		. += "<span class='notice'>The control panel is unlocked. Swipe an ID to lock it.</span>"
 
-/obj/machinery/microwave/update_icon_state()
+/obj/machinery/scanner_gate/update_icon_state()
 	if(panel_open)
 		icon_state = "scangate"
 	else

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -647,6 +647,7 @@
 #include "code\datums\wires\radio.dm"
 #include "code\datums\wires\robot.dm"
 #include "code\datums\wires\roulette.dm"
+#include "code\datums\wires\scan_gate.dm"
 #include "code\datums\wires\suit_storage_unit.dm"
 #include "code\datums\wires\syndicatebomb.dm"
 #include "code\datums\wires\tesla_coil.dm"


### PR DESCRIPTION
## About The Pull Request
 ![XGWvtJbPH9](https://user-images.githubusercontent.com/19522166/88450160-e4b8a880-ce1a-11ea-83c6-dac1cb35cd06.gif)

Scanner Gates can now have assemblies attached to them! Allow you to trigger anything you want with them!

There are 5 wires on them now.
Successful Scan
Failed Scan
Toggle Signaling
Disable Signaling
Enabling Signaling

## Why It's Good For The Game
Imagine the possibilities! Traps! Security Checkpoints!

## Changelog
:cl: Axanthic
add: Scanner Gates can now trigger assemblies!
/:cl: