### PR TITLE
Peacekeeper cyborgs now have zipties.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -376,6 +376,7 @@
 		/obj/item/holosign_creator/cyborg,
 		/obj/item/borg/cyborghug/peacekeeper,
 		/obj/item/extinguisher,
+		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/borg/projectile_dampen)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/peace/hacked)
 	cyborg_base_icon = "peace"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## DO NOT MERGE UNLESS #53276 IS MERGED

## About The Pull Request

Requested to atomise this change out of #53276.

Adds the zipties module to the Peacekeeper cyborg.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

In the original PR, I was not targetting Validhunt: The Module. I was targetting Specialise in Generality: The Module. I felt that the playstyle some grey phallic cyborgs adopted wherein they would Le Hunt La Válids wasn't necessarily a bad thing in theory.

My primary thoughts went as follows: Subverting a cyborg through any means, from laws to emags, should give you a fairly robust companion. The weaker and more useless cyborgs are, the less fun it is to turn them against the crew.

Grey marital aid cyborgs with their baseline zipties gave a decent option for antag subversion if they didn't want to go loud and are the only non-emag model capable of completely subduing a non-silicon in a non-lethal manner.

Other options include as an emag module instead of baseline.

However, I am not attached to this idea in any way and I know @optimumtact is strongly against it.

Feel free to engage in cordial discussion below. I know a number of maintainers and myself will be regularly reading the feedback and summarily dismissing all your opinions.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Following the decomissioning of Standard cyborg modules, excess ziptie supplies have been looted by Peacekeeper cyborg modules. WEEOO WEEOO - HUMAN HARM!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
