### PR TITLE
Tones down embedded damage, especially for spears

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -127,18 +127,28 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 //Combat object defines
 
 //Embedded objects
-#define EMBEDDED_PAIN_CHANCE 					15	//Chance for embedded objects to cause pain (damage user)
-#define EMBEDDED_ITEM_FALLOUT 					5	//Chance for embedded object to fall out (causing pain but removing the object)
-#define EMBED_CHANCE							45	//Chance for an object to embed into somebody when thrown (if it's sharp)
-#define EMBEDDED_PAIN_MULTIPLIER				2	//Coefficient of multiplication for the damage the item does while embedded (this*item.w_class)
-#define EMBEDDED_FALL_PAIN_MULTIPLIER			5	//Coefficient of multiplication for the damage the item does when it falls out (this*item.w_class)
-#define EMBEDDED_IMPACT_PAIN_MULTIPLIER			4	//Coefficient of multiplication for the damage the item does when it first embeds (this*item.w_class)
-#define EMBED_THROWSPEED_THRESHOLD				4	//The minimum value of an item's throw_speed for it to embed (Unless it has embedded_ignore_throwspeed_threshold set to 1)
-#define EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER 8	//Coefficient of multiplication for the damage the item does when removed without a surgery (this*item.w_class)
-#define EMBEDDED_UNSAFE_REMOVAL_TIME			30	//A Time in ticks, total removal time = (this*item.w_class)
-#define EMBEDDED_JOSTLE_CHANCE					5	//Chance for embedded objects to cause pain every time they move (jostle)
-#define EMBEDDED_JOSTLE_PAIN_MULTIPLIER			1	//Coefficient of multiplication for the damage the item does while
-#define EMBEDDED_PAIN_STAM_PCT					0.0	//This percentage of all pain will be dealt as stam damage rather than brute (0-1)
+///Chance for embedded objects to cause pain (damage user)
+#define EMBEDDED_PAIN_CHANCE 					15
+///Chance for embedded object to fall out (causing pain but removing the object)
+#define EMBEDDED_ITEM_FALLOUT 					5
+///Chance for an object to embed into somebody when thrown (if it's sharp)
+#define EMBED_CHANCE							45
+///Coefficient of multiplication for the damage the item does while embedded (this*item.w_class)
+#define EMBEDDED_PAIN_MULTIPLIER				2
+///Coefficient of multiplication for the damage the item does when it first embeds (this*item.w_class)
+#define EMBEDDED_IMPACT_PAIN_MULTIPLIER			4
+///The minimum value of an item's throw_speed for it to embed (Unless it has embedded_ignore_throwspeed_threshold set to 1)
+#define EMBED_THROWSPEED_THRESHOLD				4
+///Coefficient of multiplication for the damage the item does when it falls out or is removed without a surgery (this*item.w_class)
+#define EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER 6
+///A Time in ticks, total removal time = (this*item.w_class)
+#define EMBEDDED_UNSAFE_REMOVAL_TIME			30
+///Chance for embedded objects to cause pain every time they move (jostle)
+#define EMBEDDED_JOSTLE_CHANCE					5
+///Coefficient of multiplication for the damage the item does while
+#define EMBEDDED_JOSTLE_PAIN_MULTIPLIER			1
+///This percentage of all pain will be dealt as stam damage rather than brute (0-1)
+#define EMBEDDED_PAIN_STAM_PCT					0.0
 
 #define EMBED_HARMLESS list("pain_mult" = 0, "jostle_pain_mult" = 0, "ignore_throwspeed_threshold" = TRUE)
 #define EMBED_HARMLESS_SUPERIOR list("pain_mult" = 0, "jostle_pain_mult" = 0, "ignore_throwspeed_threshold" = TRUE, "embed_chance" = 100, "fall_chance" = 0.1)

--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -99,7 +99,7 @@
 
 	if(damage > 0)
 		var/armor = victim.run_armor_check(limb.body_zone, "melee", "Your armor has protected your [limb.name].", "Your armor has softened a hit to your [limb.name].",I.armour_penetration)
-		limb.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage, blocked=armor, sharpness = I.get_sharpness())
+		limb.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage, blocked=armor, wound_bonus = I.wound_bonus, bare_wound_bonus = I.bare_wound_bonus, sharpness = I.get_sharpness())
 
 /datum/component/embedded/Destroy()
 	var/mob/living/carbon/victim = parent
@@ -140,7 +140,7 @@
 		pain_chance_current *= 0.2
 
 	if(harmful && prob(pain_chance_current))
-		limb.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage, sharpness=TRUE, wound_bonus = CANT_WOUND)
+		limb.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage, wound_bonus = CANT_WOUND)
 		to_chat(victim, "<span class='userdanger'>[weapon] embedded in your [limb.name] hurts!</span>")
 
 	var/fall_chance_current = fall_chance
@@ -174,7 +174,7 @@
 
 	if(harmful)
 		var/damage = weapon.w_class * remove_pain_mult
-		limb.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage, sharpness=SHARP_EDGED) // can wound
+		limb.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage, wound_bonus = CANT_WOUND)
 
 	victim.visible_message("<span class='danger'>[weapon] falls [harmful ? "out" : "off"] of [victim.name]'s [limb.name]!</span>", "<span class='userdanger'>[weapon] falls [harmful ? "out" : "off"] of your [limb.name]!</span>")
 	safeRemove()
@@ -194,7 +194,7 @@
 		return
 	if(harmful)
 		var/damage = weapon.w_class * remove_pain_mult
-		limb.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage, sharpness=SHARP_EDGED) //It hurts to rip it out, get surgery you dingus.
+		limb.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage, sharpness=SHARP_EDGED) //It hurts to rip it out, get surgery you dingus. unlike the others, this CAN wound + increase slash bloodflow
 		victim.emote("scream")
 
 	victim.visible_message("<span class='notice'>[victim] successfully rips [weapon] [harmful ? "out" : "off"] of [victim.p_their()] [limb.name]!</span>", "<span class='notice'>You successfully remove [weapon] from your [limb.name].</span>")

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -69,7 +69,7 @@
 	return "<B>[msg.Join()]</B>"
 
 /datum/wound/slash/receive_damage(wounding_type, wounding_dmg, wound_bonus)
-	if(victim.stat != DEAD && wounding_type == WOUND_SLASH) // can't stab dead bodies to make it bleed faster this way
+	if(victim.stat != DEAD && wound_bonus != CANT_WOUND && wounding_type == WOUND_SLASH) // can't stab dead bodies to make it bleed faster this way
 		blood_flow += 0.05 * wounding_dmg
 
 /datum/wound/slash/drag_bleed_amount()

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -10,7 +10,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	throwforce = 20
 	throw_speed = 4
-	embedding = list("impact_pain_mult" = 3)
+	embedding = list("impact_pain_mult" = 2, "remove_pain_mult" = 4, "jostle_chance" = 2.5)
 	armour_penetration = 10
 	custom_materials = list(/datum/material/iron=1150, /datum/material/glass=2075)
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -290,7 +290,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	force = 2
-	throwforce = 10 //10 + 2 (WEIGHT_CLASS_SMALL) * 9 (EMBEDDED_IMPACT_PAIN_MULTIPLIER) = 28 damage on hit due to guaranteed embedding
+	throwforce = 10 //10 + 2 (WEIGHT_CLASS_SMALL) * 4 (EMBEDDED_IMPACT_PAIN_MULTIPLIER) = 18 damage on hit due to guaranteed embedding
 	throw_speed = 4
 	embedding = list("pain_mult" = 4, "embed_chance" = 100, "fall_chance" = 0)
 	armour_penetration = 40


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So after #51786 and maybe the first Wounds PR too, several people have mentioned that spears are incredibly deadly when thrown, and can apparently kill within a minute if you're particularly unlucky. I wasn't 100% sure whether the issue was solely with the brute damage they cause or the wounds+bloodloss they cause, but either way after some testing I realized that both needed tuning down with the advent of wounds. The changes are thus:

- Slashes no longer increase bloodflow from slashing attacks that can't wound, and now only embed impact and rip-out damage have the ability to wound, so pain, jostling, and falling out won't skyrocket your bloodloss anymore.
- Made embed impact damage respect wound bonuses and bare wound bonuses (most sharp weapons have negative wound bonuses and positive bare bonuses, so any armor/jumpsuit will drastically lower embed wound severity)
- Lowered the base unsafe/fall out damage multiplier from 8x to 6x (this is multiplied by the w_class of the weapon)
- Spears do 28 brute on embed, including normal throwforce, rather than 32. They also jostle less and hurt much less when they fall/are ripped out.

Spears and other embeddables are still dangerous and a force to be reckoned with, but are much less ggnore
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Spears were already powerful and unintentionally became much moreso with W2, this walks them back to a more reasonable level
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
balance: Spears and other embeddables are now somewhat less effective at causing damage and bloodloss
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
