### PR TITLE
Inverts the Blood Contract's functionality so it is now self-use only.

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1065,43 +1065,20 @@
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll2"
 	color = "#FF0000"
-	desc = "Mark your target for death."
-	var/used = FALSE
+	desc = "Mark yourself for death."
 
 /obj/item/blood_contract/attack_self(mob/user)
-	if(used)
-		return
-	used = TRUE
-
-	var/list/da_list = list()
-	for(var/I in GLOB.alive_mob_list & GLOB.player_list)
-		var/mob/living/L = I
-		da_list[L.real_name] = L
-
-	var/choice = input(user,"Who do you want dead?","Choose Your Victim") as null|anything in sortList(da_list)
-
-	choice = da_list[choice]
-
-	if(!choice)
-		used = FALSE
-		return
-	if(!(isliving(choice)))
-		to_chat(user, "<span class='warning'>[choice] is already dead!</span>")
-		used = FALSE
-		return
-	if(choice == user)
-		to_chat(user, "<span class='warning'>You feel like writing your own name into a cursed death warrant would be unwise.</span>")
-		used = FALSE
+	if(!(askuser(user, "Are you absolutely certain you wish the sign the [src]?", "Sign [src]?", Button1 = "Sign", Button2 = "Maybe not...") == 1))
 		return
 
-	var/mob/living/L = choice
+	message_admins("<span class='adminnotice'>[ADMIN_LOOKUPFLW(user)] has marked themselves for death using [src]! They are now an antagonist.</span>")
 
-	message_admins("<span class='adminnotice'>[ADMIN_LOOKUPFLW(L)] has been marked for death by [ADMIN_LOOKUPFLW(user)]!</span>")
+	var/mob/living/mind_user = user
 
 	var/datum/antagonist/blood_contract/A = new
-	L.mind.add_antag_datum(A)
+	mind_user.mind.add_antag_datum(A)
 
-	log_combat(user, L, "took out a blood contract on", src)
+	log_combat(user, mind_user, "took out a blood contract on", src)
 	qdel(src)
 
 //Colossus


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See #53059 for full removal alternative.
Closes #53059

Old behaviour - Select anyone else, turn them into an antag, force everyone else to kill them. You could not select yourself.

New behaviour - Use the contract on only yourself, turn yourself into an antag, force everyone else to kill you. You can not select other people.

## Why It's Good For The Game

If a miner wants to self-antag - 1. Kill Bubblegum - 2. Pray this drops - 3. Have fun.

No longer allows a non-antag to force-valid and force-antag any other player without reason. Now if the player has beef with another player, they can use the blood contract on themselves and start a one-man-murder-spree.

And of course remember; using this replaces any held items with an undroppable chainsaw. Sure hope you remember the basics of CQC, Snake.

Sell it to the clown in exchange for the Captain's spare. Give it to your blood brother to use as a distraction while you pull off a shuttle hijack. Use it on yourself and go down in a glorious orgy of blood and violence.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The Blood Contract no longer accepts forged signatures. As a result, it can not be used on behalf of other players. It now only accepts one signature. The soul of the person holding it. Damnation awaits, future antagonist!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
