### PR TITLE
Fixes xenomorph larva getting stuck by evolving while ventcrawling

### DIFF
--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -44,6 +44,10 @@
 		to_chat(L, "<span class='name'>Drones</span> <span class='info'>are the weakest and slowest of the castes, but can grow into a praetorian and then queen if no queen exists, and are vital to maintaining a hive with their resin secretion abilities.</span>")
 		var/alien_caste = alert(L, "Please choose which alien caste you shall belong to.",,"Hunter","Sentinel","Drone")
 
+		if(L.movement_type & VENTCRAWLING)
+			to_chat(user, "<span class='warning'>You cannot evolve while ventcrawling!</span>")
+			return
+
 		if(user.incapacitated()) //something happened to us while we were choosing.
 			return
 


### PR DESCRIPTION
## About The Pull Request

Simply adds a check for if larva are currently ventcrawling to prevent them evolving into a new mob which is not.

## Why It's Good For The Game

Clicking evolve from the relative safety of the atmos pipes and then needing to ahelp to get unstuck is not fun. Preventing GBJ moments is good.

## Changelog
:cl:
fix: Alien larva can no longer evolve in vents and become stuck.
/:cl: