### PR TITLE
Fix tgs DMAPI breaking sleep_offline

### DIFF
--- a/code/modules/tgs/v4/api.dm
+++ b/code/modules/tgs/v4/api.dm
@@ -114,15 +114,6 @@
 /datum/tgs_api/v4/OnInitializationComplete()
 	Export(TGS4_COMM_SERVER_PRIMED)
 
-	var/tgs4_secret_sleep_offline_sauce = 29051994
-	var/old_sleep_offline = world.sleep_offline
-	world.sleep_offline = tgs4_secret_sleep_offline_sauce
-	sleep(1)
-	if(world.sleep_offline == tgs4_secret_sleep_offline_sauce)	//if not someone changed it
-		world.sleep_offline = old_sleep_offline
-	else
-		TGS_WARNING_LOG("world.sleep_offline unexpectedly changed!")
-
 /datum/tgs_api/v4/OnTopic(T)
 	var/list/params = params2list(T)
 	var/their_sCK = params[TGS4_INTEROP_ACCESS_IDENTIFIER]

--- a/code/modules/tgs/v5/api.dm
+++ b/code/modules/tgs/v5/api.dm
@@ -88,15 +88,6 @@
 /datum/tgs_api/v5/OnInitializationComplete()
 	Bridge(DMAPI5_BRIDGE_COMMAND_PRIME)
 
-	var/tgs4_secret_sleep_offline_sauce = 29051994
-	var/old_sleep_offline = world.sleep_offline
-	world.sleep_offline = tgs4_secret_sleep_offline_sauce
-	sleep(1)
-	if(world.sleep_offline == tgs4_secret_sleep_offline_sauce)	//if not someone changed it
-		world.sleep_offline = old_sleep_offline
-	else
-		TGS_WARNING_LOG("world.sleep_offline unexpectedly changed!")
-
 /datum/tgs_api/v5/proc/TopicResponse(error_message = null)
 	var/list/response = list()
 	response[DMAPI5_RESPONSE_ERROR_MESSAGE] = error_message


### PR DESCRIPTION
Fixes the server not pausing time while nobody is connected.

https://github.com/tgstation/tgstation-server/pull/1087

http://www.byond.com/forum/post/2575184

Setting it to an out of bounds value breaks it so that it is always false.