### PR TITLE
Fixes #53290, puddles are now infinite again.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -1250,7 +1250,7 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "do" = (
-/obj/structure/legacysink/puddle{
+/obj/structure/water_source/puddle{
 	pixel_x = -3;
 	pixel_y = 1
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -1250,7 +1250,7 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "do" = (
-/obj/structure/sink/puddle{
+/obj/structure/legacysink/puddle{
 	pixel_x = -3;
 	pixel_y = 1
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -33,7 +33,7 @@
 	},
 /area/ruin/powered)
 "j" = (
-/obj/structure/legacysink/puddle,
+/obj/structure/water_source/puddle,
 /turf/open/floor/plating/asteroid{
 	name = "dirt"
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -33,7 +33,7 @@
 	},
 /area/ruin/powered)
 "j" = (
-/obj/structure/sink/puddle,
+/obj/structure/legacysink/puddle,
 /turf/open/floor/plating/asteroid{
 	name = "dirt"
 	},

--- a/_maps/RandomRuins/SpaceRuins/clownplanet.dmm
+++ b/_maps/RandomRuins/SpaceRuins/clownplanet.dmm
@@ -88,7 +88,7 @@
 	},
 /area/ruin/powered/clownplanet)
 "as" = (
-/obj/structure/sink/puddle,
+/obj/structure/legacysink/puddle,
 /turf/open/floor/grass{
 	color = "#1eff00"
 	},

--- a/_maps/RandomRuins/SpaceRuins/clownplanet.dmm
+++ b/_maps/RandomRuins/SpaceRuins/clownplanet.dmm
@@ -88,7 +88,7 @@
 	},
 /area/ruin/powered/clownplanet)
 "as" = (
-/obj/structure/legacysink/puddle,
+/obj/structure/water_source/puddle,
 /turf/open/floor/grass{
 	color = "#1eff00"
 	},

--- a/_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
@@ -79,7 +79,7 @@
 /turf/open/floor/grass,
 /area/ruin/space/has_grav)
 "u" = (
-/obj/structure/sink/puddle,
+/obj/structure/legacysink/puddle,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav)
 "v" = (

--- a/_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
@@ -79,7 +79,7 @@
 /turf/open/floor/grass,
 /area/ruin/space/has_grav)
 "u" = (
-/obj/structure/legacysink/puddle,
+/obj/structure/water_source/puddle,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav)
 "v" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -75076,7 +75076,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "tgQ" = (
-/obj/structure/sink/puddle,
+/obj/structure/legacysink/puddle,
 /obj/structure/flora/junglebush/large{
 	pixel_y = 0
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -75076,7 +75076,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "tgQ" = (
-/obj/structure/legacysink/puddle,
+/obj/structure/water_source/puddle,
 /obj/structure/flora/junglebush/large{
 	pixel_y = 0
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -26713,7 +26713,7 @@
 /turf/open/floor/grass,
 /area/medical/medbay/zone2)
 "bqU" = (
-/obj/structure/legacysink/puddle,
+/obj/structure/water_source/puddle,
 /obj/structure/flora/ausbushes/reedbush{
 	pixel_y = 6
 	},
@@ -43224,7 +43224,7 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
 "chk" = (
-/obj/structure/legacysink/puddle,
+/obj/structure/water_source/puddle,
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
@@ -51954,7 +51954,7 @@
 /turf/closed/wall/r_wall,
 /area/medical/medbay/zone2)
 "llS" = (
-/obj/structure/legacysink/puddle,
+/obj/structure/water_source/puddle,
 /obj/structure/window/reinforced{
 	dir = 1
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -26713,7 +26713,7 @@
 /turf/open/floor/grass,
 /area/medical/medbay/zone2)
 "bqU" = (
-/obj/structure/sink/puddle,
+/obj/structure/legacysink/puddle,
 /obj/structure/flora/ausbushes/reedbush{
 	pixel_y = 6
 	},
@@ -43224,7 +43224,7 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
 "chk" = (
-/obj/structure/sink/puddle,
+/obj/structure/legacysink/puddle,
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
@@ -51954,7 +51954,7 @@
 /turf/closed/wall/r_wall,
 /area/medical/medbay/zone2)
 "llS" = (
-/obj/structure/sink/puddle,
+/obj/structure/legacysink/puddle,
 /obj/structure/window/reinforced{
 	dir = 1
 	},

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -903,7 +903,7 @@
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/dodgeball)
 "cD" = (
-/obj/structure/sink/puddle,
+/obj/structure/legacysink/puddle,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
 "cE" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -903,7 +903,7 @@
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/dodgeball)
 "cD" = (
-/obj/structure/legacysink/puddle,
+/obj/structure/water_source/puddle,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
 "cE" = (

--- a/_maps/shuttles/emergency_nature.dmm
+++ b/_maps/shuttles/emergency_nature.dmm
@@ -5,7 +5,7 @@
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "au" = (
-/obj/structure/legacysink/puddle,
+/obj/structure/water_source/puddle,
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "ay" = (

--- a/_maps/shuttles/emergency_nature.dmm
+++ b/_maps/shuttles/emergency_nature.dmm
@@ -5,7 +5,7 @@
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "au" = (
-/obj/structure/sink/puddle,
+/obj/structure/legacysink/puddle,
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "ay" = (

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -574,7 +574,7 @@
 		busy = TRUE
 		if(!do_after(user, 40, target = src))
 			busy = FALSE
-			return 1
+			return TRUE
 		busy = FALSE
 		O.wash(CLEAN_WASH)
 		O.acid_level = 0

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -601,11 +601,6 @@
 /obj/structure/water_source/puddle/deconstruct(disassembled = TRUE)
 	qdel(src)
 
-/obj/structure/water_source/greyscale
-	icon_state = "sink_greyscale"
-	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
-	buildstacktype = null
-
 //End legacy sink
 
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -459,17 +459,15 @@
 		return
 	return ..()
 
-//Legacy sink and puddles, use the type water_source for unlimited water sources like classic sinks.
+//Water source, use the type water_source for unlimited water sources like classic sinks.
 /obj/structure/water_source
-	name = "sink"
+	name = "Water Source"
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "sink"
-	desc = "A sink used for washing one's hands and face."
+	desc = "A sink used for washing one's hands and face. This one seems to be infinite!"
 	anchored = TRUE
 	var/busy = FALSE 	//Something's being washed at the moment
 	var/dispensedreagent = /datum/reagent/water // for whenever plumbing happens
-	var/buildstacktype = /obj/item/stack/sheet/metal
-	var/buildstackamount = 1
 
 /obj/structure/water_source/attack_hand(mob/living/user)
 	. = ..()
@@ -546,11 +544,6 @@
 		playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
 		return
 
-	if(O.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1))
-		O.play_tool_sound(src)
-		deconstruct()
-		return
-
 	if(istype(O, /obj/item/stack/medical/gauze))
 		var/obj/item/stack/medical/gauze/G = O
 		new /obj/item/reagent_containers/glass/rag(src.loc)
@@ -560,7 +553,7 @@
 
 	if(istype(O, /obj/item/stack/ore/glass))
 		new /obj/item/stack/sheet/sandblock(loc)
-		to_chat(user, "<span class='notice'>You wet the sand in the sink and form it into a block.</span>")
+		to_chat(user, "<span class='notice'>You wet the sand and form it into a block.</span>")
 		O.use(1)
 		return
 
@@ -587,18 +580,6 @@
 	else
 		return ..()
 
-/obj/structure/water_source/deconstruct()
-	if(!(flags_1 & NODECONSTRUCT_1))
-		drop_materials()
-	..()
-
-/obj/structure/water_source/proc/drop_materials()
-	if(buildstacktype)
-		new buildstacktype(loc,buildstackamount)
-	else
-		for(var/i in custom_materials)
-			var/datum/material/M = i
-			new M.sheet_type(loc, FLOOR(custom_materials[M] / MINERAL_MATERIAL_AMOUNT, 1))
 
 /obj/structure/water_source/puddle	//splishy splashy ^_^
 	name = "puddle"

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -583,7 +583,7 @@
 		reagents.expose(O, TOUCH)
 		user.visible_message("<span class='notice'>[user] washes [O] using [src].</span>", \
 							"<span class='notice'>You wash [O] using [src].</span>")
-		return 1
+		return TRUE
 	else
 		return ..()
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -573,8 +573,8 @@
 		user.visible_message("<span class='notice'>[user] washes [O] using [src].</span>", \
 							"<span class='notice'>You wash [O] using [src].</span>")
 		return TRUE
-	else
-		return ..()
+
+	return ..()
 
 
 /obj/structure/water_source/puddle	//splishy splashy ^_^

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -555,8 +555,6 @@
 		O.use(1)
 		return
 
-	if(!istype(O))
-		return
 	if(O.item_flags & ABSTRACT) //Abstract items like grabs won't wash. No-drop items will though because it's still technically an item in your hand.
 		return
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -544,7 +544,7 @@
 
 	if(istype(O, /obj/item/stack/medical/gauze))
 		var/obj/item/stack/medical/gauze/G = O
-		new /obj/item/reagent_containers/glass/rag(src.loc)
+		new /obj/item/reagent_containers/glass/rag(loc)
 		to_chat(user, "<span class='notice'>You tear off a strip of gauze and make a rag.</span>")
 		G.use(1)
 		return

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -459,8 +459,8 @@
 		return
 	return ..()
 
-//Legacy sink and puddles, use the type legacysink for unlimited water sources like classic sinks.
-/obj/structure/legacysink
+//Legacy sink and puddles, use the type water_source for unlimited water sources like classic sinks.
+/obj/structure/water_source
 	name = "sink"
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "sink"
@@ -471,7 +471,7 @@
 	var/buildstacktype = /obj/item/stack/sheet/metal
 	var/buildstackamount = 1
 
-/obj/structure/legacysink/attack_hand(mob/living/user)
+/obj/structure/water_source/attack_hand(mob/living/user)
 	. = ..()
 	if(.)
 		return
@@ -513,7 +513,7 @@
 	user.visible_message("<span class='notice'>[user] washes [user.p_their()] [washing_face ? "face" : "hands"] using [src].</span>", \
 						"<span class='notice'>You wash your [washing_face ? "face" : "hands"] using [src].</span>")
 
-/obj/structure/legacysink/attackby(obj/item/O, mob/living/user, params)
+/obj/structure/water_source/attackby(obj/item/O, mob/living/user, params)
 	if(busy)
 		to_chat(user, "<span class='warning'>Someone's already washing here!</span>")
 		return
@@ -587,12 +587,12 @@
 	else
 		return ..()
 
-/obj/structure/legacysink/deconstruct()
+/obj/structure/water_source/deconstruct()
 	if(!(flags_1 & NODECONSTRUCT_1))
 		drop_materials()
 	..()
 
-/obj/structure/legacysink/proc/drop_materials()
+/obj/structure/water_source/proc/drop_materials()
 	if(buildstacktype)
 		new buildstacktype(loc,buildstackamount)
 	else
@@ -600,27 +600,27 @@
 			var/datum/material/M = i
 			new M.sheet_type(loc, FLOOR(custom_materials[M] / MINERAL_MATERIAL_AMOUNT, 1))
 
-/obj/structure/legacysink/puddle	//splishy splashy ^_^
+/obj/structure/water_source/puddle	//splishy splashy ^_^
 	name = "puddle"
 	desc = "A puddle used for washing one's hands and face."
 	icon_state = "puddle"
 	resistance_flags = UNACIDABLE
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
-/obj/structure/legacysink/puddle/attack_hand(mob/M)
+/obj/structure/water_source/puddle/attack_hand(mob/M)
 	icon_state = "puddle-splash"
 	. = ..()
 	icon_state = "puddle"
 
-/obj/structure/legacysink/puddle/attackby(obj/item/O, mob/user, params)
+/obj/structure/water_source/puddle/attackby(obj/item/O, mob/user, params)
 	icon_state = "puddle-splash"
 	. = ..()
 	icon_state = "puddle"
 
-/obj/structure/legacysink/puddle/deconstruct(disassembled = TRUE)
+/obj/structure/water_source/puddle/deconstruct(disassembled = TRUE)
 	qdel(src)
 
-/obj/structure/legacysink/greyscale
+/obj/structure/water_source/greyscale
 	icon_state = "sink_greyscale"
 	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	buildstacktype = null

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -473,8 +473,6 @@
 	. = ..()
 	if(.)
 		return
-	if(!user || !istype(user))
-		return
 	if(!iscarbon(user))
 		return
 	if(!Adjacent(user))

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -515,13 +515,13 @@
 		return
 
 	if(istype(O, /obj/item/reagent_containers))
-		var/obj/item/reagent_containers/RG = O
-		if(RG.is_refillable())
-			if(!RG.reagents.holder_full())
-				RG.reagents.add_reagent(dispensedreagent, min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
-				to_chat(user, "<span class='notice'>You fill [RG] from [src].</span>")
+		var/obj/item/reagent_containers/container = O
+		if(container.is_refillable())
+			if(!container.reagents.holder_full())
+				container.reagents.add_reagent(dispensedreagent, min(container.volume - container.reagents.total_volume, container.amount_per_transfer_from_this))
+				to_chat(user, "<span class='notice'>You fill [container] from [src].</span>")
 				return TRUE
-			to_chat(user, "<span class='notice'>\The [RG] is full.</span>")
+			to_chat(user, "<span class='notice'>\The [container] is full.</span>")
 			return FALSE
 
 	if(istype(O, /obj/item/melee/baton))

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -486,7 +486,7 @@
 		to_chat(user, "<span class='warning'>Someone's already washing here!</span>")
 		return
 	var/selected_area = parse_zone(user.zone_selected)
-	var/washing_face = 0
+	var/washing_face = FALSE
 	if(selected_area in list(BODY_ZONE_HEAD, BODY_ZONE_PRECISE_MOUTH, BODY_ZONE_PRECISE_EYES))
 		washing_face = TRUE
 	user.visible_message("<span class='notice'>[user] starts washing [user.p_their()] [washing_face ? "face" : "hands"]...</span>", \

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -489,7 +489,7 @@
 						"<span class='notice'>You start washing your [washing_face ? "face" : "hands"]...</span>")
 	busy = TRUE
 
-	if(!do_after(user, 40, target = src))
+	if(!do_after(user, 4 SECONDS, target = src))
 		busy = FALSE
 		return
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -525,15 +525,15 @@
 			return FALSE
 
 	if(istype(O, /obj/item/melee/baton))
-		var/obj/item/melee/baton/B = O
-		if(B.cell && B.cell.charge && B.turned_on)
+		var/obj/item/melee/baton/baton = O
+		if(baton.cell && baton.cell.charge && baton.turned_on)
 			flick("baton_active", src)
-			user.Paralyze(B.stun_time)
-			user.stuttering = B.stun_time/20
-			B.deductcharge(B.cell_hit_cost)
-			user.visible_message("<span class='warning'>[user] shocks [user.p_them()]self while attempting to wash the active [B.name]!</span>", \
-								"<span class='userdanger'>You unwisely attempt to wash [B] while it's still on.</span>")
-			playsound(src, B.stun_sound, 50, TRUE)
+			user.Paralyze(baton.stun_time)
+			user.stuttering = baton.stun_time * 0.05
+			baton.deductcharge(baton.cell_hit_cost)
+			user.visible_message("<span class='warning'>[user] shocks [user.p_them()]self while attempting to wash the active [baton.name]!</span>", \
+								"<span class='userdanger'>You unwisely attempt to wash [baton] while it's still on.</span>")
+			playsound(src, baton.stun_sound, 50, TRUE)
 			return
 
 	if(istype(O, /obj/item/mop))

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -561,7 +561,7 @@
 	if(user.a_intent != INTENT_HARM)
 		to_chat(user, "<span class='notice'>You start washing [O]...</span>")
 		busy = TRUE
-		if(!do_after(user, 40, target = src))
+		if(!do_after(user, 4 SECONDS, target = src))
 			busy = FALSE
 			return TRUE
 		busy = FALSE

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -488,7 +488,7 @@
 	var/selected_area = parse_zone(user.zone_selected)
 	var/washing_face = 0
 	if(selected_area in list(BODY_ZONE_HEAD, BODY_ZONE_PRECISE_MOUTH, BODY_ZONE_PRECISE_EYES))
-		washing_face = 1
+		washing_face = TRUE
 	user.visible_message("<span class='notice'>[user] starts washing [user.p_their()] [washing_face ? "face" : "hands"]...</span>", \
 						"<span class='notice'>You start washing your [washing_face ? "face" : "hands"]...</span>")
 	busy = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #53290 
A code oversight of #52865 that also applied plumbing changes to puddles.
Avoided snow flaking by creating a new object type called water_source. Can be used in the future instead of the sink type.
Babies first PR
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ashwalkers no longer have to wait for puddles to refill like station sinks.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Puddles are now infinite sources of water again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
