### PR TITLE
Fixed mutatelist runtime and added logging

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -132,7 +132,7 @@
 	else if(istype(Proj , /obj/projectile/energy/florayield))
 		return myseed.bullet_act(Proj)
 	else if(istype(Proj , /obj/projectile/energy/florarevolution))
-		if(myseed)
+		if(myseed && myseed.mutatelist)
 			if(myseed.mutatelist.len > 0)
 				myseed.instability = (myseed.instability/2)
 		mutatespecie()
@@ -450,7 +450,10 @@
 		return
 
 	var/oldPlantName = myseed.plantname
-	if(myseed.mutatelist.len > 0)
+	if(!myseed.mutatelist)
+		log_game("([myseed.type]:[myseed.name]) seed has a null mutatelist!")
+		return
+	else if(myseed.mutatelist.len > 0)
 		var/mutantseed = pick(myseed.mutatelist)
 		qdel(myseed)
 		myseed = null

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -132,7 +132,7 @@
 	else if(istype(Proj , /obj/projectile/energy/florayield))
 		return myseed.bullet_act(Proj)
 	else if(istype(Proj , /obj/projectile/energy/florarevolution))
-		if(myseed && myseed.mutatelist)
+		if(myseed?.mutatelist)
 			if(myseed.mutatelist.len > 0)
 				myseed.instability = (myseed.instability/2)
 		mutatespecie()


### PR DESCRIPTION
## About The Pull Request

Campbell RoundID: 144289

Found a hydroponics runtime and it seems its because mutatelist is sometimes null?  Not sure why its not set to list() in /obj/item/seeds but I couldn't find the doc on it.  So I added some checks and set up it up to log to find those seeds

It didn't cause a bug in the game per say as a null list drops to return.   Just easy runtime to fix.

## Changelog
:cl:
add: Logging seeds that have no mutation lists
fix: Runtime shouldn't come up anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
