### PR TITLE
AI core is now Abductor-proof.

### DIFF
--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -76,7 +76,6 @@
 	var/mob/living/carbon/human/C = owner
 	var/mob/camera/ai_eye/remote/remote_eye = C.remote_control
 	var/obj/machinery/abductor/pad/P = target
-	var/ppp = get_area(remote_eye)
 
 	if(istype(get_area(remote_eye), /area/ai_monitored/turret_protected/ai))
 		to_chat(owner, "<span class='warning'>This area is too heavily shielded to safely transport to.</span>")

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -68,20 +68,18 @@
 	button_icon_state = "beam_down"
 
 /datum/action/innate/teleport_in/Activate()
-	if(!target || !iscarbon(owner))
-		return
-	if(world.time < use_delay)
-		to_chat(owner, "<span class='warning'>You must wait [DisplayTimeText(use_delay - world.time)] to use the [target] again!</span>")
-		return
 	var/mob/living/carbon/human/C = owner
 	var/mob/camera/ai_eye/remote/remote_eye = C.remote_control
 	var/obj/machinery/abductor/pad/P = target
 	use_delay = (world.time + abductor_pad_cooldown)
-
+	if(!target || !iscarbon(owner))
+		return
 	if(get_area(remote_eye.loc) == /area/ai_monitored/turret_protected/ai)
 		to_chat(owner, "<span class='warning'>debug message")
 		return
-
+	if(world.time < use_delay)
+		to_chat(owner, "<span class='warning'>You must wait [DisplayTimeText(use_delay - world.time)] to use the [target] again!</span>")
+		return
 	if(GLOB.cameranet.checkTurfVis(remote_eye.loc))
 		P.PadToLoc(remote_eye.loc)
 

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -68,18 +68,22 @@
 	button_icon_state = "beam_down"
 
 /datum/action/innate/teleport_in/Activate()
-	var/mob/living/carbon/human/C = owner
-	var/mob/camera/ai_eye/remote/remote_eye = C.remote_control
-	var/obj/machinery/abductor/pad/P = target
-	use_delay = (world.time + abductor_pad_cooldown)
 	if(!target || !iscarbon(owner))
-		return
-	if(get_area(remote_eye.loc) == /area/ai_monitored/turret_protected/ai)
-		to_chat(owner, "<span class='warning'>debug message")
 		return
 	if(world.time < use_delay)
 		to_chat(owner, "<span class='warning'>You must wait [DisplayTimeText(use_delay - world.time)] to use the [target] again!</span>")
 		return
+	var/mob/living/carbon/human/C = owner
+	var/mob/camera/ai_eye/remote/remote_eye = C.remote_control
+	var/obj/machinery/abductor/pad/P = target
+	var/ppp = get_area(remote_eye)
+
+	if(istype(get_area(remote_eye), /area/ai_monitored/turret_protected/ai))
+		to_chat(owner, "<span class='warning'>This area is too heavily shielded to safely transport to.</span>")
+		return
+
+	use_delay = (world.time + abductor_pad_cooldown)
+
 	if(GLOB.cameranet.checkTurfVis(remote_eye.loc))
 		P.PadToLoc(remote_eye.loc)
 

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -78,6 +78,10 @@
 	var/obj/machinery/abductor/pad/P = target
 	use_delay = (world.time + abductor_pad_cooldown)
 
+	if(get_area(remote_eye.loc) == /area/ai_monitored/turret_protected/ai)
+		to_chat(owner, "<span class='warning'>debug message")
+		return
+
 	if(GLOB.cameranet.checkTurfVis(remote_eye.loc))
 		P.PadToLoc(remote_eye.loc)
 


### PR DESCRIPTION
## About The Pull Request

Simply prevents sending the teleport into the AI core.

## Why It's Good For The Game

Policy thread on the topic. https://tgstation13.org/phpBB/viewtopic.php?p=470229#p470229
Abductors not only having the means but strong incentive to immediately and near-unpreventably round-remove the AI rather than subverting them has long struck me as frankly unacceptable.
Their stated goal is to experiment and observe, they are explicitly not supposed to murder people, but the AI is one of the few things that actually has the power to make their life difficult; and they have free reign to dispose of one as they please.

There's no counterplay other than two things.
1. Metagaming and putting pingsky underneath your core ahead of time, and even that isn't foolproof, since there's a brief moment they can card you before he stuns them.
2. Cutting the cameras in your core (which is obviously not ideal) so they can't see the tiles to teleport to.

Even surrounding yourself with walls doesn't help, since they can teleport into solid matter somehow. It's probably the single worst-feeling way to get screwed in the game.

## Changelog
:cl:
balance: Station AI cores are now stored in a tin foil-lined room, in response to reports of mysterious teleporting AI thieves.
/:cl: