### PR TITLE
Fix check_completion()

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -56,12 +56,10 @@
 		. += "[head.icon_state]+o"
 
 /obj/item/robot_suit/proc/check_completion()
-	if(src.l_arm && src.r_arm)
-		if(src.l_leg && src.r_leg)
-			if(src.chest && src.head)
-				SSblackbox.record_feedback("amount", "cyborg_frames_built", 1)
-				return 1
-	return 0
+	if(l_arm && r_arm && l_leg && r_leg && head && head.flash1 && head.flash2 && chest && chest.wired && chest.cell)
+		SSblackbox.record_feedback("amount", "cyborg_frames_built", 1)
+		return TRUE
+	return FALSE
 
 /obj/item/robot_suit/wrench_act(mob/living/user, obj/item/I) //Deconstucts empty borg shell. Flashes remain unbroken because they haven't been used yet
 	. = ..()


### PR DESCRIPTION
check_completion() now check all parts

## About The Pull Request

check_completion() now check all parts
Fix #52542

## Why It's Good For The Game

Bugs is bad.

## Changelog
:cl:
fix: cyborg endoskeleton now check all parts for completion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
