### PR TITLE
Makes laughter demons revives spawn at laughter demon location

### DIFF
--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -214,12 +214,12 @@
 	if(!consumed_mobs)
 		return
 
+	var/turf/T = get_turf(src)
+
 	for(var/mob/living/M in consumed_mobs)
 		if(!M)
 			continue
-		var/turf/T = find_safe_turf()
-		if(!T)
-			T = get_turf(src)
+
 		M.forceMove(T)
 		if(M.revive(full_heal = TRUE, admin_revive = TRUE))
 			M.grab_ghost(force = TRUE)


### PR DESCRIPTION
Upon death, a laughter demons victims would be released on random safe locations. 

This makes it so that they burst out of the laughter demon and potentially cause an enormous clutter. 

:cl:
tweak: Laughter demons now release their victims where the demon died
/:cl:

### Why
Was sorely disappointed when I killed myself infront of the hijacking wizard just to find out that people are put at a random location, and not on me. 

Laughter demons causing an enormous clutter of confused revived people is great. Whether that is commiting suicide infront of the wizard, touching the SM or just getting shotgunned and having the shotgunner be flooded by 40 crewmen right afterwards. 