### PR TITLE
mood multipliers are applied once instead of per moodlet

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -97,8 +97,8 @@
 		mood += event.mood_change
 		if(!event.hidden)
 			shown_mood += event.mood_change
-		mood *= mood_modifier
-		shown_mood *= mood_modifier
+	mood *= mood_modifier
+	shown_mood *= mood_modifier
 
 	switch(mood)
 		if(-INFINITY to MOOD_LEVEL_SAD4)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes mood multipliers only apply after the full mood amount is calculated, otherwise the multiplier can stack to stupid amounts if you have enough moodlets
currently it looks like
moodlet applied to mood
mood multiplied
next moodlet applied to mood
mood multiplied
etc
with fix it looks like
moodlet applied to mood
moodlet applied to mood
etc
mood multiplied

## Why It's Good For The Game

fix unintended thing

## Changelog
:cl:
fix: hypersensitive and apathetic apply their modifiers after moodlets are accounted for rather than multiplying total mood per moodlet
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
