### PR TITLE
Brings back Pun Pun, soul

### DIFF
--- a/code/modules/mob/living/carbon/monkey/punpun.dm
+++ b/code/modules/mob/living/carbon/monkey/punpun.dm
@@ -1,7 +1,9 @@
 /mob/living/carbon/monkey/punpun //except for a few special persistence features, pun pun is just a normal monkey
 	name = "Pun Pun" //C A N O N
 	unique_name = 0
+	/// If we had one of the rare names in a past life
 	var/ancestor_name
+	/// This does not represent how many rounds Pun Pun has survived, instead it increases each time he dies, and resets when he gibs
 	var/ancestor_chain = 1
 	var/relic_hat	//Note: these two are paths
 	var/relic_mask
@@ -16,7 +18,6 @@
 			name += " \Roman[ancestor_chain]"
 	else if(prob(5))
 		name = pick(rare_pet_monkey_names)
-	gender = pick(MALE, FEMALE)
 	. = ..()
 
 	//These have to be after the parent new to ensure that the monkey

--- a/code/modules/mob/living/carbon/monkey/punpun.dm
+++ b/code/modules/mob/living/carbon/monkey/punpun.dm
@@ -6,7 +6,6 @@
 	var/relic_hat	//Note: these two are paths
 	var/relic_mask
 	var/memory_saved = FALSE
-	var/list/pet_monkey_names = list("Pun Pun", "Bubbles", "Mojo", "George", "Darwin", "Aldo", "Caeser", "Kanzi", "Kong", "Terk", "Grodd", "Mala", "Bojangles", "Coco", "Able", "Baker", "Scatter", "Norbit", "Travis")
 	var/list/rare_pet_monkey_names = list("Professor Bobo", "Deempisi's Revenge", "Furious George", "King Louie", "Dr. Zaius", "Jimmy Rustles", "Dinner", "Lanky")
 
 /mob/living/carbon/monkey/punpun/Initialize()
@@ -15,12 +14,9 @@
 		name = ancestor_name
 		if(ancestor_chain > 1)
 			name += " \Roman[ancestor_chain]"
-	else
-		if(prob(5))
-			name = pick(rare_pet_monkey_names)
-		else
-			name = pick(pet_monkey_names)
-		gender = pick(MALE, FEMALE)
+	else if(prob(5))
+		name = pick(rare_pet_monkey_names)
+	gender = pick(MALE, FEMALE)
 	. = ..()
 
 	//These have to be after the parent new to ensure that the monkey

--- a/code/modules/mob/living/carbon/monkey/punpun.dm
+++ b/code/modules/mob/living/carbon/monkey/punpun.dm
@@ -3,12 +3,11 @@
 	unique_name = 0
 	/// If we had one of the rare names in a past life
 	var/ancestor_name
-	/// This does not represent how many rounds Pun Pun has survived, instead it increases each time he dies, and resets when he gibs
+	/// The number of times Pun Pun has died since he was last gibbed
 	var/ancestor_chain = 1
 	var/relic_hat	//Note: these two are paths
 	var/relic_mask
 	var/memory_saved = FALSE
-	var/list/rare_pet_monkey_names = list("Professor Bobo", "Deempisi's Revenge", "Furious George", "King Louie", "Dr. Zaius", "Jimmy Rustles", "Dinner", "Lanky")
 
 /mob/living/carbon/monkey/punpun/Initialize()
 	Read_Memory()
@@ -16,8 +15,10 @@
 		name = ancestor_name
 		if(ancestor_chain > 1)
 			name += " \Roman[ancestor_chain]"
-	else if(prob(5))
-		name = pick(rare_pet_monkey_names)
+	else if(prob(10))
+		name = pick(list("Professor Bobo", "Deempisi's Revenge", "Furious George", "King Louie", "Dr. Zaius", "Jimmy Rustles", "Dinner", "Lanky"))
+		if(name == "Furious George")
+			aggressive = TRUE // Furious George is PISSED
 	. = ..()
 
 	//These have to be after the parent new to ensure that the monkey


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The bartender's monkey is the single most useless thing in the game. Monkeys in general are useless, but the bar monkey is especially useless because unlike the other, cooler pets, he has no stable identity. This changes that: no longer will the bar monkey just be some randomly named schlub that you dome with a toolbox because you're bored and need to kill five seconds, he is PUN PUN and he deserves RESPECT. 

(He won't get any and will still probably die every round, but at least people might form a tiny bit of attachment to him. Seriously, I've never seen someone refer to the bar monkey by their name, it's always either "bar monkey" or "Pun Pun".)

I left the 10% chance to get a rare name in though, cause "Furious George" and "Dinner" made me laugh. These will still be passed on down the ancestor line as before. Also if he rolls the "Furious George" special name, he starts off PISSED.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Brings soul back to the game, gives Pun Pun back his identity
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
tweak: Pun Pun is Pun Pun again (except in rare cases where he is not)
tweak: Keep an eye out for Furious George though, he's a serious loose cannon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
