### PR TITLE
Patches a shuttle curse orb exploit, increases the amount of uses from 2 to 3

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -451,12 +451,16 @@
 	color = "#333333"
 	list_reagents = list(/datum/reagent/fuel/unholywater = 50)
 
+///how many times can the shuttle be cursed?
+#define MAX_SHUTTLE_CURSES 3
+
 /obj/item/shuttle_curse
 	name = "cursed orb"
-	desc = "You peer within this smokey orb and glimpse terrible fates befalling the escape shuttle."
+	desc = "You peer within this smokey orb and glimpse terrible fates befalling the emergency escape shuttle. "
 	icon = 'icons/obj/cult.dmi'
 	icon_state ="shuttlecurse"
-	var/static/curselimit = 0
+	///how many times has the shuttle been cursed so far?
+	var/static/totalcurses = 0
 
 /obj/item/shuttle_curse/attack_self(mob/living/user)
 	if(!iscultist(user))
@@ -464,8 +468,9 @@
 		user.Paralyze(100)
 		to_chat(user, "<span class='warning'>A powerful force shoves you away from [src]!</span>")
 		return
-	if(curselimit > 1)
-		to_chat(user, "<span class='notice'>We have exhausted our ability to curse the shuttle.</span>")
+	if(totalcurses >= MAX_SHUTTLE_CURSES)
+		to_chat(user, "<span class='warning'>You try to shatter the orb, but it remains as solid as a rock!</span>")
+		to_chat(user, "<span class='danger'><span class='big'>It seems that the blood cult has exhausted its ability to curse the emergency escape shuttle. It would be unwise to create more cursed orbs or to continue to try to shatter this one.</span></span>")
 		return
 	if(locate(/obj/singularity/narsie) in GLOB.poi_list)
 		to_chat(user, "<span class='warning'>Nar'Sie is already on this plane, there is no delaying the end of all things.</span>")
@@ -487,10 +492,9 @@
 		SSshuttle.emergency.setTimer(timer)
 		if(surplus > 0)
 			SSshuttle.block_recall(surplus)
+		totalcurses++
 		to_chat(user, "<span class='danger'>You shatter the orb! A dark essence spirals into the air, then disappears.</span>")
 		playsound(user.loc, 'sound/effects/glassbr1.ogg', 50, TRUE)
-		qdel(src)
-		sleep(20)
 		var/static/list/curses
 		if(!curses)
 			curses = list("A fuel technician just slit his own throat and begged for death.",
@@ -503,7 +507,15 @@
 		var/message = pick_n_take(curses)
 		message += " The shuttle will be delayed by three minutes."
 		priority_announce("[message]", "System Failure", 'sound/misc/notice1.ogg')
-		curselimit++
+		if(MAX_SHUTTLE_CURSES-totalcurses <= 0)
+			to_chat(user, "<span class='danger'><span class='big'>You sense that the emergency escape shuttle can no longer be cursed. It would be unwise to create more cursed orbs.</span></span>")
+		else if(MAX_SHUTTLE_CURSES-totalcurses == 1)
+			to_chat(user, "<span class='danger'><span class='big'>You sense that the emergency escape shuttle can only be cursed 1 more time.</span></span>")
+		else
+			to_chat(user, "<span class='danger'><span class='big'>You sense that the emergency escape shuttle can only be cursed [MAX_SHUTTLE_CURSES-totalcurses] more times.</span></span>")
+		qdel(src)
+
+#undef MAX_SHUTTLE_CURSES
 
 /obj/item/cult_shift
 	name = "veil shifter"

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -510,7 +510,7 @@
 		if(MAX_SHUTTLE_CURSES-totalcurses <= 0)
 			to_chat(user, "<span class='danger'><span class='big'>You sense that the emergency escape shuttle can no longer be cursed. It would be unwise to create more cursed orbs.</span></span>")
 		else if(MAX_SHUTTLE_CURSES-totalcurses == 1)
-			to_chat(user, "<span class='danger'><span class='big'>You sense that the emergency escape shuttle can only be cursed 1 more time.</span></span>")
+			to_chat(user, "<span class='danger'><span class='big'>You sense that the emergency escape shuttle can only be cursed one more time.</span></span>")
 		else
 			to_chat(user, "<span class='danger'><span class='big'>You sense that the emergency escape shuttle can only be cursed [MAX_SHUTTLE_CURSES-totalcurses] more times.</span></span>")
 		qdel(src)


### PR DESCRIPTION
## About The Pull Request

The code for shuttle curse orbs no longer has a sleep(20) in it.

The number of shuttle curse orbs that can be used each round has been increased from 2 to 3 (and is now a define).

When you use a shuttle curse orb, you'll now receive feedback as to how many more shuttle curse orbs can be used. You'll also receive a better feedback when you try to use a shuttle curse orb after the shuttle curse orb limit has been reached.

## Why It's Good For The Game

That sleep(20) made an exploit possible that allowed a cult to use more shuttle curse orbs than they were supposed to be able to by quickly using more shuttle orbs within 2 seconds of using the shuttle orb that would normally put the cult at their shuttle curse orb use limit.

I noticed that this exploit was accidentally being used quite commonly (as you tend to want to blow all of your shuttle curse orbs at once as a cultist), so I raised the number of shuttle curse orbs that you're supposed to be able to use by one in order to preserve the current balance of cults/compensate for the loss of this exploit.

The extra messages are there to help new cultists hopefully not waste an archive charge on a shuttle orb that can't be used. In a perfect world, we'd make it so that new shuttle orbs can't be made once the shuttle curse limit has already been reached, but this should do for now.

## Changelog
:cl:
fix: Fixed an exploit that made it possible to use more shuttle curse orbs in a single round than you were supposed to as a blood cultist.
balance: Increased the number of shuttle curse orbs that can be used in a single round from 2 to 3.
tweak: Added better feedback for shuttle curse orbs.
/:cl: