### PR TITLE
Drones now use a radial menu to choose their skins

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/visuals_icons.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/visuals_icons.dm
@@ -101,33 +101,54 @@
   */
 /mob/living/simple_animal/drone/proc/pickVisualAppearance()
 	picked = FALSE
-	var/appearence = input("Choose your appearance!", "Appearance", "Maintenance Drone") in sortList(list("Maintenance Drone", "Repair Drone", "Scout Drone"))
-	switch(appearence)
+	var/list/drone_icons = list(
+		"Maintenance Drone" = image(icon = 'icons/mob/drone.dmi', icon_state = "[MAINTDRONE]_grey"),
+		"Repair Drone" = image(icon = 'icons/mob/drone.dmi', icon_state = REPAIRDRONE),
+		"Scout Drone" = image(icon = 'icons/mob/drone.dmi', icon_state = SCOUTDRONE)
+		)
+	var/picked_icon = show_radial_menu(src, src, drone_icons, custom_check = CALLBACK(src, .proc/check_menu), radius = 38, require_near = TRUE)
+	switch(picked_icon)
 		if("Maintenance Drone")
 			visualAppearance = MAINTDRONE
-			colour = input("Choose your colour!", "Colour", "grey") in sortList(list("grey", "blue", "red", "green", "pink", "orange"))
-			icon_state = "[visualAppearance]_[colour]"
-			icon_living = "[visualAppearance]_[colour]"
-			icon_dead = "[visualAppearance]_dead"
-
+			var/list/drone_colors = list(
+				"blue" = image(icon = 'icons/mob/drone.dmi', icon_state = "[visualAppearance]_blue"),
+				"green" = image(icon = 'icons/mob/drone.dmi', icon_state = "[visualAppearance]_green"),
+				"grey" = image(icon = 'icons/mob/drone.dmi', icon_state = "[visualAppearance]_grey"),
+				"orange" = image(icon = 'icons/mob/drone.dmi', icon_state = "[visualAppearance]_orange"),
+				"pink" = image(icon = 'icons/mob/drone.dmi', icon_state = "[visualAppearance]_pink"),
+				"red" = image(icon = 'icons/mob/drone.dmi', icon_state = "[visualAppearance]_red")
+				)
+			var/picked_color = show_radial_menu(src, src, drone_colors, custom_check = CALLBACK(src, .proc/check_menu), radius = 38, require_near = TRUE)
+			if(picked_color)
+				icon_state = "[visualAppearance]_[picked_color]"
+				icon_living = "[visualAppearance]_[picked_color]"
+			else
+				icon_state = "[visualAppearance]_grey"
+				icon_living = "[visualAppearance]_grey"
 		if("Repair Drone")
 			visualAppearance = REPAIRDRONE
 			icon_state = visualAppearance
 			icon_living = visualAppearance
-			icon_dead = "[visualAppearance]_dead"
-
 		if("Scout Drone")
 			visualAppearance = SCOUTDRONE
 			icon_state = visualAppearance
 			icon_living = visualAppearance
-			icon_dead = "[visualAppearance]_dead"
-
 		else
-			return
-
+			visualAppearance = MAINTDRONE
+			icon_state = "[visualAppearance]_grey"
+			icon_living = "[visualAppearance]_grey"
+	icon_dead = "[visualAppearance]_dead"
 	picked = TRUE
 
-
+/**
+  * check_menu: Checks if we are allowed to interact with a radial menu
+  */
+/mob/living/simple_animal/drone/proc/check_menu()
+	if(!istype(src))
+		return FALSE
+	if(incapacitated())
+		return FALSE
+	return TRUE
 
 /mob/living/simple_animal/drone/proc/getItemPixelShiftY()
 	switch(visualAppearance)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR makes drones use a radial menu to choose their visual skins, instead of navigating in the input menu with no preview of how given skin even looks like. If no option is chosen, maintenance drone skin with a grey color variant is picked by default.

Example image:

![DroneRadial1](https://user-images.githubusercontent.com/43862960/89045031-1d8cdc00-d34b-11ea-8de3-912d55e6ad1f.png)

This also includes color variants for the maintenance drone skin:

![DroneRadial2](https://user-images.githubusercontent.com/43862960/89045149-52992e80-d34b-11ea-87c0-50e20f158928.png)

## Why It's Good For The Game

Better drone skin selection method.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arkatos
add: Drones now use a radial menu to choose their skins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
