### PR TITLE
Dental implant remote signaling devices!

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -126,6 +126,10 @@
 				for(var/datum/action/item_action/hands_free/activate_signaler/AS in M.actions)
 					sig_count++
 
+				var/anom_count = 0
+				for(var/datum/action/item_action/hands_free/showoff/SO in M.actions)
+					anom_count++
+
 				if(M == user)
 					var/can_use_mirror = FALSE
 					if(isturf(user.loc))
@@ -154,6 +158,8 @@
 						to_chat(user, "<span class='notice'>You have [pill_count] implanted pill[pill_count > 1 ? "s" : ""].</span>")
 					if(sig_count)
 						to_chat(user, "<span class='notice'>You have [sig_count] implanted signaling device[sig_count > 1 ? "s" : ""].</span>")
+					if(anom_count)
+						to_chat(user, "<span class='notice'>You have [anom_count] anomaly core[anom_count > 1 ? "s" : ""] decorating your smile. Looking good!</span>")
 
 				else
 					user.visible_message("<span class='notice'>[user] directs [src] to [M]'s mouth.</span>",\
@@ -166,6 +172,17 @@
 						to_chat(user, "<span class='notice'>[M] has [pill_count] pill[pill_count > 1 ? "s" : ""] implanted in [their] teeth.</span>")
 					if(sig_count)
 						to_chat(user, "<span class='notice'>[M] has [sig_count] signaling device[sig_count > 1 ? "s" : ""] implanted in [their] teeth.</span>")
+					if(anom_count)
+						var/nice = ""
+						if(anom_count < 3)
+							nice = "Nice."
+						else if(anom_count < 5)
+							nice = "Nice!"
+						else if(anom_count < 33)
+							nice = "NICE!!"
+						else
+							nice = "That's more than humans have teeth, HOLY SHIT!!"
+						to_chat(user, "<span class='notice'>[M] has [anom_count] anomaly core[sig_count > 1 ? "s" : ""] decorating their grin. [nice]</span>")
 
 	else
 		return ..()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -122,6 +122,10 @@
 				for(var/datum/action/item_action/hands_free/activate_pill/AP in M.actions)
 					pill_count++
 
+				var/sig_count = 0
+				for(var/datum/action/item_action/hands_free/activate_signaler/AS in M.actions)
+					sig_count++
+
 				if(M == user)
 					var/can_use_mirror = FALSE
 					if(isturf(user.loc))
@@ -148,6 +152,8 @@
 						to_chat(user, "<span class='notice'>There's nothing inside your mouth.</span>")
 					if(pill_count)
 						to_chat(user, "<span class='notice'>You have [pill_count] implanted pill[pill_count > 1 ? "s" : ""].</span>")
+					if(sig_count)
+						to_chat(user, "<span class='notice'>You have [sig_count] implanted signaling device[sig_count > 1 ? "s" : ""].</span>")
 
 				else
 					user.visible_message("<span class='notice'>[user] directs [src] to [M]'s mouth.</span>",\
@@ -158,6 +164,8 @@
 						to_chat(user, "<span class='notice'>[M] doesn't have any organs in [their] mouth.</span>")
 					if(pill_count)
 						to_chat(user, "<span class='notice'>[M] has [pill_count] pill[pill_count > 1 ? "s" : ""] implanted in [their] teeth.</span>")
+					if(sig_count)
+						to_chat(user, "<span class='notice'>[M] has [sig_count] signaling device[sig_count > 1 ? "s" : ""] implanted in [their] teeth.</span>")
 
 	else
 		return ..()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -175,14 +175,14 @@
 					if(anom_count)
 						var/nice = ""
 						if(anom_count < 3)
-							nice = "Nice."
+							nice = " Nice."
 						else if(anom_count < 5)
-							nice = "Nice!"
+							nice = " Nice!"
 						else if(anom_count < 33)
-							nice = "NICE!!"
+							nice = " NICE!!"
 						else
-							nice = "That's more than humans have teeth, HOLY SHIT!!"
-						to_chat(user, "<span class='notice'>[M] has [anom_count] anomaly core[sig_count > 1 ? "s" : ""] decorating their grin. [nice]</span>")
+							nice = " That's more than humans have teeth, HOLY SHIT!!"
+						to_chat(user, "<span class='notice'>[M] has [anom_count] anomaly core[sig_count > 1 ? "s" : ""] decorating their grin.[nice]</span>")
 
 	else
 		return ..()

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -307,6 +307,11 @@
 		var/obj/pill = AP.target
 		if(pill)
 			pill.forceMove(src)
+	for(var/datum/action/item_action/hands_free/activate_signaler/AS in owner.actions)
+		AS.Remove(owner)
+		var/obj/sig = AS.target
+		if(sig)
+			sig.forceMove(src)
 
 	//Make sure de-zombification happens before organ removal instead of during it
 	var/obj/item/organ/zombie_infection/ooze = owner.getorganslot(ORGAN_SLOT_ZOMBIE)
@@ -423,6 +428,11 @@
 		for(var/datum/action/item_action/hands_free/activate_pill/AP in P.actions)
 			P.forceMove(C)
 			AP.Grant(C)
+			break
+	for(var/obj/item/assembly/signaler/S in src)
+		for(var/datum/action/item_action/hands_free/activate_signaler/AS in S.actions)
+			S.forceMove(C)
+			AS.Grant(C)
 			break
 
 	C.updatehealth()

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -312,6 +312,11 @@
 		var/obj/sig = AS.target
 		if(sig)
 			sig.forceMove(src)
+	for(var/datum/action/item_action/hands_free/showoff/SO in owner.actions)
+		SO.Remove(owner)
+		var/obj/anom = SO.target
+		if(anom)
+			anom.forceMove(src)
 
 	//Make sure de-zombification happens before organ removal instead of during it
 	var/obj/item/organ/zombie_infection/ooze = owner.getorganslot(ORGAN_SLOT_ZOMBIE)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -310,8 +310,7 @@
 	for(var/datum/action/item_action/hands_free/activate_signaler/AS in owner.actions)
 		AS.Remove(owner)
 		var/obj/sig = AS.target
-		if(sig)
-			sig.forceMove(src)
+		sig?.forceMove(src)
 	for(var/datum/action/item_action/hands_free/showoff/SO in owner.actions)
 		SO.Remove(owner)
 		var/obj/anom = SO.target

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -314,8 +314,7 @@
 	for(var/datum/action/item_action/hands_free/showoff/SO in owner.actions)
 		SO.Remove(owner)
 		var/obj/anom = SO.target
-		if(anom)
-			anom.forceMove(src)
+		anom?.forceMove(src)
 
 	//Make sure de-zombification happens before organ removal instead of during it
 	var/obj/item/organ/zombie_infection/ooze = owner.getorganslot(ORGAN_SLOT_ZOMBIE)

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -123,6 +123,8 @@
 		else if(istype(I, /obj/item/assembly/signaler))
 			for(var/datum/action/item_action/hands_free/activate_signaler/AS in I.actions)
 				qdel(AS)
+			for(var/datum/action/item_action/hands_free/showoff/SO in I.actions)
+				qdel(SO)
 		I.forceMove(T)
 	eyes = null
 	ears = null

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -117,11 +117,13 @@
 			brain.forceMove(T)
 			brain = null
 			update_icon_dropped()
-		else
-			if(istype(I, /obj/item/reagent_containers/pill))
-				for(var/datum/action/item_action/hands_free/activate_pill/AP in I.actions)
-					qdel(AP)
-			I.forceMove(T)
+		else if(istype(I, /obj/item/reagent_containers/pill))
+			for(var/datum/action/item_action/hands_free/activate_pill/AP in I.actions)
+				qdel(AP)
+		else if(istype(I, /obj/item/assembly/signaler))
+			for(var/datum/action/item_action/hands_free/activate_signaler/AS in I.actions)
+				qdel(AS)
+		I.forceMove(T)
 	eyes = null
 	ears = null
 	tongue = null

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -1,31 +1,38 @@
 /datum/surgery/dental_implant
 	name = "Dental implant"
-	steps = list(/datum/surgery_step/drill, /datum/surgery_step/insert_pill)
+	steps = list(/datum/surgery_step/drill, /datum/surgery_step/insert_object)
 	possible_locs = list(BODY_ZONE_PRECISE_MOUTH)
 
-/datum/surgery_step/insert_pill
-	name = "insert pill"
-	implements = list(/obj/item/reagent_containers/pill = 100)
+/datum/surgery_step/insert_object
+	name = "insert pill or signaling device"
+	implements = list(/obj/item/reagent_containers/pill = 100, /obj/item/assembly/signaler = 100)
 	time = 16
 
-/datum/surgery_step/insert_pill/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/insert_object/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, "<span class='notice'>You begin to wedge [tool] in [target]'s [parse_zone(target_zone)]...</span>",
 			"<span class='notice'>[user] begins to wedge \the [tool] in [target]'s [parse_zone(target_zone)].</span>",
 			"<span class='notice'>[user] begins to wedge something in [target]'s [parse_zone(target_zone)].</span>")
 
-/datum/surgery_step/insert_pill/success(mob/user, mob/living/carbon/target, target_zone, obj/item/reagent_containers/pill/tool, datum/surgery/surgery, default_display_results = FALSE)
+/datum/surgery_step/insert_object/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	if(!istype(tool))
 		return 0
 
 	user.transferItemToLoc(tool, target, TRUE)
 
-	var/datum/action/item_action/hands_free/activate_pill/P = new(tool)
-	P.button.name = "Activate [tool.name]"
-	P.target = tool
-	P.Grant(target)	//The pill never actually goes in an inventory slot, so the owner doesn't inherit actions from it
+	if(istype(tool,/obj/item/reagent_containers/pill))
+		var/datum/action/item_action/hands_free/activate_pill/P = new(tool)
+		P.button.name = "Activate [tool.name]"
+		P.target = tool
+		P.Grant(target)	//The pill never actually goes in an inventory slot, so the owner doesn't inherit actions from it
+
+	else if(tool.type == /obj/item/assembly/signaler)
+		var/datum/action/item_action/hands_free/activate_signaler/S = new(tool)
+		S.button.name = "Activate [tool.name]"
+		S.target = tool
+		S.Grant(target)
 
 	display_results(user, target, "<span class='notice'>You wedge [tool] into [target]'s [parse_zone(target_zone)].</span>",
-			"<span class='notice'>[user] wedges \the [tool] into [target]'s [parse_zone(target_zone)]!</span>",
+			"<span class='notice'>[user] wedges the [tool] into [target]'s [parse_zone(target_zone)]!</span>",
 			"<span class='notice'>[user] wedges something into [target]'s [parse_zone(target_zone)]!</span>")
 	return ..()
 
@@ -40,4 +47,17 @@
 	if(target.reagents.total_volume)
 		target.reagents.trans_to(owner, target.reagents.total_volume, transfered_by = owner, method = INGEST)
 	qdel(target)
+	return TRUE
+
+/datum/action/item_action/hands_free/activate_signaler
+	name = "Activate Signaling Device"
+
+/datum/action/item_action/hands_free/activate_signaler/Trigger()
+	if(!..())
+		return FALSE
+	var/obj/item/assembly/signaler/sig = target
+	to_chat(owner, "<span class='notice'>You slide your jaw and hear a dull click.</span>")
+	log_combat(owner, null, "activated an implanted signaling device [format_frequency(sig.frequency)]", target)
+	if(sig && sig.next_activate <= world.time)
+		sig.pulsed()
 	return TRUE

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -53,9 +53,13 @@
 	name = "Activate Signaling Device"
 
 /datum/action/item_action/hands_free/activate_signaler/Trigger()
+	var/mob/living/carbon/C = owner
 	if(!..())
 		return FALSE
 	var/obj/item/assembly/signaler/sig = target
+	if(C.InCritical()) // Presently not needed, since apparently you can't activate pill implants while in crit, but futureproofing
+		to_chat(owner, "<span class='notice'>You slide your jaw weakly...</span>")
+		return FALSE
 	to_chat(owner, "<span class='notice'>You slide your jaw and hear a dull click.</span>")
 	log_combat(owner, null, "activated an implanted signaling device [format_frequency(sig.frequency)]", target)
 	if(sig && sig.next_activate <= world.time)

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -9,8 +9,13 @@
 	time = 16
 
 /datum/surgery_step/insert_object/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(tool.type == /obj/item/assembly/signaler/)
+		var/obj/item/assembly/signaler/sig = tool
+		if(!sig.secured)
+			to_chat(user, "<span class='warning'>The [tool] is unsecured!</span>")
+			return -1
 	display_results(user, target, "<span class='notice'>You begin to wedge [tool] in [target]'s [parse_zone(target_zone)]...</span>",
-			"<span class='notice'>[user] begins to wedge \the [tool] in [target]'s [parse_zone(target_zone)].</span>",
+			"<span class='notice'>[user] begins to wedge the [tool] in [target]'s [parse_zone(target_zone)].</span>",
 			"<span class='notice'>[user] begins to wedge something in [target]'s [parse_zone(target_zone)].</span>")
 
 /datum/surgery_step/insert_object/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
@@ -28,6 +33,12 @@
 	else if(tool.type == /obj/item/assembly/signaler)
 		var/datum/action/item_action/hands_free/activate_signaler/S = new(tool)
 		S.button.name = "Activate [tool.name]"
+		S.target = tool
+		S.Grant(target)
+
+	else if(istype(tool,/obj/item/assembly/signaler/anomaly))
+		var/datum/action/item_action/hands_free/showoff/S = new(tool)
+		S.button.name = "Show off your [tool.name]"
 		S.target = tool
 		S.Grant(target)
 
@@ -61,3 +72,11 @@
 	if(sig && sig.next_activate <= world.time)
 		sig.pulsed()
 	return TRUE
+
+/datum/action/item_action/hands_free/showoff
+	name = "Show Off Implant"
+
+/datum/action/item_action/hands_free/showoff/Trigger()
+	if(!..())
+		return FALSE
+	owner.visible_message("<span class='notice'>[owner] shows off [owner.p_their()] dental [target.name] with a [pick("cheeky", "cocky", "smug")] grin. [pick("Nice!", "Classy!", "Swanky!")]")

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -53,13 +53,9 @@
 	name = "Activate Signaling Device"
 
 /datum/action/item_action/hands_free/activate_signaler/Trigger()
-	var/mob/living/carbon/C = owner
 	if(!..())
 		return FALSE
 	var/obj/item/assembly/signaler/sig = target
-	if(C.InCritical()) // Presently not needed, since apparently you can't activate pill implants while in crit, but futureproofing
-		to_chat(owner, "<span class='notice'>You slide your jaw weakly...</span>")
-		return FALSE
 	to_chat(owner, "<span class='notice'>You slide your jaw and hear a dull click.</span>")
 	log_combat(owner, null, "activated an implanted signaling device [format_frequency(sig.frequency)]", target)
 	if(sig && sig.next_activate <= world.time)

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -64,8 +64,9 @@
 	name = "Activate Signaling Device"
 
 /datum/action/item_action/hands_free/activate_signaler/Trigger()
-	if(!..())
-		return FALSE
+	. = ..()
+	if(!.)
+		return
 	var/obj/item/assembly/signaler/sig = target
 	to_chat(owner, "<span class='notice'>You slide your jaw and hear a dull click.</span>")
 	log_combat(owner, null, "activated an implanted signaling device [format_frequency(sig.frequency)]", target)

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -78,6 +78,7 @@
 	name = "Show Off Implant"
 
 /datum/action/item_action/hands_free/showoff/Trigger()
-	if(!..())
-		return FALSE
+	. = ..()
+	if(!.)
+		return
 	owner.visible_message("<span class='notice'>[owner] shows off [owner.p_their()] dental [target.name] with a [pick("cheeky", "cocky", "smug")] grin. [pick("Nice!", "Classy!", "Swanky!")]")


### PR DESCRIPTION
## About The Pull Request

With that PR nerfing voice analysers and grenade triggers in general, I had the idea of a replacement to the time-honoured tradition of code word activated suicide bombs being something that requires the participation of a second human being, making it less, you know, easy to achieve.

The dental implant surgery, previously only allowing pills to be implanted for easy "oh shit I'm dying" heals, now allows you to insert walkie-talkie sized remote signalers into your teeth! How convenient!

You can also insert anomaly cores, and for some reason they don't even show up with an action button, but there's no reason to other than, I guess, having a treasure trove of valuable items lining your teef?

Includes changes to all the references to implanted pills I could find, removing them from heads, and checking someone's mouth with a torch.

There's no way to remove them without cutting apart a severed head, which is the same for implanted pills, except that obviously you can just, swallow the pills to get rid of them; but this really shouldn't matter, I doubt many people will ever have more than 1 signaler at once. Also is signaler misspelled? Should it be signaller?

## Changelog
:cl:
add: The Dental Implant surgery can now be used to implant Remote Signaling Devices into someone's teeth, enabling hands-free activation of the device by pushing the button with your teeth.
add: The Dental Implant surgery can now be used to implant Anomaly Cores into someone's teeth, enabling hands-free showing off your expensive fillings. See how many you can decorate your smile with!
/:cl: