### PR TITLE
Makes the ash drake fight winabble, prevents master controller death when the ash drake is fought

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -136,12 +136,11 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	return W
 
 /turf/open/ChangeTurf(path, list/new_baseturfs, flags) //Resist the temptation to make this default to keeping air.
+	SSair.remove_from_active(src) //Turfs are fucking weird with refs, let's be safe yeah?
 	if ((flags & CHANGETURF_INHERIT_AIR) && ispath(path, /turf/open))
-		SSair.remove_from_active(src)
 		var/datum/gas_mixture/stashed_air = new()
 		stashed_air.copy_from(air)
-		air = null
-		. = ..()
+		. = ..() //If path == type this will return us, don't bank on making a new type
 		if (!.) // changeturf failed or didn't do anything
 			QDEL_NULL(stashed_air)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
This is where the issue starts. The ash drakes lava arena attack clears away space for lava to pop up.
![image](https://user-images.githubusercontent.com/58055496/90363028-c196a880-e016-11ea-8873-7d81b56af0cf.png)
Notice how the turf it clears with is the same as the lavaland turf?
This is what turf/open/ChangeTurf() with the right flags set does
![image](https://user-images.githubusercontent.com/58055496/90362867-69f83d00-e016-11ea-85a7-38646f40e4f2.png)
in effect it copies over the gas state from the turf we start as, to the turf we want to end as.
See how it nulls the gas? This will be important in just a second.
This is turf/ChangeTurf() does
![image](https://user-images.githubusercontent.com/58055496/90363130-f60a6480-e016-11ea-8d39-5ba0affdfe51.png)
see how it discards the change if both turfs are the same?

This means that if say, you had 2 open turfs that you flagged to share atmos, you'd end up with a null'd gas datum in the end.

This was introduced in #52713, which is a fine pr on the overall, this would be pretty hard to catch.

As a side note, datums that have no connected refs null on their own. So we don't even need to null air here.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Prevents horrible lag and runtime spam, makes the ash drake fight doable again, and adds a safeguard in case of other odd turf shit.
## Changelog
:cl:
fix: The ash drake fight is winnable again, and  the game will no longer die when he goes into the lava arena attack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
