### PR TITLE
Update food_mixtures.dm

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -132,6 +132,11 @@
 	results = list(/datum/reagent/consumable/nutriment/peptides = 0.5)
 	required_reagents = list(/datum/reagent/consumable/nutriment/ = 0.5)
 	required_catalysts = list(/datum/reagent/medicine/metafactor = 0.5)
+	
+/datum/chemical_reaction/nutriconversion2
+	results = list(/datum/reagent/consumable/nutriment/peptides = 0.5)
+	required_reagents = list(/datum/reagent/consumable/nutriment/protein = 0.5)
+	required_catalysts = list(/datum/reagent/medicine/metafactor = 0.5)
 
 /datum/chemical_reaction/bbqsauce
 	results = list(/datum/reagent/consumable/bbqsauce = 5)


### PR DESCRIPTION
Literally just 2 lines of shit because of an overlooked change

## About The Pull Request

Adds a new probital reaction, as meat foods no longer work with probital.
## Why It's Good For The Game

Essentially fixes an accidental stealth nerf. That's really it.

## Changelog
:cl:
add: Added 7 lines of shit to allow protein to be used for the probital mitogen reaction.
/:cl: