### PR TITLE
No more flipping your gun instead of reloading.

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -374,7 +374,6 @@
 			flip_cooldown = (world.time + 30)
 			user.visible_message("<span class='notice'>[user] spins the [src] around their finger by the trigger. That’s pretty badass.</span>")
 			playsound(src, 'sound/items/handling/ammobox_pickup.ogg', 20, FALSE)
-			return
 	if(!internal_magazine && magazine)
 		if(!magazine.ammo_count())
 			eject_magazine(user)


### PR DESCRIPTION
this was mad annoying

instead now you flip your gun, along with doing whatever you initially intended, instead of just flipping it.
fix: #51339
## Changelog
:cl:
tweak: Flipping your gun no longer overrides every other action. They now happen simultaneously.
/:cl: