### PR TITLE
Remove cable hubs from handcrafting.

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -379,7 +379,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 // Definitions
 ////////////////////////////////
 
-GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restraints", /obj/item/restraints/handcuffs/cable, 15), new/datum/stack_recipe("multilayer cable", /obj/structure/cable/multilayer, 1), new/datum/stack_recipe("multiZ cable", /obj/structure/cable/multilayer/multiz, 1)))
+GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restraints", /obj/item/restraints/handcuffs/cable, 15)))
 
 /obj/item/stack/cable_coil
 	name = "cable coil"


### PR DESCRIPTION

## About The Pull Request

fix #52490

## Why It's Good For The Game

Bugs is bad

## Changelog
:cl:
fix: Cable hubs no more can be created by handcraft. Cuble hubs available only in cable radial menu.
/:cl:
