### PR TITLE
Lets aloe cream autorepeat when healing

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -195,8 +195,8 @@
 	icon_state = "suture"
 	self_delay = 30
 	other_delay = 10
-	amount = 10
-	max_amount = 10
+	amount = 15
+	max_amount = 15
 	repeating = TRUE
 	heal_brute = 10
 	stop_bleeding = 0.6
@@ -215,7 +215,7 @@
 	desc = "A suture infused with drugs that speed up wound healing of the treated laceration."
 	heal_brute = 15
 	stop_bleeding = 0.75
-	grind_results = list(/datum/reagent/medicine/polypyr = 2)
+	grind_results = list(/datum/reagent/medicine/polypyr = 1)
 
 /obj/item/stack/medical/suture/heal(mob/living/M, mob/user)
 	. = ..()
@@ -357,12 +357,15 @@
 	name = "aloe cream"
 	desc = "A healing paste you can apply on wounds."
 
+	gender = PLURAL
+	singular_name = "aloe cream"
 	icon_state = "aloe_paste"
 	self_delay = 20
 	other_delay = 10
 	novariants = TRUE
 	amount = 20
 	max_amount = 20
+	repeating = TRUE
 	var/heal = 3
 	grind_results = list(/datum/reagent/consumable/aloejuice = 1)
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -195,8 +195,8 @@
 	icon_state = "suture"
 	self_delay = 30
 	other_delay = 10
-	amount = 15
-	max_amount = 15
+	amount = 10
+	max_amount = 10
 	repeating = TRUE
 	heal_brute = 10
 	stop_bleeding = 0.6


### PR DESCRIPTION
## About The Pull Request

Allows aloe cream to automatically repeat on application. Also minor grammar stuff.

## Why It's Good For The Game

~~In #50558, the stack size of sutures was reduced from 15 down to 10. Not only does this appear to be a mistake (not referenced anywhere in the changelog, appears to be a holdover from an early version of the PR where all sutures on station were replaced with the botany sutures), but it made the already poor healing density of sutures even worse. I don't think changing the stack size back to 15 is unreasonable, especially given that they're now important for stopping bleeding.~~

As for the aloe cream, it currently sucks to actually heal anyone with it due to the amount of clicking required. Making it autorepeat like every other healing item solves this issue.

## Changelog
:cl: Bumtickley00
fix: Medicated sutures no longer yield more polypyr than it takes to make them when ground
tweak: Aloe cream now automatically repeats when healing
spellcheck: Aloe cream is no longer referred to as "medical stack" in the description
/:cl: