### PR TITLE
Change signature of BINARY_INSERT to require the full type path, add test

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -37,6 +37,7 @@
 	* TYPECONT: The typepath of the contents of the list
 	* COMPARE: The object to compare against, usualy the same as INPUT
 	* COMPARISON: The variable on the objects to compare
+	* COMPTYPE: How should the values be compared? Either COMPARE_KEY or COMPARE_VALUE.
 	*/
 #define BINARY_INSERT(INPUT, LIST, TYPECONT, COMPARE, COMPARISON, COMPTYPE) \
 	do {\

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -48,7 +48,7 @@
 			var/__BIN_LEFT = 1;\
 			var/__BIN_RIGHT = __BIN_CTTL;\
 			var/__BIN_MID = (__BIN_LEFT + __BIN_RIGHT) >> 1;\
-			var/##TYPECONT/__BIN_ITEM;\
+			var ##TYPECONT/__BIN_ITEM;\
 			while(__BIN_LEFT < __BIN_RIGHT) {\
 				__BIN_ITEM = COMPTYPE;\
 				if(__BIN_ITEM.##COMPARISON <= COMPARE.##COMPARISON) {\

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -157,7 +157,7 @@ SUBSYSTEM_DEF(runechat)
 
 	// Handle insertion into the secondary queue if the required time is outside our tracked amounts
 	if (scheduled_destruction >= BUCKET_LIMIT)
-		BINARY_INSERT(src, SSrunechat.second_queue, datum/chatmessage, src, scheduled_destruction, COMPARE_KEY)
+		BINARY_INSERT(src, SSrunechat.second_queue, /datum/chatmessage, src, scheduled_destruction, COMPARE_KEY)
 		return
 
 	// Get bucket position and a local reference to the datum var, it's faster to access this way

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -121,7 +121,7 @@ SUBSYSTEM_DEF(timer)
 		if(ctime_timer.flags & TIMER_LOOP)
 			ctime_timer.spent = 0
 			ctime_timer.timeToRun = REALTIMEOFDAY + ctime_timer.wait
-			BINARY_INSERT(ctime_timer, clienttime_timers, datum/timedevent, ctime_timer, timeToRun, COMPARE_KEY)
+			BINARY_INSERT(ctime_timer, clienttime_timers, /datum/timedevent, ctime_timer, timeToRun, COMPARE_KEY)
 		else
 			qdel(ctime_timer)
 
@@ -524,7 +524,7 @@ SUBSYSTEM_DEF(timer)
 	else if (timeToRun >= TIMER_MAX)
 		L = SStimer.second_queue
 	if(L)
-		BINARY_INSERT(src, L, datum/timedevent, src, timeToRun, COMPARE_KEY)
+		BINARY_INSERT(src, L, /datum/timedevent, src, timeToRun, COMPARE_KEY)
 		return
 
 	// Get a local reference to the bucket list, this is faster than referencing the datum

--- a/code/modules/actionspeed/_actionspeed_modifier.dm
+++ b/code/modules/actionspeed/_actionspeed_modifier.dm
@@ -69,7 +69,7 @@ GLOBAL_LIST_EMPTY(actionspeed_modification_cache)
 			return TRUE
 		remove_actionspeed_modifier(existing, FALSE)
 	if(length(actionspeed_modification))
-		BINARY_INSERT(type_or_datum.id, actionspeed_modification, datum/actionspeed_modifier, type_or_datum, priority, COMPARE_VALUE)
+		BINARY_INSERT(type_or_datum.id, actionspeed_modification, /datum/actionspeed_modifier, type_or_datum, priority, COMPARE_VALUE)
 	LAZYSET(actionspeed_modification, type_or_datum.id, type_or_datum)
 	if(update)
 		update_actionspeed()

--- a/code/modules/movespeed/_movespeed_modifier.dm
+++ b/code/modules/movespeed/_movespeed_modifier.dm
@@ -80,7 +80,7 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 			return TRUE
 		remove_movespeed_modifier(existing, FALSE)
 	if(length(movespeed_modification))
-		BINARY_INSERT(type_or_datum.id, movespeed_modification, datum/movespeed_modifier, type_or_datum, priority, COMPARE_VALUE)
+		BINARY_INSERT(type_or_datum.id, movespeed_modification, /datum/movespeed_modifier, type_or_datum, priority, COMPARE_VALUE)
 	LAZYSET(movespeed_modification, type_or_datum.id, type_or_datum)
 	if(update)
 		update_movespeed()

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -12,6 +12,7 @@
 
 #include "anchored_mobs.dm"
 #include "bespoke_id.dm"
+#include "binary_insert.dm"
 #include "card_mismatch.dm"
 #include "chain_pull_through_space.dm"
 #include "component_tests.dm"

--- a/code/modules/unit_tests/binary_insert.dm
+++ b/code/modules/unit_tests/binary_insert.dm
@@ -1,0 +1,26 @@
+/// A test to ensure the sanity of BINARY_INSERT
+/datum/unit_test/binary_insert/Run()
+	var/list/datum/binary_insert_node/nodes = list()
+
+	var/datum/binary_insert_node/node_a = new /datum/binary_insert_node(10)
+	BINARY_INSERT(node_a, nodes, /datum/binary_insert_node, node_a, x, COMPARE_KEY)
+	TEST_ASSERT_EQUAL(nodes.len, 1, "List should have one node")
+
+	var/datum/binary_insert_node/node_b = new /datum/binary_insert_node(5)
+	BINARY_INSERT(node_b, nodes, /datum/binary_insert_node, node_b, x, COMPARE_KEY)
+	TEST_ASSERT_EQUAL(nodes.len, 2, "List should have two nodes")
+	TEST_ASSERT_EQUAL(nodes[1].x, 5, "The first node should be the one with 5")
+	TEST_ASSERT_EQUAL(nodes[2].x, 10, "The second node should be the one with 10")
+
+	var/datum/binary_insert_node/node_c = new /datum/binary_insert_node(15)
+	BINARY_INSERT(node_c, nodes, /datum/binary_insert_node, node_c, x, COMPARE_KEY)
+	TEST_ASSERT_EQUAL(nodes.len, 3, "List should have three nodes")
+	TEST_ASSERT_EQUAL(nodes[1].x, 5, "The first node should be the one with 5")
+	TEST_ASSERT_EQUAL(nodes[2].x, 10, "The second node should be the one with 10")
+	TEST_ASSERT_EQUAL(nodes[3].x, 15, "The third node should be the one with 15")
+
+/datum/binary_insert_node
+	var/x
+
+/datum/binary_insert_node/New(_x)
+	x = _x


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
BINARY_INSERT used to only take typepaths `like/this`. Now, it expects them to be `/like/this`, to be more consistent with ther est of the code.

Adds documentation to COMPTYPE.

Adds a test for BINARY_INSERT.