### PR TITLE
Changes how the adrenaline sacs changeling power works

### DIFF
--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/adrenaline
 	name = "Adrenaline Sacs"
 	desc = "We evolve additional sacs of adrenaline throughout our body. Costs 30 chemicals."
-	helptext = "Removes all stuns instantly and adds a short-term reduction in further stuns. Can be used while unconscious. Continued use poisons the body."
+	helptext = "Removes all stuns and heals a large amount of stamina damage instantly, then synthesizes a small amount of the changeling haste reagent, which will give us a short burst of speed to escape with. Can be used while unconscious. The changeling haste reagent produced by this ability can cause jittering and dizziness."
 	button_icon_state = "adrenaline"
 	chemical_cost = 30
 	dna_cost = 2
@@ -12,8 +12,8 @@
 /datum/action/changeling/adrenaline/sting_action(mob/living/user)
 	..()
 	to_chat(user, "<span class='notice'>Energy rushes through us.</span>")
-	user.SetKnockdown(0)
+	user.SetAllImmobility(0)
+	user.adjustStaminaLoss(-60)
 	user.set_resting(FALSE)
-	user.reagents.add_reagent(/datum/reagent/medicine/changelingadrenaline, 4) //20 seconds
-	user.reagents.add_reagent(/datum/reagent/medicine/changelinghaste, 3) //6 seconds, for a really quick burst of speed
+	user.reagents.add_reagent(/datum/reagent/medicine/changelinghaste, 3) //6 seconds, for a short-duration burst of speed
 	return TRUE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1037,58 +1037,32 @@
 	..()
 	return TRUE
 
-//used for changeling's adrenaline power
-/datum/reagent/medicine/changelingadrenaline
-	name = "Changeling Adrenaline"
-	description = "Reduces the duration of unconciousness, knockdown and stuns. Restores stamina, but deals toxin damage when overdosed."
-	color = "#C1151D"
-	overdose_threshold = 30
-
-/datum/reagent/medicine/changelingadrenaline/on_mob_life(mob/living/carbon/M as mob)
-	..()
-	M.AdjustAllImmobility(-20, FALSE)
-	M.adjustStaminaLoss(-10, 0)
-	M.Jitter(10)
-	M.Dizzy(10)
-	return TRUE
-
-/datum/reagent/medicine/changelingadrenaline/on_mob_metabolize(mob/living/L)
-	..()
-	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
-	ADD_TRAIT(L, TRAIT_STUNRESISTANCE, type)
-	L.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
-
-/datum/reagent/medicine/changelingadrenaline/on_mob_end_metabolize(mob/living/L)
-	..()
-	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
-	REMOVE_TRAIT(L, TRAIT_STUNRESISTANCE, type)
-	L.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
-	L.Dizzy(0)
-	L.Jitter(0)
-
-/datum/reagent/medicine/changelingadrenaline/overdose_process(mob/living/M as mob)
-	M.adjustToxLoss(1, 0)
-	..()
-	return TRUE
-
+///used for the adrenaline sacs changeling power
 /datum/reagent/medicine/changelinghaste
 	name = "Changeling Haste"
-	description = "Drastically increases movement speed, but deals toxin damage."
+	description = "Drastically increases movement speed, reduces the length of knockdowns received from stun batons, and grants an immunity to damage slowdown and sleep-inducing effects, but also causes jittering and dizziness. Metabolizes incredibly quickly."
 	color = "#AE151D"
 	metabolization_rate = 1
 
 /datum/reagent/medicine/changelinghaste/on_mob_metabolize(mob/living/L)
 	..()
 	L.add_movespeed_modifier(/datum/movespeed_modifier/reagent/changelinghaste)
+	L.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
+	ADD_TRAIT(L, TRAIT_STUNRESISTANCE, type)
+	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 
 /datum/reagent/medicine/changelinghaste/on_mob_end_metabolize(mob/living/L)
 	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/changelinghaste)
+	L.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
+	REMOVE_TRAIT(L, TRAIT_STUNRESISTANCE, type)
+	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	..()
 
-/datum/reagent/medicine/changelinghaste/on_mob_life(mob/living/carbon/M)
-	M.adjustToxLoss(2, 0)
+/datum/reagent/medicine/changelinghaste/on_mob_life(mob/living/carbon/M as mob)
+	M.Jitter(10)
+	M.Dizzy(10)
 	..()
-	return TRUE
+	. = TRUE
 
 /datum/reagent/medicine/higadrite
 	name = "Higadrite"


### PR DESCRIPTION
## About The Pull Request

The changeling adrenaline reagent has been removed from the game, and some of its effects (including the immunity to damage slowdown that it bestowed) have been moved over to the changeling haste reagent, which is no longer toxic.

The adrenaline sacs changeling power now clears ALL kinds of stuns from you, not just knockdowns. It also immediately heals 60 points of stamina damage from you. It no longer gives you the changeling adrenaline reagent, so it no longers has a stamina healing/stun reduction over time effect, but it still gives you a small amount of the changeling haste reagent so that you can flee the scene over the course of the next 6 seconds.

This has the overall effect of turning the adrenaline sacs changeling power into an expensive (it costs 30 changeling chemicals to use) "get me the hell out of here" card instead of a pre-combat buff. If you're specifically using it to escape staminacrit from batons, staying in combat after popping it is not recommended, as a single baton strike can still return you to staminacrit again (as the power heals the exact same amount of stamina damage that a baton strike deals).

## Why It's Good For The Game

First off, the description of this power is currently a straight-up lie. "Removes all stuns instantly" my ass. Secondly, this power currently just... doesn't really do its job of stun recovery. Sure, it'll halve the duration of that flash stun, but that'll still be more than enough time to cuff you. Yes, it can bring you out of staminacrit (from 120 stamina damage) in 4 seconds... but it takes 3 seconds to apply handcuffs, so you're batonned three times, you can still easily be cuffed.

The tox damage from changeling haste is incredibly negligible (6 tox damage per usage of the power), so I just removed it, since the whopping 30 changeling chem price of this power is already far more impactful than a trivial amount of tox damage that can be healed by just sipping a bit of multiver.

## Changelog
:cl: ATHATH
balance: The adrenaline sacs changeling power now instantly clears all of your stuns (and heals 60 points of stamina damage) when used, instead of giving you a stun/stamina damage-reduction over time effect. It also no longer deals tox damage to you. In other words, it's no longer a waste of points and changeling chemicals, and is now a viable option to use to escape arrest (or a dangerous fight that you haven't fully committed to yet).
del: The changeling adrenaline reagent has been removed from the game, but many of its effects have been transferred over to the changeling haste reagent.
/:cl: