### PR TITLE
Pipe painters now fit in toolbelts.

### DIFF
--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -1,5 +1,6 @@
 /obj/item/pipe_painter
 	name = "pipe painter"
+	desc = "Used for coloring pipes, unsurprisingly."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "labeler1"
 	inhand_icon_state = "flight"

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -69,6 +69,7 @@
 		/obj/item/inducer,
 		/obj/item/plunger,
 		/obj/item/airlock_painter
+		/obj/item/pipe_painter
 		))
 
 /obj/item/storage/belt/utility/chief

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -68,7 +68,7 @@
 		/obj/item/pipe_dispenser,
 		/obj/item/inducer,
 		/obj/item/plunger,
-		/obj/item/airlock_painter
+		/obj/item/airlock_painter,
 		/obj/item/pipe_painter
 		))
 


### PR DESCRIPTION

## About The Pull Request

I overlooked this when I made https://github.com/tgstation/tgstation/pull/53027


## Why It's Good For The Game

I'm not sure how often people use these, but if they exist, they may as well fit into toolbelts.

## Changelog
:cl:
tweak: Toolbelts can now hold pipe painters.
/:cl:

