### PR TITLE
The public can now exit the labor shuttle arrivals area on Box and Delta.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -43412,6 +43412,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "bFI" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -6089,6 +6089,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "anQ" = (


### PR DESCRIPTION

## About The Pull Request

This adds unrestricted side access helpers to the door leading out of the gulag shuttle bottom half area, on the doors leading out into the main hallway.

## Why It's Good For The Game

You did your time and worked off your points, you should be able to just get your gear from the reclaim console and be on your way, not have to pester the AI or wait for sec.

## Changelog
:cl:
fix: The public can now exit the labor shuttle arrivals area on Box and Delta, without having to wait for the AI or sec to let them out.
/:cl:

