### PR TITLE
Cyborg Module Reset wire always revealed on hacking interface.

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -74,13 +74,11 @@
 			continue
 		wires += dud
 
-
 ///Called when holder is qdeleted for us to clean ourselves as not to leave any unlawful references.
 /datum/wires/proc/on_holder_qdel(atom/source, force)
 	SIGNAL_HANDLER
 
 	qdel(src)
-
 
 /datum/wires/proc/randomize()
 	var/static/list/possible_colors = list(
@@ -253,6 +251,17 @@
 
 	return FALSE
 
+/**
+  * Whether the given wire should always be revealed.
+  *
+  * Intended to be overridden. Allows for forcing a wire's assignmenmt to always be revealed
+  * in the hacking interface.
+  * Arguments:
+  * * color - Color string of the wire to check.
+  */
+/datum/wires/proc/always_reveal_wire(color)
+	return FALSE
+
 /datum/wires/ui_host()
 	return holder
 
@@ -278,7 +287,7 @@
 	for(var/color in colors)
 		payload.Add(list(list(
 			"color" = color,
-			"wire" = ((reveal_wires && !is_dud_color(color)) ? get_wire(color) : null),
+			"wire" = (((reveal_wires || always_reveal_wire(color)) && !is_dud_color(color)) ? get_wire(color) : null),
 			"cut" = is_color_cut(color),
 			"attached" = is_attached(color)
 		)))

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -91,3 +91,10 @@
 		return TRUE
 
 	return ..()
+
+/datum/wires/robot/always_reveal_wire(color)
+	// Always reveal the reset module wire.
+	if(color == get_color_of_wire(WIRE_RESET_MODULE))
+		return TRUE
+
+	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/91586752-bc5a2780-e94d-11ea-8742-2670797e1e1b.png)

Implements a proc intended to be overridden, which allows for force-revealing of specific wires on a case-by-case basis.

Overrides this proc for the cyborg wire datum to always reveal the module reset wire.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/24975989/91586780-c845e980-e94d-11ea-903d-a6237be34add.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: When hacking cyborgs, the Module Reset wire is now far more obvious.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
