### PR TITLE
Fixes plants potentially getting duplicate random reagents.

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -563,7 +563,8 @@
 		var/random_amount = rand(4, 15) * 0.01 // this must be multiplied by 0.01, otherwise, it will not properly associate
 		var/datum/plant_gene/reagent/R = new(get_random_reagent_id(), random_amount)
 		if(R.can_add(src))
-			genes += R
+			if(!R.try_upgrade_gene(src))
+				genes += R
 		else
 			qdel(R)
 	reagents_from_genes()


### PR DESCRIPTION
## About The Pull Request

Fixes #52780. So, reagent upgrading works within pollination due to the fact that there weren't copies of that reagent being added to the plant, so `can_add`'s exception handling worked out as a result. However, `add_random_reagent`, on the other hand doesn't quite work cleanly with that, and it enabled copies of the same reagent gene with larger quantities to be added as a result. This PR fixes that by adding a check to handle either upgrading the existing reagent if it exists, or otherwise not getting the reagent as intended.

(Also yes you got super lucking even having this issue in the first place, like there's what, several hundred reagents in game total? The chance of getting one of these extremely rare reagents, AND getting a SECOND COPY is ludicrous. 

## Why It's Good For The Game

🐛 🔫 💯 
Plus I'm almost done with the plant bugs! By god I can feel it. I can _TASTE IT._

## Changelog
:cl:
fix: Plants getting random reagents due to high instability now properly upgrade instead of stack.
/:cl: