### PR TITLE
[Ready]Medipens no longer instantly inject if you walk while do_after is still going

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -232,9 +232,11 @@
 		return
 
 	to_chat(user,"<span class='notice'>You start manually releasing the low-pressure gauge...</span>")
-	if(do_mob(user, M ,10 SECONDS))
-		amount_per_transfer_from_this = initial(amount_per_transfer_from_this) * 0.5
-		return ..()
+	if(!do_mob(user, M, 10 SECONDS))
+		return
+
+	amount_per_transfer_from_this = initial(amount_per_transfer_from_this) * 0.5
+	return ..()
 
 
 /obj/item/reagent_containers/hypospray/medipen/survival/luxury

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -223,17 +223,19 @@
 	list_reagents = list( /datum/reagent/medicine/epinephrine = 8, /datum/reagent/medicine/c2/aiuri = 8, /datum/reagent/medicine/c2/libital = 8 ,/datum/reagent/medicine/leporazine = 6)
 
 /obj/item/reagent_containers/hypospray/medipen/survival/inject(mob/living/M, mob/user)
-	if(!lavaland_equipment_pressure_check(get_turf(user)))
-		if(M in user.do_afters)
-			to_chat(user,"<span class='notice'>You are too busy to use \the [src]!</span>")
-			return
-		to_chat(user,"<span class='notice'>You start manually releasing the low-pressure gauge...</span>")
-		if(do_mob(user, M ,10 SECONDS))
-			amount_per_transfer_from_this = initial(amount_per_transfer_from_this) * 0.5
-			return ..()
+	if(lavaland_equipment_pressure_check(get_turf(user)))
+		amount_per_transfer_from_this = initial(amount_per_transfer_from_this)
+		return ..()
+
+	if(M in user.do_afters)
+		to_chat(user,"<span class='notice'>You are too busy to use \the [src]!</span>")
 		return
-	amount_per_transfer_from_this = initial(amount_per_transfer_from_this)
-	return ..()
+
+	to_chat(user,"<span class='notice'>You start manually releasing the low-pressure gauge...</span>")
+	if(do_mob(user, M ,10 SECONDS))
+		amount_per_transfer_from_this = initial(amount_per_transfer_from_this) * 0.5
+		return ..()
+
 
 /obj/item/reagent_containers/hypospray/medipen/survival/luxury
 	name = "luxury medipen"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -231,6 +231,7 @@
 		if(do_mob(user, M ,10 SECONDS))
 			amount_per_transfer_from_this = initial(amount_per_transfer_from_this) * 0.5
 			return ..()
+		return
 	amount_per_transfer_from_this = initial(amount_per_transfer_from_this)
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Simple bug solved by a single return, miners shouldnt be able to instantly inject medipens by walking on station

## Why It's Good For The Game

bugfix good
## Changelog
:cl:
fix: Survival medipens work properly on station now.
/:cl:
