### PR TITLE
Adds a signal for storage exit and insert, uses it to make trading cards zoom properly

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -166,6 +166,10 @@
 #define COMSIG_ATOM_ATTACK_PAW "atom_attack_paw"
 	#define COMPONENT_NO_ATTACK_HAND (1<<0)								//works on all 3.
 //This signal return value bitflags can be found in __DEFINES/misc.dm
+//from base of atom/movable/on_enter_storage(): (datum/component/storage/concrete/S)
+#define COMISG_STORAGE_ENTERED "storage_entered"
+//from base of atom/movable/on_exit_storage(): (datum/component/storage/concrete/S)
+#define CONSIG_STORAGE_EXITED "storage_exited"
 
 ///from base of atom/expose_reagents():
 #define COMSIG_ATOM_EXPOSE_REAGENTS "atom_expose_reagents"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -166,9 +166,9 @@
 #define COMSIG_ATOM_ATTACK_PAW "atom_attack_paw"
 	#define COMPONENT_NO_ATTACK_HAND (1<<0)								//works on all 3.
 //This signal return value bitflags can be found in __DEFINES/misc.dm
-//from base of atom/movable/on_enter_storage(): (datum/component/storage/concrete/S)
+//from base of atom/movable/on_enter_storage(): (datum/component/storage/concrete/master_storage)
 #define COMISG_STORAGE_ENTERED "storage_entered"
-//from base of atom/movable/on_exit_storage(): (datum/component/storage/concrete/S)
+//from base of atom/movable/on_exit_storage(): (datum/component/storage/concrete/master_storage)
 #define CONSIG_STORAGE_EXITED "storage_exited"
 
 ///from base of atom/expose_reagents():

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -740,14 +740,12 @@
 	return blocker_opinion
 
 /// called when this atom is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.
-/atom/movable/proc/on_exit_storage(datum/component/storage/concrete/S)
-	SEND_SIGNAL(src, CONSIG_STORAGE_EXITED)
-	return
+/atom/movable/proc/on_exit_storage(datum/component/storage/concrete/master_storage)
+	SEND_SIGNAL(src, CONSIG_STORAGE_EXITED, master_storage)
 
 /// called when this atom is added into a storage item, which is passed on as S. The loc variable is already set to the storage item.
-/atom/movable/proc/on_enter_storage(datum/component/storage/concrete/S)
-	SEND_SIGNAL(src, COMISG_STORAGE_ENTERED)
-	return
+/atom/movable/proc/on_enter_storage(datum/component/storage/concrete/master_storage)
+	SEND_SIGNAL(src, COMISG_STORAGE_ENTERED, master_storage)
 
 /atom/movable/proc/get_spacemove_backup()
 	var/atom/movable/dense_object_backup

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -741,10 +741,12 @@
 
 /// called when this atom is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.
 /atom/movable/proc/on_exit_storage(datum/component/storage/concrete/S)
+	SEND_SIGNAL(src, CONSIG_STORAGE_EXITED)
 	return
 
 /// called when this atom is added into a storage item, which is passed on as S. The loc variable is already set to the storage item.
 /atom/movable/proc/on_enter_storage(datum/component/storage/concrete/S)
+	SEND_SIGNAL(src, COMISG_STORAGE_ENTERED)
 	return
 
 /atom/movable/proc/get_spacemove_backup()

--- a/code/game/objects/items/tcg/tcg.dm
+++ b/code/game/objects/items/tcg/tcg.dm
@@ -22,7 +22,9 @@ GLOBAL_LIST_EMPTY(cached_cards)
 
 /obj/item/tcgcard/Initialize(mapload, datum_series, datum_id)
 	. = ..()
-	transform = matrix(0.3,0,0,0,0.3,0)
+	zoom_out()
+	RegisterSignal(src, COMISG_STORAGE_ENTERED, .proc/zoom_in)
+	RegisterSignal(src, CONSIG_STORAGE_EXITED, .proc/zoom_out)
 	//If they are passed as null let's replace them with the vars on the card. this also means we can allow for map loaded ccards
 	if(!datum_series)
 		datum_series = series
@@ -57,10 +59,16 @@ GLOBAL_LIST_EMPTY(cached_cards)
 
 /obj/item/tcgcard/equipped(mob/user, slot, initial)
 	. = ..()
-	transform = matrix()
+	zoom_in()
 
 /obj/item/tcgcard/dropped(mob/user, silent)
 	. = ..()
+	zoom_out()
+
+/obj/item/tcgcard/proc/zoom_in()
+	transform = matrix()
+
+/obj/item/tcgcard/proc/zoom_out()
 	transform = matrix(0.3,0,0,0,0.3,0)
 
 /obj/item/cardpack
@@ -116,7 +124,9 @@ GLOBAL_LIST_EMPTY(cached_cards)
 
 /obj/item/cardpack/Initialize()
 	. = ..()
-	transform = matrix(0.4,0,0,0,0.4,0)
+	zoom_out()
+	RegisterSignal(src, COMISG_STORAGE_ENTERED, .proc/zoom_in)
+	RegisterSignal(src, CONSIG_STORAGE_EXITED, .proc/zoom_out)
 	//Pass by refrance moment
 	//This lets us only have one rarity table per pack, badmins beware
 	if(GLOB.cached_rarity_table[type])
@@ -130,10 +140,16 @@ GLOBAL_LIST_EMPTY(cached_cards)
 
 /obj/item/cardpack/equipped(mob/user, slot, initial)
 	. = ..()
-	transform = matrix()
+	zoom_in()
 
 /obj/item/cardpack/dropped(mob/user, silent)
 	. = ..()
+	zoom_out()
+
+/obj/item/cardpack/proc/zoom_in()
+	transform = matrix()
+
+/obj/item/cardpack/proc/zoom_out()
 	transform = matrix(0.4,0,0,0,0.4,0)
 
 /obj/item/cardpack/attack_self(mob/user)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds a signal to the base of on_exit/enter_storage(), uses it to make trading cards zoom in properly

## Why It's Good For The Game

I want my cards fullscreen in the backpack damnit 

## Changelog
:cl:
add: Trading cards will now ZOOM AND ENHANCE in your bag properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
