### PR TITLE
You can buckle yourself or somebody else into a chair, if you're next to the chair.

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -142,6 +142,12 @@
 		return FALSE
 
 	add_fingerprint(user)
+	if (M != user)
+		M.visible_message("<span class='warning'>[user] starts buckling [M] to [src]!</span>",\
+					"<span class='userdanger'>[user] starts buckling you to [src]!</span>",\
+					"<span class='hear'>You hear metal clanking.</span>")
+		if(!do_after(user, 3 SECONDS, TRUE, M))
+			return FALSE
 	. = buckle_mob(M, check_loc = check_loc)
 	if(.)
 		if(M == user)
@@ -150,8 +156,7 @@
 				"<span class='hear'>You hear metal clanking.</span>")
 		else
 			M.visible_message("<span class='warning'>[user] buckles [M] to [src]!</span>",\
-				"<span class='warning'>[user] buckles you to [src]!</span>",\
-				"<span class='hear'>You hear metal clanking.</span>")
+				"<span class='warning'>[user] buckles you to [src]!</span>")
 
 /atom/movable/proc/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
 	var/mob/living/M = unbuckle_mob(buckled_mob)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -138,7 +138,7 @@
 
 //Wrapper procs that handle sanity and user feedback
 /atom/movable/proc/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)
-	if(!in_range(user, src) || !isturf(user.loc) || user.incapacitated() || M.anchored)
+	if(!Adjacent(user) || !Adjacent(M) || !isturf(user.loc) || user.incapacitated() || M.anchored)
 		return FALSE
 
 	add_fingerprint(user)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -249,6 +249,9 @@
 		usr.put_in_hands(C)
 		qdel(src)
 
+/obj/structure/chair/user_buckle_mob(mob/living/M, force, check_loc = FALSE)
+	return ..()
+
 /obj/structure/chair/stool/bar
 	name = "bar stool"
 	desc = "It has some unsavory stains on it..."


### PR DESCRIPTION
## About The Pull Request

You can now buckle yourself, as well as others, into a chair as long as you (and the other person, if you're not buckling yourself) are Adjacent to said chair, and being on the same tile as the chair is no longer required.

## Why It's Good For The Game

No more god-awful pixelhunt to accomplish a very simple task.

## Changelog
:cl:
tweak: You can buckle yourself and others into chairs that you're right next to, instead of needing to be on top of the chair to do it.
/:cl:

