### PR TITLE
Fixes NPC pool runtime

### DIFF
--- a/code/controllers/subsystem/idlenpcpool.dm
+++ b/code/controllers/subsystem/idlenpcpool.dm
@@ -32,7 +32,7 @@ SUBSYSTEM_DEF(idlenpcpool)
 	while(currentrun.len)
 		var/mob/living/simple_animal/SA = currentrun[currentrun.len]
 		--currentrun.len
-		if (!SA)
+		if (QDELETED(SA))
 			GLOB.simple_animals[AI_IDLE] -= SA
 			log_world("Found a null in simple_animals list!")
 			continue

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -23,7 +23,7 @@ SUBSYSTEM_DEF(npcpool)
 		var/mob/living/simple_animal/SA = currentrun[currentrun.len]
 		--currentrun.len
 
-		if (!SA) // Some issue causes nulls to get into this list some times. This keeps it running, but the bug is still there.
+		if (QDELETED(SA)) // Some issue causes nulls to get into this list some times. This keeps it running, but the bug is still there.
 			GLOB.simple_animals[AI_ON] -= SA
 			log_world("Found a null in simple_animals list!")
 			continue


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed a runtime causing NPC AI processing to briefly break if one was deleted in the middle of the subsystem's processing.
/:cl:
