### PR TITLE
You can no longer beetlejuice yourself

### DIFF
--- a/code/datums/components/beetlejuice.dm
+++ b/code/datums/components/beetlejuice.dm
@@ -34,7 +34,7 @@
 		update_regex()
 
 /datum/component/beetlejuice/proc/say_react(datum/source, mob/speaker,message)
-	if(!speaker || !message || !active)
+	if(!speaker || speaker == parent || !message || !active)
 		return
 	var/found = R.Find(message)
 	if(found)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You cannot trigger your own beetlejuice anymore

## Why It's Good For The Game

For something with a 30 second cooldown, this is very harsh! It also does just teleport you nowhere and create the sparks at your location which is super lame

## Changelog
:cl:
fix: You can no longer beetlejuice yourself!
/:cl:
