### PR TITLE
Stasis beds now increase surgery speed with manipulator tier.

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -16,6 +16,7 @@
 	var/last_stasis_sound = FALSE
 	var/stasis_can_toggle = 0
 	var/mattress_state = "stasis_on"
+	var/part_speed_modifier = 1
 	var/obj/effect/overlay/vis/mattress_on
 	var/obj/machinery/computer/operating/op_computer
 
@@ -31,6 +32,11 @@
 	. = ..()
 	if(op_computer && op_computer.sbed == src)
 		op_computer.sbed = null
+
+/obj/machinery/stasis/RefreshParts()
+	part_speed_modifier = 0.75
+	for(var/obj/item/stock_parts/manipulator/M in component_parts)
+		part_speed_modifier += 0.25 * M.rating
 
 /obj/machinery/stasis/examine(mob/user)
 	. = ..()

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -4,7 +4,7 @@
 		return 1
 	else if(locate(/obj/machinery/stasis, T))
 		var/obj/machinery/stasis/S = locate(/obj/machinery/stasis, T)
-		return 0.9 * S.part_speed_modifier; // 0.9 at basic, 1.8 at Bluespace
+		return 0.9 * S.part_speed_modifier; // 0.9 at basic, 1.575 at Bluespace, 1.8 with Quantum.
 	else if(locate(/obj/structure/table, T))
 		return 0.8
 	else if(locate(/obj/structure/bed, T))

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -3,7 +3,8 @@
 	if(locate(/obj/structure/table/optable, T))
 		return 1
 	else if(locate(/obj/machinery/stasis, T))
-		return 0.9
+		var/obj/machinery/stasis/S = locate(/obj/machinery/stasis, T)
+		return 0.9 * S.part_speed_modifier; // 0.9 at basic, 1.8 at Bluespace
 	else if(locate(/obj/structure/table, T))
 		return 0.8
 	else if(locate(/obj/structure/bed, T))


### PR DESCRIPTION
## About The Pull Request

25% speed increase to all surgery steps per tier of manipulator used in stasis beds. This is modified by the 0.9x multiplier stasis beds get by default, effectively making is 22.5%. At T4, this is 1.575x faster than normal on an operating table (on Fulp, this would be 1.8x at Quantum).

(Capacitors still do nothing.)

## Why It's Good For The Game

Stasis beds currently have no upgrade effect. Sleeper beds used to. Every round, bodies tend to pile up in medbay. It takes minutes to deal with a single patient. Upgraded surgeries are very useful, and new medical tools are very useful, but with the constant need for bonesetting and heart cybernetics, it simply is not enough to effectively deal with surgery demand in medbay. Stasis beds should increase surgery speed, not penalize it.

All surgeries across the board could use with a speed increase, but this is a good first step.

## Changelog
:cl:
add: Stasis beds now increase surgery speed by 22.5% effective per manipulator tier.
/:cl: