### PR TITLE
Meta bar access cleanup

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -67079,7 +67079,7 @@
 "fOY" = (
 /obj/machinery/door/airlock{
 	name = "Bar";
-	req_one_access_txt = "25;28"
+	req_access_txt = "25"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/navbeacon/wayfinding/bar,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -67078,9 +67078,8 @@
 /area/quartermaster/warehouse)
 "fOY" = (
 /obj/machinery/door/airlock{
-	name = "Service Hall";
-	req_access_txt = "null";
-	req_one_access_txt = "25;26;35;28;22;37;46;38;70"
+	name = "Bar";
+	req_one_access_txt = "25;28"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/navbeacon/wayfinding/bar,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bar access was set to service hall access, this has fixed it up so that only cook and bartender can access the bar door.
Cook can access the shared door to bar so them having this door helps on lower pop shifts.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Protect the bar castle.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Meta bar access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
