### PR TITLE
I killed Metalgen for a reason, dang it. Kills infinite material duplication.

### DIFF
--- a/code/modules/reagents/chemistry/recipes/special.dm
+++ b/code/modules/reagents/chemistry/recipes/special.dm
@@ -175,7 +175,7 @@ GLOBAL_LIST_INIT(medicine_reagents, build_medicine_reagents())
 	name = "old recipe"
 
 	///List of possible recipes we could display
-	var/list/possible_recipes = list(/datum/chemical_reaction/randomized/secret_sauce, /datum/chemical_reaction/randomized/metalgen)
+	var/list/possible_recipes = list(/datum/chemical_reaction/randomized/secret_sauce)
 	///The one we actually end up displaying
 	var/recipe_id = null
 

--- a/code/modules/reagents/chemistry/recipes/special.dm
+++ b/code/modules/reagents/chemistry/recipes/special.dm
@@ -171,22 +171,6 @@ GLOBAL_LIST_INIT(medicine_reagents, build_medicine_reagents())
 			return food_reagent_ids
 	return ..()
 
-///Random recipe for meme chem metalgen. Always requires wittel and resets every 3 days
-/datum/chemical_reaction/randomized/metalgen
-	persistent = TRUE
-	persistence_period = 3 //Resets every three days. It's the ultimate meme and is best not worn out
-	randomize_req_temperature = TRUE
-	possible_catalysts = list(/datum/reagent/wittel)
-	min_catalysts = 1
-	max_catalysts = 1
-	results = list(/datum/reagent/metalgen=20)
-
-/datum/chemical_reaction/randomized/metalgen/GetPossibleReagents(kind)
-	switch(kind)
-		if(RNGCHEM_INPUT)
-			return GLOB.medicine_reagents
-	return ..()
-
 /obj/item/paper/secretrecipe
 	name = "old recipe"
 


### PR DESCRIPTION
…

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the metalgen recipe AGAIN.

## Why It's Good For The Game

Infinite mats is not a good game design. See https://github.com/tgstation/tgstation/pull/50552 for the previous reasoning. The current reasoning is that hey, material scarcity is actually important and literal alchemy just destroys any attempts at balancing resource availability.

## Changelog
:cl:
del: Removed metalgen AGAIN.
/:cl:
