### PR TITLE
Replaces 33% of the Pwr Game inside a can of Pwr Game with Stable Plasma

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -737,7 +737,7 @@
 	name = "Pwr Game"
 	desc = "The only drink with the PWR that true gamers crave. When a gamer talks about gamerfuel, this is what they're literally referring to."
 	icon_state = "purple_can"
-	list_reagents = list(/datum/reagent/consumable/pwr_game = 30)
+	list_reagents = list(/datum/reagent/consumable/pwr_game = 20, /datum/reagent/stable_plasma = 10)
 
 /obj/item/reagent_containers/food/drinks/soda_cans/shamblers
 	name = "Shambler's juice"


### PR DESCRIPTION
## About The Pull Request

Replaces the 30u of Pwr Game usually found inside of Pwr Game with 20u Pwr Game, 10u Stable Plasma.

## Why It's Good For The Game

Currently there is no ghetto chemistry way to get Stable Plasma (Which is completely non-reactive and safe for consumption).
You cannot get Stable Plasma from the Chemical Starter Kit from Cargo either.
With this new addition, not only is Pwr Game 33% more bitter, it is also an effective way to complete your Ghetto Chemistry Set!

## Changelog
:cl: Radacitus
tweak: Pwr Game cans now contain 20u Pwr Game, 10u Stable Plasma
/:cl:
