### PR TITLE
Fixes some pacifism oversights

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -302,6 +302,9 @@
 	if(reagents.total_volume<=0)
 		occupant_message("<span class=\"alert\">No available reagents to load syringe with.</span>")
 		return
+	if(HAS_TRAIT(chassis.occupant, TRAIT_PACIFISM))
+		occupant_message("<span class=\"alert\">The [src] is lethally chambered! You don't want to risk harming anyone...</span>")
+		return
 	var/turf/trg = get_turf(target)
 	var/obj/item/reagent_containers/syringe/mechsyringe = syringes[1]
 	mechsyringe.forceMove(get_turf(chassis))

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -74,6 +74,9 @@
 	if(ishuman(user))
 		if(!can_trigger_gun(user))
 			return
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, "<span class='warning'>You can't bring yourself to fire \the [src]! You don't want to risk harming anyone...</span>")
+		return
 	if(user && user.get_active_held_item() == src) // Make sure our user is still holding us
 		var/turf/target_turf = get_turf(target)
 		if(target_turf)

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -152,6 +152,9 @@
 	if(!tank && checktank)
 		to_chat(user, "<span class='warning'>\The [src] can't fire without a source of gas.</span>")
 		return
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, "<span class='warning'>You can't bring yourself to fire \the [src]! You don't want to risk harming anyone...</span>" )
+		return
 	if(tank && !tank.air_contents.remove(gasPerThrow * pressureSetting))
 		to_chat(user, "<span class='warning'>\The [src] lets out a weak hiss and doesn't react!</span>")
 		return

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -70,42 +70,45 @@
 
 
 /obj/item/melee/powerfist/attack(mob/living/target, mob/living/user)
-    if(!tank)
-        to_chat(user, "<span class='warning'>\The [src] can't operate without a source of gas!</span>")
-        return
-    var/datum/gas_mixture/gasused = tank.air_contents.remove(gasperfist * fisto_setting)
-    var/turf/T = get_turf(src)
-    if(!T)
-        return
-    T.assume_air(gasused)
-    T.air_update_turf()
-    if(!gasused)
-        to_chat(user, "<span class='warning'>\The [src]'s tank is empty!</span>")
-        target.apply_damage((force / 5), BRUTE)
-        playsound(loc, 'sound/weapons/punch1.ogg', 50, TRUE)
-        target.visible_message("<span class='danger'>[user]'s powerfist lets out a dull thunk as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
-            "<span class='userdanger'>[user]'s punches you!</span>")
-        return
-    if(gasused.total_moles() < gasperfist * fisto_setting)
-        to_chat(user, "<span class='warning'>\The [src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
-        playsound(loc, 'sound/weapons/punch4.ogg', 50, TRUE)
-        target.apply_damage((force / 2), BRUTE)
-        target.visible_message("<span class='danger'>[user]'s powerfist lets out a weak hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
-            "<span class='userdanger'>[user]'s punch strikes with force!</span>")
-        return
-    target.apply_damage(force * fisto_setting, BRUTE, wound_bonus = -25*fisto_setting**2)
-    target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
-        "<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
-    new /obj/effect/temp_visual/kinetic_blast(target.loc)
-    playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, TRUE)
-    playsound(loc, 'sound/weapons/genhit2.ogg', 50, TRUE)
+	if(!tank)
+		to_chat(user, "<span class='warning'>\The [src] can't operate without a source of gas!</span>")
+		return
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
+		return
+	var/datum/gas_mixture/gasused = tank.air_contents.remove(gasperfist * fisto_setting)
+	var/turf/T = get_turf(src)
+	if(!T)
+		return
+	T.assume_air(gasused)
+	T.air_update_turf()
+	if(!gasused)
+		to_chat(user, "<span class='warning'>\The [src]'s tank is empty!</span>")
+		target.apply_damage((force / 5), BRUTE)
+		playsound(loc, 'sound/weapons/punch1.ogg', 50, TRUE)
+		target.visible_message("<span class='danger'>[user]'s powerfist lets out a dull thunk as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
+			"<span class='userdanger'>[user]'s punches you!</span>")
+		return
+	if(gasused.total_moles() < gasperfist * fisto_setting)
+		to_chat(user, "<span class='warning'>\The [src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
+		playsound(loc, 'sound/weapons/punch4.ogg', 50, TRUE)
+		target.apply_damage((force / 2), BRUTE)
+		target.visible_message("<span class='danger'>[user]'s powerfist lets out a weak hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
+			"<span class='userdanger'>[user]'s punch strikes with force!</span>")
+		return
+	target.apply_damage(force * fisto_setting, BRUTE, wound_bonus = -25*fisto_setting**2)
+	target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
+		"<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
+	new /obj/effect/temp_visual/kinetic_blast(target.loc)
+	playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, TRUE)
+	playsound(loc, 'sound/weapons/genhit2.ogg', 50, TRUE)
 
-    var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
+	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
 
-    target.throw_at(throw_target, 5 * fisto_setting, 0.5 + (fisto_setting / 2))
+	target.throw_at(throw_target, 5 * fisto_setting, 0.5 + (fisto_setting / 2))
 
-    log_combat(user, target, "power fisted", src)
+	log_combat(user, target, "power fisted", src)
 
-    user.changeNext_move(CLICK_CD_MELEE * click_delay)
+	user.changeNext_move(CLICK_CD_MELEE * click_delay)
 
-    return
+	return

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -613,6 +613,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 /obj/item/melee/baseball_bat/attack(mob/living/target, mob/living/user)
 	. = ..()
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		return
 	var/atom/throw_target = get_edge_target_turf(target, user.dir)
 	if(homerun_ready)
 		user.visible_message("<span class='userdanger'>It's a home run!</span>")

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1181,6 +1181,9 @@
 	var/turf/T = get_turf(target)
 	if(!T || timer > world.time)
 		return
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, "<span class='warning'>You can't bring yourself to fire \the [src]! You don't want to risk harming anyone...</span>")
+		return
 	calculate_anger_mod(user)
 	timer = world.time + CLICK_CD_MELEE //by default, melee attacks only cause melee blasts, and have an accordingly short cooldown
 	if(proximity_flag)


### PR DESCRIPTION
## About The Pull Request

Adds some pacifism checks to prevent some afterattacks and one attack proc to prevent a pacifist user from violently attacking other players.
Also changes the spaces indentations for the powerfist to tabs in compliance with contribution standards.

## Why It's Good For The Game

Pacifists shouldn't be using violent weapons like these, 'cause it's antithetical to having an aversion to violence.

## Changelog
:cl:
fix: Pacifists can no longer harm people with baseball bats, powerfists, hierophant clubs, flamethrowers, pneumatic cannons, or syringe guns mounted on mechs. 
/:cl: