### PR TITLE
Kills bonus ore from the ORM.

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -35,16 +35,6 @@
 	materials = null
 	return ..()
 
-/obj/machinery/mineral/ore_redemption/RefreshParts()
-	var/point_upgrade_temp = 1
-	var/ore_multiplier_temp = 1
-	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
-		ore_multiplier_temp = 0.65 + (0.35 * B.rating)
-	for(var/obj/item/stock_parts/micro_laser/L in component_parts)
-		point_upgrade_temp = 0.65 + (0.35 * L.rating)
-	point_upgrade = point_upgrade_temp
-	ore_multiplier = round(ore_multiplier_temp, 0.01)
-
 /obj/machinery/mineral/ore_redemption/examine(mob/user)
 	. = ..()
 	if(in_range(user, src) || isobserver(user))


### PR DESCRIPTION
This was a mistake, and I regret doing it.
## About The Pull Request

Kills ore doubling with the ORM

## Why It's Good For The Game

I brought it into this world, I can take it out of it. This feature cripples ore balance, and it was a mistake.

## Changelog
:cl:
balance: The ORM no longer receives benefits from upgrades.
/:cl:

