### PR TITLE
tgui-dev-server: Reinforce netstat parser

### DIFF
--- a/tgui/README.md
+++ b/tgui/README.md
@@ -37,8 +37,8 @@ to translate concepts between old and new tgui, read this
 
 You will need these programs to start developing in tgui:
 
-- [Node v12.13+](https://nodejs.org/en/download/)
-- [Yarn v1.19+](https://yarnpkg.com/en/docs/install) (optional)
+- [Node v12.18.3+](https://nodejs.org/en/download/)
+- [Yarn v1.22.4+](https://yarnpkg.com/en/docs/install) (optional)
 - [Git Bash](https://git-scm.com/downloads)
   or [MSys2](https://www.msys2.org/) (optional)
 

--- a/tgui/README.md
+++ b/tgui/README.md
@@ -106,6 +106,14 @@ You can double-click these batch files to achieve the same thing:
 
 ## Troubleshooting
 
+**Development server is crashing**
+
+Make sure path to your working directory does not contain spaces or special
+unicode characters. If so, move codebase to a location which does not contain
+spaces or unicode characters.
+
+This is a known issue with Yarn Berry, and fix is going to happen someday.
+
 **Development server doesn't find my BYOND cache!**
 
 This happens if your Documents folder in Windows has a custom location, for

--- a/tgui/packages/tgui-dev-server/dreamseeker.js
+++ b/tgui/packages/tgui-dev-server/dreamseeker.js
@@ -52,13 +52,15 @@ DreamSeeker.getInstancesByPids = async pids => {
   }
   if (pidsToResolve.length > 0) {
     try {
-      const command = 'netstat -a -n -o';
-      const { stdout } = await promisify(exec)(command);
+      const command = 'netstat -ano | findstr LISTENING';
+      const { stdout } = await promisify(exec)(command, {
+        // Max buffer of 1MB (default is 200KB)
+        maxBuffer: 1024 * 1024,
+      });
       // Line format:
       // proto addr mask mode pid
       const entries = stdout
         .split('\r\n')
-        .filter(line => line.includes('LISTENING'))
         .map(line => {
           const words = line.match(/\S+/g);
           return {
@@ -77,7 +79,12 @@ DreamSeeker.getInstancesByPids = async pids => {
       }
     }
     catch (err) {
-      logger.error(err);
+      if (err.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+        logger.error(err.message, err.code);
+      }
+      else {
+        logger.error(err);
+      }
       return [];
     }
   }

--- a/tgui/packages/tgui-dev-server/dreamseeker.js
+++ b/tgui/packages/tgui-dev-server/dreamseeker.js
@@ -59,16 +59,21 @@ DreamSeeker.getInstancesByPids = async pids => {
       });
       // Line format:
       // proto addr mask mode pid
-      const entries = stdout
-        .split('\r\n')
-        .map(line => {
-          const words = line.match(/\S+/g);
-          return {
-            addr: words[1],
-            pid: parseInt(words[4], 10),
-          };
-        })
-        .filter(entry => pidsToResolve.includes(entry.pid));
+      const entries = [];
+      const lines = stdout.split('\r\n');
+      for (let line of lines) {
+        const words = line.match(/\S+/g);
+        if (!words || words.length === 0) {
+          continue;
+        }
+        const entry = {
+          addr: words[1],
+          pid: parseInt(words[4], 10),
+        };
+        if (pidsToResolve.includes(entry.pid)) {
+          entries.push(entry);
+        }
+      }
       const len = entries.length;
       logger.log('found', len, plural('instance', len));
       for (let entry of entries) {

--- a/tgui/packages/tgui-dev-server/index.esm.js
+++ b/tgui/packages/tgui-dev-server/index.esm.js
@@ -1,3 +1,5 @@
-const esmRequire = require('esm')(module);
+const esmRequire = require('esm')(module, {
+  cache: false,
+});
 
 esmRequire('./index.js');


### PR DESCRIPTION
## About The Pull Request

Some madmen have so many ports open on their computers, that netstat exceeds the maximum Node.js buffer (which is 256K by default).

Buffer increased to 1M, and netstat is piped through `findstr` to reduce the amount of data it prints out.

Relatively high priority, because Zxaber can't work on tgui.