### PR TITLE
Makes water recyclers fabricate-able, and makes showers preform a touch reaction only.

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -121,7 +121,6 @@
 	A.wash(CLEAN_WASH)
 	SEND_SIGNAL(A, COMSIG_ADD_MOOD_EVENT, "shower", /datum/mood_event/nice_shower)
 	reagents.expose(A, TOUCH)
-	reagents.expose(A, VAPOR)
 	if(isliving(A))
 		check_heat(A)
 

--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -370,3 +370,13 @@
 	materials = list(/datum/material/iron=50, /datum/material/glass=10)
 	build_path = /obj/item/stock_parts/card_reader
 	category = list("Stock Parts")
+
+/datum/design/water_recycler
+	name = "Water Recycler"
+	desc = "A small hydrostatic reclaimer, it takes moisture out of the air and returns it back to the source."
+	id = "w-recycler"
+	build_type = PROTOLATHE | AUTOLATHE
+	materials = list(/datum/material/plastic = 200, /datum/material/iron = 50)
+	build_path = /obj/item/stock_parts/water_recycler
+	category = list("Stock Parts")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_MEDICAL

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -56,7 +56,7 @@
 	starting_node = TRUE
 	display_name = "Basic Medical Equipment"
 	description = "Basic medical tools and equipment."
-	design_ids = list("cybernetic_liver", "cybernetic_heart", "cybernetic_lungs","cybernetic_stomach", "scalpel", "circular_saw", "bonesetter", "surgicaldrill", "retractor", "cautery", "hemostat", "stethoscope", 
+	design_ids = list("cybernetic_liver", "cybernetic_heart", "cybernetic_lungs","cybernetic_stomach", "scalpel", "circular_saw", "bonesetter", "surgicaldrill", "retractor", "cautery", "hemostat", "stethoscope",
 					"surgical_drapes", "syringe", "plumbing_rcd", "beaker", "large_beaker", "xlarge_beaker", "dropper", "defibmountdefault", "surgical_tape", "portable_chem_mixer")
 
 /////////////////////////Biotech/////////////////////////
@@ -134,7 +134,7 @@
 	display_name = "Industrial Engineering"
 	description = "A refresher course on modern engineering technology."
 	prereq_ids = list("base")
-	design_ids = list("solarcontrol", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "high_cell", "adv_matter_bin", "scanner_gate",
+	design_ids = list("solarcontrol", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "w-recycler" , "emitter", "high_cell", "adv_matter_bin", "scanner_gate",
 	"atmosalerts", "atmos_control", "recycler", "autolathe", "high_micro_laser", "nano_mani", "mesons", "welding_goggles", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod",
 	"apc_control", "cell_charger", "power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics", "cell_charger", "stack_console", "stack_machine",
 	"oxygen_tank", "plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt", "electrolyzer", "adv_electrolite")


### PR DESCRIPTION
All that testing and this never once came up on my side, dang.

## About The Pull Request

Fixes #53271, Fixes #53269.
This swaps the shower's reactions when pumping in reagents to a touch only reaction as opposed to touch and vapor, as vapor reactions introduce reagents into the player's body and can result in very large quantities of reagents in a single body.

Also, I forgot to add the stock part to the techweb, so thankfully the above issue was slightly mitigated as a result, but that wasn't the intended effect. This adds the part to the autolathe, and the engineering, science, and medical protolathes.

## Why It's Good For The Game

Bugs bad, large quantities of chems in bodies are bad, and being able to use the new feature without debug verbs is good.

## Changelog
:cl:
fix: Showers now preform a touch reaction, not a touch/vapor reaction with piped reagents.
fix: You can now build water recyclers in lathes, as intended.
/:cl: