### PR TITLE
Meta kitchen air alarm

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -37435,12 +37435,17 @@
 "bLO" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 6
 	},
 /obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bLQ" = (
@@ -39901,9 +39906,12 @@
 	req_access_txt = "28"
 	},
 /obj/machinery/light,
-/obj/structure/extinguisher_cabinet{
+/obj/machinery/button/door{
+	id = "kitchenwindow";
+	name = "Window Shutter Control";
 	pixel_x = -6;
-	pixel_y = -32
+	pixel_y = -24;
+	req_access_txt = "28"
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -65876,13 +65884,6 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "ecJ" = (
-/obj/machinery/button/door{
-	id = "kitchenwindow";
-	name = "Window Shutter Control";
-	pixel_x = 6;
-	pixel_y = -24;
-	req_access_txt = "28"
-	},
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/plasteel/cafeteria{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Placed the air alarm back in the kitchen on meta.

Fixes #53057 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Apparently people need air to breath.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Meta kitchen has an air alarm again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
