### PR TITLE
CentCom Galactic Ban DB

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -491,6 +491,8 @@
 
 /datum/config_entry/flag/auto_profile
 
+/datum/config_entry/string/centcom_ban_db	// URL for the CentCom Galactic Ban DB API
+
 // DISCORD ROLE STUFFS
 // Using strings for everything because BYOND does not like numbers this big
 // (exception to the above is required living hours haha)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -43,6 +43,8 @@
 		body += "<br><br><b>Show related accounts by:</b> "
 		body += "\[ <a href='?_src_=holder;[HrefToken()];showrelatedacc=cid;client=[REF(M.client)]'>CID</a> | "
 		body += "<a href='?_src_=holder;[HrefToken()];showrelatedacc=ip;client=[REF(M.client)]'>IP</a> \]"
+		body += "<br><br><b>CentCom Galactic Ban DB: </b> "
+		body += "<a href='?_src_=holder;[HrefToken()];centcomlookup=[M.client.ckey]'>Search</a>"
 		var/rep = 0
 		rep += SSpersistence.antag_rep[M.ckey]
 		body += "<br><br>Antagonist reputation: [rep]"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -44,7 +44,10 @@
 		body += "\[ <a href='?_src_=holder;[HrefToken()];showrelatedacc=cid;client=[REF(M.client)]'>CID</a> | "
 		body += "<a href='?_src_=holder;[HrefToken()];showrelatedacc=ip;client=[REF(M.client)]'>IP</a> \]"
 		body += "<br><br><b>CentCom Galactic Ban DB: </b> "
-		body += "<a href='?_src_=holder;[HrefToken()];centcomlookup=[M.client.ckey]'>Search</a>"
+		if(CONFIG_GET(string/centcom_ban_db))
+			body += "<a href='?_src_=holder;[HrefToken()];centcomlookup=[M.client.ckey]'>Search</a>"
+		else
+			body += "<i>Disabled</i>"
 		var/rep = 0
 		rep += SSpersistence.antag_rep[M.ckey]
 		body += "<br><br>Antagonist reputation: [rep]"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2085,7 +2085,9 @@
 		var/datum/http_request/request = new()
 		request.prepare(RUSTG_HTTP_METHOD_GET, "[CONFIG_GET(string/centcom_ban_db)]/[ckey]", "", "")
 		request.begin_async()
-		UNTIL(request.is_complete())
+		UNTIL(request.is_complete() || !usr)
+		if (!usr)
+			return
 		var/datum/http_response/response = request.into_response()
 
 		var/list/bans

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2102,24 +2102,19 @@
 			if(response.body == "[]")
 				dat += "<center><b>0 bans detected for [ckey]</b></center>"
 			else
-				bans = splittext(response.body, "},", 2, length(response.body)-1) //We don't want the [] that wraps the query
+				bans = json_decode(response["body"])
 				dat += "<center><b>[bans.len] ban\s detected for [ckey]</b></center>"
-
-				for(var/ban in bans)
-					//Okay so what's going on here is we intentionally removed }, in splittext so each ban entry wouldn't have a trailing comma (invalid json)
-					//But now we need to readd } so it's valid json.
-					//But not if it's the final entry because that retained its }
-					var/list/bandata = json_decode("[ban][ban == bans.len ? "" : "}"]")
-					dat += "<b>Server: </b> [sanitize(bandata["sourceName"])]<br>"
-					dat += "<b>Type: </b> [sanitize(bandata["type"])]<br>"
-					dat += "<b>Banned By: </b> [sanitize(bandata["bannedBy"])]<br>"
-					dat += "<b>Reason: </b> [sanitize(bandata["reason"])]<br>"
-					dat += "<b>Datetime: </b> [sanitize(bandata["bannedOn"])]<br>"
-					var/expiration = bandata["expires"]
+				for(var/list/ban in bans)
+					dat += "<b>Server: </b> [sanitize(ban["sourceName"])]<br>"
+					dat += "<b>Type: </b> [sanitize(ban["type"])]<br>"
+					dat += "<b>Banned By: </b> [sanitize(ban["bannedBy"])]<br>"
+					dat += "<b>Reason: </b> [sanitize(ban["reason"])]<br>"
+					dat += "<b>Datetime: </b> [sanitize(ban["bannedOn"])]<br>"
+					var/expiration = ban["expires"]
 					dat += "<b>Expires: </b> [expiration ? "[sanitize(expiration)]" : "Permanent"]<br>"
-					if(bandata["type"] == "job")
+					if(ban["type"] == "job")
 						dat += "<b>Jobs: </b> "
-						var/list/jobs = bandata["jobs"]
+						var/list/jobs = ban["jobs"]
 						dat += sanitize(jobs.Join(", "))
 						dat += "<br>"
 					dat += "<hr>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2083,7 +2083,7 @@
 
 		// Make the request
 		var/datum/http_request/request = new()
-		request.prepare(RUSTG_HTTP_METHOD_GET, "[CONFIG_GET(string/centcom_ban_db)][ckey]", "", "")
+		request.prepare(RUSTG_HTTP_METHOD_GET, "[CONFIG_GET(string/centcom_ban_db)]/[ckey]", "", "")
 		request.begin_async()
 		UNTIL(request.is_complete())
 		var/datum/http_response/response = request.into_response()
@@ -2117,8 +2117,8 @@
 					dat += "<b>Expires: </b> [expiration ? "[sanitize(expiration)]" : "Permanent"]<br>"
 					if(bandata["type"] == "job")
 						dat += "<b>Jobs: </b> "
-						for(var/job in bandata["jobs"])
-							dat += "[sanitize(job)], "
+						var/list/jobs = bandata["jobs"]
+						dat += sanitize(jobs.Join(", "))
 						dat += "<br>"
 					dat += "<hr>"
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2092,7 +2092,7 @@
 
 		var/list/bans
 
-		var/dat = "<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><body>"
+		var/list/dat = list("<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><body>")
 
 		if(response.errored)
 			dat += "<br>Failed to connect to CentCom."
@@ -2121,7 +2121,7 @@
 
 		dat += "<br></body>"
 		var/datum/browser/popup = new(usr, "centcomlookup-[ckey]", "<div align='center'>Central Command Galactic Ban Database</div>", 700, 600)
-		popup.set_content(dat)
+		popup.set_content(dat.Join())
 		popup.open(0)
 
 	else if(href_list["modantagrep"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2075,9 +2075,13 @@
 		if(!check_rights(R_ADMIN))
 			return
 
+		if(!CONFIG_GET(string/centcom_ban_db))
+			to_chat(usr, "<span class='warning'>Centcom Galactic Ban DB is disabled!</span>")
+			return
+
 		var/ckey = href_list["centcomlookup"]
 
-		var/list/query = json_decode(rustg_http_request_blocking(RUSTG_HTTP_METHOD_GET, "https://centcom.melonmesa.com/ban/search/[ckey]", null, null))
+		var/list/query = json_decode(rustg_http_request_blocking(RUSTG_HTTP_METHOD_GET, "[CONFIG_GET(string/centcom_ban_db)][ckey]", null, null))
 
 		var/list/bans
 
@@ -2099,17 +2103,17 @@
 					//But now we need to readd } so it's valid json.
 					//But not if it's the final entry because that retained its }
 					var/list/bandata = json_decode("[ban][ban == bans.len ? "" : "}"]")
-					dat += "<b>Server: </b> [bandata["sourceName"]]<br>"
-					dat += "<b>Type: </b> [bandata["type"]]<br>"
-					dat += "<b>Banned By: </b> [bandata["bannedBy"]]<br>"
-					dat += "<b>Reason: </b> [bandata["reason"]]<br>"
-					dat += "<b>Datetime: </b> [bandata["bannedOn"]]<br>"
+					dat += "<b>Server: </b> [sanitize(bandata["sourceName"])]<br>"
+					dat += "<b>Type: </b> [sanitize(bandata["type"])]<br>"
+					dat += "<b>Banned By: </b> [sanitize(bandata["bannedBy"])]<br>"
+					dat += "<b>Reason: </b> [sanitize(bandata["reason"])]<br>"
+					dat += "<b>Datetime: </b> [sanitize(bandata["bannedOn"])]<br>"
 					var/expiration = bandata["expires"]
-					dat += "<b>Expires: </b> [expiration ? "[expiration]" : "Permanent"]<br>"
+					dat += "<b>Expires: </b> [expiration ? "[sanitize(expiration)]" : "Permanent"]<br>"
 					if(bandata["type"] == "job")
 						dat += "<b>Jobs: </b> "
 						for(var/job in bandata["jobs"])
-							dat += "[job], "
+							dat += "[sanitize(job)], "
 						dat += "<br>"
 					dat += "<hr>"
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -494,7 +494,8 @@ DEFAULT_VIEW_SQUARE 15x15
 ## Enable automatic profiling - Byond 513.1506 and newer only.
 #AUTO_PROFILE
 
-## Uncomment to enable CentCom Galactic Ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
+## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
+## More API details can be found here: https://centcom.melonmesa.com/swagger/index.html
 #CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search/
 
 #### DISCORD STUFFS ####

--- a/config/config.txt
+++ b/config/config.txt
@@ -494,6 +494,9 @@ DEFAULT_VIEW_SQUARE 15x15
 ## Enable automatic profiling - Byond 513.1506 and newer only.
 #AUTO_PROFILE
 
+## Uncomment to enable CentCom Galactic Ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
+#CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search/
+
 #### DISCORD STUFFS ####
 ## MAKE SURE ALL SECTIONS OF THIS ARE FILLED OUT BEFORE ENABLING
 ## Discord IDs can be obtained by following this guide: https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-

--- a/config/config.txt
+++ b/config/config.txt
@@ -496,7 +496,7 @@ DEFAULT_VIEW_SQUARE 15x15
 
 ## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
 ## More API details can be found here: https://centcom.melonmesa.com/swagger/index.html
-#CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search/
+#CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search
 
 #### DISCORD STUFFS ####
 ## MAKE SURE ALL SECTIONS OF THIS ARE FILLED OUT BEFORE ENABLING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/BeeStation/BeeStation-Hornet/pull/2207

Admins will now be able to look up a player's bans from several other servers via the player panel. My hope is that this will encourage TG admins to make TG's bans public so they can be added.

See: https://centcom.melonmesa.com

Supported servers: 
* BeeStation 
* /vg/station
* FTL13

Planned support that bobbah is working on:
* Yogstation
* Oraclestation
* World Server

## Why It's Good For The Game

It makes the Feweh Global Ban Database a reality.

## Changelog
:cl: ike709 and bobbahbrown
add: Admins can now see your bans on (some) other servers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
