### PR TITLE
People drift through z levels properly now, an old wives tale made true

### DIFF
--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -186,6 +186,7 @@
 		//now we're on the new z_level, proceed the space drifting
 		stoplag()//Let a diagonal move finish, if necessary
 		A.newtonian_move(A.inertia_dir)
+		A.inertia_moving = TRUE
 
 
 /turf/open/space/MakeSlippery(wet_setting, min_wet_time, wet_time_to_add, max_wet_time, permanent)


### PR DESCRIPTION
## About The Pull Request

People drift through z levels without getting locked to a cardinal direction now.
inertia_dir was getting fucked by either Move() or Moved(), which have a check to prevent said fuckage triggered by setting inertia_moving right before any uses, which wasn't being done here.
I did that here.

## Why It's Good For The Game

You know that old wives tale about throwing your victims at an angle to help hide them? It works now.
Oh and the rod of immovabaleness will wreck shit harder now.

## Changelog
:cl:
fix: You will keep your angle when you drift through space now. Oh and immovable rods do the same, so things might get a bit more messy then usual.
/:cl:
