### PR TITLE
Pods eject things without a client on arrival

### DIFF
--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -119,7 +119,7 @@
 				for(var/thing in pod)
 					if(ismob(thing))
 						var/mob/mob_content = thing
-						if(mob_content.client)
+						if(mob_content.client && mob_content.stat < UNCONSCIOUS)
 							continue // Let the mobs with clients decide what they want to do themselves.
 					var/atom/movable/movable_content = thing
 					movable_content.forceMove(loc) //Everything else is moved out of.

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -115,6 +115,14 @@
 		if(STATION_TUBE_OPENING)
 			icon_state = "open_[base_icon]"
 			open_status = STATION_TUBE_OPEN
+			for(var/obj/structure/transit_tube_pod/pod in loc)
+				for(var/thing in pod)
+					if(ismob(thing))
+						var/mob/mob_content = thing
+						if(mob_content.client)
+							continue // Let the mobs with clients decide what they want to do themselves.
+					var/atom/movable/movable_content = thing
+					movable_content.forceMove(loc) //Everything else is moved out of.
 		if(STATION_TUBE_CLOSING)
 			icon_state = "closed_[base_icon]"
 			open_status = STATION_TUBE_CLOSED

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -146,7 +146,7 @@
 		forceMove(next_loc) // When moving from one tube to another, skip collision and such.
 		density = current_tube.density
 
-		if(current_tube && current_tube.should_stop_pod(src, next_dir))
+		if(current_tube?.should_stop_pod(src, next_dir))
 			current_tube.pod_stopped(src, dir)
 			break
 


### PR DESCRIPTION
If you place a player-less bot (like most of them) on a transit pod, the chances of it ever leaving are very slim. For example, officer pingsky.

## Changelog
:cl:
tweak: Things without a client or not alive, bots included, will be ejected out of the station pods (like the ones leading to the AI sat) on arrival, to prevent them being hidden in a very hard to detect location.
/:cl: