### PR TITLE
Voice analyzers will no longer accept any message when nothing is recorded

### DIFF
--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -15,7 +15,7 @@
 	verb_exclaim = "beeps"
 	var/listening = FALSE
 	var/recorded = "" //the activation message
-	var/mode = 1
+	var/mode = INCLUSIVE_MODE
 	var/static/list/modes = list("inclusive",
 								 "exclusive",
 								 "recognizer",
@@ -63,20 +63,24 @@
 				send_pulse()
 
 /obj/item/assembly/voice/proc/check_activation(atom/movable/speaker, raw_message)
-	. = FALSE
+	if (recorded == "")
+		return FALSE
+
 	switch(mode)
 		if(INCLUSIVE_MODE)
 			if(findtext(raw_message, recorded))
-				. = TRUE
+				return TRUE
 		if(EXCLUSIVE_MODE)
 			if(raw_message == recorded)
-				. = TRUE
+				return TRUE
 		if(RECOGNIZER_MODE)
 			if(speaker.GetVoice() == recorded)
-				. = TRUE
+				return TRUE
 		if(VOICE_SENSOR_MODE)
 			if(length(raw_message))
-				. = TRUE
+				return TRUE
+
+	return FALSE
 
 /obj/item/assembly/voice/proc/send_pulse()
 	visible_message("clicks", visible_message_flags = EMOTE_MESSAGE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

> ok so
if you dont modify a voice analyzer at all
in its default state
it will make a really annoying noise every time someone says anything
but if there are mutliple
they trigger each other
so if you have 3 voice analyzers on you without modifying them
and you say the word dab
it will trigger a lot of times


## Changelog
:cl:
fix: Voice analyzers will no longer accept any message when nothing is recorded.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
