### PR TITLE
Fixes seed mutatelist runtime

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -209,7 +209,7 @@
 		product_count = clamp(round(product_count/2),0,5)
 	while(t_amount < product_count)
 		var/obj/item/reagent_containers/food/snacks/grown/t_prod
-		if(instability >= 30 && prob(instability/3) && mutatelist)
+		if(instability >= 30 && prob(instability/3) && LAZYLEN(mutatelist))
 			var/obj/item/seeds/new_prod = pick(mutatelist)
 			t_prod = initial(new_prod.product)
 			if(t_prod)


### PR DESCRIPTION
Fixes #52568
:cl: ShizCalev
fix: Fixed a minor runtime if a seed's mutatelist was empty.
/:cl:
