### PR TITLE
Bible now uses a radial menu for choosing its skins

### DIFF
--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -50,47 +50,63 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	user.visible_message("<span class='suicide'>[user] is offering [user.p_them()]self to [deity_name]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return (BRUTELOSS)
 
-/obj/item/storage/book/bible/attack_self(mob/living/carbon/human/H)
-	if(!istype(H))
-		return
-	if(!H.can_read(src))
+/obj/item/storage/book/bible/attack_self(mob/living/carbon/human/user)
+	if(GLOB.bible_icon_state)
 		return FALSE
-	// If H is the Chaplain, we can set the icon_state of the bible (but only once!)
-	if(!GLOB.bible_icon_state && H.mind.holy_role == HOLY_ROLE_HIGHPRIEST)
-		var/dat = "<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Pick Bible Style</title></head><body><center><h2>Pick a bible style</h2></center><table>"
-		for(var/i in 1 to GLOB.biblestates.len)
-			var/icon/bibleicon = icon('icons/obj/storage.dmi', GLOB.biblestates[i])
-			var/nicename = GLOB.biblenames[i]
-			H << browse_rsc(bibleicon, nicename)
-			dat += {"<tr><td><img src="[nicename]"></td><td><a href="?src=[REF(src)];seticon=[i]">[nicename]</a></td></tr>"}
-		dat += "</table></body></html>"
-		H << browse(dat, "window=editicon;can_close=0;can_minimize=0;size=250x650")
+	if(user?.mind?.holy_role != HOLY_ROLE_HIGHPRIEST)
+		return FALSE
 
-/obj/item/storage/book/bible/Topic(href, href_list)
-	if(!usr.canUseTopic(src, BE_CLOSE))
-		return
-	if(href_list["seticon"] && !GLOB.bible_icon_state)
-		var/iconi = text2num(href_list["seticon"])
-		var/biblename = GLOB.biblenames[iconi]
-		icon_state = GLOB.biblestates[iconi]
-		inhand_icon_state = GLOB.bibleitemstates[iconi]
+	var/list/skins = list()
+	for(var/i in 1 to GLOB.biblestates.len)
+		var/image/bible_image = image(icon = 'icons/obj/storage.dmi', icon_state = GLOB.biblestates[i])
+		skins += list("[GLOB.biblenames[i]]" = bible_image)
 
-		if(icon_state == "honk1" || icon_state == "honk2")
-			var/mob/living/carbon/human/H = usr
-			H.dna.add_mutation(CLOWNMUT)
-			H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/clown_hat(H), ITEM_SLOT_MASK)
-		if(icon_state == "insuls")
-			var/mob/living/carbon/human/H =usr
+	var/choice = show_radial_menu(user, src, skins, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 40, require_near = TRUE)
+	if(!choice)
+		return FALSE
+	var/bible_index = GLOB.biblenames.Find(choice)
+	if(!bible_index)
+		return FALSE
+	icon_state = GLOB.biblestates[bible_index]
+	inhand_icon_state = GLOB.bibleitemstates[bible_index]
+
+	switch(icon_state)
+		if("honk1")
+			user.dna.add_mutation(CLOWNMUT)
+			user.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/clown_hat(user), ITEM_SLOT_MASK)
+		if("honk2")
+			user.dna.add_mutation(CLOWNMUT)
+			user.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/clown_hat(user), ITEM_SLOT_MASK)
+		if("insuls")
 			var/obj/item/clothing/gloves/color/fyellow/insuls = new
 			insuls.name = "insuls"
 			insuls.desc = "A mere copy of the true insuls."
 			insuls.siemens_coefficient = 0.99999
-			H.equip_to_slot(insuls, ITEM_SLOT_GLOVES)
-		GLOB.bible_icon_state = icon_state
-		GLOB.bible_inhand_icon_state = inhand_icon_state
+			user.equip_to_slot(insuls, ITEM_SLOT_GLOVES)
+	GLOB.bible_icon_state = icon_state
+	GLOB.bible_inhand_icon_state = inhand_icon_state
+	SSblackbox.record_feedback("text", "religion_book", 1, "[choice]")
 
-		SSblackbox.record_feedback("text", "religion_book", 1, "[biblename]")
-		usr << browse(null, "window=editicon")
+/**
+  * Checks if we are allowed to interact with a radial menu
+  *
+  * Arguments:
+  * * user The mob interacting with the menu
+  */
+/obj/item/storage/book/bible/proc/check_menu(mob/living/carbon/human/user)
+	if(GLOB.bible_icon_state)
+		return FALSE
+	if(!istype(user))
+		return FALSE
+	if(!user.is_holding(src))
+		return FALSE
+	if(!user.can_read(src))
+		return FALSE
+	if(user.incapacitated())
+		return FALSE
+	if(user.mind?.holy_role != HOLY_ROLE_HIGHPRIEST)
+		return FALSE
+	return TRUE
 
 /obj/item/storage/book/bible/proc/bless(mob/living/L, mob/living/user)
 	if(GLOB.religious_sect)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR makes bibles use a radial menu for choosing their skins, instead of using an outdated html browser menu. One small functional change is that you can actually close the menu and decide the skin later if you wish so, unlike the old html browser menu, which was unclosable.

Example image:                            

![BibleRadial](https://user-images.githubusercontent.com/43862960/90177829-657c1c00-ddab-11ea-9e2d-afe9a762f899.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Better bible skin choosing method.

## Changelog
:cl: Arkatos
add: Bible now uses a radial menu for choosing its skins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
