### PR TITLE
Clown's Tears take one bananium sheet instead of one bananium ore

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_soup.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_soup.dm
@@ -152,7 +152,7 @@
 		/datum/reagent/water = 10,
 		/obj/item/reagent_containers/glass/bowl = 1,
 		/obj/item/reagent_containers/food/snacks/grown/banana = 1,
-		/obj/item/stack/ore/bananium = 1
+		/obj/item/stack/sheet/mineral/bananium = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/clownstears
 	subcategory = CAT_SOUP


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
### suggested in https://tgstation13.org/phpBB/viewtopic.php?p=571794#p571794

## Why It's Good For The Game

Okay, I'm with the guy who suggested this. Ore is super useless in every other case, and it just fucks the recipe to go "aw nuts i accidently refined it" I understand the joke is that you're making clowns tears by making a shitty soup instead of the honk mech, but it still entirely works as bananium sheets.

## Changelog
:cl:
tweak: Clown's Tears now takes bananium sheets instead of ore to craft.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
