### PR TITLE
Bump BYOND version to 513.1528

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tgstation/byond:513.1526 as base
+FROM tgstation/byond:513.1528 as base
 
 FROM base as rust_g
 


### PR DESCRIPTION
Probably fixes the occasional 'internal max arrays' exceeded error we see in CI.