### PR TITLE
[Untested] You can now spray paint lights again

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -303,6 +303,8 @@
 	if(start_with_cell && !no_emergency)
 		cell = new/obj/item/stock_parts/cell/emergency_light(src)
 
+	AddComponent(/datum/component/spraycan_paintable) //so that you can spraypaint lights to create mood lighting
+	
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/light/LateInitialize()


### PR DESCRIPTION
## About The Pull Request

Gives the spraycan_paintable component to /obj/machinery/light and its subtypes.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/42606352/89399159-b4ed8880-d6d7-11ea-95ca-dff5e6bc9498.png)

![image](https://user-images.githubusercontent.com/42606352/89399219-c59dfe80-d6d7-11ea-99a3-fb92834c0118.png)


## Changelog
:cl: ATHATH
add: You can now spray paint lights again.
/:cl: