### PR TITLE
Immovable rods penetrate harder and show ghosts how many clongs they've racked up

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -54,7 +54,14 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/z_original = 0
 	var/destination
 	var/notify = TRUE
+	///We can designate a specific target to aim for, in which case we'll try to snipe them rather than just flying in a random direction
 	var/atom/special_target
+	///How many mobs we've penetrated one way or another
+	var/num_mobs_hit = 0
+	///How many mobs we've hit with clients
+	var/num_sentient_mobs_hit = 0
+	///How many people we've hit with clients
+	var/num_sentient_people_hit = 0
 
 /obj/effect/immovablerod/New(atom/start, atom/end, aimed_at)
 	..()
@@ -73,6 +80,20 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		walk_towards(src, special_target, 1)
 	else if(end && end.z==z_original)
 		walk_towards(src, destination, 1)
+
+/obj/effect/immovablerod/examine(mob/user)
+	. = ..()
+	if(!isobserver(user))
+		return
+
+	if(!num_mobs_hit)
+		. += "<span class='notice'>So far, this rod has not hit any mobs.</span>"
+		return
+
+	. += "\t<span class='notice'>So far, this rod has hit: \n\
+		\t\t[num_mobs_hit] mobs total, \n\
+		\t\t[num_sentient_mobs_hit] of which were sentient, and \n\
+		\t\t[num_sentient_people_hit] of which were sentient people</span>"
 
 /obj/effect/immovablerod/Topic(href, href_list)
 	if(href_list["orbit"])
@@ -137,13 +158,23 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		qdel(src)
 		qdel(other)
 
-/obj/effect/immovablerod/proc/penetrate(mob/living/L)
-	L.visible_message("<span class='danger'>[L] is penetrated by an immovable rod!</span>" , "<span class='userdanger'>The rod penetrates you!</span>" , "<span class='danger'>You hear a CLANG!</span>")
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.adjustBruteLoss(160)
-	if(L && (L.density || prob(10)))
-		L.ex_act(EXPLODE_HEAVY)
+/obj/effect/immovablerod/proc/penetrate(mob/living/smeared_mob)
+	smeared_mob.visible_message("<span class='danger'>[smeared_mob] is penetrated by an immovable rod!</span>" , "<span class='userdanger'>The rod penetrates you!</span>" , "<span class='danger'>You hear a CLANG!</span>")
+
+	num_mobs_hit++
+	if(smeared_mob.client)
+		num_sentient_mobs_hit++
+		if(iscarbon(smeared_mob))
+			num_sentient_people_hit++
+
+	if(iscarbon(smeared_mob))
+		var/mob/living/carbon/smeared_carbon = smeared_mob
+		smeared_carbon.adjustBruteLoss(100)
+		var/obj/item/bodypart/penetrated_chest = smeared_carbon.get_bodypart(BODY_ZONE_CHEST)
+		penetrated_chest?.receive_damage(60, wound_bonus = 20, sharpness=SHARP_POINTY)
+
+	if(smeared_mob.density || prob(10))
+		smeared_mob.ex_act(EXPLODE_HEAVY)
 
 /obj/effect/immovablerod/attack_hand(mob/living/user)
 	if(ishuman(user))

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -161,11 +161,12 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /obj/effect/immovablerod/proc/penetrate(mob/living/smeared_mob)
 	smeared_mob.visible_message("<span class='danger'>[smeared_mob] is penetrated by an immovable rod!</span>" , "<span class='userdanger'>The rod penetrates you!</span>" , "<span class='danger'>You hear a CLANG!</span>")
 
-	num_mobs_hit++
-	if(smeared_mob.client)
-		num_sentient_mobs_hit++
-		if(iscarbon(smeared_mob))
-			num_sentient_people_hit++
+	if(smeared_mob.stat != DEAD)
+		num_mobs_hit++
+		if(smeared_mob.client)
+			num_sentient_mobs_hit++
+			if(iscarbon(smeared_mob))
+				num_sentient_people_hit++
 
 	if(iscarbon(smeared_mob))
 		var/mob/living/carbon/smeared_carbon = smeared_mob


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Come in late to a looping immovable rod and want to know the score? Has it racked up so many bodies that no one even knows anymore? Rods now keep track of how many mobs, sentient mobs, and sentient carbons they've penetrated, which ghosts can view by examining the rod. 

[![dreamseeker_2020-08-02_00-59-22.png](https://i.imgur.com/5yOAu6Ul.jpg)](https://i.imgur.com/5yOAu6U.png)

Also, rods can now cause piercing wounds to the chest, since you're getting the shit penetrated out of you anyway. Total damage should still be 160, armor and limb percentage notwithstanding.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Provides an accurate count of how much mayhem a rod has caused, and blasting through people with the wounds makes rods more fun to watch. Keeping track with the rest of deadchat might be a bit less engaging since you can just look and see the exact number, but I think watching the numbers climb higher and higher will be fun in its own way.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
add: Observers can examine immovable rods to see how many mobs/sentient mobs/sentient carbons it has penetrated
tweak: Immovable rods can now cause piercing wounds to the chest
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
