### PR TITLE
nightmare eyes and robotic glowing eyes can now be mistaken for blood cult glowing eyes

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -83,8 +83,13 @@
 	if(!(ITEM_SLOT_EYES in obscured))
 		if(glasses)
 			. += "[t_He] [t_has] [glasses.get_examine_string(user)] covering [t_his] eyes."
-		else if(eye_color == BLOODCULT_EYE && iscultist(src) && HAS_TRAIT(src, CULT_EYES))
+		else if(eye_color == BLOODCULT_EYE)
+			if(iscultist(src) && HAS_TRAIT(src, CULT_EYES))
 			. += "<span class='warning'><B>[t_His] eyes are glowing an unnatural red!</B></span>"
+			else if(getorgan(/obj/item/organ/eyes))
+				var/obj/item/organ/eyes/E = getorgan(/obj/item/organ/eyes)
+				if(E.glowing) //blood cults aren't the only things that can make your eyes glow an unnatural red
+					. += "<span class='warning'><B>[t_His] eyes are glowing an unnatural red!</B></span>"
 
 	//ears
 	if(ears && !(ITEM_SLOT_EARS in obscured))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -85,7 +85,7 @@
 			. += "[t_He] [t_has] [glasses.get_examine_string(user)] covering [t_his] eyes."
 		else if(eye_color == BLOODCULT_EYE)
 			if(iscultist(src) && HAS_TRAIT(src, CULT_EYES))
-			. += "<span class='warning'><B>[t_His] eyes are glowing an unnatural red!</B></span>"
+				. += "<span class='warning'><B>[t_His] eyes are glowing an unnatural red!</B></span>"
 			else if(getorgan(/obj/item/organ/eyes))
 				var/obj/item/organ/eyes/E = getorgan(/obj/item/organ/eyes)
 				if(E.glowing) //blood cults aren't the only things that can make your eyes glow an unnatural red

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -30,6 +30,8 @@
 	var/lighting_alpha
 	var/no_glasses
 	var/damaged	= FALSE	//damaged indicates that our eyes are undergoing some level of negative effect
+	///can these eyes be mistaken for glowing blood cult eyes if they're the (exact) right color?
+	var/glowing = FALSE
 
 /obj/item/organ/eyes/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE, initialising)
 	. = ..()
@@ -118,6 +120,8 @@
 	name = "burning red eyes"
 	desc = "Even without their shadowy owner, looking at these eyes gives you a sense of dread."
 	icon_state = "burning_eyes"
+	glowing = TRUE
+	eye_color = BLOODCULT_EYE //they're glowing red eyes
 
 /obj/item/organ/eyes/night_vision/mushroom
 	name = "fung-eye"
@@ -298,6 +302,7 @@
 	if(!silent)
 		to_chat(owner, "<span class='warning'>Your [src] clicks and makes a whining noise, before shooting out a beam of light!</span>")
 	active = TRUE
+	glowing = TRUE //validhunter-baiting mode engaged
 	cycle_mob_overlay()
 
 /obj/item/organ/eyes/robotic/glow/proc/deactivate(silent = FALSE)
@@ -305,6 +310,7 @@
 	if(!silent)
 		to_chat(owner, "<span class='warning'>Your [src] shuts off!</span>")
 	active = FALSE
+	glowing = FALSE //IT'S JUST A PRANK BRO
 	remove_mob_overlay()
 
 /obj/item/organ/eyes/robotic/glow/proc/update_visuals(datum/source, olddir, newdir)


### PR DESCRIPTION
## About The Pull Request

If your eyes are the EXACT same color as blood cult glowing eyes AND they have the "glowing" variable set to TRUE, then they'll produce the same message that glowing blood cult eyes do when you're examined.

Currently, the only eyes that can have this "glowing" variable be set to TRUE without admin intervention are burning red eyes (from nightmares) and active high luminosity eyes.

Burning red eyes have a red eye_color now.

## Why It's Good For The Game

Baiting validhunters is funny.

Plus, this feature makes sense- their eyes are, in fact, glowing an unnatural red.

As for the eye_color change for burning red eyes, nightmares don't have eye sprites, but their eyes can be transplanted into a normal human or something (and the sprites of the extracted eyes (and the names of the eyes themselves) very heavily imply that they're supposed to be glowing red).

## Changelog
:cl: ATHATH
add: Burning red eyes and active high luminosity eyes can now be mistaken for blood cult glowing eyes if they're the exact right color.
tweak: Burning red eyes now have a red eye_color. This shouldn't really matter unless you transplant them into a non-nightmare, though.
/:cl: