### PR TITLE
Running unit tests no longer requires a launch parameter

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -429,11 +429,9 @@ GLOBAL_LIST_INIT(pda_styles, sortList(list(MONO, VT, ORBITRON, SHARE)))
 #define TELEPORT_CHANNEL_CULT "cult"			//Cult teleportation, does whatever it wants (unless there's holiness)
 #define TELEPORT_CHANNEL_FREE "free"			//Anything else
 
-//Run the world with this parameter to enable a single run though of the game setup and tear down process with unit tests in between
-#define TEST_RUN_PARAMETER "test-run"
 //Force the log directory to be something specific in the data/logs folder
 #define OVERRIDE_LOG_DIRECTORY_PARAMETER "log-directory"
-//Prevent the master controller from starting automatically, overrides TEST_RUN_PARAMETER
+//Prevent the master controller from starting automatically
 #define NO_INIT_PARAMETER "no-init"
 //Force the config directory to be something other than "config"
 #define OVERRIDE_CONFIG_DIRECTORY_PARAMETER "config-directory"

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -22,7 +22,7 @@
 //#define REFERENCE_TRACKING		//Enables extools-powered reference tracking system, letting you see what is
 									//referencing objects that refuse to hard delete
 
-//#define UNIT_TESTS			//Enables unit tests via TEST_RUN_PARAMETER
+//#define UNIT_TESTS			//If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 
 #ifndef PRELOAD_RSC				//set to:
 #define PRELOAD_RSC	2			//	0 to allow using external resources or on-demand behaviour;

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -71,7 +71,11 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	// Highlander-style: there can only be one! Kill off the old and replace it with the new.
 
 	if(!random_seed)
-		random_seed = (TEST_RUN_PARAMETER in world.params) ? 29051994 : rand(1, 1e9)
+		#ifdef UNIT_TESTS
+		random_seed = 29051994
+		#else
+		random_seed = rand(1, 1e9)
+		#endif
 		rand_seed(random_seed)
 
 	var/list/_subsystems = list()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -77,8 +77,9 @@ GLOBAL_VAR(restart_counter)
 
 	Master.Initialize(10, FALSE, TRUE)
 
-	if(TEST_RUN_PARAMETER in params)
-		HandleTestRun()
+	#ifdef UNIT_TESTS
+	HandleTestRun()
+	#endif
 
 /world/proc/InitTgs()
 	TgsNew(new /datum/tgs_event_handler/impl, TGS_SECURITY_TRUSTED)
@@ -253,9 +254,10 @@ GLOBAL_VAR(restart_counter)
 
 	TgsReboot()
 
-	if(TEST_RUN_PARAMETER in params)
-		FinishTestRun()
-		return
+	#ifdef UNIT_TESTS
+	FinishTestRun()
+	return
+	#endif
 
 	if(TgsAvailable())
 		var/do_hard_reboot

--- a/tools/travis/run_server.sh
+++ b/tools/travis/run_server.sh
@@ -9,6 +9,6 @@ mkdir travis_test/config
 cp tools/travis/travis_config.txt travis_test/config/config.txt
 
 cd travis_test
-DreamDaemon tgstation.dmb -close -trusted -verbose -params "test-run&log-directory=travis"
+DreamDaemon tgstation.dmb -close -trusted -verbose -params "log-directory=travis"
 cd ..
 cat travis_test/data/logs/travis/clean_run.lk


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Unit tests currently require you to compile with the UNIT_TESTS define in _compile_options.dm AND run the server with a special unit test parameter in order to actually run. Dreamdaemon doesn't have an option to add launch params, and I'm a baby who doesn't want to switch back and forth between a powershell window to actually run the tests, so I asked around if removing the parameter would break anything. @Cyberboss and @Jared-Fogle said they didn't see any issues with it, though obviously I don't know how the git/test pipeline works, so more insight would be appreciated.

Obviously this removes the ability to compile with UNIT_TESTS and still be able to choose between launching the game and launching the unit tests, but I don't know if anyone actually does that in practice. Also pinging @MrStonedOne cause I dunno if this may affect any of the server pipeline
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes running unit tests a little easier and less alt-tab intensive on local
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
