### PR TITLE
You can now starve to death: Hunger changes

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1141,6 +1141,13 @@
 		return FALSE
 	return ..()
 
+/mob/living/carbon/human/changeNext_move(num)
+	if(!dna)
+		next_move = world.time + ((num+next_move_adjust)*next_move_modifier)
+		return
+	dna.species.set_click_cooldown(src, num)
+
+
 /mob/living/carbon/human/species
 	var/race = null
 
@@ -1312,3 +1319,5 @@
 
 /mob/living/carbon/human/species/zombie/krokodil_addict
 	race = /datum/species/krokodil_addict
+
+

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1210,14 +1210,37 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	switch(H.nutrition)
 		if(NUTRITION_LEVEL_FULL to INFINITY)
 			H.throw_alert("nutrition", /obj/screen/alert/fat)
+			var/obj/item/organ/O = H.getorganslot(ORGAN_SLOT_HEART)
+			O.applyOrganDamage(0.25)
 		if(NUTRITION_LEVEL_HUNGRY to NUTRITION_LEVEL_FULL)
 			H.clear_alert("nutrition")
+			for(var/slot in list(ORGAN_SLOT_BRAIN, ORGAN_SLOT_HEART, ORGAN_SLOT_LUNGS, ORGAN_SLOT_APPENDIX, \
+	ORGAN_SLOT_EYES, ORGAN_SLOT_EARS, ORGAN_SLOT_TONGUE, ORGAN_SLOT_LIVER))
+				var/obj/item/organ/O = H.getorganslot(slot)
+				O.applyOrganDamage(-0.25)
 		if(NUTRITION_LEVEL_STARVING to NUTRITION_LEVEL_HUNGRY)
 			H.throw_alert("nutrition", /obj/screen/alert/hungry)
 		if(0 to NUTRITION_LEVEL_STARVING)
 			H.throw_alert("nutrition", /obj/screen/alert/starving)
-			H.adjustBruteLoss(2)
+			for(var/slot in list(ORGAN_SLOT_BRAIN, ORGAN_SLOT_HEART, ORGAN_SLOT_LUNGS, ORGAN_SLOT_APPENDIX, \
+	ORGAN_SLOT_EYES, ORGAN_SLOT_EARS, ORGAN_SLOT_TONGUE, ORGAN_SLOT_LIVER))
+				var/obj/item/organ/O = H.getorganslot(slot)
+				O.applyOrganDamage(0.25)
 
+
+/datum/species/proc/set_click_cooldown(mob/living/carbon/human/H, num)
+	var/click_cooldown = world.time + ((num+H.next_move_adjust)*H.next_move_modifier)
+	if(!HAS_TRAIT(H, TRAIT_NOHUNGER))
+		switch(H.nutrition)
+			if(NUTRITION_LEVEL_FULL to INFINITY)
+				click_cooldown += 0.5 SECONDS
+			if(NUTRITION_LEVEL_HUNGRY to NUTRITION_LEVEL_FULL)
+				click_cooldown -= 0.2 SECONDS
+			if(NUTRITION_LEVEL_STARVING to NUTRITION_LEVEL_HUNGRY)
+				click_cooldown += 0.4 SECONDS
+			if(0 to NUTRITION_LEVEL_STARVING)
+				click_cooldown += 0.8 SECONDS
+	H.next_move = click_cooldown
 /datum/species/proc/update_health_hud(mob/living/carbon/human/H)
 	return 0
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1216,6 +1216,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			H.throw_alert("nutrition", /obj/screen/alert/hungry)
 		if(0 to NUTRITION_LEVEL_STARVING)
 			H.throw_alert("nutrition", /obj/screen/alert/starving)
+			H.adjustBruteLoss(2)
 
 /datum/species/proc/update_health_hud(mob/living/carbon/human/H)
 	return 0

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -165,8 +165,8 @@
 	reagent_state = SOLID
 	color = "#FFFFFF" // rgb: 255, 255, 255
 	taste_mult = 1.5 // stop sugar drowning out other flavours
-	nutriment_factor = 10 * REAGENTS_METABOLISM
-	metabolization_rate = 2 * REAGENTS_METABOLISM
+	nutriment_factor = 2 * REAGENTS_METABOLISM
+	metabolization_rate = 4 * REAGENTS_METABOLISM
 	overdose_threshold = 200 // Hyperglycaemic shock
 	taste_description = "sweetness"
 


### PR DESCRIPTION
## About The Pull Request

You can now starve to death.

## Why It's Good For The Game

Encourages visiting the kitchen for food, or spending your money on vending machine snacks. Encourages walking to avoid burning hunger that you don't need to burn.

## Changelog
:cl:
balance: You can now starve to death.
balance: Maintaining a healthy diet will provide a bonus to your click speed and organ healing!
balance: Being out of shape won't be good for your heart.
balance: Not eating isn't good for your whole body.
balance: Sugar is now terrible for actually feeding yourself.
/:cl:
