### PR TITLE
Fixes a parallax SS runtime

### DIFF
--- a/code/controllers/subsystem/parallax.dm
+++ b/code/controllers/subsystem/parallax.dm
@@ -10,6 +10,7 @@ SUBSYSTEM_DEF(parallax)
 	var/random_layer
 	var/random_parallax_color
 
+
 //These are cached per client so needs to be done asap so people joining at roundstart do not miss these.
 /datum/controller/subsystem/parallax/PreInit()
 	. = ..()
@@ -19,7 +20,8 @@ SUBSYSTEM_DEF(parallax)
 	planet_y_offset = rand(100, 160)
 	planet_x_offset = rand(100, 160)
 
-/datum/controller/subsystem/parallax/fire(resumed = 0)
+
+/datum/controller/subsystem/parallax/fire(resumed = FALSE)
 	if (!resumed)
 		src.currentrun = GLOB.clients.Copy()
 
@@ -27,24 +29,27 @@ SUBSYSTEM_DEF(parallax)
 	var/list/currentrun = src.currentrun
 
 	while(length(currentrun))
-		var/client/C = currentrun[currentrun.len]
+		var/client/processing_client = currentrun[currentrun.len]
 		currentrun.len--
-		if (!C || !C.eye)
+		if (QDELETED(processing_client) || !processing_client.eye)
 			if (MC_TICK_CHECK)
 				return
 			continue
-		var/atom/movable/A = C.eye
-		if(!istype(A))
-			continue
-		for (A; isloc(A.loc) && !isturf(A.loc); A = A.loc);
 
-		if(A != C.movingmob)
-			if(C.movingmob != null)
-				C.movingmob.client_mobs_in_contents -= C.mob
-				UNSETEMPTY(C.movingmob.client_mobs_in_contents)
-			LAZYINITLIST(A.client_mobs_in_contents)
-			A.client_mobs_in_contents += C.mob
-			C.movingmob = A
+		var/atom/movable/movable_eye = processing_client.eye
+		if(!istype(movable_eye))
+			continue
+
+		for (movable_eye; isloc(movable_eye.loc) && !isturf(movable_eye.loc); movable_eye = movable_eye.loc);
+
+		if(movable_eye == processing_client.movingmob)
+			if (MC_TICK_CHECK)
+				return
+			continue
+		if(!isnull(processing_client.movingmob))
+			LAZYREMOVE(processing_client.movingmob.client_mobs_in_contents, processing_client.mob)
+		LAZYADD(movable_eye.client_mobs_in_contents, processing_client.mob)
+		processing_client.movingmob = movable_eye
 		if (MC_TICK_CHECK)
 			return
 	currentrun = null


### PR DESCRIPTION
Lazy list macros weren't being used properly.
Did a bit of code cleaning as well.

Runtime:
```
[17:39:46] Runtime in parallax.dm, line 43: type mismatch: null -= Sukie Braun (/mob/dead/observer)
proc name: fire (/datum/controller/subsystem/parallax/fire)
src: Parallax (/datum/controller/subsystem/parallax)
call stack:
Parallax (/datum/controller/subsystem/parallax): fire(0)
Parallax (/datum/controller/subsystem/parallax): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```