### PR TITLE
You can now activate an away mission's exit gateway regardless of whether or not the station-side gateway is still open

### DIFF
--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -259,8 +259,7 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 		if(!GLOB.the_gateway)
 			to_chat(user,"<span class='warning'>Home gateway is not responding!</span>")
 		if(GLOB.the_gateway.target)
-			to_chat(user,"<span class='warning'>Home gateway already in use!</span>")
-			return
+			GLOB.the_gateway.deactivate() //this will turn the home gateway off so that it's free for us to connect to
 		activate(GLOB.the_gateway.destination)
 	else
 		deactivate()


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/50498 / https://github.com/tgstation/tgstation/issues/51537.

Proof of testing: https://cdn.discordapp.com/attachments/326831214667235328/745557330984304711/unknown.png

## Why It's Good For The Game

Being stuck alone in an away mission for the rest of the shift because the AI ignored your law two request to close the gateway after you walk through it (or some random assistant opened the portal again 5 minutes after you went in) sucks. Also, this bug was almost certainly unintentionally created by the PR that added that fancy gateway control console a few months ago.

## Changelog
:cl: ATHATH
fix: You can now activate an away mission's exit gateway regardless of whether or not the station-side gateway is still open.
/:cl:
