### PR TITLE
Adds Assistant Borg Module

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1050,7 +1050,7 @@
 		else
 			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [M.p_their()] hands are full!</span>")
 		return
-	if(bonus_ridespeed)
+	if(bonus_ridespeed && M.stat != DEAD)
 		add_movespeed_modifier(/datum/movespeed_modifier/assistant_borg_mountspeed)
 	return ..()
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -69,6 +69,8 @@
 	var/ionpulse = FALSE // Jetpack-like effect.
 	var/ionpulse_on = FALSE // Jetpack-like effect.
 	var/datum/effect_system/trail_follow/ion/ion_trail // Ionpulse effect.
+	///Whether or not the cyborg gets bonus speed when ridden
+	var/bonus_ridespeed = FALSE
 
 	var/low_power_mode = 0 //whether the robot has no charge left.
 	var/datum/effect_system/spark_spread/spark_system // So they can initialize sparks whenever/N
@@ -215,7 +217,8 @@
 	"Medical" = /obj/item/robot_module/medical, \
 	"Miner" = /obj/item/robot_module/miner, \
 	"Janitor" = /obj/item/robot_module/janitor, \
-	"Service" = /obj/item/robot_module/butler)
+	"Service" = /obj/item/robot_module/butler, \
+	"Assistant" = /obj/item/robot_module/assistant)
 	if(!CONFIG_GET(flag/disable_peaceborg))
 		modulelist["Peacekeeper"] = /obj/item/robot_module/peacekeeper
 	if(!CONFIG_GET(flag/disable_secborg))
@@ -650,6 +653,9 @@
 /mob/living/silicon/robot/modules/janitor
 	set_module = /obj/item/robot_module/janitor
 	icon_state = "janitor"
+	
+/mob/living/silicon/robot/modules/assistant
+	set_module = /obj/item/robot_module/assistant
 
 /mob/living/silicon/robot/modules/syndicate
 	icon_state = "synd_sec"
@@ -880,6 +886,7 @@
 	hat_offset = module.hat_offset
 
 	magpulse = module.magpulsing
+	bonus_ridespeed = module.bonus_ridespeed
 	updatename()
 
 
@@ -1043,6 +1050,8 @@
 		else
 			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [M.p_their()] hands are full!</span>")
 		return
+	if(bonus_ridespeed)
+		add_movespeed_modifier(/datum/movespeed_modifier/assistant_borg_mountspeed)
 	return ..()
 
 /mob/living/silicon/robot/unbuckle_mob(mob/user, force=FALSE)
@@ -1051,6 +1060,8 @@
 		if(istype(riding_datum))
 			riding_datum.unequip_buckle_inhands(user)
 			riding_datum.restore_position(user)
+			if(bonus_ridespeed)
+				remove_movespeed_modifier(/datum/movespeed_modifier/assistant_borg_mountspeed)
 	return ..()
 
 /mob/living/silicon/robot/resist()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -24,6 +24,8 @@
 	var/can_be_pushed = TRUE
 	var/magpulsing = FALSE
 	var/clean_on_move = FALSE
+	///Whether or not this module gets a speed bonus when being ridden
+	var/bonus_ridespeed = FALSE
 
 	var/did_feedback = FALSE
 
@@ -247,6 +249,19 @@
 	if(user.incapacitated() || !user.Adjacent(src))
 		return FALSE
 	return TRUE
+
+/obj/item/robot_module/assistant
+	name = "Assistant"
+	basic_modules = list(
+		/obj/item/assembly/flash/cyborg,
+		/obj/item/reagent_containers/borghypo/epi,
+		/obj/item/weldingtool/largetank/cyborg,
+		/obj/item/crowbar/cyborg,
+		/obj/item/extinguisher)
+	emag_modules = list(/obj/item/melee/transforming/energy/sword/cyborg)
+	moduleselect_icon = "standard"
+	bonus_ridespeed = TRUE
+	hat_offset = -3
 
 /obj/item/robot_module/medical
 	name = "Medical"

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -114,3 +114,7 @@
 
 /datum/movespeed_modifier/metabolicboost
 	multiplicative_slowdown = -1.5
+	
+/datum/movespeed_modifier/assistant_borg_mountspeed
+	multiplicative_slowdown = -0.25
+	flags = IGNORE_NOSLOW


### PR DESCRIPTION
## About The Pull Request

This PR adds a replacement cyborg module to the game which uses the standard borg sprites, the assistant borg.  The assistant borg intends to fill two niches:

- A borg subtype for new players to get acquainted with playing as a cyborg without clutter
- A cyborg module primarily focused around assisting crew members in the general sense as opposed to strictly through a job

Keeping it simple, the assistant cyborg comes equipped with the following items:
- The standard cyborg flash
- A full-sized fire hydrant for putting out flaming crew members
- An epipen to stabilize crew members in critical condition
- A welder to fix simple machinery and yourself, as well as a weapon if need be
- A crowbar, in case you need to open an unpowered door
- When emagged, has a cyborg e-sword, a straightforward but strong tool originally wielded by the Default Cyborg, perfect for assisting your new friend with whatever his plans are

On top of this, to really promote using this module for assisting the crew, the assistant cyborg gains a 25% speed bonus when being ridden by a living humanoid (so you can't use a corpse to become faster).  This should promote the assistant cyborg to get involved with helping people and for people to be able to utilize it, as it can be used to get around the station at a faster rate than most other common alternatives.  It also allows a malf AI to benefit from their existence by their ability to ferry people to a borging machine quicker than other cyborgs.

Note: if there's any other items anyone can think of which would fit the theme of a "cyborg assistant" (not in the greytiding sense, moreso an actual assistant), let me know.  I'm open to suggestions just as long as it doesn't become the very thing the standard borg got removed for being.

## Why It's Good For The Game

Fills the hole in the lineup that the standard cyborg's removal created, along with giving new borg players an option which promotes learning how everything works while still being useful to the crew.

## Changelog
:cl:
add: Following the removal of standard cyborgs, a new, cheaper module called the Assistant Cyborg has been made public for usage on Nanotrasen space stations.
/:cl: