### PR TITLE
Unlimited Monkey Works Fix

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -296,6 +296,7 @@
 				recycler.use_power(500)
 				X.monkeys += recycler.cube_production
 				X.monkeys = round(X.monkeys, 0.1)		//Prevents rounding errors
+				M.moveToNullspace()						// Prevents monkey staying there giving unlimited monkeys if the gc is busy
 				qdel(M)
 				to_chat(owner, "<span class='notice'>[X] now has [X.monkeys] monkeys available.</span>")
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If you dispose of a monkey and the GC is busy, then it can stay on the tile upwards of 30 seconds.  So you can keep clicking on it for as many monkeys in the recycler as you want.  The fix is just moving it to null space first


## Changelog
:cl:
fix: Monkey Recycler doesn't give unlimited monkeys anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
