### PR TITLE
Fix runtime with CANT_WOUND weapons that use pellet_cloud

### DIFF
--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -260,13 +260,14 @@
 		var/obj/item/bodypart/hit_part
 		if(isbodypart(target))
 			hit_part = target
-			target = hit_part.owner
-			var/damage_dealt = wound_info_by_part[hit_part][CLOUD_POSITION_DAMAGE]
-			var/w_bonus = wound_info_by_part[hit_part][CLOUD_POSITION_W_BONUS]
-			var/bw_bonus = wound_info_by_part[hit_part][CLOUD_POSITION_BW_BONUS]
-			var/wound_type = (initial(P.damage_type) == BRUTE) ? WOUND_BLUNT : WOUND_BURN // sharpness is handled in the wound rolling
-			wound_info_by_part[hit_part] = null
-			hit_part.painless_wound_roll(wound_type, damage_dealt, w_bonus, bw_bonus, initial(P.sharpness))
+			if(wound_info_by_part[hit_part])
+				target = hit_part.owner
+				var/damage_dealt = wound_info_by_part[hit_part][CLOUD_POSITION_DAMAGE]
+				var/w_bonus = wound_info_by_part[hit_part][CLOUD_POSITION_W_BONUS]
+				var/bw_bonus = wound_info_by_part[hit_part][CLOUD_POSITION_BW_BONUS]
+				var/wound_type = (initial(P.damage_type) == BRUTE) ? WOUND_BLUNT : WOUND_BURN // sharpness is handled in the wound rolling
+				wound_info_by_part[hit_part] = null
+				hit_part.painless_wound_roll(wound_type, damage_dealt, w_bonus, bw_bonus, initial(P.sharpness))
 
 		if(num_hits > 1)
 			target.visible_message("<span class='danger'>[target] is hit by [num_hits] [proj_name]s[hit_part ? " in the [hit_part.name]" : ""]!</span>", null, null, COMBAT_MESSAGE_RANGE, target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In `/datum/component/pellet_cloud/proc/pellet_hit` if the projectile's `wound_bonus` is `CANT_WOUND`, then `wound_info_by_part[hit_part]` never gets a value set.

This causes an issue in `/datum/component/pellet_cloud/proc/finalize()` where it assumes that `wound_info_by_part[hit_part]` has always been set to a list(x,y,z).

I added a quick if check to skip this where there's no wound info for a part.

Weapon this behaviour manifested on: DRAGnet on net mode. Due to the runtime, I didn't notice it dealing any stamina damage. This should fix that scenario as well as any other CANT_WOUND projectiles and prevent them from runtiming early.

@Ryll-Ryll This is your baby, so I'd appreciate you looking this over too.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtime bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Runtime in wounds system fixed for projectiles that can't wound. As a result, non-woundy weapons will now complete code execution and apply appropriate damage. In particular, this fixes the DRAGnet not dealing stamina damage on net mode, may fix other weapons too.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
