### PR TITLE
Fixes minor view exploit

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -74,7 +74,10 @@
 	update_client_colour()
 	update_mouse_pointer()
 	if(client)
-		client.change_view(getScreenSize(client.prefs.widescreenpref)) // Resets the client.view in case it was changed.
+		if(client.view_size)
+			client.view_size.resetToDefault() // Resets the client.view in case it was changed.
+		else
+			client.change_view(getScreenSize(client.prefs.widescreenpref))
 
 		if(client.player_details.player_actions.len)
 			for(var/datum/action/A in client.player_details.player_actions)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can no longer store view changes when switching mobs, I didn't understand login() properly at the time, if we actually have a view datum we should reset it to base.

## Why It's Good For The Game

fixes #53184 

## Changelog
:cl:
fix: You can no longer increase your view range by messing about with ghostroles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
