### PR TITLE
Fixes #53301, Swarmers can no longer break walls with big pressure differences.

### DIFF
--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -109,12 +109,12 @@
 	for(var/turf/turf_in_range in range(1, src))
 		var/area/turf_area = get_area(turf_in_range)
 		//Check for dangerous pressure differences
-		if (return_turf_delta_p(turf_in_range) > DANGEROUS_DELTA_P)
+		if (turf_in_range.return_turf_delta_p() > DANGEROUS_DELTA_P)
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
 		//Check if breaking this door will expose the station to space/planetary atmos
-		else if(is_nearby_planetary_atmos(turf_in_range) || isspaceturf(turf_in_range) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
+		else if(turf_in_range.s_nearby_planetary_atmos() || isspaceturf(turf_in_range) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return FALSE
@@ -196,11 +196,11 @@
 	var/isonshuttle = istype(loc, /area/shuttle)
 	for(var/turf/turf_in_range in range(1, src))
 		var/area/turf_area = get_area(turf_in_range)
-		if (return_turf_delta_p(turf_in_range) > DANGEROUS_DELTA_P)
+		if (turf_in_range.return_turf_delta_p() > DANGEROUS_DELTA_P)
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
-		else if(is_nearby_planetary_atmos(turf_in_range) || isspaceturf(turf_area) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle) ))
+		else if(turf_in_range.is_nearby_planetary_atmos() || isspaceturf(turf_area) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle) ))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return TRUE
@@ -212,13 +212,14 @@
 
 /obj/structure/window/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	var/is_on_shuttle = istype(get_area(src), /area/shuttle)
-	for(var/turf/turf_in_range in range(1, src))
+	for(var/t in RANGE_TURFS(1, src))
+		var/turf/turf_in_range = t
 		var/area/turf_area = get_area(turf_in_range)
-		if (return_turf_delta_p(turf_in_range) > DANGEROUS_DELTA_P)
+		if (turf_in_range.return_turf_delta_p() > DANGEROUS_DELTA_P)
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
-		else if(is_nearby_planetary_atmos(turf_in_range) || isspaceturf(turf_in_range) || (!is_on_shuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (is_on_shuttle && !istype(turf_area, /area/shuttle)))
+		else if(turf_in_range.is_nearby_planetary_atmos() || isspaceturf(turf_in_range) || (!is_on_shuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (is_on_shuttle && !istype(turf_area, /area/shuttle)))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return TRUE

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -7,10 +7,11 @@
   */
 #define DANGEROUS_DELTA_P 250	//Value in kPa where swarmers arent allowed to break a wall or window with this difference in pressure.
 
-/turf/proc/return_turf_delta_p()	//Finds the greatest difference in pressure across a turf, only considers open turfs.
+///Finds the greatest difference in pressure across a turf, only considers open turfs.
+/turf/proc/return_turf_delta_p()
 	var/pressure_greatest = 0
 	var/pressure_smallest = INFINITY 					//Freaking terrified to use INFINITY, man
-	for(var/t in RANGE_TURFS(2, src))			//Begin processing the delta pressure across the wall.
+	for(var/t in RANGE_TURFS(1, src))			//Begin processing the delta pressure across the wall.
 		var/turf/open/turf_adjacent = t
 		if(!istype(turf_adjacent))
 			continue
@@ -19,9 +20,10 @@
 
 	return pressure_greatest - pressure_smallest
 
-/turf/proc/is_nearby_planetary_atmos()	//Runs through all adjacent open turfs and checks if any are planetary_atmos returns true if even one passes
+///Runs through all adjacent open turfs and checks if any are planetary_atmos returns true if even one passes.
+/turf/proc/is_nearby_planetary_atmos()
 	. = FALSE
-	for(var/t in RANGE_TURFS(2, src))
+	for(var/t in RANGE_TURFS(1, src))
 		if(!isopenturf(t))
 			continue
 		var/turf/open/turf_adjacent = t

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -19,6 +19,17 @@
 
 	return pressure_greatest - pressure_smallest
 
+/atom/proc/is_nearby_planetary_atmos(var/turf/target_turf)	//Runs through all adjacent open turfs and checks if any are planetary_atmos
+	var/is_planetary = FALSE
+	for(var/t in RANGE_TURFS(2, target_turf))
+		var/turf/open/turf_adjacent = t
+		if(!istype(turf_adjacent))
+			continue
+		if(turf_adjacent.planetary_atmos)
+			is_planetary = TRUE
+			break
+	return is_planetary
+
 /atom/proc/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	actor.dis_integrate(src)
 	return TRUE //return TRUE/FALSE whether or not an AI swarmer should try this swarmer_act() again, NOT whether it succeeded.
@@ -103,7 +114,7 @@
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
-		else if(isspaceturf(turf_in_range) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
+		else if(is_nearby_planetary_atmos(turf_in_range) || isspaceturf(turf_in_range) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return FALSE
@@ -188,7 +199,7 @@
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
-		else if(isspaceturf(turf_area) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle) ))
+		else if(is_nearby_planetary_atmos(turf_in_range) || isspaceturf(turf_area) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle) ))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return TRUE
@@ -206,7 +217,7 @@
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
-		else if(isspaceturf(turf_in_range) || (!is_on_shuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (is_on_shuttle && !istype(turf_area, /area/shuttle)))
+		else if(is_nearby_planetary_atmos(turf_in_range) || isspaceturf(turf_in_range) || (!is_on_shuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (is_on_shuttle && !istype(turf_area, /area/shuttle)))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return TRUE

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -203,7 +203,7 @@
 			pressure_greatest = turf_adjacent.air.return_pressure()
 		if(turf_adjacent.air.return_pressure() < pressure_smallest)
 			pressure_smallest = turf_adjacent.air.return_pressure()
-	var/delta_p = (pressure_greatest - pressure_smallest)
+	var/delta_p = pressure_greatest - pressure_smallest
 	for(var/turf/adj_turf in range(1, src))
 		var/area/adj_area = get_area(adj_turf)
 		if (delta_p > 1000) //If the delta pressure is too high it is considered too dangerous to break this. A difference of 1000 kPa is considered dangerous

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -7,10 +7,10 @@
   */
 #define DANGEROUS_DELTA_P 250	//Value in kPa where swarmers arent allowed to break a wall or window with this difference in pressure.
 
-/turf/proc/return_turf_delta_p(var/turf/target_turf)	//Finds the greatest difference in pressure across a turf, only considers open turfs.
+/turf/proc/return_turf_delta_p()	//Finds the greatest difference in pressure across a turf, only considers open turfs.
 	var/pressure_greatest = 0
 	var/pressure_smallest = INFINITY 					//Freaking terrified to use INFINITY, man
-	for(var/t in RANGE_TURFS(2, target_turf))			//Begin processing the delta pressure across the wall.
+	for(var/t in RANGE_TURFS(2, src))			//Begin processing the delta pressure across the wall.
 		var/turf/open/turf_adjacent = t
 		if(!istype(turf_adjacent))
 			continue

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -7,7 +7,7 @@
   */
 #define DANGEROUS_DELTA_P 1000	//Value in kPa where swarmers arent allowed to break a wall or window with this difference in pressure.
 
-/atom/proc/is_wall_pressure_dangerous(/var/turf/target_wall)
+/atom/proc/return_wall_delta_p(/var/turf/target_wall)	//Finds the greatest difference in pressure across a closed turf.
 	var/pressure_greatest = 0
 	var/pressure_smallest = INFINITY 			//Freaking terrified to use INFINITY, man
 	for(var/t in RANGE_TURFS(2, target_wall))	//Begin processing the delta pressure across the wall.
@@ -19,11 +19,8 @@
 		if(turf_adjacent.air.return_pressure() < pressure_smallest)
 			pressure_smallest = turf_adjacent.air.return_pressure()
 
-	var/delta_p = (pressure_greatest - pressure_smallest)
-	if(delta_p > DANGEROUS_DELTA_P) 			//If the delta pressure is too high it is considered too dangerous to break this.
-		return TRUE
-	else
-		return FALSE
+	to_chat(world, "DEBUG: RETURNED DELTA P IS " + pressure_greatest - pressure_smallest " kPa")
+	return pressure_greatest - pressure_smallest
 
 /atom/proc/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	actor.dis_integrate(src)
@@ -105,7 +102,7 @@
 	var/isonshuttle = istype(get_area(src), /area/shuttle)
 	for(var/turf/turf_in_range in range(1, src))
 		var/area/turf_area = get_area(turf_in_range)
-		if (is_wall_pressure_dangerous(src))
+		if (return_wall_delta_p(src) > DANGEROUS_DELTA_P)
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
@@ -190,7 +187,7 @@
 	var/isonshuttle = istype(loc, /area/shuttle)
 	for(var/turf/turf_in_range in range(1, src))
 		var/area/turf_area = get_area(turf_in_range)
-		if (is_wall_pressure_dangerous(src))
+		if (return_wall_delta_p(src) > DANGEROUS_DELTA_P)
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
@@ -208,7 +205,7 @@
 	var/is_on_shuttle = istype(get_area(src), /area/shuttle)
 	for(var/turf/adj_turf in range(1, src))
 		var/area/adj_area = get_area(adj_turf)
-		if (is_wall_pressure_dangerous(src))
+		if (return_wall_delta_p(src) > DANGEROUS_DELTA_P)
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -105,7 +105,7 @@
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
-		else if(turf_in_range.planetary_atmos || isspaceturf(turf_in_range) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
+		else if(isspaceturf(turf_in_range) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return FALSE
@@ -190,7 +190,7 @@
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
-		else if(turf_in_range.planetary_atmos || isspaceturf(turf_area) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle) ))
+		else if(isspaceturf(turf_area) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle) ))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return TRUE
@@ -208,7 +208,7 @@
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
-		else if(turf_in_range.planetary_atmos || isspaceturf(turf_in_range) || (!is_on_shuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (is_on_shuttle && !istype(turf_area, /area/shuttle)))
+		else if(isspaceturf(turf_in_range) || (!is_on_shuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (is_on_shuttle && !istype(turf_area, /area/shuttle)))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return TRUE

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -5,7 +5,8 @@
   * Arguments:
   * * S - A reference to the swarmer doing the interaction
   */
-  #define DANGEROUS_DELTA_P 1000	//Value in kPa where swarmers arent allowed to break a wall or window with this difference in pressure.
+#define DANGEROUS_DELTA_P 1000	//Value in kPa where swarmers arent allowed to break a wall or window with this difference in pressure.
+
 /atom/proc/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	actor.dis_integrate(src)
 	return TRUE //return TRUE/FALSE whether or not an AI swarmer should try this swarmer_act() again, NOT whether it succeeded.
@@ -178,7 +179,7 @@
 	var/delta_p = (pressure_greatest - pressure_smallest)
 	for(var/turf/turf_in_range in range(1, src))
 		var/area/turf_area = get_area(turf_in_range)
-		if (delta_p > 1000) //If the delta pressure is too high it is considered too dangerous to break this. A difference of 1000 kPa is considered dangerous
+		if (delta_p > DANGEROUS_DELTA_P) //If the delta pressure is too high it is considered too dangerous to break this. A difference of 1000 kPa is considered dangerous
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -5,7 +5,7 @@
   * Arguments:
   * * S - A reference to the swarmer doing the interaction
   */
-#define DANGEROUS_DELTA_P 1000	//Value in kPa where swarmers arent allowed to break a wall or window with this difference in pressure.
+#define DANGEROUS_DELTA_P 250	//Value in kPa where swarmers arent allowed to break a wall or window with this difference in pressure.
 
 /atom/proc/return_wall_delta_p(var/turf/target_turf)	//Finds the greatest difference in pressure across a closed turf.
 	var/pressure_greatest = 0
@@ -14,10 +14,8 @@
 		var/turf/open/turf_adjacent = t
 		if(!istype(turf_adjacent))
 			continue
-		if(turf_adjacent.air.return_pressure() > pressure_greatest)
-			pressure_greatest = turf_adjacent.air.return_pressure()
-		if(turf_adjacent.air.return_pressure() < pressure_smallest)
-			pressure_smallest = turf_adjacent.air.return_pressure()
+		pressure_greatest = max(pressure_greatest, turf_adjacent.air.return_pressure())
+		pressure_smallest = min(pressure_smallest, turf_adjacent.air.return_pressure())
 
 	return pressure_greatest - pressure_smallest
 

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -114,7 +114,7 @@
 			actor.target = null
 			return TRUE
 		//Check if breaking this door will expose the station to space/planetary atmos
-		else if(turf_in_range.s_nearby_planetary_atmos() || isspaceturf(turf_in_range) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
+		else if(turf_in_range.is_nearby_planetary_atmos() || isspaceturf(turf_in_range) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return FALSE

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -7,7 +7,7 @@
   */
 #define DANGEROUS_DELTA_P 250	//Value in kPa where swarmers arent allowed to break a wall or window with this difference in pressure.
 
-/atom/proc/return_wall_delta_p(var/turf/target_turf)	//Finds the greatest difference in pressure across a closed turf.
+/turf/proc/return_wall_delta_p(var/turf/target_turf)	//Finds the greatest difference in pressure across a closed turf.
 	var/pressure_greatest = 0
 	var/pressure_smallest = INFINITY 					//Freaking terrified to use INFINITY, man
 	for(var/t in RANGE_TURFS(2, target_turf))			//Begin processing the delta pressure across the wall.

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -20,15 +20,13 @@
 	return pressure_greatest - pressure_smallest
 
 /atom/proc/is_nearby_planetary_atmos(var/turf/target_turf)	//Runs through all adjacent open turfs and checks if any are planetary_atmos
-	var/is_planetary = FALSE
+	. = FALSE
 	for(var/t in RANGE_TURFS(2, target_turf))
-		var/turf/open/turf_adjacent = t
-		if(!istype(turf_adjacent))
+		if(!isopenturf(t))
 			continue
+		var/turf/open/turf_adjacent = t
 		if(turf_adjacent.planetary_atmos)
-			is_planetary = TRUE
-			break
-	return is_planetary
+			return TRUE
 
 /atom/proc/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	actor.dis_integrate(src)

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -7,7 +7,7 @@
   */
 #define DANGEROUS_DELTA_P 250	//Value in kPa where swarmers arent allowed to break a wall or window with this difference in pressure.
 
-/turf/proc/return_wall_delta_p(var/turf/target_turf)	//Finds the greatest difference in pressure across a closed turf.
+/turf/proc/return_turf_delta_p(var/turf/target_turf)	//Finds the greatest difference in pressure across a turf, only considers open turfs.
 	var/pressure_greatest = 0
 	var/pressure_smallest = INFINITY 					//Freaking terrified to use INFINITY, man
 	for(var/t in RANGE_TURFS(2, target_turf))			//Begin processing the delta pressure across the wall.
@@ -19,7 +19,7 @@
 
 	return pressure_greatest - pressure_smallest
 
-/atom/proc/is_nearby_planetary_atmos(var/turf/target_turf)	//Runs through all adjacent open turfs and checks if any are planetary_atmos
+/atom/proc/is_nearby_planetary_atmos(var/turf/target_turf)	//Runs through all adjacent open turfs and checks if any are planetary_atmos returns true if even one passes
 	. = FALSE
 	for(var/t in RANGE_TURFS(2, target_turf))
 		if(!isopenturf(t))
@@ -108,14 +108,17 @@
 	var/isonshuttle = istype(get_area(src), /area/shuttle)
 	for(var/turf/turf_in_range in range(1, src))
 		var/area/turf_area = get_area(turf_in_range)
-		if (return_wall_delta_p(turf_in_range) > DANGEROUS_DELTA_P)
+		//Check for dangerous pressure differences
+		if (return_turf_delta_p(turf_in_range) > DANGEROUS_DELTA_P)
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
+		//Check if breaking this door will expose the station to space/planetary atmos
 		else if(is_nearby_planetary_atmos(turf_in_range) || isspaceturf(turf_in_range) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return FALSE
+		//Check if this door is important in supermatter containment
 		else if(istype(turf_area, /area/engine/supermatter))
 			to_chat(actor, "<span class='warning'>Disrupting the containment of a supermatter crystal would not be to our benefit. Aborting.</span>")
 			actor.target = null
@@ -193,7 +196,7 @@
 	var/isonshuttle = istype(loc, /area/shuttle)
 	for(var/turf/turf_in_range in range(1, src))
 		var/area/turf_area = get_area(turf_in_range)
-		if (return_wall_delta_p(turf_in_range) > DANGEROUS_DELTA_P)
+		if (return_turf_delta_p(turf_in_range) > DANGEROUS_DELTA_P)
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
@@ -211,7 +214,7 @@
 	var/is_on_shuttle = istype(get_area(src), /area/shuttle)
 	for(var/turf/turf_in_range in range(1, src))
 		var/area/turf_area = get_area(turf_in_range)
-		if (return_wall_delta_p(turf_in_range) > DANGEROUS_DELTA_P)
+		if (return_turf_delta_p(turf_in_range) > DANGEROUS_DELTA_P)
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -5,6 +5,7 @@
   * Arguments:
   * * S - A reference to the swarmer doing the interaction
   */
+  #define DANGEROUS_DELTA_P 1000	//Value in kPa where swarmers arent allowed to break a wall or window with this difference in pressure.
 /atom/proc/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	actor.dis_integrate(src)
 	return TRUE //return TRUE/FALSE whether or not an AI swarmer should try this swarmer_act() again, NOT whether it succeeded.
@@ -206,7 +207,7 @@
 	var/delta_p = pressure_greatest - pressure_smallest
 	for(var/turf/adj_turf in range(1, src))
 		var/area/adj_area = get_area(adj_turf)
-		if (delta_p > 1000) //If the delta pressure is too high it is considered too dangerous to break this. A difference of 1000 kPa is considered dangerous
+		if (delta_p > DANGEROUS_DELTA_P) //If the delta pressure is too high it is considered too dangerous to break this. A difference of 1000 kPa is considered dangerous
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
@@ -260,4 +261,4 @@
 	to_chat(actor, "<span class='warning'>This object does not contain solid matter. Aborting.</span>")
 	return FALSE
 
-
+#undef DANGEROUS_DELTA_P

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -19,9 +19,6 @@
 		if(turf_adjacent.air.return_pressure() < pressure_smallest)
 			pressure_smallest = turf_adjacent.air.return_pressure()
 
-	to_chat(world, "DEBUG: ")
-	to_chat(world, pressure_greatest - pressure_smallest)
-	to_chat(world, " kPa")
 	return pressure_greatest - pressure_smallest
 
 /atom/proc/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
@@ -108,7 +105,7 @@
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
-		else if(isspaceturf(turf_in_range) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
+		else if(turf_in_range.planetary_atmos || isspaceturf(turf_in_range) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return FALSE
@@ -193,7 +190,7 @@
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
-		else if(isspaceturf(turf_area) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle) ))
+		else if(turf_in_range.planetary_atmos || isspaceturf(turf_area) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle) ))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return TRUE
@@ -205,17 +202,17 @@
 
 /obj/structure/window/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	var/is_on_shuttle = istype(get_area(src), /area/shuttle)
-	for(var/turf/adj_turf in range(1, src))
-		var/area/adj_area = get_area(adj_turf)
-		if (return_wall_delta_p(adj_turf) > DANGEROUS_DELTA_P)
+	for(var/turf/turf_in_range in range(1, src))
+		var/area/turf_area = get_area(turf_in_range)
+		if (return_wall_delta_p(turf_in_range) > DANGEROUS_DELTA_P)
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
-		else if(isspaceturf(adj_turf) || (!is_on_shuttle && (istype(adj_area, /area/shuttle) || istype(adj_area, /area/space))) || (is_on_shuttle && !istype(adj_area, /area/shuttle)))
+		else if(turf_in_range.planetary_atmos || isspaceturf(turf_in_range) || (!is_on_shuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (is_on_shuttle && !istype(turf_area, /area/shuttle)))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return TRUE
-		else if(istype(adj_area, /area/engine/supermatter))
+		else if(istype(turf_area, /area/engine/supermatter))
 			to_chat(actor, "<span class='warning'>Disrupting the containment of a supermatter crystal would not be to our benefit. Aborting.</span>")
 			actor.target = null
 			return TRUE

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -7,10 +7,10 @@
   */
 #define DANGEROUS_DELTA_P 1000	//Value in kPa where swarmers arent allowed to break a wall or window with this difference in pressure.
 
-/atom/proc/return_wall_delta_p(/var/turf/target_wall)	//Finds the greatest difference in pressure across a closed turf.
+/atom/proc/return_wall_delta_p(var/turf/target_turf)	//Finds the greatest difference in pressure across a closed turf.
 	var/pressure_greatest = 0
-	var/pressure_smallest = INFINITY 			//Freaking terrified to use INFINITY, man
-	for(var/t in RANGE_TURFS(2, target_wall))	//Begin processing the delta pressure across the wall.
+	var/pressure_smallest = INFINITY 					//Freaking terrified to use INFINITY, man
+	for(var/t in RANGE_TURFS(2, target_turf))			//Begin processing the delta pressure across the wall.
 		var/turf/open/turf_adjacent = t
 		if(!istype(turf_adjacent))
 			continue
@@ -19,7 +19,9 @@
 		if(turf_adjacent.air.return_pressure() < pressure_smallest)
 			pressure_smallest = turf_adjacent.air.return_pressure()
 
-	to_chat(world, "DEBUG: RETURNED DELTA P IS " + pressure_greatest - pressure_smallest " kPa")
+	to_chat(world, "DEBUG: ")
+	to_chat(world, pressure_greatest - pressure_smallest)
+	to_chat(world, " kPa")
 	return pressure_greatest - pressure_smallest
 
 /atom/proc/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
@@ -102,7 +104,7 @@
 	var/isonshuttle = istype(get_area(src), /area/shuttle)
 	for(var/turf/turf_in_range in range(1, src))
 		var/area/turf_area = get_area(turf_in_range)
-		if (return_wall_delta_p(src) > DANGEROUS_DELTA_P)
+		if (return_wall_delta_p(turf_in_range) > DANGEROUS_DELTA_P)
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
@@ -187,7 +189,7 @@
 	var/isonshuttle = istype(loc, /area/shuttle)
 	for(var/turf/turf_in_range in range(1, src))
 		var/area/turf_area = get_area(turf_in_range)
-		if (return_wall_delta_p(src) > DANGEROUS_DELTA_P)
+		if (return_wall_delta_p(turf_in_range) > DANGEROUS_DELTA_P)
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE
@@ -205,7 +207,7 @@
 	var/is_on_shuttle = istype(get_area(src), /area/shuttle)
 	for(var/turf/adj_turf in range(1, src))
 		var/area/adj_area = get_area(adj_turf)
-		if (return_wall_delta_p(src) > DANGEROUS_DELTA_P)
+		if (return_wall_delta_p(adj_turf) > DANGEROUS_DELTA_P)
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
 			actor.target = null
 			return TRUE

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -19,9 +19,9 @@
 
 	return pressure_greatest - pressure_smallest
 
-/atom/proc/is_nearby_planetary_atmos(var/turf/target_turf)	//Runs through all adjacent open turfs and checks if any are planetary_atmos returns true if even one passes
+/turf/proc/is_nearby_planetary_atmos()	//Runs through all adjacent open turfs and checks if any are planetary_atmos returns true if even one passes
 	. = FALSE
-	for(var/t in RANGE_TURFS(2, target_turf))
+	for(var/t in RANGE_TURFS(2, src))
 		if(!isopenturf(t))
 			continue
 		var/turf/open/turf_adjacent = t

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -105,7 +105,11 @@
 	var/isonshuttle = istype(get_area(src), /area/shuttle)
 	for(var/turf/turf_in_range in range(1, src))
 		var/area/turf_area = get_area(turf_in_range)
-		if(isspaceturf(turf_in_range) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
+		if (is_wall_pressure_dangerous(src))
+			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
+			actor.target = null
+			return TRUE
+		else if(isspaceturf(turf_in_range) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return FALSE

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -164,9 +164,24 @@
 
 /turf/closed/wall/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	var/isonshuttle = istype(loc, /area/shuttle)
+	var/pressure_greatest = 0
+	var/pressure_smallest = INFINITY 	//Freaking terrified to use INFINITY, man
+	for(var/t in RANGE_TURFS(2, src))	//Begin processing the delta pressure across the wall.
+		var/turf/open/turf_adjacent = t
+		if(!istype(turf_adjacent))
+			continue
+		if(turf_adjacent.air.return_pressure() > pressure_greatest)
+			pressure_greatest = turf_adjacent.air.return_pressure()
+		if(turf_adjacent.air.return_pressure() < pressure_smallest)
+			pressure_smallest = turf_adjacent.air.return_pressure()
+	var/delta_p = (pressure_greatest - pressure_smallest)
 	for(var/turf/turf_in_range in range(1, src))
 		var/area/turf_area = get_area(turf_in_range)
-		if(isspaceturf(turf_area) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
+		if (delta_p > 1000) //If the delta pressure is too high it is considered too dangerous to break this. A difference of 1000 kPa is considered dangerous
+			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
+			actor.target = null
+			return TRUE
+		else if(isspaceturf(turf_area) || (!isonshuttle && (istype(turf_area, /area/shuttle) || istype(turf_area, /area/space))) || (isonshuttle && !istype(turf_area, /area/shuttle)))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return TRUE
@@ -178,13 +193,28 @@
 
 /obj/structure/window/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	var/is_on_shuttle = istype(get_area(src), /area/shuttle)
+	var/pressure_greatest = 0
+	var/pressure_smallest = INFINITY 	//Freaking terrified to use INFINITY, man
+	for(var/t in RANGE_TURFS(2, src))	//Begin processing the delta pressure across the wall.
+		var/turf/open/turf_adjacent = t
+		if(!istype(turf_adjacent))
+			continue
+		if(turf_adjacent.air.return_pressure() > pressure_greatest)
+			pressure_greatest = turf_adjacent.air.return_pressure()
+		if(turf_adjacent.air.return_pressure() < pressure_smallest)
+			pressure_smallest = turf_adjacent.air.return_pressure()
+	var/delta_p = (pressure_greatest - pressure_smallest)
 	for(var/turf/adj_turf in range(1, src))
 		var/area/adj_area = get_area(adj_turf)
-		if(isspaceturf(adj_turf) || (!is_on_shuttle && (istype(adj_area, /area/shuttle) || istype(adj_area, /area/space))) || (is_on_shuttle && !istype(adj_area, /area/shuttle)))
+		if (delta_p > 1000) //If the delta pressure is too high it is considered too dangerous to break this. A difference of 1000 kPa is considered dangerous
+			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause an explosive pressure release. Aborting.</span>")
+			actor.target = null
+			return TRUE
+		else if(isspaceturf(adj_turf) || (!is_on_shuttle && (istype(adj_area, /area/shuttle) || istype(adj_area, /area/space))) || (is_on_shuttle && !istype(adj_area, /area/shuttle)))
 			to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			actor.target = null
 			return TRUE
-		if(istype(adj_area, /area/engine/supermatter))
+		else if(istype(adj_area, /area/engine/supermatter))
 			to_chat(actor, "<span class='warning'>Disrupting the containment of a supermatter crystal would not be to our benefit. Aborting.</span>")
 			actor.target = null
 			return TRUE
@@ -229,3 +259,5 @@
 /obj/machinery/shieldwall/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	to_chat(actor, "<span class='warning'>This object does not contain solid matter. Aborting.</span>")
 	return FALSE
+
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #53301
Holy heck I had to learn atmos code and turfs code and for lists to get this one done.
Either way, we're good!

This Pr effectively adds an extra check for swarmers breaking windows and walls to see if there is too high of a pressure difference across it (in this case 250 kPa) This value can be easily tweaked.

Creates new proc: find_turf_delta_p(var/turf/)
Returns the largest difference in pressure around a given turf. Pass a certain turf into the function.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ask Vekter why swarmers breaking open atmos stock tanks is detrimental to the game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Swarmers can no longer break walls with large pressure differences across them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
