### PR TITLE
Fixes carbon wash runtime

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1110,8 +1110,7 @@
 	. = ..()
 
 	// Wash equipped stuff that cannot be covered
-	for(var/obj/item/I in held_items)
-		var/obj/item/held_thing = I
+	for(var/obj/item/held_thing in held_items)
 		if(held_thing.wash(clean_types))
 			. = TRUE
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1110,8 +1110,8 @@
 	. = ..()
 
 	// Wash equipped stuff that cannot be covered
-	for(var/i in held_items)
-		var/obj/item/held_thing = i
+	for(var/obj/item/I in held_items)
+		var/obj/item/held_thing = I
 		if(held_thing.wash(clean_types))
 			. = TRUE
 


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed a runtime caused by trying to wash carbons who weren't holding anything.
/:cl:
Closes #52627
held_items contains nulls when nothing is held.