### PR TITLE
Fixes commendations breaking the shuttle

### DIFF
--- a/code/__HELPERS/hearted.dm
+++ b/code/__HELPERS/hearted.dm
@@ -6,7 +6,7 @@
 
 	for(var/i in GLOB.joined_player_list)
 		var/mob/check_mob = get_mob_by_ckey(i)
-		if(!check_mob?.mind || !check_mob.client) continue
+		if(!check_mob?.mind || !check_mob.client)
 			continue
 		// maybe some other filters like bans or whatever
 		INVOKE_ASYNC(check_mob, /mob.proc/query_heart, 1)

--- a/code/__HELPERS/hearted.dm
+++ b/code/__HELPERS/hearted.dm
@@ -6,10 +6,10 @@
 
 	for(var/i in GLOB.joined_player_list)
 		var/mob/check_mob = get_mob_by_ckey(i)
-		if(!check_mob || !check_mob.mind || !check_mob.client)
+		if(!check_mob?.mind || !check_mob.client) continue
 			continue
 		// maybe some other filters like bans or whatever
-		check_mob.query_heart(1)
+		INVOKE_ASYNC(check_mob, /mob.proc/query_heart, 1)
 		number_to_ask--
 		if(number_to_ask == 0)
 			break

--- a/code/__HELPERS/hearted.dm
+++ b/code/__HELPERS/hearted.dm
@@ -49,6 +49,7 @@
 	if(isnull(heart_nominee) || heart_nominee == "")
 		return
 
+	heart_nominee = lowertext(heart_nominee)
 	var/list/name_checks = get_mob_by_name(heart_nominee)
 	if(!name_checks || name_checks.len == 0)
 		query_heart(attempt + 1)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -384,7 +384,7 @@
 				launch_status = ENDGAME_LAUNCHED
 				setTimer(SSshuttle.emergencyEscapeTime * engine_coeff)
 				priority_announce("The Emergency Shuttle has left the station. Estimate [timeLeft(600)] minutes until the shuttle docks at Central Command.", null, null, "Priority")
-				SSticker.poll_hearts()
+				INVOKE_ASYNC(SSticker, /datum/controller/subsystem/ticker.proc/poll_hearts)
 				SSmapping.mapvote() //If no map vote has been run yet, start one.
 
 		if(SHUTTLE_STRANDED)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So back in #51217 I added commendations, a cute lil' feature where, when enabled, a few people may get asked after the shuttle shoves off for centcom if they had anyone who made their round better, and if they'd like to give them a little heart icon in OOC for 24h. No biggie, right?

Well, the feature has gone unused so far on tg since the config starts disabled, but fulp decided to turn it on and discovered that the input calls I was making in the ticker subsystem may have been a bad idea. Oops!

This fixes it by invoking async the way god intended, so that the inputs don't block the server. Cool!

Fixes: #52765
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
my warm heart no longer prevents you from leaving
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: The commendation config option no longer breaks the roundend sequence when enabled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
