### PR TITLE
electrified airlock fixes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -66,7 +66,6 @@
 	var/aiHacking = FALSE
 	var/closeOtherId //Cyclelinking for airlocks that aren't on the same x or y coord as the target.
 	var/obj/machinery/door/airlock/closeOther
-	var/justzap = FALSE
 	var/obj/item/electronics/airlock/electronics
 	COOLDOWN_DECLARE(shockCooldown)
 	var/obj/item/note //Any papers pinned to the airlock
@@ -305,9 +304,7 @@
 
 /obj/machinery/door/airlock/bumpopen(mob/living/user) //Airlocks now zap you when you 'bump' them open when they're electrified. --NeoFite
 	if(!issilicon(usr))
-		if(isElectrified() && !justzap && shock(user, 100))
-			justzap = TRUE
-			addtimer(VARSET_CALLBACK(src, justzap, FALSE) , 10)
+		if(isElectrified() && shock(user, 100))
 			return
 		else if(user.hallucinating() && iscarbon(user) && prob(1) && !operating)
 			var/mob/living/carbon/C = user

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -986,7 +986,7 @@
 		return
 	if(hasPower())
 		if(forced)
-			var/check_electrified = isElectrified()
+			var/check_electrified = isElectrified() //setting this so we can check if the mob got shocked during the do_after below
 			if(check_electrified && shock(user,100))
 				return //it's like sticking a fork in a power socket
 
@@ -997,7 +997,10 @@
 				var/time_to_open = 50
 				playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE) //is it aliens or just the CE being a dick?
 				prying_so_hard = TRUE
-				if(do_after(user, time_to_open, TRUE, src, extra_checks = (check_electrified ? CALLBACK(src, .proc/shock, user, 100) : null)))
+				if(do_after(user, time_to_open, TRUE, src))
+					if(check_electrified && shock(user,100))
+						prying_so_hard = FALSE
+						return
 					open(2)
 					if(density && !open(2))
 						to_chat(user, "<span class='warning'>Despite your attempts, [src] refuses to open.</span>")

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -320,9 +320,7 @@
 	..()
 
 /obj/machinery/door/airlock/proc/isElectrified()
-	if(secondsElectrified != MACHINE_NOT_ELECTRIFIED)
-		return TRUE
-	return FALSE
+	return (secondsElectrified != MACHINE_NOT_ELECTRIFIED)
 
 /obj/machinery/door/airlock/proc/canAIControl(mob/user)
 	return ((aiControlDisabled != 1) && !isAllPowerCut())

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -309,13 +309,11 @@
 			justzap = TRUE
 			addtimer(VARSET_CALLBACK(src, justzap, FALSE) , 10)
 			return
-		else if(user.hallucinating() && ishuman(user) && prob(1) && !operating)
-			var/mob/living/carbon/human/H = user
-			if(H.gloves)
-				var/obj/item/clothing/gloves/G = H.gloves
-				if(G.siemens_coefficient)//not insulated
-					new /datum/hallucination/shock(H)
-					return
+		else if(user.hallucinating() && iscarbon(user) && prob(1) && !operating)
+			var/mob/living/carbon/C = user
+			if(!C.wearing_shock_proof_gloves())
+				new /datum/hallucination/shock(C)
+				return
 	if (cyclelinkedairlock)
 		if (!shuttledocked && !emergency && !cyclelinkedairlock.shuttledocked && !cyclelinkedairlock.emergency && allowed(user))
 			if(cyclelinkedairlock.operating)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -989,7 +989,8 @@
 		return
 	if(hasPower())
 		if(forced)
-			if(isElectrified() && shock(user,100))
+			var/check_electrified = isElectrified()
+			if(check_electrified && shock(user,100))
 				return //it's like sticking a fork in a power socket
 
 			if(!density)//already open
@@ -999,7 +1000,7 @@
 				var/time_to_open = 50
 				playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE) //is it aliens or just the CE being a dick?
 				prying_so_hard = TRUE
-				if(do_after(user, time_to_open, TRUE, src))
+				if(do_after(user, time_to_open, TRUE, src, extra_checks = (check_electrified ? CALLBACK(src, .proc/shock, user, 100) : null)))
 					open(2)
 					if(density && !open(2))
 						to_chat(user, "<span class='warning'>Despite your attempts, [src] refuses to open.</span>")

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -305,14 +305,10 @@
 
 /obj/machinery/door/airlock/bumpopen(mob/living/user) //Airlocks now zap you when you 'bump' them open when they're electrified. --NeoFite
 	if(!issilicon(usr))
-		if(isElectrified())
-			if(!justzap)
-				if(shock(user, 100))
-					justzap = TRUE
-					addtimer(VARSET_CALLBACK(src, justzap, FALSE) , 10)
-					return
-			else
-				return
+		if(isElectrified() && !justzap && shock(user, 100))
+			justzap = TRUE
+			addtimer(VARSET_CALLBACK(src, justzap, FALSE) , 10)
+			return
 		else if(user.hallucinating() && ishuman(user) && prob(1) && !operating)
 			var/mob/living/carbon/human/H = user
 			if(H.gloves)
@@ -721,9 +717,9 @@
 			attack_ai(user)
 
 /obj/machinery/door/airlock/attack_animal(mob/user)
-	. = ..()
-	if(isElectrified())
-		shock(user, 100)
+	if(isElectrified() && shock(user, 100))
+		return
+	return ..()
 
 /obj/machinery/door/airlock/attack_paw(mob/user)
 	return attack_hand(user)
@@ -733,9 +729,8 @@
 	if(.)
 		return
 	if(!(issilicon(user) || isAdminGhostAI(user)))
-		if(isElectrified())
-			if(shock(user, 100))
-				return
+		if(isElectrified() && shock(user, 100))
+			return
 
 	if(ishuman(user) && prob(40) && density)
 		var/mob/living/carbon/human/H = user
@@ -791,9 +786,8 @@
 
 /obj/machinery/door/airlock/attackby(obj/item/C, mob/user, params)
 	if(!issilicon(user) && !isAdminGhostAI(user))
-		if(isElectrified())
-			if(shock(user, 75))
-				return
+		if(isElectrified() && shock(user, 75))
+			return
 	add_fingerprint(user)
 
 	if(panel_open)
@@ -997,9 +991,8 @@
 		return
 	if(hasPower())
 		if(forced)
-			if(isElectrified())
-				shock(user,100)//it's like sticking a forck in a power socket
-				return
+			if(isElectrified() && shock(user,100))
+				return //it's like sticking a fork in a power socket
 
 			if(!density)//already open
 				return
@@ -1177,9 +1170,8 @@
 		loseBackupPower()
 
 /obj/machinery/door/airlock/attack_alien(mob/living/carbon/alien/humanoid/user)
-	if(isElectrified())
+	if(isElectrified() && shock(user, 100)) //Mmm, fried xeno!
 		add_fingerprint(user)
-		shock(user, 100) //Mmm, fried xeno!
 		return
 	if(!density) //Already open
 		return ..()

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -322,7 +322,7 @@
 
 	if(victim.wearing_shock_proof_gloves())
 		SEND_SIGNAL(victim, COMSIG_LIVING_SHOCK_PREVENTED, power_source, source, siemens_coeff, dist_check)
-		return FALSE //to avoid spamming with insulated glvoes on
+		return FALSE //to avoid spamming with insulated gloves on
 
 	var/list/powernet_info = get_powernet_info_from_source(power_source)
 	if (!powernet_info)


### PR DESCRIPTION
fixes #52645
:cl: ShizCalev
fix: Fixed mobs wearing insulated gloves being unable to open electrified doors by walking into them (they had to click it to open.)
fix: Fixed aliens being unable to open electrified doors that were unpowered / on cooldown.
fix: Fixed simple animals doing damage to electrified doors even if they were shocked by them.
fix: Fixed being unable to open electrified doors with the jaws of life when the door was unable to shock the user.
/:cl:

