### PR TITLE
Fixes invasive spreading not updating plant tray identity.

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -506,6 +506,10 @@
 			HY.pestlevel = 0 // Reset
 			HY.update_icon()
 			HY.visible_message("<span class='warning'>The [H.myseed.plantname] spreads!</span>")
+			if(HY.myseed)
+				HY.name = "[initial(HY.name)] ([HY.myseed.plantname])"
+			else
+				HY.name = initial(HY.name)
 
 /**
   * A plant trait that causes the plant's food reagents to ferment instead.


### PR DESCRIPTION

## About The Pull Request

Finally fixes #50984. Basically, combined with some of the early botany bugs that are now fixed, invasive spreading on plants was the last source of plants being able to overtake trays with existing plants on them, and as a consequence, their behavior had this old behavioral bug where they'd just not update the name of the tray when they overtook an old tray. However, due to some of the overlap with the older concurrent bugs from the time, this took way WAY too long to get a fix out for.

## Why It's Good For The Game

I can finally close the last of the ancient botany bugs.
![PlantsAttractBugs](https://user-images.githubusercontent.com/41715314/90853535-6f23f780-e348-11ea-85d2-b9c9f1b6bb70.PNG)


## Changelog
:cl:
fix: Invasive spreading on plant trays now correctly updates the tray's name with the new plant's species.
/:cl: