### PR TITLE
makes lizards more robust than humans

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -17,6 +17,8 @@
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
+	punchdamagelow = 3
+	punchdamagehigh = 15 //they have claws, so they can deal a teensy bit more damage than a human can while unarmed
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard
 	skinned_type = /obj/item/stack/sheet/animalhide/lizard
 	exotic_bloodtype = "L"


### PR DESCRIPTION
## About The Pull Request

Lizards have claws. They get a different attack adjective when they hit someone unarmed. Now, they deal a teensy-weensy little bit more damage (minimum 3 brute, maximum 15 brute on a lucky hit) on unarmed attacks compared to human punches (minimum 1 brute, maximum 10 brute on a lucky hit)

It does nothing else. Knockdown chances are exactly the same, attacking with a melee weapon or firearm is exactly the same.

## Why It's Good For The Game

A lot of the races we have now lack a lot of interesting changes that make them feel unique. Adding interesting quirks to these races that have been nerfed through the ground will help them regain a bit of their luster. While we don't need to give laser eyes to moths to make them unique, having little quirks like this will make them feel more alive.

also stupid humie fist punchings dont hurt as much as sharp claws through flesh

## Changelog
:cl:
tweak: Lizardpeople claws have been sharpened, and now deal slightly more damage in unarmed combat compared to the human fist.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
