### PR TITLE
Allows xenos to use ladders properly

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -129,6 +129,9 @@
 /obj/structure/ladder/attack_paw(mob/user)
 	return use(user)
 
+/obj/structure/ladder/attack_alien(mob/user)
+	return use(user)
+
 /obj/structure/ladder/attackby(obj/item/W, mob/user, params)
 	return use(user)
 


### PR DESCRIPTION
## About The Pull Request

Fixes an undocumented bug that xenos can't use ladders

## Why It's Good For The Game

seems anti-climactic for xenos to be contained by ladders on ice-box

## Changelog
:cl:
fix: xenos can now climb ladders properly
/:cl: