### PR TITLE
magboots now update speed

### DIFF
--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -32,6 +32,7 @@
 	to_chat(user, "<span class='notice'>You [magpulse ? "enable" : "disable"] the mag-pulse traction system.</span>")
 	user.update_inv_shoes()	//so our mob-overlays update
 	user.update_gravity(user.has_gravity())
+	user.update_equipment_speed_mods() //we want to update our speed so we arent running at max speed in regular magboots
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.UpdateButtonIcon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

magboots change your speed but they dont update it so you can run at fullspeed with turned on magboots until you pick up an item and update your speed

## Why It's Good For The Game

fixes bug/exploit

## Changelog
:cl:
fix: magboots now update speed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
