### PR TITLE
Fixes some bugs with the detective's revolver.

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -114,9 +114,7 @@
 		return TRUE
 	if(magazine.ammo_count()) //If it has any ammo inside....
 		user.visible_message("<span class='danger'>[src]'s hammer drops while you're handling it!</span>") //...you learn an important lesson about firearms safety.
-		var/drop_the_gun_it_actually_fired = FALSE
-		if(chambered.BB)
-			drop_the_gun_it_actually_fired = TRUE
+		var/drop_the_gun_it_actually_fired = chambered.BB ? TRUE : FALSE
 		process_fire(user, user, FALSE, skip_missfire_check = TRUE)
 		if(drop_the_gun_it_actually_fired) //We do it like this instead of directly checking chambered.BB because process_fire will cycle the chamber.
 			user.dropItemToGround(src)

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -76,7 +76,7 @@
 
 /obj/item/gun/ballistic/revolver/detective
 	name = "\improper Colt Detective Special"
-	desc = "A classic, if not outdated, law enforcement firearm. Uses .38-special rounds."
+	desc = "A classic, if not outdated, law enforcement firearm. Uses .38 Special rounds. \nSome spread rumors that if you loosen the barrel with a wrench, you can \"improve\" it."
 	fire_sound = 'sound/weapons/gun/revolver/shot.ogg'
 	icon_state = "detective"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
@@ -102,38 +102,38 @@
 			return FALSE
 	return ..()
 
-/obj/item/gun/ballistic/revolver/detective/screwdriver_act(mob/living/user, obj/item/I)
-	if(..())
-		return TRUE
+/obj/item/gun/ballistic/revolver/detective/wrench_act(mob/living/user, obj/item/I)
+	var/live_ammo = get_ammo(FALSE, FALSE)
 	if(magazine.caliber == "38")
-		to_chat(user, "<span class='notice'>You begin to reinforce the barrel of [src]...</span>")
-		if(magazine.ammo_count())
-			afterattack(user, user)	//you know the drill
-			user.visible_message("<span class='danger'>[src] goes off!</span>", "<span class='userdanger'>[src] goes off in your face!</span>")
+		if(magazine.ammo_count() && live_ammo == 0) //It's not empty, but has no live ammo.
+			to_chat(user, "<span class='notice'>Empty the chambers first.</span>")
 			return TRUE
-		if(I.use_tool(src, user, 30))
-			if(magazine.ammo_count())
-				to_chat(user, "<span class='warning'>You can't modify it!</span>")
-				return TRUE
-			magazine.caliber = "357"
-			fire_sound = 'sound/weapons/gun/revolver/shot_alt.ogg'
-			desc = "The barrel and chamber assembly seems to have been modified."
-			to_chat(user, "<span class='notice'>You reinforce the barrel of [src]. Now it will fire .357 rounds.</span>")
+		to_chat(user, "<span class='notice'>You begin to loosen the barrel of [src]...</span>")
+		if(live_ammo > 0) //If it it has any live ammo inside....
+			afterattack(user, user)	//...you learn an important lesson about firearms safety.
+			return TRUE
+		I.play_tool_sound(src)
+		if(!I.use_tool(src, user, 3 SECONDS))
+			return TRUE
+		magazine.caliber = "357"
+		fire_sound = 'sound/weapons/gun/revolver/shot_alt.ogg'
+		desc = "A classic, if not outdated, law enforcement firearm. \nIt has been modified to fire .357 rounds."
+		to_chat(user, "<span class='notice'>You loosen the barrel of [src]. Now it will fire .357 rounds.</span>")
 	else
-		to_chat(user, "<span class='notice'>You begin to revert the modifications to [src]...</span>")
-		if(magazine.ammo_count())
-			afterattack(user, user)	//and again
-			user.visible_message("<span class='danger'>[src] goes off!</span>", "<span class='userdanger'>[src] goes off in your face!</span>")
+		if(magazine.ammo_count() && live_ammo == 0)
+			to_chat(user, "<span class='notice'>Empty the chambers first.</span>")
 			return TRUE
-		if(I.use_tool(src, user, 30))
-			if(magazine.ammo_count())
-				to_chat(user, "<span class='warning'>You can't modify it!</span>")
-				return
-			magazine.caliber = "38"
-			fire_sound = 'sound/weapons/gun/revolver/shot.ogg'
-			desc = initial(desc)
-			to_chat(user, "<span class='notice'>You remove the modifications on [src]. Now it will fire .38 rounds.</span>")
-	return TRUE
+		to_chat(user, "<span class='notice'>You begin to tighten the barrel of [src]...</span>")
+		if(live_ammo > 0)
+			afterattack(user, user)
+			return TRUE
+		I.play_tool_sound(src)
+		if(!I.use_tool(src, user, 30))
+			return TRUE
+		magazine.caliber = "38"
+		fire_sound = 'sound/weapons/gun/revolver/shot.ogg'
+		desc = initial(desc)
+		to_chat(user, "<span class='notice'>You tighten the barrel of [src]. Now it will fire .38 rounds.</span>")
 
 
 /obj/item/gun/ballistic/revolver/mateba

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -91,6 +91,8 @@
 						"The Peacemaker" = "detective_peacemaker",
 						"Black Panther" = "detective_panther"
 						)
+	
+	/// Used to avoid some redundancy on a revolver loaded with 357 regarding misfiring while being wrenched.
 	var/skip_357_missfire_check = FALSE
 
 /obj/item/gun/ballistic/revolver/detective/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -93,7 +93,7 @@
 						)
 	var/skip_357_missfire_check = FALSE
 
-/obj/item/gun/ballistic/revolver/detective/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0, skip_missfire_check = FALSE)
+/obj/item/gun/ballistic/revolver/detective/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	if(magazine && magazine.caliber != initial(magazine.caliber) && chambered.BB && !skip_357_missfire_check)
 		if(prob(70 - (magazine.ammo_count() * 10)))	//minimum probability of 10, maximum of 60
 			to_chat(user, "<span class='userdanger'>[src] misfires!</span>")

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -101,10 +101,6 @@
 	return ..()
 
 /obj/item/gun/ballistic/revolver/detective/wrench_act(mob/living/user, obj/item/I)
-//	var/live_ammo = get_ammo(FALSE, FALSE) //Find the amount of live bullets in the gun.
-//	if(magazine.ammo_count() && live_ammo == 0) //It's not empty, but has no live ammo.
-//		to_chat(user, "<span class='notice'>Empty the chambers first.</span>")
-//		return TRUE
 	if(!user.is_holding(src))
 		to_chat(user, "<span class='notice'>You need to hold [src] to modify its barrel.</span>")
 		return TRUE
@@ -113,7 +109,7 @@
 	if(!I.use_tool(src, user, 3 SECONDS))
 		return TRUE
 	if(magazine.ammo_count()) //If it has any ammo inside....
-		user.visible_message("<span class='warning'>[src] goes off!</span>") //...you learn an important lesson about firearms safety.
+		user.visible_message("<span class='danger'>[src]'s hammer drops while you're handling it!</span>") //...you learn an important lesson about firearms safety.
 		process_fire(user, user, FALSE, skip_missfire_check = TRUE)
 		user.dropItemToGround(src)
 		return TRUE

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -95,9 +95,14 @@
 /obj/item/gun/ballistic/revolver/detective/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0, skip_missfire_check = FALSE)
 	if(magazine && magazine.caliber != initial(magazine.caliber) && !skip_missfire_check) //skip_missfire_check is to reduce redundacy of a round "misfiring" when it's already misfiring from wrench_act
 		if(prob(70 - (magazine.ammo_count() * 10)))	//minimum probability of 10, maximum of 60
-			to_chat(user, "<span class='userdanger'>[src] misfires catastropically!</span>")
+			var/shot_hand = ""
+			if(user.get_item_for_held_index(1) == /obj/item/gun/ballistic/revolver/detective)
+				shot_hand = "BODY_ZONE_L_ARM"
+			else if(user.get_item_for_held_index(2) == /obj/item/gun/ballistic/revolver/detective)
+				shot_hand = "BODY_ZONE_R_ARM"
+			to_chat(user, "<span class='userdanger'>[src] misfires!</span>")
 			user.dropItemToGround(src)
-			return ..(user, user, FALSE)
+			return ..(user, user, FALSE, null, shot_hand)
 	return ..()
 
 /obj/item/gun/ballistic/revolver/detective/wrench_act(mob/living/user, obj/item/I)

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -95,14 +95,13 @@
 /obj/item/gun/ballistic/revolver/detective/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0, skip_missfire_check = FALSE)
 	if(magazine && magazine.caliber != initial(magazine.caliber) && !skip_missfire_check) //skip_missfire_check is to reduce redundacy of a round "misfiring" when it's already misfiring from wrench_act
 		if(prob(70 - (magazine.ammo_count() * 10)))	//minimum probability of 10, maximum of 60
-			var/shot_hand = ""
-			if(user.get_item_for_held_index(1) == /obj/item/gun/ballistic/revolver/detective)
-				shot_hand = "BODY_ZONE_L_ARM"
-			else if(user.get_item_for_held_index(2) == /obj/item/gun/ballistic/revolver/detective)
-				shot_hand = "BODY_ZONE_R_ARM"
 			to_chat(user, "<span class='userdanger'>[src] misfires!</span>")
-			user.dropItemToGround(src)
-			return ..(user, user, FALSE, null, shot_hand)
+			if(user.get_item_for_held_index(1) == src)
+				user.dropItemToGround(src)
+				return ..(user, user, FALSE, null, BODY_ZONE_L_ARM)
+			else if(user.get_item_for_held_index(2) == src)
+				user.dropItemToGround(src)
+				return ..(user, user, FALSE, null, BODY_ZONE_R_ARM)
 	return ..()
 
 /obj/item/gun/ballistic/revolver/detective/wrench_act(mob/living/user, obj/item/I)

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -114,9 +114,9 @@
 		return TRUE
 	if(magazine.ammo_count()) //If it has any ammo inside....
 		user.visible_message("<span class='danger'>[src]'s hammer drops while you're handling it!</span>") //...you learn an important lesson about firearms safety.
-		var/drop_the_gun_it_actually_fired = chambered.BB ? TRUE : FALSE
+		var/drop_the_gun_it_actually_fired = chambered.BB ? TRUE : FALSE //Is a live round chambered?
 		process_fire(user, user, FALSE, skip_missfire_check = TRUE)
-		if(drop_the_gun_it_actually_fired) //We do it like this instead of directly checking chambered.BB because process_fire will cycle the chamber.
+		if(drop_the_gun_it_actually_fired) //We do it like this instead of directly checking chambered.BB here because process_fire will cycle the chamber.
 			user.dropItemToGround(src)
 		return TRUE
 	if(magazine.caliber == "38")

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -93,7 +93,7 @@
 						)
 
 /obj/item/gun/ballistic/revolver/detective/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0, skip_missfire_check = FALSE)
-	if(magazine && magazine.caliber != initial(magazine.caliber) && !skip_missfire_check) //skip_missfire_check is to reduce redundacy of a round "misfiring" when it's already misfiring from wrench_act
+	if(magazine && magazine.caliber != initial(magazine.caliber) && chambered.BB && !skip_missfire_check) //skip_missfire_check is to reduce redundacy of a round "misfiring" when it's already misfiring from wrench_act
 		if(prob(70 - (magazine.ammo_count() * 10)))	//minimum probability of 10, maximum of 60
 			to_chat(user, "<span class='userdanger'>[src] misfires!</span>")
 			if(user.get_item_for_held_index(1) == src)
@@ -114,8 +114,12 @@
 		return TRUE
 	if(magazine.ammo_count()) //If it has any ammo inside....
 		user.visible_message("<span class='danger'>[src]'s hammer drops while you're handling it!</span>") //...you learn an important lesson about firearms safety.
+		var/drop_the_gun_it_actually_fired = FALSE
+		if(chambered.BB)
+			drop_the_gun_it_actually_fired = TRUE
 		process_fire(user, user, FALSE, skip_missfire_check = TRUE)
-		user.dropItemToGround(src)
+		if(drop_the_gun_it_actually_fired) //We do it like this instead of directly checking chambered.BB because process_fire will cycle the chamber.
+			user.dropItemToGround(src)
 		return TRUE
 	if(magazine.caliber == "38")
 		magazine.caliber = "357"

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -109,11 +109,12 @@
 			to_chat(user, "<span class='notice'>Empty the chambers first.</span>")
 			return TRUE
 		to_chat(user, "<span class='notice'>You begin to loosen the barrel of [src]...</span>")
-		if(live_ammo > 0) //If it it has any live ammo inside....
-			afterattack(user, user)	//...you learn an important lesson about firearms safety.
-			return TRUE
 		I.play_tool_sound(src)
 		if(!I.use_tool(src, user, 3 SECONDS))
+			return TRUE
+		if(live_ammo > 0) //If it has any live ammo inside....
+			user.visible_message("<span class='warning'>[src] goes off!</span>") //...you learn an important lesson about firearms safety.
+			process_fire(user, user, FALSE)	
 			return TRUE
 		magazine.caliber = "357"
 		fire_sound = 'sound/weapons/gun/revolver/shot_alt.ogg'
@@ -124,11 +125,12 @@
 			to_chat(user, "<span class='notice'>Empty the chambers first.</span>")
 			return TRUE
 		to_chat(user, "<span class='notice'>You begin to tighten the barrel of [src]...</span>")
-		if(live_ammo > 0)
-			afterattack(user, user)
-			return TRUE
 		I.play_tool_sound(src)
-		if(!I.use_tool(src, user, 30))
+		if(!I.use_tool(src, user, 3 SECONDS))
+			return TRUE
+		if(live_ammo > 0)
+			user.visible_message("<span class='warning'>[src] goes off!</span>")
+			process_fire(user, user, FALSE)	
 			return TRUE
 		magazine.caliber = "38"
 		fire_sound = 'sound/weapons/gun/revolver/shot.ogg'

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -91,9 +91,10 @@
 						"The Peacemaker" = "detective_peacemaker",
 						"Black Panther" = "detective_panther"
 						)
+	var/skip_357_missfire_check = FALSE
 
 /obj/item/gun/ballistic/revolver/detective/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0, skip_missfire_check = FALSE)
-	if(magazine && magazine.caliber != initial(magazine.caliber) && chambered.BB && !skip_missfire_check) //skip_missfire_check is to reduce redundacy of a round "misfiring" when it's already misfiring from wrench_act
+	if(magazine && magazine.caliber != initial(magazine.caliber) && chambered.BB && !skip_357_missfire_check) //skip_missfire_check is to reduce redundacy of a round "misfiring" when it's already misfiring from wrench_act
 		if(prob(70 - (magazine.ammo_count() * 10)))	//minimum probability of 10, maximum of 60
 			to_chat(user, "<span class='userdanger'>[src] misfires!</span>")
 			if(user.get_item_for_held_index(1) == src)
@@ -115,7 +116,9 @@
 	if(magazine.ammo_count()) //If it has any ammo inside....
 		user.visible_message("<span class='danger'>[src]'s hammer drops while you're handling it!</span>") //...you learn an important lesson about firearms safety.
 		var/drop_the_gun_it_actually_fired = chambered.BB ? TRUE : FALSE //Is a live round chambered?
-		process_fire(user, user, FALSE, skip_missfire_check = TRUE)
+		skip_357_missfire_check = TRUE
+		process_fire(user, user, FALSE)
+		skip_357_missfire_check = FALSE
 		if(drop_the_gun_it_actually_fired) //We do it like this instead of directly checking chambered.BB here because process_fire will cycle the chamber.
 			user.dropItemToGround(src)
 		return TRUE

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -94,7 +94,7 @@
 	var/skip_357_missfire_check = FALSE
 
 /obj/item/gun/ballistic/revolver/detective/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0, skip_missfire_check = FALSE)
-	if(magazine && magazine.caliber != initial(magazine.caliber) && chambered.BB && !skip_357_missfire_check) //skip_missfire_check is to reduce redundacy of a round "misfiring" when it's already misfiring from wrench_act
+	if(magazine && magazine.caliber != initial(magazine.caliber) && chambered.BB && !skip_357_missfire_check)
 		if(prob(70 - (magazine.ammo_count() * 10)))	//minimum probability of 10, maximum of 60
 			to_chat(user, "<span class='userdanger'>[src] misfires!</span>")
 			if(user.get_item_for_held_index(1) == src)
@@ -116,7 +116,7 @@
 	if(magazine.ammo_count()) //If it has any ammo inside....
 		user.visible_message("<span class='danger'>[src]'s hammer drops while you're handling it!</span>") //...you learn an important lesson about firearms safety.
 		var/drop_the_gun_it_actually_fired = chambered.BB ? TRUE : FALSE //Is a live round chambered?
-		skip_357_missfire_check = TRUE
+		skip_357_missfire_check = TRUE //We set this true, then back to false after process_fire, to reduce redundacy of a round "misfiring" when it's already misfiring from wrench_act
 		process_fire(user, user, FALSE)
 		skip_357_missfire_check = FALSE
 		if(drop_the_gun_it_actually_fired) //We do it like this instead of directly checking chambered.BB here because process_fire will cycle the chamber.


### PR DESCRIPTION
## About The Pull Request

The detective revolver's ammo mod process used screwdriver_act which messed things up with the parent proc for firing pin removal, you had to remove the firing pin inside to do it, and it also spat out a message about removing the firing pin even if one was not present. This switches it to wrench_act to modify the ammo type, and further only lets you modify the gun's ammo type if you are holding it.

This also switches the gun from using after_attack to using process_fire when it misfires (from wrenching or from firing 357 ammo), fixing some ugly and and wrongly ordered chat outputs and a bug where when it misfired from firing 357 ammo it didn't expend the chambered round.

This also generally makes the det revolver's code much nicer and cleaner.

I was also able to get the gun to damage whatever hand it is being held in when 357 ammo causes a misfire, and to make it so you **only** drop the gun on a misfire that discharges a **live round**.

## Why It's Good For The Game

![1623394153-Calvin_Hobbes-TracerBullet2](https://user-images.githubusercontent.com/51800976/90877243-6263cb80-e369-11ea-91d2-ee6a4be8a7da.jpg)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: To change the ammo type the detective's revolver can fire you must now use a wrench instead of a screwdriver, removing the need to take out or destroy its firing pin, and you must be holding it to do so.
fix: When the detective's revolver misfires from using 357 ammo, the chambered round will actually be spent now.
/:cl:

