### PR TITLE
Grenades now explode when pulsed again

### DIFF
--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -45,8 +45,8 @@
 	log_game("\An [assembly] has pulsed a grenade, which was installed by [fingerprint].")
 	var/mob/M = get_mob_by_ckey(fingerprint)
 	var/turf/T = get_turf(M)
-	G.log_grenade(M, T) //Used in preprime() too but this one convays where the mob who triggered the bomb is
-	G.preprime() //The one here convays where the bomb was when it went boom
+	G.log_grenade(M, T)
+	G.prime()
 
 /datum/wires/explosive/chem_grenade/detach_assembly(color)
 	var/obj/item/assembly/S = get_attached(color)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
https://github.com/tgstation/tgstation/pull/52710 did two things. One--it made voice analyzers not work when whispered. Two--it made grenades start their timer on pulse, rather than explode.

The justification for this is outlined by both @LemonInTheDark and oranges.

> It's not that you can make a suicide bomb, it's that you can choose when it goes off

Basically, voice analyzer grenades were bad for the game because you could use it as a "I know you're an antag, so I choose for you to die now" tool with your last whisper. I can get behind this. However, this was fixed by the PR making it so voice analyzers don't work on last whisper.

I bring this all up because it means that the justification for grenades starting a timer rather than exploding was already resolved.

Unless the maintainers were just *also* opposed to grenades exploding on pulse, and I didn't see that, this seems like an unnecessary change.

## Why It's Good For The Game
I'm going to be blunt--I love mouse trap grenades to death and want nothing more than to bring them back. It's easier to do this than to have some nonsense with mouse traps specifically.

Classic voice analyzer grenades still don't work, as the original PR intended--this was just an overstep.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Grenades now explode when pulsed again, rather than starting the timer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
