### PR TITLE
Summon item asks if you want to unmark before actually doing so

### DIFF
--- a/code/modules/spells/spell_types/summonitem.dm
+++ b/code/modules/spells/spell_types/summonitem.dm
@@ -41,9 +41,10 @@
 					message = "<span class='warning'>You must hold the desired item in your hands to mark it for recall!</span>"
 
 		else if(marked_item && (marked_item in hand_items)) //unlinking item to the spell
-			message = "<span class='notice'>You remove the mark on [marked_item] to use elsewhere.</span>"
-			name = "Instant Summons"
-			marked_item = 		null
+			if(alert(user,"Unlink the item?",,"Yes","No") == "Yes" && (marked_item in hand_items) && isliving(user))
+				message = "<span class='notice'>You remove the mark on [marked_item] to use elsewhere.</span>"
+				name = "Instant Summons"
+				marked_item = 		null
 
 		else if(marked_item && QDELETED(marked_item)) //the item was destroyed at some point
 			message = "<span class='warning'>You sense your marked item has been destroyed!</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a popup alert to summon item spell, when used with your already marked item in hand. 

## Why It's Good For The Game

I often accidentally unmark an item, which is super annoying. Now its less easy to do.

## Changelog
:cl:
tweak: summon item spell now has a warning for unlinking an item, to prevent accidentally doing so
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
