### PR TITLE
Makes Bounty Pads fireproof and prevents EconomySS from randomly opening UIs.

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -163,7 +163,6 @@ SUBSYSTEM_DEF(economy)
 		if(!is_station_level(V.z))
 			continue
 		V.reset_prices(V.product_records, V.coin_records)
-		V.updateUsrDialog()
 	earning_report = "Sector Economic Report<br /> Sector price inflation is currently at [SSeconomy.inflation_value()*100]%.<br /> The station budget is currently <b>[station_total] Credits</b>, and the station's targeted allowance is at <b>[station_target] Credits</b>.<br /> That's all from the <i>Nanotrasen Economist Division</i>."
 	GLOB.news_network.SubmitArticle(earning_report, "Station Earnings Report", "Station Announcements", null)
 

--- a/code/game/machinery/civilian_bountys.dm
+++ b/code/game/machinery/civilian_bountys.dm
@@ -24,7 +24,7 @@
 		if(id_insert(user, I, inserted_scan_id))
 			inserted_scan_id = I
 			return TRUE
-	. = ..()
+	return ..()
 
 /obj/machinery/computer/piratepad_control/multitool_act(mob/living/user, obj/item/multitool/I)
 	if(istype(I) && istype(I.buffer,/obj/machinery/piratepad/civilian))

--- a/code/game/machinery/civilian_bountys.dm
+++ b/code/game/machinery/civilian_bountys.dm
@@ -3,6 +3,7 @@
 	name = "civilian bounty pad"
 	desc = "A machine designed to send civilian bounty targets to centcom."
 	layer = TABLE_LAYER
+	resistance_flags = FIRE_PROOF
 
 ///Computer for assigning new civilian bounties, and sending bounties for collection.
 /obj/machinery/computer/piratepad_control/civilian
@@ -19,11 +20,11 @@
 	pad = /obj/machinery/piratepad/civilian
 
 /obj/machinery/computer/piratepad_control/civilian/attackby(obj/item/I, mob/living/user, params)
-	. = ..()
 	if(isidcard(I))
 		if(id_insert(user, I, inserted_scan_id))
 			inserted_scan_id = I
 			return TRUE
+	. = ..()
 
 /obj/machinery/computer/piratepad_control/multitool_act(mob/living/user, obj/item/multitool/I)
 	if(istype(I) && istype(I.buffer,/obj/machinery/piratepad/civilian))


### PR DESCRIPTION
## About The Pull Request

Fixes #52485 and fixes #52581 and fixes #52664, and here's why.
Bounty pads being firepoof was an oversight on my part, but in my defense, it was very funny to hear that this was an issue.
Now, when the EconSS fires to update prices on vending machines, it was going and updating UIs in order to show the updated prices, which would have been fine, had we not recently gotten UI recycling, so of these last few opened UIs, it would then attempt to open UI dialogs ingame for previously closed vending UIs, since after all it NEEDS you to see those NEW PRICES.
Lastly, using your ID on the bounty pad console no longer bops the screen instead of inserting it, for a more satisfying user experience.

## Why It's Good For The Game
There are bounties for burning things, and as such, burning things probably shouldn't break the pad. WACK.
The invisible hand of capitalism going and opening UIs for the latest deals at shakeshack? WACK.
Smacking the machine with your drivers licence to show your citizenship? WACK.

## Changelog
:cl:
fix: Getting your paycheck will no longer cause vending machines and other machines to mass-open the UI.
fix: Bounty Pads no longer spontaneously combust when sending bonfires.
/:cl:
