### PR TITLE
Adds Layer 1/3 Gas Meter Subtypes

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -51177,12 +51177,12 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bTp" = (
-/obj/machinery/meter,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/machinery/meter/atmos/layer3,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bTq" = (
@@ -78923,10 +78923,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
 	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "cVq" = (
-/obj/machinery/meter,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -4741,7 +4741,6 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "akL" = (
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 9
 	},
@@ -5774,7 +5773,6 @@
 /area/crew_quarters/fitness)
 "anb" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
@@ -6184,7 +6182,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/meter,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aoa" = (
@@ -6711,6 +6708,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/machinery/meter/atmos/layer3,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "apv" = (
@@ -13662,12 +13660,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aFV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/meter,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "aFW" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
@@ -20072,17 +20064,6 @@
 /obj/item/stack/package_wrap,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"aVC" = (
-/obj/machinery/meter,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "aVD" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -37102,10 +37083,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plating,
 /area/construction)
-"bKB" = (
-/obj/machinery/meter,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "bKD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
@@ -43342,13 +43319,13 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ceM" = (
-/obj/machinery/meter,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
 	},
+/obj/machinery/meter/atmos/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ceO" = (
@@ -50816,6 +50793,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"fXZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/meter/atmos/layer3,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "fYd" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -52859,6 +52844,31 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/psychology)
+"mhJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/meter/atmos/layer3,
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"miW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/meter/atmos/layer3,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "mje" = (
 /obj/machinery/door/airlock{
 	name = "Private Restroom"
@@ -54563,6 +54573,12 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"rrg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/meter/atmos/layer3,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ruy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -54832,6 +54848,12 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/break_room)
+"smt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/meter/atmos/layer3,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "soQ" = (
 /obj/machinery/power/apc{
 	areastring = "/area/vacant_room/commissary";
@@ -73105,7 +73127,7 @@ asU
 bbV
 boP
 alU
-asK
+miW
 azF
 aAS
 aFP
@@ -78006,7 +78028,7 @@ aPG
 aPG
 aPG
 aPG
-aVC
+aSX
 gjl
 baS
 aZp
@@ -78262,7 +78284,7 @@ aPI
 aRb
 aRb
 aRb
-aRb
+rrg
 aWx
 gjl
 baS
@@ -79536,7 +79558,7 @@ ayH
 ayH
 ayH
 ayH
-aFV
+ayH
 ayH
 ayH
 aKy
@@ -81592,7 +81614,7 @@ aBi
 apV
 arF
 arF
-arF
+smt
 arF
 aue
 arP
@@ -89086,8 +89108,8 @@ bDO
 bFl
 bDO
 bHU
-hxs
-bKB
+mhJ
+bAw
 bLK
 bMM
 bOd
@@ -91599,7 +91621,7 @@ anc
 anc
 anc
 bkV
-anc
+fXZ
 anD
 aoI
 arj

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -4643,10 +4643,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"alV" = (
-/obj/machinery/meter,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "alW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -38358,10 +38354,10 @@
 	},
 /area/maintenance/department/engine)
 "bSt" = (
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer3{
 	dir = 10
 	},
+/obj/machinery/meter/atmos/layer3,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bSu" = (
@@ -38610,8 +38606,7 @@
 "bTf" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer3,
 /obj/machinery/atmospherics/components/binary/pump/on/layer1{
-	name = "Virology Waste to Space";
-	pixel_x = -1
+	name = "Virology Waste to Space"
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -38619,8 +38614,7 @@
 /area/maintenance/department/engine)
 "bTg" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer1{
-	name = "Virology Waste to Space";
-	pixel_x = -1
+	name = "Virology Waste to Space"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -41230,7 +41224,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZi" = (
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -41387,6 +41380,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
 	},
+/obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "bZS" = (
@@ -44123,8 +44117,7 @@
 "clM" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer1{
 	dir = 1;
-	name = "Tcomms Sat Waste";
-	pixel_x = -1
+	name = "Tcomms Sat Waste"
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
@@ -55701,13 +55694,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "sUP" = (
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer3{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
 	},
+/obj/machinery/meter/atmos/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -76508,7 +76501,7 @@ afU
 ajG
 akw
 all
-alV
+ajD
 aiu
 vCC
 apB

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -18,6 +18,12 @@
 /obj/machinery/meter/atmos
 	frequency = FREQ_ATMOS_STORAGE
 
+/obj/machinery/meter/atmos/layer1
+	target_layer = 1
+
+/obj/machinery/meter/atmos/layer3
+	target_layer = 3
+
 /obj/machinery/meter/atmos/atmos_waste_loop
 	name = "waste loop gas flow meter"
 	id_tag = ATMOS_GAS_MONITOR_LOOP_ATMOS_WASTE
@@ -25,6 +31,11 @@
 /obj/machinery/meter/atmos/distro_loop
 	name = "distribution loop gas flow meter"
 	id_tag = ATMOS_GAS_MONITOR_LOOP_DISTRIBUTION
+
+/obj/machinery/meter/atmos/distro_loop/layer3
+	name = "distribution loop gas flow meter"
+	id_tag = ATMOS_GAS_MONITOR_LOOP_DISTRIBUTION
+	target_layer = 3
 
 /obj/machinery/meter/Destroy()
 	SSair.atmos_machinery -= src

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -32,11 +32,6 @@
 	name = "distribution loop gas flow meter"
 	id_tag = ATMOS_GAS_MONITOR_LOOP_DISTRIBUTION
 
-/obj/machinery/meter/atmos/distro_loop/layer3
-	name = "distribution loop gas flow meter"
-	id_tag = ATMOS_GAS_MONITOR_LOOP_DISTRIBUTION
-	target_layer = 3
-
 /obj/machinery/meter/Destroy()
 	SSair.atmos_machinery -= src
 	target = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
With the current rework to the air distro and scrubbers system, I completely forgot about gas meters and left a bunch of them around to no longer work. Whoops. This adds two subtypes for gas meters that work on layers 1 and 3. I found and replaced every broken gas meter, as well as moved a couple others. I originally added a subtype to atmos/distro_loop but that just seems unnecessary, so it was removed.

Thanks to Potato/LemonInTheDark for helping me get this done.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mappers can now place layer 1/3 gas meters, which will hopefully encourage more use of the layers other than 2. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added 2 new subtypes of gas meter so that they work on layers 1 and 3
fix: Deltastation: Fixes some broken gas meters to be on the correct layer
fix: Icebox station: Fixes some broken gas meters to be on the correct layer, as well as relocating the random ones in maint to actual pipes
fix: Pubbystation: Fixes some broken gas meters to be on the correct layer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
