### PR TITLE
Adds the anti-teleportation implant to the game/the space hotel

### DIFF
--- a/code/game/objects/items/implants/implant_exile.dm
+++ b/code/game/objects/items/implants/implant_exile.dm
@@ -9,14 +9,49 @@
 /obj/item/implant/exile/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
 				<b>Name:</b> Nanotrasen Employee Exile Implant<BR>
-				<b>Implant Details:</b> The onboard gateway system has been modified to reject entry by individuals containing this implant<BR>"}
+				<b>Implant Details:</b> The onboard gateway system has been modified to reject entry by individuals containing this implant.<BR>"}
 	return dat
+
+
+///Used to help the staff of the space hotel resist the urge to use the space hotel's incredibly alluring roundstart teleporter to ignore their flavor/greeting text and come to the station.
+/obj/item/implant/exile/noteleport
+	name = "anti-teleportation implant"
+	desc = "Uses impressive bluespace grounding techniques to deny the person implanted by this implant the ability to teleport (or be teleported). Used by certain slavers (or particularly strict employers) to keep their slaves from using teleporters to escape their grasp."
+
+/obj/item/implant/exile/noteleport/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Anti-Teleportation Implant<BR>
+				<b>Implant Details:</b> Keeps the implantee from using most teleportation devices. In addition, it spoofs the implant signature of an exile implant to keep the implantee from using certain gateway systems.<BR>"}
+	return dat
+
+/obj/item/implant/exile/noteleport/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
+	if(..() && isliving(target))
+		var/mob/living/L = target
+		ADD_TRAIT(L, TRAIT_NO_TELEPORT, "implant")
+		return TRUE
+	return FALSE
+
+/obj/item/implant/exile/noteleport/removed(mob/target, silent = FALSE, special = FALSE)
+	if(..() && isliving(target))
+		var/mob/living/L = target
+		REMOVE_TRAIT(L, TRAIT_NO_TELEPORT, "implant")
+		return TRUE
+	return FALSE
 
 /obj/item/implanter/exile
 	name = "implanter (exile)"
 	imp_type = /obj/item/implant/exile
 
+/obj/item/implanter/exile/noteleport
+	name = "implanter (anti-teleportation)"
+	imp_type = /obj/item/implant/exile/noteleport
+
 /obj/item/implantcase/exile
 	name = "implant case - 'Exile'"
 	desc = "A glass case containing an exile implant."
 	imp_type = /obj/item/implant/exile
+
+/obj/item/implantcase/exile/noteleport
+	name = "implant case - 'Anti-Teleportation'"
+	desc = "A glass case containing an anti-teleportation implant."
+	imp_type = /obj/item/implant/exile/noteleport

--- a/code/game/objects/items/implants/implant_exile.dm
+++ b/code/game/objects/items/implants/implant_exile.dm
@@ -4,7 +4,7 @@
 /obj/item/implant/exile
 	name = "exile implant"
 	desc = "Prevents you from returning from away missions."
-	activated = 0
+	activated = FALSE
 
 /obj/item/implant/exile/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>

--- a/code/game/objects/items/implants/implant_exile.dm
+++ b/code/game/objects/items/implants/implant_exile.dm
@@ -33,11 +33,12 @@
 	return TRUE
 
 /obj/item/implant/exile/noteleport/removed(mob/target, silent = FALSE, special = FALSE)
-	if(..() && isliving(target))
-		var/mob/living/L = target
-		REMOVE_TRAIT(L, TRAIT_NO_TELEPORT, "implant")
-		return TRUE
-	return FALSE
+	. = ..()
+	if(!. || !isliving(target))
+		return FALSE
+	var/mob/living/living_target = target
+	REMOVE_TRAIT(living_target, TRAIT_NO_TELEPORT, "implant")
+	return TRUE
 
 /obj/item/implanter/exile
 	name = "implanter (exile)"

--- a/code/game/objects/items/implants/implant_exile.dm
+++ b/code/game/objects/items/implants/implant_exile.dm
@@ -25,7 +25,9 @@
 	return dat
 
 /obj/item/implant/exile/noteleport/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
-	if(..() && isliving(target))
+	. = ..()
+	if(!. || !isliving(target))
+		return FALSE
 		var/mob/living/L = target
 		ADD_TRAIT(L, TRAIT_NO_TELEPORT, "implant")
 		return TRUE

--- a/code/game/objects/items/implants/implant_exile.dm
+++ b/code/game/objects/items/implants/implant_exile.dm
@@ -28,10 +28,9 @@
 	. = ..()
 	if(!. || !isliving(target))
 		return FALSE
-		var/mob/living/L = target
-		ADD_TRAIT(L, TRAIT_NO_TELEPORT, "implant")
-		return TRUE
-	return FALSE
+	var/mob/living/living_target = target
+	ADD_TRAIT(living_target, TRAIT_NO_TELEPORT, "implant")
+	return TRUE
 
 /obj/item/implant/exile/noteleport/removed(mob/target, silent = FALSE, special = FALSE)
 	if(..() && isliving(target))

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -374,14 +374,14 @@
 	mob_name = "hotel staff member"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper_s"
-	objectives = "Cater to visiting guests with your fellow staff. Do not leave your assigned hotel and always remember: The customer is always right!"
+	objectives = "Cater to visiting guests with your fellow staff. Do not leave your assigned hotel. Remember, the customer is always right!"
 	death = FALSE
 	roundstart = FALSE
 	random = TRUE
 	outfit = /datum/outfit/hotelstaff
 	short_desc = "You are a staff member of a top-of-the-line space hotel!"
-	flavour_text = "You are a staff member of a top-of-the-line space hotel! Cater to guests and make sure the manager doesn't fire you."
-	important_info = "DON'T leave the hotel"
+	flavour_text = "You are a staff member of a top-of-the-line space hotel! Cater to guests, advertise the hotel, and make sure the manager doesn't fire you."
+	important_info = "Do NOT leave the hotel, as that is grounds for contract termination."
 	assignedrole = "Hotel Staff"
 
 /datum/outfit/hotelstaff
@@ -390,7 +390,7 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	r_pocket = /obj/item/radio/off
 	back = /obj/item/storage/backpack
-	implants = list(/obj/item/implant/mindshield)
+	implants = list(/obj/item/implant/mindshield, /obj/item/implant/exile/noteleport)
 
 /obj/effect/mob_spawn/human/hotel_staff/security
 	name = "hotel security sleeper"
@@ -400,7 +400,7 @@
 	flavour_text = "You have been assigned to this hotel to protect the interests of the company while keeping the peace between \
 		guests and the staff."
 	important_info = "Do NOT leave the hotel, as that is grounds for contract termination."
-	objectives = "Do not leave your assigned hotel. Try and keep the peace between staff and guests, non-lethal force heavily advised if possible."
+	objectives = "Do not leave your assigned hotel. Try and keep the peace between staff and guests. Using non-lethal force instead of lethal force is heavily advised if possible."
 
 /datum/outfit/hotelstaff/security
 	name = "Hotel Security"


### PR DESCRIPTION
## About The Pull Request

The anti-teleportation implant is a currently uncraftable/unprintable subtype of the exile implant that, as the name implies, keeps you from teleporting.

Space hotel staff (and space hotel sec) will now spawn with anti-teleportation implants.

## Why It's Good For The Game

This implant will help the staff of the space hotel resist the urge to use the space hotel's incredibly alluring roundstart teleporter to ignore their flavor/greeting text and come to the station.

And yes, I know that we currently have the space hotel space ruin disabled, but maybe this change could lead to the re-enabling of that space ruin in the future.

## Changelog
:cl: ATHATH and Rohesie
add: Slavers (and particularly strict employers) have begun using anti-teleportation implants to keep their slaves (and wagies, respectively) from using teleporters to escape their grasp.
add: The staff (and sec force) of the currently-disabled (on /tg/) space hotel ruin now spawn with anti-teleportation implants.
/:cl: