### PR TITLE
Avoid resizing chat to nothing in the Fit Viewport verb

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -339,6 +339,9 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	var/split_size = splittext(sizes["mainwindow.split.size"], "x")
 	var/split_width = text2num(split_size[1])
 
+	// Avoid auto-resizing the statpanel and chat into nothing.
+	desired_width = min(desired_width, split_width - 300)
+
 	// Calculate and apply a best estimate
 	// +4 pixels are for the width of the splitter's handle
 	var/pct = 100 * (desired_width + 4) / split_width


### PR DESCRIPTION
:cl:
tweak: The "Fit Viewport" verb and preference now take into account a 300px minimum width for the chat, in case widescreen is combined with a narrow window.
/:cl: