### PR TITLE
pAIs now use a radial menu to choose their holochassis skins

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai_shell.dm
+++ b/code/modules/mob/living/silicon/pai/pai_shell.dm
@@ -70,11 +70,18 @@
 	holoform = FALSE
 	set_resting(resting)
 
+/**
+  * Sets a new holochassis skin based on a pAI's choice
+  */
 /mob/living/silicon/pai/proc/choose_chassis()
-	if(!isturf(loc) && loc != card)
-		to_chat(src, "<span class='boldwarning'>You can not change your holochassis composite while not on the ground or in your card!</span>")
-		return FALSE
-	var/choice = input(src, "What would you like to use for your holochassis composite?") as null|anything in sortList(possible_chassis)
+	var/list/skins = list()
+	for(var/holochassis_option in possible_chassis)
+		var/image/item_image = image(icon = src.icon, icon_state = holochassis_option)
+		skins += list("[holochassis_option]" = item_image)
+	sortList(skins)
+
+	var/atom/anchor = get_atom_on_turf(src)
+	var/choice = show_radial_menu(src, anchor, skins, custom_check = CALLBACK(src, .proc/check_menu, anchor), radius = 40, require_near = TRUE)
 	if(!choice)
 		return FALSE
 	chassis = choice
@@ -82,6 +89,22 @@
 	held_state = "[chassis]"
 	update_resting()
 	to_chat(src, "<span class='boldnotice'>You switch your holochassis projection composite to [chassis].</span>")
+
+/**
+  * Checks if we are allowed to interact with a radial menu
+  *
+  * * Arguments:
+  * * anchor The atom that is anchoring the menu
+  */
+/mob/living/silicon/pai/proc/check_menu(atom/anchor)
+	if(incapacitated())
+		return FALSE
+	if(get_turf(src) != get_turf(anchor))
+		return FALSE
+	if(!isturf(loc) && loc != card)
+		to_chat(src, "<span class='boldwarning'>You can not change your holochassis composite while not on the ground or in your card!</span>")
+		return FALSE
+	return TRUE
 
 /mob/living/silicon/pai/update_resting()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes pAIs use a radial menu for choosing their holochassis skins, instead of navigating in the input menu with no preview of how given skin even looks like.

Example image:

![paiRadial](https://user-images.githubusercontent.com/43862960/89949184-cd095e80-dc27-11ea-9ea6-6fe3ff6d13ae.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better holochassis skin choosing method.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arkatos
add: pAIs now use a radial menu to choose their holochassis skins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
