### PR TITLE
species now correctly do not include organs they do not use

### DIFF
--- a/code/modules/surgery/organs/appendix.dm
+++ b/code/modules/surgery/organs/appendix.dm
@@ -29,7 +29,7 @@
 		M.adjustToxLoss(4, TRUE, TRUE)	//forced to ensure people don't use it to gain tox as slime person
 
 /obj/item/organ/appendix/get_availability(datum/species/S)
-	return !(TRAIT_NOHUNGER in S.species_traits)
+	return !(TRAIT_NOHUNGER in S.inherent_traits)
 
 /obj/item/organ/appendix/Remove(mob/living/carbon/M, special = 0)
 	for(var/datum/disease/appendicitis/A in M.diseases)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -93,7 +93,7 @@
 		failed = TRUE
 
 /obj/item/organ/heart/get_availability(datum/species/S)
-	return !(NOBLOOD in S.species_traits)
+	return !(NOBLOOD in S.inherent_traits)
 
 /obj/item/organ/heart/cursed
 	name = "cursed heart"

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -59,7 +59,7 @@
 #undef HAS_PAINFUL_TOXIN
 
 /obj/item/organ/liver/get_availability(datum/species/S)
-	return !(TRAIT_NOMETABOLISM in S.species_traits)
+	return !(TRAIT_NOMETABOLISM in S.inherent_traits)
 
 /obj/item/organ/liver/fly
 	name = "insectoid liver"

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -435,7 +435,7 @@
 		failed = TRUE
 
 /obj/item/organ/lungs/get_availability(datum/species/S)
-	return !(TRAIT_NOBREATH in S.species_traits)
+	return !(TRAIT_NOBREATH in S.inherent_traits)
 
 /obj/item/organ/lungs/plasmaman
 	name = "plasma filter"

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -44,7 +44,7 @@
 			to_chat(H, "<span class='warning'>Your stomach reels in pain as you're incapable of holding down all that food!</span>")
 
 /obj/item/organ/stomach/get_availability(datum/species/S)
-	return !(NOSTOMACH in S.species_traits)
+	return !(NOSTOMACH in S.inherent_traits)
 
 /obj/item/organ/stomach/proc/handle_disgust(mob/living/carbon/human/H)
 	if(H.disgust)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

get_availability was checking the incorrect list. fffffff

## Why It's Good For The Game

skeletons don't have 4 organs they straight up do not use!

## Changelog
:cl:
fix: species no longer have organs they do not use!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
