### PR TITLE
Remove reinforcement chromosomes, AKA mutadone resistance

### DIFF
--- a/code/game/objects/items/chromosome.dm
+++ b/code/game/objects/items/chromosome.dm
@@ -75,18 +75,3 @@
 	desc = "A chromosome that reduces action based mutation cooldowns by by 50%."
 	icon_state = "energy"
 	energy_coeff = 0.5
-
-/obj/item/chromosome/reinforcer
-	name = "reinforcement chromosome"
-	desc = "A chromosome that renders mutations immune to mutadone."
-	icon_state = "reinforcer"
-	weight = 3
-
-/obj/item/chromosome/reinforcer/can_apply(datum/mutation/human/HM)
-	if(!HM || !(HM.can_chromosome == CHROMOSOME_NONE))
-		return FALSE
-	return !HM.mutadone_proof
-
-/obj/item/chromosome/reinforcer/apply(datum/mutation/human/HM)
-	HM.mutadone_proof = TRUE
-	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes reinforcement chromosomes completely. This naturally makes the chances of everything else go up a bit, and they are now:

>  Synchronizer (5/16): Gives the mind more control over the mutation, reducing some downsides by 50%.
Stabilizer (1/16): The rarest chromosome. Reduces instability gained from the mutation by 20%.
Power (5/16): Boosts strength of certain mutations. Experiment with super sneeze or even deadlier fireballs!
Energetic (5/16): Reduces cooldown on action based mutations. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mutadone resistance is not healthy for the game. For it to take effect in combat, a player must have already made the conscious decision and steps required to perform the steps needed to both create mutadone and apply it (such as by getting a syringe gun or creating a smoke grenade). They must also have the skill needed to make sure it applies. Having this effort be completely nullified is not fun for the attacker. This is different from things like traditional guns, which are useful in countless situations. The actions required to apply mutadone to someone in combat is *only* useful in that specific scenario. You must sacrifice resources (time, inventory space) in order to fight one specific threat.

Furthermore, Mutadone resistance is often used alongside two already extremely powerful mutations--Hulk and HARS. With Hulk, stun resistance makes it otherwise impossible to detain one without lethals. The only way to do so reliably is with something like mutadone. With HARS, it makes it unreasonably frustrating for doctors to cure an outbreak without getting the resources to create DNA consoles and pods. These mutations are powerful enough. They don't need mutadone resistance on top.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed reinforcement chromosomes, AKA mutadone resistance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
