### PR TITLE
Monkey powder now respects the monkey cap config

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -438,7 +438,7 @@
 		cube.Expand()
 	else
 		var/location = get_turf(holder.my_atom)
-		new /mob/living/carbon/monkey(location)
+		new /mob/living/carbon/monkey(location, TRUE)
 
 //water electrolysis
 /datum/chemical_reaction/electrolysis


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin

## Why It's Good For The Game

Stop ignoring config kthx

https://youtu.be/KT--4xo5_EQ
## Changelog
:cl:
fix: Hydrating monkey powder no longer circumvents bluespace harmonic limitations.
/:cl: