### PR TITLE
Hostile mobs will set a "home" turf, and attempt to return to it upon losing aggro.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -87,7 +87,9 @@
 	///id for a timer to call LoseTarget(), used to stop mobs fixating on a target they can't reach
 	var/lose_patience_timer_id
 	///30 seconds by default, so there's no major changes to AI behaviour, beyond actually bailing if stuck forever
-	var/lose_patience_timeout = 300
+	var/lose_patience_timeout = 30 SEONCDS
+	///Will this mob attempt to return to it's spawn turf upon losing it's target?
+	var/create_home_turf = TRUE
 	///When a hostile mob loses it's patience and gives up, it will begin pathing to this turf, typically it's spawn turf unless otherwise overridden.
 	var/turf/home_turf
 
@@ -97,7 +99,7 @@
 	if(!targets_from)
 		targets_from = src
 	wanted_objects = typecacheof(wanted_objects)
-	if(!home_turf)
+	if(!home_turf && create_home_turf)
 		home_turf = loc
 
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -87,7 +87,7 @@
 	///id for a timer to call LoseTarget(), used to stop mobs fixating on a target they can't reach
 	var/lose_patience_timer_id
 	///30 seconds by default, so there's no major changes to AI behaviour, beyond actually bailing if stuck forever
-	var/lose_patience_timeout = 30 SEONCDS
+	var/lose_patience_timeout = 30 SECONDS
 	///Will this mob attempt to return to it's spawn turf upon losing it's target?
 	var/create_home_turf = TRUE
 	///When a hostile mob loses it's patience and gives up, it will begin pathing to this turf, typically it's spawn turf unless otherwise overridden.

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -21,6 +21,7 @@
 	maxbodytemp = INFINITY
 	vision_range = 5
 	aggro_vision_range = 18
+	create_home_turf = FALSE
 	move_force = MOVE_FORCE_OVERPOWERING
 	move_resist = MOVE_FORCE_OVERPOWERING
 	pull_force = MOVE_FORCE_OVERPOWERING


### PR DESCRIPTION

## About The Pull Request

Mostly what it says on the tin, on init, hostile mobs will by default create a reference to the turf they natively spawned on, and will call that turf home.  If that hostile mob is drawn out of it's aggro zone, it will attempt to turn some of the distance  towards it's home to avoid from being constantly kited around and bated to new places.

Can be enabled/disabled on mobs by setting their create_home_turf variable to FALSE.

## Why It's Good For The Game

The ability to kite out lavaland mobs an infinite distance only makes sense if you're keeping in combat with those mobs. After a certain point, they should at least attempt to get back to their nest/hunting grounds/security post. This change adjusts this to a configurable option, in order to allow slightly more dynamic AIs, as well as keep the difficulty of extracting dangerous creatures out of their familiar environment real.

Willing to hear feedback on which critters shouldn't set a home as well, as I imagine not all of them should behave the same.
## Changelog
:cl:
add: Hostile mobs will attempt to return to their original position when losing their target.
/:cl: