### PR TITLE
Fixes powernets improperly rebuilding when a ship moves

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -332,13 +332,12 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 		var/datum/powernet/newPN = new()// creates a new powernet...
 		propagate_network(O, newPN)//... and propagates it to the other side of the cable
 
-//Makes a new network for the cable and propgates it.
-//If it finds another network in the process, aborts and uses that one and propagates off of it instead
+//Makes a new network for the cable and propgates it. If we already have one, just die
 /obj/structure/cable/proc/propagate_if_no_network()
 	if(powernet)
 		return
 	var/datum/powernet/newPN = new()
-	propagate_network(src, newPN, TRUE)
+	propagate_network(src, newPN)
 
 // cut the cable's powernet at this cable and updates the powergrid
 /obj/structure/cable/proc/cut_cable_from_powernet(remove = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Instead of asking `propagate_network` to build only that which doesn't already have a powernet, we ask it to build everything.
This fixes powernets randomly dying based on position in ships, and *maybe* fixes good old #51059 

Because of the way `afterShuttleMove` (which calls `propagate_network`) works, that is for each cable we update it and then try and update the powernet, and the fact that propagate network wasn't assimilating old networks, we'd get some machines that are disconnected from the main thing.

I could also have like an afterAfterShuttleMove proc, or maybe even store a list of cables and call propgate_network on each one, but this seemed less hacky.

## Why It's Good For The Game

People can play around with ships without powernet pain now, and it might take care of #51059, I'm not really sure. If we have no issues with power on icebox currently then the issue is solved, I just don't know if that's the case.

Thanks to the guys over at fulp for confirming my concerns, fikou/arm for finding me a test case, and the poor boys over on sybil, at least you died for a good cause.
~~fuck you boomer station, why did your hunch have to be right~~
## Changelog
:cl:
fix: Power no longer get fuckey when a ship moves with connected machines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
