### PR TITLE
Antagonists cannot also be obsessed

### DIFF
--- a/code/modules/events/creep_awakening.dm
+++ b/code/modules/events/creep_awakening.dm
@@ -17,6 +17,8 @@
 			continue
 		if(H.mind.has_antag_datum(/datum/antagonist/obsessed))
 			continue
+		if(H.mind.special_role)
+			continue
 		if(!H.getorgan(/obj/item/organ/brain))
 			continue
 		H.gain_trauma(/datum/brain_trauma/special/obsessed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You won't roll obsessed if you're already an antagonist.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Saw this with changeling the other day, hogging all of the antag, unbelievable. 
Edit: It's also somewhat inconvenient from an administrative viewpoint because the obsessed HUD icon overwrites the traitor icon.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: antagonists can no longer have an obsession awakening
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
