### PR TITLE
Update stat panel to give round time days.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -810,7 +810,11 @@
 		stat(null, "Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]")
 		stat(null, "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]")
 		if (SSticker.round_start_time)
-			stat(null, "Round Time: [gameTimestamp("hh:mm:ss", (world.time - SSticker.round_start_time))]")
+			var/round_time = world.time - SSticker.round_start_time
+			if(round_time > MIDNIGHT_ROLLOVER)
+				stat(null, "Round Time: [round(round_time/MIDNIGHT_ROLLOVER)]:[gameTimestamp("hh:mm:ss", round_time)]")
+			else
+				stat(null, "Round Time: [gameTimestamp("hh:mm:ss", round_time)]")
 		else
 			stat(null, "Lobby Time: [gameTimestamp("hh:mm:ss", 0)]")
 		stat(null, "Station Time: [station_time_timestamp()]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Someone asked about this because they couldn't believe some servers stay on shift this long *cough, Campbell*  So modified the stat panel to show days when it rolls over a day.

## Why It's Good For The Game
Have people believe in the power of the long shift


## Changelog
:cl:
add: Added day counter to the round time
/:cl:
