### PR TITLE
Explosions SS runtime fix + code cleanup

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -426,8 +426,6 @@ SUBSYSTEM_DEF(explosions)
 		lowturf = list()
 		for(var/thing in low_turf)
 			var/turf/turf_thing = thing
-			if(QDELETED(turf_thing))
-				continue
 			turf_thing.explosion_level = max(turf_thing.explosion_level, EXPLODE_LIGHT)
 			turf_thing.ex_act(EXPLODE_LIGHT)
 		cost_lowturf = MC_AVERAGE(cost_lowturf, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
@@ -437,8 +435,6 @@ SUBSYSTEM_DEF(explosions)
 		medturf = list()
 		for(var/thing in med_turf)
 			var/turf/turf_thing = thing
-			if(QDELETED(turf_thing))
-				continue
 			turf_thing.explosion_level = max(turf_thing.explosion_level, EXPLODE_HEAVY)
 			turf_thing.ex_act(EXPLODE_HEAVY)
 		cost_medturf = MC_AVERAGE(cost_medturf, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
@@ -448,8 +444,6 @@ SUBSYSTEM_DEF(explosions)
 		highturf = list()
 		for(var/thing in high_turf)
 			var/turf/turf_thing = thing
-			if(QDELETED(turf_thing))
-				continue
 			turf_thing.explosion_level = max(turf_thing.explosion_level, EXPLODE_DEVASTATE)
 			turf_thing.ex_act(EXPLODE_DEVASTATE)
 		cost_highturf = MC_AVERAGE(cost_highturf, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -16,10 +16,9 @@ SUBSYSTEM_DEF(explosions)
 
 	var/cost_throwturf = 0
 
-	var/cost_lowobj = 0
-	var/cost_medobj = 0
-	var/cost_highobj = 0
-
+	var/cost_low_mov_atom = 0
+	var/cost_med_mov_atom = 0
+	var/cost_high_mov_atom = 0
 
 	var/list/lowturf = list()
 	var/list/medturf = list()
@@ -28,9 +27,9 @@ SUBSYSTEM_DEF(explosions)
 
 	var/list/throwturf = list()
 
-	var/list/lowobj = list()
-	var/list/medobj = list()
-	var/list/highobj = list()
+	var/list/low_mov_atom = list()
+	var/list/med_mov_atom = list()
+	var/list/high_mov_atom = list()
 
 	var/list/explosions = list()
 
@@ -44,9 +43,9 @@ SUBSYSTEM_DEF(explosions)
 	msg += "HT:[round(cost_highturf,1)]|"
 	msg += "FT:[round(cost_flameturf,1)]||"
 
-	msg += "LO:[round(cost_lowobj,1)]|"
-	msg += "MO:[round(cost_medobj,1)]|"
-	msg += "HO:[round(cost_highobj,1)]|"
+	msg += "LO:[round(cost_low_mov_atom,1)]|"
+	msg += "MO:[round(cost_med_mov_atom,1)]|"
+	msg += "HO:[round(cost_high_mov_atom,1)]|"
 
 	msg += "TO:[round(cost_throwturf,1)]"
 
@@ -58,9 +57,9 @@ SUBSYSTEM_DEF(explosions)
 	msg += "HT:[highturf.len]|"
 	msg += "FT:[flameturf.len]||"
 
-	msg += "LO:[lowobj.len]|"
-	msg += "MO:[medobj.len]|"
-	msg += "HO:[highobj.len]|"
+	msg += "LO:[low_mov_atom.len]|"
+	msg += "MO:[med_mov_atom.len]|"
+	msg += "HO:[high_mov_atom.len]|"
 
 	msg += "TO:[throwturf.len]"
 
@@ -72,7 +71,7 @@ SUBSYSTEM_DEF(explosions)
 #define SSEX_OBJ "obj"
 
 /datum/controller/subsystem/explosions/proc/is_exploding()
-	return (lowturf.len || medturf.len || highturf.len || flameturf.len || throwturf.len || lowobj.len || medobj.len || highobj.len)
+	return (lowturf.len || medturf.len || highturf.len || flameturf.len || throwturf.len || low_mov_atom.len || med_mov_atom.len || high_mov_atom.len)
 
 /datum/controller/subsystem/explosions/proc/wipe_turf(turf/T)
 	lowturf -= T
@@ -304,16 +303,17 @@ SUBSYSTEM_DEF(explosions)
 				var/atom/A = I
 				if (length(A.contents) && !(A.flags_1 & PREVENT_CONTENTS_EXPLOSION_1)) //The atom/contents_explosion() proc returns null if the contents ex_acting has been handled by the atom, and TRUE if it hasn't.
 					items += A.GetAllContents()
-			for(var/O in items)
-				var/atom/A = O
-				if(!QDELETED(A))
-					switch(dist)
-						if(EXPLODE_DEVASTATE)
-							SSexplosions.highobj += A
-						if(EXPLODE_HEAVY)
-							SSexplosions.medobj += A
-						if(EXPLODE_LIGHT)
-							SSexplosions.lowobj += A
+			for(var/thing in items)
+				var/atom/movable/movable_thing = thing
+				if(QDELETED(movable_thing))
+					continue
+				switch(dist)
+					if(EXPLODE_DEVASTATE)
+						SSexplosions.high_mov_atom += movable_thing
+					if(EXPLODE_HEAVY)
+						SSexplosions.med_mov_atom += movable_thing
+					if(EXPLODE_LIGHT)
+						SSexplosions.low_mov_atom += movable_thing
 		switch(dist)
 			if(EXPLODE_DEVASTATE)
 				SSexplosions.highturf += T
@@ -425,30 +425,33 @@ SUBSYSTEM_DEF(explosions)
 		var/list/low_turf = lowturf
 		lowturf = list()
 		for(var/thing in low_turf)
-			if(thing)
-				var/turf/T = thing
-				T.explosion_level = max(T.explosion_level, EXPLODE_LIGHT)
-				T.ex_act(EXPLODE_LIGHT)
+			var/turf/turf_thing = thing
+			if(QDELETED(turf_thing))
+				continue
+			turf_thing.explosion_level = max(turf_thing.explosion_level, EXPLODE_LIGHT)
+			turf_thing.ex_act(EXPLODE_LIGHT)
 		cost_lowturf = MC_AVERAGE(cost_lowturf, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 
 		timer = TICK_USAGE_REAL
 		var/list/med_turf = medturf
 		medturf = list()
 		for(var/thing in med_turf)
-			if(thing)
-				var/turf/T = thing
-				T.explosion_level = max(T.explosion_level, EXPLODE_HEAVY)
-				T.ex_act(EXPLODE_HEAVY)
+			var/turf/turf_thing = thing
+			if(QDELETED(turf_thing))
+				continue
+			turf_thing.explosion_level = max(turf_thing.explosion_level, EXPLODE_HEAVY)
+			turf_thing.ex_act(EXPLODE_HEAVY)
 		cost_medturf = MC_AVERAGE(cost_medturf, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 
 		timer = TICK_USAGE_REAL
 		var/list/high_turf = highturf
 		highturf = list()
 		for(var/thing in high_turf)
-			if(thing)
-				var/turf/T = thing
-				T.explosion_level = max(T.explosion_level, EXPLODE_DEVASTATE)
-				T.ex_act(EXPLODE_DEVASTATE)
+			var/turf/turf_thing = thing
+			if(QDELETED(turf_thing))
+				continue
+			turf_thing.explosion_level = max(turf_thing.explosion_level, EXPLODE_DEVASTATE)
+			turf_thing.ex_act(EXPLODE_DEVASTATE)
 		cost_highturf = MC_AVERAGE(cost_highturf, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 
 		timer = TICK_USAGE_REAL
@@ -467,31 +470,34 @@ SUBSYSTEM_DEF(explosions)
 		currentpart = SSEXPLOSIONS_THROWS
 
 		timer = TICK_USAGE_REAL
-		var/list/high_obj = highobj
-		highobj = list()
-		for(var/thing in high_obj)
-			if(thing)
-				var/obj/O = thing
-				O.ex_act(EXPLODE_DEVASTATE)
-		cost_highobj = MC_AVERAGE(cost_highobj, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+		var/list/local_high_mov_atom = high_mov_atom
+		high_mov_atom = list()
+		for(var/thing in local_high_mov_atom)
+			var/atom/movable/movable_thing = thing
+			if(QDELETED(movable_thing))
+				continue
+			movable_thing.ex_act(EXPLODE_DEVASTATE)
+		cost_high_mov_atom = MC_AVERAGE(cost_high_mov_atom, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 
 		timer = TICK_USAGE_REAL
-		var/list/med_obj = medobj
-		medobj = list()
-		for(var/thing in med_obj)
-			if(thing)
-				var/obj/O = thing
-				O.ex_act(EXPLODE_HEAVY)
-		cost_medobj = MC_AVERAGE(cost_medobj, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+		var/list/local_med_mov_atom = med_mov_atom
+		med_mov_atom = list()
+		for(var/thing in local_med_mov_atom)
+			var/atom/movable/movable_thing = thing
+			if(QDELETED(movable_thing))
+				continue
+			movable_thing.ex_act(EXPLODE_HEAVY)
+		cost_med_mov_atom = MC_AVERAGE(cost_med_mov_atom, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 
 		timer = TICK_USAGE_REAL
-		var/list/low_obj = lowobj
-		lowobj = list()
-		for(var/thing in low_obj)
-			if(thing)
-				var/obj/O = thing
-				O.ex_act(EXPLODE_LIGHT)
-		cost_lowobj = MC_AVERAGE(cost_lowobj, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+		var/list/local_low_mov_atom = low_mov_atom
+		low_mov_atom = list()
+		for(var/thing in local_low_mov_atom)
+			var/atom/movable/movable_thing = thing
+			if(QDELETED(movable_thing))
+				continue
+			movable_thing.ex_act(EXPLODE_LIGHT)
+		cost_low_mov_atom = MC_AVERAGE(cost_low_mov_atom, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 
 
 	if (currentpart == SSEXPLOSIONS_THROWS)

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -140,17 +140,19 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 
 /obj/effect/meteor/proc/ram_turf(turf/T)
 	//first bust whatever is in the turf
-	for(var/atom/A in T)
-		if(A != src)
-			if(isliving(A))
-				A.visible_message("<span class='warning'>[src] slams into [A].</span>", "<span class='userdanger'>[src] slams into you!.</span>")
-			switch(hitpwr)
-				if(EXPLODE_DEVASTATE)
-					SSexplosions.highobj += A
-				if(EXPLODE_HEAVY)
-					SSexplosions.medobj += A
-				if(EXPLODE_LIGHT)
-					SSexplosions.lowobj += A
+	for(var/thing in T)
+		if(thing == src)
+			continue
+		if(isliving(thing))
+			var/mob/living/living_thing = thing
+			living_thing.visible_message("<span class='warning'>[src] slams into [living_thing].</span>", "<span class='userdanger'>[src] slams into you!.</span>")
+		switch(hitpwr)
+			if(EXPLODE_DEVASTATE)
+				SSexplosions.high_mov_atom += thing
+			if(EXPLODE_HEAVY)
+				SSexplosions.med_mov_atom += thing
+			if(EXPLODE_LIGHT)
+				SSexplosions.low_mov_atom += thing
 
 	//then, ram the turf if it still exists
 	if(T)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1083,7 +1083,7 @@
 
 	var/obj/structure/window/killthis = (locate(/obj/structure/window) in get_turf(src))
 	if(killthis)
-		SSexplosions.medobj += killthis
+		SSexplosions.med_mov_atom += killthis
 	SEND_SIGNAL(src, COMSIG_AIRLOCK_CLOSE, forced)
 	operating = TRUE
 	update_icon(AIRLOCK_CLOSING, 1)

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -128,20 +128,20 @@
 		var/obj/item/mecha_parts/mecha_equipment/ME = X
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += ME
+				SSexplosions.high_mov_atom += ME
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += ME
+				SSexplosions.med_mov_atom += ME
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += ME
+				SSexplosions.low_mov_atom += ME
 	for(var/Y in trackers)
 		var/obj/item/mecha_parts/mecha_tracking/MT = Y
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += MT
+				SSexplosions.high_mov_atom += MT
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += MT
+				SSexplosions.med_mov_atom += MT
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += MT
+				SSexplosions.low_mov_atom += MT
 	if(occupant)
 		occupant.ex_act(severity,target)
 

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -332,7 +332,7 @@
 			if(target && !target.stat)
 				O.throw_at(target, 7, 5)
 		else
-			SSexplosions.medobj += O
+			SSexplosions.med_mov_atom += O
 
 /obj/effect/anomaly/bhole/proc/grav(r, ex_act_force, pull_chance, turf_removal_chance)
 	for(var/t = -r, t < r, t++)
@@ -353,11 +353,11 @@
 			if(O.anchored)
 				switch(ex_act_force)
 					if(EXPLODE_DEVASTATE)
-						SSexplosions.highobj += O
+						SSexplosions.high_mov_atom += O
 					if(EXPLODE_HEAVY)
-						SSexplosions.medobj += O
+						SSexplosions.med_mov_atom += O
 					if(EXPLODE_LIGHT)
-						SSexplosions.lowobj += O
+						SSexplosions.low_mov_atom += O
 			else
 				step_towards(O,src)
 		for(var/mob/living/M in T.contents)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -19,14 +19,14 @@
 	return FALSE
 
 /obj/item/storage/contents_explosion(severity, target)
-	for(var/atom/A in contents)
+	for(var/thing in contents)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += A
+				SSexplosions.high_mov_atom += thing
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += A
+				SSexplosions.med_mov_atom += thing
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += A
+				SSexplosions.low_mov_atom += thing
 
 /obj/item/storage/canStrip(mob/who)
 	. = ..()

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -159,7 +159,7 @@
 	return take_damage(M.force*3, mech_damtype, "melee", play_soundeffect, get_dir(src, M)) // multiplied by 3 so we can hit objs hard but not be overpowered against mobs.
 
 /obj/singularity_act()
-	SSexplosions.highobj += src
+	SSexplosions.high_mov_atom += src
 	if(src && !QDELETED(src))
 		qdel(src)
 	return 2

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -496,14 +496,14 @@
 				req_access += pick(get_all_accesses())
 
 /obj/structure/closet/contents_explosion(severity, target)
-	for(var/atom/A in contents)
+	for(var/thing in contents)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += A
+				SSexplosions.high_mov_atom += thing
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += A
+				SSexplosions.med_mov_atom += thing
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += A
+				SSexplosions.low_mov_atom += thing
 
 /obj/structure/closet/singularity_act()
 	dump_contents()

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -35,11 +35,11 @@
 	if(stored_extinguisher)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += stored_extinguisher
+				SSexplosions.high_mov_atom += stored_extinguisher
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += stored_extinguisher
+				SSexplosions.med_mov_atom += stored_extinguisher
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += stored_extinguisher
+				SSexplosions.low_mov_atom += stored_extinguisher
 
 /obj/structure/extinguisher_cabinet/handle_atom_del(atom/A)
 	if(A == stored_extinguisher)

--- a/code/game/objects/structures/guncase.dm
+++ b/code/game/objects/structures/guncase.dm
@@ -116,14 +116,14 @@
 	update_icon()
 
 /obj/structure/guncase/contents_explosion(severity, target)
-	for(var/atom/A in contents)
+	for(var/thing in contents)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += A
+				SSexplosions.high_mov_atom += thing
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += A
+				SSexplosions.med_mov_atom += thing
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += A
+				SSexplosions.low_mov_atom += thing
 
 /obj/structure/guncase/shotgun
 	name = "shotgun locker"

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -58,14 +58,14 @@
 		empty_pod()
 
 /obj/structure/transit_tube_pod/contents_explosion(severity, target)
-	for(var/atom/movable/AM in contents)
+	for(var/thing in contents)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += AM
+				SSexplosions.high_mov_atom += thing
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += AM
+				SSexplosions.med_mov_atom += thing
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += AM
+				SSexplosions.low_mov_atom += thing
 
 /obj/structure/transit_tube_pod/singularity_pull(S, current_size)
 	..()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -446,22 +446,22 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 /turf/proc/is_shielded()
 
-/turf/contents_explosion(severity, target)
 
-	for(var/V in contents)
-		var/atom/A = V
-		if(!QDELETED(A))
-			if(ismovable(A))
-				var/atom/movable/AM = A
-				if(!AM.ex_check(explosion_id))
-					continue
-			switch(severity)
-				if(EXPLODE_DEVASTATE)
-					SSexplosions.highobj += A
-				if(EXPLODE_HEAVY)
-					SSexplosions.medobj += A
-				if(EXPLODE_LIGHT)
-					SSexplosions.lowobj += A
+/turf/contents_explosion(severity, target)
+	for(var/thing in contents)
+		var/atom/movable/movable_thing = thing
+		if(QDELETED(movable_thing))
+			continue
+		if(!movable_thing.ex_check(explosion_id))
+			continue
+		switch(severity)
+			if(EXPLODE_DEVASTATE)
+				SSexplosions.high_mov_atom += movable_thing
+			if(EXPLODE_HEAVY)
+				SSexplosions.med_mov_atom += movable_thing
+			if(EXPLODE_LIGHT)
+				SSexplosions.low_mov_atom += movable_thing
+
 
 /turf/narsie_act(force, ignore_mobs, probability = 20)
 	. = (prob(probability) || force)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -97,11 +97,11 @@
 	if(beaker)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += beaker
+				SSexplosions.high_mov_atom += beaker
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += beaker
+				SSexplosions.med_mov_atom += beaker
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += beaker
+				SSexplosions.low_mov_atom += beaker
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/handle_atom_del(atom/A)
 	..()

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -145,7 +145,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 			if(isturf(clong))
 				SSexplosions.medturf += clong
 			if(isobj(clong))
-				SSexplosions.medobj += clong
+				SSexplosions.med_mov_atom += clong
 
 	else if(isliving(clong))
 		penetrate(clong)

--- a/code/modules/events/processor_overload.dm
+++ b/code/modules/events/processor_overload.dm
@@ -34,6 +34,6 @@
 			explosion(get_turf(P), 0, 0, 2)
 			// Only a level 1 explosion actually damages the machine
 			// at all
-			SSexplosions.highobj += P
+			SSexplosions.high_mov_atom += P
 		else
 			P.emp_act(EMP_HEAVY)

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -32,11 +32,11 @@
 	if(beaker)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += beaker
+				SSexplosions.high_mov_atom += beaker
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += beaker
+				SSexplosions.med_mov_atom += beaker
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += beaker
+				SSexplosions.low_mov_atom += beaker
 
 /obj/machinery/biogenerator/handle_atom_del(atom/A)
 	..()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -406,16 +406,14 @@
 	switch (severity)
 		if (EXPLODE_DEVASTATE)
 			if(bomb_armor < EXPLODE_GIB_THRESHOLD) //gibs the mob if their bomb armor is lower than EXPLODE_GIB_THRESHOLD
-				for(var/I in contents)
-					var/atom/A = I
-					if(!QDELETED(A))
-						switch(severity)
-							if(EXPLODE_DEVASTATE)
-								SSexplosions.highobj += A
-							if(EXPLODE_HEAVY)
-								SSexplosions.medobj += A
-							if(EXPLODE_LIGHT)
-								SSexplosions.lowobj += A
+				for(var/thing in contents)
+					switch(severity)
+						if(EXPLODE_DEVASTATE)
+							SSexplosions.high_mov_atom += thing
+						if(EXPLODE_HEAVY)
+							SSexplosions.med_mov_atom += thing
+						if(EXPLODE_LIGHT)
+							SSexplosions.low_mov_atom += thing
 				gib()
 				return
 			else

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -463,7 +463,7 @@ Difficulty: Hard
 	if(charging)
 		if(isturf(A) || isobj(A) && A.density)
 			if(isobj(A))
-				SSexplosions.medobj += A
+				SSexplosions.med_mov_atom += A
 			else
 				SSexplosions.medturf += A
 		DestroySurroundings()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -273,7 +273,7 @@ Difficulty: Very Hard
 	. = ..()
 	if(isturf(target) || isobj(target))
 		if(isobj(target))
-			SSexplosions.medobj += target
+			SSexplosions.med_mov_atom += target
 		else
 			SSexplosions.medturf += target
 

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -123,11 +123,11 @@
 	if(cpu)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += cpu
+				SSexplosions.high_mov_atom += cpu
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += cpu
+				SSexplosions.med_mov_atom += cpu
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += cpu
+				SSexplosions.low_mov_atom += cpu
 	..()
 
 // EMPs are similar to explosions, but don't cause physical damage to the casing. Instead they screw up the components

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -178,7 +178,7 @@
 
 
 /obj/item/stock_parts/cell/blob_act(obj/structure/blob/B)
-	SSexplosions.highobj += src
+	SSexplosions.high_mov_atom += src
 
 /obj/item/stock_parts/cell/proc/get_electrocute_damage()
 	if(charge >= 1000)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -111,7 +111,7 @@
 	. = ..()
 	if (!QDELETED(target) && (isturf(target) || istype(target, /obj/structure/)))
 		if(isobj(target))
-			SSexplosions.medobj += target
+			SSexplosions.med_mov_atom += target
 		else
 			SSexplosions.medturf += target
 

--- a/code/modules/projectiles/projectile/special/meteor.dm
+++ b/code/modules/projectiles/projectile/special/meteor.dm
@@ -12,7 +12,7 @@
 		forceMove(A.loc)
 		return
 	if(isobj(A))
-		SSexplosions.medobj += A
+		SSexplosions.med_mov_atom += A
 	else if(isturf(A))
 		SSexplosions.medturf += A
 	playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, TRUE)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -157,11 +157,11 @@
 	if(beaker)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += beaker
+				SSexplosions.high_mov_atom += beaker
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += beaker
+				SSexplosions.med_mov_atom += beaker
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += beaker
+				SSexplosions.low_mov_atom += beaker
 
 /obj/machinery/chem_dispenser/handle_atom_del(atom/A)
 	..()

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -53,19 +53,19 @@
 	if(beaker)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += beaker
+				SSexplosions.high_mov_atom += beaker
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += beaker
+				SSexplosions.med_mov_atom += beaker
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += beaker
+				SSexplosions.low_mov_atom += beaker
 	if(bottle)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += bottle
+				SSexplosions.high_mov_atom += bottle
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += bottle
+				SSexplosions.med_mov_atom += bottle
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += bottle
+				SSexplosions.low_mov_atom += bottle
 
 /obj/machinery/chem_master/handle_atom_del(atom/A)
 	..()

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -46,11 +46,11 @@
 	if(beaker)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += beaker
+				SSexplosions.high_mov_atom += beaker
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += beaker
+				SSexplosions.med_mov_atom += beaker
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += beaker
+				SSexplosions.low_mov_atom += beaker
 
 /obj/machinery/reagentgrinder/RefreshParts()
 	speed = 1

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -26,14 +26,14 @@
 	return ..()
 
 /obj/structure/big_delivery/contents_explosion(severity, target)
-	for(var/atom/movable/AM in contents)
+	for(var/thing in contents)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += AM
+				SSexplosions.high_mov_atom += thing
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += AM
+				SSexplosions.med_mov_atom += thing
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += AM
+				SSexplosions.low_mov_atom += thing
 
 /obj/structure/big_delivery/examine(mob/user)
 	. = ..()
@@ -177,14 +177,14 @@
 	var/obj/item/barcode/sticker
 
 /obj/item/small_delivery/contents_explosion(severity, target)
-	for(var/atom/movable/AM in contents)
+	for(var/thing in contents)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
-				SSexplosions.highobj += AM
+				SSexplosions.high_mov_atom += thing
 			if(EXPLODE_HEAVY)
-				SSexplosions.medobj += AM
+				SSexplosions.med_mov_atom += thing
 			if(EXPLODE_LIGHT)
-				SSexplosions.lowobj += AM
+				SSexplosions.low_mov_atom += thing
 
 /obj/item/small_delivery/attack_self(mob/user)
 	to_chat(user, "<span class='notice'>You start to unwrap the package...</span>")

--- a/code/modules/swarmers/swarmer.dm
+++ b/code/modules/swarmers/swarmer.dm
@@ -117,7 +117,7 @@
 		var/mob/living/silicon/borg = target
 		borg.adjustBruteLoss(melee_damage_lower)
 	return ..()
-		
+
 /mob/living/simple_animal/hostile/swarmer/MiddleClickOn(atom/A)
 	. = ..()
 	if(!LAZYLEN(dronelist))
@@ -203,7 +203,7 @@
 	new /obj/effect/temp_visual/swarmer/disintegration(get_turf(target))
 	do_attack_animation(target)
 	changeNext_move(CLICK_CD_MELEE)
-	SSexplosions.lowobj += target
+	SSexplosions.low_mov_atom += target
 
 /**
   * Called when a swarmer attempts to teleport a living entity away
@@ -224,9 +224,9 @@
 
 	if(!do_mob(src, target, 30))
 		return
-		
+
 	teleport_target(target)
-		
+
 /mob/living/simple_animal/hostile/swarmer/proc/teleport_target(mob/living/target)
 	var/turf/open/floor/safe_turf = find_safe_turf(zlevels = z, extended_safety_checks = TRUE)
 


### PR DESCRIPTION
* Fixes the subsystem trying to call `ex_act()` on qdeleted things, such as mobs.
* Renames variables for clarity.
* Does minor code cleanup around, removing unnecessary checks.

Runtime:
```
[17:28:15] Runtime in human_defense.dm, line 393: Cannot read null.species
proc name: ex act (/mob/living/carbon/human/ex_act)
src: Unknown (/mob/living/carbon/human)
src.loc: null
call stack:
Unknown (/mob/living/carbon/human): ex act(3, null, null)
Explosions (/datum/controller/subsystem/explosions): fire(0)
Explosions (/datum/controller/subsystem/explosions): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```