### PR TITLE
Fix security camera console not following moving borgs

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -10,6 +10,8 @@
 
 	var/list/network = list("ss13")
 	var/obj/machinery/camera/active_camera
+	/// The turf where the camera was last updated.
+	var/turf/last_camera_turf
 	var/list/concurrent_users = list()
 
 	// Stuff needed to render the map
@@ -60,9 +62,11 @@
 /obj/machinery/computer/security/ui_interact(mob/user, datum/tgui/ui)
 	// Update UI
 	ui = SStgui.try_update_ui(user, src, ui)
-	// Show static if can't use the camera
-	if(!active_camera?.can_use())
-		show_camera_static()
+
+	// Update the camera, showing static if we can't use it and updating data if the location has moved.
+	if(active_camera)
+		update_active_camera_screen()
+
 	if(!ui)
 		var/user_ref = REF(user)
 		var/is_living = isliving(user)
@@ -104,6 +108,7 @@
 		data["cameras"] += list(list(
 			name = C.c_tag,
 		))
+
 	return data
 
 /obj/machinery/computer/security/ui_act(action, params)
@@ -118,30 +123,47 @@
 		active_camera = selected_camera
 		playsound(src, get_sfx("terminal_type"), 25, FALSE)
 
-		// Show static if can't use the camera
-		if(!selected_camera?.can_use())
-			show_camera_static()
+		if(!selected_camera)
 			return TRUE
 
-		var/list/visible_turfs = list()
-
-		// Is this camera located in or attached to a living thing? If so, assume the camera's loc is the living thing.
-		var/cam_location = isliving(selected_camera.loc) ? selected_camera.loc : selected_camera
-
-		var/list/visible_things = selected_camera.isXRay() ? range(selected_camera.view_range, cam_location) : view(selected_camera.view_range, cam_location)
-
-		for(var/turf/visible_turf in visible_things)
-			visible_turfs += visible_turf
-
-		var/list/bbox = get_bbox_of_atoms(visible_turfs)
-		var/size_x = bbox[3] - bbox[1] + 1
-		var/size_y = bbox[4] - bbox[2] + 1
-
-		cam_screen.vis_contents = visible_turfs
-		cam_background.icon_state = "clear"
-		cam_background.fill_rect(1, 1, size_x, size_y)
+		update_active_camera_screen()
 
 		return TRUE
+
+/obj/machinery/computer/security/proc/update_active_camera_screen()
+	// Show static if can't use the camera
+	if(!active_camera.can_use())
+		show_camera_static()
+		return
+
+	var/list/visible_turfs = list()
+
+	// Is this camera located in or attached to a living thing? If so, assume the camera's loc is the living thing.
+	var/cam_location = isliving(active_camera.loc) ? active_camera.loc : active_camera
+
+	// If we're not forcing an update for some reason and the cameras are in the same location,
+	// we don't need to update anything.
+	// Most security cameras will end here as they're not moving.
+	var/last_turf = last_camera_turf
+	var/newturf = get_turf(cam_location)
+	if(last_camera_turf == newturf)
+		return
+
+	// Cameras that get here are moving, and are likely attached to some moving atom such as cyborgs.
+	last_camera_turf = get_turf(cam_location)
+
+	var/list/visible_things = active_camera.isXRay() ? range(active_camera.view_range, cam_location) : view(active_camera.view_range, cam_location)
+
+	for(var/turf/visible_turf in visible_things)
+		visible_turfs += visible_turf
+
+	var/list/bbox = get_bbox_of_atoms(visible_turfs)
+	var/size_x = bbox[3] - bbox[1] + 1
+	var/size_y = bbox[4] - bbox[2] + 1
+
+	cam_screen.vis_contents = visible_turfs
+	cam_background.icon_state = "clear"
+	cam_background.fill_rect(1, 1, size_x, size_y)
 
 /obj/machinery/computer/security/ui_close(mob/user)
 	var/user_ref = REF(user)

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -66,6 +66,8 @@
 	// Update the camera, showing static if we can't use it and updating data if the location has moved.
 	if(active_camera)
 		update_active_camera_screen()
+	else
+		show_camera_static()
 
 	if(!ui)
 		var/user_ref = REF(user)

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -63,11 +63,8 @@
 	// Update UI
 	ui = SStgui.try_update_ui(user, src, ui)
 
-	// Update the camera, showing static if we can't use it and updating data if the location has moved.
-	if(active_camera)
-		update_active_camera_screen()
-	else
-		show_camera_static()
+	// Update the camera, showing static if necessary and updating data if the location has moved.
+	update_active_camera_screen()
 
 	if(!ui)
 		var/user_ref = REF(user)
@@ -134,7 +131,7 @@
 
 /obj/machinery/computer/security/proc/update_active_camera_screen()
 	// Show static if can't use the camera
-	if(!active_camera.can_use())
+	if(!active_camera?.can_use())
 		show_camera_static()
 		return
 
@@ -146,7 +143,6 @@
 	// If we're not forcing an update for some reason and the cameras are in the same location,
 	// we don't need to update anything.
 	// Most security cameras will end here as they're not moving.
-	var/last_turf = last_camera_turf
 	var/newturf = get_turf(cam_location)
 	if(last_camera_turf == newturf)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Camera consoles don't tracking moving cameras.

If the camera's turf changes between ui_updates, the camera now follows.

It's not perfect, but it gets the job done for what is ostensibly a niche feature and basically feels like any other tracking code.

![](https://cdn.discordapp.com/attachments/326831214667235328/742130125830619226/GHSBk2eSMa.gif)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes an oversight in #52767

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The security camera console will now correctly track when viewing moving cyborg cameras.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
