### PR TITLE
ACTUALLY fixes circuits disappearing when disassembling machines

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -402,6 +402,7 @@ Class Procs:
 			for(var/obj/item/I in component_parts)
 				I.forceMove(loc)
 			component_parts.Cut()
+			circuit = null
 	return ..()
 
 /obj/machinery/proc/spawn_frame(disassembled)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -17,6 +17,7 @@
 #include "component_tests.dm"
 #include "confusion.dm"
 #include "keybinding_init.dm"
+#include "machine_disassembly.dm"
 #include "medical_wounds.dm"
 #include "metabolizing.dm"
 #include "outfit_sanity.dm"

--- a/code/modules/unit_tests/machine_disassembly.dm
+++ b/code/modules/unit_tests/machine_disassembly.dm
@@ -1,0 +1,13 @@
+/// Ensures that when disassembling a machine, all the parts are given back
+/datum/unit_test/machine_disassembly/Run()
+	var/obj/machinery/freezer = allocate(/obj/machinery/atmospherics/components/unary/thermomachine/freezer)
+
+	var/turf/freezer_location = freezer.loc
+	freezer_location.ChangeTurf(/turf/open/floor/plasteel)
+	freezer.deconstruct()
+
+	// Check that the components are created
+	TEST_ASSERT(locate(/obj/item/stock_parts/micro_laser) in freezer_location, "Couldn't find micro-laser when disassembling freezer")
+
+	// Check that the circuit board itself is created
+	TEST_ASSERT(locate(/obj/item/circuitboard/machine/thermomachine/freezer) in freezer_location, "Couldn't find the circuit board when disassembling freezer")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I don't know what #52805 did, but it didn't fix it.

Fixes #52860.

Basically, the circuit IS being put on the tile. But later, in `/obj/machinery/Destroy()` (which is called by `deconstruct()`), `QDEL_NULL(circuit)` deletes the circuit object. This sets `circuit` to null before this happens. 

Adds a unit test to prevent regression.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: ACTUALLY fixed circuitboards disappearing when disassembling machines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
