### PR TITLE
Tweak passive_gate

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -3,6 +3,7 @@
 Passive gate is similar to the regular pump except:
 * It doesn't require power
 * Can not transfer low pressure to higher pressure (so it's more like a valve where you can control the flow)
+* Passes gas when output pressure lower than target pressure
 
 */
 
@@ -10,7 +11,7 @@ Passive gate is similar to the regular pump except:
 	icon_state = "passgate_map-2"
 
 	name = "passive gate"
-	desc = "A one-way air valve that does not require power."
+	desc = "A one-way air valve that does not require power. Passes gas when output pressure lower than target pressure."
 
 	can_unwrench = TRUE
 	shift_underlay_only = FALSE
@@ -112,7 +113,7 @@ Passive gate is similar to the regular pump except:
 				pressure = text2num(pressure)
 				. = TRUE
 			if(.)
-				target_pressure = clamp(pressure, 0, MAX_OUTPUT_PRESSURE)
+				target_pressure = clamp(pressure, 0, ONE_ATMOSPHERE*100)
 				investigate_log("was set to [target_pressure] kPa by [key_name(usr)]", INVESTIGATE_ATMOS)
 	update_icon()
 
@@ -134,7 +135,7 @@ Passive gate is similar to the regular pump except:
 		on = !on
 
 	if("set_output_pressure" in signal.data)
-		target_pressure = clamp(text2num(signal.data["set_output_pressure"]),0,ONE_ATMOSPHERE*50)
+		target_pressure = clamp(text2num(signal.data["set_output_pressure"]),0,ONE_ATMOSPHERE*100)
 
 	if(on != old_on)
 		investigate_log("was turned [on ? "on" : "off"] by a remote signal", INVESTIGATE_ATMOS)

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -11,7 +11,7 @@ Passive gate is similar to the regular pump except:
 	icon_state = "passgate_map-2"
 
 	name = "passive gate"
-	desc = "A one-way air valve that does not require power. Passes gas when output pressure lower than target pressure."
+	desc = "A one-way air valve that does not require power. Passes gas when the output pressure is lower than the target pressure."
 
 	can_unwrench = TRUE
 	shift_underlay_only = FALSE


### PR DESCRIPTION
## About The Pull Request

Make some more precise description.
Increased max out limit pressure settings to 100 atmospheres, since volume_pump limited 9000 kPa (~90 atmospheres)

## Why It's Good For The Game

Better description.
Now passive gate can be used in high powered setups, with high pressures.

## Changelog
:cl:
tweak: passive gate max out limit pressure settings increased
tweak: passive gate description more precise
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
