### PR TITLE
Buffs the Technophile Sect

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -17,9 +17,13 @@
 	for(var/X in C.bodyparts)
 		var/obj/item/bodypart/O = X
 		O.change_bodypart_status(BODYPART_ROBOTIC, FALSE, TRUE)
+		O.brute_reduction = 5
+		O.burn_reduction = 4
 
 /datum/species/android/on_species_loss(mob/living/carbon/C)
 	. = ..()
 	for(var/X in C.bodyparts)
 		var/obj/item/bodypart/O = X
 		O.change_bodypart_status(BODYPART_ORGANIC,FALSE, TRUE)
+		O.brute_reduction = initial(O.brute_reduction)
+		O.burn_reduction = initial(O.burn_reduction)

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -183,10 +183,10 @@
 	var/obj/item/stock_parts/cell/the_cell = I
 	if(!istype(the_cell)) //how...
 		return
-	if(the_cell.charge < 3000)
+	if(the_cell.charge < 300)
 		to_chat(L,"<span class='notice'>[GLOB.deity] does not accept pity amounts of power.</span>")
 		return
-	adjust_favor(round(the_cell.charge/3000), L)
+	adjust_favor(round(the_cell.charge/300), L)
 	to_chat(L, "<span class='notice'>You offer [the_cell]'s power to [GLOB.deity], pleasing them.</span>")
 	qdel(I)
 	return TRUE

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -63,7 +63,7 @@
 /datum/religion_rites/synthconversion
 	name = "Synthetic Conversion"
 	desc = "Convert a human-esque individual into a (superior) Android."
-	ritual_length = 1 MINUTES
+	ritual_length = 30 SECONDS
 	ritual_invocations = list("By the inner workings of our god...",
 						"... We call upon you, in the face of adversity...",
 						"... to complete us, removing that which is undesirable...")

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -68,7 +68,7 @@
 						"... We call upon you, in the face of adversity...",
 						"... to complete us, removing that which is undesirable...")
 	invoke_msg = "... Arise, our champion! Become that which your soul craves, live in the world as your true form!!"
-	favor_cost = 500
+	favor_cost = 1000
 
 /datum/religion_rites/synthconversion/perform_rite(mob/living/user, atom/religious_tool)
 	if(!ismovable(religious_tool))


### PR DESCRIPTION
## About The Pull Request

The robotic limbs of androids now have the damage reduction values that normal augmented limbs do.

The amount of favor received per point of cell charge for a cell sacrificed to the Technophile chaplain sect has been multiplied by 10 (1 point of favor per 3,000 points of cell charge -> 1 point of favor per 300 points of cell charge).

The amount of favor required to perform the Rite of Synthetic Conversion has been multiplied by 2 (500 points of favor ->1,000 points of favor).

The amount of time required to perform the Rite of Synthetic Conversion has been reduced from 1 minute to 30 seconds.

## Okay, throw me some numbers.

In order to gain favor as a Technophile chaplain, you have to sacrifice charged cells. The amount of favor that you gain from sacrificing a cell is equal to [cell's CURRENT charge]/3,000, rounded down.

Power cells made from 100 potency plants with both the electrical activity trait AND the capacitive cell production trait will have a starting charge (and maximum charge capacity) of 40,000 power units, making them tied with bluespace power cells for being **the largest (feasibly) crew-attainable power cells in the game** (unless you count beam rifle power cells, but those can't be removed from their beam rifles).

Sacrificing one of these maxed out botany cells (or a fully-charged bluespace power cell, if you're trying to grind for favor the "intended" way) will give you a mere **13** points of favor. The Rite of Synthetic Conversion costs **500** points of favor to perform, which is slightly GREATER than the amount of favor gained from sacrificing **38 fully-charged bluespace cells** (or 38 maxed out botany cells). You have to pay this price **EACH TIME YOU INVOKE THE RITUAL**.

Oh, but there's more: In order to turn those aforementioned maxed out botany plants into power cells, you have to use 5 pieces of cable coil on each of them. This means that if you're grinding for favor using just maxed out botany cells, you'll have to spend **over 190 pieces of cable coil for each invocation of the Rite of Synthetic Conversion**.

And just to add salt to the wound, performing this ritual on someone requires a full minute of both of you doing nothing but watching a bar fill up or reading the occasional ritual invocation line.

And remember, the chaplain sacrificed one of their strongest abilities (the ability to heal organic limbs with their bible) to gain access to this "amazing" ritual.

Meanwhile, a roboticist can just full-aug you (in less time than it'd take to perform the Rite of Synthetic Conversion on you) to give you better benefits than what being an android gives you, without needing to go on a 30 minute+ quest to obtain the materials/items necessary to convert you. Unlike androids, full-augged people get brute and burn damage reduction on each of their limbs, the ability to use nanites (including mechanical repair nanites), the ability to retain genetic powers from before their conversion, and the ability to process chems.

This entire situation is just really sad (especially since the Technophile sect is pretty cool flavor-wise), and this PR aims to fix that.

## Changelog
:cl: ATHATH
balance: The robotic limbs of androids now have the damage reduction values that normal augmented limbs do.
balance: The amount of favor received per point of cell charge for a cell sacrificed to the Technophile chaplain sect has been multiplied by 10 (1 point of favor per 3,000 points of cell charge -> 1 point of favor per 300 points of cell charge).
balance: The amount of favor required to perform the Rite of Synthetic Conversion has been multiplied by 2 (500 points of favor ->1,000 points of favor).
balance: The amount of time required to perform the Rite of Synthetic Conversion has been reduced from 1 minute to 30 seconds.
/:cl: