### PR TITLE
Makes nanite reduced diagnostic function baseline and adds new increased diagnostics program

### DIFF
--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -15,7 +15,7 @@
 	var/list/datum/nanite_program/protocol/protocols = list() ///Separate list of protocol programs, to avoid looping through the whole programs list when cheking for conflicts
 	var/start_time = 0 ///Timestamp to when the nanites were first inserted in the host
 	var/stealth = FALSE //if TRUE, does not appear on HUDs and health scans
-	var/diagnostics = TRUE //if TRUE, displays program list when scanned by nanite scanners
+	var/diagnostics = FALSE //if TRUE, displays program list when scanned by nanite scanners
 
 /datum/component/nanites/Initialize(amount = 100, cloud = 0)
 	if(!isliving(parent) && !istype(parent, /datum/nanite_cloud_backup))
@@ -360,7 +360,7 @@
 		to_chat(user, "<span class='info'>================</span>")
 		to_chat(user, "<span class='info'>Program List:</span>")
 		if(!diagnostics)
-			to_chat(user, "<span class='alert'>Diagnostics Disabled</span>")
+			to_chat(user, "<span class='alert'>Nanite debugging disabled.</span>")
 		else
 			for(var/X in programs)
 				var/datum/nanite_program/NP = X

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -1,3 +1,5 @@
+#define HARMONIC_REGEN_BOOST 0.1
+
 /datum/component/nanites
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
@@ -109,7 +111,7 @@
 
 /datum/component/nanites/process()
 	if(!IS_IN_STASIS(host_mob))
-		adjust_nanites(null, regen_rate)
+		adjust_nanites(null, regen_rate + (SSresearch.science_tech.researched_nodes["nanite_harmonic"] ? HARMONIC_REGEN_BOOST : 0))
 		add_research()
 		for(var/X in programs)
 			var/datum/nanite_program/NP = X
@@ -316,14 +318,6 @@
 
 	return TRUE //yup i exist
 
-/datum/component/nanites/proc/get_data(list/nanite_data)
-	nanite_data["nanite_volume"] = nanite_volume
-	nanite_data["max_nanites"] = max_nanites
-	nanite_data["cloud_id"] = cloud_id
-	nanite_data["regen_rate"] = regen_rate
-	nanite_data["safety_threshold"] = safety_threshold
-	nanite_data["stealth"] = stealth
-
 /datum/component/nanites/proc/get_programs(datum/source, list/nanite_programs)
 	SIGNAL_HANDLER
 
@@ -372,7 +366,7 @@
 
 	data["has_nanites"] = TRUE
 	data["nanite_volume"] = nanite_volume
-	data["regen_rate"] = regen_rate
+	data["regen_rate"] = regen_rate + (SSresearch.science_tech.researched_nodes["nanite_harmonic"] ? HARMONIC_REGEN_BOOST : 0)
 	data["safety_threshold"] = safety_threshold
 	data["cloud_id"] = cloud_id
 	data["cloud_active"] = cloud_active
@@ -425,3 +419,5 @@
 		id++
 		mob_programs += list(mob_program)
 	data["mob_programs"] = mob_programs
+
+#undef HARMONIC_REGEN_BOOST

--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -67,12 +67,12 @@
 	program_type = /datum/nanite_program/stealth
 	category = list("Utility Nanites")
 
-/datum/design/nanites/reduced_diagnostics
-	name = "Reduced Diagnostics"
-	desc = "Disables some high-cost diagnostics in the nanites, making them unable to communicate their program list to portable scanners. \
-	Doing so saves some power, slightly increasing their replication speed."
-	id = "red_diag_nanites"
-	program_type = /datum/nanite_program/reduced_diagnostics
+/datum/design/nanites/nanite_debugging
+	name = "Nanite Debugging"
+	desc = "Enables various high-cost diagnostics in the nanites, making them able to communicate their program list to portable scanners. \
+	Doing so uses some power, slightly decreasing their replication speed."
+	id = "debugging_nanites"
+	program_type = /datum/nanite_program/nanite_debugging
 	category = list("Utility Nanites")
 
 /datum/design/nanites/access

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -89,18 +89,20 @@
 	. = ..()
 	nanites.stealth = FALSE
 
-/datum/nanite_program/reduced_diagnostics
-	name = "Reduced Diagnostics"
-	desc = "Disables some high-cost diagnostics in the nanites, making them unable to communicate their program list to portable scanners."
+/datum/nanite_program/nanite_debugging
+	name = "Nanite Debugging"
+	desc = "Enables various high-cost diagnostics in the nanites, making them able to communicate their program list to portable scanners. \
+	Doing so uses some power, slightly decreasing their replication speed."
 	rogue_types = list(/datum/nanite_program/toxic)
+	use_rate = 0.1
 
-/datum/nanite_program/reduced_diagnostics/enable_passive_effect()
-	. = ..()
-	nanites.diagnostics = FALSE
-
-/datum/nanite_program/reduced_diagnostics/disable_passive_effect()
+/datum/nanite_program/nanite_debugging/enable_passive_effect()
 	. = ..()
 	nanites.diagnostics = TRUE
+
+/datum/nanite_program/nanite_debugging/disable_passive_effect()
+	. = ..()
+	nanites.diagnostics = FALSE
 
 /datum/nanite_program/relay
 	name = "Relay"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -873,7 +873,7 @@
 /datum/techweb_node/nanite_harmonic
 	id = "nanite_harmonic"
 	display_name = "Harmonic Nanite Programming"
-	description = "Nanite programs that require seamless integration between nanites and biology."
+	description = "Nanite programs that require seamless integration between nanites and biology. Passively increases nanite regeneration rate for all clouds upon researching."
 	prereq_ids = list("nanite_bio","nanite_smart","nanite_mesh")
 	design_ids = list("fakedeath_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","adrenaline_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000, TECHWEB_POINT_TYPE_NANITES = 3000)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -826,7 +826,7 @@
 	prereq_ids = list("datatheory")
 	design_ids = list("nanite_disk","nanite_remote","nanite_comm_remote","nanite_scanner",\
 						"nanite_chamber","public_nanite_chamber","nanite_chamber_control","nanite_programmer","nanite_program_hub","nanite_cloud_control",\
-						"relay_nanites", "monitoring_nanites", "research_nanites" ,"researchplus_nanites", "access_nanites", "repairing_nanites","sensor_nanite_volume", "repeater_nanites", "relay_repeater_nanites","red_diag_nanites")
+						"relay_nanites", "monitoring_nanites", "research_nanites" ,"researchplus_nanites", "access_nanites", "repairing_nanites","sensor_nanite_volume", "repeater_nanites", "relay_repeater_nanites","debugging_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 
 /datum/techweb_node/nanite_smart

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -876,7 +876,7 @@
 	description = "Nanite programs that require seamless integration between nanites and biology."
 	prereq_ids = list("nanite_bio","nanite_smart","nanite_mesh")
 	design_ids = list("fakedeath_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","adrenaline_nanites")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000, TECHWEB_POINT_TYPE_NANITES = 2000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000, TECHWEB_POINT_TYPE_NANITES = 3000)
 
 /datum/techweb_node/nanite_combat
 	id = "nanite_military"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alternative to #53145 
Closes #53145 

### Context
#52937 was prematurely merged before player concerns about Reduced Diagnostics having the nanite regeneration removed could actually be addressed.

The arguments against it were simple: Reduced Diagnostics should have a benefit, otherwise an antag trying to use it to hide the program list has no plausible deniability and is immediately outed as suspicious.

Removing this benefit is a huge buff to nanites and a huge nerf to antags using nanites for evil. There's no reason to include it in your nanite cloud anymore, using it immediately outs you as suspicious.

#53145 comes along to remedy the problem, but is sort of like the tail wagging the dog. It approaches the issue from the wrong direction that satisfies neither the idea behind the original nerf, nor the spirit of why Reduced Diagnostics should be available immediately in the tech tree.

[Edit] - Ath also did #53144. This PR pretty much sets out to do the same thing, without the base regen increase. Ath gave in. He negotiated with terrorists. And the terrorists won. I do not negotiate with terrorists. I consider #53144 the superior solution overall, however this is a compromise between the two.

This PR is an alternative approach. I seek to have the dog wag the tail. To have the horse put before the cart.

Nanites have reduced diagnostics by default. Reduced diagnostics is no longer a program, but the default behaviour.

Accordingly, there is now a Nanite Debugging program that adds the increased diagnostic functionality back in for a 0.1/s nanite cost.

On brief discussion with a maintainer, we have opted for a global 0.1/s nanite regen rate increase that activates when Harmonic Nanite Programming is researched. In return, Harmonic Nanite Programming now costs 1000 additional general and nanite research points.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Antags can now hide nanite program lists again without immediately being outed as suspicious.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Reduced Diagnostics nanite program has been removed.
add: Nanite Debugging nanite program has been added. This program causes your nanites to display their program list when scanned, but comes with a 0.1/s nanite cost.
tweak: Reduced Diagnostics nanite program functionality is now default behaviour. The nanite program list is hidden from nanite scanners by default. You now now to include the Nanite Debugging program to show the program list on scan.
tweak: Researching Harmonic Nanite Programming now confers a passive boost of 0.1 regen rate to all nanite clouds. This boost takes effects as soon as the node is researched.
tweak: Harmonic Nanite Programming research node now requires 3000 General and 3000 Nanite research, an increase of 1000 each.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
