### PR TITLE
Adds a new admin smite, Dock Pay.

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -103,6 +103,7 @@
 #define ADMIN_PUNISHMENT_PERFORATE ":B:erforate"
 #define ADMIN_PUNISHMENT_SCARIFY "Scarify"
 #define ADMIN_PUNISHMENT_SHOES "Knot Shoes"
+#define ADMIN_PUNISHMENT_DOCK "Dock Pay"
 
 #define AHELP_ACTIVE 1
 #define AHELP_CLOSED 2

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1071,7 +1071,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 									ADMIN_PUNISHMENT_BLEED,
 									ADMIN_PUNISHMENT_PERFORATE,
 									ADMIN_PUNISHMENT_SCARIFY,
-									ADMIN_PUNISHMENT_SHOES
+									ADMIN_PUNISHMENT_SHOES,
+									ADMIN_PUNISHMENT_DOCK
 									)
 
 	var/punishment = input("Choose a punishment", "DIVINE SMITING") as null|anything in sortList(punishment_list)
@@ -1238,6 +1239,29 @@ Traitors and the like can also be revived with the previous role mostly intact.
 				to_chat(usr,"<span class='warning'>[dude] does not have knottable shoes!</span>", confidential = TRUE)
 				return
 			sick_kicks.adjust_laces(SHOES_KNOTTED)
+		if(ADMIN_PUNISHMENT_DOCK)
+			if(!iscarbon(target))
+				to_chat(usr,"<span class='warning'>This must be used on a carbon mob.</span>", confidential = TRUE)
+				return
+			var/mob/living/carbon/dude = target
+			var/obj/item/card/id/card = dude.get_idcard(TRUE)
+			if(!card)
+				to_chat(usr,"<span class='warning'>[dude] does not have an ID card on!</span>", confidential = TRUE)
+				return
+			if(!card.registered_account)
+				to_chat(usr,"<span class='warning'>[dude] does not have an ID card with an account!</span>", confidential = TRUE)
+				return
+			var/new_cost = input("How much pay are we docking?","BUDGET CUTS") as num|null
+			if(!new_cost)
+				return
+			if(!(card.registered_account.has_money(new_cost)))
+				to_chat(usr, "<span class='warning'>ID Card lacked funds. Emptying account.</span>")
+				card.registered_account.bank_card_talk("[new_cost] credits deducted from your account based on performance review.")
+				card.registered_account.account_balance = 0
+			else
+				card.registered_account.account_balance = card.registered_account.account_balance - new_cost
+				card.registered_account.bank_card_talk("[new_cost] credits deducted from your account based on performance review.")
+			SEND_SOUND(target, 'sound/machines/buzz-sigh.ogg')
 
 	punish_log(target, punishment)
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1251,7 +1251,10 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			if(!card.registered_account)
 				to_chat(usr,"<span class='warning'>[dude] does not have an ID card with an account!</span>", confidential = TRUE)
 				return
-			var/new_cost = input("How much pay are we docking?","BUDGET CUTS") as num|null
+			if(card.registered_account.account_balance == 0)
+				to_chat(usr, "<span class='warning'>ID Card lacks any funds. No pay to dock.</span>")
+				return
+			var/new_cost = input("How much pay are we docking? Current balance: [card.registered_account.account_balance] credits.","BUDGET CUTS") as num|null
 			if(!new_cost)
 				return
 			if(!(card.registered_account.has_money(new_cost)))


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/41715314/90965958-229d0100-e49b-11ea-9d4d-4d6bd6a9cea9.png)
Admins can now smite players with an ID on by docking their pay, enabling them to remove money from a player's account remotely and swiftly. Fails if they don't have an ID on, or has on an ID that doesn't have an account.

## Why It's Good For The Game

More smites -> More ways to discourage bad behavior/dick about.

## Changelog
:cl:
add: Your sector has upgraded the BSA with a new specialty lens, Remote Economic Punishment Bombardment.
/:cl:


