### PR TITLE
Removes annoying double space from health doll examining.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -750,13 +750,13 @@
 		var/no_damage
 		if(status == "OK" || status == "no damage")
 			no_damage = TRUE
-		var/isdisabled = " "
+		var/isdisabled = ""
 		if(LB.is_disabled())
-			isdisabled = " is disabled "
+			isdisabled = " is disabled"
 			if(no_damage)
-				isdisabled += " but otherwise "
+				isdisabled += " but otherwise"
 			else
-				isdisabled += " and "
+				isdisabled += " and"
 		combined_msg += "\t <span class='[no_damage ? "notice" : "warning"]'>Your [LB.name][isdisabled][self_aware ? " has " : " is "][status].</span>"
 
 		for(var/thing in LB.wounds)


### PR DESCRIPTION
## About The Pull Request

Click your health doll and observe the chat log.

It currently is like this:
![Untitled](https://user-images.githubusercontent.com/51800976/90471249-4d760680-e0e3-11ea-9635-622b3d14f35f.png)


It will now be like this:
![Untitled1](https://user-images.githubusercontent.com/51800976/90471254-536be780-e0e3-11ea-8656-24b95d97c651.png)



## Why It's Good For The Game

Consistency?

