### PR TITLE
Intercoms can now be interacted with via the telekinesis mutation

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -55,6 +55,14 @@
 		return
 	return ..()
 
+/**
+  * Override attack_tk_grab instead of attack_tk because we actually want attack_tk's
+  * functionality. What we DON'T want is attack_tk_grab attempting to pick up the
+  * intercom as if it was an ordinary item.
+  */
+/obj/item/radio/intercom/attack_tk_grab(mob/user)
+	interact(user)
+
 /obj/item/radio/intercom/attack_ai(mob/user)
 	interact(user)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #52770 

Due to issues with item interaction code, this PR means the intercom is now **viewable** with telekinesis but is not **interactable** unless adjacent.

This is initially being addressed by #52834. This PR is not dependant on the merging of #52834.

If that PR does not get merged, a separate PR or commit with a snowflake overriding of `/obj/item/radio/intercom/can_interact()` will instead be used to address this issue instead.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex oversight.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Intercoms can now be remotely viewed via telekinesis.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
