### PR TITLE
Rewired icebox turbine

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -32031,6 +32031,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "bxt" = (
@@ -32088,6 +32089,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "bxC" = (
@@ -32110,6 +32112,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "bxE" = (
@@ -33141,6 +33144,7 @@
 	dir = 4;
 	pixel_x = 27
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "bAd" = (
@@ -35095,7 +35099,6 @@
 	dir = 1;
 	id = "incineratorturbine"
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "bEz" = (
@@ -35115,7 +35118,6 @@
 	dir = 6
 	},
 /obj/machinery/meter,
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "bEC" = (
@@ -35163,7 +35165,6 @@
 	dir = 1;
 	pixel_y = -30
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "bEI" = (
@@ -35198,7 +35199,6 @@
 	pixel_x = 6;
 	pixel_y = -24
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "bEL" = (
@@ -58139,6 +58139,17 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"xVB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/disposal/incinerator";
+	dir = 1;
+	name = "Incinerator APC";
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "xWd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -95555,7 +95566,7 @@ bzs
 bzs
 bwL
 bxh
-cjr
+xVB
 bzr
 bAP
 bCf
@@ -95812,7 +95823,7 @@ bBR
 caK
 bwO
 bxs
-cjr
+byO
 cjr
 cjr
 bDi
@@ -96583,7 +96594,7 @@ bvP
 bwg
 bxn
 bxE
-byO
+cjr
 bzQ
 byO
 byO
@@ -96841,7 +96852,7 @@ ccM
 juq
 akE
 cjr
-cjr
+byO
 bBl
 bEv
 bEV


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Icebox turbine was hardwired to grid and was missing the APC.

Fixes #52814 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Areas need proper power.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Icebox turbine is wired up to safety code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
