### PR TITLE
[Ready]Legion Cores now deal slight cellular damage

### DIFF
--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -86,6 +86,7 @@
 				to_chat(user, "<span class='notice'>You start to smear [src] on yourself. Disgusting tendrils hold you together and allow you to keep moving, but for how long?</span>")
 				SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "self"))
 			H.apply_status_effect(STATUS_EFFECT_REGENERATIVE_CORE)
+			//Hivelord cores heal you at the cost of small cellular damage, nothing really bad, but forces miner to visit medbay every once in a while.
 			H.adjustCloneLoss(5)
 			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "core", /datum/mood_event/healsbadman) //Now THIS is a miner buff (fixed - nerf)
 			qdel(src)

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -86,6 +86,7 @@
 				to_chat(user, "<span class='notice'>You start to smear [src] on yourself. Disgusting tendrils hold you together and allow you to keep moving, but for how long?</span>")
 				SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "self"))
 			H.apply_status_effect(STATUS_EFFECT_REGENERATIVE_CORE)
+			H.adjustCloneLoss(5)
 			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "core", /datum/mood_event/healsbadman) //Now THIS is a miner buff (fixed - nerf)
 			qdel(src)
 


### PR DESCRIPTION
## About The Pull Request

I'm working on a big changes to lavaland that will make it harder to aquire gamer loot, basically I;m going to add much more harder enemies and make the current loot a lot harder to aquire. This was going to be in the megaPR but i decided it will be better if i make it it's own thing.

Legion cores now deal 5 clone damage.

## Why It's Good For The Game

Forces miners that overuse legion cores to go to medbay once in a while

## Changelog
:cl:
balance: Legion cores now deal 5 clone loss.
/:cl:
