### PR TITLE
Adds an admin-only version of the chef's hat that allows mice inside of the hat to have a 100% chance to relay their movements to the person wearing the hat

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -15,6 +15,12 @@
 	dynamic_hair_suffix = ""
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/chefhat
 	dog_fashion = /datum/dog_fashion/head/chef
+	///the chance that the movements of a mouse inside of this hat get relayed to the human wearing the hat
+	var/mousecontrolprobability = 20
+
+/obj/item/clothing/head/chefhat/iamassumingdirectcontrol
+	desc = "The commander in chef's head wear. Upon closer inspection, there seem to be dozens of tiny levers, buttons, dials, and screens inside of this hat. What the hell...?"
+	mousecontrolprobability = 100
 
 /obj/item/clothing/head/chefhat/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is donning [src]! It looks like [user.p_theyre()] trying to become a chef.</span>")
@@ -26,7 +32,7 @@
 	return(FIRELOSS)
 
 /obj/item/clothing/head/chefhat/relaymove(mob/user, direction)
-	if(!istype(user, /mob/living/simple_animal/mouse) || !isliving(loc) || !prob(20))
+	if(!istype(user, /mob/living/simple_animal/mouse) || !isliving(loc) || !prob(mousecontrolprobability))
 		return
 	var/mob/living/L = loc
 	step_towards(L, get_step(L, direction))

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -18,7 +18,7 @@
 	///the chance that the movements of a mouse inside of this hat get relayed to the human wearing the hat
 	var/mouse_control_probability = 20
 
-/obj/item/clothing/head/chefhat/iamassumingdirectcontrol
+/obj/item/clothing/head/chefhat/i_am_assuming_direct_control
 	desc = "The commander in chef's head wear. Upon closer inspection, there seem to be dozens of tiny levers, buttons, dials, and screens inside of this hat. What the hell...?"
 	mouse_control_probability = 100
 
@@ -35,6 +35,8 @@
 	if(!istype(user, /mob/living/simple_animal/mouse) || !isliving(loc) || !prob(mouse_control_probability))
 		return
 	var/mob/living/L = loc
+	if(L.incapacitated(TRUE)) //just in case
+		return
 	step_towards(L, get_step(L, direction))
 
 //Captain

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -16,11 +16,11 @@
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/chefhat
 	dog_fashion = /datum/dog_fashion/head/chef
 	///the chance that the movements of a mouse inside of this hat get relayed to the human wearing the hat
-	var/mousecontrolprobability = 20
+	var/mouse_control_probability = 20
 
 /obj/item/clothing/head/chefhat/iamassumingdirectcontrol
 	desc = "The commander in chef's head wear. Upon closer inspection, there seem to be dozens of tiny levers, buttons, dials, and screens inside of this hat. What the hell...?"
-	mousecontrolprobability = 100
+	mouse_control_probability = 100
 
 /obj/item/clothing/head/chefhat/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is donning [src]! It looks like [user.p_theyre()] trying to become a chef.</span>")
@@ -32,7 +32,7 @@
 	return(FIRELOSS)
 
 /obj/item/clothing/head/chefhat/relaymove(mob/user, direction)
-	if(!istype(user, /mob/living/simple_animal/mouse) || !isliving(loc) || !prob(mousecontrolprobability))
+	if(!istype(user, /mob/living/simple_animal/mouse) || !isliving(loc) || !prob(mouse_control_probability))
 		return
 	var/mob/living/L = loc
 	step_towards(L, get_step(L, direction))


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

https://www.youtube.com/watch?v=YZvbCgnCJoA

## Changelog
:cl: ATHATH
add: A secret cabal of mice have definitely not been controlling people wearing special admin-only chef's hats. Move along, citizen.
/:cl:
