### PR TITLE
Renames instabitulari to syntflesh

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -17422,9 +17422,9 @@
 /obj/machinery/iv_drip,
 /obj/item/roller,
 /obj/item/storage/firstaid/regular,
-/obj/item/reagent_containers/medigel/instabitaluri,
-/obj/item/reagent_containers/medigel/instabitaluri,
-/obj/item/reagent_containers/medigel/instabitaluri,
+/obj/item/reagent_containers/medigel/synthflesh,
+/obj/item/reagent_containers/medigel/synthflesh,
+/obj/item/reagent_containers/medigel/synthflesh,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Qj" = (

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -31,7 +31,7 @@
 #define CLEAR_REAGENTS	4	// all reagents were cleared
 
 #define MIMEDRINK_SILENCE_DURATION 30  //ends up being 60 seconds given 1 tick every 2 seconds
-#define THRESHOLD_UNHUSK 50 //Health treshold for instabitaluri and rezadone to unhusk someone
+#define THRESHOLD_UNHUSK 50 //Health treshold for synthflesh and rezadone to unhusk someone
 
 //used by chem masters and pill presses
 #define PILL_STYLE_COUNT 22 //Update this if you add more pill icons or you die

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -6,7 +6,7 @@
 
 /obj/machinery/limbgrower
 	name = "limb grower"
-	desc = "It grows new limbs using Synthflesh (Instabitaluri)."
+	desc = "It grows new limbs using Synthflesh."
 	icon = 'icons/obj/machines/limbgrower.dmi'
 	icon_state = "limbgrower_idleoff"
 	density = TRUE
@@ -98,10 +98,10 @@
 				return
 
 
-			var/synth_cost = being_built.reagents_list[/datum/reagent/medicine/c2/instabitaluri]*prod_coeff
+			var/synth_cost = being_built.reagents_list[/datum/reagent/medicine/c2/synthflesh]*prod_coeff
 			var/power = max(2000, synth_cost/5)
 
-			if(reagents.has_reagent(/datum/reagent/medicine/c2/instabitaluri, being_built.reagents_list[/datum/reagent/medicine/c2/instabitaluri]*prod_coeff))
+			if(reagents.has_reagent(/datum/reagent/medicine/c2/synthflesh, being_built.reagents_list[/datum/reagent/medicine/c2/synthflesh]*prod_coeff))
 				busy = TRUE
 				use_power(power)
 				flick("limbgrower_fill",src)
@@ -115,8 +115,8 @@
 	return
 
 /obj/machinery/limbgrower/proc/build_item()
-	if(reagents.has_reagent(/datum/reagent/medicine/c2/instabitaluri, being_built.reagents_list[/datum/reagent/medicine/c2/instabitaluri]*prod_coeff))	//sanity check, if this happens we are in big trouble
-		reagents.remove_reagent(/datum/reagent/medicine/c2/instabitaluri,being_built.reagents_list[/datum/reagent/medicine/c2/instabitaluri]*prod_coeff)
+	if(reagents.has_reagent(/datum/reagent/medicine/c2/synthflesh, being_built.reagents_list[/datum/reagent/medicine/c2/synthflesh]*prod_coeff))	//sanity check, if this happens we are in big trouble
+		reagents.remove_reagent(/datum/reagent/medicine/c2/synthflesh,being_built.reagents_list[/datum/reagent/medicine/c2/synthflesh]*prod_coeff)
 		var/buildpath = being_built.build_path
 		if(ispath(buildpath, /obj/item/bodypart))	//This feels like spatgheti code, but i need to initilise a limb somehow
 			build_limb(buildpath)
@@ -124,7 +124,7 @@
 			//Just build whatever it is
 			new buildpath(loc)
 	else
-		src.visible_message("<span class='warning'>Something went very wrong, there isn't enough instabitaluri anymore!</span>")
+		src.visible_message("<span class='warning'>Something went very wrong, there isn't enough synthflesh anymore!</span>")
 	busy = FALSE
 	flick("limbgrower_unfill",src)
 	icon_state = "limbgrower_idleoff"
@@ -165,7 +165,7 @@
 /obj/machinery/limbgrower/examine(mob/user)
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
-		. += "<span class='notice'>The status display reads: Storing up to <b>[reagents.maximum_volume]u</b> of instabitaluri.<br>Instabitaluri consumption at <b>[prod_coeff*100]%</b>.</span>"
+		. += "<span class='notice'>The status display reads: Storing up to <b>[reagents.maximum_volume]u</b> of synthflesh.<br>Synthflesh consumption at <b>[prod_coeff*100]%</b>.</span>"
 
 /obj/machinery/limbgrower/proc/main_win(mob/user)
 	var/dat = "<div class='statusDisplay'><h3>Limb Grower Menu:</h3><br>"
@@ -217,12 +217,12 @@
 	return dat
 
 /obj/machinery/limbgrower/proc/can_build(datum/design/D)
-	return (reagents.has_reagent(/datum/reagent/medicine/c2/instabitaluri, D.reagents_list[/datum/reagent/medicine/c2/instabitaluri]*prod_coeff)) //Return whether the machine has enough instabitaluri to produce the design
+	return (reagents.has_reagent(/datum/reagent/medicine/c2/synthflesh, D.reagents_list[/datum/reagent/medicine/c2/synthflesh]*prod_coeff)) //Return whether the machine has enough synthflesh to produce the design
 
 /obj/machinery/limbgrower/proc/get_design_cost(datum/design/D)
 	var/dat
-	if(D.reagents_list[/datum/reagent/medicine/c2/instabitaluri])
-		dat += "[D.reagents_list[/datum/reagent/medicine/c2/instabitaluri] * prod_coeff] SynthFlesh (instabitaluri)"
+	if(D.reagents_list[/datum/reagent/medicine/c2/synthflesh])
+		dat += "[D.reagents_list[/datum/reagent/medicine/c2/synthflesh] * prod_coeff] SynthFlesh (synthflesh)"
 	return dat
 
 /obj/machinery/limbgrower/emag_act(mob/user)

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -222,7 +222,7 @@
 /obj/machinery/limbgrower/proc/get_design_cost(datum/design/D)
 	var/dat
 	if(D.reagents_list[/datum/reagent/medicine/c2/synthflesh])
-		dat += "[D.reagents_list[/datum/reagent/medicine/c2/synthflesh] * prod_coeff] SynthFlesh (synthflesh)"
+		dat += "[D.reagents_list[/datum/reagent/medicine/c2/synthflesh] * prod_coeff] SynthFlesh"
 	return dat
 
 /obj/machinery/limbgrower/emag_act(mob/user)

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -260,7 +260,7 @@
 	if(empty)
 		return
 	var/static/items_inside = list(
-		/obj/item/reagent_containers/pill/patch/instabitaluri = 3,
+		/obj/item/reagent_containers/pill/patch/synthflesh = 3,
 		/obj/item/reagent_containers/hypospray/medipen/atropine = 2,
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/storage/pill_bottle/penacid = 1)

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -233,7 +233,7 @@
 	//reagent that are possible to be chem factory'd
 	var/static/list/possible_reagents = list(\
 		/datum/reagent/medicine/spaceacillin,\
-		/datum/reagent/medicine/c2/instabitaluri,\
+		/datum/reagent/medicine/c2/synthflesh,\
 		/datum/reagent/medicine/pen_acid,\
 		/datum/reagent/medicine/atropine,\
 		/datum/reagent/medicine/cryoxadone,\

--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -9,7 +9,7 @@
 	meat = null
 	damage_overlay_type = "synth"
 	limbs_id = "synth"
-	var/disguise_fail_health = 75 //When their health gets to this level their instabitaluri partially falls off
+	var/disguise_fail_health = 75 //When their health gets to this level their synthflesh partially falls off
 	var/datum/species/fake_species //a species to do most of our work for us, unless we're damaged
 	var/list/initial_species_traits //for getting these values back for assume_disguise()
 	var/list/initial_inherent_traits
@@ -41,7 +41,7 @@
 	UnregisterSignal(H, COMSIG_MOB_SAY)
 
 /datum/species/synth/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
-	if(chem.type == /datum/reagent/medicine/c2/instabitaluri)
+	if(chem.type == /datum/reagent/medicine/c2/synthflesh)
 		chem.expose_mob(H, TOUCH, 2 ,0) //heal a little
 		H.reagents.remove_reagent(chem.type, REAGENTS_METABOLISM)
 		return 1

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -406,13 +406,13 @@
 #undef issyrinormusc
 /******COMBOS******/
 /*Suffix: Combo of healing, prob gonna get wack REAL fast*/
-/datum/reagent/medicine/c2/instabitaluri
-	name = "Synthflesh (Instabitaluri)"
+/datum/reagent/medicine/c2/synthflesh
+	name = "Synthflesh"
 	description = "Heals brute and burn damage at the cost of toxicity (66% of damage healed). Touch application only."
 	reagent_state = LIQUID
 	color = "#FFEBEB"
 
-/datum/reagent/medicine/c2/instabitaluri/expose_mob(mob/living/M, method=TOUCH, reac_volume,show_message = 1)
+/datum/reagent/medicine/c2/synthflesh/expose_mob(mob/living/M, method=TOUCH, reac_volume,show_message = 1)
 	if(iscarbon(M))
 		var/mob/living/carbon/carbies = M
 		if (carbies.stat == DEAD)
@@ -427,7 +427,7 @@
 			if(show_message)
 				to_chat(carbies, "<span class='danger'>You feel your burns and bruises healing! It stings like hell!</span>")
 			SEND_SIGNAL(carbies, COMSIG_ADD_MOOD_EVENT, "painful_medicine", /datum/mood_event/painful_medicine)
-			if(HAS_TRAIT_FROM(M, TRAIT_HUSK, "burn") && carbies.getFireLoss() < THRESHOLD_UNHUSK && (carbies.reagents.get_reagent_amount(/datum/reagent/medicine/c2/instabitaluri) + reac_volume >= 100))
+			if(HAS_TRAIT_FROM(M, TRAIT_HUSK, "burn") && carbies.getFireLoss() < THRESHOLD_UNHUSK && (carbies.reagents.get_reagent_amount(/datum/reagent/medicine/c2/synthflesh) + reac_volume >= 100))
 				carbies.cure_husk("burn")
 				carbies.visible_message("<span class='nicegreen'>A rubbery liquid coats [carbies]'s burns. [carbies] looks a lot healthier!") //we're avoiding using the phrases "burnt flesh" and "burnt skin" here because carbies could be a skeleton or a golem or something
 	..()

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -50,8 +50,8 @@
 	results = list(/datum/reagent/medicine/mine_salve = 15)
 	required_reagents = list(/datum/reagent/toxin/plasma = 5, /datum/reagent/iron = 5, /datum/reagent/consumable/sugar = 1) // A sheet of plasma, a twinkie and a sheet of metal makes four of these
 
-/datum/chemical_reaction/instabitaluri
-	results = list(/datum/reagent/medicine/c2/instabitaluri = 3)
+/datum/chemical_reaction/synthflesh
+	results = list(/datum/reagent/medicine/c2/synthflesh = 3)
 	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/c2/libital = 1)
 
 /datum/chemical_reaction/calomel

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -401,14 +401,14 @@
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/uranium/radium = 1, /datum/reagent/drug/space_drugs = 1, /datum/reagent/medicine/cryoxadone = 1, /datum/reagent/consumable/triple_citrus = 1)
 
 /datum/chemical_reaction/life
-	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/c2/instabitaluri = 1, /datum/reagent/blood = 1)
+	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/c2/synthflesh = 1, /datum/reagent/blood = 1)
 	required_temp = 374
 
 /datum/chemical_reaction/life/on_reaction(datum/reagents/holder, created_volume)
 	chemical_mob_spawn(holder, rand(1, round(created_volume, 1)), "Life (hostile)") //defaults to HOSTILE_SPAWN
 
 /datum/chemical_reaction/life_friendly
-	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/c2/instabitaluri = 1, /datum/reagent/consumable/sugar = 1)
+	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/c2/synthflesh = 1, /datum/reagent/consumable/sugar = 1)
 	required_temp = 374
 
 /datum/chemical_reaction/life_friendly/on_reaction(datum/reagents/holder, created_volume)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -108,7 +108,7 @@
 			return
 	..()
 
-/* 
+/*
  * On accidental consumption, make sure the container is partially glass, and continue to the reagent_container proc
  */
 /obj/item/reagent_containers/glass/on_accidental_consumption(mob/living/carbon/M, mob/living/carbon/user, obj/item/source_item, discover_after = TRUE)
@@ -213,8 +213,8 @@
 	name = "epinephrine reserve tank (diluted)"
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 50)
 
-/obj/item/reagent_containers/glass/beaker/instabitaluri
-	list_reagents = list(/datum/reagent/medicine/c2/instabitaluri = 50)
+/obj/item/reagent_containers/glass/beaker/synthflesh
+	list_reagents = list(/datum/reagent/medicine/c2/synthflesh = 50)
 
 /obj/item/reagent_containers/glass/bucket
 	name = "bucket"

--- a/code/modules/reagents/reagent_containers/medigel.dm
+++ b/code/modules/reagents/reagent_containers/medigel.dm
@@ -88,12 +88,12 @@
 	current_skin = "burngel"
 	list_reagents = list(/datum/reagent/medicine/c2/aiuri = 24, /datum/reagent/medicine/granibitaluri = 36)
 
-/obj/item/reagent_containers/medigel/instabitaluri
-	name = "medical gel (instabitaluri)"
-	desc = "A medical gel applicator bottle, designed for precision application, with an unscrewable cap. This one contains instabitaluri, a slightly toxic medicine capable of healing both bruises and burns."
+/obj/item/reagent_containers/medigel/synthflesh
+	name = "medical gel (synthflesh)"
+	desc = "A medical gel applicator bottle, designed for precision application, with an unscrewable cap. This one contains synthflesh, a slightly toxic medicine capable of healing both bruises and burns."
 	icon_state = "synthgel"
 	current_skin = "synthgel"
-	list_reagents = list(/datum/reagent/medicine/c2/instabitaluri = 60)
+	list_reagents = list(/datum/reagent/medicine/c2/synthflesh = 60)
 	custom_price = 600
 
 /obj/item/reagent_containers/medigel/sterilizine

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -39,8 +39,8 @@
 	list_reagents = list(/datum/reagent/medicine/c2/aiuri = 2, /datum/reagent/medicine/granibitaluri = 8)
 	icon_state = "bandaid_burn"
 
-/obj/item/reagent_containers/pill/patch/instabitaluri
-	name = "instabitaluri patch"
+/obj/item/reagent_containers/pill/patch/synthflesh
+	name = "synthflesh patch"
 	desc = "Helps with brute and burn injuries. Slightly toxic."
-	list_reagents = list(/datum/reagent/medicine/c2/instabitaluri = 20)
+	list_reagents = list(/datum/reagent/medicine/c2/synthflesh = 20)
 	icon_state = "bandaid_both"

--- a/code/modules/research/designs/limbgrower_designs.dm
+++ b/code/modules/research/designs/limbgrower_designs.dm
@@ -6,7 +6,7 @@
 	name = "Left Arm"
 	id = "leftarm"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/instabitaluri = 25)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 25)
 	build_path = /obj/item/bodypart/l_arm
 	category = list("initial","human","lizard","moth","plasmaman","ethereal")
 
@@ -14,7 +14,7 @@
 	name = "Right Arm"
 	id = "rightarm"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/instabitaluri = 25)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 25)
 	build_path = /obj/item/bodypart/r_arm
 	category = list("initial","human","lizard","moth","plasmaman","ethereal")
 
@@ -22,7 +22,7 @@
 	name = "Left Leg"
 	id = "leftleg"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/instabitaluri = 25)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 25)
 	build_path = /obj/item/bodypart/l_leg
 	category = list("initial","human","lizard","moth","plasmaman","ethereal")
 
@@ -30,7 +30,7 @@
 	name = "Right Leg"
 	id = "rightleg"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/instabitaluri = 25)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 25)
 	build_path = /obj/item/bodypart/r_leg
 	category = list("initial","human","lizard","moth","plasmaman","ethereal")
 
@@ -40,7 +40,7 @@
 	name = "Arm Blade"
 	id = "armblade"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/instabitaluri = 75)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 75)
 	build_path = /obj/item/melee/synthetic_arm_blade
 	category = list("other","emagged")
 
@@ -48,7 +48,7 @@
 	name = "Heart"
 	id = "heart"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/instabitaluri = 30)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 30)
 	build_path = /obj/item/organ/heart
 	category = list("other")
 
@@ -56,7 +56,7 @@
 	name = "Lungs"
 	id = "lungs"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/instabitaluri = 20)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 20)
 	build_path = /obj/item/organ/lungs
 	category = list("other")
 
@@ -64,7 +64,7 @@
 	name = "Liver"
 	id = "liver"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/instabitaluri = 20)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 20)
 	build_path = /obj/item/organ/liver
 	category = list("other")
 
@@ -72,7 +72,7 @@
 	name = "Stomach"
 	id = "stomach"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/instabitaluri = 15)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 15)
 	build_path = /obj/item/organ/stomach
 	category = list("other")
 
@@ -80,7 +80,7 @@
 	name = "Appendix"
 	id = "appendix"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/instabitaluri = 5) //why would you need this
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 5) //why would you need this
 	build_path = /obj/item/organ/appendix
 	category = list("other")
 
@@ -88,7 +88,7 @@
 	name = "Eyes"
 	id = "eyes"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/instabitaluri = 10)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10)
 	build_path = /obj/item/organ/eyes
 	category = list("other")
 
@@ -96,7 +96,7 @@
 	name = "Ears"
 	id = "ears"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/instabitaluri = 10)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10)
 	build_path = /obj/item/organ/ears
 	category = list("other")
 
@@ -104,6 +104,6 @@
 	name = "Tongue"
 	id = "tongue"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/instabitaluri = 10)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10)
 	build_path = /obj/item/organ/tongue
 	category = list("other")

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -803,7 +803,7 @@
 
 /datum/design/surgery/wing_reconstruction
 	name = "Wing Reconstruction"
-	desc = "An experimental surgical procedure that reconstructs the damaged wings of moth people. Requires Instabitaluri."
+	desc = "An experimental surgical procedure that reconstructs the damaged wings of moth people. Requires Synthflesh."
 	id = "surgery_wing_reconstruction"
 	surgery = /datum/surgery/advanced/wing_reconstruction
 	research_icon_state = "surgery_chest"

--- a/code/modules/surgery/advanced/wingreconstruction.dm
+++ b/code/modules/surgery/advanced/wingreconstruction.dm
@@ -1,6 +1,6 @@
 /datum/surgery/advanced/wing_reconstruction
 	name = "Wing Reconstruction"
-	desc = "An experimental surgical procedure that reconstructs the damaged wings of moth people. Requires Instabitaluri."
+	desc = "An experimental surgical procedure that reconstructs the damaged wings of moth people. Requires Synthflesh."
 	steps = list(/datum/surgery_step/incise,
 				/datum/surgery_step/retract_skin,
 				/datum/surgery_step/clamp_bleeders,
@@ -15,7 +15,7 @@
 	name = "start wing reconstruction"
 	implements = list(TOOL_HEMOSTAT = 85, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
 	time = 200
-	chems_needed = list(/datum/reagent/medicine/c2/instabitaluri)
+	chems_needed = list(/datum/reagent/medicine/c2/synthflesh)
 	require_all_chems = FALSE
 
 /datum/surgery_step/wing_reconstruction/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -35,7 +35,7 @@
 						/obj/item/reagent_containers/pill/multiver = 6,
 						/obj/item/storage/box/gum/happiness = 3,
 						/obj/item/storage/box/hug/medical = 1)
-	premium = list(/obj/item/reagent_containers/medigel/instabitaluri = 2,
+	premium = list(/obj/item/reagent_containers/medigel/synthflesh = 2,
 					/obj/item/storage/pill_bottle/psicodine = 2,
 					/obj/item/reagent_containers/hypospray/medipen = 3,
 					/obj/item/storage/belt/medical = 3,


### PR DESCRIPTION
###  Why It's Good For The Game
Everyone calls it synthflesh. The wiki and code both also refer to it as Synthflesh. Instabitulari is called the way it us to indicate that it heals both brute and burn. While nice, there's plenty of chemicals that also ignore this naming convention in exchange for using a more trivial name (Miner's salve, Saline-glucose solution). Instabitulari is in creation and application synthethic flesh. Apart from brute and burn healing, it can also undo husking by refreshing the skin with synthethic flesh. 

:cl:
tweak: Instabitulari is called synthflesh again
/:cl:
