### PR TITLE
merges the sunglasses from detective's office with his spy glasses, makes spy glasses use action button instead of verb

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -47682,7 +47682,6 @@
 	pixel_x = -3
 	},
 /obj/item/clothing/mask/cigarette/cigar,
-/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "bNc" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -8146,7 +8146,6 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/clothing/glasses/sunglasses,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
 	pixel_x = 3
 	},
@@ -27071,7 +27070,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -32130,7 +32128,6 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Mix to Incinerator"
 	},
 /turf/open/floor/plasteel,
@@ -33546,7 +33543,6 @@
 "bAQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Mix to Incinerator"
 	},
 /turf/open/floor/plasteel,
@@ -43695,7 +43691,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -45232,7 +45227,6 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /turf/open/floor/engine,
@@ -45641,7 +45635,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -46342,9 +46335,7 @@
 /area/ai_monitored/turret_protected/aisat/atmos)
 "cuq" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "cur" = (
@@ -49072,7 +49063,6 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Laser Room";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /turf/open/floor/engine,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3797,7 +3797,6 @@
 /obj/structure/chair/stool,
 /obj/machinery/camera{
 	c_tag = "Prison Visitation";
-	dir = 2;
 	network = list("ss13","prison")
 	},
 /obj/effect/turf_decal/trimline/red/warning{
@@ -11157,7 +11156,6 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
@@ -11496,7 +11494,6 @@
 "azT" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes,
-/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "azU" = (
@@ -12745,7 +12742,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -13705,7 +13701,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /turf/open/floor/plating,
@@ -15708,7 +15703,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/machinery/microwave{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel,
@@ -16152,7 +16146,6 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /turf/open/floor/plating,
@@ -17897,7 +17890,6 @@
 	pixel_y = 15
 	},
 /obj/item/stack/cable_coil{
-	pixel_x = 0;
 	pixel_y = 18
 	},
 /obj/machinery/requests_console{
@@ -19487,7 +19479,6 @@
 	pixel_x = -8
 	},
 /obj/item/assembly/prox_sensor{
-	pixel_x = 0;
 	pixel_y = 12
 	},
 /obj/machinery/light{
@@ -20197,9 +20188,7 @@
 /obj/item/clothing/gloves/color/fyellow{
 	pixel_y = 6
 	},
-/obj/item/clothing/gloves/color/fyellow{
-	pixel_x = 0
-	},
+/obj/item/clothing/gloves/color/fyellow,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -23576,9 +23565,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/disposal/delivery_chute{
-	dir = 2
-	},
+/obj/machinery/disposal/delivery_chute,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -24997,8 +24984,7 @@
 	pixel_y = 9
 	},
 /obj/item/cartridge/quartermaster{
-	pixel_x = 9;
-	pixel_y = 0
+	pixel_x = 9
 	},
 /obj/item/cartridge/quartermaster{
 	pixel_x = 5;
@@ -25945,8 +25931,7 @@
 /area/quartermaster/sorting)
 "biI" = (
 /obj/machinery/firealarm{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
@@ -26639,8 +26624,7 @@
 "bku" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/firealarm{
-	pixel_x = -31;
-	pixel_y = 0
+	pixel_x = -31
 	},
 /obj/machinery/light{
 	dir = 8
@@ -38131,7 +38115,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Kitchen";
-	req_access_txt = "0";
 	req_one_access_txt = "25;28"
 	},
 /obj/machinery/navbeacon/wayfinding,
@@ -44349,7 +44332,6 @@
 /obj/machinery/door/window/eastleft{
 	dir = 1;
 	name = "Service Deliveries";
-	req_access_txt = "0";
 	req_one_access_txt = "25;26;35;28;22;37;46;38;70"
 	},
 /obj/structure/disposalpipe/segment,
@@ -60311,8 +60293,7 @@
 "cSF" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/camera{
-	c_tag = "Mining Dock";
-	dir = 2
+	c_tag = "Mining Dock"
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -62684,7 +62665,6 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Laser Room";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /turf/open/floor/plating,
@@ -68359,8 +68339,6 @@
 	dir = 8
 	},
 /obj/structure/sink{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 29
 	},
 /mob/living/simple_animal/mouse/brown/tom,
@@ -72672,7 +72650,6 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -76252,7 +76229,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -12039,7 +12039,6 @@
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes,
 /obj/item/lighter,
-/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "aEp" = (
@@ -25583,9 +25582,7 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bom" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -48031,8 +48028,7 @@
 	pixel_y = 2
 	},
 /obj/item/pen{
-	pixel_x = 8;
-	pixel_y = 0
+	pixel_x = 8
 	},
 /obj/item/reagent_containers/dropper{
 	pixel_x = -1;
@@ -51457,7 +51453,6 @@
 "ktM" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -52216,7 +52211,6 @@
 /obj/machinery/requests_console{
 	department = "Genetics";
 	name = "Genetics Requests Console";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/cable,
@@ -54395,8 +54389,7 @@
 	pixel_y = 11
 	},
 /obj/item/storage/box/monkeycubes{
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -54632,9 +54625,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/computer/piratepad_control/civilian{
-	dir = 2
-	},
+/obj/machinery/computer/piratepad_control/civilian,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -55296,7 +55287,6 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -434,6 +434,10 @@
 		return
 	return ..()
 
+/datum/action/item_action/activate_remote_view
+	name = "Activate Remote View"
+	desc = "Activates the Remote View of your spy sunglasses."
+
 /datum/action/item_action/organ_action
 	check_flags = AB_CHECK_CONSCIOUS
 

--- a/code/game/objects/items/devices/spyglasses.dm
+++ b/code/game/objects/items/devices/spyglasses.dm
@@ -1,9 +1,10 @@
-//antag spyglasses. meant to be an example for map_popups.dm
-/obj/item/clothing/glasses/regular/spy
+//detective spyglasses. meant to be an example for map_popups.dm
+/obj/item/clothing/glasses/sunglasses/spy
 	desc = "Made by Nerd. Co's infiltration and surveillance department. Upon closer inspection, there's a small screen in each lens."
+	actions_types = list(/datum/action/item_action/activate_remote_view)
 	var/obj/item/spy_bug/linked_bug
 
-/obj/item/clothing/glasses/regular/spy/proc/show_to_user(mob/user)//this is the meat of it. most of the map_popup usage is in this.
+/obj/item/clothing/glasses/sunglasses/spy/proc/show_to_user(mob/user)//this is the meat of it. most of the map_popup usage is in this.
 	if(!user)
 		return
 	if(!user.client)
@@ -18,23 +19,23 @@
 		user.client.register_map_obj(plane)
 	linked_bug.update_view()
 
-/obj/item/clothing/glasses/regular/spy/equipped(mob/user, slot)
+/obj/item/clothing/glasses/sunglasses/spy/equipped(mob/user, slot)
 	. = ..()
 	if(slot != ITEM_SLOT_EYES)
 		user.client.close_popup("spypopup")
 
-/obj/item/clothing/glasses/regular/spy/dropped(mob/user)
+/obj/item/clothing/glasses/sunglasses/spy/dropped(mob/user)
 	. = ..()
 	user.client.close_popup("spypopup")
 
-/obj/item/clothing/glasses/regular/spy/verb/activate_remote_view()
-	//yada yada check to see if the glasses are in their eye slot
-	if(ishuman(usr))
-		var/mob/living/carbon/human/user = usr
-		if(user.glasses == src)
-			show_to_user(user)
+/obj/item/clothing/glasses/sunglasses/spy/ui_action_click(mob/user)
+	show_to_user(user)
 
-/obj/item/clothing/glasses/regular/spy/Destroy()
+/obj/item/clothing/glasses/sunglasses/spy/item_action_slot_check(slot)
+	if(slot == ITEM_SLOT_EYES)
+		return TRUE
+
+/obj/item/clothing/glasses/sunglasses/spy/Destroy()
 	if(linked_bug)
 		linked_bug.linked_glasses = null
 	. = ..()
@@ -46,7 +47,7 @@
 	icon_state = "pocketprotector"
 	desc = "an advanced peice of espionage equipment in the shape of a pocket protector. it has a built in 360 degree camera for all your nefarious needs. Microphone not included."
 
-	var/obj/item/clothing/glasses/regular/spy/linked_glasses
+	var/obj/item/clothing/glasses/sunglasses/spy/linked_glasses
 	var/obj/screen/map_view/cam_screen
 	var/list/cam_plane_masters
 	// Ranges higher than one can be used to see through walls.
@@ -110,7 +111,7 @@ A shrill beep coming from your SpySpeks means that they can't connect to the inc
 
 /obj/item/storage/box/rxglasses/spyglasskit/PopulateContents()
 	var/obj/item/spy_bug/newbug = new(src)
-	var/obj/item/clothing/glasses/regular/spy/newglasses = new(src)
+	var/obj/item/clothing/glasses/sunglasses/spy/newglasses = new(src)
 	newbug.linked_glasses = newglasses
 	newglasses.linked_bug = newbug
 	new /obj/item/paper/fluff/nerddocs(src)

--- a/code/game/objects/items/devices/spyglasses.dm
+++ b/code/game/objects/items/devices/spyglasses.dm
@@ -45,7 +45,7 @@
 	name = "pocket protector"
 	icon = 'icons/obj/clothing/accessories.dmi'
 	icon_state = "pocketprotector"
-	desc = "An advanced piece of espionage equipment in the shape of a pocket protector. It has a built in 360 degree camera for all your "admirable" needs. Microphone not included."
+	desc = "An advanced piece of espionage equipment in the shape of a pocket protector. It has a built in 360 degree camera for all your \"admirable\" needs. Microphone not included."
 
 	var/obj/item/clothing/glasses/sunglasses/spy/linked_glasses
 	var/obj/screen/map_view/cam_screen

--- a/code/game/objects/items/devices/spyglasses.dm
+++ b/code/game/objects/items/devices/spyglasses.dm
@@ -45,7 +45,7 @@
 	name = "pocket protector"
 	icon = 'icons/obj/clothing/accessories.dmi'
 	icon_state = "pocketprotector"
-	desc = "an advanced peice of espionage equipment in the shape of a pocket protector. it has a built in 360 degree camera for all your nefarious needs. Microphone not included."
+	desc = "An advanced piece of espionage equipment in the shape of a pocket protector. It has a built in 360 degree camera for all your "admirable" needs. Microphone not included."
 
 	var/obj/item/clothing/glasses/sunglasses/spy/linked_glasses
 	var/obj/screen/map_view/cam_screen


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

detective sunglasses from his table are gone, now the spy sunglasses in his locker are a variant of sunglasses instead of prescription, so he can do espionage without being flashed
turns the spy sunglasses verb into an action button, because it was very cryptic and thats probably the other reason why nobody uses this item
image: 
![image](https://user-images.githubusercontent.com/23585223/91719575-ddad5480-eb95-11ea-8746-0e167ff87967.png)


## Why It's Good For The Game

makes spy glasses not cryptic with verbs
makes them an actual usable thing for a sec member
now theres a reason for detectives to not get sechuds roundstart
makes it harder for assistants to tide sunglasses

## Changelog
:cl:
tweak: spy glasses now use an action button instead of a verb, so they are less cryptic and someone will know how to use them
balance: spy glasses are now sunglasses, removes the sunglasses from det's office so you can just take the spy ones from your locker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
