### PR TITLE
Fix ruin areas missing their areas_by_type entry

### DIFF
--- a/code/game/area/areas/ruins/_ruins.dm
+++ b/code/game/area/areas/ruins/_ruins.dm
@@ -4,7 +4,7 @@
 	name = "\improper Unexplored Location"
 	icon_state = "away"
 	has_gravity = STANDARD_GRAVITY
-	area_flags = HIDDEN_AREA | BLOBS_ALLOWED
+	area_flags = HIDDEN_AREA | BLOBS_ALLOWED | UNIQUE_AREA
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 	ambientsounds = RUINS
 	flags_1 = CAN_BE_DIRTY_1


### PR DESCRIPTION
Seems like an oversight from #52751.

Fixes this roundstart runtime:

> runtime error: Bad control_area path for Base turret controls, Syndicate Lavaland Primary Hallway
> > proc name: stack trace (/datum/proc/stack_trace)
> > source file: unsorted.dm,1071
> > usr: null
> > src: Base turret controls (/obj/machinery/turretid)
> > src.loc: the floor (148,82,5) (/turf/open/floor/circuit/red)
>
> call stack:
> Base turret controls (/obj/machinery/turretid): stack trace("Bad control_area path for Base...")
> Base turret controls (/obj/machinery/turretid): Initialize(1)
> Atoms (/datum/controller/subsystem/atoms): InitAtom(Base turret controls (/obj/machinery/turretid), /list (/list))
> Atoms (/datum/controller/subsystem/atoms): InitializeAtoms(null)
> Atoms (/datum/controller/subsystem/atoms): Initialize(183297)
> Master (/datum/controller/master): Initialize(10, 0, 1)
