### PR TITLE
Fixes the SM sliver tongs sprite being nulled after picking up the sliver

### DIFF
--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -247,7 +247,7 @@
 	return ..()
 
 /obj/item/hemostat/supermatter/update_icon_state()
-	icon_state = "supermatter_tongs[sliver ? "loaded" : null]"
+	icon_state = "supermatter_tongs[sliver ? "_loaded" : null]"
 
 /obj/item/hemostat/supermatter/afterattack(atom/O, mob/user, proximity)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In #52473, Shiz changed how the tongs determine what sprite to use once you picked up the sliver with them, but he missed an underscore which caused them to disappear.

_Maybe_ speedmerge since this fixes a broken traitor objective?
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Walking around with an item that can accidentally dust you or someone else as well as irradiate everything because you think it's gone is bad for spacecoin because
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Supermatter tongs are no longer rendered invisible once you pick up a supermatter sliver.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
