### PR TITLE
fixes foreigner quirk giving galactic uncommon to felinids

### DIFF
--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -21,13 +21,13 @@
 /datum/quirk/foreigner/add()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.add_blocked_language(/datum/language/common)
-	if(ishumanbasic(H) || isfelinid(H))
+	if(ishumanbasic(H))
 		H.grant_language(/datum/language/uncommon)
 
 /datum/quirk/foreigner/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.remove_blocked_language(/datum/language/common)
-	if(ishumanbasic(H) || isfelinid(H))
+	if(ishumanbasic(H))
 		H.remove_language(/datum/language/uncommon)
 
 /datum/quirk/vegetarian


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

foreigner quirk gives galactic uncommon to humans and felinids currently, because otherwise they wouldnt have any other language, but felinids now received a language in nekomimetic, so they dont need it anymore

## Why It's Good For The Game

oversight bad

## Changelog
:cl:
fix: fixes foreigner quirk giving galactic uncommon to felinids
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
