### PR TITLE
You can now mind transfer into weeping angels again.

### DIFF
--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -44,11 +44,6 @@
 		to_chat(user, "<span class='warning'>The devilish contract doesn't include the 'mind swappable' package, please try again another lifetime.</span>")
 		return
 
-	//You should not be able to enter a statue that is nearly indestructible
-	if(HAS_TRAIT_FROM(victim, TRAIT_MUTE, STATUE_MUTE)) // that means it is a statue okay?
-		to_chat(user, "<span class='warning'>Your mind leaves your body but the stone resists your influence!/span>")
-		return
-
 	//MIND TRANSFER BEGIN
 	var/mob/dead/observer/ghost = victim.ghostize()
 	user.mind.transfer_to(victim)


### PR DESCRIPTION
## About The Pull Request

See title.

## tldr;
**The reason that mind transfer was made to be unable to work on weeping angels (wizard weeping angels could cast spells to bypass their weeping angel weaknesses) is no longer applicable (as weeping angels can't cast spells with vocal components anymore, and as far as I'm aware, every wizard spell in the game has a vocal component), so this is just a pointless, snowflakey restriction of the mind transfer spell.**

## Why It's Good For The Game

About 2 months ago, a panic erupted. Someone discovered that, if you made a weeping angel as a wizard by casting flesh to stone and someone and then mind transferring into them, you could become a spellcasting weeping angel. This was a problem because the ability to cast ranged spells like fireball allowed weeping angels to bypass their incredibly common and crippling weakness (they can only damage you in melee, but they can't move while being observed) by just fireballing anyone they could see, allowing them to become invincible (they literally have the "GODMODE" flag), unstoppable avatars of death. Jackrip even made a video (https://youtu.be/R9aNm_CALzQ) on a murderbone he did as a weeping angel wizard (and then as a slaughter demon wizard)!

Clearly, this incredibly overpowered strategy had to be patched out using the most blunt means possible. And so, https://github.com/tgstation/tgstation/pull/51480 was created. Instead of doing something interesting or logical, like making weeping angels unable to cast vocal spells because they can't speak, or making slaughter demons consume their own bodies/maxHealth to fuel their spells, the PR just made weeping angels and (s)laughter demons straight up immune to the mind transfer spell for incredibly flimsy reasons ("the stone resists your spell"). This PR received 32 downthumbs and 0 upthumbs, but was merged anyway, despite the aforementioned more interesting and logical suggestions being proposed (and ignored).

However, during all of this panic and kneejerk nerfing, something had been overlooked: the flesh to stone+staff of animation+mind transfer combo does not actually make you invincible. Flesh to stone lasts for only 8 minutes, even if the statue from that spell gets animated into a weeping angel. After those 8 minutes are up, that nigh-unstoppable statue becomes a squishy humanoid again- a robeless (so you can't cast flesh to stone again without finding new robes), staff of animation-less (so you have to find/recall your staff of animation again (better hope it wasn't cremated!) to animate the statues you create) squishy humanoid at that. In short, after your 8 minute power trip is over, you'll be naked (er, technically, you'll be robeless, not necessarily naked, but you know what I mean), alone, and SCREWED. Jackrip accidentally got around this drawback by mind transferring into a slaughter demon before his 8 minutes were up, which is why that drawback wasn't featured in his video (or even known to him until I pointed it out to him). In short, this is a gimmick strategy, not something like a staff of healing+dextrous holoparasite "I win" strategy.

Furthermore, even assuming that this strategy is something degenerate that should be cracked down on, making mind transfer not work on weeping angels DIDN'T EVEN MAKE THAT STRATEGY IMPOSSIBLE. You can still just perform the flesh to stone+staff of animation combo on a destruction apprentice, creating a weeping angel that knows fireball (the main spell used with the combo) that will return to you of its own free will (because it's your apprentice) once its 8 minutes run out. Alternatively, you can just sit with an apprentice in a corner of maint and have them staff of change you until you roll the weeping angel wabbajack result- and wabbajack weeping angels DON'T turn back into meatbags after 8 minutes, making this version of the combo even STRONGER than the mind transfer+weeping angel combo.

Then https://github.com/tgstation/tgstation/pull/52054 and https://github.com/tgstation/tgstation/pull/52511 did the sensible thing and just made weeping angels unable to cast spells (with vocal components, which is basically every spell except for mime spells, IIRC), making all of the combos I described above pointless and irrelevant, as wizard weeping angels now can't cast spells to get around the weaknesses of their (temporarily) nigh-invincible weeping angel body.

I'm planning to implement the "slaughter demons spend some of their maxHealth whenever they cast a spell" idea at some point soon-ish as well, but I figured that I should do the weeping angel side of this reversion first, since the work for it has pretty much already been done for me.

## Changelog
:cl: ATHATH
balance: You can now use the mind transfer spell to swap bodies with an animated statue again.
/:cl: