### PR TITLE
Color standardization, vars moved, and signals

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -1,43 +1,72 @@
 // This is eventually for wjohn to add more color standardization stuff like I keep asking him >:(
 
-#define COLOR_INPUT_DISABLED "#F0F0F0"
-#define COLOR_INPUT_ENABLED "#D3B5B5"
+#define COLOR_INPUT_DISABLED			"#F0F0F0"
+#define COLOR_INPUT_ENABLED				"#D3B5B5"
 
-#define COLOR_DARKMODE_BACKGROUND "#202020"
-#define COLOR_DARKMODE_DARKBACKGROUND "#171717"
-#define COLOR_DARKMODE_TEXT "#a4bad6"
+#define COLOR_DARKMODE_BACKGROUND		"#202020"
+#define COLOR_DARKMODE_DARKBACKGROUND	"#171717"
+#define COLOR_DARKMODE_TEXT				"#a4bad6"
 
-#define COLOR_WHITE            "#EEEEEE"
-#define COLOR_SILVER           "#C0C0C0"
-#define COLOR_GRAY             "#808080"
-#define COLOR_FLOORTILE_GRAY   "#8D8B8B"
-#define COLOR_ALMOST_BLACK	   "#333333"
-#define COLOR_BLACK            "#000000"
-#define COLOR_RED              "#FF0000"
-#define COLOR_RED_LIGHT        "#FF3333"
-#define COLOR_MAROON           "#800000"
-#define COLOR_YELLOW           "#FFFF00"
-#define COLOR_OLIVE            "#808000"
-#define COLOR_LIME             "#32CD32"
-#define COLOR_GREEN            "#008000"
-#define COLOR_VIBRANT_LIME     "#00FF00"
-#define COLOR_CYAN             "#00FFFF"
-#define COLOR_DARK_CYAN        "#00a2ff"
-#define COLOR_TEAL             "#008080"
-#define COLOR_BLUE             "#0000FF"
-#define COLOR_BLUE_LIGHT       "#33CCFF"
-#define COLOR_NAVY             "#000080"
-#define COLOR_PINK             "#FFC0CB"
-#define COLOR_MAGENTA          "#FF00FF"
-#define COLOR_VIOLET           "#b900f7"
-#define COLOR_PURPLE           "#800080"
-#define COLOR_ORANGE           "#FF9900"
-#define COLOR_TAN_ORANGE       "#ff7b00"
-#define COLOR_BEIGE            "#CEB689"
-#define COLOR_BLUE_GRAY        "#75A2BB"
-#define COLOR_BROWN            "#BA9F6D"
-#define COLOR_DARK_BROWN       "#997C4F"
-#define COLOR_DARK_ORANGE      "#C3630C"
+#define COLOR_WHITE						"#FFFFFF"
+#define COLOR_VERY_LIGHT_GRAY			"#EEEEEE"
+#define COLOR_SILVER					"#C0C0C0"
+#define COLOR_GRAY						"#808080"
+#define COLOR_FLOORTILE_GRAY			"#8D8B8B"
+#define COLOR_ALMOST_BLACK				"#333333"
+#define COLOR_BLACK						"#000000"
+
+#define COLOR_RED						"#FF0000"
+#define COLOR_MOSTLY_PURE_RED			"#FF3300"
+#define COLOR_DARK_RED					"#A50824"
+#define COLOR_RED_LIGHT					"#FF3333"
+#define COLOR_MAROON					"#800000"
+#define COLOR_VIVID_RED					"#FF3232"
+#define COLOR_LIGHT_GRAYISH_RED			"#E4C7C5"
+/// Warm but extremely diluted red. rgb(250, 130, 130)
+#define COLOR_SOFT_RED					"#FA8282"
+
+#define COLOR_YELLOW					"#FFFF00"
+#define COLOR_VIVID_YELLOW				"#FBFF23"
+#define COLOR_VERY_SOFT_YELLOW			"#FAE48E"
+
+#define COLOR_OLIVE						"#808000"
+#define COLOR_VIBRANT_LIME				"#00FF00"
+#define COLOR_LIME						"#32CD32"
+#define COLOR_VERY_PALE_LIME_GREEN		"#DDFFD3"
+#define COLOR_VERY_DARK_LIME_GREEN		"#003300"
+#define COLOR_GREEN						"#008000"
+#define COLOR_DARK_MODERATE_LIME_GREEN	"#44964A"
+
+#define COLOR_CYAN						"#00FFFF"
+#define COLOR_DARK_CYAN					"#00A2FF"
+#define COLOR_TEAL						"#008080"
+#define COLOR_BLUE						"#0000FF"
+#define COLOR_BRIGHT_BLUE				"#2CB2E8"
+#define COLOR_MODERATE_BLUE				"#555CC2"
+#define COLOR_BLUE_LIGHT				"#33CCFF"
+#define COLOR_NAVY						"#000080"
+#define COLOR_BLUE_GRAY					"#75A2BB"
+
+#define COLOR_PINK						"#FFC0CB"
+#define COLOR_MOSTLY_PURE_PINK			"#E4005B"
+#define COLOR_MAGENTA					"#FF00FF"
+#define COLOR_STRONG_MAGENTA			"#B800B8"
+#define COLOR_PURPLE					"#800080"
+#define COLOR_VIOLET					"#B900F7"
+#define COLOR_STRONG_VIOLET				"#6927c5"
+
+#define COLOR_ORANGE					"#FF9900"
+#define COLOR_TAN_ORANGE				"#FF7B00"
+#define COLOR_BRIGHT_ORANGE				"#E2853D"
+#define COLOR_LIGHT_ORANGE				"#ffc44d"
+#define COLOR_PALE_ORANGE				"#FFBE9D"
+#define COLOR_BEIGE						"#CEB689"
+#define COLOR_DARK_ORANGE				"#C3630C"
+#define COLOR_DARK_MODERATE_ORANGE		"#8B633B"
+
+#define COLOR_BROWN						"#BA9F6D"
+#define COLOR_DARK_BROWN				"#997C4F"
+
 #define COLOR_GREEN_GRAY       "#99BB76"
 #define COLOR_RED_GRAY         "#B4696A"
 #define COLOR_PALE_BLUE_GRAY   "#98C5DF"
@@ -62,3 +91,55 @@
 #define COLOR_ASSEMBLY_LBLUE   "#5D99BE"
 #define COLOR_ASSEMBLY_BLUE    "#38559E"
 #define COLOR_ASSEMBLY_PURPLE  "#6F6192"
+
+/**
+ * Some defines to generalise colours used in lighting.
+ *
+ * Important note: colors can end up significantly different from the basic html picture, especially when saturated
+ */
+/// Bright but quickly dissipating neon green. rgb(100, 200, 100)
+#define LIGHT_COLOR_GREEN      "#64C864"
+/// Electric green. rgb(0, 255, 0)
+#define LIGHT_COLOR_ELECTRIC_GREEN      "#00FF00"
+/// Cold, diluted blue. rgb(100, 150, 250)
+#define LIGHT_COLOR_BLUE       "#6496FA"
+/// Light blueish green. rgb(125, 225, 175)
+#define LIGHT_COLOR_BLUEGREEN  "#7DE1AF"
+/// Diluted cyan. rgb(125, 225, 225)
+#define LIGHT_COLOR_CYAN       "#7DE1E1"
+/// Electric cyan rgb(0, 255, 255)
+#define LIGHT_COLOR_ELECTRIC_CYAN	"#00FFFF"
+/// More-saturated cyan. rgb(16, 21, 22)
+#define LIGHT_COLOR_LIGHT_CYAN "#40CEFF"
+/// Saturated blue. rgb(51, 117, 248)
+#define LIGHT_COLOR_DARK_BLUE  "#6496FA"
+/// Diluted, mid-warmth pink. rgb(225, 125, 225)
+#define LIGHT_COLOR_PINK       "#E17DE1"
+/// Dimmed yellow, leaning kaki. rgb(225, 225, 125)
+#define LIGHT_COLOR_YELLOW     "#E1E17D"
+/// Clear brown, mostly dim. rgb(150, 100, 50)
+#define LIGHT_COLOR_BROWN      "#966432"
+/// Mostly pure orange. rgb(250, 150, 50)
+#define LIGHT_COLOR_ORANGE     "#FA9632"
+/// Light Purple. rgb(149, 44, 244)
+#define LIGHT_COLOR_PURPLE     "#952CF4"
+/// Less-saturated light purple. rgb(155, 81, 255)
+#define LIGHT_COLOR_LAVENDER   "#9B51FF"
+///slightly desaturated bright yellow.
+#define LIGHT_COLOR_HOLY_MAGIC	"#FFF743"
+/// deep crimson
+#define LIGHT_COLOR_BLOOD_MAGIC	"#D00000"
+
+/* These ones aren't a direct colour like the ones above, because nothing would fit */
+/// Warm orange color, leaning strongly towards yellow. rgb(250, 160, 25)
+#define LIGHT_COLOR_FIRE       "#FAA019"
+/// Very warm yellow, leaning slightly towards orange. rgb(196, 138, 24)
+#define LIGHT_COLOR_LAVA       "#C48A18"
+/// Bright, non-saturated red. Leaning slightly towards pink for visibility. rgb(250, 100, 75)
+#define LIGHT_COLOR_FLARE      "#FA644B"
+/// Weird color, between yellow and green, very slimy. rgb(175, 200, 75)
+#define LIGHT_COLOR_SLIME_LAMP "#AFC84B"
+/// Extremely diluted yellow, close to skin color (for some reason). rgb(250, 225, 175)
+#define LIGHT_COLOR_TUNGSTEN   "#FAE1AF"
+/// Barely visible cyan-ish hue, as the doctor prescribed. rgb(240, 250, 250)
+#define LIGHT_COLOR_HALOGEN    "#F0FAFA"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -171,7 +171,14 @@
 #define COMSIG_ATOM_EXPOSE_REAGENTS "atom_expose_reagents"
 	/// Prevents the atom from being exposed to reagents if returned on [COMPONENT_ATOM_EXPOSE_REAGENTS]
 	#define COMPONENT_NO_EXPOSE_REAGENTS (1<<0)
-
+///Called right before the atom changes the value of light_range to a different one, from base atom/set_light_range(): (new_range)
+#define COMSIG_ATOM_SET_LIGHT_RANGE "atom_set_light_range"
+///Called right before the atom changes the value of light_power to a different one, from base atom/set_light_power(): (new_power)
+#define COMSIG_ATOM_SET_LIGHT_POWER "atom_set_light_power"
+///Called right before the atom changes the value of light_color to a different one, from base atom/set_light_color(): (new_color)
+#define COMSIG_ATOM_SET_LIGHT_COLOR "atom_set_light_color"
+///Called right before the atom changes the value of light_on to a different one, from base atom/set_light_on(): (new_value)
+#define COMSIG_ATOM_SET_LIGHT_ON "atom_set_light_on"
 ///called for each movable in a turf contents on /turf/zImpact(): (atom/movable/A, levels)
 #define COMSIG_ATOM_INTERCEPT_Z_FALL "movable_intercept_z_impact"
 ///called on a movable (NOT living) when someone starts pulling it (atom/movable/puller, state, force)

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -31,56 +31,6 @@
 		0, 0, 0, 1           \
 	)                        \
 
-
-//Some defines to generalise colours used in lighting.
-//Important note on colors. Colors can end up significantly different from the basic html picture, especially when saturated
-#define LIGHT_COLOR_WHITE		"#FFFFFF"
-/// Warm but extremely diluted red. rgb(250, 130, 130)
-#define LIGHT_COLOR_RED        "#FA8282"
-/// Bright but quickly dissipating neon green. rgb(100, 200, 100)
-#define LIGHT_COLOR_GREEN      "#64C864"
-/// Cold, diluted blue. rgb(100, 150, 250)
-#define LIGHT_COLOR_BLUE       "#6496FA"
-/// Light blueish green. rgb(125, 225, 175)
-#define LIGHT_COLOR_BLUEGREEN  "#7DE1AF"
-/// Diluted cyan. rgb(125, 225, 225)
-#define LIGHT_COLOR_CYAN       "#7DE1E1"
-/// More-saturated cyan. rgb(64, 206, 255)
-#define LIGHT_COLOR_LIGHT_CYAN "#40CEFF"
-/// Saturated blue. rgb(51, 117, 248)
-#define LIGHT_COLOR_DARK_BLUE  "#6496FA"
-/// Diluted, mid-warmth pink. rgb(225, 125, 225)
-#define LIGHT_COLOR_PINK       "#E17DE1"
-/// Dimmed yellow, leaning kaki. rgb(225, 225, 125)
-#define LIGHT_COLOR_YELLOW     "#E1E17D"
-/// Clear brown, mostly dim. rgb(150, 100, 50)
-#define LIGHT_COLOR_BROWN      "#966432"
-/// Mostly pure orange. rgb(250, 150, 50)
-#define LIGHT_COLOR_ORANGE     "#FA9632"
-/// Light Purple. rgb(149, 44, 244)
-#define LIGHT_COLOR_PURPLE     "#952CF4"
-/// Less-saturated light purple. rgb(155, 81, 255)
-#define LIGHT_COLOR_LAVENDER   "#9B51FF"
-
-///slightly desaturated bright yellow.
-#define LIGHT_COLOR_HOLY_MAGIC	"#FFF743"
-/// deep crimson
-#define LIGHT_COLOR_BLOOD_MAGIC	"#D00000"
-
-//These ones aren't a direct colour like the ones above, because nothing would fit
-/// Warm orange color, leaning strongly towards yellow. rgb(250, 160, 25)
-#define LIGHT_COLOR_FIRE       "#FAA019"
-/// Very warm yellow, leaning slightly towards orange. rgb(196, 138, 24)
-#define LIGHT_COLOR_LAVA       "#C48A18"
-/// Bright, non-saturated red. Leaning slightly towards pink for visibility. rgb(250, 100, 75)
-#define LIGHT_COLOR_FLARE      "#FA644B"
-/// Weird color, between yellow and green, very slimy. rgb(175, 200, 75)
-#define LIGHT_COLOR_SLIME_LAMP "#AFC84B"
-/// Extremely diluted yellow, close to skin color (for some reason). rgb(250, 225, 175)
-#define LIGHT_COLOR_TUNGSTEN   "#FAE1AF"
-/// Barely visible cyan-ish hue, as the doctor prescribed. rgb(240, 250, 250)
-#define LIGHT_COLOR_HALOGEN    "#F0FAFA"
-
 ///How many tiles standard fires glow.
 #define LIGHT_RANGE_FIRE		3
 
@@ -130,7 +80,7 @@
 /// Parse the hexadecimal color into lumcounts of each perspective.
 #define PARSE_LIGHT_COLOR(source) \
 do { \
-	if (source.light_color) { \
+	if (source.light_color != COLOR_WHITE) { \
 		var/__light_color = source.light_color; \
 		source.lum_r = GETREDPART(__light_color) / 255; \
 		source.lum_g = GETGREENPART(__light_color) / 255; \

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -230,7 +230,7 @@
 	locked = TRUE
 
 /datum/mutation/human/glow/anti/glow_color()
-	return COLOR_WHITE
+	return COLOR_VERY_LIGHT_GRAY
 
 /datum/mutation/human/strong
 	name = "Strength"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -92,6 +92,19 @@
 	/// Last appearance of the atom for demo saving purposes
 	var/image/demo_last_appearance
 
+	///Range of the light in tiles. Zero means no light.
+	var/light_range = 0
+	///Intensity of the light. The stronger, the less shadows you will see on the lit area.
+	var/light_power = 1
+	///Hexadecimal RGB string representing the colour of the light. White by default.
+	var/light_color = COLOR_WHITE
+	///Boolean variable for toggleable lights. Has no effect without the proper light_system, light_range and light_power values.
+	var/light_on = TRUE
+	///Our light source. Don't fuck with this directly unless you have a good reason!
+	var/tmp/datum/light_source/light
+	///Any light sources that are "inside" of us, for example, if src here was a mob that's carrying a flashlight, that flashlight's light source would be part of this list.
+	var/tmp/list/light_sources
+
 	/// Last name used to calculate a color for the chatmessage overlays
 	var/chat_color_name
 	/// Last color calculated for the the chatmessage overlays

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -67,7 +67,7 @@
 	sharpness = SHARP_NONE
 	sword_color = "yellow"
 	heat = 0
-	light_color = "#ffff00"
+	light_color = COLOR_YELLOW
 	var/next_trombone_allowed = 0
 
 /obj/item/melee/transforming/energy/sword/bananium/ComponentInitialize()

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -62,8 +62,8 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	icon_state = "arcade"
 	icon_keyboard = "no_keyboard"
 	icon_screen = "invaders"
-	var/list/prize_override
 	light_color = LIGHT_COLOR_GREEN
+	var/list/prize_override
 
 /obj/machinery/computer/arcade/proc/Reset()
 	return

--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -4,12 +4,12 @@
 	circuit = /obj/item/circuitboard/computer/atmos_alert
 	icon_screen = "alert:0"
 	icon_keyboard = "atmos_key"
+	light_color = LIGHT_COLOR_CYAN
 	var/list/priority_alarms = list()
 	var/list/minor_alarms = list()
 	var/receive_frequency = FREQ_ATMOS_ALARMS
 	var/datum/radio_frequency/radio_connection
 
-	light_color = LIGHT_COLOR_CYAN
 
 /obj/machinery/computer/atmos_alert/Initialize()
 	. = ..()

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -92,6 +92,7 @@ GLOBAL_LIST_EMPTY(atmos_air_controllers)
 	icon_screen = "tank"
 	icon_keyboard = "atmos_key"
 	circuit = /obj/item/circuitboard/computer/atmos_control
+	light_color = LIGHT_COLOR_CYAN
 
 	var/frequency = FREQ_ATMOS_STORAGE
 	var/list/sensors = list(
@@ -110,7 +111,6 @@ GLOBAL_LIST_EMPTY(atmos_air_controllers)
 	var/list/sensor_information = list()
 	var/datum/radio_frequency/radio_connection
 
-	light_color = LIGHT_COLOR_CYAN
 
 /obj/machinery/computer/atmos_control/Initialize()
 	. = ..()

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -6,7 +6,7 @@
 	icon_screen = "cameras"
 	icon_keyboard = "security_key"
 	circuit = /obj/item/circuitboard/computer/security
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 	var/list/network = list("ss13")
 	var/obj/machinery/camera/active_camera

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -3,6 +3,7 @@
 	desc = "Used to access the various cameras on the station."
 	icon_screen = "cameras"
 	icon_keyboard = "security_key"
+	light_color = COLOR_SOFT_RED
 	var/list/z_lock = list() // Lock use to these z levels
 	var/lock_override = NONE
 	var/mob/camera/ai_eye/remote/eyeobj
@@ -13,7 +14,6 @@
 	var/list/actions = list()
 	///Should we supress any view changes?
 	var/should_supress_view_changes  = TRUE
-	light_color = LIGHT_COLOR_RED
 
 /obj/machinery/computer/camera_advanced/Initialize()
 	. = ..()

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -16,6 +16,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	icon_keyboard = "id_key"
 	req_one_access = list(ACCESS_HEADS, ACCESS_CHANGE_IDS)
 	circuit = /obj/item/circuitboard/computer/card
+	light_color = LIGHT_COLOR_BLUE
 	var/mode = 0
 	var/printing = null
 	var/target_dept = 0 //Which department this computer has access to. 0=all departments
@@ -48,7 +49,6 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	var/list/region_access = null
 	var/list/head_subordinates = null
 
-	light_color = LIGHT_COLOR_BLUE
 
 /obj/machinery/computer/card/proc/get_jobs()
 	return get_all_jobs()
@@ -610,7 +610,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	target_dept = 2
 	icon_screen = "idhos"
 
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 /obj/machinery/computer/card/minor/cmo
 	target_dept = 3

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -18,6 +18,7 @@
 	icon_keyboard = "tech_key"
 	req_access = list(ACCESS_HEADS)
 	circuit = /obj/item/circuitboard/computer/communications
+	light_color = LIGHT_COLOR_BLUE
 	var/auth_id = "Unknown" //Who is currently logged in?
 	var/list/datum/comm_message/messages = list()
 	var/datum/comm_message/currmsg
@@ -31,7 +32,6 @@
 	var/stat_msg1
 	var/stat_msg2
 
-	light_color = LIGHT_COLOR_BLUE
 
 /obj/machinery/computer/communications/proc/checkCCcooldown()
 	var/obj/item/circuitboard/computer/communications/CM = circuit

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -7,6 +7,7 @@
 	icon_keyboard = "med_key"
 	req_one_access = list(ACCESS_MEDICAL, ACCESS_FORENSICS_LOCKERS)
 	circuit = /obj/item/circuitboard/computer/med_data
+	light_color = LIGHT_COLOR_BLUE
 	var/rank = null
 	var/screen = null
 	var/datum/data/record/active1
@@ -17,7 +18,6 @@
 	var/sortBy = "name"
 	var/order = 1 // -1 = Descending - 1 = Ascending
 
-	light_color = LIGHT_COLOR_BLUE
 
 /obj/machinery/computer/med_data/syndie
 	icon_keyboard = "syndie_key"

--- a/code/game/machinery/computer/prisoner/gulag_teleporter.dm
+++ b/code/game/machinery/computer/prisoner/gulag_teleporter.dm
@@ -6,6 +6,7 @@
 	icon_keyboard = "security_key"
 	req_access = list(ACCESS_ARMORY)
 	circuit = /obj/item/circuitboard/computer/gulag_teleporter_console
+	light_color = COLOR_SOFT_RED
 
 	var/default_goal = 200
 	var/obj/machinery/gulag_teleporter/teleporter = null
@@ -13,7 +14,6 @@
 	var/mob/living/carbon/human/prisoner = null
 	var/datum/data/record/temporary_record = null
 
-	light_color = LIGHT_COLOR_RED
 
 /obj/machinery/computer/prisoner/gulag_teleporter_computer/Initialize()
 	. = ..()

--- a/code/game/machinery/computer/prisoner/management.dm
+++ b/code/game/machinery/computer/prisoner/management.dm
@@ -4,6 +4,7 @@
 	icon_screen = "explosive"
 	icon_keyboard = "security_key"
 	req_access = list(ACCESS_BRIG)
+	light_color = COLOR_SOFT_RED
 	var/id = 0
 	var/temp = null
 	var/status = 0
@@ -12,7 +13,6 @@
 	var/screen = 0 // 0 - No Access Denied, 1 - Access allowed
 	circuit = /obj/item/circuitboard/computer/prisoner
 
-	light_color = LIGHT_COLOR_RED
 
 /obj/machinery/computer/prisoner/management/ui_interact(mob/user)
 	. = ..()

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -5,6 +5,7 @@
 	icon_keyboard = "security_key"
 	req_one_access = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS)
 	circuit = /obj/item/circuitboard/computer/secure_data
+	light_color = COLOR_SOFT_RED
 	var/rank = null
 	var/screen = null
 	var/datum/data/record/active1 = null
@@ -18,7 +19,6 @@
 	var/sortBy = "name"
 	var/order = 1 // -1 = Descending - 1 = Ascending
 
-	light_color = LIGHT_COLOR_RED
 
 /obj/machinery/computer/secure_data/syndie
 	icon_keyboard = "syndie_key"

--- a/code/game/machinery/computer/warrant.dm
+++ b/code/game/machinery/computer/warrant.dm
@@ -4,7 +4,7 @@
 	icon_screen = "security"
 	icon_keyboard = "security_key"
 	circuit = /obj/item/circuitboard/computer/warrant
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	var/screen = null
 	var/datum/data/record/current = null
 

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -186,57 +186,57 @@
 	FOR_DVIEW(var/turf/t, 3, get_turf(src),INVISIBILITY_LIGHTING)
 		if(t.x == cen.x && t.y > cen.y)
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_RED
-			L.light_power = 30-(get_dist(src,L)*8)
+			L.set_light_color(COLOR_SOFT_RED)
+			L.set_light_power(30-(get_dist(src,L)*8))
 			L.range = 1+get_dist(src, L)
 			spotlights+=L
 			continue
 		if(t.x == cen.x && t.y < cen.y)
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_PURPLE
-			L.light_power = 30-(get_dist(src,L)*8)
+			L.set_light_color(LIGHT_COLOR_PURPLE)
+			L.set_light_power(30-(get_dist(src,L)*8))
 			L.range = 1+get_dist(src, L)
 			spotlights+=L
 			continue
 		if(t.x > cen.x && t.y == cen.y)
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_YELLOW
-			L.light_power = 30-(get_dist(src,L)*8)
+			L.set_light_color(LIGHT_COLOR_YELLOW)
+			L.set_light_power(30-(get_dist(src,L)*8))
 			L.range = 1+get_dist(src, L)
 			spotlights+=L
 			continue
 		if(t.x < cen.x && t.y == cen.y)
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_GREEN
-			L.light_power = 30-(get_dist(src,L)*8)
+			L.set_light_color(LIGHT_COLOR_GREEN)
+			L.set_light_power(30-(get_dist(src,L)*8))
 			L.range = 1+get_dist(src, L)
 			spotlights+=L
 			continue
 		if((t.x+1 == cen.x && t.y+1 == cen.y) || (t.x+2==cen.x && t.y+2 == cen.y))
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_ORANGE
-			L.light_power = 30-(get_dist(src,L)*8)
+			L.set_light_color(LIGHT_COLOR_ORANGE)
+			L.set_light_power(30-(get_dist(src,L)*8))
 			L.range = 1.4+get_dist(src, L)
 			spotlights+=L
 			continue
 		if((t.x-1 == cen.x && t.y-1 == cen.y) || (t.x-2==cen.x && t.y-2 == cen.y))
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_CYAN
-			L.light_power = 30-(get_dist(src,L)*8)
+			L.set_light_color(LIGHT_COLOR_CYAN)
+			L.set_light_power(30-(get_dist(src,L)*8))
 			L.range = 1.4+get_dist(src, L)
 			spotlights+=L
 			continue
 		if((t.x-1 == cen.x && t.y+1 == cen.y) || (t.x-2==cen.x && t.y+2 == cen.y))
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_BLUEGREEN
-			L.light_power = 30-(get_dist(src,L)*8)
+			L.set_light_color(LIGHT_COLOR_BLUEGREEN)
+			L.set_light_power(30-(get_dist(src,L)*8))
 			L.range = 1.4+get_dist(src, L)
 			spotlights+=L
 			continue
 		if((t.x+1 == cen.x && t.y-1 == cen.y) || (t.x+2==cen.x && t.y-2 == cen.y))
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_BLUE
-			L.light_power = 30-(get_dist(src,L)*8)
+			L.set_light_color(LIGHT_COLOR_BLUE)
+			L.set_light_power(30-(get_dist(src,L)*8))
 			L.range = 1.4+get_dist(src, L)
 			spotlights+=L
 			continue
@@ -276,50 +276,50 @@
 		for(var/obj/item/flashlight/spotlight/glow in spotlights) // The multiples reflects custom adjustments to each colors after dozens of tests
 			if(QDELETED(src) || !active || QDELETED(glow))
 				return
-			if(glow.light_color == LIGHT_COLOR_RED)
-				glow.light_color = LIGHT_COLOR_BLUE
-				glow.light_power = glow.light_power * 1.48
-				glow.light_range = 0
+			if(glow.light_color == COLOR_SOFT_RED)
+				glow.set_light_color(LIGHT_COLOR_BLUE)
+				glow.set_light_power(glow.light_power * 1.48)
+				glow.set_light_range(0)
 				glow.update_light()
 				continue
 			if(glow.light_color == LIGHT_COLOR_BLUE)
-				glow.light_color = LIGHT_COLOR_GREEN
-				glow.light_range = glow.range * DISCO_INFENO_RANGE
-				glow.light_power = glow.light_power * 2 // Any changes to power must come in pairs to neutralize it for other colors
+				glow.set_light_color(LIGHT_COLOR_GREEN)
+				glow.set_light_range(glow.range * DISCO_INFENO_RANGE)
+				glow.set_light_power(glow.light_power * 2) // Any changes to power must come in pairs to neutralize it for other colors
 				glow.update_light()
 				continue
 			if(glow.light_color == LIGHT_COLOR_GREEN)
-				glow.light_color = LIGHT_COLOR_ORANGE
-				glow.light_power = glow.light_power * 0.5
-				glow.light_range = 0
+				glow.set_light_color(LIGHT_COLOR_ORANGE)
+				glow.set_light_power(glow.light_power * 0.5)
+				glow.set_light_range(0)
 				glow.update_light()
 				continue
 			if(glow.light_color == LIGHT_COLOR_ORANGE)
-				glow.light_color = LIGHT_COLOR_PURPLE
-				glow.light_power = glow.light_power * 2.27
-				glow.light_range = glow.range * DISCO_INFENO_RANGE
+				glow.set_light_color(LIGHT_COLOR_PURPLE)
+				glow.set_light_power(glow.light_power * 2.27)
+				glow.set_light_range(glow.range * DISCO_INFENO_RANGE)
 				glow.update_light()
 				continue
 			if(glow.light_color == LIGHT_COLOR_PURPLE)
-				glow.light_color = LIGHT_COLOR_BLUEGREEN
-				glow.light_power = glow.light_power * 0.44
-				glow.light_range = 0
+				glow.set_light_color(LIGHT_COLOR_BLUEGREEN)
+				glow.set_light_power(glow.light_power * 0.44)
+				glow.set_light_range(0)
 				glow.update_light()
 				continue
 			if(glow.light_color == LIGHT_COLOR_BLUEGREEN)
-				glow.light_color = LIGHT_COLOR_YELLOW
-				glow.light_range = glow.range * DISCO_INFENO_RANGE
+				glow.set_light_color(LIGHT_COLOR_YELLOW)
+				glow.set_light_range(glow.range * DISCO_INFENO_RANGE)
 				glow.update_light()
 				continue
 			if(glow.light_color == LIGHT_COLOR_YELLOW)
-				glow.light_color = LIGHT_COLOR_CYAN
-				glow.light_range = 0
+				glow.set_light_color(LIGHT_COLOR_CYAN)
+				glow.set_light_range(0)
 				glow.update_light()
 				continue
 			if(glow.light_color == LIGHT_COLOR_CYAN)
-				glow.light_color = LIGHT_COLOR_RED
-				glow.light_power = glow.light_power * 0.68
-				glow.light_range = glow.range * DISCO_INFENO_RANGE
+				glow.set_light_color(COLOR_SOFT_RED)
+				glow.set_light_power(glow.light_power * 0.68)
+				glow.set_light_range(glow.range * DISCO_INFENO_RANGE)
 				glow.update_light()
 				continue
 		if(prob(2))  // Unique effects for the dance floor that show up randomly to mix things up

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -28,7 +28,7 @@
 
 	light_power = 0
 	light_range = 7
-	light_color = "#ff3232"
+	light_color = COLOR_VIVID_RED
 
 	//Trick to get the glowing overlay visible from a distance
 	luminosity = 1

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -7,7 +7,7 @@
 	icon_state = "mflash1"
 	max_integrity = 250
 	integrity_failure = 0.4
-	light_color = LIGHT_COLOR_WHITE
+	light_color = COLOR_WHITE
 	light_power = FLASH_LIGHT_POWER
 	damage_deflection = 10
 	var/obj/item/assembly/flash/handheld/bulb

--- a/code/game/machinery/roulette_machine.dm
+++ b/code/game/machinery/roulette_machine.dm
@@ -360,7 +360,7 @@
 		if("green")
 			set_light(2,2, LIGHT_COLOR_GREEN)
 		if("red")
-			set_light(2,2, LIGHT_COLOR_RED)
+			set_light(2,2, COLOR_SOFT_RED)
 
 /obj/machinery/roulette/welder_act(mob/living/user, obj/item/I)
 	. = ..()

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -23,6 +23,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 50
 	circuit = /obj/item/circuitboard/computer/slot_machine
+	light_color = LIGHT_COLOR_BROWN
 	var/money = 3000 //How much money it has CONSUMED
 	var/plays = 0
 	var/working = 0
@@ -34,7 +35,6 @@
 	var/list/reels = list(list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0)
 	var/list/symbols = list(SEVEN = 1, "<font color='orange'>&</font>" = 2, "<font color='yellow'>@</font>" = 2, "<font color='green'>$</font>" = 2, "<font color='blue'>?</font>" = 2, "<font color='grey'>#</font>" = 2, "<font color='white'>!</font>" = 2, "<font color='fuchsia'>%</font>" = 2) //if people are winning too much, multiply every number in this list by 2 and see if they are still winning too much.
 
-	light_color = LIGHT_COLOR_BROWN
 
 /obj/machinery/computer/slot_machine/Initialize()
 	. = ..()

--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -17,6 +17,7 @@
 	desc = "Used to monitor the crew's PDA messages, as well as request console messages."
 	icon_screen = "comm_logs"
 	circuit = /obj/item/circuitboard/computer/message_monitor
+	light_color = LIGHT_COLOR_GREEN
 	//Server linked to.
 	var/obj/machinery/telecomms/message_server/linkedServer = null
 	//Sparks effect - For emag
@@ -38,7 +39,6 @@
 	var/customjob		= "Admin"
 	var/custommessage 	= "This is a test, please ignore."
 
-	light_color = LIGHT_COLOR_GREEN
 
 /obj/machinery/computer/message_monitor/attackby(obj/item/O, mob/living/user, params)
 	if(O.tool_behaviour == TOOL_SCREWDRIVER && (obj_flags & EMAGGED))

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -86,8 +86,8 @@
 	icon_screen = "recharge_comp"
 	icon_keyboard = "rd_key"
 	circuit = /obj/item/circuitboard/computer/mech_bay_power_console
-	var/obj/machinery/mech_bay_recharge_port/recharge_port
 	light_color = LIGHT_COLOR_PINK
+	var/obj/machinery/mech_bay_recharge_port/recharge_port
 
 /obj/machinery/computer/mech_bay_power_console/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -75,8 +75,8 @@
 	name = "lighting fx obj"
 	desc = "Tell a coder if you're seeing this."
 	icon_state = "nothing"
-	light_color = "#FFFFFF"
 	light_range = MINIMUM_USEFUL_LIGHT_RANGE
+	light_color = COLOR_WHITE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/effect/dummy/lighting_obj/Initialize(mapload, _color, _range, _power, _duration)

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -751,7 +751,7 @@ RLD
 						var/obj/machinery/light/L = new /obj/machinery/light(light)
 						L.setDir(align)
 						L.color = color_choice
-						L.light_color = L.color
+						L.set_light_color(L.color)
 						return TRUE
 				return FALSE
 
@@ -771,7 +771,7 @@ RLD
 						var/destination = get_turf(A)
 						var/obj/machinery/light/floor/FL = new /obj/machinery/light/floor(destination)
 						FL.color = color_choice
-						FL.light_color = FL.color
+						FL.set_light_color(FL.color)
 						return TRUE
 				return FALSE
 
@@ -781,7 +781,7 @@ RLD
 				to_chat(user, "<span class='notice'>You fire a glowstick!</span>")
 				var/obj/item/flashlight/glowstick/G  = new /obj/item/flashlight/glowstick(start)
 				G.color = color_choice
-				G.light_color = G.color
+				G.set_light_color(G.color)
 				G.throw_at(A, 9, 3, user)
 				G.on = TRUE
 				G.update_brightness()

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -613,6 +613,11 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	w_class = WEIGHT_CLASS_TINY
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
+	heat = 1500
+	resistance_flags = FIRE_PROOF
+	grind_results = list(/datum/reagent/iron = 1, /datum/reagent/fuel = 5, /datum/reagent/fuel/oil = 5)
+	custom_price = 55
+	light_color = LIGHT_COLOR_FIRE
 	var/lit = 0
 	var/fancy = TRUE
 	var/overlay_state
@@ -622,11 +627,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		"thirteen",
 		"snake"
 		)
-	heat = 1500
-	resistance_flags = FIRE_PROOF
-	light_color = LIGHT_COLOR_FIRE
-	grind_results = list(/datum/reagent/iron = 1, /datum/reagent/fuel = 5, /datum/reagent/fuel/oil = 5)
-	custom_price = 55
 
 /obj/item/lighter/Initialize()
 	. = ..()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -452,7 +452,7 @@
 
 /obj/item/flashlight/glowstick/Initialize()
 	fuel = rand(1600, 2000)
-	light_color = color
+	set_light_color(color)
 	. = ..()
 
 /obj/item/flashlight/glowstick/Destroy()
@@ -514,7 +514,7 @@
 
 /obj/item/flashlight/glowstick/red
 	name = "red glowstick"
-	color = LIGHT_COLOR_RED
+	color = COLOR_SOFT_RED
 
 /obj/item/flashlight/glowstick/blue
 	name = "blue glowstick"
@@ -549,7 +549,7 @@
 	name = "disco light"
 	desc = "Groovy..."
 	icon_state = null
-	light_color = null
+	light_color = COLOR_WHITE
 	brightness_on = 0
 	light_range = 0
 	light_power = 10

--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -13,11 +13,9 @@
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
-	var/w_class_on = WEIGHT_CLASS_BULKY
 	hitsound = "swing_hit"
 	armour_penetration = 35
-	var/saber_color = "green"
-	light_color = "#00ff00"//green
+	light_color = LIGHT_COLOR_ELECTRIC_GREEN
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "tore", "lacerated", "ripped", "diced", "cut")
 	block_chance = 75
 	max_integrity = 200
@@ -25,6 +23,8 @@
 	resistance_flags = FIRE_PROOF
 	wound_bonus = -110
 	bare_wound_bonus = 20
+	var/w_class_on = WEIGHT_CLASS_BULKY
+	var/saber_color = "green"
 	var/two_hand_force = 34
 	var/hacked = FALSE
 	var/brightness_on = 6 //TWICE AS BRIGHT AS A REGULAR ESWORD
@@ -97,13 +97,13 @@
 		saber_color = pick(possible_colors)
 		switch(saber_color)
 			if("red")
-				light_color = LIGHT_COLOR_RED
+				set_light_color(COLOR_SOFT_RED)
 			if("green")
-				light_color = LIGHT_COLOR_GREEN
+				set_light_color(LIGHT_COLOR_GREEN)
 			if("blue")
-				light_color = LIGHT_COLOR_LIGHT_CYAN
+				set_light_color(LIGHT_COLOR_LIGHT_CYAN)
 			if("purple")
-				light_color = LIGHT_COLOR_LAVENDER
+				set_light_color(LIGHT_COLOR_LAVENDER)
 
 /obj/item/dualsaber/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -141,7 +141,7 @@
 /obj/item/dualsaber/process()
 	if(wielded)
 		if(hacked)
-			light_color = pick(LIGHT_COLOR_RED, LIGHT_COLOR_GREEN, LIGHT_COLOR_LIGHT_CYAN, LIGHT_COLOR_LAVENDER)
+			set_light_color(pick(COLOR_SOFT_RED, LIGHT_COLOR_GREEN, LIGHT_COLOR_LIGHT_CYAN, LIGHT_COLOR_LAVENDER))
 		open_flame()
 	else
 		STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -9,13 +9,12 @@
 	flags_1 = CONDUCT_1
 	force = 3
 	throwforce = 10
-	var/acti_sound = 'sound/items/welderactivate.ogg'
-	var/deac_sound = 'sound/items/welderdeactivate.ogg'
 	throw_speed = 1
 	throw_range = 5
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron=500)
 	resistance_flags = FIRE_PROOF
+	trigger_guard = TRIGGER_GUARD_NORMAL
 	var/status = FALSE
 	var/lit = FALSE	//on or off
 	var/operating = FALSE//cooldown
@@ -27,7 +26,8 @@
 	var/create_full = FALSE
 	var/create_with_tank = FALSE
 	var/igniter_type = /obj/item/assembly/igniter
-	trigger_guard = TRIGGER_GUARD_NORMAL
+	var/acti_sound = 'sound/items/welderactivate.ogg'
+	var/deac_sound = 'sound/items/welderdeactivate.ogg'
 
 /obj/item/flamethrower/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -14,7 +14,7 @@
 		return
 	do_sparks(rand(5, 9), FALSE, src)
 	playsound(flashbang_turf, 'sound/weapons/flashbang.ogg', 100, TRUE, 8, 0.9)
-	new /obj/effect/dummy/lighting_obj (flashbang_turf, LIGHT_COLOR_WHITE, (flashbang_range + 2), 4, 2)
+	new /obj/effect/dummy/lighting_obj (flashbang_turf, COLOR_WHITE, (flashbang_range + 2), 4, 2)
 	for(var/mob/living/M in get_hearers_in_view(flashbang_range, flashbang_turf))
 		bang(get_turf(M), M)
 	qdel(src)
@@ -82,7 +82,7 @@
 		return
 	do_sparks(rand(5, 9), FALSE, src)
 	playsound(flashbang_turf, 'sound/weapons/flashbang.ogg', 50, TRUE, 8, 0.9)
-	new /obj/effect/dummy/lighting_obj (flashbang_turf, LIGHT_COLOR_WHITE, (flashbang_range + 2), 2, 1)
+	new /obj/effect/dummy/lighting_obj (flashbang_turf, COLOR_WHITE, (flashbang_range + 2), 2, 1)
 	for(var/mob/living/M in get_hearers_in_view(flashbang_range, flashbang_turf))
 		pop(get_turf(M), M)
 	qdel(src)

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -80,7 +80,7 @@
 	armour_penetration = 100
 	attack_verb_off = list("attacked", "chopped", "cleaved", "tore", "lacerated", "cut")
 	attack_verb_on = list()
-	light_color = "#40ceff"
+	light_color = LIGHT_COLOR_LIGHT_CYAN
 
 /obj/item/melee/transforming/energy/axe/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] swings [src] towards [user.p_their()] head! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -139,7 +139,7 @@
 	hitcost = 75 //Costs more than a standard cyborg esword
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = SHARP_EDGED
-	light_color = "#40ceff"
+	light_color = LIGHT_COLOR_LIGHT_CYAN
 	tool_behaviour = TOOL_SAW
 	toolspeed = 0.7 //faster as a saw
 
@@ -152,7 +152,7 @@
 	return 0
 
 /obj/item/melee/transforming/energy/sword/saber
-	var/list/possible_colors = list("red" = LIGHT_COLOR_RED, "blue" = LIGHT_COLOR_LIGHT_CYAN, "green" = LIGHT_COLOR_GREEN, "purple" = LIGHT_COLOR_LAVENDER)
+	var/list/possible_colors = list("red" = COLOR_SOFT_RED, "blue" = LIGHT_COLOR_LIGHT_CYAN, "green" = LIGHT_COLOR_GREEN, "purple" = LIGHT_COLOR_LAVENDER)
 	var/hacked = FALSE
 
 /obj/item/melee/transforming/energy/sword/saber/Initialize(mapload)
@@ -160,17 +160,17 @@
 	if(LAZYLEN(possible_colors))
 		var/set_color = pick(possible_colors)
 		sword_color = set_color
-		light_color = possible_colors[set_color]
+		set_light_color(possible_colors[set_color])
 
 /obj/item/melee/transforming/energy/sword/saber/process()
 	. = ..()
 	if(hacked)
 		var/set_color = pick(possible_colors)
-		light_color = possible_colors[set_color]
+		set_light_color(possible_colors[set_color])
 		update_light()
 
 /obj/item/melee/transforming/energy/sword/saber/red
-	possible_colors = list("red" = LIGHT_COLOR_RED)
+	possible_colors = list("red" = COLOR_SOFT_RED)
 
 /obj/item/melee/transforming/energy/sword/saber/blue
 	possible_colors = list("blue" = LIGHT_COLOR_LIGHT_CYAN)
@@ -203,7 +203,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	icon_state_on = "cutlass1"
-	light_color = "#ff0000"
+	light_color = COLOR_RED
 
 /obj/item/melee/transforming/energy/blade
 	name = "energy blade"

--- a/code/game/objects/items/pitchfork.dm
+++ b/code/game/objects/items/pitchfork.dm
@@ -43,7 +43,7 @@
 
 /obj/item/pitchfork/demonic/Initialize()
 	. = ..()
-	set_light(3,6,LIGHT_COLOR_RED)
+	set_light(3,6,COLOR_SOFT_RED)
 
 /obj/item/pitchfork/demonic/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -16,14 +16,17 @@
 	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
 	drop_sound = 'sound/items/handling/weldingtool_drop.ogg'
 	pickup_sound =  'sound/items/handling/weldingtool_pickup.ogg'
-	var/acti_sound = 'sound/items/welderactivate.ogg'
-	var/deac_sound = 'sound/items/welderdeactivate.ogg'
+	light_color = LIGHT_COLOR_FIRE
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 30)
 	resistance_flags = FIRE_PROOF
-
+	heat = 3800
+	tool_behaviour = TOOL_WELDER
+	toolspeed = 1
+	wound_bonus = 10
+	bare_wound_bonus = 15
 	custom_materials = list(/datum/material/iron=70, /datum/material/glass=30)
 	var/welding = 0 	//Whether or not the welding tool is off(0), on(1) or currently welding(2)
 	var/status = TRUE 		//Whether the welder is secured or unsecured (able to attach rods to it to make a flamethrower)
@@ -32,11 +35,8 @@
 	var/can_off_process = 0
 	var/light_intensity = 2 //how powerful the emitted light is when used.
 	var/burned_fuel_for = 0	//when fuel was last removed
-	heat = 3800
-	tool_behaviour = TOOL_WELDER
-	toolspeed = 1
-	wound_bonus = 10
-	bare_wound_bonus = 15
+	var/acti_sound = 'sound/items/welderactivate.ogg'
+	var/deac_sound = 'sound/items/welderdeactivate.ogg'
 
 /obj/item/weldingtool/Initialize()
 	. = ..()
@@ -358,11 +358,11 @@
 	inhand_icon_state = "exwelder"
 	max_fuel = 40
 	custom_materials = list(/datum/material/iron=70, /datum/material/glass=120)
-	var/last_gen = 0
 	change_icons = 0
 	can_off_process = 1
 	light_intensity = 1
 	toolspeed = 0.5
+	var/last_gen = 0
 	var/nextrefueltick = 0
 
 /obj/item/weldingtool/experimental/process()

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -52,7 +52,7 @@
 /obj/item/wrench/medical/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] is praying to the medical wrench to take [user.p_their()] soul. It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	user.Stun(100, ignore_canstun = TRUE)// Stun stops them from wandering off
-	user.light_color = "#FAE48E"
+	user.set_light_color(COLOR_VERY_SOFT_YELLOW)
 	user.set_light(2)
 	user.add_overlay(mutable_appearance('icons/effects/genetics.dmi', "servitude", -MUTATIONS_LAYER))
 	playsound(loc, 'sound/effects/pray.ogg', 50, TRUE, -1)

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -371,7 +371,7 @@
 	name = "photosynthetic potted plant"
 	desc = "A bioluminescent plant."
 	icon_state = "plant-09"
-	light_color = "#2cb2e8"
+	light_color = COLOR_BRIGHT_BLUE
 	light_range = 3
 
 /obj/item/kirbyplants/fullysynthetic

--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -76,7 +76,7 @@ GLOBAL_LIST_INIT(ore_probability, list(/obj/item/stack/ore/uranium = 50,
 	icon_state = "nether"
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/ice_demon)
 	light_range = 1
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 /obj/structure/spawner/ice_moon/demonic_portal/clear_rock()
 	for(var/turf/F in RANGE_TURFS(3, src))

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -102,7 +102,7 @@
 	floor_tile = /obj/item/stack/tile/fairygrass
 	light_range = 2
 	light_power = 0.80
-	light_color = "#33CCFF"
+	light_color = COLOR_BLUE_LIGHT
 
 /turf/open/floor/grass/snow
 	gender = PLURAL

--- a/code/game/turfs/open/floor/light_floor.dm
+++ b/code/game/turfs/open/floor/light_floor.dm
@@ -15,7 +15,7 @@
 	///defines on top
 	var/state = LIGHTFLOOR_FINE
 	///list of colours to choose
-	var/static/list/coloredlights = list(LIGHT_COLOR_CYAN, LIGHT_COLOR_RED, LIGHT_COLOR_ORANGE, LIGHT_COLOR_GREEN, LIGHT_COLOR_YELLOW, LIGHT_COLOR_DARK_BLUE, LIGHT_COLOR_LAVENDER, LIGHT_COLOR_WHITE,  LIGHT_COLOR_SLIME_LAMP, LIGHT_COLOR_FIRE)
+	var/static/list/coloredlights = list(LIGHT_COLOR_CYAN, COLOR_SOFT_RED, LIGHT_COLOR_ORANGE, LIGHT_COLOR_GREEN, LIGHT_COLOR_YELLOW, LIGHT_COLOR_DARK_BLUE, LIGHT_COLOR_LAVENDER, COLOR_WHITE,  LIGHT_COLOR_SLIME_LAMP, LIGHT_COLOR_FIRE)
 	///current light color
 	var/currentcolor = LIGHT_COLOR_CYAN
 	///var to prevent changing color on certain admin spawn only tiles
@@ -36,13 +36,13 @@
 /turf/open/floor/light/proc/populate_lighttile_designs()
 	lighttile_designs = list(
 		LIGHT_COLOR_CYAN = image(icon = src.icon, icon_state = "light_on-1"),
-		LIGHT_COLOR_RED = image(icon = src.icon, icon_state = "light_on-2"),
+		COLOR_SOFT_RED = image(icon = src.icon, icon_state = "light_on-2"),
 		LIGHT_COLOR_ORANGE = image(icon = src.icon, icon_state = "light_on-3"),
 		LIGHT_COLOR_GREEN = image(icon = src.icon, icon_state = "light_on-4"),
 		LIGHT_COLOR_YELLOW = image(icon = src.icon, icon_state = "light_on-5"),
 		LIGHT_COLOR_DARK_BLUE = image(icon = src.icon, icon_state = "light_on-6"),
 		LIGHT_COLOR_LAVENDER = image(icon = src.icon, icon_state = "light_on-7"),
-		LIGHT_COLOR_WHITE = image(icon = src.icon, icon_state = "light_on-8"),
+		COLOR_WHITE = image(icon = src.icon, icon_state = "light_on-8"),
 		LIGHT_COLOR_SLIME_LAMP = image(icon = src.icon, icon_state = "light_on-9"),
 		LIGHT_COLOR_FIRE = image(icon = src.icon, icon_state = "light_on-10")
 		)
@@ -64,12 +64,12 @@
 		switch(state)
 			if(LIGHTFLOOR_FINE)
 				icon_state = "light_on-[LAZYFIND(coloredlights, currentcolor)]"
-				light_color = currentcolor
+				set_light_color(currentcolor)
 				set_light(5)
 				light_range = 3
 			if(LIGHTFLOOR_FLICKER)
 				icon_state = "light_on_flicker-[LAZYFIND(coloredlights, currentcolor)]"
-				light_color = currentcolor
+				set_light_color(currentcolor)
 				set_light(3)
 				light_range = 2
 			if(LIGHTFLOOR_BREAKING)

--- a/code/game/turfs/open/floor/misc_floor.dm
+++ b/code/game/turfs/open/floor/misc_floor.dm
@@ -31,10 +31,10 @@
 	if(on)
 		if(LAZYLEN(SSmapping.nuke_threats))
 			icon_state = "rcircuitanim"
-			light_color = LIGHT_COLOR_FLARE
+			set_light_color(LIGHT_COLOR_FLARE)
 		else
 			icon_state = icon_normal
-			light_color = initial(light_color)
+			set_light_color(initial(light_color))
 		set_light(1.4, 0.5)
 	else
 		icon_state = "[icon_normal]off"

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -92,7 +92,7 @@
 	throw_speed = 1
 	throw_range = 3
 	sharpness = SHARP_EDGED
-	light_color = "#ff0000"
+	light_color = COLOR_RED
 	attack_verb = list("cleaved", "slashed", "tore", "lacerated", "hacked", "ripped", "diced", "carved")
 	icon_state = "cultbastard"
 	inhand_icon_state = "cultbastard"

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -168,7 +168,7 @@
 	desc = "A floating crystal that slowly heals those faithful to Nar'Sie."
 	icon_state = "pylon"
 	light_range = 1.5
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	break_sound = 'sound/effects/glassbr2.ogg'
 	break_message = "<span class='warning'>The blood-red crystal falls to the floor and shatters!</span>"
 	var/heal_delay = 25

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -430,11 +430,11 @@ structure_check() searches for nearby cultist structures required for the invoca
 	playsound(T, pick('sound/effects/sparks1.ogg', 'sound/effects/sparks2.ogg', 'sound/effects/sparks3.ogg', 'sound/effects/sparks4.ogg'), 100, TRUE, 14)
 	inner_portal = new /obj/effect/temp_visual/cult/portal(T)
 	if(portal_type == "space")
-		light_color = color
+		set_light_color(color)
 		desc += "<br><b>A tear in reality reveals a black void interspersed with dots of light... something recently teleported here from space.<br><u>The void feels like it's trying to pull you to the [dir2text(get_dir(T, origin))]!</u></b>"
 	else
 		inner_portal.icon_state = "lava"
-		light_color = LIGHT_COLOR_FIRE
+		set_light_color(LIGHT_COLOR_FIRE)
 		desc += "<br><b>A tear in reality reveals a coursing river of lava... something recently teleported here from the Lavaland Mines!</b>"
 	outer_portal = new(T, 600, color)
 	light_range = 4

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -9,7 +9,7 @@
 	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
 	custom_materials = list(/datum/material/iron = 300, /datum/material/glass = 300)
-	light_color = LIGHT_COLOR_WHITE
+	light_color = COLOR_WHITE
 	light_power = FLASH_LIGHT_POWER
 	var/flashing_overlay = "flash-f"
 	var/times_used = 0 //Number of times it's been used.

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -52,6 +52,7 @@
 	light_range = LIGHT_RANGE_FIRE
 	light_color = LIGHT_COLOR_FIRE
 	blend_mode = BLEND_ADD
+	light_color = LIGHT_COLOR_FIRE
 
 	var/volume = 125
 	var/temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST

--- a/code/modules/cargo/bounty_console.dm
+++ b/code/modules/cargo/bounty_console.dm
@@ -5,7 +5,7 @@
 	desc = "Used to check and claim bounties offered by Nanotrasen"
 	icon_screen = "bounty"
 	circuit = /obj/item/circuitboard/computer/bounty
-	light_color = "#E2853D"//orange
+	light_color = COLOR_BRIGHT_ORANGE
 	var/printer_ready = 0 //cooldown var
 	var/static/datum/bank_account/cargocash
 

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -17,7 +17,7 @@
 	var/message_cooldown
 	var/list/loaded_coupons
 
-	light_color = "#E2853D"//orange
+	light_color = COLOR_BRIGHT_ORANGE
 
 /obj/machinery/computer/cargo/request
 	name = "supply request console"

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -3,6 +3,7 @@
 	desc = "Used to order supplies, approve requests, and control the shuttle."
 	icon_screen = "supply"
 	circuit = /obj/item/circuitboard/computer/cargo
+	light_color = COLOR_BRIGHT_ORANGE
 
 	var/requestonly = FALSE
 	var/contraband = FALSE
@@ -17,7 +18,6 @@
 	var/message_cooldown
 	var/list/loaded_coupons
 
-	light_color = COLOR_BRIGHT_ORANGE
 
 /obj/machinery/computer/cargo/request
 	name = "supply request console"

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -179,7 +179,7 @@
 	shuttleId = "pirateship"
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	possible_destinations = "pirateship_away;pirateship_home;pirateship_custom"
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/pirate

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -151,7 +151,7 @@
 	var/hash = md5(hidden_message)
 	var/newcolor = copytext_char(hash, 1, 7)
 	add_atom_colour("#[newcolor]", FIXED_COLOUR_PRIORITY)
-	light_color = "#[newcolor]"
+	set_light_color("#[newcolor]")
 	set_light(1)
 
 /obj/structure/chisel_message/proc/pack()

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -1,12 +1,4 @@
 
-/atom
-	var/light_power = 1 // Intensity of the light.
-	var/light_range = 0 // Range in tiles of the light.
-	var/light_color     // Hexadecimal RGB string representing the colour of the light.
-
-	var/tmp/datum/light_source/light // Our light source. Don't fuck with this directly unless you have a good reason!
-	var/tmp/list/light_sources       // Any light sources that are "inside" of us, for example, if src here was a mob that's carrying a flashlight, that flashlight's light source would be part of this list.
-
 // The proc you should always use to set the light of this atom.
 // Nonesensical value for l_color default, so we can detect if it gets set to null.
 #define NONSENSICAL_VALUE -99999
@@ -98,15 +90,15 @@
 	return ..()
 
 
-/atom/proc/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = LIGHT_COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
+/atom/proc/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
 	return
 
-/turf/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = LIGHT_COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
+/turf/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
 	if(!_duration)
 		stack_trace("Lighting FX obj created on a turf without a duration")
 	new /obj/effect/dummy/lighting_obj (src, _color, _range, _power, _duration)
 
-/obj/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = LIGHT_COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
+/obj/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
 	var/temp_color
 	var/temp_power
 	var/temp_range
@@ -117,10 +109,41 @@
 	set_light(_range, _power, _color)
 	addtimer(CALLBACK(src, /atom/proc/set_light, _reset_lighting ? initial(light_range) : temp_range, _reset_lighting ? initial(light_power) : temp_power, _reset_lighting ? initial(light_color) : temp_color), _duration, TIMER_OVERRIDE|TIMER_UNIQUE)
 
-/mob/living/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = LIGHT_COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
+/mob/living/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
 	mob_light(_color, _range, _power, _duration)
 
 /mob/living/proc/mob_light(_color, _range, _power, _duration)
 	var/obj/effect/dummy/lighting_obj/moblight/mob_light_obj = new (src, _color, _range, _power, _duration)
 	return mob_light_obj
 
+
+/atom/proc/set_light_range(new_range)
+	if(new_range == light_range)
+		return
+	SEND_SIGNAL(src, COMSIG_ATOM_SET_LIGHT_RANGE, new_range)
+	. = light_range
+	light_range = new_range
+
+
+/atom/proc/set_light_power(new_power)
+	if(new_power == light_power)
+		return
+	SEND_SIGNAL(src, COMSIG_ATOM_SET_LIGHT_POWER, new_power)
+	. = light_power
+	light_power = new_power
+
+
+/atom/proc/set_light_color(new_color)
+	if(new_color == light_color)
+		return
+	SEND_SIGNAL(src, COMSIG_ATOM_SET_LIGHT_COLOR, new_color)
+	. = light_color
+	light_color = new_color
+
+
+/atom/proc/set_light_on(new_value)
+	if(new_value == light_on)
+		return
+	SEND_SIGNAL(src, COMSIG_ATOM_SET_LIGHT_ON, new_value)
+	. = light_on
+	light_on = new_value

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -20,12 +20,12 @@
 	sharpness = SHARP_EDGED
 	actions_types = list(/datum/action/item_action/toggle_light)
 	obj_flags = UNIQUE_RENAME
+	light_on = FALSE
 	var/list/trophies = list()
 	var/charged = TRUE
 	var/charge_time = 15
 	var/detonation_damage = 50
 	var/backstab_bonus = 30
-	var/light_on = FALSE
 	var/brightness_on = 5
 	var/wielded = FALSE // track wielded status on item
 
@@ -148,7 +148,7 @@
 		playsound(src.loc, 'sound/weapons/kenetic_reload.ogg', 60, TRUE)
 
 /obj/item/kinetic_crusher/ui_action_click(mob/user, actiontype)
-	light_on = !light_on
+	set_light_on(!light_on)
 	playsound(user, 'sound/weapons/empty.ogg', 100, TRUE)
 	update_brightness(user)
 	update_icon()

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -191,7 +191,7 @@
 	base_build_path = /obj/machinery/smartfridge/survival_pod
 	light_range = 5
 	light_power = 1.2
-	light_color = "#DDFFD3"
+	light_color = COLOR_VERY_PALE_LIME_GREEN
 	max_n_of_items = 10
 	pixel_y = -4
 	flags_1 = NODECONSTRUCT_1

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -35,8 +35,8 @@
 	healable = 0
 	loot = list(/obj/effect/decal/cleanable/robot_debris)
 	del_on_death = TRUE
+	light_on = FALSE
 	var/mode = MINEDRONE_COLLECT
-	var/light_on = 0
 	var/obj/item/gun/energy/kinetic_accelerator/minebot/stored_gun
 
 /mob/living/simple_animal/hostile/mining_drone/Initialize()

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -449,8 +449,8 @@
 	name = "luminescent glow"
 	desc = "Tell a coder if you're seeing this."
 	icon_state = "nothing"
-	light_color = "#FFFFFF"
 	light_range = LUMINESCENT_DEFAULT_GLOW
+	light_color = COLOR_WHITE
 
 /obj/effect/dummy/luminescent_glow/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -30,7 +30,7 @@ Difficulty: Medium
 	icon = 'icons/mob/broadMobs.dmi'
 	health_doll_icon = "miner"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	light_color = "#E4C7C5"
+	light_color = COLOR_LIGHT_GRAYISH_RED
 	movement_type = GROUND
 	speak_emote = list("roars")
 	speed = 3

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
@@ -16,7 +16,7 @@ Difficulty: Extremely Hard
 	attack_verb_simple = "pummels"
 	attack_sound = 'sound/weapons/sonic_jackhammer.ogg'
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	light_color = "#E4C7C5"
+	light_color = COLOR_LIGHT_GRAYISH_RED
 	movement_type = GROUND
 	weather_immunities = list("snow")
 	speak_emote = list("roars")

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -376,7 +376,7 @@
 	damage = 19
 	range = 6
 	eyeblur = 0
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	impact_effect_type = /obj/effect/temp_visual/kinetic_blast
 	tracer_type = /obj/effect/projectile/tracer/legion
 	muzzle_type = /obj/effect/projectile/tracer/legion

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
@@ -194,7 +194,7 @@ Difficulty: Hard
 	var/obj/effect/portal/permanent/one_way/exit = new /obj/effect/portal/permanent/one_way(starting)
 	exit.id = "wendigo arena exit"
 	exit.add_atom_colour(COLOR_RED_LIGHT, ADMIN_COLOUR_PRIORITY)
-	exit.set_light(20, 1, LIGHT_COLOR_RED)
+	exit.set_light(20, 1, COLOR_SOFT_RED)
 	return ..()
 
 /obj/item/wendigo_blood

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -95,7 +95,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	icon = 'icons/obj/lavaland/tumor.dmi'
 	icon_state = "tumor"
 	pixel_x = -16
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	light_range = 3
 	anchored = TRUE
 	density = FALSE
@@ -308,7 +308,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	layer = BELOW_MOB_LAYER
 	color = rgb(255,0,0)
 	light_range = MINIMUM_USEFUL_LIGHT_RANGE
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	var/mob/living/carbon/human/activator = null
 	var/mob/living/simple_animal/hostile/asteroid/elite/ourelite = null
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -97,7 +97,7 @@
 			bonfire_teleport()
 		if(SPEW_SMOKE)
 			spew_smoke()
-			
+
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/Move()
 	if(charging)
 		return FALSE
@@ -111,7 +111,7 @@
 	if(T)
 		myhead.LoseTarget()
 		myhead.Goto(T, myhead.move_to_delay)
-		
+
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/legionnaire_charge(target)
 	ranged_cooldown = world.time + 3.5 SECONDS
 	charging = TRUE
@@ -274,7 +274,7 @@
 	anchored = TRUE
 	density = FALSE
 	light_range = 4
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	var/mob/living/simple_animal/hostile/asteroid/elite/legionnaire/myowner = null
 
 
@@ -321,7 +321,7 @@
 	A.GiveTarget(target)
 	A.friends += user
 	A.faction = user.faction.Copy()
-	
+
 /obj/item/crusher_trophy/legionnaire_spine/attack_self(mob/user)
 	if(!isliving(user))
 		return

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -11,7 +11,7 @@
 /obj/effect/light_emitter/red_energy_sword //used so there's a combination of both their head light and light coming off the energy sword
 	set_luminosity = 2
 	set_cap = 2.5
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 
 /mob/living/simple_animal/hostile/syndicate
@@ -117,7 +117,7 @@
 	attack_verb_simple = "slash"
 	attack_sound = 'sound/weapons/blade1.ogg'
 	armour_penetration = 35
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	status_flags = 0
 	var/obj/effect/light_emitter/red_energy_sword/sord
 	projectile_deflect_chance = 50

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -4,6 +4,12 @@
 /obj/item/modular_computer
 	name = "modular microcomputer"
 	desc = "A small portable microcomputer."
+	icon = 'icons/obj/computer.dmi'
+	icon_state = "laptop-open"
+	light_on = FALSE
+	integrity_failure = 0.5
+	max_integrity = 100
+	armor = list("melee" = 0, "bullet" = 20, "laser" = 20, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
 
 	var/enabled = 0											// Whether the computer is turned on.
 	var/screen_on = 1										// Whether the computer is active/opened/it's screen is on.
@@ -22,18 +28,12 @@
 	// must have it's own DMI file. Icon states must be called exactly the same in all files, but may look differently
 	// If you create a program which is limited to Laptops and Consoles you don't have to add it's icon_state overlay for Tablets too, for example.
 
-	icon = 'icons/obj/computer.dmi'
-	icon_state = "laptop-open"
 	var/icon_state_unpowered = null							// Icon state when the computer is turned off.
 	var/icon_state_powered = null							// Icon state when the computer is turned on.
 	var/icon_state_menu = "menu"							// Icon state overlay when the computer is turned on, but no program is loaded that would override the screen.
 	var/display_overlays = TRUE								// If FALSE, don't draw overlays on this device at all
 	var/max_hardware_size = 0								// Maximal hardware w_class. Tablets/PDAs have 1, laptops 2, consoles 4.
 	var/steel_sheet_cost = 5								// Amount of steel sheets refunded when disassembling an empty frame of this computer.
-
-	integrity_failure = 0.5
-	max_integrity = 100
-	armor = list("melee" = 0, "bullet" = 20, "laser" = 20, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
 
 	// Important hardware (must be installed for computer to work)
 
@@ -44,7 +44,6 @@
 	var/list/idle_threads							// Idle programs on background. They still receive process calls but can't be interacted with.
 	var/obj/physical = null									// Object that represents our computer. It's used for Adjacent() and UI visibility checks.
 	var/has_light = FALSE						//If the computer has a flashlight/LED light/what-have-you installed
-	var/light_on = FALSE						//If that light is enabled
 	var/comp_light_luminosity = 3				//The brightness of that light
 	var/comp_light_color			//The color of that light
 

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -160,7 +160,7 @@
 			return 1
 
 		if("PC_toggle_light")
-			light_on = !light_on
+			set_light_on(!light_on)
 			if(light_on)
 				set_light(comp_light_luminosity, 1, comp_light_color)
 			else
@@ -178,7 +178,7 @@
 					to_chat(user, "<span class='warning'>That color is too dark! Choose a lighter one.</span>")
 					new_color = null
 			comp_light_color = new_color
-			light_color = new_color
+			set_light_color(new_color)
 			update_light()
 			return TRUE
 

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -9,7 +9,7 @@
 	inhand_icon_state = "camera"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
-	light_color = LIGHT_COLOR_WHITE
+	light_color = COLOR_WHITE
 	light_power = FLASH_LIGHT_POWER
 	w_class = WEIGHT_CLASS_SMALL
 	flags_1 = CONDUCT_1

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -332,14 +332,14 @@
 	if(update_state & UPSTATE_ALLGOOD)
 		switch(charging)
 			if(APC_NOT_CHARGING)
-				light_color = LIGHT_COLOR_RED
+				set_light_color(COLOR_SOFT_RED)
 			if(APC_CHARGING)
-				light_color = LIGHT_COLOR_BLUE
+				set_light_color(LIGHT_COLOR_BLUE)
 			if(APC_FULLY_CHARGED)
-				light_color = LIGHT_COLOR_GREEN
+				set_light_color(LIGHT_COLOR_GREEN)
 		set_light(lon_range)
 	else if(update_state & UPSTATE_BLUESCREEN)
-		light_color = LIGHT_COLOR_BLUE
+		set_light_color(LIGHT_COLOR_BLUE)
 		set_light(lon_range)
 	else
 		set_light(0)

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -14,7 +14,7 @@
 	consume_range = 6 //How many tiles out do we eat
 	light_power = 0.7
 	light_range = 15
-	light_color = rgb(255, 0, 0)
+	light_color = COLOR_RED
 	gender = FEMALE
 
 /obj/singularity/narsie/large

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -10,7 +10,7 @@
 	flag = "laser"
 	eyeblur = 2
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	ricochets_max = 50	//Honk!
 	ricochet_chance = 80
 	reflectable = REFLECT_NORMAL
@@ -164,7 +164,7 @@
 	icon_state = "laser"
 	suit_types = list(/obj/item/clothing/suit/bluetag)
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
@@ -198,7 +198,7 @@
 /obj/projectile/beam/instakill/red
 	icon_state = "red_laser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 /obj/projectile/beam/instakill/on_hit(atom/target)
 	. = ..()

--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -54,7 +54,7 @@ Slimecrossing Armor
 /obj/structure/light_prism/Initialize(mapload, newcolor)
 	. = ..()
 	color = newcolor
-	light_color = newcolor
+	set_light_color(newcolor)
 	set_light(5)
 
 /obj/structure/light_prism/attack_hand(mob/user)

--- a/code/modules/ruins/spaceruin_code/caravanambush.dm
+++ b/code/modules/ruins/spaceruin_code/caravanambush.dm
@@ -78,7 +78,7 @@
 	desc = "Used to control the Pirate Cutter."
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	circuit = /obj/item/circuitboard/computer/caravan/pirate
 	shuttleId = "caravanpirate"
 	possible_destinations = "caravanpirate_custom;caravanpirate_ambush"
@@ -101,7 +101,7 @@
 	desc = "Used to control the Syndicate Fighter."
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	req_access = list(ACCESS_SYNDICATE)
 	circuit = /obj/item/circuitboard/computer/caravan/syndicate1
 	shuttleId = "caravansyndicate1"
@@ -126,7 +126,7 @@
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
 	req_access = list(ACCESS_SYNDICATE)
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	circuit = /obj/item/circuitboard/computer/caravan/syndicate2
 	shuttleId = "caravansyndicate2"
 	possible_destinations = "caravansyndicate2_custom;caravansyndicate2_ambush;caravansyndicate1_listeningpost"
@@ -150,7 +150,7 @@
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
 	req_access = list(ACCESS_SYNDICATE)
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	circuit = /obj/item/circuitboard/computer/caravan/syndicate3
 	shuttleId = "caravansyndicate3"
 	possible_destinations = "caravansyndicate3_custom;caravansyndicate3_ambush;caravansyndicate3_listeningpost"

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -6,7 +6,7 @@
 	circuit = /obj/item/circuitboard/computer/syndicate_shuttle
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	req_access = list(ACCESS_SYNDICATE)
 	shuttleId = "syndicate"
 	possible_destinations = "syndicate_away;syndicate_z5;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s;syndicate_custom"

--- a/code/modules/spells/spell_types/lichdom.dm
+++ b/code/modules/spells/spell_types/lichdom.dm
@@ -80,8 +80,8 @@
 	desc = "Stores souls. Revives liches. Also repels mosquitos."
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "bluespace"
-	color = "#003300"
-	light_color = "#003300"
+	color = COLOR_VERY_DARK_LIME_GREEN
+	light_color = COLOR_VERY_DARK_LIME_GREEN
 	var/lon_range = 3
 	var/resurrections = 0
 	var/datum/mind/mind

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -314,7 +314,7 @@
 	icon_state = "surgicaldrill_a"
 	hitsound = 'sound/items/welder.ogg'
 	toolspeed = 0.7
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 /obj/item/surgicaldrill/advanced/Initialize()
 	. = ..()

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -134,7 +134,7 @@
 	extra_price = 120
 	payment_department = NO_FREEBIES
 	light_mask = "wardrobe-light-mask"
-	light_color = "#00FF00"
+	light_color = LIGHT_COLOR_ELECTRIC_GREEN
 
 /obj/machinery/vending/clothing/canLoadItem(obj/item/I,mob/user)
 	return (I.type in products)

--- a/code/modules/vending/coffee.dm
+++ b/code/modules/vending/coffee.dm
@@ -13,7 +13,7 @@
 	extra_price = 150
 	payment_department = ACCOUNT_SRV
 	light_mask = "coffee-light-mask"
-	light_color = "#8b633b"
+	light_color = COLOR_DARK_MODERATE_ORANGE
 
 /obj/item/vending_refill/coffee
 	machine_name = "Solar's Best Hot Drinks"

--- a/code/modules/vending/cola.dm
+++ b/code/modules/vending/cola.dm
@@ -44,7 +44,7 @@
 /obj/machinery/vending/cola/blue
 	icon_state = "Cola_Machine"
 	light_mask = "cola-light-mask"
-	light_color = "#555cc2"
+	light_color = COLOR_MODERATE_BLUE
 
 /obj/machinery/vending/cola/black
 	icon_state = "cola_black"
@@ -56,7 +56,7 @@
 	desc = "It vends cola, in space."
 	product_slogans = "Cola in space!"
 	light_mask = "red_cola-light-mask"
-	light_color = "#a50824"
+	light_color = COLOR_DARK_RED
 
 /obj/machinery/vending/cola/space_up
 	icon_state = "space_up"
@@ -64,7 +64,7 @@
 	desc = "Indulge in an explosion of flavor."
 	product_slogans = "Space-up! Like a hull breach in your mouth."
 	light_mask = "space_up-light-mask"
-	light_color = "#44964a"
+	light_color = COLOR_DARK_MODERATE_LIME_GREEN
 
 /obj/machinery/vending/cola/starkist
 	icon_state = "starkist"
@@ -72,12 +72,12 @@
 	desc = "The taste of a star in liquid form."
 	product_slogans = "Drink the stars! Star-kist!"
 	light_mask = "starkist-light-mask"
-	light_color = "#ffc44d"
+	light_color = COLOR_LIGHT_ORANGE
 
 /obj/machinery/vending/cola/sodie
 	icon_state = "soda"
 	light_mask = "soda-light-mask"
-	light_color = ""
+	light_color = COLOR_WHITE
 
 /obj/machinery/vending/cola/pwr_game
 	icon_state = "pwr_game"
@@ -85,7 +85,7 @@
 	desc = "You want it, we got it. Brought to you in partnership with Vlad's Salads."
 	product_slogans = "The POWER that gamers crave! PWR GAME!"
 	light_mask = "pwr_game-light-mask"
-	light_color = "#6927c5"
+	light_color = COLOR_STRONG_VIOLET
 
 /obj/machinery/vending/cola/shamblers
 	name = "\improper Shambler's Vendor"
@@ -103,4 +103,4 @@
 	product_slogans = "~Shake me up some of that Shambler's Juice!~"
 	product_ads = "Refreshing!;Jyrbv dv lg jfdv fw kyrk Jyrdscvi'j Alztv!;Over 1 trillion souls drank!;Thirsty? Nyp efk uizeb kyv uribevjj?;Kyv Jyrdscvi uizebj kyv ezxyk!;Drink up!;Krjkp."
 	light_mask = "shamblers-light-mask"
-	light_color = "#e4005b"
+	light_color = COLOR_MOSTLY_PURE_PINK

--- a/code/modules/vending/sovietsoda.dm
+++ b/code/modules/vending/sovietsoda.dm
@@ -11,7 +11,7 @@
 	default_price = 1
 	extra_price = 1
 	payment_department = NO_FREEBIES
-	light_color = "#ffbe9d"
+	light_color = COLOR_PALE_ORANGE
 
 /obj/item/vending_refill/sovietsoda
 	machine_name = "BODA"

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -36,7 +36,7 @@
 					/obj/item/clothing/head/beret/sec/navyofficer = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/sec_wardrobe
 	payment_department = ACCOUNT_SEC
-	light_color = "#ff3300"
+	light_color = COLOR_MOSTLY_PURE_RED
 
 /obj/item/vending_refill/wardrobe/sec_wardrobe
 	machine_name = "SecDrobe"
@@ -93,7 +93,7 @@
 					/obj/item/clothing/head/hardhat/weldhat = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/engi_wardrobe
 	payment_department = ACCOUNT_ENG
-	light_color = "#fbff23"
+	light_color = COLOR_VIVID_YELLOW
 
 /obj/item/vending_refill/wardrobe/engi_wardrobe
 	machine_name = "EngiDrobe"
@@ -114,7 +114,7 @@
 					/obj/item/clothing/shoes/sneakers/black = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/atmos_wardrobe
 	payment_department = ACCOUNT_ENG
-	light_color = "#fbff23"
+	light_color = COLOR_VIVID_YELLOW
 
 /obj/item/vending_refill/wardrobe/atmos_wardrobe
 	machine_name = "AtmosDrobe"
@@ -199,7 +199,7 @@
 					/obj/item/clothing/accessory/armband/hydro = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/hydro_wardrobe
 	payment_department = ACCOUNT_SRV
-	light_color = "#00FF00"
+	light_color = LIGHT_COLOR_ELECTRIC_GREEN
 
 /obj/item/vending_refill/wardrobe/hydro_wardrobe
 	machine_name = "HyDrobe"
@@ -310,7 +310,7 @@
 					/obj/item/storage/belt/janitor = 2)
 	refill_canister = /obj/item/vending_refill/wardrobe/jani_wardrobe
 	payment_department = ACCOUNT_SRV
-	light_color = "#b800b8"
+	light_color = COLOR_STRONG_MAGENTA
 
 /obj/item/vending_refill/wardrobe/jani_wardrobe
 	machine_name = "JaniDrobe"


### PR DESCRIPTION
* Defined all the existing `light_color` values.
* Moved their definitions to `colors.dm`
* Made white the default color. It was so already, but that was very obscured.
* Moved the atom light-related variables to the atom definition.
* Wrapped changes to variables such as `light_color` into procs that report the event through signals.
* Moved the `light_on` variable to the `atom` level, also adding a signal for its changing, to represent toggling lights.
* Cleaned up a little bit of code in where new variables were defined before redefinitions.

This is all atomization to reduce changes in #52413
None of this affect gameplay at all, it's all code cleaning and refactoring.

There's more colors to standardize, a search for `color = ` will find lots of targets, and I see little need to have both the `LIGHT_COLOR` and `COLOR` patterns, but I don't want to make this PR bigger than it already is.