### PR TITLE
Wires delta prison APC

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -110992,6 +110992,7 @@
 	name = "Prison Wing Cells APC";
 	pixel_x = -24
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "epU" = (


### PR DESCRIPTION
Alternative to / Closes #52617
Fixes #52610
:cl: ShizCalev
fix: Hooked up delta's perma APC to the power grid. honk.
/:cl:

Difference is that this just wires it without moving the APC inside one of the perma cells, because prisoners go in that place and that's a bad idea.