### PR TITLE
Fixes floorbots potentially ending up with negative tiles in their inventory

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -349,11 +349,11 @@
 			mode = BOT_REPAIRING
 			visible_message("<span class='notice'>[src] begins replacing the floor tiles.</span>")
 			sleep(50)
-			if(mode == BOT_REPAIRING && F && src.loc == F)
+			if(mode == BOT_REPAIRING && F && loc == F && replacetiles && specialtiles) //make sure our mode and tiles are the same after sleeping.
 				F.broken = FALSE
 				F.burnt = FALSE
 				F.PlaceOnTop(initial(tiletype.turf_type), flags = CHANGETURF_INHERIT_AIR)
-				specialtiles -= 1
+				specialtiles--
 				if(specialtiles == 0)
 					speak("Requesting refill of custom floor tiles to continue replacing.")
 	mode = BOT_IDLE


### PR DESCRIPTION
Fixes #52768
:cl: ShizCalev
fix: Fixed a scenario which could cause floorbots to end up with negative tiles in their inventory.
fix: Fixed floorbots not stopping the process of replacing tiles after turning off replace tiles while they're in the middle of replacing tiles.
/:cl:
