### PR TITLE
shuttle navigation consoles can no longer dock at tiles that the shuttle is on

### DIFF
--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -227,9 +227,6 @@
 	// Too close to the map edge is never allowed
 	if(!T || T.x <= 10 || T.y <= 10 || T.x >= world.maxx - 10 || T.y >= world.maxy - 10)
 		return SHUTTLE_DOCKER_BLOCKED
-	// If it's one of our shuttle areas assume it's ok to be there
-	if(shuttle_port.shuttle_areas[T.loc])
-		return SHUTTLE_DOCKER_LANDING_CLEAR
 	. = SHUTTLE_DOCKER_LANDING_CLEAR
 	// See if the turf is hidden from us
 	var/list/hidden_turf_info

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -227,6 +227,9 @@
 	// Too close to the map edge is never allowed
 	if(!T || T.x <= 10 || T.y <= 10 || T.x >= world.maxx - 10 || T.y >= world.maxy - 10)
 		return SHUTTLE_DOCKER_BLOCKED
+	/* // If it's one of our shuttle areas assume it's ok to be there
+	if(shuttle_port.shuttle_areas[T.loc])
+		return SHUTTLE_DOCKER_LANDING_CLEAR */
 	. = SHUTTLE_DOCKER_LANDING_CLEAR
 	// See if the turf is hidden from us
 	var/list/hidden_turf_info


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

previously the shuttle could dock onto itself, causing this

![image](https://user-images.githubusercontent.com/23585223/90957489-28401a00-e48e-11ea-9a4e-f119e35c964e.png)

this is kind of a bandaid but its better if we dont have shuttles deleting themselves
fixes #47764
maybe fixes #45853 but that one is weirdly specific do i dont know
 
## Why It's Good For The Game

oh god oh fuck

## Changelog
:cl:
fix: shuttle navigation consoles can no longer dock at tiles that the shuttle is on
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
