### PR TITLE
Caps chem emps so shit doesn't go sideways

### DIFF
--- a/code/game/objects/effects/effect_system/effects_other.dm
+++ b/code/game/objects/effects/effect_system/effects_other.dm
@@ -105,4 +105,4 @@
 		location.visible_message("<span class='danger'>The solution violently explodes!</span>", \
 								"<span class='hear'>You hear an explosion!</span>")
 
-	dyn_explosion(location, amount, flashing_factor, ignore_cap = FALSE)
+	dyn_explosion(location, amount, flashing_factor, ignorecap = FALSE)

--- a/code/game/objects/effects/effect_system/effects_other.dm
+++ b/code/game/objects/effects/effect_system/effects_other.dm
@@ -105,4 +105,4 @@
 		location.visible_message("<span class='danger'>The solution violently explodes!</span>", \
 								"<span class='hear'>You hear an explosion!</span>")
 
-	dyn_explosion(location, amount, flashing_factor)
+	dyn_explosion(location, amount, flashing_factor, ignore_cap = FALSE)

--- a/code/game/objects/effects/effect_system/effects_other.dm
+++ b/code/game/objects/effects/effect_system/effects_other.dm
@@ -105,4 +105,4 @@
 		location.visible_message("<span class='danger'>The solution violently explodes!</span>", \
 								"<span class='hear'>You hear an explosion!</span>")
 
-	dyn_explosion(location, amount, flashing_factor, ignorecap = FALSE)
+	dyn_explosion(location, amount, flashing_factor)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -179,9 +179,10 @@
 
 /datum/chemical_reaction/emp_pulse/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
-	// 100 created volume = 8 heavy range & 14 light range. A few tiles smaller than traitor EMP grandes.
-	// 200 created volume = 10 heavy range & 24 light range. 4 tiles larger than traitor EMP grenades.
-	empulse(location, min(round(created_volume / 12), 10), min(round(created_volume / 7), 24), 1) // Don't emp the station mr chemist, I like my time dialiation how it is
+	// 50 created volume = 4 heavy range & 7 light range. A few tiles smaller than traitor EMP grandes.
+	// 100 created volume = 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades.
+	// The below is 18/26 with 5000 units, or 2500 created volume
+	empulse(location, min(round(created_volume / 12), log(2, round(created_volume / 12)) + 7), min(round(created_volume / 7), log(2, round(created_volume / 7)) + 15), 1) // Don't emp the station mr chemist, I like my time dialiation how it is
 	holder.clear_reagents()
 
 

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -179,8 +179,8 @@
 
 /datum/chemical_reaction/emp_pulse/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
-	// 100 created volume = 4 heavy range & 7 light range. A few tiles smaller than traitor EMP grandes.
-	// 200 created volume = 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades.
+	// 100 created volume = 8 heavy range & 14 light range. A few tiles smaller than traitor EMP grandes.
+	// 200 created volume = 10 heavy range & 24 light range. 4 tiles larger than traitor EMP grenades.
 	empulse(location, min(round(created_volume / 12), 10), min(round(created_volume / 7), 1), 24) // Don't emp the station mr chemist, I like my time dialiation how it is
 	holder.clear_reagents()
 

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -181,7 +181,7 @@
 	var/location = get_turf(holder.my_atom)
 	// 100 created volume = 8 heavy range & 14 light range. A few tiles smaller than traitor EMP grandes.
 	// 200 created volume = 10 heavy range & 24 light range. 4 tiles larger than traitor EMP grenades.
-	empulse(location, min(round(created_volume / 12), 10), min(round(created_volume / 7), 1), 24) // Don't emp the station mr chemist, I like my time dialiation how it is
+	empulse(location, min(round(created_volume / 12), 10), min(round(created_volume / 7), 24), 1) // Don't emp the station mr chemist, I like my time dialiation how it is
 	holder.clear_reagents()
 
 

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -181,7 +181,7 @@
 	var/location = get_turf(holder.my_atom)
 	// 100 created volume = 4 heavy range & 7 light range. A few tiles smaller than traitor EMP grandes.
 	// 200 created volume = 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades.
-	empulse(location, round(created_volume / 12), round(created_volume / 7), 1)
+	empulse(location, min(round(created_volume / 12), 10), min(round(created_volume / 7), 1), 24) // Don't emp the station mr chemist, I like my time dialiation how it is
 	holder.clear_reagents()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Chem based emps are now soft capped at about 10/24

## Why It's Good For The Game

Station wide emps are dumb man, realllly dumb.

## Changelog
:cl:
balance: EMPs generated by chems are now soft capped at about 10/24
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
