### PR TITLE
fixes ice box pods landing 3 tiles away...

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -6330,7 +6330,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
 "aog" = (
-/obj/docking_port/stationary/random{
+/obj/docking_port/stationary/random/icemoon{
 	dir = 8;
 	id = "pod_lavaland2";
 	name = "lavaland"
@@ -10504,7 +10504,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ayw" = (
-/obj/docking_port/stationary/random{
+/obj/docking_port/stationary/random/icemoon{
 	dir = 4;
 	id = "pod_lavaland3";
 	name = "lavaland"
@@ -22321,7 +22321,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "baC" = (
-/obj/docking_port/stationary/random{
+/obj/docking_port/stationary/random/icemoon{
 	dir = 8;
 	id = "pod_lavaland1";
 	name = "lavaland"
@@ -31392,7 +31392,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "bvM" = (
-/obj/docking_port/stationary/random{
+/obj/docking_port/stationary/random/icemoon{
 	dir = 4;
 	id = "pod_lavaland4";
 	name = "lavaland"

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -516,6 +516,9 @@
 	WARNING("docking port '[id]' could not be randomly placed in [target_area]: of [original_len] turfs, none were suitable")
 	return INITIALIZE_HINT_QDEL
 
+/obj/docking_port/stationary/random/icemoon
+	target_area = /area/icemoon/surface/outdoors
+
 //Pod suits/pickaxes
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

they now land in a random place on the same z level.
the docking ports for pods check for the lavaland area for random tiles place themselves on, but ice moon doesnt have a lavaland, so they land in the default space, which is 3 tiles away

## Why It's Good For The Game

it makes errors every round

## Changelog
:cl:
fix: fixes ice box pods landing 3 tiles away
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
