### PR TITLE
Add missing left parenthesis to 'View tracked playtime' output

### DIFF
--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -110,7 +110,7 @@ GLOBAL_PROTECT(exp_to_update)
 				jobs_unlocked += job.title
 			else
 				var/xp_req = job.get_exp_req_amount()
-				jobs_locked += "[job.title] [get_exp_format(text2num(calc_exp_type(job.get_exp_req_type())))] / [get_exp_format(xp_req)] as [job.get_exp_req_type()])"
+				jobs_locked += "[job.title] ([get_exp_format(text2num(calc_exp_type(job.get_exp_req_type())))] / [get_exp_format(xp_req)] as [job.get_exp_req_type()])"
 	if(jobs_unlocked.len)
 		return_text += "<BR><BR>Jobs Unlocked:<UL><LI>"
 		return_text += jobs_unlocked.Join("</LI><LI>")


### PR DESCRIPTION
Previously looked like:

> Jobs Not Unlocked:
> - AI 5h / 15h as Silicon)
> - Research Director 4h / 15h as Science)