### PR TITLE
Flash powder and sonic powder can now damage organs

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -291,6 +291,10 @@
 	var/location = get_turf(holder.my_atom)
 	do_sparks(2, TRUE, location)
 	var/range = created_volume/3
+	if (created_volume >= 15)
+		for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/3, location))
+			C.adjustOrganLoss(ORGAN_SLOT_EYES,created_volume*1.5)
+
 	if(isatom(holder.my_atom))
 		var/atom/A = holder.my_atom
 		A.flash_lighting_fx(_range = (range + 2))
@@ -310,6 +314,11 @@
 	var/location = get_turf(holder.my_atom)
 	do_sparks(2, TRUE, location)
 	var/range = created_volume/10
+
+	if (created_volume >= 15)
+		for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/3, location))
+			C.adjustOrganLoss(ORGAN_SLOT_EYES,created_volume*1.5)
+
 	if(isatom(holder.my_atom))
 		var/atom/A = holder.my_atom
 		A.flash_lighting_fx(_range = (range + 2))
@@ -363,11 +372,16 @@
 /datum/chemical_reaction/sonic_powder/on_reaction(datum/reagents/holder, created_volume)
 	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
 		return
-	holder.remove_reagent(/datum/reagent/sonic_powder, created_volume*3)
+	holder.remove_reagent(/datum/reagent/sonic_powder, created_volume*1.5)
 	var/location = get_turf(holder.my_atom)
 	playsound(location, 'sound/effects/bang.ogg', 25, TRUE)
+	if (created_volume >= 15)
+		for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/3, location))
+			C.adjustOrganLoss(ORGAN_SLOT_EARS,created_volume*2)
+
 	for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/3, location))
 		C.soundbang_act(1, 100, rand(0, 5))
+
 
 /datum/chemical_reaction/sonic_powder_deafen
 	required_reagents = list(/datum/reagent/sonic_powder = 1)
@@ -376,6 +390,10 @@
 /datum/chemical_reaction/sonic_powder_deafen/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
 	playsound(location, 'sound/effects/bang.ogg', 25, TRUE)
+	if (created_volume >= 15)
+		for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/3, location))
+			C.adjustOrganLoss(ORGAN_SLOT_EARS,created_volume*1.5)
+
 	for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/10, location))
 		C.soundbang_act(1, 100, rand(0, 5))
 


### PR DESCRIPTION
## About The Pull Request
Flash powder and Sonic powder can now damage organs.

## Why It's Good For The Game
Because it's dumb when massive reactions which can effect half the map don't damage your eyes/ears

## Changelog
:cl:
add: Flash powder and Sonic powder can now damage organs.
/:cl:
