### PR TITLE
Fixes clown car runtime

### DIFF
--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -177,20 +177,28 @@
 			to_chat(owner, "<span class='notice'>Please wait for the vehicle to finish its current action first.</span>")
 		C.ToggleCannon()
 
+
 /datum/action/vehicle/sealed/thank
 	name = "Thank the Clown Car Driver"
 	desc = "They're just doing their job."
 	button_icon_state = "car_thanktheclown"
-	var/last_thank_time
+	COOLDOWN_DECLARE(thank_time_cooldown)
+
 
 /datum/action/vehicle/sealed/thank/Trigger()
-	if(istype(vehicle_entered_target, /obj/vehicle/sealed/car/clowncar))
-		var/obj/vehicle/sealed/car/clowncar/C = vehicle_entered_target
-		if(world.time >= last_thank_time + 60)
-			var/mob/living/carbon/human/clown = pick(C.return_drivers())
-			owner.say("Thank you for the fun ride, [clown.name]!")
-			last_thank_time = world.time
-			C.ThanksCounter()
+	if(!istype(vehicle_entered_target, /obj/vehicle/sealed/car/clowncar))
+		return
+	if(!COOLDOWN_FINISHED(src, thank_time_cooldown))
+		return
+	COOLDOWN_START(src, thank_time_cooldown, 6 SECONDS)
+	var/obj/vehicle/sealed/car/clowncar/clown_car = vehicle_entered_target
+	var/list/drivers = clown_car.return_drivers()
+	if(!length(drivers))
+		return
+	var/mob/living/carbon/human/clown = pick(drivers)
+	owner.say("Thank you for the fun ride, [clown.name]!")
+	clown_car.ThanksCounter()
+
 
 /datum/action/vehicle/ridden/scooter/skateboard/ollie
 	name = "Ollie"


### PR DESCRIPTION
* Happened when people thanked and there was no driver.
* Cleaned the code a little for early returns and cooldown macros.

Runtime:
```
[15:08:56] Runtime in vehicle_actions.dm, line 190: pick() from empty list
proc name: Trigger (/datum/action/vehicle/sealed/thank/Trigger)
usr: CKEY/(Mob Name)
usr.loc: (Aft Primary Hallway (113,104,4))
src: Thank the Clown Car Driver (/datum/action/vehicle/sealed/thank)
call stack:
Thank the Clown Car Driver (/datum/action/vehicle/sealed/thank): Trigger()
Thank the Clown Car Driver (/obj/screen/movable/action_button): Click(null, "mapwindow.map", "icon-x=26;icon-y=10;left=1;scr...")
CKEY (/client): Click(Thank the Clown Car Driver (/obj/screen/movable/action_button), null, "mapwindow.map", "icon-x=26;icon-y=10;left=1;scr...")
```
