### PR TITLE
Fixes Virology Civilian Bounties.

### DIFF
--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -130,7 +130,7 @@
 		var/datum/bounty/reagent/chemical = civilian_bounty
 		return "[chemical.shipped_volume]/[chemical.required_volume] u"
 	if(istype(civilian_bounty, /datum/bounty/virus))
-		return "A least 1 u"
+		return "At least 1u"
 
 /**
   * Produces the value of the account's civilian bounty reward, if able.

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -114,12 +114,8 @@
 /datum/bank_account/proc/bounty_text()
 	if(!civilian_bounty)
 		return FALSE
-	if(istype(civilian_bounty, /datum/bounty/item))
-		var/datum/bounty/item/item = civilian_bounty
-		return item.description
-	if(istype(civilian_bounty, /datum/bounty/reagent))
-		var/datum/bounty/reagent/chemical = civilian_bounty
-		return chemical.description
+	return civilian_bounty.description
+
 
 /**
   * Returns the required item count, or required chemical units required to submit a bounty.
@@ -133,6 +129,8 @@
 	if(istype(civilian_bounty, /datum/bounty/reagent))
 		var/datum/bounty/reagent/chemical = civilian_bounty
 		return "[chemical.shipped_volume]/[chemical.required_volume] u"
+	if(istype(civilian_bounty, /datum/bounty/virus))
+		return "A least 1 u"
 
 /**
   * Produces the value of the account's civilian bounty reward, if able.


### PR DESCRIPTION

## About The Pull Request

Whooops. Turns out virology bounties aren't covered by reagent bounties, somehow, so here we are.
This does some minor codewise cleanup of civilian bounties so that virologist bounties can actually be completed reasonably. Stat requirements on bounties are the usual requirement, send at least one unit to complete, etc etc.

## Why It's Good For The Game

🐛 🔨 💥 

## Changelog
:cl:
fix: Virology civilian bounties can now be completed again.
/:cl:
