### PR TITLE
Civilian bounty consoles don't interact when depowered anymore.

### DIFF
--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -138,7 +138,7 @@
 		return
 	if(!pad)
 		return
-	if(!usr.canUseTopic(src, BE_CLOSE))
+	if(!usr.canUseTopic(src, BE_CLOSE) || (machine_stat & (NOPOWER|BROKEN)))
 		return
 	switch(action)
 		if("recalc")


### PR DESCRIPTION

## About The Pull Request

Prevents players from using a bounty console by refreshing their UI with the recycling feature, by preventing broken/off civilain bounty consoles from calling their ui_acts when de-powered.

## Why It's Good For The Game

Fixes #53022.
Consistency issue, and fixes a bug.

## Changelog
:cl:
fix: You can't use the civilain bounty console while depowered anymore.
/:cl:

