### PR TITLE
RPG Loot's summoning affix can no longer summon mecha pilots and elites

### DIFF
--- a/code/datums/components/fantasy/suffixes.dm
+++ b/code/datums/components/fantasy/suffixes.dm
@@ -100,7 +100,7 @@
 		// Some types to remove them and their subtypes
 		possible_mobtypes -= typecacheof(list(
 			/mob/living/carbon/human/species,
-			/mob/living/simple_animal/hostile/syndicate/mecha_pilot
+			/mob/living/simple_animal/hostile/syndicate/mecha_pilot,
 			/mob/living/simple_animal/hostile/asteroid/elite,
 			/mob/living/simple_animal/hostile/megafauna,
 			))

--- a/code/datums/components/fantasy/suffixes.dm
+++ b/code/datums/components/fantasy/suffixes.dm
@@ -100,6 +100,8 @@
 		// Some types to remove them and their subtypes
 		possible_mobtypes -= typecacheof(list(
 			/mob/living/carbon/human/species,
+			/mob/living/simple_animal/hostile/syndicate/mecha_pilot
+			/mob/living/simple_animal/hostile/asteroid/elite,
 			/mob/living/simple_animal/hostile/megafauna,
 			))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mecha pilots and elites have been banned from the summoning. The rest is left in.

## Why It's Good For The Game

Jesus christ mecha pilots in marauders and elites wiped out most of the station, they can summon what like three of them? For the same reason megafauna are banned, these must go too

## Changelog
:cl:
balance: removes mecha pilots and elites from the summoning pool
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
