### PR TITLE
Fixes cabling on the hellfactory ruin.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
@@ -294,6 +294,7 @@
 	pixel_x = 4;
 	pixel_y = -10
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "aS" = (
@@ -362,6 +363,15 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hellfactory)
 "bf" = (
+/obj/machinery/door/keycard/office,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/hellfactoryoffice)
+"bg" = (
+/obj/machinery/modular_computer/console/preset/civilian,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/hellfactory)
+"bh" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -374,17 +384,8 @@
 /obj/item/chair/plastic{
 	pixel_y = 12
 	},
+/obj/structure/rack,
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/hellfactory)
-"bg" = (
-/obj/machinery/modular_computer/console/preset/civilian,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/hellfactory)
-"bh" = (
-/obj/item/pressure_plate/hologrid{
-	reward = /obj/item/keycard/office
-	},
-/turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bi" = (
 /obj/machinery/light{
@@ -437,9 +438,11 @@
 /turf/closed/wall/r_wall/rust,
 /area/ruin/space/has_grav/hellfactory)
 "br" = (
-/obj/machinery/door/keycard/stockroom,
+/obj/item/pressure_plate/hologrid{
+	reward = /obj/item/keycard/office
+	},
 /obj/structure/cable,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bs" = (
 /obj/machinery/conveyor/auto,
@@ -542,9 +545,10 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bF" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 4
+/obj/item/pressure_plate/hologrid{
+	reward = /obj/item/skub
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bG" = (
@@ -555,6 +559,11 @@
 	},
 /obj/item/reagent_containers/food/drinks/flask,
 /obj/item/stack/sheet/glass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hellfactory)
+"bH" = (
+/obj/item/pressure_plate/hologrid,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bI" = (
@@ -678,8 +687,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bZ" = (
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plating,
+/obj/machinery/door/keycard/stockroom,
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/hellfactory)
 "ca" = (
 /obj/machinery/door/airlock,
@@ -775,8 +784,10 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cp" = (
-/obj/effect/turf_decal/box/white/corners,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cq" = (
@@ -840,11 +851,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cz" = (
-/obj/machinery/light/broken,
-/obj/structure/marker_beacon{
-	icon_state = "markerburgundy-on"
-	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot_white,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cA" = (
 /obj/item/trash/raisins,
@@ -852,6 +861,13 @@
 /area/ruin/space/has_grav/hellfactory)
 "cB" = (
 /obj/item/stack/tile/plasteel,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hellfactory)
+"cC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cD" = (
@@ -932,6 +948,12 @@
 /obj/structure/holobox,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
+"cP" = (
+/obj/effect/turf_decal/box/white/corners,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hellfactory)
 "cQ" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -948,23 +970,20 @@
 /obj/item/keycard/entry,
 /turf/open/space/basic,
 /area/ruin/space/has_grav/hellfactory)
-"cU" = (
-/obj/machinery/door/keycard/office,
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/hellfactoryoffice)
+"cT" = (
+/obj/machinery/light/broken,
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/hellfactory)
 "cV" = (
 /obj/structure/table,
 /obj/item/stack/ducts/fifty,
 /obj/structure/window,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hellfactory)
-"fj" = (
-/obj/structure/cable,
-/turf/closed/indestructible{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
-	},
-/area/ruin/space/has_grav/hellfactoryoffice)
 "hv" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plastic,
@@ -995,12 +1014,6 @@
 /area/ruin/space/has_grav/hellfactory)
 "oJ" = (
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/hellfactory)
-"qB" = (
-/obj/item/pressure_plate/hologrid{
-	reward = /obj/item/skub
-	},
-/turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "ry" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1036,19 +1049,11 @@
 /obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/hellfactory)
-"EP" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/hellfactory)
 "Fs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/hellfactory)
-"Gs" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall/rust,
 /area/ruin/space/has_grav/hellfactory)
 "GE" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1057,10 +1062,6 @@
 "Mv" = (
 /obj/structure/sign/poster/random,
 /turf/closed/wall,
-/area/ruin/space/has_grav/hellfactory)
-"MR" = (
-/obj/item/pressure_plate/hologrid,
-/turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "OJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -1357,7 +1358,7 @@ ao
 ao
 aF
 ah
-bf
+bh
 aA
 bp
 cV
@@ -1437,19 +1438,19 @@ an
 ao
 aI
 aR
-cU
-bh
-qB
-MR
-by
+bf
+br
 bF
-by
-by
-bZ
-by
-bZ
-cl
+bH
+cq
 cp
+cq
+cq
+cz
+cq
+cz
+cC
+cP
 cy
 cJ
 aa
@@ -1464,10 +1465,10 @@ wv
 UN
 aJ
 aX
-fj
-EP
-Gs
-EP
+ah
+ac
+aW
+ac
 by
 by
 bK
@@ -1476,8 +1477,8 @@ ca
 aL
 ca
 aL
-by
-cz
+cq
+cT
 cE
 ac
 cR
@@ -1494,7 +1495,7 @@ Yd
 ah
 aA
 bn
-Gs
+aW
 by
 Wh
 Fs
@@ -1521,7 +1522,7 @@ ao
 ah
 aB
 bL
-br
+bZ
 by
 by
 nT
@@ -1529,8 +1530,8 @@ aL
 cc
 aL
 xK
-Gs
-EP
+ac
+ac
 aW
 ac
 aW
@@ -1548,15 +1549,15 @@ aP
 ah
 bi
 aB
-Gs
-EP
-EP
-Gs
-EP
-Gs
-EP
-Gs
-EP
+aW
+ac
+ac
+aW
+ac
+aW
+ac
+aW
+ac
 Zh
 cA
 by


### PR DESCRIPTION
## About The Pull Request

There were cables in the walls and the squad was laughen, too late, I fixed it, get dunked on

## Why It's Good For The Game
There appears to be an issue with ruins loading lower layer objects out of order, so these "hidden cables" were visually pretty ugly.

## Changelog
:cl:
tweak: The Heck Brewing Factory now has wires outside of it's walls.
/:cl:
