### PR TITLE
Allows blind people to touch things to examine them

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -190,7 +190,8 @@
 		if (!Adjacent(user))
 			return
 		if (user.a_intent == INTENT_HELP)
-			user.examinate(src)
+			if(!user.is_blind())
+				user.examinate(src)
 			return
 		user.visible_message("<span class='danger'>[user] kicks the display case.</span>", null, null, COMBAT_MESSAGE_RANGE)
 		log_combat(user, src, "kicks")

--- a/code/game/objects/structures/plaques/_plaques.dm
+++ b/code/game/objects/structures/plaques/_plaques.dm
@@ -33,7 +33,7 @@
 
 /obj/structure/plaque/attack_hand(mob/user)
 	. = ..()
-	if(.)
+	if(. || user.is_blind())
 		return
 	user.examinate(src)
 

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -49,7 +49,7 @@
 
 /obj/structure/sign/attack_hand(mob/user)
 	. = ..()
-	if(.)
+	if(. || user.is_blind())
 		return
 	user.examinate(src)
 

--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -140,7 +140,7 @@ GLOBAL_LIST(labor_sheet_values)
 
 /obj/machinery/mineral/labor_points_checker/attack_hand(mob/user)
 	. = ..()
-	if(.)
+	if(. || user.is_blind())
 		return
 	user.examinate(src)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -447,10 +447,15 @@
 		return
 
 	if(is_blind()) //blind people see things differently (through touch)
-		//need to be next to something, awake, on help intent, and have an empty hand
-		if(!in_range(A, src) || incapacitated() || a_intent != INTENT_HELP || LAZYLEN(do_afters) >= get_num_arms() || get_active_held_item())
+		//need to be next to something and awake
+		if(!in_range(A, src) || incapacitated())
 			to_chat(src, "<span class='warning'>Something is there, but you can't see it!</span>")
 			return
+		//also neeed an empty hand, and you can only initiate as many examines as you have hands
+		if(LAZYLEN(do_afters) >= get_num_arms() || get_active_held_item())
+			to_chat(src, "<span class='warning'>You don't have a free hand to examine this!</span>")
+			return
+		//can only queue up one examine on something at a time
 		if(A in do_afters)
 			return
 
@@ -469,8 +474,13 @@
 		if(examine_delay_length > 0 && !do_after(src, examine_delay_length, target = A))
 			to_chat(src, "<span class='notice'>You can't get a good feel for what is there.</span>")
 			return
-		//now we go ahead and touch it with our hand
+
+		//now we touch the thing we're examining
+		/// our current intent, so we can go back to it after touching
+		var/previous_intent = a_intent
+		a_intent = INTENT_HELP
 		A.attack_hand(src)
+		a_intent = previous_intent
 
 	face_atom(A)
 	var/list/result

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -446,9 +446,31 @@
 		// shift-click catcher may issue examinate() calls for out-of-sight turfs
 		return
 
-	if(is_blind())
-		to_chat(src, "<span class='warning'>Something is there but you can't see it!</span>")
-		return
+	if(is_blind()) //blind people see things differently (through touch)
+		//need to be next to something, awake, on help intent, and have an empty hand
+		if(!in_range(A, src) || incapacitated() || a_intent != INTENT_HELP || LAZYLEN(do_afters) >= get_num_arms() || get_active_held_item())
+			to_chat(src, "<span class='warning'>Something is there, but you can't see it!</span>")
+			return
+		if(A in do_afters)
+			return
+
+		to_chat(src, "<span class='notice'>You start feeling around for something...</span>")
+		visible_message("<span class='notice'> [name] begins feeling around for \the [A.name]...</span>")
+
+		/// how long it takes for the blind person to find the thing they're examining
+		var/examine_delay_length = rand(1 SECONDS, 2 SECONDS)
+		if(client?.recent_examines && client?.recent_examines[A]) //easier to find things we just touched
+			examine_delay_length = 0.5 SECONDS
+		else if(isobj(A))
+			examine_delay_length *= 1.5
+		else if(ismob(A) && A != src)
+			examine_delay_length *= 2
+
+		if(examine_delay_length > 0 && !do_after(src, examine_delay_length, target = A))
+			to_chat(src, "<span class='notice'>You can't get a good feel for what is there.</span>")
+			return
+		//now we go ahead and touch it with our hand
+		A.attack_hand(src)
 
 	face_atom(A)
 	var/list/result


### PR DESCRIPTION
## About The Pull Request

Allows blind people to shift-click examine on things in touch range. If they have an empty hand, a do_after will begin, allowing them to examine things if successful.

Also goes through and prevents some looping examines for blind people.

## Why It's Good For The Game

A lot of things are placed in examine text, such as keybinds or information, or if a player is SSD or catatonic. This lets players who are blinded figure out some of these things while also giving them some more interesting flavor (for example, managing to examine a supermatter crystal will dust you).

## Changelog
:cl: Melbert
add: NanoTrasen has added braille support to literally everything. If a blind person has an empty hand, they can now shift-click examine (or right click -> examine) nearby things via touch after a short timer.
/:cl:
