### PR TITLE
Megafauna teleportion exploit fix

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -83,9 +83,9 @@
 	if(interrupted || !ismob(target))
 		to_chat(owner, "<span class='warning'>The bluespace tug fades away, and you feel that the force has passed you by.</span>")
 		return
-	owner.visible_message("<span class='warning'>[owner] disappears in a flurry of sparks!</span>",
+	if(do_teleport(owner, target.loc, channel = TELEPORT_CHANNEL_QUANTUM)) //despite being named a bluespace teleportation method the quantum channel is used to preserve precision teleporting with a bag of holding
+		owner.visible_message("<span class='warning'>[owner] disappears in a flurry of sparks!</span>",
 		"<span class='warning'>The unknown force snatches briefly you from reality, and deposits you next to [target]!</span>")
-	do_teleport(owner, target.loc, channel = TELEPORT_CHANNEL_QUANTUM) //despite being named a bluespace teleportation method the quantum channel is used to preserve precision teleporting with a bag of holding
 
 /obj/screen/alert/status_effect/freon/stasis
 	desc = "You're frozen inside of a protective ice cube! While inside, you can't do anything, but are immune to harm! Resist to get out."

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -83,9 +83,10 @@
 	if(interrupted || !ismob(target))
 		to_chat(owner, "<span class='warning'>The bluespace tug fades away, and you feel that the force has passed you by.</span>")
 		return
+	var/turf/old_location = get_turf(owner)
 	if(do_teleport(owner, target.loc, channel = TELEPORT_CHANNEL_QUANTUM)) //despite being named a bluespace teleportation method the quantum channel is used to preserve precision teleporting with a bag of holding
-		owner.visible_message("<span class='warning'>[owner] disappears in a flurry of sparks!</span>",
-		"<span class='warning'>The unknown force snatches briefly you from reality, and deposits you next to [target]!</span>")
+		old_location.visible_message("<span class='warning'>[owner] disappears in a flurry of sparks!</span>")
+		to_chat(owner, "<span class='warning'>The unknown force snatches briefly you from reality, and deposits you next to [target]!</span>")
 
 /obj/screen/alert/status_effect/freon/stasis
 	desc = "You're frozen inside of a protective ice cube! While inside, you can't do anything, but are immune to harm! Resist to get out."

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -85,8 +85,7 @@
 		return
 	owner.visible_message("<span class='warning'>[owner] disappears in a flurry of sparks!</span>",
 		"<span class='warning'>The unknown force snatches briefly you from reality, and deposits you next to [target]!</span>")
-	do_sparks(3, TRUE, owner)
-	owner.forceMove(target.loc)
+	do_teleport(owner, target.loc, channel = TELEPORT_CHANNEL_QUANTUM) //despite being named a bluespace teleportation method the quantum channel is used to preserve precision teleporting with a bag of holding
 
 /obj/screen/alert/status_effect/freon/stasis
 	desc = "You're frozen inside of a protective ice cube! While inside, you can't do anything, but are immune to harm! Resist to get out."

--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -149,6 +149,9 @@ Chilling extracts:
 /obj/item/slimecross/chilling/bluespace/afterattack(atom/target, mob/user, proximity)
 	if(!proximity || !isliving(target) || active)
 		return
+	if(ismegafauna(target))
+		to_chat(user, "<span class='warning'>[target] is it too powerful to link with [src]!</span>")
+		return
 	if(target in allies)
 		allies -= target
 		to_chat(user, "<span class='notice'>You unlink [src] with [target].</span>")

--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -149,8 +149,8 @@ Chilling extracts:
 /obj/item/slimecross/chilling/bluespace/afterattack(atom/target, mob/user, proximity)
 	if(!proximity || !isliving(target) || active)
 		return
-	if(ismegafauna(target))
-		to_chat(user, "<span class='warning'>[target] is it too powerful to link with [src]!</span>")
+	if(HAS_TRAIT(target, TRAIT_NO_TELEPORT))
+		to_chat(user, "<span class='warning'>[target] resists being linked with [src]!</span>")
 		return
 	if(target in allies)
 		allies -= target

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -23,11 +23,11 @@ Regenerative extracts:
 		to_chat(user, "<span class='warning'>[src] will not work on the dead!</span>")
 		return
 	if(H != user)
-		user.visible_message("<span class='notice'>[user] crushes the [src] over [H], the milky goo quickly regenerating all of [H.p_their()] injuries!</span>",
-			"<span class='notice'>You squeeze the [src], and it bursts over [H], the milky goo regenerating [H.p_their()] injuries.</span>")
+		user.visible_message("<span class='notice'>[user] crushes [src] over [H], the milky goo quickly regenerating all of [H.p_their()] injuries!</span>",
+			"<span class='notice'>You squeeze [src], and it bursts over [H], the milky goo regenerating [H.p_their()] injuries.</span>")
 	else
-		user.visible_message("<span class='notice'>[user] crushes the [src] over [user.p_them()]self, the milky goo quickly regenerating all of [user.p_their()] injuries!</span>",
-			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates your injuries!</span>")
+		user.visible_message("<span class='notice'>[user] crushes [src] over [user.p_them()]self, the milky goo quickly regenerating all of [user.p_their()] injuries!</span>",
+			"<span class='notice'>You squeeze [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates your injuries!</span>")
 	core_effect_before(H, user)
 	H.revive(full_heal = TRUE, admin_revive = FALSE)
 	core_effect(H, user)
@@ -144,8 +144,10 @@ Regenerative extracts:
 	var/turf/open/T
 
 /obj/item/slimecross/regenerative/bluespace/core_effect(mob/living/target, mob/user)
-	do_teleport(target, T, channel = TELEPORT_CHANNEL_QUANTUM) //despite being named a bluespace teleportation method the quantum channel is used to preserve precision teleporting with a bag of holding
-	target.visible_message("<span class='warning'>[src] disappears in a shower of sparks!</span>","<span class='danger'>The milky goo teleports you somewhere it remembers!</span>")
+	var/turf/old_location = get_turf(target)
+	if(do_teleport(target, T, channel = TELEPORT_CHANNEL_QUANTUM)) //despite being named a bluespace teleportation method the quantum channel is used to preserve precision teleporting with a bag of holding
+		old_location.visible_message("<span class='warning'>[target] disappears in a shower of sparks!</span>")
+		to_chat(target, "<span class='danger'>The milky goo teleports you somewhere it remembers!</span>")
 
 
 /obj/item/slimecross/regenerative/bluespace/Initialize()

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -144,13 +144,9 @@ Regenerative extracts:
 	var/turf/open/T
 
 /obj/item/slimecross/regenerative/bluespace/core_effect(mob/living/target, mob/user)
-	if(ismegafauna(target))
-		to_chat(user, "<span class='warning'>[target] resists being teleported by [src]!</span>")
-		return
+	do_teleport(target, T, channel = TELEPORT_CHANNEL_QUANTUM) //despite being named a bluespace teleportation method the quantum channel is used to preserve precision teleporting with a bag of holding
 	target.visible_message("<span class='warning'>[src] disappears in a shower of sparks!</span>","<span class='danger'>The milky goo teleports you somewhere it remembers!</span>")
-	do_sparks(5,FALSE,target)
-	target.forceMove(T)
-	do_sparks(5,FALSE,target)
+
 
 /obj/item/slimecross/regenerative/bluespace/Initialize()
 	. = ..()

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -144,6 +144,9 @@ Regenerative extracts:
 	var/turf/open/T
 
 /obj/item/slimecross/regenerative/bluespace/core_effect(mob/living/target, mob/user)
+	if(ismegafauna(target))
+		to_chat(user, "<span class='warning'>[target] resists being teleported by [src]!</span>")
+		return
 	target.visible_message("<span class='warning'>[src] disappears in a shower of sparks!</span>","<span class='danger'>The milky goo teleports you somewhere it remembers!</span>")
 	do_sparks(5,FALSE,target)
 	target.forceMove(T)


### PR DESCRIPTION
## About The Pull Request

Prevents megafauna from being added to a chilling bluespace extract's linked list, removing a way of teleporting all the megafauna from lavaland onto the station at once.
Also prevents regenerative bluespace extracts from instantly teleporting megas to where the extract was made.

## Why It's Good For The Game

Fuck your exploits, I literally do not care.

![image](https://user-images.githubusercontent.com/51932756/90820786-2be96a80-e2ef-11ea-8a1a-7cae9324339c.png)

## Changelog
:cl:
fix: Megafauna no longer can be teleported by chilling or regenerative bluespace extracts.
/:cl:
