### PR TITLE
Mobs with TRAIT_NODEATH can no longer succumb.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -383,7 +383,7 @@
 
 /mob/living/verb/succumb(whispered as null)
 	set hidden = TRUE
-	if (InCritical())
+	if (InCritical() && !HAS_TRAIT(src, TRAIT_NODEATH))
 		log_message("Has [whispered ? "whispered his final words" : "succumbed to death"] while in [InFullCritical() ? "hard":"soft"] critical with [round(health, 0.1)] points of health!", LOG_ATTACK)
 		adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)
 		updatehealth()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #52729

Functionality changed by https://github.com/tgstation/tgstation/commit/2384a7aafc6db0cbb179397e5013af264861a931 giving zombies a species death proc.

Likely an oversight.

Fixes this by preventing succumbing when TRAIT_NODEATH is present. Guess it's time to die another day?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/24975989/89757619-adfeb580-dadd-11ea-8efe-d3a0e913b0b1.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Those with an unnatural attachment to life will no longer succumb to critical wounds when whispering.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
