### PR TITLE
Revert "You can buckle yourself or somebody else into a chair, if you're next to the chair."

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -140,16 +140,10 @@
 
 //Wrapper procs that handle sanity and user feedback
 /atom/movable/proc/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)
-	if(!Adjacent(user) || !Adjacent(M) || !isturf(user.loc) || user.incapacitated() || M.anchored)
+	if(!in_range(user, src) || !isturf(user.loc) || user.incapacitated() || M.anchored)
 		return FALSE
 
 	add_fingerprint(user)
-	if (M != user)
-		M.visible_message("<span class='warning'>[user] starts buckling [M] to [src]!</span>",\
-					"<span class='userdanger'>[user] starts buckling you to [src]!</span>",\
-					"<span class='hear'>You hear metal clanking.</span>")
-		if(!do_after(user, 3 SECONDS, TRUE, M))
-			return FALSE
 	. = buckle_mob(M, check_loc = check_loc)
 	if(.)
 		if(M == user)
@@ -158,7 +152,8 @@
 				"<span class='hear'>You hear metal clanking.</span>")
 		else
 			M.visible_message("<span class='warning'>[user] buckles [M] to [src]!</span>",\
-				"<span class='warning'>[user] buckles you to [src]!</span>")
+				"<span class='warning'>[user] buckles you to [src]!</span>",\
+				"<span class='hear'>You hear metal clanking.</span>")
 
 /atom/movable/proc/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
 	var/mob/living/M = unbuckle_mob(buckled_mob)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -249,9 +249,6 @@
 		usr.put_in_hands(C)
 		qdel(src)
 
-/obj/structure/chair/user_buckle_mob(mob/living/M, force, check_loc = FALSE)
-	return ..()
-
 /obj/structure/chair/stool/bar
 	name = "bar stool"
 	desc = "It has some unsavory stains on it..."


### PR DESCRIPTION
its bugged and bad, if you dragclick a mob on yourself or anything else it does the do after, it sucks

## Changelog
:cl:
fix: clickdragging mobs should be fixed
del: you can no longer buckle people next to a chair to a chair 
/:cl: