### PR TITLE
Asset store uses hash subfolders.

### DIFF
--- a/code/modules/asset_cache/transports/webroot_transport.dm
+++ b/code/modules/asset_cache/transports/webroot_transport.dm
@@ -43,10 +43,10 @@
 	return "[url][get_asset_suffex(asset_cache_item)]"
 
 /datum/asset_transport/webroot/proc/get_asset_suffex(datum/asset_cache_item/asset_cache_item)
-	var/base = ""
+	var/base = "[copytext(asset_cache_item.hash, 1, 3)]/"
 	var/filename = "asset.[asset_cache_item.hash][asset_cache_item.ext]"
 	if (length(asset_cache_item.namespace))
-		base = "namespaces/[asset_cache_item.namespace]/"
+		base = "namespaces/[copytext(asset_cache_item.namespace, 1, 3)]/[asset_cache_item.namespace]/"
 		if (!asset_cache_item.namespace_parent)
 			filename = "[asset_cache_item.name]"
 	return base + filename


### PR DESCRIPTION
`/asset.5a684ab7bcc937c7fec1d13d15858d1c.png` -> `/5a/asset.5a684ab7bcc937c7fec1d13d15858d1c.png`
`/namespaces/2e6c7310df20688d68b437f8bf125ece/padlock.png` -> `/namespaces/2e/2e6c7310df20688d68b437f8bf125ece/asset.da24a17749106d0e3dd3ff70415de10d.css`

![image](https://user-images.githubusercontent.com/7069733/90952804-78ca5f80-e41b-11ea-8b9e-3fdc05c9c654.png)
![image](https://user-images.githubusercontent.com/7069733/90952850-b0d1a280-e41b-11ea-8487-bdae1a8c4c48.png)

