### PR TITLE
Fixes machinery circuit boards getting deleted when dropped

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -404,6 +404,8 @@ Class Procs:
 			spawn_frame(disassembled)
 			for(var/obj/item/I in component_parts)
 				I.forceMove(loc)
+				if(I == circuit)
+					circuit = null
 			component_parts.Cut()
 	return ..()
 
@@ -435,6 +437,8 @@ Class Procs:
 		occupant = null
 		update_icon()
 		updateUsrDialog()
+	else if(A == circuit)
+		circuit = null
 	return ..()
 
 /obj/machinery/CanAllowThrough(atom/movable/mover, turf/target)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -166,10 +166,7 @@ Class Procs:
 	GLOB.machines.Remove(src)
 	end_processing()
 	dropContents()
-	if(length(component_parts))
-		for(var/atom/A in component_parts)
-			qdel(A)
-		component_parts.Cut()
+	QDEL_LIST(component_parts)
 	QDEL_NULL(circuit)
 	return ..()
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -404,8 +404,6 @@ Class Procs:
 			spawn_frame(disassembled)
 			for(var/obj/item/I in component_parts)
 				I.forceMove(loc)
-				if(I == circuit)
-					circuit = null
 			component_parts.Cut()
 	return ..()
 
@@ -437,7 +435,7 @@ Class Procs:
 		occupant = null
 		update_icon()
 		updateUsrDialog()
-	else if(A == circuit)
+	if(A == circuit)
 		circuit = null
 	return ..()
 
@@ -595,6 +593,8 @@ Class Procs:
 	. = ..()
 	if (AM == occupant)
 		occupant = null
+	if(AM == circuit)
+		circuit = null
 
 /obj/machinery/proc/adjust_item_drop_location(atom/movable/AM)	// Adjust item drop location to a 3x3 grid inside the tile, returns slot id from 0 to 8
 	var/md5 = md5(AM.name)										// Oh, and it's deterministic too. A specific item will always drop from the same slot.


### PR DESCRIPTION
:cl: ShizCalev
fix: Machines will now properly drop their circuit boards again.
/:cl:

Fixes #52811
Closes #52795

Circuit reference wasn't being nullified after the circuit boards were removed from a machine.