### PR TITLE
Fixes bookshelves with shelf removed still showing shelf.

### DIFF
--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -166,10 +166,9 @@
 
 
 /obj/structure/bookcase/update_icon_state()
-	if(state == BOOKCASE_UNANCHORED)
+	if(state == BOOKCASE_UNANCHORED || state == BOOKCASE_ANCHORED)
 		icon_state = "bookempty"
 		return
-
 	var/amount = contents.len
 	if(load_random_books)
 		amount += books_to_load


### PR DESCRIPTION

## About The Pull Request

Currently if you use a crowbar on an empty bookshelf, it spawns wood and disables inserting books into the shelf, but does not update the icon properly.

## Why It's Good For The Game


## Changelog
:cl:
fix: Bookshelves do not show shelves inside anymore when you crowbar them out.
/:cl:

