### PR TITLE
Cleaning machines and the cleanbot now scrubs instead of washes, wiping forensics

### DIFF
--- a/code/datums/elements/cleaning.dm
+++ b/code/datums/elements/cleaning.dm
@@ -14,17 +14,17 @@
 	if(!isturf(tile))
 		return
 
-	tile.wash(CLEAN_WASH)
+	tile.wash(CLEAN_SCRUB)
 	for(var/A in tile)
 		// Clean small items that are lying on the ground
 		if(isitem(A))
 			var/obj/item/I = A
 			if(I.w_class <= WEIGHT_CLASS_SMALL && !ismob(I.loc))
-				I.wash(CLEAN_WASH)
+				I.wash(CLEAN_SCRUB)
 		// Clean humans that are lying down
 		else if(ishuman(A))
 			var/mob/living/carbon/human/cleaned_human = A
 			if(!(cleaned_human.mobility_flags & MOBILITY_STAND))
-				cleaned_human.wash(CLEAN_WASH)
+				cleaned_human.wash(CLEAN_SCRUB)
 				cleaned_human.regenerate_icons()
 				to_chat(cleaned_human, "<span class='danger'>[AM] cleans your face!</span>")

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -318,7 +318,7 @@
 
 		var/turf/T = get_turf(A)
 		if(do_after(src, 1, target = T))
-			T.wash(CLEAN_WASH)
+			T.wash(CLEAN_SCRUB)
 			visible_message("<span class='notice'>[src] cleans \the [T].</span>")
 			target = null
 

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -177,7 +177,7 @@
 
 /mob/living/simple_animal/hostile/alien/maid/AttackingTarget()
 	if(ismovable(target))
-		target.wash(CLEAN_WASH)
+		target.wash(CLEAN_SCRUB)
 		if(istype(target, /obj/effect/decal/cleanable))
 			visible_message("<span class='notice'>[src] cleans up \the [target].</span>")
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
These machines icons evidently shows that they use a scrubbing action to clean, so their wash proc should also reflect that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The cleaning system is now slightly more intuitive. If you need to get rid of forensic evidence, it's enough to find something that cleans using a scrubbing action.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Cleaning system is now more intuitive. Scrubbing action = forensic wiping, only spraying = forensics kept.
balance: Cleaning machines (janicart, etc) and the cleanbot will now get rid of forensic evidence
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
