### PR TITLE
NPC lightgeists will now actually try to heal people

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -678,15 +678,13 @@ Difficulty: Very Hard
 	initial_language_holder = /datum/language_holder/lightbringer
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	light_range = 4
-	faction = list("neutral")
+	faction = list("lightgeist")
 	del_on_death = TRUE
 	unsuitable_atmos_damage = 0
 	minbodytemp = 0
 	maxbodytemp = 1500
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE
-	AIStatus = AI_OFF
-	stop_automated_movement = TRUE
 
 /mob/living/simple_animal/hostile/lightgeist/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -697,7 +697,10 @@ Difficulty: Very Hard
 	if(isliving(target) && target != src)
 		var/mob/living/L = target
 		if(L.stat != DEAD)
-			L.heal_overall_damage(melee_damage_upper, melee_damage_upper)
+			if(client)
+				L.heal_overall_damage(melee_damage_upper, melee_damage_upper)
+			else
+				L.heal_overall_damage(melee_damage_upper/5, melee_damage_upper/5) //much slower healing if there isn't a player behind the wheel
 			new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
 			visible_message("<span class='notice'>[src] mends the wounds of [target].</span>","<span class='notice'>You mend the wounds of [target].</span>")
 


### PR DESCRIPTION
## About The Pull Request

See the title.

Also, lightgeists who aren't player-controlled heal 1/5th as much health per "attack" as player-controlled lightgeists do.

## Why It's Good For The Game

who thought that putting AI_OFF mobs in space ruins and in the hostile_spawn gold slime core pool was a good idea

## Changelog
:cl:
fix: NPC lightgeists will now actually try to heal people.
balance: Lightgeists who aren't player-controlled heal at 1/5th the rate that player-controlled lightgeists do.
/:cl: