### PR TITLE
Curse of the Barnyard now costs 1 spell point instead of 2

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -238,6 +238,7 @@
 /datum/spellbook_entry/barnyard
 	name = "Barnyard Curse"
 	spell_type = /obj/effect/proc_holder/spell/pointed/barnyardcurse
+	cost = 1
 
 /datum/spellbook_entry/charge
 	name = "Charge"


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

CoB is a pranking spell that forces people to make animal noises whenever they try to speak, why does it cost 2 spell points?

And who knows, maybe this will allow some wizard to take Curse of the Barnyard 5 times and make it their god-given mission to give everyone on the station an animal mask for Christmas. Or maybe someone will spam it while standing in an n2o cloud. Either way, it's at least a reason to consider this spell over, say, mind transfer.

## Changelog
:cl: ATHATH
balance: The Curse of the Barnyard now costs 1 spell point to purchase instead of 2.
/:cl: