### PR TITLE
Reworks the Hierophant Club as a general utility item and removes attacks.

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -296,27 +296,6 @@
 	button_icon_state = "thermal_[suit.thermal_on ? "on" : "off"]"
 	UpdateButtonIcon()
 
-/datum/action/item_action/toggle_unfriendly_fire
-	name = "Toggle Friendly Fire \[ON\]"
-	desc = "Toggles if the club's blasts cause friendly fire."
-	icon_icon = 'icons/mob/actions/actions_items.dmi'
-	button_icon_state = "vortex_ff_on"
-
-/datum/action/item_action/toggle_unfriendly_fire/Trigger()
-	if(..())
-		UpdateButtonIcon()
-
-/datum/action/item_action/toggle_unfriendly_fire/UpdateButtonIcon(status_only = FALSE, force)
-	if(istype(target, /obj/item/hierophant_club))
-		var/obj/item/hierophant_club/H = target
-		if(H.friendly_fire_check)
-			button_icon_state = "vortex_ff_off"
-			name = "Toggle Friendly Fire \[OFF\]"
-		else
-			button_icon_state = "vortex_ff_on"
-			name = "Toggle Friendly Fire \[ON\]"
-	..()
-
 /datum/action/item_action/vortex_recall
 	name = "Vortex Recall"
 	desc = "Recall yourself, and anyone nearby, to an attuned hierophant beacon at any time.<br>If the beacon is still attached, will detach it."

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1176,7 +1176,7 @@
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	slot_flags = ITEM_SLOT_BACK
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	force = 15
 	attack_verb_continuous = list("clubs", "beats", "pummels")
 	attack_verb_simple = list("club", "beat", "pummel")

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1128,6 +1128,11 @@
 	new /obj/item/crusher_trophy/blaster_tubes(src)
 
 //Hierophant
+/datum/action/innate/dash/hierophant
+	current_charges = 1
+	max_charges = 1
+	charge_rate = 10 SECONDS
+
 /obj/item/hierophant_club
 	name = "hierophant club"
 	desc = "The strange technology of this large club allows various nigh-magical teleportation feats. It used to beat you, but now you can set the beat."
@@ -1144,7 +1149,7 @@
 	attack_verb_continuous = list("clubs", "beats", "pummels")
 	attack_verb_simple = list("club", "beat", "pummel")
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
-	actions_types = list(/datum/action/item_action/vortex_recall)
+	actions_types = list(/datum/action/item_action/vortex_recall, /datum/action/innate/dash/hierophant)
 
 	var/cooldown_time = 20 //how long the cooldown between non-melee ranged attacks is
 	var/obj/effect/hierophant/beacon //the associated beacon we teleport to
@@ -1170,8 +1175,7 @@
 		if(I != src)
 			user.dropItemToGround(I)
 	for(var/turf/T in RANGE_TURFS(1, user))
-		var/obj/effect/temp_visual/hierophant/blast/B = new(T, user, TRUE)
-		B.damage = 0
+		new /obj/effect/temp_visual/hierophant/blast/visual(T, user, TRUE)
 	user.dropItemToGround(src) //Drop us last, so it goes on top of their stuff
 	qdel(user)
 
@@ -1265,10 +1269,10 @@
 		new /obj/effect/temp_visual/hierophant/telegraph/teleport(T, user)
 		new /obj/effect/temp_visual/hierophant/telegraph/teleport(source, user)
 		for(var/t in RANGE_TURFS(1, T))
-			var/obj/effect/temp_visual/hierophant/blast/B = new /obj/effect/temp_visual/hierophant/blast(t, user, TRUE) //blasts produced will not hurt allies
+			var/obj/effect/temp_visual/hierophant/blast/damaging/B = new(t, user, TRUE) //blasts produced will not hurt allies
 			B.damage = 30
 		for(var/t in RANGE_TURFS(1, source))
-			var/obj/effect/temp_visual/hierophant/blast/B = new /obj/effect/temp_visual/hierophant/blast(t, user, TRUE) //but absolutely will hurt enemies
+			var/obj/effect/temp_visual/hierophant/blast/damaging/B = new(t, user, TRUE) //but absolutely will hurt enemies
 			B.damage = 30
 		for(var/mob/living/L in range(1, source))
 			INVOKE_ASYNC(src, .proc/teleport_mob, source, L, T, user) //regardless, take all mobs near us along

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1192,7 +1192,7 @@
 	var/datum/action/innate/dash/hierophant/blink
 	/// Whether the blink ability is activated. IF TRUE, left clicking a location will blink to it. If FALSE, this is disabled.
 	var/blink_activated = TRUE
-	/// Whether the blink is charged. Set by
+	/// Whether the blink is charged. Set and unset by the blink action. Used as part of setting the appropriate icon states.
 	var/blink_charged = TRUE
 
 /obj/item/hierophant_club/Initialize()

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1364,3 +1364,6 @@
 			new /obj/item/wisp_lantern(src)
 		if(3)
 			new /obj/item/prisoncube(src)
+
+#undef HIEROPHANT_BLINK_RANGE
+#undef HIEROPHANT_BLINK_COOLDOWN

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1229,7 +1229,6 @@
 		return
 	if(blink_toggled)
 		blink.Teleport(user, target)
-		return
 
 /obj/item/hierophant_club/update_icon_state()
 	icon_state = inhand_icon_state = "hierophant_club[charged ? "_ready":""][(!QDELETED(beacon)) ? "":"_beacon"]"

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1149,13 +1149,13 @@
 	if(!current_charges)
 		var/obj/item/hierophant_club/club = src.target
 		if(istype(club))
-			club.charged = FALSE
+			club.blink_charged = FALSE
 			club.update_icon()
 
 /datum/action/innate/dash/hierophant/charge()
 	var/obj/item/hierophant_club/club = target
 	if(istype(club))
-		club.charged = TRUE
+		club.blink_charged = TRUE
 		club.update_icon()
 
 	current_charges = clamp(current_charges + 1, 0, max_charges)
@@ -1183,14 +1183,17 @@
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	actions_types = list(/datum/action/item_action/vortex_recall)
 
-	var/datum/action/innate/dash/hierophant/blink
-
-	var/cooldown_time = 20 //how long the cooldown between non-melee ranged attacks is
-	var/obj/effect/hierophant/beacon //the associated beacon we teleport to
+	/// Linked teleport beacon for the group teleport functionality.
+	var/obj/effect/hierophant/beacon
+	/// TRUE if currently doing a teleport to the beacon, FALSE otherwise.
 	var/teleporting = FALSE //if we ARE teleporting
 
-	var/blink_toggled = TRUE
-	var/charged = TRUE
+	/// Action enabling the blink-dash functionality.
+	var/datum/action/innate/dash/hierophant/blink
+	/// Whether the blink ability is activated. IF TRUE, left clicking a location will blink to it. If FALSE, this is disabled.
+	var/blink_activated = TRUE
+	/// Whether the blink is charged. Set by
+	var/blink_charged = TRUE
 
 /obj/item/hierophant_club/Initialize()
 	. = ..()
@@ -1219,19 +1222,19 @@
 	qdel(user)
 
 /obj/item/hierophant_club/attack_self(mob/user)
-	blink_toggled = !blink_toggled
-	to_chat(user, "<span class='notice'>You [blink_toggled ? "enable" : "disable"] the blink function on [src].</span>")
+	blink_activated = !blink_activated
+	to_chat(user, "<span class='notice'>You [blink_activated ? "enable" : "disable"] the blink function on [src].</span>")
 
 /obj/item/hierophant_club/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
 	// If our target is the beacon and the hierostaff is next to the beacon, we're trying to pick it up.
 	if((target == beacon) && target.Adjacent(src))
 		return
-	if(blink_toggled)
+	if(blink_activated)
 		blink.Teleport(user, target)
 
 /obj/item/hierophant_club/update_icon_state()
-	icon_state = inhand_icon_state = "hierophant_club[charged ? "_ready":""][(!QDELETED(beacon)) ? "":"_beacon"]"
+	icon_state = inhand_icon_state = "hierophant_club[blink_charged ? "_ready":""][(!QDELETED(beacon)) ? "":"_beacon"]"
 
 /obj/item/hierophant_club/ui_action_click(mob/user, action)
 	if(!user.is_holding(src)) //you need to hold the staff to teleport

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -716,11 +716,11 @@ Difficulty: Hard
 /obj/effect/hierophant/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/hierophant_club))
 		var/obj/item/hierophant_club/H = I
-		if(H.timer > world.time)
+		if(COOLDOWN_FINISHED(H, cooldown))
 			return
 		if(H.beacon == src)
 			to_chat(user, "<span class='notice'>You start removing your hierophant beacon...</span>")
-			H.timer = world.time + 51
+			COOLDOWN_START(H, cooldown, 51)
 			INVOKE_ASYNC(H, /obj/item/hierophant_club.proc/prepare_icon_update)
 			if(do_after(user, 50, target = src))
 				playsound(src,'sound/magic/blind.ogg', 200, TRUE, -4)
@@ -730,7 +730,7 @@ Difficulty: Hard
 				user.update_action_buttons_icon()
 				qdel(src)
 			else
-				H.timer = world.time
+				COOLDOWN_RESET(H, cooldown)
 				INVOKE_ASYNC(H, /obj/item/hierophant_club.proc/prepare_icon_update)
 		else
 			to_chat(user, "<span class='hierophant_warning'>You touch the beacon with the club, but nothing happens.</span>")

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -731,21 +731,16 @@ Difficulty: Hard
 /obj/effect/hierophant/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/hierophant_club))
 		var/obj/item/hierophant_club/H = I
-		if(!H.usable)
-			return
 		if(H.beacon == src)
 			to_chat(user, "<span class='notice'>You start removing your hierophant beacon...</span>")
-			H.usable = FALSE
-			H.update_icon()
 			if(do_after(user, 50, target = src))
 				playsound(src,'sound/magic/blind.ogg', 200, TRUE, -4)
 				new /obj/effect/temp_visual/hierophant/telegraph/teleport(get_turf(src), user)
 				to_chat(user, "<span class='hierophant_warning'>You collect [src], reattaching it to the club!</span>")
 				H.beacon = null
+				H.update_icon()
 				user.update_action_buttons_icon()
 				qdel(src)
-			H.usable = TRUE
-			H.update_icon()
 		else
 			to_chat(user, "<span class='hierophant_warning'>You touch the beacon with the club, but nothing happens.</span>")
 	else

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -279,7 +279,7 @@ Difficulty: Hard
 		new /obj/effect/temp_visual/hierophant/telegraph(T, src)
 	playsound(T,'sound/effects/bin_close.ogg', 200, TRUE)
 	SLEEP_CHECK_DEATH(2)
-	new /obj/effect/temp_visual/hierophant/blast(T, src, FALSE)
+	new /obj/effect/temp_visual/hierophant/blast/damaging(T, src, FALSE)
 	for(var/d in directions)
 		INVOKE_ASYNC(src, .proc/blast_wall, T, d)
 
@@ -288,7 +288,7 @@ Difficulty: Hard
 	var/turf/previousturf = T
 	var/turf/J = get_step(previousturf, set_dir)
 	for(var/i in 1 to range)
-		new /obj/effect/temp_visual/hierophant/blast(J, src, FALSE)
+		new /obj/effect/temp_visual/hierophant/blast/damaging(J, src, FALSE)
 		previousturf = J
 		J = get_step(previousturf, set_dir)
 
@@ -304,7 +304,7 @@ Difficulty: Hard
 	for(var/t in RANGE_TURFS(11, T))
 		if(t && get_dist(t, T) == 11)
 			new /obj/effect/temp_visual/hierophant/wall(t, src)
-			new /obj/effect/temp_visual/hierophant/blast(t, src, FALSE)
+			new /obj/effect/temp_visual/hierophant/blast/damaging(t, src, FALSE)
 	if(get_dist(src, T) >= 11) //hey you're out of range I need to get closer to you!
 		INVOKE_ASYNC(src, .proc/blink, T)
 
@@ -361,7 +361,7 @@ Difficulty: Hard
 	playsound(T,'sound/effects/bin_close.ogg', 200, TRUE)
 	SLEEP_CHECK_DEATH(2)
 	for(var/t in RANGE_TURFS(1, T))
-		new /obj/effect/temp_visual/hierophant/blast(t, src, FALSE)
+		new /obj/effect/temp_visual/hierophant/blast/damaging(t, src, FALSE)
 
 //expanding square
 /proc/hierophant_burst(mob/caster, turf/original, burst_range, spread_speed = 0.5)
@@ -375,7 +375,7 @@ Difficulty: Hard
 		if(dist > last_dist)
 			last_dist = dist
 			sleep(1 + min(burst_range - last_dist, 12) * spread_speed) //gets faster as it gets further out
-		new /obj/effect/temp_visual/hierophant/blast(T, caster, FALSE)
+		new /obj/effect/temp_visual/hierophant/blast/damaging(T, caster, FALSE)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/burst(turf/original, spread_speed)
 	hierophant_burst(src, original, burst_range, spread_speed)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -731,12 +731,12 @@ Difficulty: Hard
 /obj/effect/hierophant/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/hierophant_club))
 		var/obj/item/hierophant_club/H = I
-		if(COOLDOWN_FINISHED(H, cooldown))
+		if(!H.usable)
 			return
 		if(H.beacon == src)
 			to_chat(user, "<span class='notice'>You start removing your hierophant beacon...</span>")
-			COOLDOWN_START(H, cooldown, 51)
-			INVOKE_ASYNC(H, /obj/item/hierophant_club.proc/prepare_icon_update)
+			H.usable = FALSE
+			H.update_icon()
 			if(do_after(user, 50, target = src))
 				playsound(src,'sound/magic/blind.ogg', 200, TRUE, -4)
 				new /obj/effect/temp_visual/hierophant/telegraph/teleport(get_turf(src), user)
@@ -744,9 +744,8 @@ Difficulty: Hard
 				H.beacon = null
 				user.update_action_buttons_icon()
 				qdel(src)
-			else
-				COOLDOWN_RESET(H, cooldown)
-				INVOKE_ASYNC(H, /obj/item/hierophant_club.proc/prepare_icon_update)
+			H.usable = TRUE
+			H.update_icon()
 		else
 			to_chat(user, "<span class='hierophant_warning'>You touch the beacon with the club, but nothing happens.</span>")
 	else

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -332,10 +332,10 @@ Difficulty: Hard
 	new /obj/effect/temp_visual/hierophant/telegraph/teleport(T, src)
 	new /obj/effect/temp_visual/hierophant/telegraph/teleport(source, src)
 	for(var/t in RANGE_TURFS(1, T))
-		var/obj/effect/temp_visual/hierophant/blast/B = new(t, src, FALSE)
+		var/obj/effect/temp_visual/hierophant/blast/damaging/B = new(t, src, FALSE)
 		B.damage = 30
 	for(var/t in RANGE_TURFS(1, source))
-		var/obj/effect/temp_visual/hierophant/blast/B = new(t, src, FALSE)
+		var/obj/effect/temp_visual/hierophant/blast/damaging/B = new(t, src, FALSE)
 		B.damage = 30
 	animate(src, alpha = 0, time = 2, easing = EASE_OUT) //fade out
 	SLEEP_CHECK_DEATH(1)
@@ -602,7 +602,7 @@ Difficulty: Hard
 				sleep(speed)
 			targetturf = get_turf(target)
 /obj/effect/temp_visual/hierophant/chaser/proc/make_blast()
-	var/obj/effect/temp_visual/hierophant/blast/B = new(loc, caster, friendly_fire_check)
+	var/obj/effect/temp_visual/hierophant/blast/damaging/B = new(loc, caster, friendly_fire_check)
 	B.damage = damage
 	B.monster_damage_boost = monster_damage_boost
 
@@ -634,13 +634,15 @@ Difficulty: Hard
 	light_power = 2
 	desc = "Get out of the way!"
 	duration = 9
+
+/obj/effect/temp_visual/hierophant/blast/damaging
 	var/damage = 10 //how much damage do we do?
 	var/monster_damage_boost = TRUE //do we deal extra damage to monsters? Used by the boss
 	var/list/hit_things = list() //we hit these already, ignore them
 	var/friendly_fire_check = FALSE
 	var/bursting = FALSE //if we're bursting and need to hit anyone crossing us
 
-/obj/effect/temp_visual/hierophant/blast/Initialize(mapload, new_caster, friendly_fire)
+/obj/effect/temp_visual/hierophant/blast/damaging/Initialize(mapload, new_caster, friendly_fire)
 	. = ..()
 	friendly_fire_check = friendly_fire
 	if(new_caster)
@@ -650,7 +652,7 @@ Difficulty: Hard
 		M.gets_drilled(caster)
 	INVOKE_ASYNC(src, .proc/blast)
 
-/obj/effect/temp_visual/hierophant/blast/proc/blast()
+/obj/effect/temp_visual/hierophant/blast/damaging/proc/blast()
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
@@ -661,12 +663,12 @@ Difficulty: Hard
 	sleep(1.3) //slightly forgiving; the burst animation is 1.5 deciseconds
 	bursting = FALSE //we no longer damage crossers
 
-/obj/effect/temp_visual/hierophant/blast/Crossed(atom/movable/AM)
+/obj/effect/temp_visual/hierophant/blast/damaging/Crossed(atom/movable/AM)
 	..()
 	if(bursting)
 		do_damage(get_turf(src))
 
-/obj/effect/temp_visual/hierophant/blast/proc/do_damage(turf/T)
+/obj/effect/temp_visual/hierophant/blast/damaging/proc/do_damage(turf/T)
 	if(!damage)
 		return
 	for(var/mob/living/L in T.contents - hit_things) //find and damage mobs...
@@ -700,6 +702,19 @@ Difficulty: Hard
 			to_chat(M.occupant, "<span class='userdanger'>Your [M.name] is struck by a [name]!</span>")
 		playsound(M,'sound/weapons/sear.ogg', 50, TRUE, -4)
 		M.take_damage(damage, BURN, 0, 0)
+
+/obj/effect/temp_visual/hierophant/blast/visual
+	icon_state = "hierophant_blast"
+	name = "vortex blast"
+	light_range = 2
+	light_power = 2
+	desc = "Get out of the way!"
+	duration = 9
+
+/obj/effect/temp_visual/hierophant/blast/visual/Initialize(mapload, new_caster)
+	. = ..()
+	var/turf/src_turf = get_turf(src)
+	playsound(src_turf,'sound/magic/blind.ogg', 125, TRUE, -5)
 
 /obj/effect/hierophant
 	name = "hierophant beacon"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
@@ -115,7 +115,7 @@
 /mob/living/simple_animal/hostile/asteroid/elite/pandora/proc/singular_shot_line(procsleft, angleused, turf/T)
 	if(procsleft <= 0)
 		return
-	new /obj/effect/temp_visual/hierophant/blast/pandora(T, src)
+	new /obj/effect/temp_visual/hierophant/blast/damaging/pandora(T, src)
 	T = get_step(T, angleused)
 	procsleft = procsleft - 1
 	addtimer(CALLBACK(src, .proc/singular_shot_line, procsleft, angleused, T), 2)
@@ -125,7 +125,7 @@
 	var/turf/T = get_turf(target)
 	for(var/t in spiral_range_turfs(3, T))
 		if(get_dist(t, T) > 1)
-			new /obj/effect/temp_visual/hierophant/blast/pandora(t, src)
+			new /obj/effect/temp_visual/hierophant/blast/damaging/pandora(t, src)
 
 /mob/living/simple_animal/hostile/asteroid/elite/pandora/proc/pandora_teleport(target)
 	ranged_cooldown = world.time + (cooldown_time * 2)
@@ -140,9 +140,9 @@
 	new /obj/effect/temp_visual/hierophant/telegraph/teleport(T, src)
 	new /obj/effect/temp_visual/hierophant/telegraph/teleport(source, src)
 	for(var/t in RANGE_TURFS(1, T))
-		new /obj/effect/temp_visual/hierophant/blast/pandora(t, src)
+		new /obj/effect/temp_visual/hierophant/blast/damaging/pandora(t, src)
 	for(var/t in RANGE_TURFS(1, source))
-		new /obj/effect/temp_visual/hierophant/blast/pandora(t, src)
+		new /obj/effect/temp_visual/hierophant/blast/damaging/pandora(t, src)
 	animate(src, alpha = 0, time = 2, easing = EASE_OUT) //fade out
 	visible_message("<span class='hierophant_warning'>[src] fades out!</span>")
 	density = FALSE
@@ -157,7 +157,7 @@
 /mob/living/simple_animal/hostile/asteroid/elite/pandora/proc/aoe_squares(target)
 	ranged_cooldown = world.time + cooldown_time
 	var/turf/T = get_turf(target)
-	new /obj/effect/temp_visual/hierophant/blast/pandora(T, src)
+	new /obj/effect/temp_visual/hierophant/blast/damaging/pandora(T, src)
 	var/max_size = 2
 	addtimer(CALLBACK(src, .proc/aoe_squares_2, T, 0, max_size), 2)
 
@@ -166,11 +166,11 @@
 		return
 	for(var/t in spiral_range_turfs(ring, T))
 		if(get_dist(t, T) == ring)
-			new /obj/effect/temp_visual/hierophant/blast/pandora(t, src)
+			new /obj/effect/temp_visual/hierophant/blast/damaging/pandora(t, src)
 	addtimer(CALLBACK(src, .proc/aoe_squares_2, T, (ring + 1), max_size), 2)
 
 //The specific version of hiero's squares pandora uses
-/obj/effect/temp_visual/hierophant/blast/pandora
+/obj/effect/temp_visual/hierophant/blast/damaging/pandora
 	damage = 20
 	monster_damage_boost = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR reworks the Hierophant Club into a utility item. Mining? Gone. Attacks? Gone.

In their place? 5-tile range point-and-click instant teleport similar to the ninja. Max charge is 1. Recharge time is 15 seconds.

With the removal of this bloat, the item is now small enough to fit in the average backpack.

The hiero club establishes itself as the entry-level megafauna drop from the entry-level megafauna. 

![8Tvr0emnUA](https://user-images.githubusercontent.com/24975989/89952047-6e8eb100-dc24-11ea-891a-722440d98933.gif)

![BCQct9LSSk](https://user-images.githubusercontent.com/24975989/89952071-7c443680-dc24-11ea-898b-cc8e416ad569.gif)

![EsLSoTq8Ai](https://user-images.githubusercontent.com/24975989/89952098-8403db00-dc24-11ea-9abf-88b99999cf30.gif)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The Hierophant Club was a mistake.

It has 3 different attacks, all of which are AoE. One of the attacks is homing and hits multiple times. Two of the attacks do 30 burn damage each, the other does 15. It has infinite ammo. It attacks through walls. It has a beacon that you can teleport yourself and your buddies too. It mines rocks. Oh, and it also gets more powerful to more hurt the user is, increasing the attack AoE and chaser attack tracking (and thus attack) speed.

It is overloaded. Even locked behind a harder Hierophant, it would still be overloaded. It is also of limited use against megafauna, but is exceptionally good against squishy carbons, malfunctioning AI cores, hidden cultist bases and anything the opposite side of a wall.

The Hierophant itself is easy to kill from roundstart with the starting miner equipment for an inexperienced miner. This is not a bad thing. It's an entry-level megafauna and something everyone should be able to kill. The power of this item should reflect the fact that it's a megafauna item and that you take a risk in attempting to obtain it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The Hierophant Club has received a number of changes. It is no longer able to attack at range or mine and instead has been given a 5-tile range instant teleport on a 15 second cooldown. It still retains the teleport beacon functionality.
tweak: With so much bloat removed, the Hierophant Club has shrunk down to the size of an ordinary item and can now fit nicely in most backpacks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
