### PR TITLE
snowballs deal stamina damage now instead of brute

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1091,7 +1091,8 @@
 	desc = "A compact ball of snow. Good for throwing at people."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "snowball"
-	throwforce = 12 //pelt your enemies to death with lumps of snow
+	throwforce = 20 //the same damage as a disabler shot
+	damtype = STAMINA //maybe someday we can add stuffing rocks (or perhaps ore?) into snowballs to make them deal brute damage
 
 /obj/item/toy/snowball/afterattack(atom/target as mob|obj|turf|area, mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

The throwforce of snowballs has gone up from 12 throwforce to 20 throwforce, but their damage type has been changed from brute to stamina.

## Why It's Good For The Game

Having a snowball fight with your mates shoudn't require a paramedic to be on standby to heal the people who are somehow taking lethal damage from SNOWBALLS (without rocks in 'em!).

Also, this should make snow golems slightly less absolutely pathetic, as their main power (creating snowballs) is now a sort of shitty pseudo-disabler instead of something that's about as effective as just throwing any nearby object at your foes.

It also makes the snow from the geladikinesis power useful for more thant just instantly making snow walls.

## Changelog
:cl: ATHATH
balance: Snowballs deal a moderate amount of stamina damage instead of a mediocre amount of brute damage now. In other words, having a snowball fight with your friends won't hospitalize them anymore.
/:cl: