### PR TITLE
Blob spore tweaks

### DIFF
--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -111,7 +111,7 @@
 	movement_type = FLYING
 	del_on_death = TRUE
 	deathmessage = "explodes into a cloud of gas!"
-	gold_core_spawnable = HOSTILE_SPAWN
+	gold_core_spawnable = NO_SPAWN //gold slime cores should only spawn the independent subtype
 	var/death_cloud_size = 1 //size of cloud produced from a dying spore
 	var/mob/living/carbon/human/oldguy
 	var/is_zombie = FALSE
@@ -232,7 +232,7 @@
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_BLOBSPORE, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
 
 /mob/living/simple_animal/hostile/blob/blobspore/independent
-	gold_core_spawnable = FALSE
+	gold_core_spawnable = HOSTILE_SPAWN
 	independent = TRUE
 
 /mob/living/simple_animal/hostile/blob/blobspore/weak
@@ -243,7 +243,6 @@
 	melee_damage_upper = 2
 	death_cloud_size = 0
 	is_weak = TRUE
-	gold_core_spawnable = NO_SPAWN
 
 /////////////////
 // BLOBBERNAUT //

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -100,8 +100,8 @@
 	verb_yell = "psychically screams"
 	melee_damage_lower = 2
 	melee_damage_upper = 4
-	obj_damage = 20
-	environment_smash = ENVIRONMENT_SMASH_STRUCTURES
+	environment_smash = ENVIRONMENT_SMASH_NONE
+	obj_damage = 0
 	attack_verb_continuous = "hits"
 	attack_verb_simple = "hit"
 	attack_sound = 'sound/weapons/genhit1.ogg'
@@ -166,6 +166,8 @@
 	mob_biotypes |= MOB_HUMANOID
 	melee_damage_lower += 8
 	melee_damage_upper += 11
+	obj_damage = 20 //now that it has a corpse to puppet, it can properly attack structures
+	environment_smash = ENVIRONMENT_SMASH_STRUCTURES
 	movement_type = GROUND
 	death_cloud_size = 0
 	icon = H.icon

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -73,9 +73,6 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/blob/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
-	if(!overmind)
-		..()
-		return
 	var/spanned_message = say_quote(message)
 	var/rendered = "<font color=\"#EE4000\"><b>\[Blob Telepathy\] [real_name]</b> [spanned_message]</font>"
 	for(var/M in GLOB.mob_list)


### PR DESCRIPTION
## About The Pull Request

This PR removes default blob spores from the gold slime core spawning pool, but adds independent blob spores to the gold slime core spawning pool in their place.

Independent blob spores and blobbernauts can now speak over blob chat like overmind-dependent blob mobs do. This also means that, like overmind-dependent blob mobs, they can't speak out loud (trying to speak will just send your message out over blob chat). They should still be able to emote, though.

Blob spores can no longer harm objects/structures before they become blob zombies (once they possess a corpse, though, they'll start damaging stuff again).

## Why It's Good For The Game

Default blob spores can't drag stuff, but independent ones can (independent ones can't walk through blob tiles freely, however). Also, independent blobbernauts are in the gold slime core pool, but normal blobbernauts are not, so it seems pretty clear that the independent blob creatures are the ones that're supposed to be in the gold slime core pool, not the overmind-dependent ones.

Independent blob spores and blobbernauts could hear blob chat before this PR, but couldn't speak over it. Now, if a xenobiologist amasses an army of blob mobs, they can all metacomm with each other, making blobbernauts slightly more unique in comparison to the other available "unga dunga me smash" mobs.

Finally, the blobs spore structure damage thing is in here because https://github.com/tgstation/tgstation/pull/52998 mentioned it in its "About The Pull Request" section and its changelog, but then forgot to actually, well, implement it. Since that PR's merged and I'm editing the blob spore file anwyay, I figured that I might as well fix that so that Indieana doesn't have to make another PR ~~and so that my vat-grown blob spores won't destroy my vats and delicate plumbing machinery~~.

## Changelog
:cl: ATHATH
fix: Blob spores from gold slime core and hostile life reactions are now marked as being independent, meaning that they can now drag things, but can no longer freely walk through blob tiles.
balance: Independent blob spores and blobbernauts can now speak over blob chat like overmind-dependent blob mobs do.
fix: Blob spores can no longer damage the environment, for realzies this time. This change does not affect blob zombies.
/:cl: