### PR TITLE
You can no longer pry up floor tiles in the holodeck photobooth.

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -8464,7 +8464,9 @@
 /turf/open/floor/plating,
 /area/centcom/ferry)
 "tb" = (
-/turf/open/floor/white,
+/turf/open/floor/holofloor{
+	icon_state = "pure_white"
+	},
 /area/holodeck/rec_center/photobooth)
 "tc" = (
 /obj/effect/spawner/structure/window/reinforced,


### PR DESCRIPTION

## About The Pull Request

This program was using non-holodeck turfs.

## Why It's Good For The Game

Prying up a tile shuts the holodeck off.

## Changelog
:cl:
fix: You cannot pry up floor tiles in the holodeck photobooth anymore.
/:cl:
