### PR TITLE
Object reskins now use a radial menu

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -298,7 +298,7 @@
 		reskin_obj(user)
 
 /**
-  * Reskins object based on a user's skin selection
+  * Reskins object based on a user's choice
   *
   * Arguments:
   * * M The mob choosing a reskin option
@@ -326,7 +326,7 @@
   * Checks if we are allowed to interact with a radial menu for reskins
   *
   * Arguments:
-  * * user The mob interacting with a menu
+  * * user The mob interacting with the menu
   */
 /obj/proc/check_reskin_menu(mob/user)
 	if(QDELETED(src))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -297,21 +297,47 @@
 	if(unique_reskin && !current_skin && user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
 		reskin_obj(user)
 
+/**
+  * Reskins object based on a user's skin selection
+  *
+  * Arguments:
+  * * M The mob choosing a reskin option
+  */
 /obj/proc/reskin_obj(mob/M)
 	if(!LAZYLEN(unique_reskin))
 		return
-	to_chat(M, "<b>Reskin options for [name]:</b>")
-	for(var/V in unique_reskin)
-		var/output = icon2html(src, M, unique_reskin[V])
-		to_chat(M, "[V]: <span class='reallybig'>[output]</span>")
 
-	var/choice = input(M,"Warning, you can only reskin [src] once!","Reskin Object") as null|anything in sortList(unique_reskin)
-	if(!QDELETED(src) && choice && !current_skin && !M.incapacitated() && in_range(M,src))
-		if(!unique_reskin[choice])
-			return
-		current_skin = choice
-		icon_state = unique_reskin[choice]
-		to_chat(M, "[src] is now skinned as '[choice].'")
+	var/list/items = list()
+	for(var/reskin_option in unique_reskin)
+		var/image/item_image = image(icon = src.icon, icon_state = unique_reskin[reskin_option])
+		items += list("[reskin_option]" = item_image)
+	sortList(items)
+
+	var/pick = show_radial_menu(M, src, items, custom_check = CALLBACK(src, .proc/check_reskin_menu, M), radius = 38, require_near = TRUE)
+	if(!pick)
+		return
+	if(!unique_reskin[pick])
+		return
+	current_skin = pick
+	icon_state = unique_reskin[pick]
+	to_chat(M, "[src] is now skinned as '[pick].'")
+
+/**
+  * Checks if we are allowed to interact with a radial menu for reskins
+  *
+  * Arguments:
+  * * user The mob interacting with a menu
+  */
+/obj/proc/check_reskin_menu(mob/user)
+	if(QDELETED(src))
+		return FALSE
+	if(current_skin)
+		return FALSE
+	if(!istype(user))
+		return FALSE
+	if(user.incapacitated())
+		return FALSE
+	return TRUE
 
 /obj/analyzer_act(mob/living/user, obj/item/I)
 	if(atmosanalyzer_scan(user, src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR makes generic object reskins use a radial menu to choose their visual skins instead of having a lengthy html output with a small icon previews along with an input menu for choosing a reskin option. This is to make sure that users can see the reskin options clearly instead of having to strain their eyes and playing spot 10 differences on the small icon previews.

**BEFORE:**

![ReskinsOutput](https://user-images.githubusercontent.com/43862960/89711844-230ea580-d98d-11ea-8a81-7ae130a778ff.png)

**AFTER:**

![ReskinsRadial](https://user-images.githubusercontent.com/43862960/89711848-286bf000-d98d-11ea-8a84-e25c3e2e7509.png)

## Why It's Good For The Game

Better object reskins choosing method.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arkatos
add: Object reskins now use a radial menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
