### PR TITLE
Fixes a slime emote runtime

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/emote.dm
+++ b/code/modules/mob/living/simple_animal/slime/emote.dm
@@ -28,9 +28,11 @@
 
 /datum/emote/slime/mood/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
-	var/mob/living/simple_animal/slime/S = user
-	S.mood = mood
-	S.regenerate_icons()
+	if(!.)
+		return
+	var/mob/living/simple_animal/slime/slime_user = user
+	slime_user.mood = mood
+	slime_user.regenerate_icons()
 
 /datum/emote/slime/mood/sneaky
 	key = "moodsneaky"


### PR DESCRIPTION
It wasn't checking the parent call return value.
This is the runtime:
```
[17:32:36] Runtime in emote.dm, line 32: Undefined variable /mob/living/carbon/human/var/mood 
proc name: run emote (/datum/emote/slime/mood/run_emote)
usr: CKEY/(Carilyn Fugaz)
usr.loc: (Head of Personnel's Office (139,129,2))
src: /datum/emote/slime/mood/smile (/datum/emote/slime/mood/smile)
call stack:
/datum/emote/slime/mood/smile (/datum/emote/slime/mood/smile): run emote(Carilyn Fugaz (/mob/living/carbon/human), null, null, 1)
Carilyn Fugaz (/mob/living/carbon/human): emote("moodsmile", null, null, 1)
moodsmile (/datum/keybinding/emote): down(CKEY(/client))
CKEY(/client): keyDown("1")
```