### PR TITLE
Fixed runtime involving crew pinpointers by removing indestructibility from non-nuke pinpointers

### DIFF
--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -92,6 +92,7 @@
 	icon_state = "pinpointer_crew"
 	custom_price = 900
 	custom_premium_price = 900
+	resistance_flags = NONE
 	var/has_owner = FALSE
 	var/pinpointer_owner = null
 	var/ignore_suit_sensor_level = FALSE /// Do we find people even if their suit sensors are turned off

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -14,7 +14,6 @@
 	throw_speed = 3
 	throw_range = 7
 	custom_materials = list(/datum/material/iron = 500, /datum/material/glass = 250)
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/active = FALSE
 	var/atom/movable/target //The thing we're searching for
 	var/minimum_range = 0 //at what range the pinpointer declares you to be at your destination
@@ -92,7 +91,6 @@
 	icon_state = "pinpointer_crew"
 	custom_price = 900
 	custom_premium_price = 900
-	resistance_flags = NONE
 	var/has_owner = FALSE
 	var/pinpointer_owner = null
 	var/ignore_suit_sensor_level = FALSE /// Do we find people even if their suit sensors are turned off

--- a/code/game/objects/items/wayfinding.dm
+++ b/code/game/objects/items/wayfinding.dm
@@ -126,7 +126,6 @@
 	name = "wayfinding pinpointer"
 	desc = "A handheld tracking device that points to useful places."
 	icon_state = "pinpointer_way"
-	resistance_flags = NONE
 	var/owner = null
 	var/list/beacons = list()
 	var/roundstart = FALSE

--- a/code/modules/antagonists/nukeop/equipment/pinpointer.dm
+++ b/code/modules/antagonists/nukeop/equipment/pinpointer.dm
@@ -1,4 +1,5 @@
 /obj/item/pinpointer/nuke
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/mode = TRACK_NUKE_DISK
 
 /obj/item/pinpointer/nuke/examine(mob/user)
@@ -66,6 +67,7 @@
 	name = "cyborg syndicate pinpointer"
 	desc = "An integrated tracking device, jury-rigged to search for living Syndicate operatives."
 	flags_1 = NONE
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/pinpointer/syndicate_cyborg/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://sb.atlantaned.space/rounds/143956/logs/runtime.txt/raw

runtime error: No valid destination passed into forceMove
 - proc name: forceMove (/atom/movable/proc/forceMove)
 -   source file: atoms_movable.dm,492
 -   usr: null
 -   src: the proximity crew pinpointer (/obj/item/pinpointer/crew/prox)
 -   src.loc: the medical belt (/obj/item/storage/belt/medical/paramedic)
 -   call stack:
 - the proximity crew pinpointer (/obj/item/pinpointer/crew/prox): forceMove(null)
 - the medical belt (/obj/item/storage/belt/medical/paramedic): Destroy(0)
 - qdel(the medical belt (/obj/item/storage/belt/medical/paramedic), 0)
 - Francisco Newbern (/mob/living/carbon/human/dummy): delete equipment()
 - Francisco Newbern (/mob/living/carbon/human/dummy): wipe state()
 - unset busy human dummy("dummy_manifest_generation")
 - get flat human icon(null, /datum/job/paramedic (/datum/job/paramedic), /datum/preferences (/datum/preferences), "dummy_manifest_generation", /list (/list), null)
 - /datum/datacore (/datum/datacore): get id photo( (/mob/living/carbon/human), LloydLander (/client), /list (/list))
 - /datum/datacore (/datum/datacore): manifest inject( (/mob/living/carbon/human), LloydLander (/client))
 - /datum/datacore (/datum/datacore): manifest()
 - Ticker (/datum/controller/subsystem/ticker): setup()
 - Ticker (/datum/controller/subsystem/ticker): fire(0)
 - Ticker (/datum/controller/subsystem/ticker): ignite(0)

Crew pinpointer and its sub-classes are indestructible, inheriting from the parent pinpointer.

This leads to a runtime on the main menu and when entering game, where the mannequin used to generate the preview sprite would attempt to delete the contents of the paramedic belt when it was destroyed, encounter the indestructible prox scanner and then attempt to forceMove() it into null.

I felt it more prudent to address the fact that pinpointers were all indestructible and resistant by default. Following discussions, I have opted to remove indestructibility and resistance from all pinpointers except the nukey pinpointer. As a result, the following are no longer indestructible:
/obj/item/pinpointer
/obj/item/pinpointer/crew
/obj/item/pinpointer/crew/contractor
/obj/item/pinpointer/pair
/obj/item/pinpointer/shuttle

The following was not indestructible to begin with, meaning no change:
/obj/item/pinpointer/wayfinding

And the following were indestructible before and are still indestructible:
/obj/item/pinpointer/nuke
/obj/item/pinpointer/nuke/syndicate

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtimes bad. Feexes good. No reason for so many pinpointers to be indestructible anyway.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Pinpointers are no longer indestructible be default. The Nuke Pinpointers are still indestructible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
