### PR TITLE
Fixes Wild Mutation produce being the wrong size.

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -221,6 +221,8 @@
 			t_prod.seed.name = initial(new_prod.name)
 			t_prod.seed.desc = initial(new_prod.desc)
 			t_prod.seed.plantname = initial(new_prod.plantname)
+			t_prod.transform = initial(t_prod.transform)
+			t_prod.transform *= TRANSFORM_USING_VARIABLE(t_prod.seed.potency, 100) + 0.5
 			t_amount++
 			if(t_prod.seed)
 				//t_prod.seed = new new_prod


### PR DESCRIPTION

## About The Pull Request

Fixes #52996. Turns out that the transform for plant produce wasn't updating off of the parent's seed changing to it's new mutated seed, so this resets and appropriately re-transforms the plant's size to what it should be for it's new, mutated size/seed. 

## Why It's Good For The Game

Bonks a bug, and helps with consistency in keeping plant produce identifiable and distinguishable based on it's true stats.

## Changelog
:cl:
fix: Plants mutated via wild mutation now spawn at the correct size based on the mutated seed's potency.
/:cl:
