### PR TITLE
The holodeck will no longer spawn invisible tables, and WILL spawn floor decals.

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -161,9 +161,9 @@
 /area/holodeck/rec_center/bunker)
 "az" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/matches{
-	pixel_x = -4;
-	pixel_y = 8
+/obj/item/lighter{
+	pixel_x = 3;
+	pixel_y = 3
 	},
 /turf/open/floor/holofloor{
 	dir = 9;
@@ -305,13 +305,11 @@
 /area/holodeck/rec_center/lounge)
 "aU" = (
 /turf/open/floor/holofloor{
-	dir = 9;
 	icon_state = "stairs-l"
 	},
 /area/holodeck/rec_center/lounge)
 "aV" = (
 /turf/open/floor/holofloor{
-	dir = 9;
 	icon_state = "stairs-r"
 	},
 /area/holodeck/rec_center/lounge)

--- a/code/modules/holodeck/area_copy.dm
+++ b/code/modules/holodeck/area_copy.dm
@@ -2,7 +2,7 @@
 GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 	"tag", "datum_components", "area", "type", "loc", "locs", "vars", "parent", "parent_type", "verbs", "ckey", "key",
 	"power_supply", "contents", "reagents", "stat", "x", "y", "z", "group", "atmos_adjacent_turfs", "comp_lookup",
-	"client_mobs_in_contents", "bodyparts", "internal_organs", "hand_bodyparts", "overlays", "overlays_standing", "hud_list",
+	"client_mobs_in_contents", "bodyparts", "internal_organs", "hand_bodyparts", "overlays", "bottom_left_corner", "bottom_right_corner", "top_left_corner", "top_right_corner",  "overlays_standing", "hud_list", //Corner vars added here to fix new table smoothing breaking the holodeck, issue #52859
 	"actions", "AIStatus", "appearance", "managed_overlays", "managed_vis_overlays", "computer_id", "lastKnownIP", "implants",
 	"tgui_shared_states"
 	))

--- a/code/modules/holodeck/area_copy.dm
+++ b/code/modules/holodeck/area_copy.dm
@@ -2,7 +2,7 @@
 GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 	"tag", "datum_components", "area", "type", "loc", "locs", "vars", "parent", "parent_type", "verbs", "ckey", "key",
 	"power_supply", "contents", "reagents", "stat", "x", "y", "z", "group", "atmos_adjacent_turfs", "comp_lookup",
-	"client_mobs_in_contents", "bodyparts", "internal_organs", "hand_bodyparts", "overlays", "bottom_left_corner", "bottom_right_corner", "top_left_corner", "top_right_corner",  "overlays_standing", "hud_list",
+	"client_mobs_in_contents", "bodyparts", "internal_organs", "hand_bodyparts", "overlays", "bottom_left_corner", "bottom_right_corner", "top_left_corner", "top_right_corner", "overlays_standing", "hud_list",
 	"actions", "AIStatus", "appearance", "managed_overlays", "managed_vis_overlays", "computer_id", "lastKnownIP", "implants",
 	"tgui_shared_states"
 	))

--- a/code/modules/holodeck/area_copy.dm
+++ b/code/modules/holodeck/area_copy.dm
@@ -2,7 +2,7 @@
 GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 	"tag", "datum_components", "area", "type", "loc", "locs", "vars", "parent", "parent_type", "verbs", "ckey", "key",
 	"power_supply", "contents", "reagents", "stat", "x", "y", "z", "group", "atmos_adjacent_turfs", "comp_lookup",
-	"client_mobs_in_contents", "bodyparts", "internal_organs", "hand_bodyparts", "overlays", "bottom_left_corner", "bottom_right_corner", "top_left_corner", "top_right_corner", "overlays_standing", "hud_list",
+	"client_mobs_in_contents", "bodyparts", "internal_organs", "hand_bodyparts", "overlays_standing", "hud_list",
 	"actions", "AIStatus", "appearance", "managed_overlays", "managed_vis_overlays", "computer_id", "lastKnownIP", "implants",
 	"tgui_shared_states"
 	))

--- a/code/modules/holodeck/area_copy.dm
+++ b/code/modules/holodeck/area_copy.dm
@@ -2,7 +2,7 @@
 GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 	"tag", "datum_components", "area", "type", "loc", "locs", "vars", "parent", "parent_type", "verbs", "ckey", "key",
 	"power_supply", "contents", "reagents", "stat", "x", "y", "z", "group", "atmos_adjacent_turfs", "comp_lookup",
-	"client_mobs_in_contents", "bodyparts", "internal_organs", "hand_bodyparts", "overlays", "bottom_left_corner", "bottom_right_corner", "top_left_corner", "top_right_corner",  "overlays_standing", "hud_list", //Corner vars added here to fix new table smoothing breaking the holodeck, issue #52859
+	"client_mobs_in_contents", "bodyparts", "internal_organs", "hand_bodyparts", "overlays", "bottom_left_corner", "bottom_right_corner", "top_left_corner", "top_right_corner",  "overlays_standing", "hud_list",
 	"actions", "AIStatus", "appearance", "managed_overlays", "managed_vis_overlays", "computer_id", "lastKnownIP", "implants",
 	"tgui_shared_states"
 	))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

~~It seems tables have been broken on the holodeck since new table smoothing went in, certain vars were being copied over that shouldn't have been included, which messed up smoothing/overlay code.~~
Whoever slapped `overlays` into the forbidden vars list apparently didn't test or account for what this would do to the holodeck, because it turns out this also completely breaks floor decals for the holodeck, not just tables. I am therefor just removing it, as I see no reason to forbid overlays when copying a holodeck room, they're despawned anyway when the sim is shut off or changed. As decals are **entirely dependent** upon overlays, I can think of no other way to solve part of this problem.

Thanks to @Rohesie and @optimumtact for help.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This fixes https://github.com/tgstation/tgstation/issues/52859
and fixes https://github.com/tgstation/tgstation/issues/52964

Also fixes two small issues in the lounge holodeck sim:
Replaces the matches with a zippo lighter, since the matches don't despawn properly.
Sets the `dir` of stairs properly..

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Nanotrasen software division has fixed an issue with station holodecks creating invisible tables and floor decals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
