### PR TITLE
Janiborgs can now repair damaged hull platings

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -562,7 +562,7 @@
 
 /obj/item/cautery/prt //it's a subtype of cauteries so that it inherits the cautery sprites and behavior and stuff, because I'm too lazy to make sprites for this thing
 	name = "plating repair tool"
-	desc = "A tiny heating device that's powered by a cyborg's excess heat. Its intended purpose is to repair damaged hull platings, but it can also be used as a crude lighter or cautery."
+	desc = "A tiny heating device that's powered by a cyborg's excess heat. Its intended purpose is to repair burnt or damaged hull platings, but it can also be used as a crude lighter or cautery."
 	toolspeed = 1.5 //it's not designed to be used as a cautery (although it's close enough to one to be considered to be a proper cautery instead of just a hot object for the purposes of surgery) 
 	heat = 3800 //this thing is intended for metal-shaping, so it's the same temperature as a lit welder
 	resistance_flags = FIRE_PROOF //if it's channeling a cyborg's excess heat, it's probably fireproof

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -560,6 +560,18 @@
 		S.change_head_color(color2)
 		dropped = TRUE
 
+/obj/item/cautery/prt //it's a subtype of cauteries so that it inherits the cautery sprites and behavior and stuff, because I'm too lazy to make sprites for this thing
+	name = "plating repair tool"
+	desc = "A tiny heating device that's powered by a cyborg's excess heat. Its intended purpose is to repair damaged platings, but it can also be used as a crude lighter or cautery."
+	toolspeed = 1.5 //it's not designed to be used as a cautery (although it's close enough to one to be considered to be a proper cautery instead of just a hot object for the purposes of surgery) 
+	heat = 3800 //this thing is intended for metal-shaping, so it's the same temperature as a lit welder
+	resistance_flags = FIRE_PROOF //if it's channeling a cyborg's excess heat, it's probably fireproof
+	force = 5
+	damtype = BURN
+	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg') //the usesounds of a lit welder
+	hitsound = 'sound/items/welder.ogg' //the hitsound of a lit welder
+
+
 #define PKBORG_DAMPEN_CYCLE_DELAY 20
 
 //Peacekeeper Cyborg Projectile Dampenening Field

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -562,7 +562,7 @@
 
 /obj/item/cautery/prt //it's a subtype of cauteries so that it inherits the cautery sprites and behavior and stuff, because I'm too lazy to make sprites for this thing
 	name = "plating repair tool"
-	desc = "A tiny heating device that's powered by a cyborg's excess heat. Its intended purpose is to repair damaged platings, but it can also be used as a crude lighter or cautery."
+	desc = "A tiny heating device that's powered by a cyborg's excess heat. Its intended purpose is to repair damaged hull platings, but it can also be used as a crude lighter or cautery."
 	toolspeed = 1.5 //it's not designed to be used as a cautery (although it's close enough to one to be considered to be a proper cautery instead of just a hot object for the purposes of surgery) 
 	heat = 3800 //this thing is intended for metal-shaping, so it's the same temperature as a lit welder
 	resistance_flags = FIRE_PROOF //if it's channeling a cyborg's excess heat, it's probably fireproof

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -237,6 +237,27 @@
 		R.module.basic_modules += M
 		R.module.add_module(M, FALSE, TRUE)
 
+/obj/item/borg/upgrade/prt
+	name = "janitor cyborg plating repair tool"
+	desc = "A tiny heating device to repair burnt and damaged hull platings with."
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+	module_type = list(/obj/item/robot_module/janitor)
+	module_flags = BORG_MODULE_JANITOR
+
+/obj/item/borg/upgrade/prt/action(mob/living/silicon/robot/R)
+	. = ..()
+	if(.)
+		var/obj/item/cautery/prt/P = new (R.module)
+		R.module.basic_modules += P
+		R.module.add_module(P, FALSE, TRUE)
+
+/obj/item/borg/upgrade/prt/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(.)
+		for(var/obj/item/cautery/prt/P in R.module.modules)
+			R.module.remove_module(P, TRUE)
+
 /obj/item/borg/upgrade/syndicate
 	name = "illegal equipment module"
 	desc = "Unlocks the hidden, deadlier functions of a cyborg."

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -88,6 +88,13 @@
 			playsound(src, 'sound/weapons/genhit.ogg', 50, TRUE)
 		else
 			to_chat(user, "<span class='warning'>This section is too damaged to support a tile! Use a welder to fix the damage.</span>")
+	else if(istype(C, /obj/item/cautery/prt)) //plating repair tool
+		if((broken || burnt) && I.use_tool(src, user, 0, volume=80))
+			to_chat(user, "<span class='danger'>You fix some dents on the broken plating.</span>")
+			icon_state = icon_plating
+			burnt = FALSE
+			broken = FALSE
+
 
 /turf/open/floor/plating/welder_act(mob/living/user, obj/item/I)
 	..()

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -51,7 +51,10 @@
 		return
 	if(istype(C, /obj/item/stack/rods) && attachment_holes)
 		if(broken || burnt)
-			to_chat(user, "<span class='warning'>Repair the plating first!</span>")
+			if(!iscyborg(user))
+				to_chat(user, "<span class='warning'>Repair the plating first! Use a welding tool to fix the damage.</span>")
+			else
+				to_chat(user, "<span class='warning'>Repair the plating first! Use a welding tool or a plating repair tool to fix the damage.</span>") //we don't need to confuse humans by giving them a message about plating repair tools, since only janiborgs should have access to them outside of Christmas presents or admin intervention
 			return
 		var/obj/item/stack/rods/R = C
 		if (R.get_amount() < 2)
@@ -87,7 +90,10 @@
 
 			playsound(src, 'sound/weapons/genhit.ogg', 50, TRUE)
 		else
-			to_chat(user, "<span class='warning'>This section is too damaged to support a tile! Use a welder to fix the damage.</span>")
+			if(!iscyborg(user))
+				to_chat(user, "<span class='warning'>This section is too damaged to support a tile! Use a welding tool to fix the damage.</span>")
+			else
+				to_chat(user, "<span class='warning'>This section is too damaged to support a tile! Use a welding tool or a plating repair tool to fix the damage.</span>")
 	else if(istype(C, /obj/item/cautery/prt)) //plating repair tool
 		if((broken || burnt) && I.use_tool(src, user, 0, volume=80))
 			to_chat(user, "<span class='danger'>You fix some dents on the broken plating.</span>")

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -95,7 +95,7 @@
 			else
 				to_chat(user, "<span class='warning'>This section is too damaged to support a tile! Use a welding tool or a plating repair tool to fix the damage.</span>")
 	else if(istype(C, /obj/item/cautery/prt)) //plating repair tool
-		if((broken || burnt) && I.use_tool(src, user, 0, volume=80))
+		if((broken || burnt) && C.use_tool(src, user, 0, volume=80))
 			to_chat(user, "<span class='danger'>You fix some dents on the broken plating.</span>")
 			icon_state = icon_plating
 			burnt = FALSE

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -403,6 +403,7 @@
 		/obj/item/reagent_containers/glass/bucket,
 		/obj/item/paint/paint_remover,
 		/obj/item/lightreplacer/cyborg,
+		/obj/item/cautery/prt,
 		/obj/item/holosign_creator/janibarrier,
 		/obj/item/reagent_containers/spray/cyborg_drying)
 	radio_channels = list(RADIO_CHANNEL_SERVICE)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -403,7 +403,6 @@
 		/obj/item/reagent_containers/glass/bucket,
 		/obj/item/paint/paint_remover,
 		/obj/item/lightreplacer/cyborg,
-		/obj/item/cautery/prt,
 		/obj/item/holosign_creator/janibarrier,
 		/obj/item/reagent_containers/spray/cyborg_drying)
 	radio_channels = list(RADIO_CHANNEL_SERVICE)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -750,6 +750,15 @@
 	construction_time = 40
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_prt
+	name = "Cyborg Upgrade (Plating Repair Tool)"
+	id = "borg_upgrade_prt"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/prt
+	materials = list(/datum/material/iron = 2500, /datum/material/glass = 750) //same price as a cautery
+	construction_time = 40
+	category = list("Cyborg Upgrade Modules")
+
 /datum/design/borg_upgrade_expand
 	name = "Cyborg Upgrade (Expand)"
 	id = "borg_upgrade_expand"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -311,7 +311,7 @@
 	display_name = "Cyborg Upgrades: Utility"
 	description = "Utility upgrades for cyborgs."
 	prereq_ids = list("adv_robotics")
-	design_ids = list("borg_upgrade_thrusters", "borg_upgrade_selfrepair", "borg_upgrade_expand", "borg_upgrade_disablercooler", "borg_upgrade_trashofholding", "borg_upgrade_advancedmop", "borg_upgrade_broomer")
+	design_ids = list("borg_upgrade_thrusters", "borg_upgrade_selfrepair", "borg_upgrade_expand", "borg_upgrade_disablercooler", "borg_upgrade_trashofholding", "borg_upgrade_advancedmop", "borg_upgrade_broomer", "borg_upgrade_prt")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 5000
 


### PR DESCRIPTION
## About The Pull Request

The "plating repair tool" has been added to the game in the form of a printable upgrade for janiborgs. It's a subtype of the cautery that can repair burnt or damaged hull platings, allowing floor tiles to be placed over them once again.

The upgrade that adds it to a janiborg's list of tools can be printed once the Cyborg Upgrades: Utility tech node is researched.

## Why It's Good For The Game

Janiborgs get floor tiles (and a crowbar), but have no way of dealing with burnt platings. Thus, what ends up happening is that, after fixing some flooring after a minor explosion, you'll often be left with one or two ugly, OCD-triggering untiled spots on the floor that you can't put a floor tile over because you don't have a welder. What makes these spots even more infuriating is that it would actually be BETTER if they had been broken down to just being space-exposed rods, because then you COULD place a floor tile on their tile.

## Changelog
:cl: ATHATH
add: The "plating repair tool" has been added to the game in the form of a printable upgrade for janiborgs. It's a subtype of the cautery that can repair burnt or damaged hull platings, allowing floor tiles to be placed over them once again.
add: The upgrade that adds it to a janiborg's list of tools can be printed once the Cyborg Upgrades: Utility tech node is researched.
/:cl: