### PR TITLE
border firedoors are no longer "glass" doors and closed regular firedoors are no longer opaque

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -12,6 +12,7 @@
 	max_integrity = 300
 	resistance_flags = FIRE_PROOF
 	heat_proof = TRUE
+	glass = TRUE
 	sub_door = TRUE
 	explosion_block = 1
 	safe = FALSE
@@ -48,7 +49,6 @@
 
 /obj/machinery/door/firedoor/closed
 	icon_state = "door_closed"
-	opacity = TRUE
 	density = TRUE
 
 //see also turf/AfterChange for adjacency shennanigans
@@ -218,6 +218,7 @@
 	can_crush = FALSE
 	flags_1 = ON_BORDER_1
 	CanAtmosPass = ATMOS_PASS_PROC
+	glass = FALSE
 
 /obj/machinery/door/firedoor/border_only/closed
 	icon_state = "door_closed"

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -12,7 +12,6 @@
 	max_integrity = 300
 	resistance_flags = FIRE_PROOF
 	heat_proof = TRUE
-	glass = TRUE
 	sub_door = TRUE
 	explosion_block = 1
 	safe = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the border firedoor opacity broke when you opened them and they would never become opaque again
glass doors shouldnt be opaque when you spawn them

## Why It's Good For The Game

bug bad

## Changelog
:cl:
fix: border firelocks will now be opaque after closing, regular now wont be opaque on spawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
