### PR TITLE
Pipe cleaner cable color fix

### DIFF
--- a/code/modules/power/pipecleaners.dm
+++ b/code/modules/power/pipecleaners.dm
@@ -203,7 +203,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	grind_results = list("copper" = 2) //2 copper per pipe_cleaner in the coil
 	usesound = 'sound/items/deconstruct.ogg'
 	/// Currently set cable color
-	var/pipe_cleaner_color = "red"
+	var/pipe_cleaner_color = COLOR_RED
 
 /obj/item/stack/pipe_cleaner_coil/cyborg
 	is_cyborg = 1
@@ -211,7 +211,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	cost = 1
 
 /obj/item/stack/pipe_cleaner_coil/cyborg/attack_self(mob/user)
-	var/selected_color = input(user, "Pick a pipe cleaner color.", "Cable Color") in sortList(list("red", "yellow", "green", "blue", "pink", "orange", "cyan", "white"))
+	var/selected_color = input(user, "Pick a pipe cleaner color.", "Cable Color") in list("red", "yellow", "green", "blue", "pink", "orange", "cyan", "white")
 	pipe_cleaner_color = GLOB.pipe_cleaner_colors[selected_color]
 	update_icon()
 

--- a/code/modules/power/pipecleaners.dm
+++ b/code/modules/power/pipecleaners.dm
@@ -211,7 +211,9 @@ By design, d1 is the smallest direction and d2 is the highest
 	cost = 1
 
 /obj/item/stack/pipe_cleaner_coil/cyborg/attack_self(mob/user)
-	var/selected_color = input(user, "Pick a pipe cleaner color.", "Cable Color") in list("red", "yellow", "green", "blue", "pink", "orange", "cyan", "white")
+	var/selected_color = input(user, "Pick a pipe cleaner color.", "Cable Color") as null|anything in list("blue", "cyan", "green", "orange", "pink", "red", "white", "yellow")
+	if(!selected_color)
+		return
 	pipe_cleaner_color = GLOB.pipe_cleaner_colors[selected_color]
 	update_icon()
 

--- a/code/modules/power/pipecleaners.dm
+++ b/code/modules/power/pipecleaners.dm
@@ -190,7 +190,6 @@ By design, d1 is the smallest direction and d2 is the highest
 	max_amount = MAXCOIL
 	amount = MAXCOIL
 	merge_type = /obj/item/stack/pipe_cleaner_coil // This is here to let its children merge between themselves
-	var/pipe_cleaner_color = "red"
 	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 3
@@ -203,6 +202,8 @@ By design, d1 is the smallest direction and d2 is the highest
 	full_w_class = WEIGHT_CLASS_SMALL
 	grind_results = list("copper" = 2) //2 copper per pipe_cleaner in the coil
 	usesound = 'sound/items/deconstruct.ogg'
+	/// Currently set cable color
+	var/pipe_cleaner_color = "red"
 
 /obj/item/stack/pipe_cleaner_coil/cyborg
 	is_cyborg = 1
@@ -210,8 +211,8 @@ By design, d1 is the smallest direction and d2 is the highest
 	cost = 1
 
 /obj/item/stack/pipe_cleaner_coil/cyborg/attack_self(mob/user)
-	var/pipe_cleaner_color = input(user,"Pick a pipe cleaner color.","Cable Color") in sortList(list("red","yellow","green","blue","pink","orange","cyan","white"))
-	pipe_cleaner_color = pipe_cleaner_color
+	var/selected_color = input(user, "Pick a pipe cleaner color.", "Cable Color") in sortList(list("red", "yellow", "green", "blue", "pink", "orange", "cyan", "white"))
+	pipe_cleaner_color = GLOB.pipe_cleaner_colors[selected_color]
 	update_icon()
 
 /obj/item/stack/pipe_cleaner_coil/suicide_act(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes a bug where service cyborgs were unable to set a color of the pipe cleaner cable they possess due to not setting an actual color code for a cable colorization and a duplicit name variable.

Also adds an option for cancelling color choosing input as per maintainer suggestion.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arkatos
fix: Service cyborgs are now able to properly set a pipe cleaner cable color for their art needs.
tweak: Service cyborgs can now cancel color choosing input for pipe cleaner cables in case they have changed their minds about it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
