### PR TITLE
Splits the Summon Equipment spell into two different spells, fixes a bug with Summon Equipment

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -667,14 +667,14 @@
 	return TRUE
 
 
-//Armor: Gives the target a basic cultist combat loadout
+//Armor: Gives the target (cultist) a basic cultist combat loadout
 /obj/item/melee/blood_magic/armor
 	name = "Arming Aura"
 	desc = "Will equipt cult combat gear onto a cultist on contact."
 	color = "#33cc33" // green
 
 /obj/item/melee/blood_magic/armor/afterattack(atom/target, mob/living/carbon/user, proximity)
-	if(iscarbon(target) && proximity)
+	if(iscarbon(target) && iscultist(target) && proximity)
 		uses--
 		var/mob/living/carbon/C = target
 		C.visible_message("<span class='warning'>Otherworldly armor suddenly appears on [C]!</span>")

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -159,10 +159,10 @@
 	invocation = "Ta'gh fara'qha fel d'amar det!"
 
 /datum/action/innate/cult/blood_spell/emp/Activate()
+	owner.whisper(invocation, language = /datum/language/common)
 	owner.visible_message("<span class='warning'>[owner]'s hand flashes a bright blue!</span>", \
 						 "<span class='cultitalic'>You speak the cursed words, emitting an EMP blast from your hand.</span>")
 	empulse(owner, 2, 5)
-	owner.whisper(invocation, language = /datum/language/common)
 	charges--
 	if(charges<=0)
 		qdel(src)
@@ -182,31 +182,32 @@
 	health_cost = 12
 
 /datum/action/innate/cult/blood_spell/equipment
-	name = "Summon Equipment"
-	desc = "Allows you to summon a ritual dagger, or empowers your hand to summon combat gear onto a cultist you touch, including cult armor, a cult bola, and a cult sword."
+	name = "Summon Combat Equipment"
+	desc = "Empowers your hand to summon combat gear onto a cultist you touch, including cult armor, a cult bola, and a cult sword. Not recommended for use before the blood cult's presence has been revealed."
 	button_icon_state = "equip"
 	magic_path = "/obj/item/melee/blood_magic/armor"
 
-/datum/action/innate/cult/blood_spell/equipment/Activate()
-	var/choice = alert(owner,"Choose your equipment type",,"Combat Equipment","Ritual Dagger","Cancel")
-	if(choice == "Ritual Dagger")
-		var/turf/T = get_turf(owner)
-		owner.visible_message("<span class='warning'>[owner]'s hand glows red for a moment.</span>", \
-			"<span class='cultitalic'>Red light begins to shimmer and take form within your hand!</span>")
-		var/obj/O = new /obj/item/melee/cultblade/dagger(T)
-		if(owner.put_in_hands(O))
-			to_chat(owner, "<span class='warning'>A ritual dagger appears in your hand!</span>")
-		else
-			owner.visible_message("<span class='warning'>A ritual dagger appears at [owner]'s feet!</span>", \
-				 "<span class='cultitalic'>A ritual dagger materializes at your feet.</span>")
-		SEND_SOUND(owner, sound('sound/effects/magic.ogg',0,1,25))
-		charges--
-		desc = base_desc
-		desc += "<br><b><u>Has [charges] use\s remaining</u></b>."
-		if(charges<=0)
-			qdel(src)
-	else if(choice == "Combat Equipment")
-		..()
+/datum/action/innate/cult/blood_spell/dagger
+	name = "Summon Ritual Dagger"
+	desc = "Allows you to summon a ritual dagger, in case you've lost the dagger that was given to you."
+	invocation = "Wur d'dai leev'mai k'sagan!" //where did I leave my keys, again?
+	button_icon_state = "equip" //this is the same icon that summon equipment uses, but eh, I'm not a spriter
+
+/datum/action/innate/cult/blood_spell/dagger/Activate()
+	var/turf/T = get_turf(owner)
+	owner.whisper(invocation, language = /datum/language/common)
+	owner.visible_message("<span class='warning'>[owner]'s hand glows red for a moment.</span>", \
+		"<span class='cultitalic'>Your plea for aid is answered, and light begins to shimmer and take form within your hand!</span>")
+	var/obj/O = new /obj/item/melee/cultblade/dagger(T)
+	if(owner.put_in_hands(O))
+		to_chat(owner, "<span class='warning'>A ritual dagger appears in your hand!</span>")
+	else
+		owner.visible_message("<span class='warning'>A ritual dagger appears at [owner]'s feet!</span>", \
+			 "<span class='cultitalic'>A ritual dagger materializes at your feet.</span>")
+	SEND_SOUND(owner, sound('sound/effects/magic.ogg',0,1,25))
+	charges--
+	if(charges<=0)
+		qdel(src)
 
 /datum/action/innate/cult/blood_spell/horror
 	name = "Hallucinations"

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -194,19 +194,19 @@
 	button_icon_state = "equip" //this is the same icon that summon equipment uses, but eh, I'm not a spriter
 
 /datum/action/innate/cult/blood_spell/dagger/Activate()
-	var/turf/T = get_turf(owner)
+	var/turf/onwer_turf = get_turf(owner)
 	owner.whisper(invocation, language = /datum/language/common)
 	owner.visible_message("<span class='warning'>[owner]'s hand glows red for a moment.</span>", \
 		"<span class='cultitalic'>Your plea for aid is answered, and light begins to shimmer and take form within your hand!</span>")
-	var/obj/O = new /obj/item/melee/cultblade/dagger(T)
-	if(owner.put_in_hands(O))
+	var/obj/item/melee/cultblade/dagger/summoned_blade = new (onwer_turf)
+	if(owner.put_in_hands(summoned_blade))
 		to_chat(owner, "<span class='warning'>A ritual dagger appears in your hand!</span>")
 	else
 		owner.visible_message("<span class='warning'>A ritual dagger appears at [owner]'s feet!</span>", \
 			 "<span class='cultitalic'>A ritual dagger materializes at your feet.</span>")
-	SEND_SOUND(owner, sound('sound/effects/magic.ogg',0,1,25))
+	SEND_SOUND(owner, sound('sound/effects/magic.ogg', FALSE, 0, 25))
 	charges--
-	if(charges<=0)
+	if(charges <= 0)
 		qdel(src)
 
 /datum/action/innate/cult/blood_spell/horror

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -194,11 +194,11 @@
 	button_icon_state = "equip" //this is the same icon that summon equipment uses, but eh, I'm not a spriter
 
 /datum/action/innate/cult/blood_spell/dagger/Activate()
-	var/turf/onwer_turf = get_turf(owner)
+	var/turf/owner_turf = get_turf(owner)
 	owner.whisper(invocation, language = /datum/language/common)
 	owner.visible_message("<span class='warning'>[owner]'s hand glows red for a moment.</span>", \
 		"<span class='cultitalic'>Your plea for aid is answered, and light begins to shimmer and take form within your hand!</span>")
-	var/obj/item/melee/cultblade/dagger/summoned_blade = new (onwer_turf)
+	var/obj/item/melee/cultblade/dagger/summoned_blade = new (owner_turf)
 	if(owner.put_in_hands(summoned_blade))
 		to_chat(owner, "<span class='warning'>A ritual dagger appears in your hand!</span>")
 	else


### PR DESCRIPTION
## About The Pull Request

The Summon Equipment spell, which formerly asked you to choose between its two possible effects whenever you casted it, has been split into the Summon Combat Equipment and Summon Ritual Dagger spells.

## Why It's Good For The Game

Apparently, not many cultists know that they can use Summon Equipment to summon a backup dagger for themselves. Since Summon Ritual Dagger is now its own spell in the list of blood spells, this should help make that fact/ability a bit more obvious.

Also, it was a bit janky being prompted to choose between the two options for the Summon Equipment spell whenever you cast it.

Also, uh, bug bad. If Summon Combat Equipment didn't make your hand glow green while you were preparing to boop someone with it, I'd consider changing the description(s) of the spell instead of its effect, but there's not much opportunity for "HEY, THIS GUY'S A CULTIST, LYNCH 'EM!" trickery with a spell that makes your hand magically glow a very obvious shade of green when you cast it/just before you use it on someone.

## Changelog
:cl: ATHATH
balance: The Summon Equipment spell, which formerly asked you to choose between its two possible effects whenever you casted it, has been split into the Summon Combat Equipment and Summon Ritual Dagger spells.
fix: Summon Combat Equipment can now only be used on cultists, as its description implies.
/:cl: