### PR TITLE
canSmoothWithAreas typecache turned into a boolean

### DIFF
--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -265,9 +265,7 @@
 
 	var/area/target_area = get_area(target_turf)
 	var/area/source_area = get_area(source)
-	if(source_area.canSmoothWithAreas && !is_type_in_typecache(target_area, source_area.canSmoothWithAreas))
-		return null
-	if(target_area.canSmoothWithAreas && !is_type_in_typecache(source_area, target_area.canSmoothWithAreas))
+	if((source_area.area_limited_icon_smoothing || target_area.area_limited_icon_smoothing) && !istype(source_area, target_area.type) && !istype(target_area, source_area.type))
 		return null
 
 	if(source.canSmoothWith)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -87,8 +87,8 @@
 	var/firedoors_last_closed_on = 0
 	/// Can the Xenobio management console transverse this area by default?
 	var/xenobiology_compatible = FALSE
-	/// typecache to limit the areas that atoms in this area can smooth with, used for shuttles IIRC
-	var/list/canSmoothWithAreas
+	///Boolean to limit the areas (subtypes included) that atoms in this area can smooth with. Used for shuttles.
+	var/area_limited_icon_smoothing = FALSE
 
 	var/list/power_usage
 
@@ -150,7 +150,6 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	icon_state = ""
 	layer = AREA_LAYER
 	map_name = name // Save the initial (the name set in the map) name of the area.
-	canSmoothWithAreas = typecacheof(canSmoothWithAreas)
 
 	if(requires_power)
 		luminosity = 0

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -14,11 +14,8 @@
 	unique = FALSE
 	blob_allowed = FALSE
 	flags_1 = CAN_BE_DIRTY_1
+	area_limited_icon_smoothing = TRUE
 
-/area/shuttle/Initialize()
-	if(!canSmoothWithAreas)
-		canSmoothWithAreas = type
-	. = ..()
 
 /area/shuttle/PlaceOnTopReact(list/new_baseturfs, turf/fake_turf_type, flags)
 	. = ..()
@@ -34,7 +31,6 @@
 /area/shuttle/syndicate
 	name = "Syndicate Infiltrator"
 	ambientsounds = HIGHSEC
-	canSmoothWithAreas = /area/shuttle/syndicate
 
 /area/shuttle/syndicate/bridge
 	name = "Syndicate Infiltrator Control"
@@ -58,21 +54,18 @@
 /area/shuttle/pirate
 	name = "Pirate Shuttle"
 	requires_power = TRUE
-	canSmoothWithAreas = /area/shuttle/pirate
 
 ////////////////////////////Bounty Hunter Shuttles////////////////////////////
 
 /area/shuttle/hunter
 	name = "Hunter Shuttle"
 	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
-	canSmoothWithAreas = /area/shuttle/hunter
 
 ////////////////////////////White Ship////////////////////////////
 
 /area/shuttle/abandoned
 	name = "Abandoned Ship"
 	requires_power = TRUE
-	canSmoothWithAreas = /area/shuttle/abandoned
 
 /area/shuttle/abandoned/bridge
 	name = "Abandoned Ship Bridge"


### PR DESCRIPTION
Exactly the same functionality for a cheaper cost, no typecache lists being built.

One could argue that this diminishes expansibility. I'd argue back that this is a rather lazy hack and shouldn't be expanded on.
If you want to add more complex smoothing functionality then don't make it area-based.