### PR TITLE
Buffs the mind reader mutation to be a bit more consistent/reliable

### DIFF
--- a/code/datums/mutations/antenna.dm
+++ b/code/datums/mutations/antenna.dm
@@ -81,7 +81,7 @@
 						break
 			if(LAZYLEN(say_log))
 				for(var/spoken_memory in say_log)
-					if(recent_speech.len >= 3)//up to 3 recent lines of speech
+					if(recent_speech.len >= 3) //up to 3 recent lines of speech
 						break
 					recent_speech[spoken_memory] = say_log[spoken_memory]
 			if(recent_speech.len)

--- a/code/datums/mutations/antenna.dm
+++ b/code/datums/mutations/antenna.dm
@@ -81,10 +81,9 @@
 						break
 			if(LAZYLEN(say_log))
 				for(var/spoken_memory in say_log)
-					if(recent_speech.len >= 3)//up to 3 random lines of speech, favoring more recent speech
+					if(recent_speech.len >= 3)//up to 3 recent lines of speech
 						break
-					if(prob(50))
-						recent_speech[spoken_memory] = say_log[spoken_memory]
+					recent_speech[spoken_memory] = say_log[spoken_memory]
 			if(recent_speech.len)
 				to_chat(user, "<span class='boldnotice'>You catch some drifting memories of their past conversations...</span>")
 				for(var/spoken_memory in recent_speech)


### PR DESCRIPTION
## About The Pull Request

The mind reader mutation no longer has a 50% chance to "skip over" a given line when searching for someone's most recent lines of speech. In layman's terms, the mutation will now ALWAYS show you the last three things that your target said (unless they've said less than 3 things so far, in which case it'll just show you those), instead of a semi-random list of the things that your target has said recently.

## Why It's Good For The Game

Now you can determine with 100% certainty that that mime has indeed not spoken so far this round.

It will now also be easier to determine what the subject of your target's last conversation was, allowing you to be much more confident while delivering your smug educated guesses about what someone's been up to recently.

This shouldn't affect the balance of the mind reader mutation too much, as you could effectively get around this RNG-based limitation by just using the power multiple times in a row anyway.

I'm also considering increasing the number of lines revealed by this mutation from 3 lines to 5 lines, to compensate for effectively shortening how far back you can look at your target's conversation history with this mutation.

## Changelog
:cl: ATHATH
balance: The mind reader mutation no longer has a 50% chance to "skip over" a given line when searching for someone's most recent lines of speech. In layman's terms, the mutation will now ALWAYS show you the last three things that your target said (unless they've said less than 3 things so far, in which case it'll just show you those), instead of a semi-random list of the things that your target has said recently.
/:cl: