### PR TITLE
Sharpness fixes

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -12,6 +12,7 @@
 	throwforce = 5
 	throw_speed = 3
 	throw_range = 5
+	sharpness = SHARP_EDGED
 	w_class = WEIGHT_CLASS_SMALL
 	hitsound = "swing_hit"
 	armour_penetration = 35
@@ -43,7 +44,6 @@
 			to_chat(user, "<span class='warning'>You lack the grace to wield this!</span>")
 			return COMPONENT_TWOHANDED_BLOCK_WIELD
 	wielded = TRUE
-	sharpness = SHARP_EDGED
 	w_class = w_class_on
 	hitsound = 'sound/weapons/blade1.ogg'
 	START_PROCESSING(SSobj, src)
@@ -53,11 +53,13 @@
 /// switch hitsounds
 /obj/item/dualsaber/proc/on_unwield(obj/item/source, mob/living/carbon/user)
 	wielded = FALSE
-	sharpness = initial(sharpness)
 	w_class = initial(w_class)
 	hitsound = "swing_hit"
 	STOP_PROCESSING(SSobj, src)
 	set_light(0)
+
+/obj/item/dualsaber/get_sharpness()
+	return wielded * sharpness
 
 /obj/item/dualsaber/update_icon_state()
 	if(wielded)

--- a/code/game/objects/items/sharpener.dm
+++ b/code/game/objects/items/sharpener.dm
@@ -21,7 +21,7 @@
 	if(requires_sharpness && !I.get_sharpness())
 		to_chat(user, "<span class='warning'>You can only sharpen items that are already sharp, such as knives!</span>")
 		return
-	if(istype(I, /obj/item/melee/transforming/energy))
+	if(is_type_in_list(I, list(/obj/item/melee/transforming/energy, /obj/item/dualsaber)))
 		to_chat(user, "<span class='warning'>You don't think \the [I] will be the thing getting modified if you use it on \the [src]!</span>")
 		return
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -126,7 +126,7 @@
 		return
 
 	// Cutting out skill chips.
-	if(length(skillchips) && O.sharpness == SHARP_EDGED)
+	if(length(skillchips) && O.get_sharpness())
 		to_chat(user,"<span class='notice'>You begin to excise skillchips from [src].</span>")
 		if(do_after(user, 15 SECONDS, target = src))
 			for(var/obj/item/skillchip/skill_chip in skillchips)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -126,7 +126,7 @@
 		return
 
 	// Cutting out skill chips.
-	if(length(skillchips) && O.get_sharpness())
+	if(length(skillchips) && O.get_sharpness() == SHARP_EDGED)
 		to_chat(user,"<span class='notice'>You begin to excise skillchips from [src].</span>")
 		if(do_after(user, 15 SECONDS, target = src))
 			for(var/obj/item/skillchip/skill_chip in skillchips)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -467,11 +467,12 @@
 GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 	/obj/item/gun/energy/plasmacutter,
 	/obj/item/melee/transforming/energy,
+	/obj/item/dualsaber
 	)))
 
 ///Handles all the logic of sawing off guns,
 /obj/item/gun/ballistic/proc/sawoff(mob/user, obj/item/saw)
-	if(!saw.get_sharpness() || !is_type_in_typecache(saw, GLOB.gun_saw_types) && !saw.tool_behaviour == TOOL_SAW) //needs to be sharp. Otherwise turned off eswords can cut this.
+	if(!saw.get_sharpness() || (!is_type_in_typecache(saw, GLOB.gun_saw_types) && saw.tool_behaviour != TOOL_SAW)) //needs to be sharp. Otherwise turned off eswords can cut this.
 		return
 	if(sawn_off)
 		to_chat(user, "<span class='warning'>\The [src] is already shortened!</span>")


### PR DESCRIPTION
:cl: ShizCalev
fix: You can no longer sharpen dual energy swords.
fix: Skill chips can no longer be removed with edaggers and eswords while they're turned off.
fix: Guns can now be sawn-off with dual eswords.
fix: Sawing-down a gun will now require an item actually be a saw / esword / plasmacutters, instead of just any sharp item that doesn't have a tool type.
/:cl:

Fixes #52715