### PR TITLE
Removes Lone Operative's starting Bulldog, gives him 8TCs more instead

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -161,8 +161,8 @@
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/engi
 	internals_slot = ITEM_SLOT_RPOCKET
 	belt = /obj/item/storage/belt/military
-	r_hand = /obj/item/gun/ballistic/shotgun/bulldog
 	backpack_contents = list(/obj/item/storage/box/survival/syndie=1,\
 		/obj/item/tank/jetpack/oxygen/harness=1,\
 		/obj/item/gun/ballistic/automatic/pistol=1,\
 		/obj/item/kitchen/knife/combat/survival)
+	tc = 33


### PR DESCRIPTION
## About The Pull Request

As in title
## Why It's Good For The Game

I think it's good for the game as loneop is fairly rare antag to get, and while that bulldog is cool, it basically makes player commit to working with weapon arbitrarily chosen by coderman. With lots of gear being basically exclusive to nukies, this will hopefully encourage people to experiment with loadouts more. I doubt it would tip the balance in favour of loneop too much.

## Changelog
:cl:
del: Removed Bulldog from loneop's starting gear
tweak: Added equivalent of bulldog's cost to loneop's uplink
/:cl:
