### PR TITLE
Fix grammar on random vent names

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -159,8 +159,9 @@
 
 	var/area/vent_area = get_area(src)
 	if(!GLOB.air_vent_names[id_tag])
-		// If we do not have a name, assign one
-		name = "[assign_random_name()] [vent_area.name] Vent Pump" // matching case
+		// If we do not have a name, assign one.
+		// Produces names like "Port Quarter Solar vent pump hZ2l6".
+		name = "\proper [vent_area.name] vent pump [assign_random_name()]"
 		GLOB.air_vent_names[id_tag] = name
 
 	vent_area.air_vent_info[id_tag] = signal.data

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -117,7 +117,7 @@
 	var/area/scrub_area = get_area(src)
 	if(!GLOB.air_scrub_names[id_tag])
 		// If we do not have a name, assign one
-		name = "[assign_random_name()] [scrub_area.name] Air Scrubber" // matching case
+		name = "\proper [scrub_area.name] air scrubber [assign_random_name()]"
 		GLOB.air_scrub_names[id_tag] = name
 
 	scrub_area.air_scrub_info[id_tag] = signal.data


### PR DESCRIPTION
Iteration upon #52398.

Before, inconsistent:

> That's a hZ2l6 Atmospherics Hallway Vent Pump.
> That's RJkb5 Departure Lounge Air Scrubber.

After, consistent:

> That's Atmospherics Hallway vent pump hZ2l6.
> That's Departure Lounge air scrubber 29m5z.