### PR TITLE
Updates wire datum proper_name vars

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -26,7 +26,7 @@
 	var/holder_type = null
 	/// Key that enables wire assignments to be common across different holders. If null, will use the holder_type as a key.
 	var/dictionary_key = null
-	/// The display name for the wire set shown in station blueprints. Not used if randomize is true or it's an item NT wouldn't know about (Explosives/Nuke)
+	/// The display name for the wire set shown in station blueprints. Not shown in blueprints if randomize is TRUE or it's an item NT wouldn't know about (Explosives/Nuke). Also used in the hacking interface.
 	var/proper_name = "Unknown"
 
 	/// List of all wires.

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -3,6 +3,7 @@
 	proper_name = "Generic Airlock"
 
 /datum/wires/airlock/secure
+	proper_name = "High Security Airlock"
 	randomize = TRUE
 
 /datum/wires/airlock/maint

--- a/code/datums/wires/conveyor.dm
+++ b/code/datums/wires/conveyor.dm
@@ -1,6 +1,6 @@
 /datum/wires/conveyor
 	holder_type = /obj/machinery/conveyor_switch
-	proper_name = "conveyor"
+	proper_name = "Conveyor"
 	/// var holder that logs who put the assembly inside and gets transfered to the switch on pulse
 	var/mob/fingerman
 

--- a/code/datums/wires/emitter.dm
+++ b/code/datums/wires/emitter.dm
@@ -1,6 +1,7 @@
 
 /datum/wires/emitter
 	holder_type = /obj/machinery/power/emitter
+	proper_name = "Emitter"
 
 /datum/wires/emitter/New(atom/holder)
 	wires = list(WIRE_ZAP,WIRE_HACK)

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -1,5 +1,6 @@
 /datum/wires/explosive
 	var/duds_number = 2 // All "dud" wires cause an explosion when cut or pulsed
+	proper_name = "Explosive Device"
 	randomize = TRUE // Prevents wires from showing up on blueprints
 
 /datum/wires/explosive/New(atom/holder)

--- a/code/datums/wires/mulebot.dm
+++ b/code/datums/wires/mulebot.dm
@@ -1,5 +1,6 @@
 /datum/wires/mulebot
 	holder_type = /mob/living/simple_animal/bot/mulebot
+	proper_name = "Mulebot"
 	randomize = TRUE
 
 /datum/wires/mulebot/New(atom/holder)

--- a/code/datums/wires/r_n_d.dm
+++ b/code/datums/wires/r_n_d.dm
@@ -1,5 +1,6 @@
 /datum/wires/rnd
 	holder_type = /obj/machinery/rnd
+	proper_name = "R&D Machinery"
 	randomize = TRUE
 
 /datum/wires/rnd/New(atom/holder)

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -1,5 +1,6 @@
 /datum/wires/robot
 	holder_type = /mob/living/silicon/robot
+	proper_name = "Cyborg"
 	randomize = TRUE
 
 /datum/wires/robot/New(atom/holder)

--- a/code/datums/wires/syndicatebomb.dm
+++ b/code/datums/wires/syndicatebomb.dm
@@ -1,5 +1,6 @@
 /datum/wires/syndicatebomb
 	holder_type = /obj/machinery/syndicatebomb
+	proper_name = "Syndicate Explosive Device"
 	randomize = TRUE
 
 /datum/wires/syndicatebomb/New(atom/holder)

--- a/code/datums/wires/tesla_coil.dm
+++ b/code/datums/wires/tesla_coil.dm
@@ -1,6 +1,6 @@
-
 /datum/wires/tesla_coil
-	randomize = 1	//Only one wire don't need blueprints
+	proper_name = "Tesla Coil"
+	randomize = TRUE	//Only one wire don't need blueprints
 	holder_type = /obj/machinery/power/tesla_coil
 
 /datum/wires/tesla_coil/New(atom/holder)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Follow-up PR to #52563 

![image](https://user-images.githubusercontent.com/24975989/89130551-ae0b1e00-d4fd-11ea-8b94-654a49986d8f.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

All wire hacking interfaces are now brought up to date to give a hint showing their active wire configuration.

![image](https://user-images.githubusercontent.com/24975989/89241785-bf385580-d5f7-11ea-85be-f40915a5ac57.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: When hacking wires, all interfaces will now show a notice box at the top telling you which wire configuration you're attempting to hack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
