### PR TITLE
Chemistry machines drop beakers on floor if you are not beside them

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -204,6 +204,22 @@ Class Procs:
 			L.update_mobility()
 	occupant = null
 
+/**
+ * Places passed object in to users hand
+ *
+ * Places the passed object in to the users hand if they are ajacent.
+ * If the user is not ajacent then place the object on top of the machine.
+ *
+ * Vars:
+ * * object (obj) The object to be moved in to the users hand.
+ * * user (mob/living) The user to recive the object
+ */
+/obj/machinery/proc/hand_object(obj/object, mob/living/user)
+	if(!issilicon(user) && in_range(src, user))
+		user.put_in_hands(object)
+	else
+		object.forceMove(drop_location())
+
 /obj/machinery/proc/can_be_occupant(atom/movable/am)
 	return occupant_typecache ? is_type_in_typecache(am, occupant_typecache) : isliving(am)
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -205,16 +205,16 @@ Class Procs:
 	occupant = null
 
 /**
- * Places passed object in to users hand
+ * Puts passed object in to user's hand
  *
- * Places the passed object in to the users hand if they are ajacent.
- * If the user is not ajacent then place the object on top of the machine.
+ * Puts the passed object in to the users hand if they are adjacent.
+ * If the user is not adjacent then place the object on top of the machine.
  *
  * Vars:
  * * object (obj) The object to be moved in to the users hand.
  * * user (mob/living) The user to recive the object
  */
-/obj/machinery/proc/hand_object(obj/object, mob/living/user)
+/obj/machinery/proc/try_put_in_hand(obj/object, mob/living/user)
 	if(!issilicon(user) && in_range(src, user))
 		user.put_in_hands(object)
 	else

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -387,7 +387,7 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		if(in_range(src, user))
+		if(!issilicon(user) && in_range(src, user))
 			user.put_in_hands(beaker)
 		else // if they are not beside the machine
 			beaker.forceMove(drop_location())

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -387,7 +387,10 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		user.put_in_hands(beaker)
+		if(in_range(src, user))
+			user.put_in_hands(beaker)
+		else // if they are not beside the machine
+			beaker.forceMove(drop_location())
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -387,10 +387,7 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		if(!issilicon(user) && in_range(src, user))
-			user.put_in_hands(beaker)
-		else // if they are not beside the machine
-			beaker.forceMove(drop_location())
+		hand_object(beaker, user)
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -387,7 +387,7 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		hand_object(beaker, user)
+		try_put_in_hand(beaker, user)
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -39,7 +39,7 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		if(in_range(src, user))
+		if(!issilicon(user) && in_range(src, user))
 			user.put_in_hands(beaker)
 		else // if they are not beside the machine
 			beaker.forceMove(drop_location())

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -39,7 +39,10 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		user.put_in_hands(beaker)
+		if(in_range(src, user))
+			user.put_in_hands(beaker)
+		else // if they are not beside the machine
+			beaker.forceMove(drop_location())
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -39,10 +39,7 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		if(!issilicon(user) && in_range(src, user))
-			user.put_in_hands(beaker)
-		else // if they are not beside the machine
-			beaker.forceMove(drop_location())
+		hand_object(beaker, user)
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -39,7 +39,7 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		hand_object(beaker, user)
+		try_put_in_hand(beaker, user)
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -135,7 +135,10 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		user.put_in_hands(beaker)
+		if(in_range(src, user))
+			user.put_in_hands(beaker)
+		else // if they are not beside the machine do not put things in hand
+			beaker.forceMove(drop_location())
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -135,7 +135,7 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		if(in_range(src, user))
+		if(!issilicon(user) && in_range(src, user))
 			user.put_in_hands(beaker)
 		else // if they are not beside the machine do not put things in hand
 			beaker.forceMove(drop_location())

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -135,10 +135,7 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		if(!issilicon(user) && in_range(src, user))
-			user.put_in_hands(beaker)
-		else // if they are not beside the machine do not put things in hand
-			beaker.forceMove(drop_location())
+		hand_object(beaker, user)
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -135,7 +135,7 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		hand_object(beaker, user)
+		try_put_in_hand(beaker, user)
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/chem_synthesizer.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_synthesizer.dm
@@ -23,9 +23,7 @@
 	switch(action)
 		if("ejectBeaker")
 			if(beaker)
-				beaker.forceMove(drop_location())
-				if(Adjacent(usr) && !issilicon(usr))
-					usr.put_in_hands(beaker)
+				hand_object(beaker, usr)
 				beaker = null
 				. = TRUE
 		if("input")

--- a/code/modules/reagents/chemistry/machinery/chem_synthesizer.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_synthesizer.dm
@@ -23,7 +23,7 @@
 	switch(action)
 		if("ejectBeaker")
 			if(beaker)
-				hand_object(beaker, usr)
+				try_put_in_hand(beaker, usr)
 				beaker = null
 				. = TRUE
 		if("input")

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -139,7 +139,7 @@
 
 /obj/machinery/computer/pandemic/proc/eject_beaker()
 	if(beaker)
-		beaker.forceMove(drop_location())
+		hand_object(beaker, usr)
 		beaker = null
 		update_icon()
 

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -139,7 +139,7 @@
 
 /obj/machinery/computer/pandemic/proc/eject_beaker()
 	if(beaker)
-		hand_object(beaker, usr)
+		try_put_in_hand(beaker, usr)
 		beaker = null
 		update_icon()
 

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -112,10 +112,7 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		if(can_interact(user))
-			user.put_in_hands(beaker)
-		else
-			beaker.drop_location(get_turf(src))
+		hand_object(beaker, user)
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -112,7 +112,7 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		hand_object(beaker, user)
+		try_put_in_hand(beaker, user)
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When ejecting a beaker it would teleport to your hand.
This checks that you are in range, if not the beaker drops at the machine.

Fixes #52882

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No teleportation of beakers.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Removed beaker teleportation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
