### PR TITLE
Adds a chemical reaction to stabilize plasma

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -31,6 +31,11 @@
 	results = list(/datum/reagent/consumable/sodiumchloride = 3)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/sodium = 1, /datum/reagent/chlorine = 1)
 
+/datum/chemical_reaction/stable_plasma
+	results = list(/datum/reagent/stable_plasma = 1)
+	required_reagents = list(/datum/reagent/toxin/plasma = 1)
+	required_catalysts = list(/datum/reagent/stabilizing_agent = 1)
+
 /datum/chemical_reaction/plasmasolidification
 	required_reagents = list(/datum/reagent/iron = 5, /datum/reagent/consumable/frostoil = 5, /datum/reagent/toxin/plasma = 20)
 	mob_react = FALSE


### PR DESCRIPTION
## About The Pull Request

With Stabilizing Agent as a catalyst, Plasma can become Stable Plasma.
Keep in mind that there are no reactions that require both Stabilizing Agent and Plasma, and there are no reagents that need to be stabilized that contain Plasma.
Previous PR for all those that watched its 7 minute lifespan #53074 

## Why It's Good For The Game

Currently there is no ghetto chemistry way to get Stable Plasma (Which is completely non-reactive).
You cannot get Stable Plasma from the Chemical Starter Kit from Cargo either.
This will allow smart players to finish their Ghetto Chemistry Sets!

## Changelog
:cl: Radacitus
add: Added a chemical recipe for Stabilizing Plasma
/:cl: