### PR TITLE
Removes do_after from buckling code.

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -144,12 +144,6 @@
 		return FALSE
 
 	add_fingerprint(user)
-	if (M != user)
-		M.visible_message("<span class='warning'>[user] starts buckling [M] to [src]!</span>",\
-					"<span class='userdanger'>[user] starts buckling you to [src]!</span>",\
-					"<span class='hear'>You hear metal clanking.</span>")
-		if(!do_after(user, 3 SECONDS, TRUE, M))
-			return FALSE
 	. = buckle_mob(M, check_loc = check_loc)
 	if(.)
 		if(M == user)


### PR DESCRIPTION
## About The Pull Request

~~Fixes a bug from https://github.com/tgstation/tgstation/pull/53255 wherein a do_after timer was being applied  to actions that aren't buckling.~~

I am in favor of one of these two being merged, instead.

https://github.com/tgstation/tgstation/pull/53363

https://github.com/tgstation/tgstation/pull/53356

## Why It's Good For The Game

Fixes a bug.

## Changelog
:cl:
fix: Click-dragging a mob will no longer create a timer.
/:cl:

