### PR TITLE
Crafting category changes

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -76,6 +76,9 @@
 //tablecrafting defines
 #define CAT_NONE	""
 #define CAT_WEAPONRY	"Weaponry"
+#define CAT_BAKING	"Baking"
+#define CAT_HEARTY	"Hearty Meals"
+#define CAT_MISC	"Miscellanious food items"
 #define CAT_WEAPON	"Weapons"
 #define CAT_AMMO	"Ammunition"
 #define CAT_ROBOT	"Robots"

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -3,8 +3,6 @@
 		RegisterSignal(parent, COMSIG_MOB_CLIENT_LOGIN, .proc/create_mob_button)
 
 /datum/component/personal_crafting/proc/create_mob_button(mob/user, client/CL)
-	SIGNAL_HANDLER
-
 	var/datum/hud/H = user.hud_used
 	var/obj/screen/craft/C = new()
 	C.icon = H.ui_style
@@ -19,30 +17,17 @@
 	var/list/categories = list(
 				CAT_WEAPONRY = list(
 					CAT_WEAPON,
-					CAT_AMMO,
-				),
+					CAT_AMMO),
 				CAT_ROBOT = CAT_NONE,
 				CAT_MISC = CAT_NONE,
 				CAT_PRIMAL = CAT_NONE,
 				CAT_FOOD = list(
-					CAT_BREAD,
-					CAT_BURGER,
-					CAT_CAKE,
-					CAT_EGG,
-					CAT_ICE,
-					CAT_MEAT,
+					CAT_BAKING,
+					CAT_HEARTY,
 					CAT_MISCFOOD,
-					CAT_PASTRY,
-					CAT_PIE,
-					CAT_PIZZA,
-					CAT_SALAD,
-					CAT_SANDWICH,
-					CAT_SOUP,
-					CAT_SPAGHETTI,
 				),
 				CAT_DRINK = CAT_NONE,
-				CAT_CLOTHING = CAT_NONE,
-			)
+				CAT_CLOTHING = CAT_NONE)
 
 	var/cur_category = CAT_NONE
 	var/cur_subcategory = CAT_NONE
@@ -314,8 +299,6 @@
 		qdel(DL)
 
 /datum/component/personal_crafting/proc/component_ui_interact(obj/screen/craft/image, location, control, params, user)
-	SIGNAL_HANDLER_DOES_SLEEP
-
 	if(user == parent)
 		ui_interact(user)
 
@@ -348,7 +331,7 @@
 	for(var/rec in GLOB.crafting_recipes)
 		var/datum/crafting_recipe/R = rec
 
-		if(!R.always_available && !(R.type in user?.mind?.learned_recipes)) //User doesn't actually know how to make this.
+		if(!R.always_availible && !(R.type in user?.mind?.learned_recipes)) //User doesn't actually know how to make this.
 			continue
 
 		if((R.category != cur_category) || (R.subcategory != cur_subcategory))
@@ -369,7 +352,7 @@
 		if(R.name == "") //This is one of the invalid parents that sneaks in
 			continue
 
-		if(!R.always_available && !(R.type in user?.mind?.learned_recipes)) //User doesn't actually know how to make this.
+		if(!R.always_availible && !(R.type in user?.mind?.learned_recipes)) //User doesn't actually know how to make this.
 			continue
 
 		if(isnull(crafting_recipes[R.category]))

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_bread.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_bread.dm
@@ -6,84 +6,84 @@
 /datum/crafting_recipe/food/meatbread
 	name = "Meat bread"
 	reqs = list(
-		/obj/item/food/bread/plain = 1,
+		/obj/item/reagent_containers/food/snacks/store/bread/plain = 1,
 		/obj/item/reagent_containers/food/snacks/meat/cutlet/plain = 3,
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 3
 	)
-	result = /obj/item/food/bread/meat
-	subcategory = CAT_BREAD
+	result = /obj/item/reagent_containers/food/snacks/store/bread/meat
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/xenomeatbread
 	name = "Xenomeat bread"
 	reqs = list(
-		/obj/item/food/bread/plain = 1,
+		/obj/item/reagent_containers/food/snacks/store/bread/plain = 1,
 		/obj/item/reagent_containers/food/snacks/meat/cutlet/xeno = 3,
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 3
 	)
-	result = /obj/item/food/bread/xenomeat
-	subcategory = CAT_BREAD
+	result = /obj/item/reagent_containers/food/snacks/store/bread/xenomeat
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/spidermeatbread
 	name = "Spidermeat bread"
 	reqs = list(
-		/obj/item/food/bread/plain = 1,
+		/obj/item/reagent_containers/food/snacks/store/bread/plain = 1,
 		/obj/item/reagent_containers/food/snacks/meat/cutlet/spider = 3,
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 3
 	)
-	result = /obj/item/food/bread/spidermeat
-	subcategory = CAT_BREAD
+	result = /obj/item/reagent_containers/food/snacks/store/bread/spidermeat
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/banananutbread
 	name = "Banana nut bread"
 	reqs = list(
 		/datum/reagent/consumable/milk = 5,
-		/obj/item/food/bread/plain = 1,
+		/obj/item/reagent_containers/food/snacks/store/bread/plain = 1,
 		/obj/item/reagent_containers/food/snacks/boiledegg = 3,
 		/obj/item/reagent_containers/food/snacks/grown/banana = 1
 	)
-	result = /obj/item/food/bread/banana
-	subcategory = CAT_BREAD
+	result = /obj/item/reagent_containers/food/snacks/store/bread/banana
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/tofubread
 	name = "Tofu bread"
 	reqs = list(
-		/obj/item/food/bread/plain = 1,
+		/obj/item/reagent_containers/food/snacks/store/bread/plain = 1,
 		/obj/item/reagent_containers/food/snacks/tofu = 3,
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 3
 	)
-	result = /obj/item/food/bread/tofu
-	subcategory = CAT_BREAD
+	result = /obj/item/reagent_containers/food/snacks/store/bread/tofu
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/creamcheesebread
 	name = "Cream cheese bread"
 	reqs = list(
 		/datum/reagent/consumable/milk = 5,
-		/obj/item/food/bread/plain = 1,
+		/obj/item/reagent_containers/food/snacks/store/bread/plain = 1,
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 2
 	)
-	result = /obj/item/food/bread/creamcheese
-	subcategory = CAT_BREAD
+	result = /obj/item/reagent_containers/food/snacks/store/bread/creamcheese
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/mimanabread
 	name = "Mimana bread"
 	reqs = list(
 		/datum/reagent/consumable/soymilk = 5,
-		/obj/item/food/bread/plain = 1,
+		/obj/item/reagent_containers/food/snacks/store/bread/plain = 1,
 		/obj/item/reagent_containers/food/snacks/tofu = 3,
 		/obj/item/reagent_containers/food/snacks/grown/banana/mime = 1
 	)
-	result = /obj/item/food/bread/mimana
-	subcategory = CAT_BREAD
+	result = /obj/item/reagent_containers/food/snacks/store/bread/mimana
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/garlicbread
 	name = "Garlic Bread"
 	time = 40
 	reqs = list(/obj/item/reagent_containers/food/snacks/grown/garlic = 1,
-				/obj/item/food/breadslice/plain = 1,
+				/obj/item/reagent_containers/food/snacks/breadslice/plain = 1,
 				/obj/item/reagent_containers/food/snacks/butter = 1
 	)
-	result = /obj/item/food/garlicbread
-	subcategory = CAT_BREAD
+	result = /obj/item/reagent_containers/food/snacks/garlicbread
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/butterbiscuit
 	name = "Butter Biscuit"
@@ -91,8 +91,8 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1,
 		/obj/item/reagent_containers/food/snacks/butter = 1
 	)
-	result = /obj/item/food/butterbiscuit
-	subcategory = CAT_BREAD
+	result = /obj/item/reagent_containers/food/snacks/butterbiscuit
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/butterdog
 	name = "Butterdog"
@@ -100,14 +100,14 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1,
 		/obj/item/reagent_containers/food/snacks/butter = 3,
 		)
-	result = /obj/item/food/butterdog
-	subcategory = CAT_BREAD
+	result = /obj/item/reagent_containers/food/snacks/butterdog
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/moldybread // why would you make this?
 	name = "Moldy Bread"
 	reqs = list(
-		/obj/item/food/breadslice/plain = 1,
+		/obj/item/reagent_containers/food/snacks/breadslice/plain = 1,
 		/obj/item/reagent_containers/food/snacks/grown/mushroom/amanita = 1
 		)
-	result = /obj/item/food/breadslice/moldy
-	subcategory = CAT_BREAD
+	result = /obj/item/reagent_containers/food/snacks/breadslice/moldy
+	subcategory = CAT_BAKING

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_burger.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_burger.dm
@@ -14,7 +14,7 @@
 		/obj/item/reagent_containers/food/snacks/meat/steak/plain/human = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/human
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/burger
 	name = "Burger"
@@ -24,7 +24,7 @@
 	)
 
 	result = /obj/item/reagent_containers/food/snacks/burger/plain
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/corgiburger
 	name = "Corgi burger"
@@ -34,7 +34,7 @@
 	)
 
 	result = /obj/item/reagent_containers/food/snacks/burger/corgi
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/appendixburger
 	name = "Appendix burger"
@@ -43,7 +43,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/appendix
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/brainburger
 	name = "Brain burger"
@@ -52,7 +52,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/brain
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/xenoburger
 	name = "Xeno burger"
@@ -61,7 +61,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/xeno
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/bearger
 	name = "Bearger"
@@ -70,7 +70,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/bearger
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/fishburger
 	name = "Fish burger"
@@ -80,7 +80,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/fish
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/tofuburger
 	name = "Tofu burger"
@@ -89,7 +89,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/tofu
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/ghostburger
 	name = "Ghost burger"
@@ -99,7 +99,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/ghost
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/clownburger
 	name = "Clown burger"
@@ -108,7 +108,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/clown
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/mimeburger
 	name = "Mime burger"
@@ -117,7 +117,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/mime
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/redburger
 	name = "Red burger"
@@ -127,7 +127,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/red
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/orangeburger
 	name = "Orange burger"
@@ -137,7 +137,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/orange
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/yellowburger
 	name = "Yellow burger"
@@ -147,7 +147,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/yellow
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/greenburger
 	name = "Green burger"
@@ -157,7 +157,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/green
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/blueburger
 	name = "Blue burger"
@@ -167,7 +167,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/blue
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/purpleburger
 	name = "Purple burger"
@@ -177,7 +177,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/purple
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/blackburger
 	name = "Black burger"
@@ -187,7 +187,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/black
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/whiteburger
 	name = "White burger"
@@ -197,7 +197,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/white
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/spellburger
 	name = "Spell burger"
@@ -206,7 +206,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/spell
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/spellburger2
 	name = "Spell burger"
@@ -215,7 +215,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/spell
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/bigbiteburger
 	name = "Big bite burger"
@@ -225,7 +225,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/bigbite
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/superbiteburger
 	name = "Super bite burger"
@@ -241,7 +241,7 @@
 
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/superbite
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/slimeburger
 	name = "Jelly burger"
@@ -250,7 +250,7 @@
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/jelly/slime
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/jellyburger
 	name = "Jelly burger"
@@ -259,7 +259,7 @@
 			/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/jelly/cherry
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/fivealarmburger
 	name = "Five alarm burger"
@@ -269,7 +269,7 @@
 			/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/fivealarm
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/ratburger
 	name = "Rat burger"
@@ -278,7 +278,7 @@
 			/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/rat
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/baseballburger
 	name = "Home run baseball burger"
@@ -287,7 +287,7 @@
 			/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/baseball
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/baconburger
 	name = "Bacon Burger"
@@ -297,7 +297,7 @@
 	)
 
 	result = /obj/item/reagent_containers/food/snacks/burger/baconburger
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/empoweredburger
 	name = "Empowered Burger"
@@ -307,7 +307,7 @@
 	)
 
 	result = /obj/item/reagent_containers/food/snacks/burger/empoweredburger
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/crabburger
 	name = "Crab Burger"
@@ -317,7 +317,7 @@
 	)
 
 	result = /obj/item/reagent_containers/food/snacks/burger/crab
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/cheeseburger
 	name = "Cheese Burger"
@@ -327,7 +327,7 @@
 			/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/cheese
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/soylentburger
 	name = "Soylent Burger"
@@ -337,7 +337,7 @@
 			/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/soylent
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/ribburger
 	name = "McRib"
@@ -347,7 +347,7 @@
 			/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/rib
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/mcguffin
 	name = "McGuffin"
@@ -357,7 +357,7 @@
 			/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/mcguffin
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/chickenburger
 	name = "Chicken Sandwich"
@@ -367,4 +367,4 @@
 			/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/chicken
-	subcategory = CAT_BURGER
+	subcategory = CAT_HEARTY

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
@@ -10,7 +10,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/carrot = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/carrot
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/cheesecake
 	name = "Cheese cake"
@@ -19,7 +19,7 @@
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/cheese
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/applecake
 	name = "Apple cake"
@@ -28,7 +28,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/apple = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/apple
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/orangecake
 	name = "Orange cake"
@@ -37,7 +37,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/citrus/orange = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/orange
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/limecake
 	name = "Lime cake"
@@ -46,7 +46,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/citrus/lime = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/lime
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/lemoncake
 	name = "Lemon cake"
@@ -55,7 +55,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/citrus/lemon = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/lemon
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/chocolatecake
 	name = "Chocolate cake"
@@ -64,7 +64,7 @@
 		/obj/item/reagent_containers/food/snacks/chocolatebar = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/chocolate
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/birthdaycake
 	name = "Birthday cake"
@@ -75,7 +75,7 @@
 		/datum/reagent/consumable/caramel = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/birthday
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/energycake
 	name = "Energy cake"
@@ -85,7 +85,7 @@
 	)
 	blacklist = list(/obj/item/reagent_containers/food/snacks/store/cake/birthday/energy)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/birthday/energy
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/braincake
 	name = "Brain cake"
@@ -94,7 +94,7 @@
 		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/brain
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/slimecake
 	name = "Slime cake"
@@ -103,7 +103,7 @@
 		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/slimecake
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/pumpkinspicecake
 	name = "Pumpkin spice cake"
@@ -112,7 +112,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/pumpkin = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/pumpkinspice
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/holycake
 	name = "Angel food cake"
@@ -121,7 +121,7 @@
 		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/holy_cake
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/poundcake
 	name = "Pound cake"
@@ -129,7 +129,7 @@
 		/obj/item/reagent_containers/food/snacks/store/cake/plain = 4
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/pound_cake
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/hardwarecake
 	name = "Hardware cake"
@@ -139,7 +139,7 @@
 		/datum/reagent/toxin/acid = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/hardware_cake
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/bscccake
 	name = "blackberry and strawberry chocolate cake"
@@ -149,7 +149,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/berries = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/bscc
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/bscvcake
 	name = "blackberry and strawberry vanilla cake"
@@ -158,28 +158,28 @@
 		/obj/item/reagent_containers/food/snacks/grown/berries = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/bsvc
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/clowncake
 	name = "clown cake"
-	always_available = FALSE
+	always_availible = FALSE
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1,
 		/obj/item/reagent_containers/food/snacks/sundae = 2,
 		/obj/item/reagent_containers/food/snacks/grown/banana = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/clown_cake
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/vanillacake
 	name = "vanilla cake"
-	always_available = FALSE
+	always_availible = FALSE
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1,
 		/obj/item/reagent_containers/food/snacks/grown/vanillapod = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/vanilla_cake
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/trumpetcake
 	name = "Spaceman's Cake"
@@ -190,7 +190,7 @@
 		/datum/reagent/consumable/berryjuice = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/trumpet
-	subcategory = CAT_CAKE
+	subcategory = CAT_BAKING
 
 
 /datum/crafting_recipe/food/cak
@@ -205,4 +205,4 @@
 		/datum/reagent/teslium = 1 //To shock the whole thing into life
 	)
 	result = /mob/living/simple_animal/pet/cat/cak
-	subcategory = CAT_CAKE //Cat! Haha, get it? CAT? GET IT? We get it - Love Felines
+	subcategory = CAT_BAKING //Cat! Haha, get it? CAT? GET IT? We get it - Love Felines

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
@@ -138,7 +138,7 @@
 	result = /obj/item/reagent_containers/food/drinks/bottle/pruno
 	time = 30
 	reqs = list(/obj/item/storage/bag/trash = 1,
-	            /obj/item/food/breadslice/moldy = 1,
+	            /obj/item/reagent_containers/food/snacks/breadslice/moldy = 1,
 	            /obj/item/reagent_containers/food/snacks/grown = 4,
 	            /obj/item/reagent_containers/food/snacks/candy_corn = 2,
 	            /datum/reagent/water = 15)

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_egg.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_egg.dm
@@ -11,7 +11,7 @@
 		/obj/item/reagent_containers/food/snacks/egg = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/friedegg
-	subcategory = CAT_EGG
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/omelette
 	name = "Omelette"
@@ -20,7 +20,7 @@
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/omelette
-	subcategory = CAT_EGG
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/chocolateegg
 	name = "Chocolate egg"
@@ -29,17 +29,17 @@
 		/obj/item/reagent_containers/food/snacks/chocolatebar = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/chocolateegg
-	subcategory = CAT_EGG
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/eggsbenedict
 	name = "Eggs benedict"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/friedegg = 1,
 		/obj/item/reagent_containers/food/snacks/meat/steak = 1,
-		/obj/item/food/breadslice/plain = 1,
+		/obj/item/reagent_containers/food/snacks/breadslice/plain = 1,
 	)
 	result = /obj/item/reagent_containers/food/snacks/benedict
-	subcategory = CAT_EGG
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/eggbowl
 	name = "Egg bowl"
@@ -50,4 +50,4 @@
 		/obj/item/reagent_containers/food/snacks/grown/corn = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/salad/eggbowl
-	subcategory = CAT_EGG
+	subcategory = CAT_HEARTY

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_frozen.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_frozen.dm
@@ -11,7 +11,7 @@
 		/obj/item/reagent_containers/food/snacks/icecream = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/icecreamsandwich
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/strawberryicecreamsandwich
 	name = "Strawberry ice cream sandwich"
@@ -21,7 +21,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/berries = 2,
 	)
 	result = /obj/item/reagent_containers/food/snacks/strawberryicecreamsandwich
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/spacefreezy
 	name ="Space freezy"
@@ -31,7 +31,7 @@
 		/obj/item/reagent_containers/food/snacks/icecream = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/spacefreezy
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/sundae
 	name ="Sundae"
@@ -42,7 +42,7 @@
 		/obj/item/reagent_containers/food/snacks/icecream = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/sundae
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/honkdae
 	name ="Honkdae"
@@ -54,7 +54,7 @@
 		/obj/item/reagent_containers/food/snacks/icecream = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/honkdae
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/cornuto
 	name = "Cornuto"
@@ -66,7 +66,7 @@
 		/datum/reagent/consumable/sugar = 4
 	)
 	result = /obj/item/reagent_containers/food/snacks/cornuto
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 //////////////////////////SNOW CONES///////////////////////
 
@@ -77,7 +77,7 @@
 		/datum/reagent/consumable/ice = 15
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/pineapple_sc
 	name = "Pineapple snowcone"
@@ -87,7 +87,7 @@
 		/datum/reagent/consumable/pineapplejuice = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/pineapple
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/lime_sc
 	name = "Lime snowcone"
@@ -97,7 +97,7 @@
 		/datum/reagent/consumable/limejuice = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/lime
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/lemon_sc
 	name = "Lemon snowcone"
@@ -107,7 +107,7 @@
 		/datum/reagent/consumable/lemonjuice = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/lemon
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/apple_sc
 	name = "Apple snowcone"
@@ -117,7 +117,7 @@
 		/datum/reagent/consumable/applejuice = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/apple
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/grape_sc
 	name = "Grape snowcone"
@@ -127,7 +127,7 @@
 		/datum/reagent/consumable/grapejuice = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/grape
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/orange_sc
 	name = "Orange snowcone"
@@ -137,7 +137,7 @@
 		/datum/reagent/consumable/orangejuice = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/orange
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/blue_sc
 	name = "Bluecherry snowcone"
@@ -147,7 +147,7 @@
 		/datum/reagent/consumable/bluecherryjelly= 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/blue
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/red_sc
 	name = "Cherry snowcone"
@@ -157,7 +157,7 @@
 		/datum/reagent/consumable/cherryjelly= 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/red
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/berry_sc
 	name = "Berry snowcone"
@@ -167,7 +167,7 @@
 		/datum/reagent/consumable/berryjuice = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/berry
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/fruitsalad_sc
 	name = "Fruit Salad snowcone"
@@ -180,7 +180,7 @@
 		/datum/reagent/consumable/lemonjuice = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/fruitsalad
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/mime_sc
 	name = "Mime snowcone"
@@ -190,7 +190,7 @@
 		/datum/reagent/consumable/nothing = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/mime
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/clown_sc
 	name = "Clown snowcone"
@@ -200,7 +200,7 @@
 		/datum/reagent/consumable/laughter = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/clown
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/soda_sc
 	name = "Space Cola snowcone"
@@ -210,7 +210,7 @@
 		/datum/reagent/consumable/space_cola = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/soda
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/spacemountainwind_sc
 	name = "Space Mountain Wind snowcone"
@@ -220,7 +220,7 @@
 		/datum/reagent/consumable/spacemountainwind = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/spacemountainwind
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/pwrgame_sc
 	name = "Pwrgame snowcone"
@@ -230,7 +230,7 @@
 		/datum/reagent/consumable/pwr_game = 15
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/pwrgame
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/honey_sc
 	name = "Honey snowcone"
@@ -240,7 +240,7 @@
 		/datum/reagent/consumable/honey = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/honey
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/rainbow_sc
 	name = "Rainbow snowcone"
@@ -250,7 +250,7 @@
 		/datum/reagent/colorful_reagent = 1 //Harder to make
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/rainbow
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 //////////////////////////POPSICLES///////////////////////
 
@@ -268,7 +268,7 @@
 		/datum/reagent/consumable/sugar = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/popsicle/creamsicle_orange
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/berry_popsicle
 	name = "Berry popsicle"
@@ -281,7 +281,7 @@
 		/datum/reagent/consumable/sugar = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/popsicle/creamsicle_berry
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/jumbo
 	name = "Jumbo icecream"
@@ -294,7 +294,7 @@
 		/datum/reagent/consumable/sugar = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/popsicle/jumbo
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/nogga_black
 	name = "Nogga black"
@@ -308,4 +308,4 @@
 		/datum/reagent/consumable/sugar = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/popsicle/nogga_black
-	subcategory = CAT_ICE
+	subcategory = CAT_MISCFOOD

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_meat.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_meat.dm
@@ -9,7 +9,7 @@
 		/obj/item/reagent_containers/food/snacks/meat/steak/plain/human = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/kebab/human
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/kebab
 	name = "Kebab"
@@ -18,7 +18,7 @@
 		/obj/item/reagent_containers/food/snacks/meat/steak = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/kebab/monkey
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/tofukebab
 	name = "Tofu kebab"
@@ -27,7 +27,7 @@
 		/obj/item/reagent_containers/food/snacks/tofu = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/kebab/tofu
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/tailkebab
 	name = "Lizard tail kebab"
@@ -36,7 +36,7 @@
 		/obj/item/organ/tail/lizard = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/kebab/tail
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/fiestaskewer
 	name = "Fiesta Skewer"
@@ -48,7 +48,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/kebab/fiesta
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 ////////////////////////////////////////////////FISH////////////////////////////////////////////////
 
@@ -60,7 +60,7 @@
 		/obj/item/reagent_containers/food/snacks/carpmeat = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/cubancarp
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/fishandchips
 	name = "Fish and chips"
@@ -69,7 +69,7 @@
 		/obj/item/reagent_containers/food/snacks/carpmeat = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/fishandchips
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/fishfingers
 	name = "Fish fingers"
@@ -79,7 +79,7 @@
 		/obj/item/reagent_containers/food/snacks/carpmeat = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/fishfingers
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/sashimi
 	name = "Sashimi"
@@ -89,7 +89,7 @@
 		/obj/item/reagent_containers/food/snacks/carpmeat = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/sashimi
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 ////////////////////////////////////////////////MR SPIDER////////////////////////////////////////////////
 
@@ -101,7 +101,7 @@
 		/obj/item/reagent_containers/food/snacks/meat/cutlet/spider = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/spidereggsham
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 ////////////////////////////////////////////////MISC RECIPE's////////////////////////////////////////////////
 
@@ -113,7 +113,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/cabbage = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/cornedbeef
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/bearsteak
 	name = "Filet migrawr"
@@ -123,7 +123,7 @@
 	)
 	tools = list(/obj/item/lighter)
 	result = /obj/item/reagent_containers/food/snacks/bearsteak
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/enchiladas
 	name = "Enchiladas"
@@ -133,7 +133,7 @@
 		/obj/item/reagent_containers/food/snacks/tortilla = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/enchiladas
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/stewedsoymeat
 	name = "Stewed soymeat"
@@ -143,7 +143,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/stewedsoymeat
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/sausage
 	name = "Sausage"
@@ -152,7 +152,7 @@
 		/obj/item/reagent_containers/food/snacks/meat/cutlet = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/sausage
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/nugget
 	name = "Chicken nugget"
@@ -160,7 +160,7 @@
 		/obj/item/reagent_containers/food/snacks/meat/cutlet = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/nugget
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/rawkhinkali
 	name = "Raw Khinkali"
@@ -170,7 +170,7 @@
 		/obj/item/reagent_containers/food/snacks/meatball = 1
 	)
 	result =  /obj/item/reagent_containers/food/snacks/rawkhinkali
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/pigblanket
 	name = "Pig in a Blanket"
@@ -180,7 +180,7 @@
 		/obj/item/reagent_containers/food/snacks/meat/cutlet = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pigblanket
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/ratkebab
 	name = "Rat Kebab"
@@ -189,7 +189,7 @@
 		/obj/item/reagent_containers/food/snacks/deadmouse = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/kebab/rat
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/doubleratkebab
 	name = "Double Rat Kebab"
@@ -198,7 +198,7 @@
 		/obj/item/reagent_containers/food/snacks/deadmouse = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/kebab/rat/double
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/ricepork
 	name = "Rice and Pork"
@@ -207,7 +207,7 @@
 		/obj/item/reagent_containers/food/snacks/meat/cutlet = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/salad/ricepork
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/ribs
 	name = "BBQ Ribs"
@@ -217,7 +217,7 @@
 		/obj/item/stack/rods = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/bbqribs
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/meatclown
 	name = "Meat Clown"
@@ -226,4 +226,4 @@
 		/obj/item/reagent_containers/food/snacks/grown/banana = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/meatclown
-	subcategory = CAT_MEAT
+	subcategory = CAT_HEARTY

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -102,7 +102,7 @@
 				/datum/reagent/consumable/blackpepper = 1,
 				/obj/item/reagent_containers/food/snacks/pastrybase = 2
 	)
-	result = /obj/item/food/baguette
+	result = /obj/item/reagent_containers/food/snacks/baguette
 	subcategory = CAT_MISCFOOD
 
 ////////////////////////////////////////////////TOAST////////////////////////////////////////////////
@@ -111,7 +111,7 @@
 	name = "Slime toast"
 	reqs = list(
 		/datum/reagent/toxin/slimejelly = 5,
-		/obj/item/food/breadslice/plain = 1
+		/obj/item/reagent_containers/food/snacks/breadslice/plain = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/jelliedtoast/slime
 	subcategory = CAT_MISCFOOD
@@ -120,7 +120,7 @@
 	name = "Jellied toast"
 	reqs = list(
 		/datum/reagent/consumable/cherryjelly = 5,
-		/obj/item/food/breadslice/plain = 1
+		/obj/item/reagent_containers/food/snacks/breadslice/plain = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/jelliedtoast/cherry
 	subcategory = CAT_MISCFOOD
@@ -128,7 +128,7 @@
 /datum/crafting_recipe/food/butteredtoast
 	name = "Buttered Toast"
 	reqs = list(
-		/obj/item/food/breadslice/plain = 1,
+		/obj/item/reagent_containers/food/snacks/breadslice/plain = 1,
 		/obj/item/reagent_containers/food/snacks/butter = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/butteredtoast
@@ -138,7 +138,7 @@
 	name = "Two bread"
 	reqs = list(
 		/datum/reagent/consumable/ethanol/wine = 5,
-		/obj/item/food/breadslice/plain = 2
+		/obj/item/reagent_containers/food/snacks/breadslice/plain = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/twobread
 	subcategory = CAT_MISCFOOD

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -11,7 +11,7 @@
 		/obj/item/reagent_containers/food/snacks/pastrybase = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/donut/plain
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 
 /datum/crafting_recipe/food/donut/chaos
@@ -257,7 +257,7 @@
 		/obj/item/reagent_containers/food/snacks/pastrybase = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/waffles
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 
 /datum/crafting_recipe/food/soylenviridians
@@ -267,7 +267,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/soybeans = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soylenviridians
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/soylentgreen
 	name = "Soylent green"
@@ -276,7 +276,7 @@
 		/obj/item/reagent_containers/food/snacks/meat/slab/human = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/soylentgreen
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 
 /datum/crafting_recipe/food/rofflewaffles
@@ -286,7 +286,7 @@
 		/obj/item/reagent_containers/food/snacks/pastrybase = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/rofflewaffles
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/pancakes
 	name = "Pancake"
@@ -294,7 +294,7 @@
 		/obj/item/reagent_containers/food/snacks/pastrybase = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pancakes
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/bbpancakes
 	name = "Blueberry pancake"
@@ -303,7 +303,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/berries = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pancakes/blueberry
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/ccpancakes
 	name = "Chocolate chip pancake"
@@ -312,7 +312,7 @@
 		/obj/item/reagent_containers/food/snacks/chocolatebar = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pancakes/chocolatechip
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 
 ////////////////////////////////////////////////DONKPOCCKETS////////////////////////////////////////////////
@@ -325,7 +325,7 @@
 		/obj/item/reagent_containers/food/snacks/meatball = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/donkpocket
-	subcategory = CAT_PASTRY
+	subcategory =  CAT_BAKING
 
 /datum/crafting_recipe/food/dankpocket
 	time = 15
@@ -335,7 +335,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/cannabis = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/dankpocket
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/donkpocket/spicy
 	time = 15
@@ -346,7 +346,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/chili
 	)
 	result = /obj/item/reagent_containers/food/snacks/donkpocket/spicy
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/donkpocket/teriyaki
 	time = 15
@@ -357,7 +357,7 @@
 		/datum/reagent/consumable/soysauce = 3
 	)
 	result = /obj/item/reagent_containers/food/snacks/donkpocket/teriyaki
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/donkpocket/pizza
 	time = 15
@@ -368,7 +368,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/donkpocket/pizza
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/donkpocket/honk
 	time = 15
@@ -379,7 +379,7 @@
 		/datum/reagent/consumable/sugar = 3
 	)
 	result = /obj/item/reagent_containers/food/snacks/donkpocket/honk
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/donkpocket/berry
 	time = 15
@@ -389,7 +389,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/berries = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/donkpocket/berry
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/donkpocket/gondola
 	time = 15
@@ -400,7 +400,7 @@
 		/datum/reagent/tranquility = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/donkpocket/gondola
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 ////////////////////////////////////////////////MUFFINS////////////////////////////////////////////////
 
@@ -412,7 +412,7 @@
 		/obj/item/reagent_containers/food/snacks/pastrybase = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/muffin
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/berrymuffin
 	name = "Berry muffin"
@@ -422,7 +422,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/berries = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/muffin/berry
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/booberrymuffin
 	name = "Booberry muffin"
@@ -433,7 +433,7 @@
 		/obj/item/ectoplasm = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/muffin/booberry
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/chawanmushi
 	name = "Chawanmushi"
@@ -444,7 +444,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/mushroom/chanterelle = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/chawanmushi
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 ////////////////////////////////////////////OTHER////////////////////////////////////////////
 
@@ -456,7 +456,7 @@
 		/obj/item/reagent_containers/food/snacks/sausage = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/hotdog
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/meatbun
 	name = "Meat bun"
@@ -467,17 +467,17 @@
 		/obj/item/reagent_containers/food/snacks/grown/cabbage = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/meatbun
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/khachapuri
 	name = "Khachapuri"
 	reqs = list(
 		/datum/reagent/consumable/eggyolk = 5,
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 1,
-		/obj/item/food/bread/plain = 1
+		/obj/item/reagent_containers/food/snacks/store/bread/plain = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/khachapuri
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/sugarcookie
 	time = 15
@@ -487,7 +487,7 @@
 		/obj/item/reagent_containers/food/snacks/pastrybase = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/sugarcookie
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/fortunecookie
 	time = 15
@@ -500,7 +500,7 @@
 		/obj/item/paper = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/fortunecookie
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/poppypretzel
 	time = 15
@@ -510,7 +510,7 @@
 		/obj/item/reagent_containers/food/snacks/pastrybase = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/poppypretzel
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/plumphelmetbiscuit
 	time = 15
@@ -520,7 +520,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/plumphelmetbiscuit
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/cracker
 	time = 15
@@ -530,7 +530,7 @@
 		/obj/item/reagent_containers/food/snacks/pastrybase = 1,
 	)
 	result = /obj/item/reagent_containers/food/snacks/cracker
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/chococornet
 	name = "Choco cornet"
@@ -540,7 +540,7 @@
 		/obj/item/reagent_containers/food/snacks/chocolatebar = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/chococornet
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/oatmealcookie
 	name = "Oatmeal cookie"
@@ -549,7 +549,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/oat = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/oatmealcookie
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/raisincookie
 	name = "Raisin cookie"
@@ -559,7 +559,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/oat = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/raisincookie
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/cherrycupcake
 	name = "Cherry cupcake"
@@ -568,7 +568,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/cherries = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/cherrycupcake
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/bluecherrycupcake
 	name = "Blue cherry cupcake"
@@ -577,7 +577,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/bluecherries = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/bluecherrycupcake
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/honeybun
 	name = "Honey bun"
@@ -586,7 +586,7 @@
 		/datum/reagent/consumable/honey = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/honeybun
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/cannoli
 	name = "Cannoli"
@@ -596,4 +596,4 @@
 		/datum/reagent/consumable/sugar = 3,
 	)
 	result = /obj/item/reagent_containers/food/snacks/cannoli
-	subcategory = CAT_PASTRY
+	subcategory = CAT_BAKING

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pie.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pie.dm
@@ -11,7 +11,7 @@
 		 /obj/item/reagent_containers/food/snacks/grown/banana = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/cream
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/meatpie
 	name = "Meat pie"
@@ -22,7 +22,7 @@
 		/obj/item/reagent_containers/food/snacks/meat/steak/plain = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/meatpie
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/tofupie
 	name = "Tofu pie"
@@ -31,7 +31,7 @@
 		/obj/item/reagent_containers/food/snacks/tofu = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/tofupie
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/xenopie
 	name = "Xeno pie"
@@ -40,7 +40,7 @@
 		/obj/item/reagent_containers/food/snacks/meat/cutlet/xeno = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/xemeatpie
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/cherrypie
 	name = "Cherry pie"
@@ -49,7 +49,7 @@
 		 /obj/item/reagent_containers/food/snacks/grown/cherries = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/cherrypie
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/berryclafoutis
 	name = "Berry clafoutis"
@@ -58,7 +58,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/berries = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/berryclafoutis
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/bearypie
 	name = "Beary Pie"
@@ -68,7 +68,7 @@
 		/obj/item/reagent_containers/food/snacks/meat/steak/bear = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/bearypie
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/amanitapie
 	name = "Amanita pie"
@@ -77,7 +77,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/mushroom/amanita = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/amanita_pie
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/plumppie
 	name = "Plump pie"
@@ -86,7 +86,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/plump_pie
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/applepie
 	name = "Apple pie"
@@ -95,7 +95,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/apple = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/applepie
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/pumpkinpie
 	name = "Pumpkin pie"
@@ -106,7 +106,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/pumpkin = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/pumpkinpie
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/goldenappletart
 	name = "Golden apple tart"
@@ -117,7 +117,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/apple/gold = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/appletart
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/grapetart
 	name = "Grape tart"
@@ -128,11 +128,11 @@
 	        /obj/item/reagent_containers/food/snacks/grown/grapes = 3
 	        )
 	result = /obj/item/reagent_containers/food/snacks/pie/grapetart
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/mimetart
 	name = "Mime tart"
-	always_available = FALSE
+	always_availible = FALSE
 	reqs = list(
             /datum/reagent/consumable/milk = 5,
             /datum/reagent/consumable/sugar = 5,
@@ -140,11 +140,11 @@
 	        /datum/reagent/consumable/nothing = 5
 	        )
 	result = /obj/item/reagent_containers/food/snacks/pie/mimetart
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/berrytart
 	name = "Berry tart"
-	always_available = FALSE
+	always_availible = FALSE
 	reqs = list(
             /datum/reagent/consumable/milk = 5,
             /datum/reagent/consumable/sugar = 5,
@@ -152,11 +152,11 @@
 	        /obj/item/reagent_containers/food/snacks/grown/berries = 3
 	        )
 	result = /obj/item/reagent_containers/food/snacks/pie/berrytart
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/cocolavatart
 	name = "Chocolate Lava tart"
-	always_available = FALSE
+	always_availible = FALSE
 	reqs = list(
             /datum/reagent/consumable/milk = 5,
             /datum/reagent/consumable/sugar = 5,
@@ -165,7 +165,7 @@
 	        /obj/item/slime_extract = 1 //The reason you dont know how to make it!
 	        )
 	result = /obj/item/reagent_containers/food/snacks/pie/cocolavatart
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/blumpkinpie
 	name = "Blumpkin pie"
@@ -176,7 +176,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/blumpkin = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/blumpkinpie
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/dulcedebatata
 	name = "Dulce de batata"
@@ -186,7 +186,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/potato/sweet = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/dulcedebatata
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/frostypie
 	name = "Frosty pie"
@@ -195,7 +195,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/bluecherries = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/frostypie
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/baklava
 	name = "Baklava pie"
@@ -205,4 +205,4 @@
 		/obj/item/seeds/wheat/oat = 4
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/baklava
-	subcategory = CAT_PIE
+	subcategory = CAT_BAKING

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pizza.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pizza.dm
@@ -11,7 +11,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pizza/margherita
-	subcategory = CAT_PIZZA
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/meatpizza
 	name = "Meat pizza"
@@ -22,7 +22,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pizza/meat
-	subcategory = CAT_PIZZA
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/arnold
 	name = "Arnold pizza"
@@ -34,7 +34,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pizza/arnold
-	subcategory = CAT_PIZZA
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/mushroompizza
 	name = "Mushroom pizza"
@@ -43,7 +43,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/mushroom = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/pizza/mushroom
-	subcategory = CAT_PIZZA
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/vegetablepizza
 	name = "Vegetable pizza"
@@ -55,7 +55,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pizza/vegetable
-	subcategory = CAT_PIZZA
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/donkpocketpizza
 	name = "Donkpocket pizza"
@@ -66,7 +66,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pizza/donkpocket
-	subcategory = CAT_PIZZA
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/dankpizza
 	name = "Dank pizza"
@@ -77,7 +77,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pizza/dank
-	subcategory = CAT_PIZZA
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/sassysagepizza
 	name = "Sassysage pizza"
@@ -88,7 +88,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pizza/sassysage
-	subcategory = CAT_PIZZA
+	subcategory = CAT_BAKING
 
 /datum/crafting_recipe/food/pineapplepizza
 	name = "Hawaiian pizza"
@@ -100,4 +100,4 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pizza/pineapple
-	subcategory = CAT_PIZZA
+	subcategory = CAT_BAKING

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_salad.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_salad.dm
@@ -11,7 +11,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/apple = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/salad/herbsalad
-	subcategory = CAT_SALAD
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/aesirsalad
 	name = "Aesir salad"
@@ -21,7 +21,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/apple/gold = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/salad/aesirsalad
-	subcategory = CAT_SALAD
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/validsalad
 	name = "Valid salad"
@@ -32,7 +32,7 @@
 		/obj/item/reagent_containers/food/snacks/meatball = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/salad/validsalad
-	subcategory = CAT_SALAD
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/monkeysdelight
 	name = "Monkeys delight"
@@ -45,7 +45,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/banana = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/monkeysdelight
-	subcategory = CAT_SALAD
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/oatmeal
 	name = "Oatmeal"
@@ -55,7 +55,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/oat = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/salad/oatmeal
-	subcategory = CAT_SALAD
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/fruitsalad
 	name = "Fruit salad"
@@ -68,7 +68,7 @@
 
 	)
 	result = /obj/item/reagent_containers/food/snacks/salad/fruit
-	subcategory = CAT_SALAD
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/junglesalad
 	name = "Jungle salad"
@@ -81,7 +81,7 @@
 
 	)
 	result = /obj/item/reagent_containers/food/snacks/salad/jungle
-	subcategory = CAT_SALAD
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/citrusdelight
 	name = "Citrus delight"
@@ -93,4 +93,4 @@
 
 	)
 	result = /obj/item/reagent_containers/food/snacks/salad/citrusdelight
-	subcategory = CAT_SALAD
+	subcategory = CAT_MISCFOOD

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_sandwich.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_sandwich.dm
@@ -9,48 +9,48 @@
 /datum/crafting_recipe/food/sandwich
 	name = "Sandwich"
 	reqs = list(
-		/obj/item/food/breadslice/plain = 2,
+		/obj/item/reagent_containers/food/snacks/breadslice/plain = 2,
 		/obj/item/reagent_containers/food/snacks/meat/steak = 1,
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/sandwich
-	subcategory = CAT_SANDWICH
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/grilledcheesesandwich
 	name = "Cheese sandwich"
 	reqs = list(
-		/obj/item/food/breadslice/plain = 2,
+		/obj/item/reagent_containers/food/snacks/breadslice/plain = 2,
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/grilledcheese
-	subcategory = CAT_SANDWICH
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/slimesandwich
 	name = "Jelly sandwich"
 	reqs = list(
 		/datum/reagent/toxin/slimejelly = 5,
-		/obj/item/food/breadslice/plain = 2,
+		/obj/item/reagent_containers/food/snacks/breadslice/plain = 2,
 	)
 	result = /obj/item/reagent_containers/food/snacks/jellysandwich/slime
-	subcategory = CAT_SANDWICH
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/cherrysandwich
 	name = "Jelly sandwich"
 	reqs = list(
 		/datum/reagent/consumable/cherryjelly = 5,
-		/obj/item/food/breadslice/plain = 2,
+		/obj/item/reagent_containers/food/snacks/breadslice/plain = 2,
 	)
 	result = /obj/item/reagent_containers/food/snacks/jellysandwich/cherry
-	subcategory = CAT_SANDWICH
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/notasandwich
 	name = "Not a sandwich"
 	reqs = list(
-		/obj/item/food/breadslice/plain = 2,
+		/obj/item/reagent_containers/food/snacks/breadslice/plain = 2,
 		/obj/item/clothing/mask/fakemoustache = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/notasandwich
-	subcategory = CAT_SANDWICH
+	subcategory = CAT_HEARTY
 
 
 

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_soup.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_soup.dm
@@ -13,7 +13,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/potato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/meatball
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/vegetablesoup
 	name = "Vegetable soup"
@@ -26,7 +26,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/potato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/vegetable
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/nettlesoup
 	name = "Nettle soup"
@@ -38,7 +38,7 @@
 		/obj/item/reagent_containers/food/snacks/boiledegg = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/nettle
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/wingfangchu
 	name = "Wingfangchu"
@@ -48,7 +48,7 @@
 		/obj/item/reagent_containers/food/snacks/meat/cutlet/xeno = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/wingfangchu
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/wishsoup
 	name = "Wish soup"
@@ -57,7 +57,7 @@
 		/obj/item/reagent_containers/glass/bowl = 1
 	)
 	result= /obj/item/reagent_containers/food/snacks/soup/wish
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/hotchili
 	name = "Hot chili"
@@ -68,7 +68,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/hotchili
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/coldchili
 	name = "Cold chili"
@@ -79,7 +79,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/coldchili
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/clownchili
 	name = "Chili con carnival"
@@ -91,7 +91,7 @@
 		/obj/item/clothing/shoes/clown_shoes = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/clownchili
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/tomatosoup
 	name = "Tomato soup"
@@ -101,7 +101,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/tomato
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/eyeballsoup
 	name = "Eyeball soup"
@@ -112,7 +112,7 @@
 		/obj/item/organ/eyes = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/tomato/eyeball
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 
 /datum/crafting_recipe/food/milosoup
@@ -124,7 +124,7 @@
 		/obj/item/reagent_containers/food/snacks/tofu = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/milo
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/bloodsoup
 	name = "Blood soup"
@@ -134,7 +134,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato/blood = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/blood
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/slimesoup
 	name = "Slime soup"
@@ -144,7 +144,7 @@
 			/obj/item/reagent_containers/glass/bowl = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/slime
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/clownstears
 	name = "Clowns tears"
@@ -155,7 +155,7 @@
 		/obj/item/stack/sheet/mineral/bananium = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/clownstears
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/mysterysoup
 	name = "Mystery soup"
@@ -168,7 +168,7 @@
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 1,
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/mystery
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/mushroomsoup
 	name = "Mushroom soup"
@@ -179,7 +179,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/mushroom/chanterelle = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/mushroom
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/beetsoup
 	name = "Beet soup"
@@ -190,7 +190,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/cabbage = 1,
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/beet
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/stew
 	name = "Stew"
@@ -205,7 +205,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/mushroom = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/stew
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/spacylibertyduff
 	name = "Spacy liberty duff"
@@ -215,7 +215,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/mushroom/libertycap = 3
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/spacylibertyduff
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/amanitajelly
 	name = "Amanita jelly"
@@ -225,7 +225,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/mushroom/amanita = 3
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/amanitajelly
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/sweetpotatosoup
 	name = "Sweet potato soup"
@@ -236,7 +236,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/potato/sweet = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/sweetpotato
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/redbeetsoup
 	name = "Red beet soup"
@@ -247,7 +247,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/cabbage = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/beet/red
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/onionsoup
 	name = "French onion soup"
@@ -258,7 +258,7 @@
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 1,
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/onion
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/bisque
 	name = "Bisque"
@@ -269,7 +269,7 @@
 		/obj/item/reagent_containers/food/snacks/salad/boiledrice = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/bisque
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/bungocurry
 	name = "Bungo Curry"
@@ -281,7 +281,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/bungofruit = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/bungocurry
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY
 
 /datum/crafting_recipe/food/electron
 	name = "Electron Soup"
@@ -292,4 +292,4 @@
 		/obj/item/reagent_containers/food/snacks/grown/mushroom/jupitercup = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/electron
-	subcategory = CAT_SOUP
+	subcategory = CAT_HEARTY

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_spaghetti.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_spaghetti.dm
@@ -10,7 +10,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/spaghetti/pastatomato
-	subcategory = CAT_SPAGHETTI
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/copypasta
 	name = "Copypasta"
@@ -18,7 +18,7 @@
 		/obj/item/reagent_containers/food/snacks/spaghetti/pastatomato = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/spaghetti/copypasta
-	subcategory = CAT_SPAGHETTI
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/spaghettimeatball
 	name = "Spaghetti meatball"
@@ -27,7 +27,7 @@
 		/obj/item/reagent_containers/food/snacks/meatball = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/spaghetti/meatballspaghetti
-	subcategory = CAT_SPAGHETTI
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/spesslaw
 	name = "Spesslaw"
@@ -36,7 +36,7 @@
 		/obj/item/reagent_containers/food/snacks/meatball = 4
 	)
 	result = /obj/item/reagent_containers/food/snacks/spaghetti/spesslaw
-	subcategory = CAT_SPAGHETTI
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/beefnoodle
 	name = "Beef noodle"
@@ -47,7 +47,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/cabbage = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/spaghetti/beefnoodle
-	subcategory = CAT_SPAGHETTI
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/chowmein
 	name = "Chowmein"
@@ -58,7 +58,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/carrot = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/spaghetti/chowmein
-	subcategory = CAT_SPAGHETTI
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/butternoodles
 	name = "Butter Noodles"
@@ -67,4 +67,4 @@
 		/obj/item/reagent_containers/food/snacks/butter = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/spaghetti/butternoodles
-	subcategory = CAT_SPAGHETTI
+	subcategory = CAT_MISCFOOD


### PR DESCRIPTION
Shifted and removed a couple of personal crafting categories to prevent from cluttering.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Shifted the recipes into fewer categories (recipe files can be found under
\tgstation\code\modules\food_and_drinks\recipes\tablecraft  

Category files can be found at 
\tgstation\code\datums\components\crafting\crafting.dm

Category definitons can be found at

\tgstation\code\_DEFINES\construction.dm


## Why It's Good For The Game

It makes the category menu of the game less cluttered. I think it would make the chefs' lives easier.

## Changelog
:cl:

tweak: tweaked a few things
code: changed some code
refactor: refactored some code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
