### PR TITLE
Fixes pill presses not checking for bottles

### DIFF
--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -72,7 +72,9 @@
 			stored_products += P
 	if(stored_products.len)
 		var/pill_amount = 0
-		for(var/obj/item/reagent_containers/pill/P in loc)
+		for(var/thing in loc)
+			if(!istype(thing, /obj/item/reagent_containers/glass/bottle) && !istype(thing, /obj/item/reagent_containers/pill))
+				continue
 			pill_amount++
 			if(pill_amount >= max_floor_products) //too much so just stop
 				break


### PR DESCRIPTION
Fixes #52587
:cl: ShizCalev
fix: Fixed pill presses somethings spawning a billion bottles on the ground.
/:cl: