### PR TITLE
Makes the felenid language not break the "no netspeak" rules

### DIFF
--- a/code/modules/language/nekomimetic.dm
+++ b/code/modules/language/nekomimetic.dm
@@ -1,14 +1,12 @@
 /datum/language/nekomimetic
 	name = "Nekomimetic"
-	desc = "To the casual observer, this langauge is an incomprehensible mess of broken Japanese. To the felinids, it's somehow comprehensible."
+	desc = "To the casual observer, this langauge is an incomprehensible mess of cat noises. To the felinids, it's somehow comprehensible."
 	key = "f"
 	space_chance = 70
 	syllables = list(
-		"neko", "nyan", "mimi", "moe", "mofu", "fuwa", "kyaa", "kawaii", "poka", "munya",
-		"puni", "munyu", "ufufu", "uhuhu", "icha", "doki", "kyun", "kusu", "nya", "nyaa",
-		"desu", "kis", "ama", "chuu", "baka", "hewo", "boop", "gato", "kit", "sune", "yori",
-		"sou", "baka", "chan", "san", "kun", "mahou", "yatta", "suki", "usagi", "domo", "ori",
-		"uwa", "zaazaa", "shiku", "puru", "ira", "heto", "etto"
-	)
+		"mao", "cht", "skr", "pspsps", "mew", "maw", "sss" "hss", "mouw", 
+		"reow", "meow", "krr", "cht-cht", "nya", "chrp", "chipt" 
+		"baou", "reeaow", "aaahou"
+		)
 	icon_state = "neko"
 	default_priority = 90

--- a/code/modules/language/nekomimetic.dm
+++ b/code/modules/language/nekomimetic.dm
@@ -4,8 +4,8 @@
 	key = "f"
 	space_chance = 70
 	syllables = list(
-		"mao", "cht", "skr", "pspsps", "mew", "maw", "sss", "hss", "mouw", 
-		"reow", "meow", "krr", "cht-cht", "nya", "chrp", "chipt",
-		"baou", "reeaow", "aaahou")
+		"mao", "cht", "skr", "pspsps", "mew", "maw", "sss", "hss", "mouw", "reow", "meow",krr", "cht-cht", 
+		"nya", "chrp", "chipt", "baou", "reeaow", "aaahou")
 	icon_state = "neko"
+
 	default_priority = 90

--- a/code/modules/language/nekomimetic.dm
+++ b/code/modules/language/nekomimetic.dm
@@ -5,8 +5,7 @@
 	space_chance = 70
 	syllables = list(
 		"mao", "cht", "skr", "pspsps", "mew", "maw", "sss" "hss", "mouw", 
-		"reow", "meow", "krr", "cht-cht", "nya", "chrp", "chipt" 
-		"baou", "reeaow", "aaahou"
-		)
+		"reow", "meow", "krr", "cht-cht", "nya", "chrp", "chipt",
+		"baou", "reeaow", "aaahou")
 	icon_state = "neko"
 	default_priority = 90

--- a/code/modules/language/nekomimetic.dm
+++ b/code/modules/language/nekomimetic.dm
@@ -4,7 +4,7 @@
 	key = "f"
 	space_chance = 70
 	syllables = list(
-		"mao", "cht", "skr", "pspsps", "mew", "maw", "sss" "hss", "mouw", 
+		"mao", "cht", "skr", "pspsps", "mew", "maw", "sss", "hss", "mouw", 
 		"reow", "meow", "krr", "cht-cht", "nya", "chrp", "chipt",
 		"baou", "reeaow", "aaahou")
 	icon_state = "neko"

--- a/code/modules/language/nekomimetic.dm
+++ b/code/modules/language/nekomimetic.dm
@@ -4,7 +4,7 @@
 	key = "f"
 	space_chance = 70
 	syllables = list(
-		"mao", "cht", "skr", "pspsps", "mew", "maw", "sss", "hss", "mouw", "reow", "meow",krr", "cht-cht", 
+		"mao", "cht", "skr", "pspsps", "mew", "maw", "sss", "hss", "mouw", "reow", "meow", "krr", "cht-cht", 
 		"nya", "chrp", "chipt", "baou", "reeaow", "aaahou")
 	icon_state = "neko"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This changes the felenid language from mostly Japanese themed netspeak to a rough approximation of real cat noises.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Saying half this stuff IC might or might not be ok on the norp servers depending on which admin you ask but would likely get you a stern talking to on the medrp servers. It's bad to give players a mechanic as basic as this and risk them getting punished just for using it. 


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GuyonBroadway 
tweak: adjusted the felenid language to be more cat-like
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
