### PR TITLE
You can now shove pets and some pushover bots away

### DIFF
--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -29,7 +29,7 @@
 			log_combat(M, src, "shoved", "pushing it")
 			visible_message("<span class='danger'>[M.name] shoves [src], pushing [p_them()]!</span>",
 				"<span class='danger'>You shove [src], pushing [p_them()]!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", COMBAT_MESSAGE_RANGE, src)
-			to_chat(src, "<span class='userdanger'>You're pushed by a shove by [name]!</span>")
+			to_chat(src, "<span class='userdanger'>You're pushed by [name]!</span>")
 			return TRUE
 
 		if("harm")

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -22,13 +22,13 @@
 			var/shove_dir = get_dir(M, src)
 			if(!Move(get_step(src, shove_dir), shove_dir))
 				log_combat(M, src, "shoved", "failing to move it")
-				visible_message("<span class='danger'>[M.name] shoves [src]!</span>",
-					"<span class='danger'>You shove [src]!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", COMBAT_MESSAGE_RANGE, src)
+				M.visible_message("<span class='danger'>[M.name] shoves [src]!</span>",
+					"<span class='danger'>You shove [src]!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", COMBAT_MESSAGE_RANGE, list(src))
 				to_chat(src, "<span class='userdanger'>You're shoved by [M.name]!</span>")
 				return TRUE
 			log_combat(M, src, "shoved", "pushing it")
-			visible_message("<span class='danger'>[M.name] shoves [src], pushing [p_them()]!</span>",
-				"<span class='danger'>You shove [src], pushing [p_them()]!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", COMBAT_MESSAGE_RANGE, src)
+			M.visible_message("<span class='danger'>[M.name] shoves [src], pushing [p_them()]!</span>",
+				"<span class='danger'>You shove [src], pushing [p_them()]!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", COMBAT_MESSAGE_RANGE, list(src))
 			to_chat(src, "<span class='userdanger'>You're pushed by [name]!</span>")
 			return TRUE
 

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -16,7 +16,23 @@
 		if("grab")
 			grabbedby(M)
 
-		if("harm", "disarm")
+		if("disarm")
+			M.do_attack_animation(src, ATTACK_EFFECT_DISARM)
+			playsound(src, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
+			var/shove_dir = get_dir(M, src)
+			if(!Move(get_step(src, shove_dir), shove_dir))
+				log_combat(M, src, "shoved", "failing to move it")
+				visible_message("<span class='danger'>[M.name] shoves [src]!</span>",
+					"<span class='danger'>You shove [src]!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", COMBAT_MESSAGE_RANGE, src)
+				to_chat(src, "<span class='userdanger'>You're shoved by [M.name]!</span>")
+				return TRUE
+			log_combat(M, src, "shoved", "pushing it")
+			visible_message("<span class='danger'>[M.name] shoves [src], pushing [p_them()]!</span>",
+				"<span class='danger'>You shove [src], pushing [p_them()]!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", COMBAT_MESSAGE_RANGE, src)
+			to_chat(src, "<span class='userdanger'>You're pushed by a shove by [name]!</span>")
+			return TRUE
+
+		if("harm")
 			if(HAS_TRAIT(M, TRAIT_PACIFISM))
 				to_chat(M, "<span class='warning'>You don't want to hurt [src]!</span>")
 				return


### PR DESCRIPTION
Chiefly I was tired of beating certain mobs while on disarm intent when it wasn't the idea. This is pretty simple and straightforward.
Someone resourceful could use unlocked bots to gain certain illicit accesses, which sounds fair to me.

## Changelog
:cl:
tweak: Pets and some pushover bots (don't try it on beespky) can now be shoved away. No need to beat them up any longer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
