### PR TITLE
Augment Manipulator now uses a radial menu

### DIFF
--- a/code/game/machinery/aug_manipulator.dm
+++ b/code/game/machinery/aug_manipulator.dm
@@ -101,18 +101,35 @@
 	add_fingerprint(user)
 
 	if(storedpart)
-		var/augstyle = input(user, "Select style.", "Augment Custom Fitting") as null|anything in style_list_icons
-		if(!augstyle)
+		var/list/skins = list()
+		for(var/skin_option in style_list_icons)
+			var/image/part_image = image(icon = style_list_icons[skin_option], icon_state = storedpart.icon_state)
+			skins += list("[skin_option]" = part_image)
+		var/choice = show_radial_menu(user, src, skins, custom_check = CALLBACK(src, .proc/check_menu, user, storedpart), require_near = TRUE)
+		if(!choice)
 			return
-		if(!in_range(src, user))
-			return
-		if(!storedpart)
-			return
-		storedpart.icon = style_list_icons[augstyle]
+		storedpart.icon = style_list_icons[choice]
 		eject_part(user)
-
 	else
 		to_chat(user, "<span class='warning'>\The [src] is empty!</span>")
+
+/**
+  * Checks if we are allowed to interact with a radial menu
+  *
+  * Arguments:
+  * * user The mob interacting with the menu
+  * * part The body part that is being customized
+  */
+/obj/machinery/aug_manipulator/proc/check_menu(mob/living/user, obj/item/bodypart/part)
+	if(!istype(user))
+		return FALSE
+	if(user.incapacitated())
+		return FALSE
+	if(QDELETED(part))
+		return FALSE
+	if(part != storedpart)
+		return FALSE
+	return TRUE
 
 /obj/machinery/aug_manipulator/proc/eject_part(mob/living/user)
 	if(storedpart)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR makes Augment Manipulator use a radial menu for choosing bodypart skins, instead of an input menu with no preview of how given skin even looks like.

Example image:

![AugRadial](https://user-images.githubusercontent.com/43862960/90963768-fc875900-e4ba-11ea-9a69-f97fab6f743b.png)

## Why It's Good For The Game

Better skin choosing method.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arkatos
add: Augment Manipulator now uses a radial menu. Get augmenting!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
