### PR TITLE
Revert "Cleans up some refs"

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -170,7 +170,6 @@ Class Procs:
 		for(var/atom/A in component_parts)
 			qdel(A)
 		component_parts.Cut()
-	QDEL_NULL(circuit)
 	return ..()
 
 /obj/machinery/proc/locate_machinery()

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -23,6 +23,10 @@
 		circuit = C
 		C.moveToNullspace()
 
+/obj/machinery/computer/Destroy()
+	QDEL_NULL(circuit)
+	return ..()
+
 /obj/machinery/computer/process()
 	if(machine_stat & (NOPOWER|BROKEN))
 		return 0

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -68,7 +68,7 @@
 
 /obj/item/tank/Destroy()
 	if(air_contents)
-		QDEL_NULL(air_contents)
+		qdel(air_contents)
 
 	STOP_PROCESSING(SSobj, src)
 	. = ..()

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -140,7 +140,6 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		SSair.remove_from_active(src)
 		var/datum/gas_mixture/stashed_air = new()
 		stashed_air.copy_from(air)
-		air = null
 		. = ..()
 		if (!.) // changeturf failed or didn't do anything
 			QDEL_NULL(stashed_air)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -4,9 +4,9 @@
 	var/heat_capacity = 1
 	var/temperature_archived
 
-	///list of open turfs adjacent to us
+	//list of open turfs adjacent to us
 	var/list/atmos_adjacent_turfs
-	///bitfield of dirs in which we are superconducitng
+	//bitfield of dirs in which we are superconducitng
 	var/atmos_supeconductivity = NONE
 
 	//used to determine whether we should archive


### PR DESCRIPTION
Reverts tgstation/tgstation#52713

This change is causing boards to not drop from any machines after deconstructing them.

![image](https://user-images.githubusercontent.com/7019927/89705093-f96b6500-d91f-11ea-99e4-5dd4a410db19.png)

That's a heater, but I tried it with freezers and chem dispensers as well. Likely affecting all machines.

I'm putting up a revert instead of fixing it as I'm not 100% sure it _can_ be fixed - the code just doesn't function the way Tivi thought it did.