### PR TITLE
Riders will now turn with their vehicle

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -117,8 +117,6 @@
 #define COMSIG_ATOM_SET_LIGHT "atom_set_light"
 ///from base of atom/setDir(): (old_dir, new_dir). Called before the direction changes.
 #define COMSIG_ATOM_DIR_CHANGE "atom_dir_change"
-///from base of atom/setDir(): (old_dir). Called after the direction changes.
-#define COMSIG_ATOM_AFTER_DIR_CHANGE "atom_after_dir_change"
 ///from base of atom/handle_atom_del(): (atom/deleted)
 #define COMSIG_ATOM_CONTENTS_DEL "atom_contents_del"
 ///from base of atom/has_gravity(): (turf/location, list/forced_gravities)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -115,8 +115,10 @@
 	#define COMSIG_ATOM_BLOCKS_BSA_BEAM (1<<0)
 ///from base of atom/set_light(): (l_range, l_power, l_color)
 #define COMSIG_ATOM_SET_LIGHT "atom_set_light"
-///from base of atom/setDir(): (old_dir, new_dir)
+///from base of atom/setDir(): (old_dir, new_dir). Called before the direction changes.
 #define COMSIG_ATOM_DIR_CHANGE "atom_dir_change"
+///from base of atom/setDir(): (old_dir). Called after the direction changes.
+#define COMSIG_ATOM_AFTER_DIR_CHANGE "atom_after_dir_change"
 ///from base of atom/handle_atom_del(): (atom/deleted)
 #define COMSIG_ATOM_CONTENTS_DEL "atom_contents_del"
 ///from base of atom/has_gravity(): (turf/location, list/forced_gravities)

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -59,7 +59,7 @@
 
 /datum/component/riding/proc/vehicle_moved(datum/source, dir)
 	var/atom/movable/movable_parent = parent
-	if (dir == null)
+	if (isnull(dir))
 		dir = movable_parent.dir
 	for (var/buckled_mob in movable_parent.buckled_mobs)
 		ride_check(buckled_mob)

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -28,7 +28,7 @@
 /datum/component/riding/Initialize()
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
-	RegisterSignal(parent, COMSIG_ATOM_AFTER_DIR_CHANGE, .proc/vehicle_moved)
+	RegisterSignal(parent, COMSIG_ATOM_DIR_CHANGE, .proc/vehicle_turned)
 	RegisterSignal(parent, COMSIG_MOVABLE_BUCKLE, .proc/vehicle_mob_buckle)
 	RegisterSignal(parent, COMSIG_MOVABLE_UNBUCKLE, .proc/vehicle_mob_unbuckle)
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/vehicle_moved)
@@ -41,14 +41,15 @@
 		qdel(src)
 
 /datum/component/riding/proc/vehicle_mob_buckle(datum/source, mob/living/M, force = FALSE)
-	handle_vehicle_offsets()
+	var/atom/movable/movable_parent = parent
+	handle_vehicle_offsets(movable_parent.dir)
 
-/datum/component/riding/proc/handle_vehicle_layer()
+/datum/component/riding/proc/handle_vehicle_layer(dir)
 	var/atom/movable/AM = parent
 	var/static/list/defaults = list(TEXT_NORTH = OBJ_LAYER, TEXT_SOUTH = ABOVE_MOB_LAYER, TEXT_EAST = ABOVE_MOB_LAYER, TEXT_WEST = ABOVE_MOB_LAYER)
-	. = defaults["[AM.dir]"]
-	if(directional_vehicle_layers["[AM.dir]"])
-		. = directional_vehicle_layers["[AM.dir]"]
+	. = defaults["[dir]"]
+	if(directional_vehicle_layers["[dir]"])
+		. = directional_vehicle_layers["[dir]"]
 	if(isnull(.))	//you can set it to null to not change it.
 		. = AM.layer
 	AM.layer = .
@@ -56,12 +57,17 @@
 /datum/component/riding/proc/set_vehicle_dir_layer(dir, layer)
 	directional_vehicle_layers["[dir]"] = layer
 
-/datum/component/riding/proc/vehicle_moved(datum/source)
-	var/atom/movable/AM = parent
-	for(var/i in AM.buckled_mobs)
-		ride_check(i)
-	handle_vehicle_offsets()
-	handle_vehicle_layer()
+/datum/component/riding/proc/vehicle_moved(datum/source, dir)
+	var/atom/movable/movable_parent = parent
+	if (dir == null)
+		dir = movable_parent.dir
+	for (var/buckled_mob in movable_parent.buckled_mobs)
+		ride_check(buckled_mob)
+	handle_vehicle_offsets(dir)
+	handle_vehicle_layer(dir)
+
+/datum/component/riding/proc/vehicle_turned(datum/source, _old_dir, new_dir)
+	vehicle_moved(source, new_dir)
 
 /datum/component/riding/proc/ride_check(mob/living/M)
 	var/atom/movable/AM = parent
@@ -92,17 +98,16 @@
 			M.throw_at(target, 14, 5, AM, gentle = FALSE)
 		M.Knockdown(3 SECONDS)
 
-/datum/component/riding/proc/handle_vehicle_offsets()
+/datum/component/riding/proc/handle_vehicle_offsets(dir)
 	var/atom/movable/AM = parent
-	var/AM_dir = "[AM.dir]"
+	var/AM_dir = "[dir]"
 	var/passindex = 0
 	if(AM.has_buckled_mobs())
 		for(var/m in AM.buckled_mobs)
 			passindex++
 			var/mob/living/buckled_mob = m
 			var/list/offsets = get_offsets(passindex)
-			var/rider_dir = get_rider_dir(passindex)
-			buckled_mob.setDir(rider_dir)
+			buckled_mob.setDir(dir)
 			dir_loop:
 				for(var/offsetdir in offsets)
 					if(offsetdir == AM_dir)
@@ -141,12 +146,6 @@
 	if(!islist(offsets))
 		return FALSE
 	riding_offsets["[index]"] = offsets
-
-//Override this to set the passengers/riders dir based on which passenger they are.
-//ie: rider facing the vehicle's dir, but passenger 2 facing backwards, etc.
-/datum/component/riding/proc/get_rider_dir(pass_index)
-	var/atom/movable/AM = parent
-	return AM.dir
 
 //KEYS
 /datum/component/riding/proc/keycheck(mob/user)
@@ -199,8 +198,8 @@
 		else
 			last_move_diagonal = FALSE
 
-		handle_vehicle_layer()
-		handle_vehicle_offsets()
+		handle_vehicle_layer(AM.dir)
+		handle_vehicle_offsets(AM.dir)
 	else
 		to_chat(user, "<span class='warning'>You'll need a special item in one of your hands to [drive_verb] [AM].</span>")
 
@@ -243,18 +242,18 @@
 	if(H.a_intent == INTENT_DISARM && (target in H.buckled_mobs))
 		force_dismount(target)
 
-/datum/component/riding/human/handle_vehicle_layer()
+/datum/component/riding/human/handle_vehicle_layer(dir)
 	var/atom/movable/AM = parent
 	if(AM.buckled_mobs && AM.buckled_mobs.len)
 		for(var/mob/M in AM.buckled_mobs) //ensure proper layering of piggyback and carry, sometimes weird offsets get applied
 			M.layer = MOB_LAYER
 		if(!AM.buckle_lying)
-			if(AM.dir == SOUTH)
+			if(dir == SOUTH)
 				AM.layer = ABOVE_MOB_LAYER
 			else
 				AM.layer = OBJ_LAYER
 		else
-			if(AM.dir == NORTH)
+			if(dir == NORTH)
 				AM.layer = OBJ_LAYER
 			else
 				AM.layer = ABOVE_MOB_LAYER
@@ -298,10 +297,10 @@
 			to_chat(user, "<span class='warning'>You can't grab onto [AM] with no hands!</span>")
 			return
 
-/datum/component/riding/cyborg/handle_vehicle_layer()
+/datum/component/riding/cyborg/handle_vehicle_layer(dir)
 	var/atom/movable/AM = parent
 	if(AM.buckled_mobs && AM.buckled_mobs.len)
-		if(AM.dir == SOUTH)
+		if(dir == SOUTH)
 			AM.layer = ABOVE_MOB_LAYER
 		else
 			AM.layer = OBJ_LAYER
@@ -311,16 +310,16 @@
 /datum/component/riding/cyborg/get_offsets(pass_index) // list(dir = x, y, layer)
 	return list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 4), TEXT_EAST = list(-6, 3), TEXT_WEST = list( 6, 3))
 
-/datum/component/riding/cyborg/handle_vehicle_offsets()
+/datum/component/riding/cyborg/handle_vehicle_offsets(dir)
 	var/atom/movable/AM = parent
 	if(AM.has_buckled_mobs())
 		for(var/mob/living/M in AM.buckled_mobs)
-			M.setDir(AM.dir)
+			M.setDir(dir)
 			if(iscyborg(AM))
 				var/mob/living/silicon/robot/R = AM
 				if(istype(R.module))
-					M.pixel_x = R.module.ride_offset_x[dir2text(AM.dir)]
-					M.pixel_y = R.module.ride_offset_y[dir2text(AM.dir)]
+					M.pixel_x = R.module.ride_offset_x[dir2text(dir)]
+					M.pixel_y = R.module.ride_offset_y[dir2text(dir)]
 			else
 				..()
 

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -28,6 +28,7 @@
 /datum/component/riding/Initialize()
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
+	RegisterSignal(parent, COMSIG_ATOM_AFTER_DIR_CHANGE, .proc/vehicle_moved)
 	RegisterSignal(parent, COMSIG_MOVABLE_BUCKLE, .proc/vehicle_mob_buckle)
 	RegisterSignal(parent, COMSIG_MOVABLE_UNBUCKLE, .proc/vehicle_mob_unbuckle)
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/vehicle_moved)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -891,11 +891,9 @@
   * Not recommended to use, listen for the [COMSIG_ATOM_DIR_CHANGE] signal instead (sent by this proc)
   */
 /atom/proc/setDir(newdir)
-	var/old_dir = dir
 	SHOULD_CALL_PARENT(TRUE)
-	SEND_SIGNAL(src, COMSIG_ATOM_DIR_CHANGE, old_dir, newdir)
+	SEND_SIGNAL(src, COMSIG_ATOM_DIR_CHANGE, dir, newdir)
 	dir = newdir
-	SEND_SIGNAL(src, COMSIG_ATOM_AFTER_DIR_CHANGE, old_dir)
 
 ///Handle melee attack by a mech
 /atom/proc/mech_melee_attack(obj/mecha/M)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -891,9 +891,11 @@
   * Not recommended to use, listen for the [COMSIG_ATOM_DIR_CHANGE] signal instead (sent by this proc)
   */
 /atom/proc/setDir(newdir)
+	var/old_dir = dir
 	SHOULD_CALL_PARENT(TRUE)
-	SEND_SIGNAL(src, COMSIG_ATOM_DIR_CHANGE, dir, newdir)
+	SEND_SIGNAL(src, COMSIG_ATOM_DIR_CHANGE, old_dir, newdir)
 	dir = newdir
+	SEND_SIGNAL(src, COMSIG_ATOM_AFTER_DIR_CHANGE, old_dir)
 
 ///Handle melee attack by a mech
 /atom/proc/mech_melee_attack(obj/mecha/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Riders will now turn with their vehicle. Notably with piggybacking, if the carrier turned without moving, the person on top would stay still.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Riders will now correctly turn with their vehicles. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
