### PR TITLE
Adds a sound effect for when the Captain tries to change the station's name

### DIFF
--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -60,10 +60,10 @@
 	// Autoapproves after a certain time
 	response_timer_id = addtimer(CALLBACK(src, .proc/rename_station, new_name, user.name, user.real_name, key_name(user)), approval_time, TIMER_STOPPABLE)
 	to_chat(GLOB.admins, "<span class='adminnotice'><b><font color=orange>CUSTOM STATION RENAME:</font></b>[ADMIN_LOOKUPFLW(user)] proposes to rename the [name_type] to [new_name] (will autoapprove in [DisplayTimeText(approval_time)]). [ADMIN_SMITE(user)] (<A HREF='?_src_=holder;[HrefToken(TRUE)];reject_custom_name=[REF(src)]'>REJECT</A>) [ADMIN_CENTCOM_REPLY(user)]</span>")
-	for(var/client/X in GLOB.admins)
-		if(X.prefs.toggles & SOUND_ADMINHELP)
-			window_flash(X, ignorepref = TRUE)
-			SEND_SOUND(X, sound('sound/effects/gong.ogg'))
+	for(var/client/admin_client in GLOB.admins)
+		if(admin_client.prefs.toggles & SOUND_ADMINHELP)
+			window_flash(admin_client, ignorepref = TRUE)
+			SEND_SOUND(admin_client, sound('sound/effects/gong.ogg'))
 
 /obj/item/station_charter/proc/reject_proposed(user)
 	if(!user)

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -60,6 +60,10 @@
 	// Autoapproves after a certain time
 	response_timer_id = addtimer(CALLBACK(src, .proc/rename_station, new_name, user.name, user.real_name, key_name(user)), approval_time, TIMER_STOPPABLE)
 	to_chat(GLOB.admins, "<span class='adminnotice'><b><font color=orange>CUSTOM STATION RENAME:</font></b>[ADMIN_LOOKUPFLW(user)] proposes to rename the [name_type] to [new_name] (will autoapprove in [DisplayTimeText(approval_time)]). [ADMIN_SMITE(user)] (<A HREF='?_src_=holder;[HrefToken(TRUE)];reject_custom_name=[REF(src)]'>REJECT</A>) [ADMIN_CENTCOM_REPLY(user)]</span>")
+	for(var/client/X in GLOB.admins)
+		if(X.prefs.toggles & SOUND_ADMINHELP)
+			window_flash(X, ignorepref = TRUE)
+			SEND_SOUND(X, sound('sound/effects/gong.ogg'))
 
 /obj/item/station_charter/proc/reject_proposed(user)
 	if(!user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Exactly what it says on the tin. When someone tries to change the name using the charter, a sound plays that only admins can hear. Obeys the same preferences as the adminhelp sounds.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Since it's something admins might need to respond to and it's awkward to do so after the station's already had a name change,
we should probably get a notification on these.
## Changelog
:cl:
admin: Admins will now hear a sound and get a screen flash when someone tries to rename the station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
