### PR TITLE
Utility belts can now hold airlock and decal painters.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -67,7 +67,8 @@
 		/obj/item/construction/rcd,
 		/obj/item/pipe_dispenser,
 		/obj/item/inducer,
-		/obj/item/plunger
+		/obj/item/plunger,
+		/obj/item/airlock_painter
 		))
 
 /obj/item/storage/belt/utility/chief


### PR DESCRIPTION


## About The Pull Request

Self-explanatory.


## Why It's Good For The Game

If you can fit the jaws of life in this belt you should probably be able to hold a little paint gun inside it.


## Changelog
:cl:
tweak: Tool belts can now hold airlock and decal painters inside them.
/:cl:

