### PR TITLE
Removes Standard cyborg module.

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -630,11 +630,11 @@
 	name = "borg module picker (Standard)"
 	desc = "Allows you to to turn a cyborg into a standard cyborg."
 	icon_state = "cyborg_upgrade3"
-	var/obj/item/robot_module/new_module = /obj/item/robot_module/standard
+	var/obj/item/robot_module/new_module = null
 
 /obj/item/borg/upgrade/transform/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
-	if(.)
+	if(. && new_module)
 		R.module.transform_to(new_module)
 
 /obj/item/borg/upgrade/transform/clown

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -211,8 +211,7 @@
 		to_chat(src,"<span class='userdanger'>ERROR: Module installer reply timeout. Please check internal connections.</span>")
 		return
 
-	var/list/modulelist = list("Standard" = /obj/item/robot_module/standard, \
-	"Engineering" = /obj/item/robot_module/engineering, \
+	var/list/modulelist = list("Engineering" = /obj/item/robot_module/engineering, \
 	"Medical" = /obj/item/robot_module/medical, \
 	"Miner" = /obj/item/robot_module/miner, \
 	"Janitor" = /obj/item/robot_module/janitor, \
@@ -625,9 +624,6 @@
 /mob/living/silicon/robot/modules/Initialize()
 	. = ..()
 	module.transform_to(set_module)
-
-/mob/living/silicon/robot/modules/standard
-	set_module = /obj/item/robot_module/standard
 
 /mob/living/silicon/robot/modules/medical
 	set_module = /obj/item/robot_module/medical

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -248,28 +248,6 @@
 		return FALSE
 	return TRUE
 
-/obj/item/robot_module/standard
-	name = "Standard"
-	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
-		/obj/item/reagent_containers/borghypo/epi,
-		/obj/item/healthanalyzer,
-		/obj/item/weldingtool/largetank/cyborg,
-		/obj/item/wrench/cyborg,
-		/obj/item/crowbar/cyborg,
-		/obj/item/stack/sheet/metal/cyborg,
-		/obj/item/stack/rods/cyborg,
-		/obj/item/stack/tile/plasteel/cyborg,
-		/obj/item/extinguisher,
-		/obj/item/pickaxe,
-		/obj/item/t_scanner/adv_mining_scanner,
-		/obj/item/restraints/handcuffs/cable/zipties,
-		/obj/item/soap/nanotrasen,
-		/obj/item/borg/cyborghug)
-	emag_modules = list(/obj/item/melee/transforming/energy/sword/cyborg)
-	moduleselect_icon = "standard"
-	hat_offset = -3
-
 /obj/item/robot_module/medical
 	name = "Medical"
 	basic_modules = list(
@@ -376,6 +354,7 @@
 		/obj/item/holosign_creator/cyborg,
 		/obj/item/borg/cyborghug/peacekeeper,
 		/obj/item/extinguisher,
+		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/borg/projectile_dampen)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/peace/hacked)
 	cyborg_base_icon = "peace"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -354,7 +354,6 @@
 		/obj/item/holosign_creator/cyborg,
 		/obj/item/borg/cyborghug/peacekeeper,
 		/obj/item/extinguisher,
-		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/borg/projectile_dampen)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/peace/hacked)
 	cyborg_base_icon = "peace"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the Standard borgo module loadout.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Cyborg modules should be hyper-specialised to a single task. The Standard module breaks away from that design philsophy by making a single module that can do basically a bit of everything.

If a cyborg wants to be a jack-of-all-trades, they always have the option of getting a module reset to operate in a new area.

Cyborgs are encouraged to change modules as and when appropriate throughout the shift to deal with problems across the station depending on their own experience.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: NanoTrasen has stopped supporting Standard cyborg modules, citing spiralling costs with managing legacy hardware and ancient upgrades.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
