### PR TITLE
trying to add a mushroom to an Arnold pizza will now mute you

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_pizza.dm
+++ b/code/modules/food_and_drinks/food/snacks_pizza.dm
@@ -195,7 +195,7 @@
 		to_chat(user, "<font color='red' size='7'>If you want something crazy like pineapple, I'll kill you.</font>") //this is in bigger text because it's hard to spam something that gibs you, and so that you're perfectly aware of the reason why you died
 		user.gib() //if you want something crazy like pineapple, i'll kill you
 	else if(istype(I, /obj/item/reagent_containers/food/snacks/grown/mushroom) && iscarbon(user))
-		to_chat(user, "<font color='red' size='4'>So, if you want mushroom, shut up.</font>") //not as large as the pineapple text, because you could in theory spam it
+		to_chat(user, "<span class='userdanger'>So, if you want mushroom, shut up.</span>") //not as large as the pineapple text, because you could in theory spam it
 		var/mob/living/carbon/shutup = user
 		shutup.gain_trauma(/datum/brain_trauma/severe/mute)
 

--- a/code/modules/food_and_drinks/food/snacks_pizza.dm
+++ b/code/modules/food_and_drinks/food/snacks_pizza.dm
@@ -182,7 +182,7 @@
 	var/obj/item/bodypart/l_arm = user.get_bodypart(BODY_ZONE_L_ARM)
 	var/obj/item/bodypart/r_arm = user.get_bodypart(BODY_ZONE_R_ARM)
 	if(prob(50) && iscarbon(user) && M == user && (r_arm || l_arm))
-		to_chat(user, "<font color='red' size='4'>Maybe I'll give you a pizza, maybe I'll break off your arm.</font>") //makes the reference more obvious
+		to_chat(user, "<span class='userdanger'>Maybe I'll give you a pizza, maybe I'll break off your arm.</span>") //makes the reference more obvious
 		user.visible_message("<span class='warning'>\The [src] breaks off [user]'s arm!</span>", "<span class='warning'>\The [src] breaks off your arm!</span>")
 		if(l_arm)
 			l_arm.dismember()

--- a/code/modules/food_and_drinks/food/snacks_pizza.dm
+++ b/code/modules/food_and_drinks/food/snacks_pizza.dm
@@ -178,11 +178,12 @@
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "pepperoni" = 2, "9 millimeter bullets" = 2)
 	value = FOOD_ILLEGAL
 
-/obj/item/reagent_containers/food/snacks/proc/try_break_off(mob/living/M, mob/living/user) //maybe i give you a pizza maybe i break off your arm
+/obj/item/reagent_containers/food/snacks/proc/try_break_off(mob/living/M, mob/living/user) //maybe i'll give you a pizza, maybe i'll break off your arm
 	var/obj/item/bodypart/l_arm = user.get_bodypart(BODY_ZONE_L_ARM)
 	var/obj/item/bodypart/r_arm = user.get_bodypart(BODY_ZONE_R_ARM)
 	if(prob(50) && iscarbon(user) && M == user && (r_arm || l_arm))
-		user.visible_message("<span class='warning'>\The [src] breaks off [user]'s arm!!</span>", "<span class='warning'>\The [src] breaks off your arm!</span>")
+		to_chat(user, "<font color='red' size='4'>Maybe I'll give you a pizza, maybe I'll break off your arm.</font>") //makes the reference more obvious
+		user.visible_message("<span class='warning'>\The [src] breaks off [user]'s arm!</span>", "<span class='warning'>\The [src] breaks off your arm!</span>")
 		if(l_arm)
 			l_arm.dismember()
 		else
@@ -191,8 +192,12 @@
 
 /obj/item/reagent_containers/food/snacks/proc/i_kill_you(obj/item/I, mob/user)
 	if(istype(I, /obj/item/reagent_containers/food/snacks/pineappleslice))
-		to_chat(user, "<font color='red' size='7'>If you want something crazy like pineapple, I kill you.</font>")
-		user.gib() //if you want something crazy like pineapple, i kill you
+		to_chat(user, "<font color='red' size='7'>If you want something crazy like pineapple, I'll kill you.</font>") //this is in bigger text because it's hard to spam something that gibs you, and so that you're perfectly aware of the reason why you died
+		user.gib() //if you want something crazy like pineapple, i'll kill you
+	else if(istype(I, /obj/item/reagent_containers/food/snacks/grown/mushroom) && iscarbon(user))
+		to_chat(user, "<font color='red' size='4'>So, if you want mushroom, shut up.</font>") //not as large as the pineapple text, because you could in theory spam it
+		var/mob/living/carbon/shutup = user
+		shutup.gain_trauma(/datum/brain_trauma/severe/mute)
 
 /obj/item/reagent_containers/food/snacks/pizza/arnold/attack(mob/living/M, mob/living/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Attempting to add a mushroom to an Arnold pizza as a carbon will give you the "mutism" brain trauma (at its default resilience tier of TRAUMA_RESILIENCE_SURGERY).

Arnold pizza now sends you a message in bigtext when it breaks off your arm and when it mutes you. These bigtext messages are smaller than the message that Arnold pizza sends you when you try to put pineapple on it, so as to avoid filling up the chat box of the person interacting with the pizza (the pineapple gibbing message is still as obnoxiously large as it was before, though).

Also, I noticed that the to_chat message sent to people who try to put a pineapple slice on an Arnold pizza actually slightly misquotes the original source material (he does actually say "I'll kill you" (or, well, "Ah'll keel you") in the original video, not "I kill you").

## Why It's Good For The Game

https://www.youtube.com/watch?v=pKV74qkokmk

## Changelog
:cl: ATHATH
add: A special interaction for trying to put a mushroom on an Arnold pizza has been added.
add: Arnold pizza references its source material more accurately/often now.
/:cl:
