### PR TITLE
Tweaks to Delta Surgery atmos

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -87160,9 +87160,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "dmf" = (
@@ -108177,9 +108175,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "eNA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery/room_b)
 "eRh" = (
@@ -111127,6 +111123,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"nJq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery/room_b)
 "nLd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -113059,6 +113061,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"tyl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "tzj" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -113623,6 +113641,23 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"uTf" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "uTQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -114455,6 +114490,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery/room_b)
 "xAi" = (
@@ -162426,7 +162465,7 @@ dCO
 uxC
 wZq
 eNA
-dEe
+nJq
 xzY
 vFc
 dLo
@@ -162669,7 +162708,7 @@ dhq
 diJ
 dkv
 dma
-dnG
+uTf
 dnG
 dro
 dsN
@@ -163440,7 +163479,7 @@ cPv
 diM
 dkE
 dme
-dnD
+tyl
 dnG
 dro
 dsQ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A few tweaks to Delta's surgery area atmos:

- Adds an air alarm to Surgery Room B
- Moves a vent in Surgery Observation (it was under the airlock before)
- Moves a scrubber in Surgery B (so it's symmetrical with the vent location)
- Adds an air alarm to Surgery Observation (technically this is Surgery which had an air alarm but this area is airtight and has vents so it should probably have its own air alarm)

See picture below circling the changes
![image](https://user-images.githubusercontent.com/1313921/91087727-87c93180-e616-11ea-93ca-77c976b7c43a.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Improves atmos in this area to closer match the rest of the station. Consistency is good.
Also fixes #53176 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: VexingRaven
tweak: A few tweaks have been made to DeltaStation's surgery atmos piping
add: Added a missing air alarm in DeltaStation's Surgery Room B
add: Added an air alarm in DeltaStation's surgery observation area
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
