### PR TITLE
Food trays drop their contents when deleted or destroyed.

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -351,6 +351,11 @@
 	. = ..()
 	update_icon()
 
+/obj/item/storage/bag/tray/Destroy()
+	for(var/obj/objects in contents)
+		objects.forceMove(drop_location())
+	return ..()
+
 /obj/item/storage/bag/tray/cafeteria
 	name = "cafeteria tray"
 	icon = 'icons/obj/food/containers.dmi'

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -351,11 +351,6 @@
 	. = ..()
 	update_icon()
 
-/obj/item/storage/bag/tray/Destroy()
-	for(var/obj/objects in contents)
-		objects.forceMove(drop_location())
-	return ..()
-
 /obj/item/storage/bag/tray/cafeteria
 	name = "cafeteria tray"
 	icon = 'icons/obj/food/containers.dmi'

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -48,3 +48,10 @@
 /obj/item/storage/proc/emptyStorage()
 	var/datum/component/storage/ST = GetComponent(/datum/component/storage)
 	ST.do_quick_empty()
+
+/obj/item/storage/Destroy()
+	for(var/obj/important_thing in contents)
+		if(!(important_thing.resistance_flags & INDESTRUCTIBLE))
+			continue
+		important_thing.forceMove(drop_location())
+	return ..()


### PR DESCRIPTION

## About The Pull Request

Fixes #52666. This makes it so deleting a tray, either by using the tray on an autolathe or having it destroyed will drop it's contents as opposed to deleting.

## Why It's Good For The Game

It feels weird that an autolathe would be capable of destroying the contents of the tray, despite it's strict requirements on what it can/can't accept. Plus It feels like a bug so 🐛 💥 

## Changelog
:cl:
fix: Food trays now drop their contents when fed into an autolathe.
/:cl: