### PR TITLE
Each nuke (and clown) op now spawns with both a syndicate tablet AND a pinpointer

### DIFF
--- a/code/game/gamemodes/clown_ops/clown_ops.dm
+++ b/code/game/gamemodes/clown_ops/clown_ops.dm
@@ -41,7 +41,8 @@
 		/obj/item/kitchen/knife/combat/survival,
 		/obj/item/dnainjector/clumsymut, //in case you want to be clumsy for the memes
 		/obj/item/storage/box/syndie_kit/clownpins, //for any guns that you get your grubby little clown op mitts on
-		/obj/item/reagent_containers/spray/waterflower/lube)
+		/obj/item/reagent_containers/spray/waterflower/lube,
+		/obj/item/modular_computer/tablet/nukeops)
 	implants = list(/obj/item/implant/sad_trombone)
 
 	uplink_type = /obj/item/uplink/clownop

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -113,12 +113,12 @@
 	gloves =  /obj/item/clothing/gloves/combat
 	back = /obj/item/storage/backpack/fireproof
 	ears = /obj/item/radio/headset/syndicate/alt
-	l_pocket = /obj/item/modular_computer/tablet/nukeops
+	l_pocket = /obj/item/pinpointer/nuke/syndicate
 	id = /obj/item/card/id/syndicate
 	belt = /obj/item/gun/ballistic/automatic/pistol
 	backpack_contents = list(/obj/item/storage/box/survival/syndie=1,\
-		/obj/item/kitchen/knife/combat/survival)
-
+		/obj/item/kitchen/knife/combat/survival,
+		/obj/item/modular_computer/tablet/nukeops)
 	var/tc = 25
 	var/command_radio = FALSE
 	var/uplink_type = /obj/item/uplink/nuclear
@@ -163,6 +163,7 @@
 	belt = /obj/item/storage/belt/military
 	r_hand = /obj/item/gun/ballistic/shotgun/bulldog
 	backpack_contents = list(/obj/item/storage/box/survival/syndie=1,\
-		/obj/item/tank/jetpack/oxygen/harness=1,\
-		/obj/item/gun/ballistic/automatic/pistol=1,\
-		/obj/item/kitchen/knife/combat/survival)
+		/obj/item/tank/jetpack/oxygen/harness,
+		/obj/item/gun/ballistic/automatic/pistol,
+		/obj/item/kitchen/knife/combat/survival,
+		/obj/item/modular_computer/tablet/nukeops)

--- a/code/modules/antagonists/nukeop/equipment/pinpointer.dm
+++ b/code/modules/antagonists/nukeop/equipment/pinpointer.dm
@@ -58,7 +58,7 @@
 	scan_for_target()
 
 /obj/item/pinpointer/nuke/syndicate // Syndicate pinpointers automatically point towards the infiltrator once the nuke is active.
-	name = "nuclear disk pinpointer"
+	name = "nuclear authentication disk pinpointer"
 	desc = "A handheld tracking device that locks onto certain signals. It's configured to switch tracking modes once it detects the activation signal of a nuclear device, but normally, it will point towards the nuclear authentication disk."
 	icon_state = "pinpointer_syndicate"
 

--- a/code/modules/antagonists/nukeop/equipment/pinpointer.dm
+++ b/code/modules/antagonists/nukeop/equipment/pinpointer.dm
@@ -58,8 +58,8 @@
 	scan_for_target()
 
 /obj/item/pinpointer/nuke/syndicate // Syndicate pinpointers automatically point towards the infiltrator once the nuke is active.
-	name = "syndicate pinpointer"
-	desc = "A handheld tracking device that locks onto certain signals. It's configured to switch tracking modes once it detects the activation signal of a nuclear device."
+	name = "nuclear disk pinpointer"
+	desc = "A handheld tracking device that locks onto certain signals. It's configured to switch tracking modes once it detects the activation signal of a nuclear device, but normally, it will point towards the nuclear authentication disk."
 	icon_state = "pinpointer_syndicate"
 
 /obj/item/pinpointer/syndicate_cyborg // Cyborg pinpointers just look for a random operative.


### PR DESCRIPTION
## About The Pull Request

Nuke ops now spawn with pinpointers again (their syndicate tablets have been moved to their backpacks).

Clown ops now spawn with syndicate tablets (the pinpointers that they had before this PR will still spawn in their pockets).

The name of the syndicate pinpointer item (that each nuke op and clown op spawns with) has been changed to instead be "nuclear authentication disk pinpointer", so as to make the function of the device more clear. Its description has received some clarifications as well.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/42606352/89138785-4b685100-d502-11ea-8a6a-2ab07abdb524.png)

Listen, zxaber, I get it, tablets are cool and you want people to use them more. FORCING ops to use tablets in order to locate the disk is not the way to go about this, however. Nuke op is a rare role to get to play as, so trying to force the usage of niche (as a crewmember, anyway) mechanics in order to not fail horribly/get laughed at is just making our fluke op rate higher. Even in the future, when tablets become commonplace, I'd still prefer nuke ops to have both a tablet AND a pinpointer, for those newer players who haven't dived into understanding the wonders of modular computing yet (or, worse, for those who assume that nuke ops get tablets just because everyone else (in this future world) gets them, and not because they NEED them to find the disk).

If a nuke op is an experienced player who knows what they're doing, they can decide to use their tablet instead of their pinpointer to save space. For the less-experienced nukies, the pinpointer is much simpler/much more intuitive to use (you just have to press a single button).

## Changelog
:cl:
balance: Each nuke (and clown) op now spawns with both a syndicate tablet AND a pinpointer.
tweak: The name of the syndicate pinpointer item (that each nuke op and clown op spawns with) has been changed to instead be "nuclear authentication disk pinpointer", so as to make the function of the device more clear. Its description has received some clarifications as well.
/:cl: