### PR TITLE
True sight, true hearing, more skeleton organ removal

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -16,7 +16,9 @@
 #define CLOWNMUT	/datum/mutation/human/clumsy
 #define TOURETTES	/datum/mutation/human/tourettes
 #define DEAFMUT		/datum/mutation/human/deaf
+#define TRUEHEARING	/datum/mutation/human/true_hearing
 #define BLINDMUT	/datum/mutation/human/blind
+#define TRUESIGHT	/datum/mutation/human/true_sight
 #define RACEMUT		/datum/mutation/human/race
 #define BADSIGHT	/datum/mutation/human/nearsight
 #define LASEREYES	/datum/mutation/human/laser_eyes

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -108,6 +108,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_TESLA_SHOCKIMMUNE	"tesla_shock_immunity"
 #define TRAIT_STABLEHEART		"stable_heart"
 #define TRAIT_STABLELIVER		"stable_liver"
+#define TRAIT_TRUE_SIGHT		"true_sight" //doesn't need eyes to see
+#define TRAIT_TRUE_HEARING		"true_hearing" //doesn't need ears to hear
 #define TRAIT_RESISTHEAT		"resist_heat"
 #define TRAIT_RESISTHEATHANDS	"resist_heat_handsonly" //For when you want to be able to touch hot things, but still want fire to be an issue.
 #define TRAIT_RESISTCOLD		"resist_cold"

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -153,6 +153,7 @@
 	name = "Deafness"
 	desc = "The holder of this genome is completely deaf."
 	quality = NEGATIVE
+	conflicts = list(TRUEHEARING)
 	text_gain_indication = "<span class='danger'>You can't seem to hear anything.</span>"
 
 /datum/mutation/human/deaf/on_acquiring(mob/living/carbon/human/owner)
@@ -165,6 +166,26 @@
 		return
 	REMOVE_TRAIT(owner, TRAIT_DEAF, GENETIC_MUTATION)
 
+/datum/mutation/human/true_hearing
+	name = "True Hearing"
+	desc = "The holder of this genome can hear without assistance."
+	instability = 10
+	quality = POSITIVE
+	conflicts = list(DEAFMUT)
+	text_gain_indication = "<span class='notice'>Your hearing feels unhindered.</span>"
+
+/datum/mutation/human/true_hearing/on_acquiring(mob/living/carbon/human/owner)
+	if(..())
+		return TRUE
+	if(owner.has_quirk(/datum/quirk/deafness))
+		to_chat(H, "<span class='warning'>Even True Hearing cannot fix your incurable deafness. The gene is completely muted out.</span>")
+		return TRUE
+	ADD_TRAIT(owner, TRAIT_TRUE_HEARING, GENETIC_MUTATION)
+
+/datum/mutation/human/true_hearing/on_losing(mob/living/carbon/human/owner)
+	if(..())
+		return
+	REMOVE_TRAIT(owner, TRAIT_TRUE_HEARING, GENETIC_MUTATION)
 
 //Monified turns you into a monkey.
 /datum/mutation/human/race

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -169,7 +169,7 @@
 /datum/mutation/human/true_hearing
 	name = "True Hearing"
 	desc = "The holder of this genome can hear without assistance."
-	instability = 10
+	instability = 25
 	quality = POSITIVE
 	conflicts = list(DEAFMUT)
 	text_gain_indication = "<span class='notice'>Your hearing feels unhindered.</span>"

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -178,7 +178,7 @@
 	if(..())
 		return TRUE
 	if(owner.has_quirk(/datum/quirk/deafness))
-		to_chat(H, "<span class='warning'>Even True Hearing cannot fix your incurable deafness. The gene is completely muted out.</span>")
+		to_chat(owner, "<span class='warning'>Even True Hearing cannot fix your incurable deafness. The gene is completely muted out.</span>")
 		return TRUE
 	ADD_TRAIT(owner, TRAIT_TRUE_HEARING, GENETIC_MUTATION)
 

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -169,7 +169,7 @@
 /datum/mutation/human/true_hearing
 	name = "True Hearing"
 	desc = "The holder of this genome can hear without assistance."
-	instability = 25
+	instability = 40
 	quality = POSITIVE
 	conflicts = list(DEAFMUT)
 	text_gain_indication = "<span class='notice'>Your hearing feels unhindered.</span>"

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -39,7 +39,7 @@
 	desc = "The holder of this genome can see without assistance."
 	quality = POSITIVE
 	conflicts = list(BLINDMUT)
-	instability = 10
+	instability = 25
 	text_gain_indication = "<span class='notice'>Your sight feels unhindered.</span>"
 
 /datum/mutation/human/true_sight/on_acquiring(mob/living/carbon/human/owner)

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -21,6 +21,7 @@
 	name = "Blindness"
 	desc = "Renders the subject completely blind."
 	quality = NEGATIVE
+	conflicts = list(TRUESIGHT)
 	text_gain_indication = "<span class='danger'>You can't seem to see anything.</span>"
 
 /datum/mutation/human/blind/on_acquiring(mob/living/carbon/human/owner)
@@ -32,6 +33,29 @@
 	if(..())
 		return
 	owner.cure_blind(GENETIC_MUTATION)
+
+/datum/mutation/human/true_sight
+	name = "True Sight"
+	desc = "The holder of this genome can see without assistance."
+	quality = POSITIVE
+	conflicts = list(BLINDMUT)
+	instability = 10
+	text_gain_indication = "<span class='notice'>Your sight feels unhindered.</span>"
+
+/datum/mutation/human/true_sight/on_acquiring(mob/living/carbon/human/owner)
+	if(..())
+		return TRUE
+	if(owner.has_quirk(/datum/quirk/blindness))
+		to_chat(H, "<span class='warning'>Even True Sight cannot fix your incurable blindness. The gene is completely blackened out.</span>")
+		return TRUE
+	ADD_TRAIT(owner, TRAIT_TRUE_SIGHT, GENETIC_MUTATION)
+	owner.update_sight()//if we're blind because of no eyes or something, that's gotta update
+
+/datum/mutation/human/true_sight/on_losing(mob/living/carbon/human/owner)
+	if(..())
+		return
+	REMOVE_TRAIT(owner, TRAIT_TRUE_SIGHT, GENETIC_MUTATION)
+	owner.update_sight()
 
 ///Thermal Vision lets you see mobs through walls
 /datum/mutation/human/thermal

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -39,7 +39,7 @@
 	desc = "The holder of this genome can see without assistance."
 	quality = POSITIVE
 	conflicts = list(BLINDMUT)
-	instability = 25
+	instability = 40
 	text_gain_indication = "<span class='notice'>Your sight feels unhindered.</span>"
 
 /datum/mutation/human/true_sight/on_acquiring(mob/living/carbon/human/owner)

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -46,7 +46,7 @@
 	if(..())
 		return TRUE
 	if(owner.has_quirk(/datum/quirk/blindness))
-		to_chat(H, "<span class='warning'>Even True Sight cannot fix your incurable blindness. The gene is completely blackened out.</span>")
+		to_chat(owner, "<span class='warning'>Even True Sight cannot fix your incurable blindness. The gene is completely blackened out.</span>")
 		return TRUE
 	ADD_TRAIT(owner, TRAIT_TRUE_SIGHT, GENETIC_MUTATION)
 	owner.update_sight()//if we're blind because of no eyes or something, that's gotta update

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -574,7 +574,7 @@
 	sight = initial(sight)
 	lighting_alpha = initial(lighting_alpha)
 	var/obj/item/organ/eyes/E = getorganslot(ORGAN_SLOT_EYES)
-	if(!E)
+	if(!E) //this is where true sight is handled
 		update_tint()
 	else
 		see_invisible = E.see_invisible
@@ -628,6 +628,8 @@
 
 /mob/living/carbon/proc/get_total_tint()
 	. = 0
+	if(HAS_TRAIT(src, TRAIT_TRUE_SIGHT))
+		return 0 //you just have no issues seeing with true sight
 	if(isclothing(head))
 		. += head.tint
 	if(isclothing(wear_mask))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -368,7 +368,7 @@
 
 /mob/living/carbon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0)
 	var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
-	if(!eyes) //can't flash what can't see!
+	if(!eyes) //can't flash what can't see! //ignoring true sight here, if there's no eyes to damage we'd be just chucking half the proc out the window
 		return
 
 	. = ..()
@@ -465,7 +465,7 @@
 /mob/living/carbon/can_hear()
 	. = FALSE
 	var/obj/item/organ/ears/ears = getorganslot(ORGAN_SLOT_EARS)
-	if(ears && !HAS_TRAIT(src, TRAIT_DEAF))
+	if((ears && !HAS_TRAIT(src, TRAIT_DEAF)) || HAS_TRAIT(src, TRAIT_TRUE_HEARING))
 		. = TRUE
 
 

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -5,9 +5,9 @@
 	say_mod = "rattles"
 	sexes = 0
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton
-	species_traits = list(NOBLOOD, HAS_BONE)
+	species_traits = list(NOBLOOD, HAS_BONE, NOEYESPRITES)
 	inherent_traits = list(TRAIT_NOMETABOLISM,TRAIT_TOXIMMUNE,TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_RADIMMUNE,TRAIT_GENELESS,\
-	TRAIT_PIERCEIMMUNE,TRAIT_NOHUNGER,TRAIT_EASYDISMEMBER,TRAIT_LIMBATTACHMENT,TRAIT_FAKEDEATH,TRAIT_XENO_IMMUNE,TRAIT_NOCLONELOSS)
+	TRAIT_PIERCEIMMUNE,TRAIT_NOHUNGER,TRAIT_EASYDISMEMBER,TRAIT_LIMBATTACHMENT,TRAIT_FAKEDEATH,TRAIT_XENO_IMMUNE,TRAIT_NOCLONELOSS, TRAIT_TRUE_SIGHT, TRAIT_TRUE_HEARING)
 	inherent_biotypes = MOB_UNDEAD|MOB_HUMANOID
 	mutanttongue = /obj/item/organ/tongue/bone
 	damage_overlay_type = ""//let's not show bloody wounds or burns over bones.
@@ -21,6 +21,10 @@
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
 		return TRUE
 	return ..()
+
+/datum/species/skeleton/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
+	..()
+	C.update_sight()
 
 //Can still metabolize milk through meme magic
 /datum/species/skeleton/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -409,6 +409,8 @@
 		update_blindness()
 
 /mob/living/proc/become_blind(source)
+	if(HAS_TRAIT(src, TRAIT_TRUE_SIGHT))
+		return
 	if(!HAS_TRAIT(src, TRAIT_BLIND)) // not blind already, add trait then overlay
 		ADD_TRAIT(src, TRAIT_BLIND, source)
 		update_blindness()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -286,10 +286,10 @@
 	if(hud_used && hud_used.action_intent)
 		hud_used.action_intent.icon_state = "[a_intent]"
 
-///Checks if the mob is able to see or not. eye_blind is temporary blindness, the trait is if they're permanently blind.
+///Checks if the mob is able to see or not. eye_blind is temporary blindness which can be countered by true sight, the trait is if they're permanently blind.
 /mob/proc/is_blind()
 	SHOULD_BE_PURE(TRUE)
-	return eye_blind ? TRUE : HAS_TRAIT(src, TRAIT_BLIND)
+	return eye_blind ? HAS_TRAIT(src, TRAIT_TRUE_SIGHT) : HAS_TRAIT(src, TRAIT_BLIND)
 
 ///Is the mob hallucinating?
 /mob/proc/hallucinating()

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -57,6 +57,9 @@
 	damage = max(damage + (ddmg*damage_multiplier), 0)
 	deaf = max(deaf + (ddeaf*damage_multiplier), 0)
 
+/obj/item/organ/ears/get_availability(datum/species/S)
+	return !(TRAIT_TRUE_HEARING in S.inherent_traits)
+
 /obj/item/organ/ears/invincible
 	damage_multiplier = 0
 

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -83,6 +83,9 @@
 		C.clear_fullscreen("eye_damage")
 	return
 
+/obj/item/organ/eyes/get_availability(datum/species/S)
+	return !(TRAIT_TRUE_SIGHT in S.inherent_traits)
+
 /obj/item/organ/eyes/night_vision
 	name = "shadow eyes"
 	desc = "A spooky set of eyes that can see in the dark."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
### species change approved by anturke, but if they're unhappy with implementation i could stick this to mutation only

True Sight and True Hearing are two new traits that work as a "No eyes" and "No ears" species trait. Essentially, they make you able to see and hear without any requirements.

Genetics also has these, but they are VERY unstable.

## Why It's Good For The Game

<details>
  <summary>VERY short tl;dr</summary>
  this is so bad bros

  ![image](https://user-images.githubusercontent.com/40974010/90547659-b9d32300-e140-11ea-9c44-aa9ae4c2473d.png)
  
</details>

I needed support for species that don't need eyes and ears, and to be frank i'm a little tired of having species with I SEE EVERYTHING I AM OP I AM THE BEST EYEBALLS YOU HAVE EVER SEEN and then like fuckin' science cuts it out of the thing and now science spots cult all the way from white castle

Also, and I didn't think I had to say this, the combination of HARS and True Sight and True Hearing is so fucking expensive stability wise and there's really barely any reason to do this **but it is the best thing that I have ever made, ever. period. I've peaked. I'm done. Seriously, there's no going up from here.**

## Changelog
:cl:
add: Skeletons no longer have human ears and eyes.
add: A few new genetic traits that let you rip out your own eyes and barely notice the difference!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
