### PR TITLE
The great Spectral Blade permanent ghost trap unGBJing - 10/10 ghosts hated that sword

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -42,6 +42,14 @@
 		begin_orbit(arglist(args.Copy(3)))
 		return
 	// The following only happens on component transfers
+	for(var/i in newcomp.orbiters)
+		var/mob/orbiter_mob = i
+		orbiter_mob.orbiting = src
+		// It is important to transfer the signals so we don't get locked to the new orbiter component for all time
+		UnregisterSignal(orbiter_mob, COMSIG_MOVABLE_MOVED)
+		RegisterSignal(orbiter_mob, COMSIG_MOVABLE_MOVED, .proc/orbiter_move_react)
+		RegisterSignal(parent, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, .proc/orbiter_glide_size_update)
+
 	orbiters += newcomp.orbiters
 
 /datum/component/orbiter/PostTransfer()

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -45,7 +45,8 @@
 		begin_orbit(arglist(args.Copy(3)))
 		return
 	// The following only happens on component transfers
-	for(var/atom/movable/incoming_orbiter in newcomp.orbiters)
+	for(var/o in newcomp.orbiters)
+		var/atom/movable/incoming_orbiter = o
 		incoming_orbiter.orbiting = src
 		// It is important to transfer the signals so we don't get locked to the new orbiter component for all time
 		newcomp.UnregisterSignal(incoming_orbiter, COMSIG_MOVABLE_MOVED)

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -32,7 +32,8 @@
 
 /datum/component/orbiter/Destroy()
 	var/atom/master = parent
-	master.orbiters = null
+	if(master.orbiters == src)
+		master.orbiters = null
 	for(var/i in orbiters)
 		end_orbit(i)
 	orbiters = null
@@ -44,14 +45,14 @@
 		begin_orbit(arglist(args.Copy(3)))
 		return
 	// The following only happens on component transfers
-	for(var/i in newcomp.orbiters)
-		var/mob/orbiter_mob = i
-		orbiter_mob.orbiting = src
+	for(var/atom/movable/incoming_orbiter in newcomp.orbiters)
+		incoming_orbiter.orbiting = src
 		// It is important to transfer the signals so we don't get locked to the new orbiter component for all time
-		UnregisterSignal(orbiter_mob, COMSIG_MOVABLE_MOVED)
-		RegisterSignal(orbiter_mob, COMSIG_MOVABLE_MOVED, .proc/orbiter_move_react)
+		newcomp.UnregisterSignal(incoming_orbiter, COMSIG_MOVABLE_MOVED)
+		RegisterSignal(incoming_orbiter, COMSIG_MOVABLE_MOVED, .proc/orbiter_move_react)
 
 	orbiters += newcomp.orbiters
+	newcomp.orbiters = null
 
 /datum/component/orbiter/PostTransfer()
 	if(!isatom(parent) || isarea(parent) || !get_turf(parent))

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -25,6 +25,7 @@
 		tracker = new(target, CALLBACK(src, .proc/move_react))
 
 /datum/component/orbiter/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE)
 	var/atom/target = parent
 	target.orbiters = null
 	QDEL_NULL(tracker)
@@ -39,6 +40,7 @@
 
 /datum/component/orbiter/InheritComponent(datum/component/orbiter/newcomp, original, atom/movable/orbiter, radius, clockwise, rotation_speed, rotation_segments, pre_rotation)
 	if(!newcomp)
+		RegisterSignal(parent, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, .proc/orbiter_glide_size_update)
 		begin_orbit(arglist(args.Copy(3)))
 		return
 	// The following only happens on component transfers
@@ -48,7 +50,6 @@
 		// It is important to transfer the signals so we don't get locked to the new orbiter component for all time
 		UnregisterSignal(orbiter_mob, COMSIG_MOVABLE_MOVED)
 		RegisterSignal(orbiter_mob, COMSIG_MOVABLE_MOVED, .proc/orbiter_move_react)
-		RegisterSignal(parent, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, .proc/orbiter_glide_size_update)
 
 	orbiters += newcomp.orbiters
 
@@ -66,7 +67,6 @@
 	orbiters[orbiter] = TRUE
 	orbiter.orbiting = src
 	RegisterSignal(orbiter, COMSIG_MOVABLE_MOVED, .proc/orbiter_move_react)
-	RegisterSignal(parent, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, .proc/orbiter_glide_size_update)
 
 	SEND_SIGNAL(parent, COMSIG_ATOM_ORBIT_BEGIN, orbiter)
 
@@ -102,7 +102,6 @@
 	if(!orbiters[orbiter])
 		return
 	UnregisterSignal(orbiter, COMSIG_MOVABLE_MOVED)
-	UnregisterSignal(parent, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE)
 	SEND_SIGNAL(parent, COMSIG_ATOM_ORBIT_STOP, orbiter)
 	orbiter.SpinAnimation(0, 0)
 	if(istype(orbiters[orbiter],/matrix)) //This is ugly.

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -853,7 +853,7 @@
 
 	notify_ghosts("[user] is raising [user.p_their()] [src], calling for your help!",
 		enter_link="<a href=?src=[REF(src)];orbit=1>(Click to help)</a>",
-		source = user, action=NOTIFY_ORBIT, ignore_key = POLL_IGNORE_SPECTRAL_BLADE, header = "Spectral blade")
+		source = user, ignore_key = POLL_IGNORE_SPECTRAL_BLADE, header = "Spectral blade")
 
 	summon_cooldown = world.time + 600
 


### PR DESCRIPTION
## About The Pull Request

Fixes a bug caused by transferring an orbiter component to a parent where one already exists. Causing the old original orbiter to update the added ghosts positions when the parent moves, but not allowing them to ever break orbit and also setting the ref to null for the component on the whole due to old signals it would seem.

Also tweaks the blades use in hand ghost notification message to remove the redundant `(Orbit)` link.

Fixes: #48408 

I would like a TM to make sure this change does not cause any other issues to crop up for the ghost gang.

## Why It's Good For The Game

### Getting stuck to an object that literally beckons you to orbit it feels super bad and completely breaks your game until the round ends unless you have a body to return to, or some other way of moving your mind, or an admin fixes you manually.

#### Should bring an end to dchat messages like:
```
Bugger (DEAD): "is there a way i can stop orbiting ... the blade"
Terry Hunter (DEAD): "FCKING ANNOYING GHOST BLADE"
Wapons Shellar (DEAD): "why cant we stop orbiting the sword?"
Samuel Chilton (DEAD): "i fucking hate the ghost blade"
```

## Changelog
:cl:
fix: Spectral Blade - Ghosts that orbit it or the holder are no longer forced to spectate it until the end of time. Huzzah!
fix: For real. Not kidding. You can answer the call to aid someone with your spooky presence and then STOP ORBITING ON YOUR OWN AT ANY TIME just like any other object.
fix: Ghosts no longer receive a redundant orbit link when the Spectral Blade is raised.
/:cl:

