### PR TITLE
Plants now show their maximum reagent capacity on plant analyzer examine with reagent mode on.

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -74,6 +74,7 @@
 		var/reag_txt = ""
 		if(seed && P_analyzer.scan_mode == PLANT_SCANMODE_CHEMICALS)
 			msg += "<br><span class='info'>*Plant Reagents*</span>"
+			msg += "<br><span class='info'>Maximum reagent capacity: [reagents.maximum_volume]</span>"
 			var/chem_cap = 0
 			for(var/reagent_id in reagents.reagent_list)
 				var/datum/reagent/R  = reagent_id


### PR DESCRIPTION
## About The Pull Request

Most of this change is in the title.

Now being able to see the maximum capacity of reagents in produce is a consistency issue that I was reminded about, but this should fix it in a single line. This keeps it limited to having hydroponics knowledge about the plants, but still useful in theory-crafting why and how to get that perfect plant mix for player utility.

## Why It's Good For The Game

Between omega weed, regular plants, and densified chemicals, there are one or two different sources of reagent modifiers in plants that could use this small bit of clarity.

## Changelog
:cl:
tweak: Plants now show their maximum reagent capacity on plant analyzer examine with reagent mode on.
/:cl:

