### PR TITLE
You can now print stethoscopes from autolathes and medical protolathes

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -558,6 +558,15 @@
 	category = list("initial", "Medical", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/stethoscope
+	name = "Stethoscope"
+	id = "stethoscope"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/iron = 1000)
+	build_path = /obj/item/clothing/neck/stethoscope
+	category = list("initial", "Medical", "Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
 /datum/design/beaker
 	name = "Beaker"
 	id = "beaker"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -56,7 +56,7 @@
 	starting_node = TRUE
 	display_name = "Basic Medical Equipment"
 	description = "Basic medical tools and equipment."
-	design_ids = list("cybernetic_liver", "cybernetic_heart", "cybernetic_lungs","cybernetic_stomach", "scalpel", "circular_saw", "bonesetter", "surgicaldrill", "retractor", "cautery", "hemostat",
+	design_ids = list("cybernetic_liver", "cybernetic_heart", "cybernetic_lungs","cybernetic_stomach", "scalpel", "circular_saw", "bonesetter", "surgicaldrill", "retractor", "cautery", "hemostat", "stethoscope", 
 					"surgical_drapes", "syringe", "plumbing_rcd", "beaker", "large_beaker", "xlarge_beaker", "dropper", "defibmountdefault", "surgical_tape", "portable_chem_mixer")
 
 /////////////////////////Biotech/////////////////////////


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

They're supposed to be the way (other than repeated explosions) that you (sanely) crack a safe, but you can't print them, so if the map you're on doesn't have one or if someone else has already yoinked it, you're kinda shit outta luck.

In particular, this makes it so that a stethoscope doesn't need to be added to https://github.com/tgstation/tgstation/pull/53185 in order to make its safe (sanely) crackable without the usage of explosives.

Also, it just doesn't really make sense for stethoscopes, of all things, to be rare and unprintable.

## Changelog
:cl: ATHATH
add: You can now print stethoscopes from autolathes and medical protolathes.
/:cl:
