### PR TITLE
makes some events only work on crewmembers, and some not work on centcom

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -14,6 +14,7 @@
 			continue
 		if(!H.getorgan(/obj/item/organ/brain)) // If only I had a brain
 			continue
+		if(!SSjob.GetJob(H.mind.assigned_role) || (H.mind.assigned_role in GLOB.nonhuman_positions)) //please stop giving my centcom admin gimmicks full body paralysis
 
 		traumatize(H)
 		announce_to_ghosts(H)

--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -15,7 +15,7 @@
 		if(!H.getorgan(/obj/item/organ/brain)) // If only I had a brain
 			continue
 		if(!SSjob.GetJob(H.mind.assigned_role) || (H.mind.assigned_role in GLOB.nonhuman_positions)) //please stop giving my centcom admin gimmicks full body paralysis
-
+			continue
 		traumatize(H)
 		announce_to_ghosts(H)
 		break

--- a/code/modules/events/fake_virus.dm
+++ b/code/modules/events/fake_virus.dm
@@ -6,7 +6,7 @@
 /datum/round_event/fake_virus/start()
 	var/list/fake_virus_victims = list()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
-		if(!H.client || H.stat == DEAD || H.InCritical())
+		if(!H.client || H.stat == DEAD || H.InCritical() || (!SSjob.GetJob(H.mind.assigned_role) || (H.mind.assigned_role in GLOB.nonhuman_positions)))
 			continue
 		fake_virus_victims += H
 

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -10,6 +10,8 @@
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
 		if(!H.client || H.stat == DEAD || H.InCritical() || !H.can_heartattack() || H.has_status_effect(STATUS_EFFECT_EXERCISED) || (/datum/disease/heart_failure in H.diseases) || H.undergoing_cardiac_arrest())
 			continue
+		if(!SSjob.GetJob(H.mind.assigned_role) || (H.mind.assigned_role in GLOB.nonhuman_positions))//only crewmembers can get one, a bit unfair for some ghost roles and it wastes the event
+			continue
 		if(H.satiety <= -60) //Multiple junk food items recently
 			heart_attack_contestants[H] = 3
 		else

--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -13,14 +13,20 @@
 		if(1) //same sound for everyone
 			var/sound = pick("airlock","airlock_pry","console","explosion","far_explosion","mech","glass","alarm","beepsky","mech","wall_decon","door_hack","tesla")
 			for(var/mob/living/carbon/C in GLOB.alive_mob_list)
+				if(C.z in SSmapping.levels_by_trait(ZTRAIT_CENTCOM))//not for admin/ooc stuff
+					continue
 				new /datum/hallucination/sounds(C, TRUE, sound)
 		if(2)
 			var/weirdsound = pick("phone","hallelujah","highlander","hyperspace","game_over","creepy","tesla")
 			for(var/mob/living/carbon/C in GLOB.alive_mob_list)
+				if(C.z in SSmapping.levels_by_trait(ZTRAIT_CENTCOM))//not for admin/ooc stuff
+					continue
 				new /datum/hallucination/weird_sounds(C, TRUE, weirdsound)
 		if(3)
 			var/stationmessage = pick("ratvar","shuttle_dock","blob_alert","malf_ai","meteors","supermatter")
 			for(var/mob/living/carbon/C in GLOB.alive_mob_list)
+				if(C.z in SSmapping.levels_by_trait(ZTRAIT_CENTCOM))//not for admin/ooc stuff
+					continue
 				new /datum/hallucination/stationmessage(C, TRUE, stationmessage)
 		if(4 to 6)
 			var/picked_hallucination = pick(	/datum/hallucination/bolts,
@@ -35,4 +41,6 @@
 												/datum/hallucination/delusion,
 												/datum/hallucination/oh_yeah)
 			for(var/mob/living/carbon/C in GLOB.alive_mob_list)
+				if(C.z in SSmapping.levels_by_trait(ZTRAIT_CENTCOM))//not for admin/ooc stuff
+					continue
 				new picked_hallucination(C, TRUE)

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -19,7 +19,8 @@
 			continue
 		if(!(H.mob_biotypes & MOB_ORGANIC)) //biotype sleeper bugs strike again, once again making appendicitis pick a target that can't take it
 			continue
-		if(C.z in SSmapping.levels_by_trait(ZTRAIT_CENTCOM))//not for admin/ooc stuff
+		if(H.z in SSmapping.levels_by_trait(ZTRAIT_CENTCOM))//not for admin/ooc stuff
+			continue
 		var/foundAlready = FALSE	//don't infect someone that already has appendicitis
 		for(var/datum/disease/appendicitis/A in H.diseases)
 			foundAlready = TRUE

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -19,6 +19,7 @@
 			continue
 		if(!(H.mob_biotypes & MOB_ORGANIC)) //biotype sleeper bugs strike again, once again making appendicitis pick a target that can't take it
 			continue
+		if(C.z in SSmapping.levels_by_trait(ZTRAIT_CENTCOM))//not for admin/ooc stuff
 		var/foundAlready = FALSE	//don't infect someone that already has appendicitis
 		for(var/datum/disease/appendicitis/A in H.diseases)
 			foundAlready = TRUE


### PR DESCRIPTION
STOP

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

brain trauma, fake virus, and heart attack only work on crewmembers.
mass hallucination and appendicitis don't give the effect/pick to people on centcom, respectively

## Why It's Good For The Game

Mafia players getting paralysis and mental traumas, random single person ghost roles taking a heart attack event that would hit the station, etc etc. These are wasting events at best and really fucking meddling at worst.

## Changelog
:cl:
balance: some really dangerous "you're fucked" events don't trigger on ghost roles...
admin: and some events have been forbidden from centcom. stop messing with my events on the OOC zlevel!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
