### PR TITLE
Fixes Swarmer Teleport and Swarmer Typo

### DIFF
--- a/code/modules/swarmers/swarmer.dm
+++ b/code/modules/swarmers/swarmer.dm
@@ -130,15 +130,17 @@
 		drone.LoseTarget()
 		drone.Goto(clicked_turf, drone.move_to_delay)
 
-/mob/living/simple_animal/hostile/swarmer/CtrlClickOn(atom/A)
-	face_atom(A)
+/mob/living/simple_animal/hostile/swarmer/CtrlClickOn(atom/target)
+	face_atom(target)
+	if(!istype(target, /mob/living))
+		return
 	if(!isturf(loc))
 		return
 	if(next_move > world.time)
 		return
-	if(!A.Adjacent(src))
+	if(!target.Adjacent(src))
 		return
-	prepare_target(src)
+	prepare_target(target)
 
 ////END CTRL CLICK FOR SWARMERS////
 

--- a/code/modules/swarmers/swarmer_objs.dm
+++ b/code/modules/swarmers/swarmer_objs.dm
@@ -75,7 +75,7 @@
 	var/mob/living/simple_animal/hostile/swarmer/newswarmer = new /mob/living/simple_animal/hostile/swarmer(src)
 	newswarmer.key = user.key
 	addtimer(CALLBACK(src, .proc/release_swarmer, newswarmer), 30 SECONDS)
-	to_chat(newswarmer, "<span class='boldannounce'>SWARMER CONSTURCTION INITIALIZED.  TIME TO COMPLETION: 30 SECONDS</span>")
+	to_chat(newswarmer, "<span class='boldannounce'>SWARMER CONSTRUCTION INITIALIZED.  TIME TO COMPLETION: 30 SECONDS</span>")
 	processing_swarmer = TRUE
 	return TRUE
 
@@ -87,7 +87,7 @@
   * * swarmer - The swarmer being released and told what to do
   */
 /obj/structure/swarmer_beacon/proc/release_swarmer(mob/swarmer)
-	to_chat(swarmer, "<span class='bold'>SWARMER CONSTURCTION COMPLETED.  OBJECTIVES:\n\
+	to_chat(swarmer, "<span class='bold'>SWARMER CONSTRUCTION COMPLETED.  OBJECTIVES:\n\
 	                     1. CONSUME RESOURCES AND REPLICATE UNTIL THERE ARE NO MORE RESOURCES LEFT\n\
 						 2. ENSURE PROTECTION OF THE BEACON SO THIS LOCATION CAN BE INVADED AT A LATER DATE; DO NOT PERFORM ACTIONS THAT WOULD RENDER THIS LOCATION DANGEROUS OR INHOSPITABLE\n\
 						 3. BIOLOGICAL RESOURCES WILL BE HARVESTED AT A LATER DATE: DO NOT HARM THEM\n\


### PR DESCRIPTION
## About The Pull Request

Fixes #52939 and a typo with the word "Construction" being written as the word "Consturction" in Swarmer code.

## Why It's Good For The Game

One of these bugs forces swarmers to submit the crew to eternal tickle torture and the other just makes us look stupid

## Changelog
:cl:
fix: Swarmers are not able to teleport their subdued targets again
fix: Removed references to Consturction in the Swarmer Beacon
/:cl: