### PR TITLE
Re-enables cyborg cameras through camera consoles and AI eye vision.

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -114,24 +114,24 @@
 	if(action == "switch_camera")
 		var/c_tag = params["name"]
 		var/list/cameras = get_available_cameras()
-		var/obj/machinery/camera/C = cameras[c_tag]
-		active_camera = C
+		var/obj/machinery/camera/selected_camera = cameras[c_tag]
+		active_camera = selected_camera
 		playsound(src, get_sfx("terminal_type"), 25, FALSE)
 
 		// Show static if can't use the camera
-		if(!active_camera?.can_use())
+		if(!selected_camera?.can_use())
 			show_camera_static()
 			return TRUE
 
 		var/list/visible_turfs = list()
 
 		// Is this camera located in or attached to a living thing? If so, assume the camera's loc is the living thing.
-		var/cam_location = isliving(C.loc) ? C.loc : C
+		var/cam_location = isliving(selected_camera.loc) ? selected_camera.loc : selected_camera
 
-		var/list/things = C.isXRay() ? range(C.view_range, cam_location) : view(C.view_range, cam_location)
+		var/list/visible_things = selected_camera.isXRay() ? range(selected_camera.view_range, cam_location) : view(selected_camera.view_range, cam_location)
 
-		for(var/turf/T in things)
-			visible_turfs += T
+		for(var/turf/visible_turf in visible_things)
+			visible_turfs += visible_turf
 
 		var/list/bbox = get_bbox_of_atoms(visible_turfs)
 		var/size_x = bbox[3] - bbox[1] + 1

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -124,9 +124,15 @@
 			return TRUE
 
 		var/list/visible_turfs = list()
-		for(var/turf/T in (C.isXRay() \
-				? range(C.view_range, C) \
-				: view(C.view_range, C)))
+
+		var/cam_location = C.loc
+
+		if(isliving(cam_location))
+			cam_location = C.loc
+
+		var/list/things = C.isXRay() ? range(C.view_range, cam_location) : view(C.view_range, cam_location)
+
+		for(var/turf/T in things)
 			visible_turfs += T
 
 		var/list/bbox = get_bbox_of_atoms(visible_turfs)

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -125,10 +125,8 @@
 
 		var/list/visible_turfs = list()
 
-		var/cam_location = C.loc
-
-		if(isliving(cam_location))
-			cam_location = C.loc
+		// Is this camera located in or attached to a living thing? If so, assume the camera's loc is the living thing.
+		var/cam_location = isliving(C.loc) ? C.loc : C
 
 		var/list/things = C.isXRay() ? range(C.view_range, cam_location) : view(C.view_range, cam_location)
 

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -112,7 +112,7 @@
 		if(c.can_use())
 			cameras += c
 
-	for(var/mob/living/silicon/robot/borgo in urange(CHUNK_SIZE, locate(x + (CHUNK_SIZE / 2), y + (CHUNK_SIZE / 2), z)))
+	for(var/mob/living/silicon/sillycone in urange(CHUNK_SIZE, locate(x + (CHUNK_SIZE / 2), y + (CHUNK_SIZE / 2), z)))
 		if(borgo.builtInCamera?.can_use())
 			cameras += borgo.builtInCamera
 

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -113,8 +113,8 @@
 			cameras += c
 
 	for(var/mob/living/silicon/sillycone in urange(CHUNK_SIZE, locate(x + (CHUNK_SIZE / 2), y + (CHUNK_SIZE / 2), z)))
-		if(borgo.builtInCamera?.can_use())
-			cameras += borgo.builtInCamera
+		if(sillycone.builtInCamera?.can_use())
+			cameras += sillycone.builtInCamera
 
 	for(var/turf/t in block(locate(max(x, 1), max(y, 1), z), locate(min(x + CHUNK_SIZE - 1, world.maxx), min(y + CHUNK_SIZE - 1, world.maxy), z)))
 		turfs[t] = t

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -112,6 +112,10 @@
 		if(c.can_use())
 			cameras += c
 
+	for(var/mob/living/silicon/robot/borgo in urange(CHUNK_SIZE, locate(x + (CHUNK_SIZE / 2), y + (CHUNK_SIZE / 2), z)))
+		if(borgo.builtInCamera?.can_use())
+			cameras += borgo.builtInCamera
+
 	for(var/turf/t in block(locate(max(x, 1), max(y, 1), z), locate(min(x + CHUNK_SIZE - 1, world.maxx), min(y + CHUNK_SIZE - 1, world.maxy), z)))
 		turfs[t] = t
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -149,6 +149,11 @@
 
 			playsound(src, 'sound/machines/warning-buzzer.ogg', 75, TRUE, TRUE)
 			audible_message("<span class='warning'>[src] sounds an alarm! \"CRITICAL ERROR: ALL modules OFFLINE.\"</span>")
+
+			if(builtInCamera)
+				builtInCamera.status = FALSE
+				to_chat(src, "<span class='userdanger'>CRITICAL ERROR: Built in security camera OFFLINE.</span>")
+
 			to_chat(src, "<span class='userdanger'>CRITICAL ERROR: ALL modules OFFLINE.</span>")
 
 		if(2)
@@ -175,7 +180,6 @@
 
 	return TRUE
 
-
 /**
   * Breaks all of a cyborg's slots.
   */
@@ -200,6 +204,9 @@
 
 			inv1.icon_state = initial(inv1.icon_state)
 			disabled_modules &= ~BORG_MODULE_ALL_DISABLED
+			if(builtInCamera)
+				builtInCamera.status = TRUE
+				to_chat(src, "<span class='notice'>You hear your built in security camera focus adjust as it comes back online!</span>")
 		if(2)
 			if(!(disabled_modules & BORG_MODULE_TWO_DISABLED))
 				return FALSE
@@ -388,3 +395,4 @@
 
 /mob/living/silicon/robot/swap_hand()
 	cycle_modules()
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Why is viewing through cyborg cameras broken for consoles?
![image](https://user-images.githubusercontent.com/24975989/89595155-b475fe80-d84b-11ea-94c9-049f4923e278.png)

Turns out cameras built into cyborgs can only see the contents of that cyborg as well as themselves and the cyborg itself.

They can see zero turfs. So the screen is just black.

### Camera Console Feex
I did a simple change; if the camera is located in a mob, we do the view check based on the mob itself. This still respects the camera's x-ray status.

Of course, if the camera isn't active (camera.can_use() == FALSE) then you still can't see through it - So specifically for cyborgs when they take enough damage, their internal camera now goes offline. Thrilling stuff!

### Why is viewing through cyborg cameras broken for AI eyes?
It doesn't exist. There's no code path enabling it.

### AI Eye (and by extension Advanced Camera Console) Feex
I added a new code path to allow the AI to see through borgo cameras alongside static station cameras. Cyborgs are once again the eyes of the AI and can act as remote, mobile cameras for the AI.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/24975989/89596766-0c166900-d850-11ea-8abd-0ae088211014.png)
![image](https://user-images.githubusercontent.com/24975989/89596726-ee490400-d84f-11ea-8063-bfa34eb986ab.png)
![image](https://user-images.githubusercontent.com/24975989/89596750-01f46a80-d850-11ea-8f83-7b03dbd2e28c.png)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Camera consoles can now see through Cyborg cameras.
add: The AI's camera network now includes the integrated cameras on their cyborgs.
add: The Advanced Camera Console camera network now includes the integrated cameras on cyborgs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
