### PR TITLE
Fixes eye damage overlay

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -113,7 +113,6 @@
 				update_tint()
 			if(G.vision_correction)
 				clear_fullscreen("nearsighted")
-				clear_fullscreen("eye_damage")
 			if(G.vision_flags || G.darkness_view || G.invis_override || G.invis_view || !isnull(G.lighting_alpha))
 				update_sight()
 			update_inv_glasses()

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -58,6 +58,7 @@
 	M.cure_nearsighted(EYE_DAMAGE)
 	M.set_blindness(0)
 	M.set_blurriness(0)
+	M.clear_fullscreen("eye_damage", 0)
 	M.update_sight()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #52061, #49659 and #50436
Removes the eye damage overlay when you replace your eyes.  Also fixes prescription glasses from "fixing" eye damage.

## Why It's Good For The Game
It's annoying to have shiny new eyes and still have the full screen overlay.  Also glasses shouldn't fix that overlay when someone stabs you in the eye.

## Changelog
:cl:
fix: Replacing damaged eyes actually fixes your eyes.
fix: You cannot fix your eyes by just putting on glasses
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
