### PR TITLE
Fixes up bigger shuttle wall smoothing

### DIFF
--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -261,9 +261,8 @@
 
 	var/area/target_area = get_area(target_turf)
 	var/area/source_area = get_area(src)
-	if((source_area.area_limited_icon_smoothing || target_area.area_limited_icon_smoothing) && !istype(source_area, target_area.type) && !istype(target_area, source_area.type))
-		if(!source_area.area_smoothing_parent || !istype(target_area, source_area.area_smoothing_parent))
-			return NO_ADJ_FOUND
+	if((source_area.area_limited_icon_smoothing && !istype(target_area, source_area.area_limited_icon_smoothing)) || (target_area.area_limited_icon_smoothing && !istype(source_area, target_area.area_limited_icon_smoothing)))
+		return NO_ADJ_FOUND
 
 	if(isnull(canSmoothWith)) //special case in which it will only smooth with itself
 		if(isturf(src))

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -262,7 +262,8 @@
 	var/area/target_area = get_area(target_turf)
 	var/area/source_area = get_area(src)
 	if((source_area.area_limited_icon_smoothing || target_area.area_limited_icon_smoothing) && !istype(source_area, target_area.type) && !istype(target_area, source_area.type))
-		return NO_ADJ_FOUND
+		if(!source_area.area_smoothing_parent || !istype(target_area, source_area.area_smoothing_parent))
+			return NO_ADJ_FOUND
 
 	if(isnull(canSmoothWith)) //special case in which it will only smooth with itself
 		if(isturf(src))

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -60,10 +60,8 @@
 	var/list/firealarms
 	var/firedoors_last_closed_on = 0
 
-	///Boolean to limit the areas (subtypes included) that atoms in this area can smooth with. Used for shuttles.
-	var/area_limited_icon_smoothing = FALSE
-	///Parent area can smooth with when using limited area smoothing
-	var/area/area_smoothing_parent
+	///Type path to limit the areas (subtypes included) that atoms in this area can smooth with. Used for shuttles.
+	var/area/area_limited_icon_smoothing = FALSE
 
 	var/list/power_usage
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -60,8 +60,8 @@
 	var/list/firealarms
 	var/firedoors_last_closed_on = 0
 
-	///Type path to limit the areas (subtypes included) that atoms in this area can smooth with. Used for shuttles.
-	var/area/area_limited_icon_smoothing = FALSE
+	///Typepath to limit the areas (subtypes included) that atoms in this area can smooth with. Used for shuttles.
+	var/area/area_limited_icon_smoothing
 
 	var/list/power_usage
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -62,6 +62,8 @@
 
 	///Boolean to limit the areas (subtypes included) that atoms in this area can smooth with. Used for shuttles.
 	var/area_limited_icon_smoothing = FALSE
+	///Parent area can smooth with when using limited area smoothing
+	var/area/area_smoothing_parent
 
 	var/list/power_usage
 

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -12,7 +12,7 @@
 	area_flags = NONE
 	icon_state = "shuttle"
 	flags_1 = CAN_BE_DIRTY_1
-	area_limited_icon_smoothing = TRUE
+	area_limited_icon_smoothing = /area/shuttle
 
 
 /area/shuttle/PlaceOnTopReact(list/new_baseturfs, turf/fake_turf_type, flags)
@@ -29,7 +29,7 @@
 /area/shuttle/syndicate
 	name = "Syndicate Infiltrator"
 	ambientsounds = HIGHSEC
-	area_smoothing_parent=/area/shuttle/syndicate
+	area_limited_icon_smoothing=/area/shuttle/syndicate
 
 /area/shuttle/syndicate/bridge
 	name = "Syndicate Infiltrator Control"
@@ -65,7 +65,7 @@
 /area/shuttle/abandoned
 	name = "Abandoned Ship"
 	requires_power = TRUE
-	area_smoothing_parent=/area/shuttle/abandoned
+	area_limited_icon_smoothing=/area/shuttle/abandoned
 
 /area/shuttle/abandoned/bridge
 	name = "Abandoned Ship Bridge"

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -29,7 +29,7 @@
 /area/shuttle/syndicate
 	name = "Syndicate Infiltrator"
 	ambientsounds = HIGHSEC
-	area_limited_icon_smoothing=/area/shuttle/syndicate
+	area_limited_icon_smoothing = /area/shuttle/syndicate
 
 /area/shuttle/syndicate/bridge
 	name = "Syndicate Infiltrator Control"
@@ -65,7 +65,7 @@
 /area/shuttle/abandoned
 	name = "Abandoned Ship"
 	requires_power = TRUE
-	area_limited_icon_smoothing=/area/shuttle/abandoned
+	area_limited_icon_smoothing = /area/shuttle/abandoned
 
 /area/shuttle/abandoned/bridge
 	name = "Abandoned Ship Bridge"

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -29,6 +29,7 @@
 /area/shuttle/syndicate
 	name = "Syndicate Infiltrator"
 	ambientsounds = HIGHSEC
+	area_smoothing_parent=/area/shuttle/syndicate
 
 /area/shuttle/syndicate/bridge
 	name = "Syndicate Infiltrator Control"
@@ -64,6 +65,7 @@
 /area/shuttle/abandoned
 	name = "Abandoned Ship"
 	requires_power = TRUE
+	area_smoothing_parent=/area/shuttle/abandoned
 
 /area/shuttle/abandoned/bridge
 	name = "Abandoned Ship Bridge"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Syndicate Infiltrator and the Abandoned Ship had some bad wall smoothing based on how areas were compared.
Without a parent area designated two sub types areas could not smooth. (/area/shuttle/abandoned/bar, /area/shuttle/abandoned/crew)

Adding area_smoothing_parent lets areas with area_limited_icon_smoothing=TRUE can now smooth with it's parent and all sub types retaining the limited smoothing effect.

Fixes #52809 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Smoother walls are sexy.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed some shuttle wall smoothing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
