### PR TITLE
Shapeshift spell now uses a radial menu for choosing transformations

### DIFF
--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -33,10 +33,14 @@
 	for(var/mob/living/M in targets)
 		if(!shapeshift_type)
 			var/list/animal_list = list()
+			var/list/display_animals = list()
 			for(var/path in possible_shapes)
-				var/mob/living/simple_animal/A = path
-				animal_list[initial(A.name)] = path
-			var/new_shapeshift_type = input(M, "Choose Your Animal Form!", "It's Morphing Time!", null) as null|anything in sortList(animal_list)
+				var/mob/living/simple_animal/animal = path
+				animal_list[initial(animal.name)] = path
+				var/image/animal_image = image(icon = initial(animal.icon), icon_state = initial(animal.icon_state))
+				display_animals += list(initial(animal.name) = animal_image)
+			sortList(display_animals)
+			var/new_shapeshift_type = show_radial_menu(M, M, display_animals, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 38, require_near = TRUE)
 			if(shapeshift_type)
 				return
 			shapeshift_type = new_shapeshift_type
@@ -71,6 +75,19 @@
 				M.death()
 				qdel(M)
 				return
+
+/**
+  * check_menu: Checks if we are allowed to interact with a radial menu
+  *
+  * Arguments:
+  * * user The mob interacting with a menu
+  */
+/obj/effect/proc_holder/spell/targeted/shapeshift/proc/check_menu(mob/user)
+	if(!istype(user))
+		return FALSE
+	if(user.incapacitated())
+		return FALSE
+	return TRUE
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/proc/Shapeshift(mob/living/caster)
 	var/obj/shapeshift_holder/H = locate() in caster


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR makes shapeshift spell use a radial menu for choosing transformations, instead of navigating in the input menu with no preview of how given transformation even looks like.

Example image:

![ShapeRadialWizard](https://user-images.githubusercontent.com/43862960/89329051-9616d400-d68e-11ea-8407-c788b24e3e75.png)

## Why It's Good For The Game

Better spell usability.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arkatos
add: Shapeshift spell now uses a radial menu for choosing transformations.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
