### PR TITLE
Adds Hand Drill and Jaws of Life to Science lathe.

### DIFF
--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -11,7 +11,7 @@
 	materials = list(/datum/material/iron = 3500, /datum/material/silver = 1500, /datum/material/titanium = 2500)
 	build_path = /obj/item/screwdriver/power
 	category = list("Tool Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/jawsoflife
 	name = "Jaws of Life"
@@ -21,7 +21,7 @@
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 4500, /datum/material/silver = 2500, /datum/material/titanium = 3500)
 	category = list("Tool Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/exwelder
 	name = "Experimental Welding Tool"


### PR DESCRIPTION
## About The Pull Request

You can now print Jaws of Life and Hand Drills from the Science Lathe.

## Why It's Good For The Game

You can print the experimental welder tool but not the other experimental tools right now. It would also make sense for science to have access to "experimental" tools. Roboticists and the RD by extension use tools often, and it can be argued that science makes as much machines and computers as Engineering, so the tools would benefit everyone.

## Changelog
:cl: Kathy Ryals
add: NanoTrasen updated their science lathe OS, and it can now print Jaws of Life and Hand Drills !

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
