### PR TITLE
Skeletons can treat their bone wounds again, improves door crush dislocation fix

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -355,6 +355,8 @@
 ///from base of mob/swap_hand(): (obj/item)
 #define COMSIG_MOB_SWAP_HANDS "mob_swap_hands"
 	#define COMPONENT_BLOCK_SWAP (1<<0)
+///from /obj/structure/door/crush(): (mob/living/crushed)
+#define COMSIG_LIVING_DOORCRUSH "living_doorcrush"
 
 ///from base of mob/living/resist() (/mob/living)
 #define COMSIG_LIVING_RESIST "living_resist"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -355,8 +355,8 @@
 ///from base of mob/swap_hand(): (obj/item)
 #define COMSIG_MOB_SWAP_HANDS "mob_swap_hands"
 	#define COMPONENT_BLOCK_SWAP (1<<0)
-///from /obj/structure/door/crush(): (mob/living/crushed)
-#define COMSIG_LIVING_DOORCRUSH "living_doorcrush"
+///from /obj/structure/door/crush(): (mob/living/crushed, /obj/machinery/door/crushing_door)
+#define COMSIG_LIVING_DOORCRUSHED "living_doorcrush"
 
 ///from base of mob/living/resist() (/mob/living)
 #define COMSIG_LIVING_RESIST "living_resist"

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -252,9 +252,10 @@
 
 	// next we check if the bodypart in actually accessible (not under thick clothing). We skip the species trait check since skellies
 	// & such may need to use bone gel but may be wearing a space suit for..... whatever reason a skeleton would wear a space suit for
-	var/mob/living/carbon/human/victim_human = victim
-	if(istype(victim_human) && !victim_human.can_inject(user, TRUE, ignore_species = TRUE))
-		return TRUE
+	if(ishuman(victim))
+		var/mob/living/carbon/human/victim_human = victim
+		if(!victim_human.can_inject(user, TRUE, ignore_species = TRUE))
+			return TRUE
 
 	// lastly, treat them
 	treat(I, user)

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -250,7 +250,9 @@
 		to_chat(user, "<span class='warning'>You're already interacting with [victim]!</span>")
 		return TRUE
 
-	if(!victim.can_inject(user, TRUE))
+	// next we check if the bodypart in actually accessible (not under thick clothing). We skip the species trait check since skellies
+	// & such may need to use bone gel but may be wearing a space suit for..... whatever reason a skeleton would wear a space suit for
+	if(!victim.can_inject(user, TRUE, ignore_species = TRUE))
 		return TRUE
 
 	// lastly, treat them

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -252,7 +252,8 @@
 
 	// next we check if the bodypart in actually accessible (not under thick clothing). We skip the species trait check since skellies
 	// & such may need to use bone gel but may be wearing a space suit for..... whatever reason a skeleton would wear a space suit for
-	if(!victim.can_inject(user, TRUE, ignore_species = TRUE))
+	var/mob/living/carbon/human/victim_human = victim
+	if(istype(victim_human) && !victim_human.can_inject(user, TRUE, ignore_species = TRUE))
 		return TRUE
 
 	// lastly, treat them

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -297,10 +297,6 @@
 /datum/wound/proc/on_stasis()
 	return
 
-/// Called when we're crushed in an airlock or firedoor, for one of the improvised joint dislocation fixes
-/datum/wound/proc/crush()
-	return
-
 /// Used when we're being dragged while bleeding, the value we return is how much bloodloss this wound causes from being dragged. Since it's a proc, you can let bandages soak some of the blood
 /datum/wound/proc/drag_bleed_amount()
 	return

--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -199,14 +199,14 @@
 	status_effect_type = /datum/status_effect/wound/blunt/moderate
 	scar_keyword = "bluntmoderate"
 
-/datum/wound/blunt/moderate/wound_injury(datum/wound/old_wound)
-	. = ..()
-	RegisterSignal(victim, COMSIG_LIVING_DOORCRUSH, .proc/door_crush)
-
 /datum/wound/blunt/moderate/Destroy()
 	if(victim)
-		UnregisterSignal(victim, COMSIG_LIVING_DOORCRUSH)
+		UnregisterSignal(victim, COMSIG_LIVING_DOORCRUSHED)
 	return ..()
+
+/datum/wound/blunt/moderate/wound_injury(datum/wound/old_wound)
+	. = ..()
+	RegisterSignal(victim, COMSIG_LIVING_DOORCRUSHED, .proc/door_crush)
 
 /// Getting smushed in an airlock/firelock is a last-ditch attempt to try relocating your limb
 /datum/wound/blunt/moderate/proc/door_crush()

--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -199,7 +199,17 @@
 	status_effect_type = /datum/status_effect/wound/blunt/moderate
 	scar_keyword = "bluntmoderate"
 
-/datum/wound/blunt/moderate/crush()
+/datum/wound/blunt/moderate/wound_injury(datum/wound/old_wound)
+	. = ..()
+	RegisterSignal(victim, COMSIG_LIVING_DOORCRUSH, .proc/door_crush)
+
+/datum/wound/blunt/moderate/Destroy()
+	if(victim)
+		UnregisterSignal(victim, COMSIG_LIVING_DOORCRUSH)
+	return ..()
+
+/// Getting smushed in an airlock/firelock is a last-ditch attempt to try relocating your limb
+/datum/wound/blunt/moderate/proc/door_crush()
 	if(prob(33))
 		victim.visible_message("<span class='danger'>[victim]'s dislocated [limb.name] pops back into place!</span>", "<span class='userdanger'>Your dislocated [limb.name] pops back into place! Ow!</span>")
 		remove_wound()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -349,11 +349,7 @@
 /obj/machinery/door/proc/crush()
 	for(var/mob/living/L in get_turf(src))
 		L.visible_message("<span class='warning'>[src] closes on [L], crushing [L.p_them()]!</span>", "<span class='userdanger'>[src] closes on you and crushes you!</span>")
-		if(iscarbon(L))
-			var/mob/living/carbon/C = L
-			for(var/i in C.all_wounds) // should probably replace with signal
-				var/datum/wound/W = i
-				W.crush(DOOR_CRUSH_DAMAGE)
+		SEND_SIGNAL(L, COMSIG_LIVING_DOORCRUSH)
 		if(isalien(L))  //For xenos
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE * 1.5) //Xenos go into crit after aproximately the same amount of crushes as humans.
 			L.emote("roar")

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -349,7 +349,7 @@
 /obj/machinery/door/proc/crush()
 	for(var/mob/living/L in get_turf(src))
 		L.visible_message("<span class='warning'>[src] closes on [L], crushing [L.p_them()]!</span>", "<span class='userdanger'>[src] closes on you and crushes you!</span>")
-		SEND_SIGNAL(L, COMSIG_LIVING_DOORCRUSH)
+		SEND_SIGNAL(L, COMSIG_LIVING_DOORCRUSHED, src)
 		if(isalien(L))  //For xenos
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE * 1.5) //Xenos go into crit after aproximately the same amount of crushes as humans.
 			L.emote("roar")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -533,12 +533,16 @@
 /mob/living/carbon/human/proc/canUseHUD()
 	return (mobility_flags & MOBILITY_USE)
 
-/mob/living/carbon/human/can_inject(mob/user, error_msg, target_zone, penetrate_thick = 0)
-	. = 1 // Default to returning true.
+/mob/living/carbon/human/can_inject(mob/user, error_msg, target_zone, penetrate_thick = FALSE, ignore_species = FALSE)
+	. = TRUE // Default to returning true.
 	if(user && !target_zone)
 		target_zone = user.zone_selected
-	if(HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
-		. = 0
+	// we may choose to ignore species trait pierce immunity in case we still want to check skellies for thick clothing without insta failing them (wounds)
+	if(ignore_species)
+		if(HAS_TRAIT_NOT_FROM(src, TRAIT_PIERCEIMMUNE, SPECIES_TRAIT))
+			. = FALSE
+	else if(HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
+		. = FALSE
 	// If targeting the head, see if the head item is thin enough.
 	// If targeting anything else, see if the wear suit is thin enough.
 	if (!penetrate_thick)
@@ -546,12 +550,12 @@
 			if(head && istype(head, /obj/item/clothing))
 				var/obj/item/clothing/CH = head
 				if (CH.clothing_flags & THICKMATERIAL)
-					. = 0
+					. = FALSE
 		else
 			if(wear_suit && istype(wear_suit, /obj/item/clothing))
 				var/obj/item/clothing/CS = wear_suit
 				if (CS.clothing_flags & THICKMATERIAL)
-					. = 0
+					. = FALSE
 	if(!. && error_msg && user)
 		// Might need re-wording.
 		to_chat(user, "<span class='alert'>There is no exposed flesh or thin material [above_neck(target_zone) ? "on [p_their()] head" : "on [p_their()] body"].</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When I did #52951 and checked for pierce immunity to disallow treatments through thick clothing, I forgot about the existence of skeletons who would always fail that check. This specific can_inject() check now ignores species traits so they can still apply bone_gel and slings as needed

In addition, the "get crushed in an airlock/firelock" improvised fix for dislocated limbs is now done by a signal instead of a direct proc like it should have a while ago.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lets bone species fix their bone wounds without surgery/milk again, improves a sinful bit of my snowflake code in door crushes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Skeletons and other boneheads can now treat their bone wounds with bone gel and slings without getting messages about their flesh being impenetrable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
