### PR TITLE
Fixes an embed runtime

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -580,6 +580,8 @@
 
 ///from base of /obj/projectile/proc/on_hit(): (atom/movable/firer, atom/target, Angle, hit_limb)
 #define COMSIG_PROJECTILE_SELF_ON_HIT "projectile_self_on_hit"
+	#define COMPONENT_PROJECTILE_SELF_ON_HIT_EMBED_SUCCESS (1<<0)
+	#define COMPONENT_PROJECTILE_SELF_ON_HIT_SELF_DELETE (1<<1)
 ///from base of /obj/projectile/proc/on_hit(): (atom/movable/firer, atom/target, Angle)
 #define COMSIG_PROJECTILE_ON_HIT "projectile_on_hit"
 ///from base of /obj/projectile/proc/fire(): (obj/projectile, atom/original_target)

--- a/code/datums/elements/embed.dm
+++ b/code/datums/elements/embed.dm
@@ -143,7 +143,7 @@
 	if(!limb)
 		limb = C.get_bodypart()
 
-	payload.tryEmbed(limb)
+	. = payload.tryEmbed(limb)
 	Detach(P)
 
 /**

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -951,11 +951,13 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	if(embedding)
 		return !isnull(embedding["pain_mult"]) && !isnull(embedding["jostle_pain_mult"]) && embedding["pain_mult"] == 0 && embedding["jostle_pain_mult"] == 0
 
-///In case we want to do something special (like self delete) upon failing to embed in something, return true
+///In case we want to do something special (like self delete) upon failing to embed in something. Returns a bitflag.
 /obj/item/proc/failedEmbed()
 	if(item_flags & DROPDEL)
-		QDEL_NULL(src)
-		return TRUE
+		qdel(src)
+		return COMPONENT_PROJECTILE_SELF_ON_HIT_SELF_DELETE
+	return NONE
+
 
 ///Called by the carbon throw_item() proc. Returns null if the item negates the throw, or a reference to the thing to suffer the throw else.
 /obj/item/proc/on_thrown(mob/living/carbon/user, atom/target)
@@ -972,19 +974,22 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
   *
   * Really, this is used mostly with projectiles with shrapnel payloads, from [/datum/element/embed/proc/checkEmbedProjectile], and called on said shrapnel. Mostly acts as an intermediate between different embed elements.
   *
+  * Returns bitflags informing whether the item was able to embed itself, deleted itself in the process, or nothing happened.
+  *
   * Arguments:
   * * target- Either a body part or a carbon. What are we hitting?
   * * forced- Do we want this to go through 100%?
   */
 /obj/item/proc/tryEmbed(atom/target, forced=FALSE, silent=FALSE)
 	if(!isbodypart(target) && !iscarbon(target))
-		return
+		return NONE
 	if(!forced && !LAZYLEN(embedding))
-		return
+		return NONE
 
 	if(SEND_SIGNAL(src, COMSIG_EMBED_TRY_FORCE, target, forced, silent))
-		return TRUE
-	failedEmbed()
+		return COMPONENT_PROJECTILE_SELF_ON_HIT_EMBED_SUCCESS
+	return failedEmbed()
+
 
 ///For when you want to disable an item's embedding capabilities (like transforming weapons and such), this proc will detach any active embed elements from it.
 /obj/item/proc/disableEmbedding()
@@ -1043,10 +1048,13 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 
 		M.apply_damage(max(15, force), BRUTE, BODY_ZONE_HEAD, wound_bonus = 10, sharpness = TRUE)
 		M.losebreath += 2
-		if(tryEmbed(M.get_bodypart(BODY_ZONE_CHEST), TRUE, TRUE)) //and if it embeds in their chest, cause a lot of pain
-			M.apply_damage(max(25, force*1.5), BRUTE, BODY_ZONE_CHEST, wound_bonus = 7, sharpness = TRUE)
-			M.losebreath += 6
-			discover_after = FALSE
+		switch(tryEmbed(M.get_bodypart(BODY_ZONE_CHEST), TRUE, TRUE)) //and if it embeds in their chest, cause a lot of pain
+			if(COMPONENT_PROJECTILE_SELF_ON_HIT_SELF_DELETE)
+				return
+			if(COMPONENT_PROJECTILE_SELF_ON_HIT_EMBED_SUCCESS)
+				M.apply_damage(max(25, force*1.5), BRUTE, BODY_ZONE_CHEST, wound_bonus = 7, sharpness = TRUE)
+				M.losebreath += 6
+				discover_after = FALSE
 
 		if(S?.tastes?.len) //is that blood in my mouth?
 			S.tastes += "iron"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -186,7 +186,8 @@
 	if(isliving(target))
 		var/mob/living/L = target
 		hit_limb = L.check_limb_hit(def_zone)
-	SEND_SIGNAL(src, COMSIG_PROJECTILE_SELF_ON_HIT, firer, target, Angle, hit_limb)
+	if(SEND_SIGNAL(src, COMSIG_PROJECTILE_SELF_ON_HIT, firer, target, Angle, hit_limb) & COMPONENT_PROJECTILE_SELF_ON_HIT_SELF_DELETE)
+		return BULLET_ACT_HIT
 	var/turf/target_loca = get_turf(target)
 
 	var/hitx


### PR DESCRIPTION
* Failing to embed qdeleted the item, which continued being thrown and doing things even after it should have been gone.
* This could use @Ryll-Ryll 's review.

Runtime:
```
[15:12:07] Runtime in atoms_movable.dm, line 632: Qdeleted thing being thrown around.
proc name: throw at (/atom/movable/proc/throw_at)
usr: CKEY/(Human Name)
usr.loc: (Brig (116,171,4))
src: the lollipop (/obj/item/shrapnel/bullet)
src.loc: null
call stack:
the lollipop (/obj/item/shrapnel/bullet): throw at(the floor (113,170,4) (/turf/open/floor/plasteel), 7, 2, Human Name (/mob/living/carbon/human), 1, 0, /datum/callback (/datum/callback), 1000, 0, 1)
the lollipop (/obj/item/shrapnel/bullet): throw at(the floor (113,170,4) (/turf/open/floor/plasteel), 7, 2, Human Name (/mob/living/carbon/human), 1, 0, /datum/callback (/datum/callback), 1000, 0, 1)
the lollipop (/obj/item/shrapnel/bullet): throw at(the floor (113,170,4) (/turf/open/floor/plasteel), 7, 2, Human Name (/mob/living/carbon/human), 1, 0, /datum/callback (/datum/callback), 1000, 0, 1)
the lollipop (/obj/item/shrapnel/bullet): safe throw at(the floor (113,170,4) (/turf/open/floor/plasteel), 7, 2, Human Name (/mob/living/carbon/human), 1, 0, null, 1000, 0)
Human Name (/mob/living/carbon/human): throw item(the floor (113,170,4) (/turf/open/floor/plasteel))
Human Name (/mob/living/carbon/human): ClickOn(the floor (113,170,4) (/turf/open/floor/plasteel), "icon-x=18;icon-y=30;left=1;scr...")
the floor (113,170,4) (/turf/open/floor/plasteel): Click(the floor (113,170,4) (/turf/open/floor/plasteel), "mapwindow.map", "icon-x=18;icon-y=30;left=1;scr...")
CKEY (/client): Click(the floor (113,170,4) (/turf/open/floor/plasteel), the floor (113,170,4) (/turf/open/floor/plasteel), "mapwindow.map", "icon-x=18;icon-y=30;left=1;scr...")
```