### PR TITLE
Tweaks meta brig and vault area to expand the Warden's Office

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1881,7 +1881,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "aet" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/security_unit{
@@ -1928,8 +1928,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "aey" = (
 /turf/closed/wall,
 /area/security/range)
@@ -2623,15 +2626,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/security/warden";
-	dir = 8;
-	name = "Gear Room APC";
-	pixel_x = -25
-	},
-/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "afZ" = (
 /obj/structure/table,
 /obj/item/storage/box/evidence{
@@ -3101,7 +3097,7 @@
 "agS" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
-/area/security/warden)
+/area/security/main)
 "agT" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -3417,8 +3413,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ahB" = (
-/turf/closed/wall,
-/area/security/warden)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "ahC" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -3479,13 +3477,13 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ahG" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "ahI" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/disposalpipe/segment{
@@ -3814,12 +3812,12 @@
 /area/security/brig)
 "ait" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "aiv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -3931,17 +3929,9 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aiC" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "aiD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -3975,7 +3965,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "aiI" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #3";
@@ -4269,9 +4259,12 @@
 /area/security/brig)
 "ajs" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "ajt" = (
 /obj/structure/closet{
 	name = "Evidence Closet 5"
@@ -4352,7 +4345,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "ajz" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4378,7 +4371,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "ajB" = (
 /obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/tile/neutral{
@@ -4981,8 +4974,9 @@
 "akI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "akJ" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/tile/red{
@@ -4993,7 +4987,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "akK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -5632,7 +5626,7 @@
 	req_one_access_txt = "1;4"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "alY" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -5668,7 +5662,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "amd" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -5681,14 +5675,15 @@
 /area/security/main)
 "ame" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "amf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "amg" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -6358,7 +6353,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "anv" = (
 /obj/machinery/camera{
 	c_tag = "Security - Office - Port";
@@ -6648,23 +6643,19 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aog" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port/fore)
-"aoh" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"aoh" = (
+/obj/item/vending_refill/cigarette,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "aoi" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/item/tank/internals/oxygen,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoj" = (
@@ -6736,7 +6727,6 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aor" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
@@ -6825,7 +6815,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "aoB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -7280,11 +7270,9 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "apy" = (
-/obj/structure/light_construct/small{
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
-	},
-/obj/structure/chair{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -7305,11 +7293,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "apC" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/item/tank/internals/oxygen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "apD" = (
@@ -7391,7 +7377,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "apR" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -32
@@ -7887,16 +7873,21 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqQ" = (
-/obj/item/vending_refill/cigarette,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"aqR" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
+/area/maintenance/port/fore)
+"aqR" = (
+/obj/structure/light_construct/small{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqS" = (
 /obj/structure/closet/crate,
@@ -7909,14 +7900,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 6
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqX" = (
@@ -7980,14 +7968,14 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
 /obj/machinery/camera{
 	c_tag = "Brig - Hallway - Port"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -8052,7 +8040,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "arj" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/tile/red,
@@ -8060,11 +8048,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "ark" = (
 /obj/machinery/newscaster/security_unit,
 /turf/closed/wall,
-/area/security/warden)
+/area/security/main)
 "arl" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/tile/red{
@@ -8461,21 +8449,22 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"asm" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"asm" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Brig Maintenance";
-	req_one_access_txt = "63;12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -9092,6 +9081,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
@@ -9104,13 +9094,13 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "atG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	name = "Brig Maintenance";
+	req_one_access_txt = "63;12"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "atH" = (
@@ -9143,13 +9133,9 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "atK" = (
-/obj/machinery/computer/shuttle/labor{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "atL" = (
@@ -9181,11 +9167,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -9193,18 +9179,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "atQ" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction{
+/obj/machinery/computer/shuttle/labor{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "atR" = (
@@ -9572,13 +9560,7 @@
 /area/hallway/primary/central)
 "auU" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -9625,19 +9607,21 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "auZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/security/warden)
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ava" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
@@ -9647,9 +9631,14 @@
 /area/security/brig)
 "avb" = (
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 6
 	},
-/obj/structure/cable,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "avc" = (
@@ -10031,36 +10020,23 @@
 	},
 /area/maintenance/port/fore)
 "avY" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/security/warden)
 "avZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/obj/machinery/button/door{
-	id = "prison release";
-	name = "Labor Camp Shuttle Lockdown";
-	pixel_y = -25;
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"awa" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"awa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -10070,10 +10046,10 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 6
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 6
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -10099,11 +10075,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"awf" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "awg" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -10402,7 +10373,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "awV" = (
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -10410,6 +10383,37 @@
 /turf/closed/wall/r_wall,
 /area/security/nuke_storage)
 "awZ" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"axc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
+"axe" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/machinery/button/door{
+	id = "prison release";
+	name = "Labor Camp Shuttle Lockdown";
+	pixel_y = -25;
+	req_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"axf" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -10417,34 +10421,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"axc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
-"axe" = (
-/obj/machinery/door_timer{
-	id = "Cell 2";
-	name = "Cell 2";
-	pixel_y = -32
-	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"axf" = (
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "axg" = (
@@ -10462,14 +10438,14 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "axi" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control";
+	req_access_txt = "3"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "axj" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -10515,7 +10491,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "axm" = (
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/security/brig";
@@ -10773,15 +10749,13 @@
 	},
 /area/maintenance/starboard/fore)
 "axR" = (
-/obj/machinery/photocopier{
-	pixel_y = 3
+/obj/machinery/door_timer{
+	id = "Cell 2";
+	name = "Cell 2";
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "axS" = (
@@ -10954,21 +10928,6 @@
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
 "ayo" = (
-/obj/machinery/computer/bank_machine,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/nuke_storage)
-"ayp" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
@@ -10976,7 +10935,7 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
-"ayq" = (
+"ayp" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
@@ -10987,7 +10946,7 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
-"ayr" = (
+"ayq" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/nuke_storage";
 	dir = 1;
@@ -10999,7 +10958,7 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
-"ays" = (
+"ayr" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
 /obj/effect/turf_decal/bot_white,
@@ -11015,6 +10974,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
+"ays" = (
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	name = "Cell 3";
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ayw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
@@ -11025,41 +10999,25 @@
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
 "ayx" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 1";
-	name = "Cell 1"
+/obj/machinery/computer/prisoner/management{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "ayy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ayz" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control";
-	req_access_txt = "3"
-	},
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"ayA" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Warden's Office";
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/security/warden";
+	dir = 1;
+	name = "Brig Control APC";
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -11400,23 +11358,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "azv" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/nuke_storage)
-"azw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 10
 	},
@@ -11424,7 +11365,7 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
-"azx" = (
+"azw" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -11438,7 +11379,7 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
-"azy" = (
+"azx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
@@ -11447,7 +11388,7 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
-"azz" = (
+"azy" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -11464,45 +11405,58 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
-"azC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/primary/fore)
-"azD" = (
-/obj/machinery/flasher{
-	id = "Cell 1";
-	pixel_x = -28
+"azz" = (
+/obj/machinery/computer/bank_machine,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
+"azD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "azE" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 1";
+	name = "Cell 1"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "azG" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 2";
+	name = "Cell 2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "azK" = (
@@ -11926,10 +11880,22 @@
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "aAN" = (
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 3";
+	name = "Cell 3"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "aAO" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/turf_decal/tile/brown,
@@ -11942,21 +11908,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aAP" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/structure/closet/crate/goldcrate,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/nuke_storage)
-"aAQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
 	},
@@ -11964,7 +11915,7 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
-"aAR" = (
+"aAQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
 	},
@@ -11975,7 +11926,7 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
-"aAS" = (
+"aAR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
@@ -11984,7 +11935,7 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
-"aAT" = (
+"aAS" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/structure/closet/crate/silvercrate,
 /obj/effect/turf_decal/tile/neutral{
@@ -11999,25 +11950,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
-"aAV" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_home";
-	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
-	width = 9
+"aAT" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/turf/open/space/basic,
-/area/space)
-"aAW" = (
+/obj/machinery/camera{
+	c_tag = "Warden's Office";
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
+"aAV" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock"
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"aAX" = (
+"aAW" = (
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 28
@@ -12039,21 +11989,39 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"aAX" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "aAY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
+	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aBa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/flasher{
+/obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
-	pixel_x = -23;
-	pixel_y = -23
+	name = "Cell 3 Locker"
 	},
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aBb" = (
@@ -12454,31 +12422,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/fore)
 "aCd" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/machinery/ore_silo,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/nuke_storage)
-"aCe" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
-"aCf" = (
+"aCe" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -12488,7 +12442,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
-"aCg" = (
+"aCf" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
 	dir = 1;
@@ -12501,7 +12455,7 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
-"aCh" = (
+"aCg" = (
 /obj/structure/safe,
 /obj/item/storage/secure/briefcase{
 	contents = newlist(/obj/item/clothing/suit/armor/vest,/obj/item/gun/ballistic/automatic/pistol,/obj/item/suppressor,/obj/item/melee/classic_baton/telescopic,/obj/item/clothing/mask/balaclava,/obj/item/bodybag,/obj/item/soap/nanotrasen)
@@ -12531,13 +12485,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
-"aCj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Shuttle Airlock"
-	},
-/turf/open/floor/plasteel/dark,
+"aCh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/hallway/primary/fore)
+"aCj" = (
+/obj/machinery/flasher{
+	id = "Cell 1";
+	pixel_x = -28
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "aCk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -12871,7 +12833,8 @@
 /area/quartermaster/miningoffice)
 "aDl" = (
 /obj/structure/disposalpipe/segment,
-/turf/closed/wall,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aDm" = (
 /obj/structure/disposalpipe/segment,
@@ -12908,6 +12871,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aDr" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/security/nuke_storage)
+"aDs" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/vault{
 	name = "Vault";
@@ -12930,14 +12897,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
-"aDs" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/security/nuke_storage)
 "aDu" = (
-/turf/closed/wall,
-/area/hallway/primary/fore)
-"aDv" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "prison release";
 	name = "prisoner processing blast door"
@@ -12951,6 +12911,9 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"aDv" = (
+/turf/closed/wall,
+/area/hallway/primary/fore)
 "aDw" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -12958,33 +12921,33 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aDx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"aDy" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aDy" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aDz" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
 	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Fore Primary Hallway Cells"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/security/brig)
 "aDA" = (
 /obj/machinery/light{
 	dir = 1
@@ -13015,10 +12978,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aDE" = (
-/obj/machinery/computer/prisoner/management{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aDF" = (
@@ -13045,7 +13004,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "aDH" = (
 /obj/structure/closet/secure_closet/brig,
 /turf/open/floor/plasteel/dark,
@@ -13439,6 +13398,45 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aEG" = (
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching Prison Wing holding areas.";
+	name = "Prison Monitor";
+	network = list("prison");
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
+"aEH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/construction/storage_wing)
+"aEI" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"aEJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"aEK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"aEL" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/structure/closet/crate/goldcrate,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -13449,43 +13447,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
-/area/construction/storage_wing)
-"aEH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/construction/storage_wing)
-"aEI" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"aEJ" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"aEK" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=1.5-Fore-Central";
-	location = "1-BrigCells"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"aEL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/security/nuke_storage)
 "aEM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -13545,7 +13508,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "aEX" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
@@ -13888,28 +13851,17 @@
 /turf/closed/wall,
 /area/construction/storage_wing)
 "aFR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Vault Storage"
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 2;
+	height = 5;
+	id = "laborcamp_home";
+	name = "fore bay 1";
+	roundstart_template = /datum/map_template/shuttle/labour/box;
+	width = 9
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/construction/storage_wing)
+/turf/open/space/basic,
+/area/space)
 "aFV" = (
 /obj/machinery/status_display/supply{
 	pixel_y = 32
@@ -13924,11 +13876,11 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aFW" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "aFX" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/brown{
@@ -13943,14 +13895,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aFY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Security-Storage Backroom";
-	req_access_txt = "63"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -23;
+	pixel_y = -23
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "aFZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -14517,23 +14471,32 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aHn" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"aHp" = (
-/obj/structure/cable,
-/obj/item/kirbyplants/random,
-/obj/machinery/camera{
-	c_tag = "Outer Vault";
-	dir = 4;
-	name = "storage wing camera"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/flasher{
+	id = "Cell 3";
+	pixel_x = -23;
+	pixel_y = -23
 	},
+/obj/structure/bed,
+/obj/item/bedsheet,
 /turf/open/floor/plasteel,
-/area/construction/storage_wing)
+/area/security/brig)
+"aHp" = (
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "aHs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -14902,30 +14865,33 @@
 /area/maintenance/starboard/fore)
 "aIw" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/construction/storage_wing)
-"aIx" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
-"aIz" = (
-/obj/machinery/light{
+"aIx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/construction/storage_wing)
+"aIz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 10
+	},
+/obj/machinery/camera{
+	c_tag = "Outer Vault";
+	dir = 8;
+	name = "storage wing camera"
 	},
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
@@ -15214,13 +15180,20 @@
 /turf/closed/wall,
 /area/hydroponics/garden)
 "aJi" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 10
+/obj/effect/turf_decal/bot_white/right,
+/obj/machinery/ore_silo,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "aJj" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/field/generator,
@@ -60832,13 +60805,11 @@
 /area/maintenance/department/science/xenobiology)
 "cTY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/flasher{
+/obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
-	pixel_x = -23;
-	pixel_y = -23
+	name = "Cell 2 Locker"
 	},
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cUL" = (
@@ -63553,19 +63524,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dhv" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 2";
-	name = "Cell 2"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Labor Camp Shuttle Airlock"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
 "dhw" = (
 /obj/structure/closet,
 /obj/item/poster/random_contraband,
@@ -63580,13 +63544,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dhy" = (
@@ -63658,15 +63622,15 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "dhG" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;63;48;50"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/construction/storage_wing)
 "dhH" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/sign/poster/contraband/random{
@@ -64399,22 +64363,26 @@
 	},
 /area/maintenance/port/fore)
 "dnM" = (
-/obj/structure/chair{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "dnO" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dnP" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/port/fore)
 "dnR" = (
 /obj/structure/grille,
@@ -65042,22 +65010,17 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "dBX" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 3";
-	name = "Cell 3"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Fore Primary Hallway Cells"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/fore)
 "dBY" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
@@ -65135,7 +65098,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "dCg" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -65147,6 +65110,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dCh" = (
@@ -66005,8 +65969,10 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "ejE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -66126,7 +66092,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "epU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -66466,14 +66432,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison/safe)
 "eYX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/port/fore)
 "eZe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -67731,6 +67695,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"gGR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/port/fore)
 "gHf" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -67999,19 +67972,21 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "hjl" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 9
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/dark,
+/area/construction/storage_wing)
 "hkq" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -68222,6 +68197,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"hzr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/port/fore)
 "hzY" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -68713,7 +68697,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "ixE" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -71252,9 +71236,6 @@
 "mDQ" = (
 /obj/structure/cable,
 /obj/structure/bed/dogbed/mcgriff,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8
-	},
 /mob/living/simple_animal/pet/dog/pug/mcgriff,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -71328,6 +71309,16 @@
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"mLy" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;63;48;50"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "mNE" = (
 /obj/machinery/light{
 	dir = 4
@@ -71556,7 +71547,7 @@
 "npx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
+	dir = 9
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -71677,14 +71668,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "nEv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/fore)
 "nHj" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -71707,14 +71696,12 @@
 	},
 /area/medical/break_room)
 "nIb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=1.5-Fore-Central";
+	location = "1-BrigCells"
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/port/fore)
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "nJh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -72482,7 +72469,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "oWY" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow{
@@ -72796,9 +72783,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "pvK" = (
-/obj/machinery/computer/security{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -73822,8 +73806,11 @@
 	c_tag = "Security - Gear Room";
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/security/main)
 "qRO" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -74076,14 +74063,8 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "roZ" = (
-/obj/machinery/computer/secure_data{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
-	pixel_x = -30
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -74993,6 +74974,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "sJW" = (
@@ -75220,6 +75204,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/mixing/chamber)
+"tjB" = (
+/obj/structure/cable,
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/construction/storage_wing)
 "tmp" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -75867,14 +75856,33 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "uvH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Vault Storage"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/dark,
+/area/construction/storage_wing)
+"uvS" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "uxd" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -77696,9 +77704,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "xjc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+/obj/machinery/light/small{
 	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -78416,6 +78432,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/security/prison)
+"ykl" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Security-Storage Backroom";
+	req_access_txt = "63"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
 "ylE" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
@@ -97283,7 +97308,7 @@ aqN
 ask
 alM
 auI
-att
+awV
 dne
 aBZ
 dpG
@@ -98055,16 +98080,16 @@ dne
 aty
 auL
 avS
-aAN
+auL
 aDl
 aEv
-aIu
-aRG
-aRG
-dnZ
+aEJ
+aHk
+aHk
+eYX
 aHm
-aRG
-dnZ
+aHk
+hzr
 aSZ
 aKZ
 aNV
@@ -98310,18 +98335,18 @@ apw
 dod
 dne
 atH
-fVm
-doJ
-awV
-dnu
 dne
-aJi
-aFW
-aHk
-aHk
-aHk
-aHk
-aIs
+dne
+dne
+dne
+dne
+dne
+dne
+dne
+dne
+dne
+aHl
+aIu
 aSZ
 aLa
 aNW
@@ -98562,23 +98587,23 @@ ajl
 akr
 alI
 amX
-aRG
+aoh
 dnZ
 aqP
 dne
 atA
 dne
+aaa
+aaa
+aaf
+aaa
+aaa
+aaf
+aaa
+aaa
 dne
-dne
-dne
-dne
-dne
-dne
-dne
-dne
-dne
-aHl
-aIu
+dnk
+gGR
 aSZ
 aLb
 aNX
@@ -98819,23 +98844,23 @@ aio
 aks
 alJ
 amY
-aRG
-aRG
+aoi
+aqR
 aqQ
 dne
 atB
 dne
-aaa
-aaa
 aaf
-aaa
-aaa
+awW
+awW
+awW
+awW
+awW
+awW
 aaf
-aaa
-aaa
 dne
-dnk
-nIb
+uvS
+aIu
 cTs
 aRS
 asY
@@ -99076,23 +99101,23 @@ aio
 aio
 aio
 aio
-dnM
-apy
-aqR
+dne
+dne
+dne
 dne
 akm
 dne
-aaf
+aaa
 awW
+azz
+aAX
+aEL
+aJi
 awW
-awW
-awW
-awW
-awW
-aaf
+aaa
 dne
-aHn
-aIu
+dne
+mLy
 aSZ
 bOq
 aNY
@@ -99331,11 +99356,11 @@ aaa
 aaf
 aaf
 aaf
-aaf
 dne
 dne
-dne
-dne
+dnO
+dnk
+aqS
 dne
 dhx
 anb
@@ -99345,10 +99370,10 @@ ayo
 azv
 aAP
 aCd
-awW
-aaa
-dne
-dne
+aDr
+aEH
+aEH
+tjB
 dhG
 aSZ
 aQq
@@ -99589,10 +99614,10 @@ aeJ
 aaa
 aaa
 dne
-dne
-dnO
-dnk
-aqS
+dnu
+apy
+dod
+dnZ
 dne
 atE
 anb
@@ -99603,9 +99628,9 @@ azw
 aAQ
 aCe
 aDs
-aEH
-aEH
-aHp
+hjl
+uvH
+aXo
 aIw
 aSZ
 aLe
@@ -99845,12 +99870,12 @@ eWu
 aeJ
 lMJ
 lMJ
-dne
-dnu
+aip
+ana
 dnP
-dod
-dnZ
-dne
+doe
+aqT
+asm
 atP
 anb
 aaa
@@ -99860,9 +99885,9 @@ azx
 aAR
 aCf
 aDr
-aEG
-aFR
-aXo
+aEH
+aEH
+rVn
 aIx
 aSZ
 aNF
@@ -100102,13 +100127,13 @@ qCa
 aeJ
 aaa
 aaa
-aip
-ana
+dne
+dnd
 aog
-doe
-aqT
-asl
-atG
+dne
+dne
+dne
+atH
 anb
 aaa
 awW
@@ -100116,8 +100141,8 @@ ayr
 azy
 aAS
 aCg
-aDs
-aEH
+awW
+aaa
 aEH
 aHt
 pMn
@@ -100360,21 +100385,21 @@ aeJ
 lMJ
 lMJ
 dne
-dnd
-aoh
 dne
 dne
 dne
-atH
-anb
-aaa
+asl
+atG
+atI
+dne
+aaf
 awW
-ays
-azz
-aAT
-aCh
 awW
-aaa
+awW
+awW
+awW
+awW
+lMJ
 aEH
 aIB
 aIz
@@ -100616,23 +100641,23 @@ qCa
 aeJ
 aaa
 aaa
+lMJ
 dne
-dne
-dne
-dne
+apC
+doe
 aqU
-asm
-atI
 dne
-aaf
-awW
-awW
-awW
-awW
-awW
-awW
-lAu
-aEH
+dne
+dne
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aFN
 aHt
 aFN
 aJO
@@ -100875,12 +100900,12 @@ lMJ
 lMJ
 lMJ
 dne
-aoi
-aHk
-apC
+aRG
+aRG
+ajT
 dne
-dne
-dne
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -101913,7 +101938,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aFR
 aaa
 aaa
 anb
@@ -102164,18 +102189,18 @@ aon
 vsp
 aqX
 ajm
+ajo
+ajo
+awZ
+ajo
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aCh
 aAV
-aaa
-aaa
-dne
-doJ
-aio
+aCh
+aDv
+aDv
+ykl
+aHx
 anb
 anb
 aio
@@ -102421,17 +102446,17 @@ aoo
 pCw
 iUe
 ajm
+atQ
 ajo
-ajo
-avY
+avk
 ajo
 aaa
-azC
+aDv
 aAW
-azC
+dhv
 aDu
-aDu
-aFY
+nEv
+aFZ
 aHx
 aaa
 aaa
@@ -102679,13 +102704,13 @@ xke
 aqY
 ahx
 atK
-ajo
-avk
-ajo
-aaa
-aDu
-aAX
-aCj
+ahx
+axe
+ahx
+ahx
+ajm
+ajm
+ajm
 aDv
 aEI
 aFZ
@@ -102936,15 +102961,15 @@ gEY
 aqZ
 ahx
 aws
-ahx
+avb
 avZ
-ahx
-ahx
-ajm
-ajm
-ajm
-aDu
-aEJ
+axf
+aiq
+aCj
+aFW
+aCk
+aDy
+aDC
 aFZ
 aHx
 aaa
@@ -103195,13 +103220,13 @@ agT
 aws
 auU
 awa
-awZ
-aiq
+axp
+azE
 azD
 aAY
 aCk
-aDx
-aDC
+aDw
+nIb
 aGb
 aHx
 aaf
@@ -103452,12 +103477,12 @@ apF
 atM
 auV
 awb
-axp
-ayx
-azE
-uvH
-aCk
-aDw
+axg
+ahx
+aiq
+aiq
+ajm
+dnM
 aEK
 aFZ
 aHx
@@ -103709,13 +103734,13 @@ alS
 atN
 alS
 awc
-axg
-ahx
+aws
 aiq
-aiq
-ajm
+aDx
+aFY
+aCk
 aDy
-aEL
+aDC
 aGd
 aHx
 aaa
@@ -103966,12 +103991,12 @@ irI
 sJV
 auW
 ara
-aws
-aiq
+axp
+azG
 xjc
 cTY
 aCk
-aDx
+aDw
 aDC
 asC
 aHx
@@ -104223,13 +104248,13 @@ asp
 ahE
 aiq
 atO
-axp
-dhv
-azG
-eYX
-aCk
-aDw
-aHA
+axR
+ahx
+aiq
+aiq
+ajm
+dnM
+dCr
 aGf
 aHx
 aaf
@@ -104478,15 +104503,15 @@ apJ
 arb
 asq
 ava
-axR
+anB
 awe
-axe
-ahx
+aws
 aiq
-aiq
-ajm
+aDx
+aHn
+aCk
 aDy
-dCr
+aHA
 aGg
 aHx
 aaa
@@ -104736,13 +104761,13 @@ arb
 asr
 ahF
 auY
-avb
-awp
-aiq
-xjc
+awn
+ays
+aAN
+aDz
 aBa
 aCk
-aDx
+aDw
 aHA
 aGh
 aHx
@@ -104991,15 +105016,15 @@ agb
 apL
 aeq
 ass
-ahG
-aiC
+ahI
+adY
 axi
-axf
+ajx
+adY
+ajx
+ajx
+adY
 dBX
-hjl
-nEv
-aCk
-aDw
 aHA
 aHw
 aHy
@@ -105248,15 +105273,15 @@ agc
 apM
 aeq
 ast
-ahI
-adY
+auZ
+avY
 ayz
-ajx
+ayx
+aAT
+aEG
+aHp
 adY
-ajx
-ajx
-adY
-aDz
+aDw
 aHA
 aIr
 aHx
@@ -105505,11 +105530,11 @@ agK
 apN
 cZk
 asu
-atQ
-auZ
-awf
+ahI
+ajx
+pvK
 aDE
-ayA
+aDE
 roZ
 pvK
 aBc
@@ -106263,10 +106288,10 @@ aaf
 aaf
 lMJ
 agS
-ajx
-ajx
+aiD
+aiD
 agS
-adY
+aqa
 aeq
 anl
 anl
@@ -106518,12 +106543,12 @@ aaa
 aaa
 aaf
 aaa
-adY
+aqa
 agS
 aDG
 eph
 oVO
-adY
+aqa
 aes
 ajy
 arj
@@ -106531,7 +106556,7 @@ amb
 afY
 amf
 dCf
-ajx
+aiD
 ahC
 atS
 aaD
@@ -106775,11 +106800,11 @@ aaa
 aaa
 aaf
 aaa
-ajx
+aiD
 axl
 ame
-ame
-ame
+ahB
+ahG
 ehi
 ajs
 akI
@@ -107032,20 +107057,20 @@ aaa
 aaa
 aaf
 aaa
-adY
+aqa
 agS
 aEW
 ixj
 qRr
-adY
+aqa
 aex
 ajA
 akJ
-ame
+aiC
 anu
 aoz
 apQ
-ajx
+aiD
 asz
 ahP
 anB
@@ -107291,17 +107316,17 @@ aaf
 aav
 lMJ
 agS
-ajx
-ajx
+aiD
+aiD
 agS
-adY
-adY
-adY
-ajx
+aqa
+aqa
+aqa
+aiD
 alX
-ahB
-ajx
-ahB
+ajD
+aiD
+ajD
 ark
 aiD
 ajD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This change slides the vault and surrounding areas over by 1 tile, giving room to slide the brig cells area over 1 and give that tile to the Warden. Warden's office (Brig Control) becomes its own area with an APC and air alarm, where previously it had neither of these things and received power from an APC in the Gear Room which was technically Brig Control. This does not add or remove any items from anywhere on the map, although it does make a small part of main slightly smaller.

Before:
![image](https://user-images.githubusercontent.com/1313921/91115847-bd8b0c00-e650-11ea-998a-faf6b4af67de.png)

After:
![image](https://user-images.githubusercontent.com/1313921/91115858-c4198380-e650-11ea-8342-ef21ac4e7be0.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Brig Control on meta currently is absolutely tiny and can't even fit an APC or air alarm. It's the smallest Brig Control of any current map by far. It's still the smallest, but at least now it's a proper area and doesn't piggyback strangely off another part of the brig.
Fixes #50909 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: VexingRaven
tweak: Tweak's MetaStation's vault and brig cells area
tweak: MetaStation's Brig Control is now slightly less claustrophobic
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
