### PR TITLE
Non-machine machines no longer runtime when built off a machine board.

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -184,7 +184,7 @@
 				if(component_check)
 					P.play_tool_sound(src)
 					var/obj/potential_machine = new circuit.build_path(loc)
-					if(ismachinery(new_machine))
+					if(ismachinery(potential_machine))
 						var/obj/machinery/new_machine = potential_machine
 						if(new_machine.circuit)
 							QDEL_NULL(new_machine.circuit)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -183,11 +183,9 @@
 						break
 				if(component_check)
 					P.play_tool_sound(src)
-					var/obj/machinery/new_machine = new circuit.build_path(loc)
-					if(!istype(new_machine, /obj/machinery))
-						qdel(src)
-						return
+					var/obj/potential_machine = new circuit.build_path(loc)
 					if(ismachinery(new_machine))
+						var/obj/machinery/new_machine = potential_machine
 						if(new_machine.circuit)
 							QDEL_NULL(new_machine.circuit)
 						new_machine.circuit = circuit

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -187,19 +187,20 @@
 					if(!istype(new_machine, /obj/machinery))
 						qdel(src)
 						return
-					if(new_machine.circuit)
-						QDEL_NULL(new_machine.circuit)
-					new_machine.circuit = circuit
-					new_machine.set_anchored(anchored)
-					new_machine.on_construction()
-					for(var/obj/O in new_machine.component_parts)
-						qdel(O)
-					new_machine.component_parts = list()
-					for(var/obj/O in src)
-						O.moveToNullspace()
-						new_machine.component_parts += O
-					circuit.moveToNullspace()
-					new_machine.RefreshParts()
+					if(ismachinery(new_machine))
+						if(new_machine.circuit)
+							QDEL_NULL(new_machine.circuit)
+						new_machine.circuit = circuit
+						new_machine.set_anchored(anchored)
+						new_machine.on_construction()
+						for(var/obj/O in new_machine.component_parts)
+							qdel(O)
+						new_machine.component_parts = list()
+						for(var/obj/O in src)
+							O.moveToNullspace()
+							new_machine.component_parts += O
+						circuit.moveToNullspace()
+						new_machine.RefreshParts()
 					qdel(src)
 				return
 

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -184,6 +184,9 @@
 				if(component_check)
 					P.play_tool_sound(src)
 					var/obj/machinery/new_machine = new circuit.build_path(loc)
+					if(!istype(new_machine, /obj/machinery))
+						qdel(src)
+						return
 					if(new_machine.circuit)
 						QDEL_NULL(new_machine.circuit)
 					new_machine.circuit = circuit


### PR DESCRIPTION
## About The Pull Request

God shut the fuck megarop
Anyway, adds a check for machine construction when building something that's not an actual machine subtype for ease of use, just building it as a default and returning as expected.

## Why It's Good For The Game

Fixes #52504

## Changelog
:cl:
fix: You can no longer create infinite vend-a-trays.
/:cl: