### PR TITLE
Various virus fixes

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -62,24 +62,22 @@
 /datum/disease/proc/admin_details()
 	return "[src.name] : [src.type]"
 
+
+///Proc to process the disease and decide on whether to advance, cure or make the sympthoms appear. Returns a boolean on whether to continue acting on the symptoms or not.
 /datum/disease/proc/stage_act()
-	var/cure = has_cure()
-
-	if(carrier && !cure)
-		return
-
-	stage = min(stage, max_stages)
-
-	if(!cure)
-		if(prob(stage_prob))
-			update_stage(min(stage + 1,max_stages))
-	else
+	if(has_cure())
 		if(prob(cure_chance))
 			update_stage(max(stage - 1, 1))
 
-	if(disease_flags & CURABLE)
-		if(cure && prob(cure_chance))
+		if(disease_flags & CURABLE && prob(cure_chance))
 			cure()
+			return FALSE
+
+	else if(prob(stage_prob))
+		update_stage(min(stage + 1, max_stages))
+
+	return !carrier
+
 
 /datum/disease/proc/update_stage(new_stage)
 	stage = new_stage

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -103,22 +103,28 @@
 	infect(infectee, make_copy)
 	return TRUE
 
+
 // Randomly pick a symptom to activate.
 /datum/disease/advance/stage_act()
-	..()
-	if(carrier || QDELETED(src)) // Could be cured in parent call.
+	. = ..()
+	if(!.)
 		return
 
-	if(symptoms && symptoms.len)
-		if(!processing)
-			processing = TRUE
-			for(var/datum/symptom/S in symptoms)
-				if(S.Start(src)) //this will return FALSE if the symptom is neutered
-					S.next_activation = world.time + rand(S.symptom_delay_min * 10, S.symptom_delay_max * 10)
-				S.on_stage_change(src)
+	if(!length(symptoms))
+		return
 
-		for(var/datum/symptom/S in symptoms)
-			S.Activate(src)
+	if(!processing)
+		processing = TRUE
+		for(var/s in symptoms)
+			var/datum/symptom/symptom_datum = s
+			if(symptom_datum.Start(src)) //this will return FALSE if the symptom is neutered
+				symptom_datum.next_activation = world.time + rand(symptom_datum.symptom_delay_min SECONDS, symptom_datum.symptom_delay_max SECONDS)
+			symptom_datum.on_stage_change(src)
+
+	for(var/s in symptoms)
+		var/datum/symptom/symptom_datum = s
+		symptom_datum.Activate(src)
+
 
 // Tell symptoms stage changed
 /datum/disease/advance/update_stage(new_stage)

--- a/code/datums/diseases/anxiety.dm
+++ b/code/datums/diseases/anxiety.dm
@@ -11,8 +11,12 @@
 	desc = "If left untreated subject will regurgitate butterflies."
 	severity = DISEASE_SEVERITY_MINOR
 
+
 /datum/disease/anxiety/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(2) //also changes say, see say.dm
 			if(prob(5))
@@ -38,4 +42,3 @@
 													"<span class='userdanger'>You cough up butterflies!</span>")
 				new /mob/living/simple_animal/butterfly(affected_mob.loc)
 				new /mob/living/simple_animal/butterfly(affected_mob.loc)
-	return

--- a/code/datums/diseases/appendicitis.dm
+++ b/code/datums/diseases/appendicitis.dm
@@ -14,8 +14,12 @@
 	required_organs = list(/obj/item/organ/appendix)
 	bypasses_immunity = TRUE // Immunity is based on not having an appendix; this isn't a virus
 
+
 /datum/disease/appendicitis/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(1)
 			if(prob(5))
@@ -29,7 +33,7 @@
 				to_chat(affected_mob, "<span class='warning'>You feel a stabbing pain in your abdomen!</span>")
 				affected_mob.adjustOrganLoss(ORGAN_SLOT_APPENDIX, 5)
 				affected_mob.Stun(rand(40,60))
-				affected_mob.adjustToxLoss(1)
+				affected_mob.adjustToxLoss(1, FALSE)
 		if(3)
 			if(prob(1))
 				affected_mob.vomit(95)

--- a/code/datums/diseases/beesease.dm
+++ b/code/datums/diseases/beesease.dm
@@ -12,8 +12,12 @@
 	severity = DISEASE_SEVERITY_MEDIUM
 	infectable_biotypes = MOB_ORGANIC|MOB_UNDEAD //bees nesting in corpses
 
+
 /datum/disease/beesease/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(2) //also changes say, see say.dm
 			if(prob(2))
@@ -25,7 +29,6 @@
 				to_chat(affected_mob, "<span class='danger'>Your stomach stings painfully.</span>")
 				if(prob(20))
 					affected_mob.adjustToxLoss(2)
-					affected_mob.updatehealth()
 		if(4)
 			if(prob(10))
 				affected_mob.visible_message("<span class='danger'>[affected_mob] buzzes.</span>", \
@@ -36,4 +39,3 @@
 				affected_mob.visible_message("<span class='danger'>[affected_mob] coughs up a swarm of bees!</span>", \
 													"<span class='userdanger'>You cough up a swarm of bees!</span>")
 				new /mob/living/simple_animal/hostile/poison/bees(affected_mob.loc)
-	return

--- a/code/datums/diseases/brainrot.dm
+++ b/code/datums/diseases/brainrot.dm
@@ -12,8 +12,11 @@
 	required_organs = list(/obj/item/organ/brain)
 	severity = DISEASE_SEVERITY_HARMFUL
 
+
 /datum/disease/brainrot/stage_act() //Removed toxloss because damaging diseases are pretty horrible. Last round it killed the entire station because the cure didn't work -- Urist -ACTUALLY Removed rather than commented out, I don't see it returning - RR
-	..()
+	. = ..()
+	if(!.)
+		return
 
 	switch(stage)
 		if(2)
@@ -25,7 +28,6 @@
 				to_chat(affected_mob, "<span class='danger'>You don't feel like yourself.</span>")
 			if(prob(5))
 				affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1, 170)
-				affected_mob.updatehealth()
 		if(3)
 			if(prob(2))
 				affected_mob.emote("stare")
@@ -33,7 +35,6 @@
 				affected_mob.emote("drool")
 			if(prob(10))
 				affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 170)
-				affected_mob.updatehealth()
 				if(prob(2))
 					to_chat(affected_mob, "<span class='danger'>Your try to remember something important...but can't.</span>")
 
@@ -44,7 +45,6 @@
 				affected_mob.emote("drool")
 			if(prob(15))
 				affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3, 170)
-				affected_mob.updatehealth()
 				if(prob(2))
 					to_chat(affected_mob, "<span class='danger'>Strange buzzing fills your head, removing all thoughts.</span>")
 			if(prob(3))
@@ -56,5 +56,3 @@
 					affected_mob.emote("snore")
 			if(prob(15))
 				affected_mob.stuttering += 3
-
-	return

--- a/code/datums/diseases/cold.dm
+++ b/code/datums/diseases/cold.dm
@@ -9,18 +9,22 @@
 	desc = "If left untreated the subject will contract the flu."
 	severity = DISEASE_SEVERITY_NONTHREAT
 
+
 /datum/disease/cold/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(2)
 			if(!(affected_mob.mobility_flags & MOBILITY_STAND) && prob(40))  //changed FROM prob(10) until sleeping is fixed
 				to_chat(affected_mob, "<span class='notice'>You feel better.</span>")
 				cure()
-				return
-			if(prob(1) && prob(5))
+				return FALSE
+			if(prob(0.05))
 				to_chat(affected_mob, "<span class='notice'>You feel better.</span>")
 				cure()
-				return
+				return FALSE
 			if(prob(1))
 				affected_mob.emote("sneeze")
 			if(prob(1))
@@ -33,11 +37,11 @@
 			if(!(affected_mob.mobility_flags & MOBILITY_STAND) && prob(25))  //changed FROM prob(5) until sleeping is fixed
 				to_chat(affected_mob, "<span class='notice'>You feel better.</span>")
 				cure()
-				return
-			if(prob(1) && prob(1))
+				return FALSE
+			if(prob(0.01))
 				to_chat(affected_mob, "<span class='notice'>You feel better.</span>")
 				cure()
-				return
+				return FALSE
 			if(prob(1))
 				affected_mob.emote("sneeze")
 			if(prob(1))
@@ -46,8 +50,8 @@
 				to_chat(affected_mob, "<span class='danger'>Your throat feels sore.</span>")
 			if(prob(1))
 				to_chat(affected_mob, "<span class='danger'>Mucous runs down the back of your throat.</span>")
-			if(prob(1) && prob(50))
-				if(!LAZYFIND(affected_mob.disease_resistances, /datum/disease/flu))
-					var/datum/disease/Flu = new /datum/disease/flu()
-					affected_mob.ForceContractDisease(Flu, FALSE, TRUE)
-					cure()
+			if(prob(0.5) && !LAZYFIND(affected_mob.disease_resistances, /datum/disease/flu))
+				var/datum/disease/Flu = new /datum/disease/flu()
+				affected_mob.ForceContractDisease(Flu, FALSE, TRUE)
+				cure()
+				return FALSE

--- a/code/datums/diseases/cold9.dm
+++ b/code/datums/diseases/cold9.dm
@@ -10,15 +10,19 @@
 	desc = "If left untreated the subject will slow, as if partly frozen."
 	severity = DISEASE_SEVERITY_HARMFUL
 
+
 /datum/disease/cold9/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(2)
 			affected_mob.adjust_bodytemperature(-10)
-			if(prob(1) && prob(10))
+			if(prob(0.1))
 				to_chat(affected_mob, "<span class='notice'>You feel better.</span>")
 				cure()
-				return
+				return FALSE
 			if(prob(1))
 				affected_mob.emote("sneeze")
 			if(prob(1))

--- a/code/datums/diseases/decloning.dm
+++ b/code/datums/diseases/decloning.dm
@@ -14,10 +14,14 @@
 	process_dead = TRUE
 
 /datum/disease/decloning/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	if(affected_mob.stat == DEAD)
 		cure()
-		return
+		return FALSE
+
 	switch(stage)
 		if(2)
 			if(prob(2))
@@ -30,7 +34,7 @@
 			if(prob(2))
 				affected_mob.emote("drool")
 			if(prob(3))
-				affected_mob.adjustCloneLoss(1)
+				affected_mob.adjustCloneLoss(1, FALSE)
 			if(prob(2))
 				to_chat(affected_mob, "<span class='danger'>Your skin feels strange.</span>")
 
@@ -41,7 +45,7 @@
 				affected_mob.emote("drool")
 			if(prob(5))
 				affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1, 170)
-				affected_mob.adjustCloneLoss(2)
+				affected_mob.adjustCloneLoss(2, FALSE)
 			if(prob(15))
 				affected_mob.stuttering += 3
 		if(5)
@@ -52,8 +56,9 @@
 			if(prob(5))
 				to_chat(affected_mob, "<span class='danger'>Your skin starts degrading!</span>")
 			if(prob(10))
-				affected_mob.adjustCloneLoss(5)
+				affected_mob.adjustCloneLoss(5, FALSE)
 				affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 170)
 			if(affected_mob.cloneloss >= 100)
 				affected_mob.visible_message("<span class='danger'>[affected_mob] skin turns to dust!</span>", "<span class='boldwarning'>Your skin turns to dust!</span>")
 				affected_mob.dust()
+				return FALSE

--- a/code/datums/diseases/dna_spread.dm
+++ b/code/datums/diseases/dna_spread.dm
@@ -15,11 +15,17 @@
 
 
 /datum/disease/dnaspread/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	if(!affected_mob.dna)
 		cure()
+		return FALSE
+
 	if((NOTRANSSTING in affected_mob.dna.species.species_traits) || (NO_DNA_COPY in affected_mob.dna.species.species_traits)) //Only species that can be spread by transformation sting can be spread by the retrovirus
 		cure()
+		return FALSE
 
 	if(!strain_data["dna"])
 		//Absorbs the target DNA.
@@ -38,12 +44,11 @@
 			if(prob(1))
 				to_chat(affected_mob, "<span class='danger'>Your muscles ache.</span>")
 				if(prob(20))
-					affected_mob.take_bodypart_damage(1)
+					affected_mob.take_bodypart_damage(1, updating_health = FALSE)
 			if(prob(1))
 				to_chat(affected_mob, "<span class='danger'>Your stomach hurts.</span>")
 				if(prob(20))
-					affected_mob.adjustToxLoss(2)
-					affected_mob.updatehealth()
+					affected_mob.adjustToxLoss(2, FALSE)
 		if(4)
 			if(!transformed && !carrier)
 				//Save original dna for when the disease is cured.
@@ -61,7 +66,6 @@
 				transformed = 1
 				carrier = 1 //Just chill out at stage 4
 
-	return
 
 /datum/disease/dnaspread/Destroy()
 	if (original_dna && transformed && affected_mob)

--- a/code/datums/diseases/fake_gbs.dm
+++ b/code/datums/diseases/fake_gbs.dm
@@ -10,8 +10,12 @@
 	desc = "If left untreated death will occur."
 	severity = DISEASE_SEVERITY_BIOHAZARD
 
+
 /datum/disease/fake_gbs/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(2)
 			if(prob(1))

--- a/code/datums/diseases/flu.dm
+++ b/code/datums/diseases/flu.dm
@@ -11,8 +11,12 @@
 	desc = "If left untreated the subject will feel quite unwell."
 	severity = DISEASE_SEVERITY_MINOR
 
+
 /datum/disease/flu/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(2)
 			if(!(affected_mob.mobility_flags & MOBILITY_STAND) && prob(20))
@@ -26,12 +30,11 @@
 			if(prob(1))
 				to_chat(affected_mob, "<span class='danger'>Your muscles ache.</span>")
 				if(prob(20))
-					affected_mob.take_bodypart_damage(1)
+					affected_mob.take_bodypart_damage(1, updating_health = FALSE)
 			if(prob(1))
 				to_chat(affected_mob, "<span class='danger'>Your stomach hurts.</span>")
 				if(prob(20))
-					affected_mob.adjustToxLoss(1)
-					affected_mob.updatehealth()
+					affected_mob.adjustToxLoss(1, FALSE)
 
 		if(3)
 			if(!(affected_mob.mobility_flags & MOBILITY_STAND) && prob(15))
@@ -45,10 +48,8 @@
 			if(prob(1))
 				to_chat(affected_mob, "<span class='danger'>Your muscles ache.</span>")
 				if(prob(20))
-					affected_mob.take_bodypart_damage(1)
+					affected_mob.take_bodypart_damage(1, updating_health = FALSE)
 			if(prob(1))
 				to_chat(affected_mob, "<span class='danger'>Your stomach hurts.</span>")
 				if(prob(20))
-					affected_mob.adjustToxLoss(1)
-					affected_mob.updatehealth()
-	return
+					affected_mob.adjustToxLoss(1, FALSE)

--- a/code/datums/diseases/fluspanish.dm
+++ b/code/datums/diseases/fluspanish.dm
@@ -11,8 +11,12 @@
 	desc = "If left untreated the subject will burn to death for being a heretic."
 	severity = DISEASE_SEVERITY_DANGEROUS
 
+
 /datum/disease/fluspanish/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(2)
 			affected_mob.adjust_bodytemperature(10)
@@ -22,7 +26,7 @@
 				affected_mob.emote("cough")
 			if(prob(1))
 				to_chat(affected_mob, "<span class='danger'>You're burning in your own skin!</span>")
-				affected_mob.take_bodypart_damage(0,5)
+				affected_mob.take_bodypart_damage(0, 5, updating_health = FALSE)
 
 		if(3)
 			affected_mob.adjust_bodytemperature(20)
@@ -32,5 +36,4 @@
 				affected_mob.emote("cough")
 			if(prob(5))
 				to_chat(affected_mob, "<span class='danger'>You're burning in your own skin!</span>")
-				affected_mob.take_bodypart_damage(0,5)
-	return
+				affected_mob.take_bodypart_damage(0, 5, updating_health = FALSE)

--- a/code/datums/diseases/gastrolisis.dm
+++ b/code/datums/diseases/gastrolisis.dm
@@ -10,10 +10,16 @@
 	disease_flags = CURABLE
 	cures = list(/datum/reagent/consumable/sodiumchloride,  /datum/reagent/medicine/mutadone)
 
+
 /datum/disease/gastrolosis/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	if(is_species(affected_mob, /datum/species/snail))
 		cure()
+		return FALSE
+
 	switch(stage)
 		if(2)
 			if(prob(2))
@@ -60,12 +66,14 @@
 				affected_mob.visible_message("<span class='warning'>[affected_mob] turns into a snail!</span>", \
 				"<span class='boldnotice'>You turned into a snail person! You feel an urge to cccrrraaawwwlll...</span>")
 				cure()
+				return FALSE
 			if(prob(10))
 				affected_mob.emote("gag")
 			if(prob(10))
 				var/turf/open/OT = get_turf(affected_mob)
 				if(isopenturf(OT))
 					OT.MakeSlippery(TURF_WET_LUBE, 100)
+
 
 /datum/disease/gastrolosis/cure()
 	. = ..()

--- a/code/datums/diseases/gbs.dm
+++ b/code/datums/diseases/gbs.dm
@@ -13,7 +13,10 @@
 	severity = DISEASE_SEVERITY_BIOHAZARD
 
 /datum/disease/gbs/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(2)
 			if(prob(5))
@@ -27,5 +30,4 @@
 			to_chat(affected_mob, "<span class='userdanger'>Your body feels as if it's trying to rip itself apart!</span>")
 			if(prob(50))
 				affected_mob.gib()
-		else
-			return
+				return FALSE

--- a/code/datums/diseases/heart_failure.dm
+++ b/code/datums/diseases/heart_failure.dm
@@ -21,45 +21,49 @@
 	D.sound = sound
 	return D
 
+
 /datum/disease/heart_failure/stage_act()
-	..()
-	var/obj/item/organ/heart/O = affected_mob.getorgan(/obj/item/organ/heart)
-	var/mob/living/carbon/H = affected_mob
-	if(O && H.can_heartattack())
-		switch(stage)
-			if(1 to 2)
-				if(prob(2))
-					to_chat(H, "<span class='warning'>You feel [pick("discomfort", "pressure", "a burning sensation", "pain")] in your chest.</span>")
-				if(prob(2))
-					to_chat(H, "<span class='warning'>You feel dizzy.</span>")
-					H.add_confusion(6)
-				if(prob(3))
-					to_chat(H, "<span class='warning'>You feel [pick("full", "nauseated", "sweaty", "weak", "tired", "short on breath", "uneasy")].</span>")
-			if(3 to 4)
-				if(!sound)
-					H.playsound_local(H, 'sound/health/slowbeat.ogg',40,0, channel = CHANNEL_HEARTBEAT)
-					sound = TRUE
-				if(prob(3))
-					to_chat(H, "<span class='danger'>You feel a sharp pain in your chest!</span>")
-					if(prob(25))
-						affected_mob.vomit(95)
-					H.emote("cough")
-					H.Paralyze(40)
-					H.losebreath += 4
-				if(prob(3))
-					to_chat(H, "<span class='danger'>You feel very weak and dizzy...</span>")
-					H.add_confusion(8)
-					H.adjustStaminaLoss(40)
-					H.emote("cough")
-			if(5)
-				H.stop_sound_channel(CHANNEL_HEARTBEAT)
-				H.playsound_local(H, 'sound/effects/singlebeat.ogg', 100, 0)
-				if(H.stat == CONSCIOUS)
-					H.visible_message("<span class='danger'>[H] clutches at [H.p_their()] chest as if [H.p_their()] heart is stopping!</span>", \
-						"<span class='userdanger'>You feel a terrible pain in your chest, as if your heart has stopped!</span>")
-				H.adjustStaminaLoss(60)
-				H.set_heartattack(TRUE)
-				H.reagents.add_reagent(/datum/reagent/medicine/c2/penthrite, 3) // To give the victim a final chance to shock their heart before losing consciousness
-				cure()
-	else
+	. = ..()
+	if(!.)
+		return
+
+	if(!affected_mob.can_heartattack())
 		cure()
+		return FALSE
+
+	switch(stage)
+		if(1 to 2)
+			if(prob(2))
+				to_chat(affected_mob, "<span class='warning'>You feel [pick("discomfort", "pressure", "a burning sensation", "pain")] in your chest.</span>")
+			if(prob(2))
+				to_chat(affected_mob, "<span class='warning'>You feel dizzy.</span>")
+				affected_mob.add_confusion(6)
+			if(prob(3))
+				to_chat(affected_mob, "<span class='warning'>You feel [pick("full", "nauseated", "sweaty", "weak", "tired", "short on breath", "uneasy")].</span>")
+		if(3 to 4)
+			if(!sound)
+				affected_mob.playsound_local(affected_mob, 'sound/health/slowbeat.ogg', 40, FALSE, channel = CHANNEL_HEARTBEAT)
+				sound = TRUE
+			if(prob(3))
+				to_chat(affected_mob, "<span class='danger'>You feel a sharp pain in your chest!</span>")
+				if(prob(25))
+					affected_mob.vomit(95)
+				affected_mob.emote("cough")
+				affected_mob.Paralyze(40)
+				affected_mob.losebreath += 4
+			if(prob(3))
+				to_chat(affected_mob, "<span class='danger'>You feel very weak and dizzy...</span>")
+				affected_mob.add_confusion(8)
+				affected_mob.adjustStaminaLoss(40, FALSE)
+				affected_mob.emote("cough")
+		if(5)
+			affected_mob.stop_sound_channel(CHANNEL_HEARTBEAT)
+			affected_mob.playsound_local(affected_mob, 'sound/effects/singlebeat.ogg', 100, FALSE)
+			if(affected_mob.stat == CONSCIOUS)
+				affected_mob.visible_message("<span class='danger'>[affected_mob] clutches at [affected_mob.p_their()] chest as if [affected_mob.p_their()] heart is stopping!</span>", \
+					"<span class='userdanger'>You feel a terrible pain in your chest, as if your heart has stopped!</span>")
+			affected_mob.adjustStaminaLoss(60, FALSE)
+			affected_mob.set_heartattack(TRUE)
+			affected_mob.reagents.add_reagent(/datum/reagent/medicine/c2/penthrite, 3) // To give the victim a final chance to shock their heart before losing consciousness
+			cure()
+			return FALSE

--- a/code/datums/diseases/magnitis.dm
+++ b/code/datums/diseases/magnitis.dm
@@ -13,56 +13,64 @@
 	infectable_biotypes = MOB_ORGANIC|MOB_ROBOTIC
 	process_dead = TRUE
 
+
 /datum/disease/magnitis/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(2)
 			if(prob(2))
 				to_chat(affected_mob, "<span class='danger'>You feel a slight shock course through your body.</span>")
 			if(prob(2))
-				for(var/obj/M in orange(2,affected_mob))
-					if(!M.anchored && (M.flags_1 & CONDUCT_1))
-						step_towards(M,affected_mob)
-				for(var/mob/living/silicon/S in orange(2,affected_mob))
-					if(isAI(S))
+				for(var/obj/nearby_object in orange(2, affected_mob))
+					if(nearby_object.anchored || !(nearby_object.flags_1 & CONDUCT_1))
 						continue
-					step_towards(S,affected_mob)
+					var/move_dir = get_dir(nearby_object, affected_mob)
+					nearby_object.Move(get_step(nearby_object, move_dir), move_dir)
+				for(var/mob/living/silicon/nearby_silicon in orange(2, affected_mob))
+					if(isAI(nearby_silicon))
+						continue
+					var/move_dir = get_dir(nearby_silicon, affected_mob)
+					nearby_silicon.Move(get_step(nearby_silicon, move_dir), move_dir)
 		if(3)
 			if(prob(2))
 				to_chat(affected_mob, "<span class='danger'>You feel a strong shock course through your body.</span>")
 			if(prob(2))
 				to_chat(affected_mob, "<span class='danger'>You feel like clowning around.</span>")
 			if(prob(4))
-				for(var/obj/M in orange(4,affected_mob))
-					if(!M.anchored && (M.flags_1 & CONDUCT_1))
-						var/i
-						var/iter = rand(1,2)
-						for(i=0,i<iter,i++)
-							step_towards(M,affected_mob)
-				for(var/mob/living/silicon/S in orange(4,affected_mob))
-					if(isAI(S))
+				for(var/obj/nearby_object in orange(4, affected_mob))
+					if(nearby_object.anchored || !(nearby_object.flags_1 & CONDUCT_1))
 						continue
-					var/i
-					var/iter = rand(1,2)
-					for(i=0,i<iter,i++)
-						step_towards(S,affected_mob)
+					for(var/i in 1 to rand(1, 2))
+						var/move_dir = get_dir(nearby_object, affected_mob)
+						if(!nearby_object.Move(get_step(nearby_object, move_dir), move_dir))
+							break
+				for(var/mob/living/silicon/nearby_silicon in orange(4, affected_mob))
+					if(isAI(nearby_silicon))
+						continue
+					for(var/i in 1 to rand(1, 2))
+						var/move_dir = get_dir(nearby_silicon, affected_mob)
+						if(!nearby_silicon.Move(get_step(nearby_silicon, move_dir), move_dir))
+							break
 		if(4)
 			if(prob(2))
 				to_chat(affected_mob, "<span class='danger'>You feel a powerful shock course through your body.</span>")
 			if(prob(2))
 				to_chat(affected_mob, "<span class='danger'>You query upon the nature of miracles.</span>")
 			if(prob(8))
-				for(var/obj/M in orange(6,affected_mob))
-					if(!M.anchored && (M.flags_1 & CONDUCT_1))
-						var/i
-						var/iter = rand(1,3)
-						for(i=0,i<iter,i++)
-							step_towards(M,affected_mob)
-				for(var/mob/living/silicon/S in orange(6,affected_mob))
-					if(isAI(S))
+				for(var/obj/nearby_object in orange(6, affected_mob))
+					if(nearby_object.anchored || !(nearby_object.flags_1 & CONDUCT_1))
 						continue
-					var/i
-					var/iter = rand(1,3)
-					for(i=0,i<iter,i++)
-						step_towards(S,affected_mob)
-	return
+					for(var/i in 1 to rand(1, 3))
+						var/move_dir = get_dir(nearby_object, affected_mob)
+						if(!nearby_object.Move(get_step(nearby_object, move_dir), move_dir))
+							break
+				for(var/mob/living/silicon/nearby_silicon in orange(6, affected_mob))
+					if(isAI(nearby_silicon))
+						continue
+					for(var/i in 1 to rand(1, 3))
+						var/move_dir = get_dir(nearby_silicon, affected_mob)
+						if(!nearby_silicon.Move(get_step(nearby_silicon, move_dir), move_dir))
+							break

--- a/code/datums/diseases/parasitic_infection.dm
+++ b/code/datums/diseases/parasitic_infection.dm
@@ -14,13 +14,18 @@
 	required_organs = list(/obj/item/organ/liver)
 	bypasses_immunity = TRUE
 
+
 /datum/disease/parasite/stage_act()
 	. = ..()
-	var/mob/living/carbon/C = affected_mob
-	var/obj/item/organ/liver/L = C.getorgan(/obj/item/organ/liver)
-	if(!L)
-		src.cure()
-		C.visible_message("<span class='notice'><B>[C]'s liver is covered in tiny larva! They quickly shrivel and die after being exposed to the open air.</B></span>")
+	if(!.)
+		return
+
+	var/obj/item/organ/liver/affected_liver = affected_mob.getorgan(/obj/item/organ/liver)
+	if(!affected_liver)
+		affected_mob.visible_message("<span class='notice'><B>[affected_mob]'s liver is covered in tiny larva! They quickly shrivel and die after being exposed to the open air.</B></span>")
+		cure()
+		return FALSE
+
 	switch(stage)
 		if(1)
 			if(prob(5))
@@ -42,9 +47,9 @@
 						to_chat(affected_mob, "<span class='warning'>You feel like your body's shedding weight rapidly!</span>")
 					affected_mob.adjust_nutrition(-12)
 				else
-					var/turf/T = get_turf(C)
 					to_chat(affected_mob, "<span class='warning'>You feel much, MUCH lighter!</span>")
 					affected_mob.vomit(20, TRUE)
-					L.Remove(C)
-					L.forceMove(T)
-					src.cure()
+					affected_liver.Remove(affected_mob)
+					affected_liver.forceMove(get_turf(affected_mob))
+					cure()
+					return FALSE

--- a/code/datums/diseases/parrotpossession.dm
+++ b/code/datums/diseases/parrotpossession.dm
@@ -15,13 +15,19 @@
 	bypasses_immunity = TRUE //2spook
 	var/mob/living/simple_animal/parrot/poly/ghost/parrot
 
+
 /datum/disease/parrot_possession/stage_act()
-	..()
-	if(!parrot || parrot.loc != affected_mob)
+	. = ..()
+	if(!.)
+		return
+
+	if(QDELETED(parrot) || parrot.loc != affected_mob)
 		cure()
-	else if(prob(parrot.speak_chance))
-		if(parrot.speech_buffer.len)
-			affected_mob.say(pick(parrot.speech_buffer), forced = "parrot possession")
+		return FALSE
+
+	if(length(parrot.speech_buffer) && prob(parrot.speak_chance))
+		affected_mob.say(pick(parrot.speech_buffer), forced = "parrot possession")
+
 
 /datum/disease/parrot_possession/cure()
 	if(parrot && parrot.loc == affected_mob)

--- a/code/datums/diseases/pierrot_throat.dm
+++ b/code/datums/diseases/pierrot_throat.dm
@@ -11,8 +11,12 @@
 	desc = "If left untreated the subject will probably drive others to insanity."
 	severity = DISEASE_SEVERITY_MEDIUM
 
+
 /datum/disease/pierrot_throat/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(1)
 			if(prob(10))
@@ -26,6 +30,7 @@
 		if(4)
 			if(prob(5))
 				affected_mob.say( pick( list("HONK!", "Honk!", "Honk.", "Honk?", "Honk!!", "Honk?!", "Honk...") ) , forced = "pierrot's throat")
+
 
 /datum/disease/pierrot_throat/after_add()
 	RegisterSignal(affected_mob, COMSIG_MOB_SAY, .proc/handle_speech)

--- a/code/datums/diseases/retrovirus.dm
+++ b/code/datums/diseases/retrovirus.dm
@@ -27,14 +27,17 @@
 	return D
 
 /datum/disease/dna_retrovirus/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(1)
 			if(restcure)
 				if(!(affected_mob.mobility_flags & MOBILITY_STAND) && prob(30))
 					to_chat(affected_mob, "<span class='notice'>You feel better.</span>")
 					cure()
-					return
+					return FALSE
 			if (prob(8))
 				to_chat(affected_mob, "<span class='danger'>Your head hurts.</span>")
 			if (prob(9))
@@ -46,7 +49,7 @@
 				if(!(affected_mob.mobility_flags & MOBILITY_STAND) && prob(20))
 					to_chat(affected_mob, "<span class='notice'>You feel better.</span>")
 					cure()
-					return
+					return FALSE
 			if (prob(8))
 				to_chat(affected_mob, "<span class='danger'>Your skin feels loose.</span>")
 			if (prob(10))
@@ -61,7 +64,7 @@
 				if(!(affected_mob.mobility_flags & MOBILITY_STAND) && prob(20))
 					to_chat(affected_mob, "<span class='notice'>You feel better.</span>")
 					cure()
-					return
+					return FALSE
 			if (prob(10))
 				to_chat(affected_mob, "<span class='danger'>Your entire body vibrates.</span>")
 
@@ -76,7 +79,7 @@
 				if(!(affected_mob.mobility_flags & MOBILITY_STAND) && prob(5))
 					to_chat(affected_mob, "<span class='notice'>You feel better.</span>")
 					cure()
-					return
+					return FALSE
 			if (prob(60))
 				if(prob(50))
 					scramble_dna(affected_mob, 1, 0, rand(50,75))

--- a/code/datums/diseases/rhumba_beat.dm
+++ b/code/datums/diseases/rhumba_beat.dm
@@ -11,15 +11,14 @@
 	severity = DISEASE_SEVERITY_BIOHAZARD
 
 /datum/disease/rhumba_beat/stage_act()
-	..()
-	if(affected_mob.ckey == "rosham")
-		cure()
+	. = ..()
+	if(!.)
 		return
+
 	switch(stage)
 		if(2)
 			if(prob(45))
-				affected_mob.adjustFireLoss(5)
-				affected_mob.updatehealth()
+				affected_mob.adjustFireLoss(5, FALSE)
 			if(prob(1))
 				to_chat(affected_mob, "<span class='danger'>You feel strange...</span>")
 		if(3)
@@ -41,5 +40,3 @@
 			to_chat(affected_mob, "<span class='danger'>Your body is unable to contain the Rhumba Beat...</span>")
 			if(prob(50))
 				explosion(get_turf(affected_mob), -1, 0, 2, 3, 0, 2) // This is equivalent to a lvl 1 fireball
-		else
-			return

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -29,23 +29,28 @@
 	D.new_form = D.new_form
 	return D
 
+
 /datum/disease/transformation/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(1)
-			if (prob(stage_prob) && stage1)
+			if (stage1 && prob(stage_prob))
 				to_chat(affected_mob, pick(stage1))
 		if(2)
-			if (prob(stage_prob) && stage2)
+			if (stage2 && prob(stage_prob))
 				to_chat(affected_mob, pick(stage2))
 		if(3)
-			if (prob(stage_prob*2) && stage3)
+			if (stage3 && prob(stage_prob * 2))
 				to_chat(affected_mob, pick(stage3))
 		if(4)
-			if (prob(stage_prob*2) && stage4)
+			if (stage4 && prob(stage_prob * 2))
 				to_chat(affected_mob, pick(stage4))
 		if(5)
 			do_disease_transformation(affected_mob)
+
 
 /datum/disease/transformation/proc/do_disease_transformation(mob/living/affected_mob)
 	if(istype(affected_mob, /mob/living/carbon) && affected_mob.stat != DEAD)
@@ -125,8 +130,12 @@
 		var/mob/living/carbon/monkey/M = affected_mob.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_KEEPSTUNS | TR_KEEPREAGENTS | TR_KEEPSE)
 		M.ventcrawler = VENTCRAWLER_ALWAYS
 
+
 /datum/disease/transformation/jungle_fever/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(2)
 			if(prob(2))
@@ -138,6 +147,7 @@
 		if(4)
 			if(prob(3))
 				affected_mob.say(pick("Eeek, ook ook!", "Eee-eeek!", "Eeee!", "Ungh, ungh."), forced = "jungle fever")
+
 
 /datum/disease/transformation/jungle_fever/cure()
 	remove_monkey(affected_mob.mind)
@@ -172,8 +182,12 @@
 	infectable_biotypes = MOB_ORGANIC|MOB_UNDEAD|MOB_ROBOTIC
 	bantype = "Cyborg"
 
+
 /datum/disease/transformation/robot/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(3)
 			if (prob(8))
@@ -204,8 +218,12 @@
 	new_form = /mob/living/carbon/alien/humanoid/hunter
 	bantype = ROLE_ALIEN
 
+
 /datum/disease/transformation/xeno/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(3)
 			if (prob(4))
@@ -232,8 +250,12 @@
 	stage5	= list("<span class='danger'>You have become a slime.</span>")
 	new_form = /mob/living/simple_animal/slime/random
 
+
 /datum/disease/transformation/slime/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(1)
 			if(ishuman(affected_mob) && affected_mob.dna)
@@ -244,6 +266,7 @@
 				var/mob/living/carbon/human/human = affected_mob
 				if(human.dna.species.id != "slime" && affected_mob.dna.species.id != "stargazer" && affected_mob.dna.species.id != "lum")
 					human.set_species(/datum/species/jelly/slime)
+
 
 /datum/disease/transformation/corgi
 	name = "The Barkening"
@@ -260,8 +283,11 @@
 	stage5	= list("<span class='danger'>AUUUUUU!!!</span>")
 	new_form = /mob/living/simple_animal/pet/dog/corgi
 
+
 /datum/disease/transformation/corgi/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
 	switch(stage)
 		if(3)
 			if (prob(8))
@@ -269,6 +295,7 @@
 		if(4)
 			if (prob(20))
 				affected_mob.say(pick("Bark!", "AUUUUUU"), forced = "corgi transformation")
+
 
 /datum/disease/transformation/morph
 	name = "Gluttony's Blessing"
@@ -305,8 +332,12 @@
 	stage5	= list("<span class='danger'>You have become a Gondola.</span>")
 	new_form = /mob/living/simple_animal/pet/gondola
 
+
 /datum/disease/transformation/gondola/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(2)
 			if (prob(5))
@@ -324,6 +355,7 @@
 			if (prob(20))
 				affected_mob.reagents.add_reagent_list(list(/datum/reagent/pax = 5))
 			if (prob(2))
-				to_chat(affected_mob, "<span class='danger'>You let go of what you were holding.</span>")
-				var/obj/item/I = affected_mob.get_active_held_item()
-				affected_mob.dropItemToGround(I)
+				var/obj/item/held_item = affected_mob.get_active_held_item()
+				if(held_item)
+					to_chat(affected_mob, "<span class='danger'>You let go of what you were holding.</span>")
+					affected_mob.dropItemToGround(held_item)

--- a/code/datums/diseases/tuberculosis.dm
+++ b/code/datums/diseases/tuberculosis.dm
@@ -14,7 +14,10 @@
 	bypasses_immunity = TRUE // TB primarily impacts the lungs; it's also bacterial or fungal in nature; viral immunity should do nothing.
 
 /datum/disease/tuberculosis/stage_act() //it begins
-	..()
+	. = ..()
+	if(!.)
+		return
+
 	switch(stage)
 		if(2)
 			if(prob(2))
@@ -30,18 +33,18 @@
 				affected_mob.Dizzy(5)
 			if(prob(2))
 				to_chat(affected_mob, "<span class='danger'>You feel a sharp pain from your lower chest!</span>")
-				affected_mob.adjustOxyLoss(5)
+				affected_mob.adjustOxyLoss(5, FALSE)
 				affected_mob.emote("gasp")
 			if(prob(10))
 				to_chat(affected_mob, "<span class='danger'>You feel air escape from your lungs painfully.</span>")
-				affected_mob.adjustOxyLoss(25)
+				affected_mob.adjustOxyLoss(25, FALSE)
 				affected_mob.emote("gasp")
 		if(5)
 			if(prob(2))
 				to_chat(affected_mob, "<span class='userdanger'>[pick("You feel your heart slowing...", "You relax and slow your heartbeat.")]</span>")
-				affected_mob.adjustStaminaLoss(70)
+				affected_mob.adjustStaminaLoss(70, FALSE)
 			if(prob(10))
-				affected_mob.adjustStaminaLoss(100)
+				affected_mob.adjustStaminaLoss(100, FALSE)
 				affected_mob.visible_message("<span class='warning'>[affected_mob] faints!</span>", "<span class='userdanger'>You surrender yourself and feel at peace...</span>")
 				affected_mob.AdjustSleeping(100)
 			if(prob(2))
@@ -56,4 +59,3 @@
 			if(prob(15))
 				to_chat(affected_mob, "<span class='danger'>[pick("You feel uncomfortably hot...", "You feel like unzipping your jumpsuit", "You feel like taking off some clothes...")]</span>")
 				affected_mob.adjust_bodytemperature(40)
-	return

--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -24,34 +24,30 @@ STI KALY - blind
 */
 
 /datum/disease/wizarditis/stage_act()
-	..()
+	. = ..()
+	if(!.)
+		return
 
 	switch(stage)
 		if(2)
-			if(prob(1)&&prob(50))
+			if(prob(0.5))
 				affected_mob.say(pick("You shall not pass!", "Expeliarmus!", "By Merlins beard!", "Feel the power of the Dark Side!"), forced = "wizarditis")
-			if(prob(1)&&prob(50))
+			if(prob(0.5))
 				to_chat(affected_mob, "<span class='danger'>You feel [pick("that you don't have enough mana", "that the winds of magic are gone", "an urge to summon familiar")].</span>")
-
-
 		if(3)
-			if(prob(1)&&prob(50))
+			if(prob(0.5))
 				affected_mob.say(pick("NEC CANTIO!","AULIE OXIN FIERA!", "STI KALY!", "TARCOL MINTI ZHERI!"), forced = "wizarditis")
-			if(prob(1)&&prob(50))
+			if(prob(0.5))
 				to_chat(affected_mob, "<span class='danger'>You feel [pick("the magic bubbling in your veins","that this location gives you a +1 to INT","an urge to summon familiar")].</span>")
-
 		if(4)
-
 			if(prob(1))
 				affected_mob.say(pick("NEC CANTIO!","AULIE OXIN FIERA!","STI KALY!","EI NATH!"), forced = "wizarditis")
 				return
-			if(prob(1)&&prob(50))
+			if(prob(0.5))
 				to_chat(affected_mob, "<span class='danger'>You feel [pick("the tidal wave of raw power building inside","that this location gives you a +2 to INT and +1 to WIS","an urge to teleport")].</span>")
 				spawn_wizard_clothes(50)
-			if(prob(1)&&prob(1))
+			if(prob(0.01))
 				teleport()
-	return
-
 
 
 /datum/disease/wizarditis/proc/spawn_wizard_clothes(chance = 0)

--- a/code/modules/antagonists/revenant/revenant_blight.dm
+++ b/code/modules/antagonists/revenant/revenant_blight.dm
@@ -24,23 +24,28 @@
 		to_chat(affected_mob, "<span class='notice'>You feel better.</span>")
 	..()
 
+
 /datum/disease/revblight/stage_act()
 	if(!finalstage)
-		if(!(affected_mob.mobility_flags & MOBILITY_STAND) && prob(stage*6))
+		if(!(affected_mob.mobility_flags & MOBILITY_STAND) && prob(stage * 6))
 			cure()
-			return
-		if(prob(stage*3))
+			return FALSE
+		if(prob(stage * 3))
 			to_chat(affected_mob, "<span class='revennotice'>You suddenly feel [pick("sick and tired", "disoriented", "tired and confused", "nauseated", "faint", "dizzy")]...</span>")
 			affected_mob.add_confusion(8)
-			affected_mob.adjustStaminaLoss(20)
+			affected_mob.adjustStaminaLoss(20, FALSE)
 			new /obj/effect/temp_visual/revenant(affected_mob.loc)
 		if(stagedamage < stage)
 			stagedamage++
-			affected_mob.adjustToxLoss(stage*2) //should, normally, do about 30 toxin damage.
+			affected_mob.adjustToxLoss(stage * 2, FALSE) //should, normally, do about 30 toxin damage.
 			new /obj/effect/temp_visual/revenant(affected_mob.loc)
 		if(prob(45))
-			affected_mob.adjustStaminaLoss(stage)
-	..() //So we don't increase a stage before applying the stage damage.
+			affected_mob.adjustStaminaLoss(stage, FALSE)
+
+	. = ..() //So we don't increase a stage before applying the stage damage.
+	if(!.)
+		return
+
 	switch(stage)
 		if(2)
 			if(prob(5))
@@ -55,13 +60,11 @@
 			if(!finalstage)
 				finalstage = TRUE
 				to_chat(affected_mob, "<span class='revenbignotice'>You feel like [pick("nothing's worth it anymore", "nobody ever needed your help", "nothing you did mattered", "everything you tried to do was worthless")].</span>")
-				affected_mob.adjustStaminaLoss(45)
+				affected_mob.adjustStaminaLoss(45, FALSE)
 				new /obj/effect/temp_visual/revenant(affected_mob.loc)
 				if(affected_mob.dna && affected_mob.dna.species)
 					affected_mob.dna.species.handle_mutant_bodyparts(affected_mob,"#1d2953")
 					affected_mob.dna.species.handle_hair(affected_mob,"#1d2953")
 				affected_mob.visible_message("<span class='warning'>[affected_mob] looks terrifyingly gaunt...</span>", "<span class='revennotice'>You suddenly feel like your skin is <i>wrong</i>...</span>")
 				affected_mob.add_atom_colour("#1d2953", TEMPORARY_COLOUR_PRIORITY)
-				addtimer(CALLBACK(src, .proc/cure), 100)
-		else
-			return
+				addtimer(CALLBACK(src, .proc/cure), 10 SECONDS)

--- a/code/modules/antagonists/revenant/revenant_blight.dm
+++ b/code/modules/antagonists/revenant/revenant_blight.dm
@@ -26,6 +26,10 @@
 
 
 /datum/disease/revblight/stage_act()
+	. = ..()
+	if(!.)
+		return
+
 	if(!finalstage)
 		if(!(affected_mob.mobility_flags & MOBILITY_STAND) && prob(stage * 6))
 			cure()
@@ -41,10 +45,6 @@
 			new /obj/effect/temp_visual/revenant(affected_mob.loc)
 		if(prob(45))
 			affected_mob.adjustStaminaLoss(stage, FALSE)
-
-	. = ..() //So we don't increase a stage before applying the stage damage.
-	if(!.)
-		return
 
 	switch(stage)
 		if(2)


### PR DESCRIPTION
* Fixes being a carrier not working for any diseases besides the advance-symptoms one one.
* Cleans up a lot of code.
* Removes repeated health updates. No damage done in `life()` should be updating health, as that already happens at the end of it.
* Magnitis makes use of `Move()` instead of `step_towards()` so we can keep a higher control of it (and deal with grabs and other movement limiters properly).
* Removes one very old player reference. Nothing against the soul of it, but this just made them immune to a specific disease, it's not a really good or visible feature.
* All `stage_act()` calls the parent and checks the return, which is `FALSE` when it should not carry on, such as when the disease is cured or the host is destroyed.

This fixes the following runtime:
```
[17:43:45] Runtime in tuberculosis.dm, line 44: Cannot execute null.adjustStaminaLoss().
proc name: stage act (/datum/disease/tuberculosis/stage_act)
src: Fungal tuberculosis (/datum/disease/tuberculosis)
call stack:
Fungal tuberculosis (/datum/disease/tuberculosis): stage act()
Ojay Loc (/mob/living/carbon/human): handle diseases()
Ojay Loc (/mob/living/carbon/human): Life(2, 676)
Ojay Loc (/mob/living/carbon/human): Life(2, 676)
Ojay Loc (/mob/living/carbon/human): Life(2, 676)
Mobs (/datum/controller/subsystem/mobs): fire(1)
Mobs (/datum/controller/subsystem/mobs): ignite(1)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```