### PR TITLE
Adds a recommended fps option.

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -118,3 +118,6 @@
 #define RANDOM_FACIAL_HAIRSTYLE "random_facial_hairstyle"
 #define RANDOM_SKIN_TONE "random_skin_tone"
 #define RANDOM_EYE_COLOR "random_eye_color"
+
+//recommened client FPS
+#define RECOMMENED_FPS 40

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -120,4 +120,4 @@
 #define RANDOM_EYE_COLOR "random_eye_color"
 
 //recommened client FPS
-#define RECOMMENED_FPS 40
+#define RECOMMENDED_FPS 40

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -255,7 +255,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		GLOB.preferences_datums[ckey] = prefs
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
-	fps = prefs.clientfps
+	fps = prefs.clientfps ? prefs.clientfps : RECOMMENED_FPS
 
 	if(fexists(roundend_report_file()))
 		verbs += /client/proc/show_previous_roundend_report

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -255,7 +255,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		GLOB.preferences_datums[ckey] = prefs
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
-	fps = prefs.clientfps ? prefs.clientfps : RECOMMENDED_FPS
+	fps = (prefs.clientfps < 0) ? RECOMMENDED_FPS : prefs.clientfps
 
 	if(fexists(roundend_report_file()))
 		verbs += /client/proc/show_previous_roundend_report

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -255,7 +255,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		GLOB.preferences_datums[ckey] = prefs
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
-	fps = prefs.clientfps ? prefs.clientfps : RECOMMENED_FPS
+	fps = prefs.clientfps ? prefs.clientfps : RECOMMENDED_FPS
 
 	if(fexists(roundend_report_file()))
 		verbs += /client/proc/show_previous_roundend_report

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1540,7 +1540,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/desiredfps = input(user, "Choose your desired fps.\n-1 means recommended value (currently:[RECOMMENDED_FPS])\n0 means world fps (currently:[world.fps])", "Character Preference", clientfps)  as null|num
 					if (!isnull(desiredfps))
 						clientfps = sanitize_integer(desiredfps, -1, 1000, clientfps)
-						parent.fps = (desiredfps < 0) ? RECOMMENDED_FPS : desiredfps
+						parent.fps = (clientfps < 0) ? RECOMMENDED_FPS : clientfps
 				if("ui")
 					var/pickedui = input(user, "Choose your UI style.", "Character Preference", UI_style)  as null|anything in sortList(GLOB.available_ui_styles)
 					if(pickedui)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1537,10 +1537,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						preferred_map = maplist[pickedmap]
 
 				if ("clientfps")
-					var/desiredfps = input(user, "Choose your desired fps. (0 = synced with server tick rate (currently:[world.fps]))", "Character Preference", clientfps)  as null|num
+					var/desiredfps = input(user, "Choose your desired fps. (0 = defaults to recommened value (currently:[RECOMMENED_FPS]))", "Character Preference", clientfps)  as null|num
 					if (!isnull(desiredfps))
 						clientfps = desiredfps
-						parent.fps = desiredfps
+						parent.fps = desiredfps ? desiredfps : RECOMMENED_FPS
 				if("ui")
 					var/pickedui = input(user, "Choose your UI style.", "Character Preference", UI_style)  as null|anything in sortList(GLOB.available_ui_styles)
 					if(pickedui)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1537,10 +1537,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						preferred_map = maplist[pickedmap]
 
 				if ("clientfps")
-					var/desiredfps = input(user, "Choose your desired fps. (0 = defaults to recommened value (currently:[RECOMMENED_FPS]))", "Character Preference", clientfps)  as null|num
+					var/desiredfps = input(user, "Choose your desired fps. (0 = defaults to recommened value (currently:[RECOMMENDED_FPS]))", "Character Preference", clientfps)  as null|num
 					if (!isnull(desiredfps))
 						clientfps = desiredfps
-						parent.fps = desiredfps ? desiredfps : RECOMMENED_FPS
+						parent.fps = desiredfps ? desiredfps : RECOMMENDED_FPS
 				if("ui")
 					var/pickedui = input(user, "Choose your UI style.", "Character Preference", UI_style)  as null|anything in sortList(GLOB.available_ui_styles)
 					if(pickedui)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1537,10 +1537,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						preferred_map = maplist[pickedmap]
 
 				if ("clientfps")
-					var/desiredfps = input(user, "Choose your desired fps. (0 = defaults to recommened value (currently:[RECOMMENDED_FPS]))", "Character Preference", clientfps)  as null|num
+					var/desiredfps = input(user, "Choose your desired fps.\n-1 means recommended value (currently:[RECOMMENDED_FPS])\n0 means world fps (currently:[world.fps])", "Character Preference", clientfps)  as null|num
 					if (!isnull(desiredfps))
-						clientfps = desiredfps
-						parent.fps = desiredfps ? desiredfps : RECOMMENDED_FPS
+						clientfps = sanitize_integer(desiredfps, -1, 1000, clientfps)
+						parent.fps = (desiredfps < 0) ? RECOMMENDED_FPS : desiredfps
 				if("ui")
 					var/pickedui = input(user, "Choose your UI style.", "Character Preference", UI_style)  as null|anything in sortList(GLOB.available_ui_styles)
 					if(pickedui)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -102,7 +102,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/list/ignoring = list()
 
-	var/clientfps = 0
+	var/clientfps = -1
 
 	var/parallax
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -162,7 +162,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	windowflashing	= sanitize_integer(windowflashing, FALSE, TRUE, initial(windowflashing))
 	default_slot	= sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
 	toggles			= sanitize_integer(toggles, 0, (2**24)-1, initial(toggles))
-	clientfps		= sanitize_integer(clientfps, 0, 1000, 0)
+	clientfps		= sanitize_integer(clientfps, -1, 1000, 0)
 	parallax		= sanitize_integer(parallax, PARALLAX_INSANE, PARALLAX_DISABLE, null)
 	ambientocclusion	= sanitize_integer(ambientocclusion, FALSE, TRUE, initial(ambientocclusion))
 	auto_fit_viewport	= sanitize_integer(auto_fit_viewport, FALSE, TRUE, initial(auto_fit_viewport))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a recommended fps option. Setting fps to -1 now sets client.fps to RECOMMENDED_FPS.
Sets recommended fps as the default option for new players.
Current value for recommended fps is 40. https://github.com/tgstation/tgstation/pull/52532#pullrequestreview-458928795 for info for why that's the case

## Changelog
:cl:
tweak: Added a new option for clients fps: "Recommended". Setting fps in the options to -1 now sets it to the recommended value. Byond version higher or equal to 513.1523 should be used.
tweak: Due to interal byond workings the recommended value for fps is currently 40. Another good value is 100. 60 is not advised.
/:cl:
