### PR TITLE
medical first aid kits come with epipens now, not emergency first aid medipens

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -124,7 +124,7 @@
 		/obj/item/stack/medical/gauze/twelve = 1,
 		/obj/item/stack/medical/suture = 2,
 		/obj/item/stack/medical/mesh = 2,
-		/obj/item/reagent_containers/hypospray/medipen/ekit = 1,
+		/obj/item/reagent_containers/hypospray/medipen = 1,
 		/obj/item/surgical_drapes = 1,
 		/obj/item/scalpel = 1,
 		/obj/item/hemostat = 1,


### PR DESCRIPTION
## About The Pull Request

The special expanded medkits that medical doctors start the shift with now start with an epinephrine medipen instead of an emergency first aid medipen.

Emergency first aid kits still have their two emergency first aid medipens, of course.

## Why It's Good For The Game

A normal first aid kit starts the shift with an epipen in it, but for some reason, the "superior" version of them that MDs spawn with comes with a worse medipen. Worse, emergency first aid kit medipens have identical sprites to epipens, but don't contain formaldehyde, so an uninformed doctors (even I thought that MD medkits came with normal epipens) can and do accidentally use the wrong kind of medipen on a corpse and move it off of a stasis bed, thinking that they've preserved it (because surely, the expanded capacity white kit that you start the shift with must contain the same kind of medipen as a normal white kit, right???), leading to the rotting of the patient's organs.

## Changelog
:cl: ATHATH
balance: The expanded medkits that medical doctors start the round with now come with epinephrine medipens (the kind normally found in white medkits/roundstart internals boxes), not emergency first aid kit medipens (the kind normally found in emergency first aid kits from oxygen lockers).
/:cl: