### PR TITLE
Reduces the light range of all beam (lasers, disablers, emitter shots) projectiles

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -10,7 +10,7 @@
 	eyeblur = 2
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	light_system = MOVABLE_LIGHT
-	light_range = 2
+	light_range = 1
 	light_power = 1
 	light_color = COLOR_SOFT_RED
 	ricochets_max = 50	//Honk!


### PR DESCRIPTION

## About The Pull Request

This reduces the light range of lasers, disablers, emitters projectiles from 2 tiles, which created a 3x3 square of intensity 1 light, to a 1x1 square.

## Why It's Good For The Game

This fixes #53309, so that nightmares can dodge beam projectiles on dark tiles once more. 

Before projectile lights updated properly with the position of the projectile, the light would trail behind it, and this was less of an issue, but now they are intertwined, meaning that nightmares cannot dodge these projectiles, creating a balance issue as a result of unforeseen consequences of code changes.

## Changelog
:cl:
balance: nightmares can now dodge beam projectiles on dark tiles
tweak: lasers', emitters', and disablers' projectiles, now emit light only on their own tile, instead of a 3x3 square
/:cl:
