### PR TITLE
Adds the Stealth Nanite Programming node, brings back old!Reduced Diagnostics

### DIFF
--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -91,8 +91,10 @@
 
 /datum/nanite_program/reduced_diagnostics
 	name = "Reduced Diagnostics"
-	desc = "Disables some high-cost diagnostics in the nanites, making them unable to communicate their program list to portable scanners."
+	desc = "Disables some high-cost diagnostics in the nanites, making them unable to communicate their program list to portable scanners. \
+	Doing so saves some power, slightly increasing their replication speed."
 	rogue_types = list(/datum/nanite_program/toxic)
+	use_rate = -0.1
 
 /datum/nanite_program/reduced_diagnostics/enable_passive_effect()
 	. = ..()

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -917,7 +917,7 @@
 	prereq_ids = list("datatheory")
 	design_ids = list("nanite_disk","nanite_remote","nanite_comm_remote","nanite_scanner",\
 						"nanite_chamber","public_nanite_chamber","nanite_chamber_control","nanite_programmer","nanite_program_hub","nanite_cloud_control",\
-						"relay_nanites", "monitoring_nanites", "research_nanites" ,"researchplus_nanites", "access_nanites", "repairing_nanites","sensor_nanite_volume", "repeater_nanites", "relay_repeater_nanites","red_diag_nanites")
+						"relay_nanites", "monitoring_nanites", "research_nanites" ,"researchplus_nanites", "access_nanites", "repairing_nanites","sensor_nanite_volume", "repeater_nanites", "relay_repeater_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 	export_price = 5000
 
@@ -926,9 +926,18 @@
 	display_name = "Smart Nanite Programming"
 	description = "Nanite programs that require nanites to perform complex actions, act independently, roam or seek targets."
 	prereq_ids = list("nanite_base","robotics")
-	design_ids = list("purging_nanites", "metabolic_nanites", "stealth_nanites", "memleak_nanites","sensor_voice_nanites", "voice_nanites")
+	design_ids = list("purging_nanites", "metabolic_nanites", "memleak_nanites","sensor_voice_nanites", "voice_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 500, TECHWEB_POINT_TYPE_NANITES = 500)
 	export_price = 4000
+
+/datum/techweb_node/nanite_stealth
+	id = "nanite_stealth"
+	display_name = "Stealth Nanite Programming"
+	description = "Nanite programs that reduce the feedback that nanites give to portable scanners and other detection devices."
+	prereq_ids = list("nanite_smart")
+	design_ids = list("red_diag_nanites", "stealth_nanites")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000, TECHWEB_POINT_TYPE_NANITES = 1000)
+	export_price = 5000
 
 /datum/techweb_node/nanite_mesh
 	id = "nanite_mesh"
@@ -971,7 +980,7 @@
 	id = "nanite_harmonic"
 	display_name = "Harmonic Nanite Programming"
 	description = "Nanite programs that require seamless integration between nanites and biology."
-	prereq_ids = list("nanite_bio","nanite_smart","nanite_mesh")
+	prereq_ids = list("nanite_bio","nanite_smart","nanite_mesh","nanite_synaptic","nanite_stealth")
 	design_ids = list("fakedeath_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","adrenaline_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000, TECHWEB_POINT_TYPE_NANITES = 2000)
 	export_price = 8000


### PR DESCRIPTION
## About The Pull Request

The Reduced Diagnostics program generates 0.1 nanite volume points/second again.

The Stealth program and the Reduced Diagnostics program have been moved out of their respective nodes and into a new research node: Stealth Nanite Programming. This new node requires the expenditure of 1,000 normal research points and 1,000 nanite research points to be researched, and has Smart Nanite Programming as a prerequisite.

The Harmonic Nanite Programming node now has the Synaptic Nanite Programming and Stealth Nanite Programming nodes as additional prerequisites, making it require you to research all other normal (so, not locked behind Syndicate or ayy tech) nanite research nodes before it can be researched.

## Why It's Good For The Game

This PR was created after I talked to CRITAWAKETS (the creator of https://github.com/tgstation/tgstation/pull/52937, the PR that nerfed Reduced Diagnostics) on Discord and reached a compromise/agreement with him.

This new node adds the additional cost to the Reduced Diagnostics program that CRITAWAKETS was seeking, and the additional prerequisites for the Harmonic Nanite Programming node add a plausible reason (other than the Mental Barrier program) for a non-antag to research the Synaptic Nanite Programming node (and the Stealth Nanite Programming node was added to its prerequisites because NOT adding it would make it the only normal nanite node that WOULDN'T be required for researching the Harmonic Nanite Programming node).

## Changelog
:cl: ATHATH
balance: The Reduced Diagnostics generates 0.1 nanite volume points/second again.
add: The Stealth program and the Reduced Diagnostics program have been moved out of their respective nodes and into a new research node: Stealth Nanite Programming. This new node requires the expenditure of 1,000 normal research points and 1,000 nanite research points to be researched, and has Smart Nanite Programming as a prerequisite.
balance: The Harmonic Nanite Programming node now has the Synaptic Nanite Programming and Stealth Nanite Programming nodes as additional prerequisites, making it require you to research all other normal (so, not locked behind Syndicate or ayy tech) nanite research nodes before it can be researched.
/:cl: