### PR TITLE
Dying people (and stunned borgies) can gasp and deathgasp again

### DIFF
--- a/code/datums/wounds/loss.dm
+++ b/code/datums/wounds/loss.dm
@@ -17,6 +17,7 @@
 		return
 
 	already_scarred = TRUE // so we don't scar a limb we don't have. If I add different levels of amputation desc, do it here
+	victim = dismembered_part.owner
 
 	if(dismembered_part.body_zone == BODY_ZONE_CHEST)
 		occur_text = "is split open, causing [victim.p_their()] internals organs to spill out!"
@@ -40,8 +41,6 @@
 				occur_text = "is pierced through the last tissue holding it together, severing it completely!"
 			if(WOUND_BURN)
 				occur_text = "is completely incinerated, falling to dust!"
-
-	victim = dismembered_part.owner
 
 	var/msg = "<span class='bolddanger'>[victim]'s [dismembered_part.name] [occur_text]!</span>"
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -80,7 +80,7 @@
 	message_monkey = "lets out a faint chimper as it collapses and stops moving..."
 	message_simple =  "stops moving..."
 	cooldown = (15 SECONDS)
-	stat_allowed = UNCONSCIOUS
+	stat_allowed = HARD_CRIT
 
 /datum/emote/living/deathgasp/run_emote(mob/user, params, type_override, intentional)
 	var/mob/living/simple_animal/S = user
@@ -155,7 +155,7 @@
 	key_third_person = "gasps"
 	message = "gasps!"
 	emote_type = EMOTE_AUDIBLE
-	stat_allowed = UNCONSCIOUS
+	stat_allowed = HARD_CRIT
 
 /datum/emote/living/giggle
 	key = "giggle"

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -113,17 +113,17 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		client?.dsay(message)
 		return
 
-	if(stat != DEAD && check_emote(original_message, forced))
-		return
 
 	switch(stat)
 		if(SOFT_CRIT)
+			if(check_emote(original_message, forced))
+				return
 			message_mods[WHISPER_MODE] = MODE_WHISPER
 		if(UNCONSCIOUS)
-			if(!(message_mods[MODE_CHANGELING] || message_mods[MODE_ALIEN]))
+			if(check_emote(original_message, forced) || !(message_mods[MODE_CHANGELING] || message_mods[MODE_ALIEN]))
 				return
 		if(HARD_CRIT)
-			if(!(message_mods[WHISPER_MODE] || message_mods[MODE_CHANGELING] || message_mods[MODE_ALIEN]))
+			if(check_emote(original_message, forced) || !(message_mods[WHISPER_MODE] || message_mods[MODE_CHANGELING] || message_mods[MODE_ALIEN]))
 				return
 		if(DEAD)
 			say_dead(original_message)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -113,6 +113,9 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		client?.dsay(message)
 		return
 
+	if(stat != DEAD && check_emote(original_message, forced))
+		return
+
 	switch(stat)
 		if(SOFT_CRIT)
 			message_mods[WHISPER_MODE] = MODE_WHISPER
@@ -126,7 +129,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			say_dead(original_message)
 			return
 
-	if(check_emote(original_message, forced) || !can_speak_basic(original_message, ignore_spam, forced))
+	if(!can_speak_basic(original_message, ignore_spam, forced))
 		return
 
 	language = message_mods[LANGUAGE_EXTENSION]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The addition of HARD_CRIT to stat in #53117 wasn't accounted for in the gasp and deathgasp emotes, meaning you couldn't do them in hard crit. This fixes that. It also fixed a related issue with borgs not being able to deathgasp while stunned. Specifically, it-
Fixes: #53310
Fixes: #53259

It also fixes there being no visible message on disemboweling because I was an idiot
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
"What is best in life?" "To crush your enemies, to see them driven before you, and to hear the deathgasps of their assistants!"
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Dying people can gasp and deathgasp again
fix: Borgs can deathgasp (and normal gasp I guess) while stunned again
fix: The message for disembowelment now properly displays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
