### PR TITLE
hotfix for the ammo boxes in the lavaland comms base having the wrong ammo type

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -516,10 +516,10 @@
 /obj/structure/closet/crate/secure/weapon{
 	req_access_txt = "150"
 	},
-/obj/item/ammo_box/c10mm{
+/obj/item/ammo_box/c9mm{
 	pixel_y = 6
 	},
-/obj/item/ammo_box/c10mm,
+/obj/item/ammo_box/c9mm,
 /obj/item/ammo_box/magazine/m9mm{
 	pixel_x = -5;
 	pixel_y = 5


### PR DESCRIPTION
## About The Pull Request

Fixes #52647
the two ammo boxes in the lavaland comms base now use the same ammo type as the 9mm magazines that are literally in the same crate as them

## Why It's Good For The Game

when stetchkins were changed to use 9mm ammo instead of 10mm ammo, someone went through and replaced a lot of the 10mm magazines with 9mm ones so that ghost roles and corpses and such that are supposed to use stetchkins wouldn't be left with spare ammo of the wrong ammo type. this is all well and good, but they only checked for 10mm MAGAZINES, not 10mm AMMO BOXES. many more ruins and away missions than just the lavaland comms base were affected by this, but the lavaland comms base is the most important location that's been affected. 

necromanceranne has stated on discord that she (he? they?) doesn't give a shit about how this negatively impacts away missions (most notably, the intended route through the wishgranter away mission), so it's apparently up to me to fix their mistake. I'll try to go through with github desktop later today and patch the other ruins with a second PR.

boy, my birthday is off to a SWELL start, wouldn't you say?

## Changelog
:cl: ATHATH
fix: The ammo boxes in the comms agent base now use the same ammo type as the magazines that are literally in the same crate as them. In other words, they're compatible with stetchkins now.
/:cl: