### PR TITLE
[Ready]Optimalizes rust_spread loop

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -223,7 +223,7 @@
 /datum/eldritch_knowledge/spell/basic
 	name = "Break of dawn"
 	desc = "Starts your journey in the mansus. Allows you to select a target using a living heart on a transmutation rune."
-	gain_text = "Gates of mansus open up to your mind."
+	gain_text = "Another day at a meaningless job. You feel a shimmer around you, as a realization of something weird in your backpack unfolds. You look at it, unknowingly opening a new chapter in your life."
 	next_knowledge = list(/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_flesh)
 	cost = 0
 	spell_to_add = /obj/effect/proc_holder/spell/targeted/touch/mansus_grasp

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -11,7 +11,7 @@
 
 /datum/eldritch_knowledge/spell/ashen_shift
 	name = "Ashen Shift"
-	gain_text = "Ash is all the same, how can one man master it all?"
+	gain_text = "The Nightwatcher was the first of them, his treason has started it all."
 	desc = "Short range jaunt that can help you escape from bad situations."
 	cost = 1
 	spell_to_add = /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/ash
@@ -20,7 +20,7 @@
 
 /datum/eldritch_knowledge/ashen_grasp
 	name = "Grasp of Ash"
-	gain_text = "Gates have opened, minds have flooded, I remain."
+	gain_text = "He well knew how to walk between the planes."
 	desc = "Empowers your mansus grasp to throw away enemies."
 	cost = 1
 	next_knowledge = list(/datum/eldritch_knowledge/spell/ashen_shift)
@@ -58,7 +58,7 @@
 
 /datum/eldritch_knowledge/ash_mark
 	name = "Mark of ash"
-	gain_text = "Spread the famine."
+	gain_text = "Nightwatcher was a very particular man, always watching, in the night. In spite of his duty, he has tranced through the manse, with his blazing lantern."
 	desc = "Your sickly blade now applies ash mark on hit. Use your mansus grasp to proc the mark. Mark of Ash causes stamina damage, and fire loss, and spreads to a nearby carbon. Damage decreases with how many times the mark has spread."
 	cost = 2
 	next_knowledge = list(/datum/eldritch_knowledge/curse/blindness)
@@ -73,7 +73,7 @@
 
 /datum/eldritch_knowledge/curse/blindness
 	name = "Curse of blindness"
-	gain_text = "Blind man walks through the world, unnoticed by the masses."
+	gain_text = "He walks through the world, unnoticed by the masses."
 	desc = "Curse someone with 2 minutes of complete blindness by sacrificing a pair of eyes, a screwdriver and a pool of blood, with an object that the victim has touched with their bare hands."
 	cost = 1
 	required_atoms = list(/obj/item/organ/eyes,/obj/item/screwdriver,/obj/effect/decal/cleanable/blood)
@@ -100,7 +100,7 @@
 
 /datum/eldritch_knowledge/ash_blade_upgrade
 	name = "Fiery blade"
-	gain_text = "May the sun burn the heretics."
+	gain_text = "He has swung and swung, the ash fell from the skies, his city... his people, all gone, and yet he was alive in his charred body."
 	desc = "Your blade of choice will now add firestacks."
 	cost = 2
 	next_knowledge = list(/datum/eldritch_knowledge/spell/flame_birth)
@@ -162,7 +162,7 @@
 
 /datum/eldritch_knowledge/final/ash_final
 	name = "Ashlord's rite"
-	gain_text = "The forgotten lords have spoken! The lord of ash have come! Fear the fire!"
+	gain_text = "Nightwacher has found the ascension and shares it between the men! For I am one with the fire, WATCH ME RISE!"
 	desc = "Bring 3 corpses onto a transmutation rune, you will become immune to fire ,space ,cold and other enviromental hazards and become overall sturdier to all other damages. You will gain a spell that passively creates ring of fire around you as well ,as you will gain a powerful abiltiy that let's you create a wave of flames all around you."
 	required_atoms = list(/mob/living/carbon/human)
 	cost = 3
@@ -170,7 +170,7 @@
 	var/list/trait_list = list(TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOFIRE,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER,TRAIT_BOMBIMMUNE)
 
 /datum/eldritch_knowledge/final/ash_final/on_finished_recipe(mob/living/user, list/atoms, loc)
-	priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear the blaze, for Ashbringer [user.real_name] has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", 'sound/ai/spanomalies.ogg')
+	priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear the blaze, for Ashlord [user.real_name] has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", 'sound/ai/spanomalies.ogg')
 	user.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/fire_cascade/big)
 	user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/fire_sworn)
 	var/mob/living/carbon/human/H = user

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -145,7 +145,7 @@
 
 /datum/eldritch_knowledge/flesh_blade_upgrade
 	name = "Bleeding Steel"
-	gain_text = "It rained blood, that's when i understood the gravekeeper's advice."
+	gain_text = "It rained blood, that's when i understood the Marchal's advice."
 	desc = "Your blade will now cause additional bleeding."
 	cost = 2
 	next_knowledge = list(/datum/eldritch_knowledge/summon/stalker)
@@ -162,7 +162,7 @@
 
 /datum/eldritch_knowledge/summon/raw_prophet
 	name = "Raw Ritual"
-	gain_text = "Uncanny man, walks alone in the valley, I was able to call his aid."
+	gain_text = "Uncanny man, walks alone in the valley between the worlds , I was able to call his aid."
 	desc = "You can now summon a Raw Prophet using eyes, a left arm, right arm and a pool of blood. Raw prophets have increased seeing range, as well as Xray. But are very fragile and weak."
 	cost = 1
 	required_atoms = list(/obj/item/organ/eyes,/obj/item/bodypart/l_arm,/obj/item/bodypart/r_arm,/obj/effect/decal/cleanable/blood)
@@ -172,7 +172,7 @@
 
 /datum/eldritch_knowledge/summon/stalker
 	name = "Lonely Ritual"
-	gain_text = "I was able to combine my greed and desires to summon an eldritch beast i have not seen before."
+	gain_text = "I was able to combine my greed and desires to summon an eldritch beast i have not seen before. Ever shapeshifting mass of flesh, it well knew my goals."
 	desc = "You can now summon a Stalker using a knife, a flower, a pen and a piece of paper. Stalkers can shapeshift into harmeless animals and get close to the victim."
 	cost = 1
 	required_atoms = list(/obj/item/kitchen/knife,/obj/item/reagent_containers/food/snacks/grown/poppy,/obj/item/pen,/obj/item/paper)
@@ -182,7 +182,7 @@
 
 /datum/eldritch_knowledge/summon/ashy
 	name = "Ashen Ritual"
-	gain_text = "I combined principle of hunger with desire of destruction. The eyeful lords have noticed me."
+	gain_text = "I combined principle of hunger with desire of destruction. The Nightwatcher has noticed me."
 	desc = "You can now summon an Ash Man by transmutating a pile of ash , a head and a book."
 	cost = 1
 	required_atoms = list(/obj/effect/decal/cleanable/ash,/obj/item/bodypart/head,/obj/item/book)
@@ -191,7 +191,7 @@
 
 /datum/eldritch_knowledge/summon/rusty
 	name = "Rusted Ritual"
-	gain_text = "I combined principle of hunger with desire of corruption. The rusted hills call my name."
+	gain_text = "I combined principle of hunger with desire of corruption. The Rusted Hills call my name."
 	desc = "You can now summon a Rust Walker transmutating vomit pool, a head and a book."
 	cost = 1
 	required_atoms = list(/obj/effect/decal/cleanable/vomit,/obj/item/bodypart/head,/obj/item/book)
@@ -200,7 +200,7 @@
 
 /datum/eldritch_knowledge/spell/blood_siphon
 	name = "Blood Siphon"
-	gain_text = "Our blood is all the same after all, the owl told me."
+	gain_text = "Our blood is all the same after all, the Colonel told me."
 	desc = "You gain a spell that drains enemies health and restores yours."
 	cost = 1
 	spell_to_add = /obj/effect/proc_holder/spell/targeted/touch/blood_siphon
@@ -208,7 +208,7 @@
 
 /datum/eldritch_knowledge/final/flesh_final
 	name = "Priest's Final Hymn"
-	gain_text = "Man of this world. Hear me! For the time of the lord of arms has come!"
+	gain_text = "Man of this world. Hear me! For the time of the lord of arms has come! Emperor of Flesh guides my army!"
 	desc = "Bring 3 bodies onto a transmutation rune to either ascend as a terror of the night prime or you can summon a regular terror of the night."
 	required_atoms = list(/mob/living/carbon/human)
 	cost = 3
@@ -241,7 +241,7 @@
 			var/mob/living/summoned = new /mob/living/simple_animal/hostile/eldritch/armsy/prime(loc,TRUE,10)
 			summoned.ghostize(0)
 			user.SetImmobilized(0)
-			priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear the dark, for king of arms has ascended! Lord of the night has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", 'sound/ai/spanomalies.ogg')
+			priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear the dark, for lord of arms has ascended! Lord of the night has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", 'sound/ai/spanomalies.ogg')
 			log_game("[user.real_name] ascended as [summoned.real_name]")
 			var/mob/living/carbon/carbon_user = user
 			var/datum/antagonist/heretic/ascension = carbon_user.mind.has_antag_datum(/datum/antagonist/heretic)

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -200,7 +200,7 @@
 
 /datum/eldritch_knowledge/spell/blood_siphon
 	name = "Blood Siphon"
-	gain_text = "Our blood is all the same after all, the Colonel told me."
+	gain_text = "Our blood is all the same after all, the Marshal told me."
 	desc = "You gain a spell that drains enemies health and restores yours."
 	cost = 1
 	spell_to_add = /obj/effect/proc_holder/spell/targeted/touch/blood_siphon

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -167,6 +167,7 @@
 	var/turf/turf_loc = get_turf(loc)
 	turf_loc.rust_heretic_act()
 	turfs += turf_loc
+	prev_edge_turfs += turf_loc
 	START_PROCESSING(SSprocessing,src)
 
 /datum/rust_spread/Destroy(force, ...)

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -197,12 +197,13 @@
   */
 /datum/rust_spread/proc/compile_turfs()
 	edge_turfs = list()
+	var/list/removal_list = list()
 	var/max_dist = 1
 	for(var/X in turfs)
 		if(!istype(X,/turf/closed/wall/rust) && !istype(X,/turf/closed/wall/r_wall/rust) && !istype(X,/turf/open/floor/plating/rust))
-			turfs -=X
+			removal_list +=X
 		max_dist = max(max_dist,get_dist(X,centre)+1)
-
+	turfs -= removal_list
 	for(var/X in spiral_range_turfs(max_dist,centre,FALSE))
 		if(X in turfs || is_type_in_typecache(X,blacklisted_turfs))
 			continue

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -62,7 +62,7 @@
 /datum/eldritch_knowledge/rust_mark
 	name = "Mark of Rust"
 	desc = "Your eldritch blade now applies a rust mark. Rust mark has a chance to deal between 0 to 200 damage to 75% of enemies items. To Detonate the mark use your mansus grasp on it."
-	gain_text = "Lords of the depths help those in dire need at a cost."
+	gain_text = "Rusted Hills help those in dire need at a cost."
 	cost = 2
 	next_knowledge = list(/datum/eldritch_knowledge/spell/area_conversion)
 	banned_knowledge = list(/datum/eldritch_knowledge/ash_mark,/datum/eldritch_knowledge/flesh_mark)
@@ -101,7 +101,7 @@
 /datum/eldritch_knowledge/armor
 	name = "Armorer's ritual"
 	desc = "You can now create eldritch armor using a table and a gas mask."
-	gain_text = "For I am the heir to the throne of doom."
+	gain_text = "Rusted Hills have welcomed Blacksmith with their generosity."
 	cost = 1
 	next_knowledge = list(/datum/eldritch_knowledge/rust_regen,/datum/eldritch_knowledge/flesh_ghoul)
 	required_atoms = list(/obj/structure/table,/obj/item/clothing/mask/gas)
@@ -110,7 +110,7 @@
 /datum/eldritch_knowledge/essence
 	name = "Priest's ritual"
 	desc = "You can now transmute a tank of water into a bottle of eldritch water."
-	gain_text = "This is an old recipe, i got it from an owl."
+	gain_text = "Old recipe, the Owl has whispered it to me."
 	cost = 1
 	next_knowledge = list(/datum/eldritch_knowledge/rust_regen,/datum/eldritch_knowledge/spell/ashen_shift)
 	required_atoms = list(/obj/structure/reagent_dispensers/watertank)
@@ -119,7 +119,7 @@
 /datum/eldritch_knowledge/final/rust_final
 	name = "Rustbringer's Oath"
 	desc = "Bring 3 corpses onto the transmutation rune. After you finish the ritual rust will now automatically spread from the rune. Your healing on rust is also tripled, while you become more resillient overall."
-	gain_text = "Champion of rust. Corruptor of steel. Fear the dark for Rustbringer has come!"
+	gain_text = "Champion of rust. Corruptor of steel. Fear the dark for Rustbringer has come! Rusted Hills YELL MY NAME!"
 	cost = 3
 	required_atoms = list(/mob/living/carbon/human)
 	route = PATH_RUST
@@ -166,20 +166,21 @@
 	var/turf/turf_loc = get_turf(loc)
 	turf_loc.rust_heretic_act()
 	turfs += turf_loc
+	compile_turfs()
 	START_PROCESSING(SSprocessing,src)
-
 
 /datum/rust_spread/Destroy(force, ...)
 	STOP_PROCESSING(SSprocessing,src)
 	return ..()
 
 /datum/rust_spread/process()
-	compile_turfs()
+
 	var/turf/T
 	for(var/i in 0 to spread_per_tick)
 		T = pick(edge_turfs)
 		T.rust_heretic_act()
 		turfs += get_turf(T)
+		CHECK_TICK
 
 /**
   * Compile turfs
@@ -198,3 +199,5 @@
 			if(is_type_in_typecache(T,blacklisted_turfs))
 				continue
 			edge_turfs += T
+			CHECK_TICK
+	addtimer(CALLBACK(src, .proc/compile_turfs), round(edge_turfs.len/spread_per_tick))

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -206,9 +206,9 @@
 	for(var/X in spiral_range_turfs(max_dist,centre,FALSE))
 		if(X in turfs)
 			continue
-		for(var/T in getline(X,centre))
-			if(!(T in turfs) || is_type_in_typecache(T,blacklisted_turfs))
+		if(!(X in turfs) || is_type_in_typecache(X,blacklisted_turfs))
 				continue
+		for(var/T in getline(X,centre))
 			if(get_dist(X,T) <= 1)
 				edge_turfs += X
 		CHECK_TICK

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -199,13 +199,15 @@
 	edge_turfs = list()
 	var/max_dist = 1
 	for(var/X in turfs)
+		if(!istype(X,/turf/closed/wall/rust) && !istype(X,/turf/closed/wall/r_wall/rust) && !istype(X,/turf/open/floor/plating/rust))
+			turfs -=X
 		max_dist = max(max_dist,get_dist(X,centre)+1)
 
 	for(var/X in spiral_range_turfs(max_dist,centre,FALSE))
 		if(X in turfs)
 			continue
 		for(var/T in getline(X,centre))
-			if(!(T in turfs))
+			if(!(T in turfs) || is_type_in_typecache(T,blacklisted_turfs))
 				continue
 			if(get_dist(X,T) <= 1)
 				edge_turfs += X

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -157,6 +157,7 @@
 /datum/rust_spread
 	var/list/edge_turfs = list()
 	var/list/turfs = list()
+	var/list/prev_edge_turfs = list()
 	var/static/list/blacklisted_turfs = typecacheof(list(/turf/open/indestructible,/turf/closed/indestructible,/turf/open/space,/turf/open/lava,/turf/open/chasm))
 	var/spread_per_tick = 6
 
@@ -178,9 +179,13 @@
 	var/turf/T
 	for(var/i in 0 to spread_per_tick)
 		T = pick(edge_turfs)
+		edge_turfs -= T
 		T.rust_heretic_act()
 		turfs += get_turf(T)
-		CHECK_TICK
+		prev_edge_turfs += get_turf(T)
+
+	if(edge_turfs.len < spread_per_tick)
+		compile_turfs()
 
 /**
   * Compile turfs
@@ -189,7 +194,7 @@
   */
 /datum/rust_spread/proc/compile_turfs()
 	edge_turfs = list()
-	for(var/X in turfs)
+	for(var/X in prev_edge_turfs)
 		if(!istype(X,/turf/closed/wall/rust) && !istype(X,/turf/closed/wall/r_wall/rust) && !istype(X,/turf/open/floor/plating/rust))
 			turfs -=X
 			continue
@@ -199,5 +204,5 @@
 			if(is_type_in_typecache(T,blacklisted_turfs))
 				continue
 			edge_turfs += T
-			CHECK_TICK
-	addtimer(CALLBACK(src, .proc/compile_turfs), round(edge_turfs.len/spread_per_tick))
+		CHECK_TICK
+	prev_edge_turfs = list()

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -167,7 +167,6 @@
 	var/turf/turf_loc = get_turf(loc)
 	turf_loc.rust_heretic_act()
 	turfs += turf_loc
-	compile_turfs()
 	START_PROCESSING(SSprocessing,src)
 
 /datum/rust_spread/Destroy(force, ...)
@@ -175,6 +174,9 @@
 	return ..()
 
 /datum/rust_spread/process()
+
+	if(edge_turfs.len < spread_per_tick)
+		compile_turfs()
 
 	var/turf/T
 	for(var/i in 0 to spread_per_tick)
@@ -184,8 +186,7 @@
 		turfs += get_turf(T)
 		prev_edge_turfs += get_turf(T)
 
-	if(edge_turfs.len < spread_per_tick)
-		compile_turfs()
+
 
 /**
   * Compile turfs

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -199,8 +199,7 @@
 	edge_turfs = list()
 	var/max_dist = 1
 	for(var/X in turfs)
-		if(get_dist(X,centre)+1 > max_dist)
-			max_dist = get_dist(X,centre)+1
+		max_dist = max(max_dist,get_dist(X,centre)+1)
 
 	for(var/X in spiral_range_turfs(max_dist,centre,FALSE))
 		if(X in turfs)

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -184,8 +184,8 @@
 		T = pick(edge_turfs)
 		edge_turfs -= T
 		T.rust_heretic_act()
-		turfs += get_turf(T)
-		prev_edge_turfs += get_turf(T)
+		turfs += T
+		prev_edge_turfs += T
 
 
 

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -137,14 +137,15 @@
 
 /datum/eldritch_knowledge/final/rust_final/on_life(mob/user)
 	. = ..()
-	if(!finished)
+	var/turf/user_loc_turf = get_turf(user)
+	if(!istype(user_loc_turf, /turf/open/floor/plating/rust) || !isliving(user) || !finished)
 		return
 	var/mob/living/carbon/human/human_user = user
-	human_user.adjustBruteLoss(-3, FALSE)
-	human_user.adjustFireLoss(-3, FALSE)
-	human_user.adjustToxLoss(-3, FALSE)
-	human_user.adjustOxyLoss(-1, FALSE)
-	human_user.adjustStaminaLoss(-10)
+	human_user.adjustBruteLoss(-4, FALSE)
+	human_user.adjustFireLoss(-4, FALSE)
+	human_user.adjustToxLoss(-4, FALSE)
+	human_user.adjustOxyLoss(-2, FALSE)
+	human_user.adjustStaminaLoss(-20)
 
 
 /**

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -204,10 +204,8 @@
 		max_dist = max(max_dist,get_dist(X,centre)+1)
 
 	for(var/X in spiral_range_turfs(max_dist,centre,FALSE))
-		if(X in turfs)
+		if(X in turfs || is_type_in_typecache(X,blacklisted_turfs))
 			continue
-		if(!(X in turfs) || is_type_in_typecache(X,blacklisted_turfs))
-				continue
 		for(var/T in getline(X,centre))
 			if(get_dist(X,T) <= 1)
 				edge_turfs += X

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -210,3 +210,4 @@
 				continue
 			if(get_dist(X,T) <= 1)
 				edge_turfs += X
+		CHECK_TICK

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -200,7 +200,7 @@
 	var/list/removal_list = list()
 	var/max_dist = 1
 	for(var/turfie in turfs)
-		if(!istype(turfie,/turf/closed/wall/rust) && !istype(X,/turf/closed/wall/r_wall/rust) && !istype(X,/turf/open/floor/plating/rust))
+		if(!istype(turfie,/turf/closed/wall/rust) && !istype(turfie,/turf/closed/wall/r_wall/rust) && !istype(turfie,/turf/open/floor/plating/rust))
 			removal_list +=turfie
 		max_dist = max(max_dist,get_dist(turfie,centre)+1)
 	turfs -= removal_list

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -58,6 +58,7 @@
 	living_user.adjustToxLoss(-2, FALSE)
 	living_user.adjustOxyLoss(-0.5, FALSE)
 	living_user.adjustStaminaLoss(-2)
+	living_user.AdjustAllImmobility(-5)
 
 /datum/eldritch_knowledge/rust_mark
 	name = "Mark of Rust"
@@ -146,7 +147,7 @@
 	human_user.adjustToxLoss(-4, FALSE)
 	human_user.adjustOxyLoss(-2, FALSE)
 	human_user.adjustStaminaLoss(-20)
-
+	living_user.AdjustAllImmobility(-10)
 
 /**
   * #Rust spread datum

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -199,15 +199,15 @@
 	edge_turfs = list()
 	var/list/removal_list = list()
 	var/max_dist = 1
-	for(var/X in turfs)
-		if(!istype(X,/turf/closed/wall/rust) && !istype(X,/turf/closed/wall/r_wall/rust) && !istype(X,/turf/open/floor/plating/rust))
-			removal_list +=X
-		max_dist = max(max_dist,get_dist(X,centre)+1)
+	for(var/turfie in turfs)
+		if(!istype(turfie,/turf/closed/wall/rust) && !istype(X,/turf/closed/wall/r_wall/rust) && !istype(X,/turf/open/floor/plating/rust))
+			removal_list +=turfie
+		max_dist = max(max_dist,get_dist(turfie,centre)+1)
 	turfs -= removal_list
-	for(var/X in spiral_range_turfs(max_dist,centre,FALSE))
-		if(X in turfs || is_type_in_typecache(X,blacklisted_turfs))
+	for(var/turfie in spiral_range_turfs(max_dist,centre,FALSE))
+		if(turfie in turfs || is_type_in_typecache(turfie,blacklisted_turfs))
 			continue
-		for(var/T in getline(X,centre))
-			if(get_dist(X,T) <= 1)
-				edge_turfs += X
+		for(var/T in getline(turfie,centre))
+			if(get_dist(turfie,T) <= 1)
+				edge_turfs += turfie
 		CHECK_TICK

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -207,7 +207,7 @@
 	for(var/turfie in spiral_range_turfs(max_dist,centre,FALSE))
 		if(turfie in turfs || is_type_in_typecache(turfie,blacklisted_turfs))
 			continue
-		for(var/T in getline(turfie,centre))
-			if(get_dist(turfie,T) <= 1)
+		for(var/line_turfie_owo in getline(turfie,centre))
+			if(get_dist(turfie,line_turfie_owo) <= 1)
 				edge_turfs += turfie
 		CHECK_TICK

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -147,7 +147,7 @@
 	human_user.adjustToxLoss(-4, FALSE)
 	human_user.adjustOxyLoss(-2, FALSE)
 	human_user.adjustStaminaLoss(-20)
-	living_user.AdjustAllImmobility(-10)
+	human_user.AdjustAllImmobility(-10)
 
 /**
   * #Rust spread datum


### PR DESCRIPTION
## About The Pull Request

Makes edge_turfs not rebuild literally every process, but every few ticks, depending on the size of the list. 
Also changes a few flavour texts.
Also fixes a bug i left acidentaly in rustbringers oath. oops

## Why It's Good For The Game

Faster is better.

## Changelog
:cl:
tweak: Rust_spread will no longer lag servers into oblivion
tweak: Changed a few flavour texts to better represent lore.
fix: Rustbringer's oath now properly only heals while on rusted tiles.
/:cl:

