### PR TITLE
Adds new Signal and changes how heretic and cult runes work detect being clicked on.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -167,6 +167,9 @@
 	#define COMPONENT_NO_ATTACK_HAND (1<<0)								//works on all 3.
 //This signal return value bitflags can be found in __DEFINES/misc.dm
 
+///from base of mob/RangedAttack(): (atom/A, params) sent to the atom that was clicked. This is sent regardless if you stand 1 tile away or if you are 100 tiles away and try to click on it.
+#define COMSIG_ATOM_ATTACKED_RANGE_IGNORE "atom_attacked_ignore_range"
+
 ///from base of atom/expose_reagents():
 #define COMSIG_ATOM_EXPOSE_REAGENTS "atom_expose_reagents"
 	/// Prevents the atom from being exposed to reagents if returned on [COMPONENT_ATOM_EXPOSE_REAGENTS]
@@ -308,7 +311,7 @@
 #define COMSIG_MOB_ITEM_AFTERATTACK "mob_item_afterattack"
 ///from base of obj/item/attack_qdeleted(): (atom/target, mob/user, proxiumity_flag, click_parameters)
 #define COMSIG_MOB_ITEM_ATTACK_QDELETED "mob_item_attack_qdeleted"
-///from base of mob/RangedAttack(): (atom/A, params)
+///from base of mob/RangedAttack(): (atom/A, params) sent to the one that clicks
 #define COMSIG_MOB_ATTACK_RANGED "mob_attack_ranged"
 ///from base of /mob/throw_item(): (atom/target)
 #define COMSIG_MOB_THROW "mob_throw"

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -145,6 +145,11 @@
 		return
 
 	//Standard reach turf to turf or reaching inside storage
+
+	//This is sent regardless of range and is primarily used for 3x3 runes so that you can use them while not standing one them.
+	SEND_SIGNAL(A, COMSIG_ATOM_ATTACKED_RANGE_IGNORE, src)
+
+
 	if(CanReach(A,W))
 		if(W)
 			W.melee_attack_chain(src, A, params)
@@ -277,6 +282,7 @@
   */
 /mob/proc/RangedAttack(atom/A, params)
 	SEND_SIGNAL(src, COMSIG_MOB_ATTACK_RANGED, A, params)
+
 /**
   * Restrained ClickOn
   *

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -72,7 +72,7 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 		qdel(src)
 
 /obj/effect/rune/proc/try_invoke(datum/source,mob/user)
-	if(!isliving(user) || get_dist(src,user) >= usable_distance)
+	if(!isliving(user) || get_dist(src,user) > usable_distance)
 		return
 	if(!iscultist(user))
 		to_chat(user, "<span class='warning'>You aren't able to understand the words of [src].</span>")
@@ -465,7 +465,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	pixel_y = -32
 	scribe_delay = 500 //how long the rune takes to create
 	scribe_damage = 40.1 //how much damage you take doing it
-	usable_distance = 3
+	usable_distance = 2
 	var/used = FALSE
 
 /obj/effect/rune/narsie/Initialize(mapload, set_keyword)
@@ -888,7 +888,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	color = RUNE_COLOR_DARKRED
 	req_cultists = 3
 	scribe_delay = 100
-	usable_distance = 3
+	usable_distance = 2
 
 /obj/effect/rune/apocalypse/invoke(var/list/invokers)
 	if(rune_in_use)

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -38,8 +38,13 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 	var/req_keyword = 0 //If the rune requires a keyword - go figure amirite
 	var/keyword //The actual keyword for the rune
 
+	///Used to determine how far away can you stand and invoke the rune
+	var/usable_distance = 1
+
 /obj/effect/rune/Initialize(mapload, set_keyword)
 	. = ..()
+	RegisterSignal(src,COMSIG_ATOM_ATTACKED_RANGE_IGNORE,.proc/try_invoke)
+
 	if(set_keyword)
 		keyword = set_keyword
 	var/image/I = image(icon = 'icons/effects/blood.dmi', icon_state = null, loc = src)
@@ -66,9 +71,8 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 		to_chat(user, "<span class='danger'>You disrupt the magic of [src] with [I].</span>")
 		qdel(src)
 
-/obj/effect/rune/attack_hand(mob/living/user)
-	. = ..()
-	if(.)
+/obj/effect/rune/proc/try_invoke(datum/source,mob/user)
+	if(!isliving(user) || get_dist(src,user) >= usable_distance)
 		return
 	if(!iscultist(user))
 		to_chat(user, "<span class='warning'>You aren't able to understand the words of [src].</span>")
@@ -116,7 +120,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	if(user)
 		invokers += user
 	if(req_cultists > 1 || istype(src, /obj/effect/rune/convert))
-		var/list/things_in_range = range(1, src)
+		var/list/things_in_range = range(usable_distance, src)
 		for(var/mob/living/L in things_in_range)
 			if(iscultist(L))
 				if(L == user)
@@ -461,6 +465,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	pixel_y = -32
 	scribe_delay = 500 //how long the rune takes to create
 	scribe_damage = 40.1 //how much damage you take doing it
+	usable_distance = 3
 	var/used = FALSE
 
 /obj/effect/rune/narsie/Initialize(mapload, set_keyword)
@@ -883,6 +888,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	color = RUNE_COLOR_DARKRED
 	req_cultists = 3
 	scribe_delay = 100
+	usable_distance = 3
 
 /obj/effect/rune/apocalypse/invoke(var/list/invokers)
 	if(rune_in_use)

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -8,17 +8,15 @@
 	///Used mainly for summoning ritual to prevent spamming the rune to create millions of monsters.
 	var/is_in_use = FALSE
 
-/obj/effect/eldritch/attack_hand(mob/living/user)
+/obj/effect/eldritch/Initialize()
 	. = ..()
-	if(.)
-		return
-	try_activate(user)
+	RegisterSignal(src,COMSIG_ATOM_ATTACKED_RANGE_IGNORE,.proc/try_activate)
 
-/obj/effect/eldritch/proc/try_activate(mob/living/user)
-	if(!IS_HERETIC(user))
+/obj/effect/eldritch/proc/try_activate(datum/source,mob/user)
+	var/dist = get_dist(src,user)
+	if(!isliving(user) || dist > 2 || !IS_HERETIC(user) || is_in_use)
 		return
-	if(!is_in_use)
-		INVOKE_ASYNC(src, .proc/activate , user)
+	INVOKE_ASYNC(src, .proc/activate , user)
 
 /obj/effect/eldritch/attacked_by(obj/item/I, mob/living/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Adds a signal that sends data to the atom telling it was clicked, It ignores range and is sent whenever you click on something in your view range. It is used to expand how runes work to make heretic 3x3 rune able to be used when not standing on it, same with cultist runes.

## Why It's Good For The Game

Making it easier to use 3x3 runes is good

## Changelog
:cl:
tweak: 3x3 runes can be used when standing near them
/:cl:
