### PR TITLE
Revives metalgen as a secret chem

### DIFF
--- a/code/modules/reagents/chemistry/recipes/special.dm
+++ b/code/modules/reagents/chemistry/recipes/special.dm
@@ -19,7 +19,7 @@ GLOBAL_LIST_INIT(medicine_reagents, build_medicine_reagents())
 			.[r] += type
 		qdel(item)
 
-//Just grab every craftable medicine you can think off
+///Just grab every craftable medicine you can think off
 /proc/build_medicine_reagents()
 	. = list()
 
@@ -177,6 +177,8 @@ GLOBAL_LIST_INIT(medicine_reagents, build_medicine_reagents())
 	persistence_period = 3 //Resets every three days. It's the ultimate meme and is best not worn out
 	randomize_req_temperature = TRUE
 	possible_catalysts = list(/datum/reagent/wittel)
+	min_catalysts = 1
+	max_catalysts = 1
 	results = list(/datum/reagent/metalgen=20)
 
 /datum/chemical_reaction/randomized/metalgen/GetPossibleReagents(kind)

--- a/code/modules/reagents/chemistry/recipes/special.dm
+++ b/code/modules/reagents/chemistry/recipes/special.dm
@@ -1,4 +1,5 @@
 GLOBAL_LIST_INIT(food_reagents, build_reagents_to_food()) //reagentid = related food types
+GLOBAL_LIST_INIT(medicine_reagents, build_medicine_reagents())
 
 /proc/build_reagents_to_food()
 	. = list()
@@ -18,6 +19,14 @@ GLOBAL_LIST_INIT(food_reagents, build_reagents_to_food()) //reagentid = related 
 			.[r] += type
 		qdel(item)
 
+//Just grab every craftable medicine you can think off
+/proc/build_medicine_reagents()
+	. = list()
+
+	for(var/A in subtypesof(/datum/reagent/medicine))
+		var/datum/reagent/R = A
+		if(initial(R.can_synth))
+			. += R
 
 #define RNGCHEM_INPUT "input"
 #define RNGCHEM_CATALYSTS "catalysts"
@@ -162,10 +171,27 @@ GLOBAL_LIST_INIT(food_reagents, build_reagents_to_food()) //reagentid = related 
 			return food_reagent_ids
 	return ..()
 
+///Random recipey for meme chem metalgen. Always requires wittel and resets every 3 days
+/datum/chemical_reaction/randomized/metalgen
+	persistent = TRUE
+	persistence_period = 3 //Resets every three days. It's the ultimate meme and is best not worn out
+	randomize_req_temperature = TRUE
+	possible_catalysts = list(/datum/reagent/wittel)
+	results = list(/datum/reagent/metalgen=1)
+
+/datum/chemical_reaction/randomized/metalgen/GetPossibleReagents(kind)
+	switch(kind)
+		if(RNGCHEM_INPUT)
+			return GLOB.medicine_reagents
+	return ..()
 
 /obj/item/paper/secretrecipe
 	name = "old recipe"
-	var/recipe_id = /datum/chemical_reaction/randomized/secret_sauce
+
+	///List of possible recipeys we could display
+	var/list/possible_recipeys = list(/datum/chemical_reaction/randomized/secret_sauce, /datum/chemical_reaction/randomized/metalgen)
+	///The one we actually end up displaying
+	var/recipe_id = null
 
 /obj/item/paper/secretrecipe/examine(mob/user) //Extra secret
 	if(isobserver(user))
@@ -174,6 +200,9 @@ GLOBAL_LIST_INIT(food_reagents, build_reagents_to_food()) //reagentid = related 
 
 /obj/item/paper/secretrecipe/Initialize()
 	. = ..()
+
+	recipe_id = pick(possible_recipeys)
+
 	if(SSpersistence.initialized)
 		UpdateInfo()
 	else

--- a/code/modules/reagents/chemistry/recipes/special.dm
+++ b/code/modules/reagents/chemistry/recipes/special.dm
@@ -171,7 +171,7 @@ GLOBAL_LIST_INIT(medicine_reagents, build_medicine_reagents())
 			return food_reagent_ids
 	return ..()
 
-///Random recipey for meme chem metalgen. Always requires wittel and resets every 3 days
+///Random recipe for meme chem metalgen. Always requires wittel and resets every 3 days
 /datum/chemical_reaction/randomized/metalgen
 	persistent = TRUE
 	persistence_period = 3 //Resets every three days. It's the ultimate meme and is best not worn out
@@ -188,8 +188,8 @@ GLOBAL_LIST_INIT(medicine_reagents, build_medicine_reagents())
 /obj/item/paper/secretrecipe
 	name = "old recipe"
 
-	///List of possible recipeys we could display
-	var/list/possible_recipeys = list(/datum/chemical_reaction/randomized/secret_sauce, /datum/chemical_reaction/randomized/metalgen)
+	///List of possible recipes we could display
+	var/list/possible_recipes = list(/datum/chemical_reaction/randomized/secret_sauce, /datum/chemical_reaction/randomized/metalgen)
 	///The one we actually end up displaying
 	var/recipe_id = null
 
@@ -201,7 +201,7 @@ GLOBAL_LIST_INIT(medicine_reagents, build_medicine_reagents())
 /obj/item/paper/secretrecipe/Initialize()
 	. = ..()
 
-	recipe_id = pick(possible_recipeys)
+	recipe_id = pick(possible_recipes)
 
 	if(SSpersistence.initialized)
 		UpdateInfo()

--- a/code/modules/reagents/chemistry/recipes/special.dm
+++ b/code/modules/reagents/chemistry/recipes/special.dm
@@ -177,7 +177,7 @@ GLOBAL_LIST_INIT(medicine_reagents, build_medicine_reagents())
 	persistence_period = 3 //Resets every three days. It's the ultimate meme and is best not worn out
 	randomize_req_temperature = TRUE
 	possible_catalysts = list(/datum/reagent/wittel)
-	results = list(/datum/reagent/metalgen=1)
+	results = list(/datum/reagent/metalgen=20)
 
 /datum/chemical_reaction/randomized/metalgen/GetPossibleReagents(kind)
 	switch(kind)


### PR DESCRIPTION
The metalgen recipey was removed a while back because of balance concerns. 
This readds it as a random secret recipey without changing anything about the chem itself.

Example recipey:
![image](https://user-images.githubusercontent.com/7501474/88565741-50765d80-d035-11ea-9134-d2783495bb93.png)

It always requires wittel (the super rare geyser chem). So instead of the old recipey where you had to absolutely search every inch of lavaland for it, you now still have to do that while also needing to know it's secret recipey and having to make a bunch of complicated medicines aswell. 

:cl:
add: Rumors are a recipey for metalgen has been discovered! Although it's very secret and very random (you can find a paper in some ruins with the recipey, it resets every three days).
/:cl:

### Why this is good for the game
Metalgen is the chem that turns other stuff into whatever material you imprint metalgen with. You can turn hallways into gold or something else. It was removed because it seriously fucked over economy by allowing near-infinite mat-duping, but now economy doesn't allow material exports anymore. 

This makes it so people can't hunt all of lavaland for it without having found the recipey for it (or having the luck of someone else having found it). This should make it more of an opportunistic chem and make crafting of the actual metalgen chem a once-in-a-blue-moon occurence

