### PR TITLE
Lawyers with jumpskirt preference will no longer start the round with a jumpsuit.

### DIFF
--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -42,5 +42,8 @@
 	var/datum/job/lawyer/J = SSjob.GetJobType(jobtype)
 	J.lawyers++
 	if(J.lawyers>1)
-		uniform = /obj/item/clothing/under/rank/civilian/lawyer/purpsuit
+		if(H.jumpsuit_style == PREF_SKIRT)
+			uniform = /obj/item/clothing/under/rank/civilian/lawyer/purpsuit/skirt
+		else
+			uniform = /obj/item/clothing/under/rank/civilian/lawyer/purpsuit
 		suit = /obj/item/clothing/suit/toggle/lawyer/purple

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -38,7 +38,7 @@
 	if(visualsOnly)
 		return ..()
 
-	var/static/use_purple_suit = FALSE
+	var/static/use_purple_suit = FALSE //If there is one lawyer, they get the default blue suit. If another lawyer joins the round, they start with a purple suit.
 	if(use_purple_suit)
 		uniform = /obj/item/clothing/under/rank/civilian/lawyer/purpsuit
 		suit = /obj/item/clothing/suit/toggle/lawyer/purple

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -35,15 +35,13 @@
 
 
 /datum/outfit/job/lawyer/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
 	if(visualsOnly)
-		return
+		return ..()
 
-	var/datum/job/lawyer/J = SSjob.GetJobType(jobtype)
-	J.lawyers++
-	if(J.lawyers>1)
-		if(H.jumpsuit_style == PREF_SKIRT)
-			uniform = /obj/item/clothing/under/rank/civilian/lawyer/purpsuit/skirt
-		else
-			uniform = /obj/item/clothing/under/rank/civilian/lawyer/purpsuit
+	var/static/use_purple_suit = FALSE
+	if(use_purple_suit)
+		uniform = /obj/item/clothing/under/rank/civilian/lawyer/purpsuit
 		suit = /obj/item/clothing/suit/toggle/lawyer/purple
+	else
+		use_purple_suit = TRUE
+	..()


### PR DESCRIPTION

## About The Pull Request

Lawyers were spawning with a purple lawyer suit, never a purple lawyer suitskirt, regardless of jumpsuit/jumpskirt preference.
This remedies that.

## Why It's Good For The Game

Nanotrasen cannot afford any more sexual harassment lawsuits for supplying incorrect clothing to employees.

## Changelog
:cl:
fix: Lawyers with jumpskirt preference will now actually spawn with a lawyer jumpskirt.
/:cl:

