### PR TITLE
Returns hot ice to "sane" plasma output

### DIFF
--- a/code/game/objects/items/stacks/sheets/hot_ice.dm
+++ b/code/game/objects/items/stacks/sheets/hot_ice.dm
@@ -5,7 +5,7 @@
 	singular_name = "hot ice"
 	icon = 'icons/obj/stack_objects.dmi'
 	custom_materials = list(/datum/material/hot_ice=MINERAL_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/toxin/hot_ice = 50)
+	grind_results = list(/datum/reagent/toxin/hot_ice = 25)
 	material_type = /datum/material/hot_ice
 
 /obj/item/stack/sheet/hot_ice/suicide_act(mob/living/carbon/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So uh the hot ice sheet to plasma ratio used to be 1-300u. I may or may not have doubled it accidentally. 

## Why It's Good For The Game

Ahhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh thanks zeta for letting me know

## Changelog
:cl:
fix: Hot ice is worth what it should be again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
