### PR TITLE
Makes admin view obey the overlay limit.

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -716,7 +716,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set desc = "switches between 1x and custom views"
 
 	if(view_size.getView() == view_size.default)
-		view_size.setTo(input("Select view range:", "FUCK YE", 7) in list(1,2,3,4,5,6,7,8,9,10,11,12,13,14,128) - 7)
+		view_size.setTo(input("Select view range:", "FUCK YE", 7) in list(1,2,3,4,5,6,7,8,9,10,11,12,13,14,37) - 7)
 	else
 		view_size.resetToDefault(getScreenSize(prefs.widescreenpref))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Caps admin view at 68x68, or 37, in order to prevent it creating more then 100 overlays, causing the parallax system to crash due to exceeding our overlay hardcap of 100

(Hey admemes, that 128 view thing was a ~~meme~~ absurdity, in testing I can't get view sizes to go above an effective 70 square tiles, or 37 or so.)

## Why It's Good For The Game

Parallax won't die randomly when a badmin presses buttons, and the admin team will release my family from their grasp.

## Changelog
:cl:
admin: Hello admins, I've made your view options better reflect reality, you can't crash parallax for yourself by using them now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
