### PR TITLE
Remove duplicate supply boxes from Delta warden's locker.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -55936,8 +55936,6 @@
 "cbF" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/item/clothing/under/rank/security/warden/grey,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/handcuffs,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4


### PR DESCRIPTION

## About The Pull Request

This removes a box of zipties and a box of flashbangs from Delta's warden locker.

## Why It's Good For The Game

This locker type already contains a box of each of the above, it certainly does not need two of each. I messed this up when making a recent PR involving pets.