### PR TITLE
medipens can be quickused when resting

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -74,6 +74,7 @@
 #define BE_CLOSE TRUE		//in the case of a silicon, to select if they need to be next to the atom
 #define NO_DEXTERITY TRUE	//if other mobs (monkeys, aliens, etc) can use this // I had to change 20+ files because some non-dnd-playing fuckchumbis can't spell "dexterity"
 #define NO_TK TRUE
+#define FLOOR_OKAY TRUE     // if you can use it while resting
 //used by canUseTopic()
 
 //singularity defines

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -123,7 +123,7 @@
 		update_icon()
 
 /obj/item/reagent_containers/hypospray/medipen/attack_self(mob/user)
-	if(user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+	if(user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK, FLOOR_OKAY))
 		inject(user, user)
 
 /obj/item/reagent_containers/hypospray/medipen/update_icon_state()


### PR DESCRIPTION
🆑
fix: medipens can be used in hand while resting on the floor
/🆑
you can click yourself but you cant use the shortcut because the can use topic wasnt set right ( its not set right anywhere so there are probably other canuse checks that should work when resting but they dont)
