### PR TITLE
removes parent_type on map preloaders

### DIFF
--- a/code/modules/mapping/preloader.dm
+++ b/code/modules/mapping/preloader.dm
@@ -4,7 +4,6 @@ GLOBAL_DATUM_INIT(_preloader, /datum/map_preloader, new)
 
 /// Preloader datum
 /datum/map_preloader
-	parent_type = /datum
 	var/list/attributes
 	var/target_path
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/23585223/89224299-89d03f80-d5d8-11ea-950b-4708c742c422.png)
when duncathan removed simulated turfs he turned map preloaders from /dmm_suite/preloader to /datum/map_preloader but he didnt change parent_type so we have an useless var

## Why It's Good For The Game

idk

## Changelog
:cl:
code: removes parent_type on map preloaders
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
