### PR TITLE
Fixes chasms to oblivion not killing living mobs before deletion

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -131,6 +131,9 @@
 		if(iscyborg(AM))
 			var/mob/living/silicon/robot/S = AM
 			qdel(S.mmi)
+		if(isliving(AM))
+			var/mob/living/L = AM
+			L.death(TRUE)
 
 		falling_atoms -= AM
 		qdel(AM)

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -133,7 +133,8 @@
 			qdel(S.mmi)
 		if(isliving(AM))
 			var/mob/living/L = AM
-			L.death(TRUE)
+			if(L.stat != DEAD)
+				L.death(TRUE)
 
 		falling_atoms -= AM
 		qdel(AM)


### PR DESCRIPTION
## About The Pull Request

Adds a call to `/mob/living/death()` before `qdel()` for living mobs that fall to their doom if they aren't already dead.

## Why It's Good For The Game

Fixes the lack of a signal and deathrattle notice when unfortunate players fall in.

## Changelog
:cl:
fix: Fixed chasms deleting living victims without killing them first.
/:cl:
