### PR TITLE
Move cable radial menu to attack_self. Move recipe crafting to radial menu chose

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -450,7 +450,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 
 GLOBAL_LIST(cable_radial_layer_list)
 
-/obj/item/stack/cable_coil/CtrlClick(mob/living/user)
+/obj/item/stack/cable_coil/attack_self(mob/living/user)
 	if(loc!=user)
 		return ..()
 	if(!user)
@@ -461,7 +461,8 @@ GLOBAL_LIST(cable_radial_layer_list)
 		"Layer 2" = image(icon = 'icons/mob/radial.dmi', icon_state = "coil-yellow"),
 		"Layer 3" = image(icon = 'icons/mob/radial.dmi', icon_state = "coil-blue"),
 		"Multilayer cable hub" = image(icon = 'icons/obj/power.dmi', icon_state = "cable_bridge"),
-		"Multi Z layer cable hub" = image(icon = 'icons/obj/power.dmi', icon_state = "cablerelay-broken-cable")
+		"Multi Z layer cable hub" = image(icon = 'icons/obj/power.dmi', icon_state = "cablerelay-broken-cable"),
+		"Cable crafting" = image(icon = 'icons/obj/items_and_weapons.dmi', icon_state = "cuff")
 		)
 	var/layer_result = show_radial_menu(user, src, GLOB.cable_radial_layer_list, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE, tooltips = TRUE)
 	if(!check_menu(user))
@@ -498,6 +499,8 @@ GLOBAL_LIST(cable_radial_layer_list)
 			target_type = /obj/structure/cable/multilayer/multiz
 			target_layer = CABLE_LAYER_2
 			novariants = TRUE
+		if("Cable crafting")
+			interact(user)
 	update_icon()
 
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -451,8 +451,6 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 GLOBAL_LIST(cable_radial_layer_list)
 
 /obj/item/stack/cable_coil/attack_self(mob/living/user)
-	if(loc!=user)
-		return ..()
 	if(!user)
 		return
 	if(!GLOB.cable_radial_layer_list)


### PR DESCRIPTION
## About The Pull Request

Move cable radial menu to attack_self.
Move recipe crafting to radial menu chose

## Why It's Good For The Game

Easy acces to cable radial menu.
Return of ability to take part of cable coil via alt click.

## Changelog
:cl:
tweak: Move cable radial menu to attack_self.
tweak: Move recipe crafting to radial menu chose.
tweak: Return of ability to take part of cable coil via alt click.
/:cl:
