### PR TITLE
Penthrite no longer makes you immune to staminacrit, among other things: Not a web edit this time

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -447,22 +447,21 @@
 */
 /datum/reagent/medicine/c2/penthrite
 	name = "Penthrite"
-	description = "An expensive medicine that aids with pumping blood around the body even without a heart, and prevents the heart from slowing down. It reacts violently with other emergency medication."
+	description = "An expensive medicine that aids with pumping blood around the body even without a heart, and prevents the heart from slowing down. Mixing it with epinephrine or atropine will cause an explosion."
 	color = "#F5F5F5"
 	overdose_threshold = 50
 
-/datum/reagent/medicine/c2/penthrite/on_mob_add(mob/living/M)
+/datum/reagent/medicine/c2/penthrite/on_mob_metabolize(mob/living/M)
 	. = ..()
 	to_chat(M,"<span class='notice'>Your heart begins to beat with great force!")
 	ADD_TRAIT(M, TRAIT_STABLEHEART, type)
 	ADD_TRAIT(M, TRAIT_NOHARDCRIT,type)
 	ADD_TRAIT(M, TRAIT_NOSOFTCRIT,type)
-	M.crit_threshold = M.crit_threshold + HEALTH_THRESHOLD_FULLCRIT*2 //your heart is still pumping!
-
+	ADD_TRAIT(M, TRAIT_NOCRITDAMAGE,type)
 
 /datum/reagent/medicine/c2/penthrite/on_mob_life(mob/living/carbon/human/H)
 	H.adjustOrganLoss(ORGAN_SLOT_STOMACH,0.25)
-	if(H.health <= HEALTH_THRESHOLD_CRIT && H.health > H.crit_threshold) //we cannot save someone above our raised crit threshold.
+	if(H.health <= HEALTH_THRESHOLD_CRIT && H.health > (H.crit_threshold + HEALTH_THRESHOLD_FULLCRIT*2)) //we cannot save someone below our lowered crit threshold.
 
 		H.adjustToxLoss(-2 * REM, 0)
 		H.adjustBruteLoss(-2 * REM, 0)
@@ -480,8 +479,8 @@
 		if(prob(33))
 			to_chat(H,"<span class='danger'>Your body is trying to give up, but your heart is still beating!</span>")
 
-	if(H.health <= H.crit_threshold) //certain death above this threshold
-		REMOVE_TRAIT(H, TRAIT_STABLEHEART, type) //we have to remove the stable heart before we give him heart attack
+	if(H.health <= (H.crit_threshold + HEALTH_THRESHOLD_FULLCRIT*2)) //certain death below this threshold
+		REMOVE_TRAIT(H, TRAIT_STABLEHEART, type) //we have to remove the stable heart trait before we give them a heart attack
 		to_chat(H,"<span class='danger'>You feel something rupturing inside your chest!</span>")
 		H.emote("scream")
 		H.set_heartattack(TRUE)
@@ -489,10 +488,10 @@
 	. = ..()
 
 /datum/reagent/medicine/c2/penthrite/on_mob_end_metabolize(mob/living/M)
-	M.crit_threshold = M.crit_threshold - HEALTH_THRESHOLD_FULLCRIT*2 //your heart is still pumping!
 	REMOVE_TRAIT(M, TRAIT_STABLEHEART, type)
 	REMOVE_TRAIT(M, TRAIT_NOHARDCRIT,type)
 	REMOVE_TRAIT(M, TRAIT_NOSOFTCRIT,type)
+	REMOVE_TRAIT(M, TRAIT_NOCRITDAMAGE,type)
 	. = ..()
 
 /datum/reagent/medicine/c2/penthrite/overdose_process(mob/living/carbon/human/H)


### PR DESCRIPTION
## About The Pull Request

This is just https://github.com/tgstation/tgstation/pull/53203, but made in github desktop instead of as a web edit.

Also, this changes the description of penthrite to be a bit more clear about which "emergency medications" it reacts violently with. Nobody reads chem descriptions anyway, but maybe they will in the future if doing so gets made easier.

Proof of testing:

![image](https://user-images.githubusercontent.com/42606352/91351498-06a4a280-e7ae-11ea-96ec-9b2cf216f0f0.png)

![image](https://user-images.githubusercontent.com/42606352/91351656-4075a900-e7ae-11ea-84b4-c5fd85b403f0.png)

![image](https://user-images.githubusercontent.com/42606352/91351668-48cde400-e7ae-11ea-9f1e-c8106c70bac2.png)

![image](https://user-images.githubusercontent.com/42606352/91351744-68fda300-e7ae-11ea-9315-796986869536.png)

![image](https://user-images.githubusercontent.com/42606352/91351940-b1b55c00-e7ae-11ea-8dfa-4d6d5d6143d7.png)

## Why It's Good For The Game

h

## Changelog
:cl: ATHATH
fix: Penthrite no longer makes you immune to staminacrit.
fix: Penthrite no longer has an effect on people who can't metabolize it.
fix: Spam-buckling and spam-unbuckling someone to/from a stasis bed while they have penthrite in their system will no longer cause them to enter a state of permanent critical condition.
fix: If you regain the ability to metabolize chems while you have penthrite in your system, you'll also regain the special traits (immunity to hardcrit, immunity to softcrit, and immunity to the effects of heart failure) that penthrite's supposed to give you.
balance: Penthrite now makes you immune to the damage over time that being in crit gives you, so as to better mimic its previous/intended effects.
tweak: Penthrite's description has been modified slightly.
/:cl: