### PR TITLE
Greentext can now be turned off

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -625,9 +625,9 @@
 	var/count = 1
 	for(var/datum/objective/objective in objectives)
 		if(objective.check_completion())
-			objective_parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='greentext'>Success!</span>"
+			objective_parts += "<b>Objective #[count]</b>: [objective.explanation_text]	[CONFIG_GET(flag/disable_greentext) ? "" : "<span class='greentext'>Success!</span>"]"
 		else
-			objective_parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
+			objective_parts += "<b>Objective #[count]</b>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='redtext'>Fail.</span>"]"
 		count++
 	return objective_parts.Join("<br>")
 

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -68,6 +68,8 @@
 
 /datum/config_entry/flag/disable_warops
 
+/datum/config_entry/flag/disable_greentext	//note this still generates objectives
+
 /datum/config_entry/number/traitor_scaling_coeff	//how much does the amount of players get divided by to determine traitors
 	config_entry_value = 6
 	integer = FALSE

--- a/code/game/gamemodes/gang/gang_handler.dm
+++ b/code/game/gamemodes/gang/gang_handler.dm
@@ -603,14 +603,15 @@ GLOBAL_VAR_INIT(deaths_during_shift, 0)
 				continue
 			alive_cops++
 
-	if(alive_gangsters > alive_cops)
-		if(!objective_failures)
-			report = "<span class='header greentext'>[highest_gang] won the round by completing their objective and having the most points!</span>"
+	if(!CONFIG_GET(flag/disable_greentext))
+		if(alive_gangsters > alive_cops)
+			if(!objective_failures)
+				report = "<span class='header greentext'>[highest_gang] won the round by completing their objective and having the most points!</span>"
+			else
+				report = "<span class='header greentext'>[highest_gang] won the round by having the most points!</span>"
+		else if(alive_gangsters == alive_cops)
+			report = "<span class='header redtext'>Legend has it the police and the families are still duking it out to this day!</span>"
 		else
-			report = "<span class='header greentext'>[highest_gang] won the round by having the most points!</span>"
-	else if(alive_gangsters == alive_cops)
-		report = "<span class='header redtext'>Legend has it the police and the families are still duking it out to this day!</span>"
-	else
-		report = "<span class='header greentext'>The police put the boots to the families, medium style!</span>"
+			report = "<span class='header greentext'>The police put the boots to the families, medium style!</span>"
 
 	return "</div><div class='panel redborder'>[report]" // </div> at the front not the back because this proc is intended for normal text not a whole new panel

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -182,11 +182,11 @@ GLOBAL_LIST_EMPTY(antagonists)
 			if(!objective.check_completion())
 				objectives_complete = FALSE
 				break
-
-	if(objectives.len == 0 || objectives_complete)
-		report += "<span class='greentext big'>The [name] was successful!</span>"
-	else
-		report += "<span class='redtext big'>The [name] has failed!</span>"
+	if(!CONFIG_GET(flag/disable_greentext))
+		if(objectives.len == 0 || objectives_complete)
+			report += "<span class='greentext big'>The [name] was successful!</span>"
+		else
+			report += "<span class='redtext big'>The [name] has failed!</span>"
 
 	return report.Join("<br>")
 

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -48,15 +48,16 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 		var/objective_count = 1
 		for(var/datum/objective/objective in objectives)
 			if(objective.check_completion())
-				report += "<B>Objective #[objective_count]</B>: [objective.explanation_text] <span class='greentext'>Success!</span>"
+				report += "<B>Objective #[objective_count]</B>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='greentext'>Success!</span>"]"
 			else
-				report += "<B>Objective #[objective_count]</B>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
+				report += "<B>Objective #[objective_count]</B>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='redtext'>Fail.</span>"]"
 				win = FALSE
 			objective_count++
-		if(win)
-			report += "<span class='greentext'>The [name] was successful!</span>"
-		else
-			report += "<span class='redtext'>The [name] have failed!</span>"
+		if(!CONFIG_GET(flag/disable_greentext))
+			if(win)
+				report += "<span class='greentext'>The [name] was successful!</span>"
+			else
+				report += "<span class='redtext'>The [name] have failed!</span>"
 
 
 	return "<div class='panel redborder'>[report.Join("<br>")]</div>"

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -149,14 +149,15 @@
 /datum/team/abductor_team/roundend_report()
 	var/list/result = list()
 
-	var/won = TRUE
-	for(var/datum/objective/O in objectives)
-		if(!O.check_completion())
-			won = FALSE
-	if(won)
-		result += "<span class='greentext big'>[name] team fulfilled its mission!</span>"
-	else
-		result += "<span class='redtext big'>[name] team failed its mission.</span>"
+	if(!CONFIG_GET(flag/disable_greentext))
+		var/won = TRUE
+		for(var/datum/objective/O in objectives)
+			if(!O.check_completion())
+				won = FALSE
+		if(won)
+			result += "<span class='greentext big'>[name] team fulfilled its mission!</span>"
+		else
+			result += "<span class='redtext big'>[name] team failed its mission.</span>"
 
 	result += "<span class='header'>The abductors of [name] were:</span>"
 	for(var/datum/mind/abductor_mind in members)

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -126,15 +126,16 @@
 	var/objective_count = 1
 	for(var/datum/objective/objective in objectives)
 		if(objective.check_completion())
-			parts += "<B>Objective #[objective_count]</B>: [objective.explanation_text] <span class='greentext'>Success!</span>"
+			parts += "<B>Objective #[objective_count]</B>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='greentext'>Success!</span>"]"
 		else
-			parts += "<B>Objective #[objective_count]</B>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
+			parts += "<B>Objective #[objective_count]</B>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='redtext'>Fail.</span>"]"
 			win = FALSE
 		objective_count++
-	if(win)
-		parts += "<span class='greentext'>The blood brothers were successful!</span>"
-	else
-		parts += "<span class='redtext'>The blood brothers have failed!</span>"
+	if(!CONFIG_GET(flag/disable_greentext))
+		if(win)
+			parts += "<span class='greentext'>The blood brothers were successful!</span>"
+		else
+			parts += "<span class='redtext'>The blood brothers have failed!</span>"
 
 	return "<div class='panel redborder'>[parts.Join("<br>")]</div>"
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -576,16 +576,16 @@
 		var/count = 1
 		for(var/datum/objective/objective in objectives)
 			if(objective.check_completion())
-				parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='greentext'>Success!</b></span>"
+				parts += "<b>Objective #[count]</b>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='greentext'>Success!</span>"]</b></span>"
 			else
-				parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
-				changelingwin = FALSE
+				parts += "<b>Objective #[count]</b>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='redtext'>Fail.</span>"]"
 			count++
 
-	if(changelingwin)
-		parts += "<span class='greentext'>The changeling was successful!</span>"
-	else
-		parts += "<span class='redtext'>The changeling has failed.</span>"
+	if(!CONFIG_GET(flag/disable_greentext))
+		if(changelingwin)
+			parts += "<span class='greentext'>The changeling was successful!</span>"
+		else
+			parts += "<span class='redtext'>The changeling has failed.</span>"
 
 	return parts.Join("<br>")
 

--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -121,6 +121,9 @@
 	else
 		report += "<span class='redtext'>The [name] had no trauma attached to their antagonist ways! Either it bugged out or an admin incorrectly gave this good samaritan antag and it broke! You might as well show yourself!!</span>"
 
+	if(CONFIG_GET(flag/disable_greentext))
+		return report.Join("<br>")
+
 	if(objectives.len == 0 || objectives_complete)
 		report += "<span class='greentext big'>The [name] was successful!</span>"
 	else

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -387,21 +387,22 @@
 	var/list/parts = list()
 	var/victory = check_cult_victory()
 
-	if(victory == CULT_NARSIE_KILLED) // Epic failure, you summoned your god and then someone killed it.
-		parts += "<span class='redtext big'>Nar'sie has been killed! The cult will haunt the universe no longer!</span>"
-	else if(victory)
-		parts += "<span class='greentext big'>The cult has succeeded! Nar'Sie has snuffed out another torch in the void!</span>"
-	else
-		parts += "<span class='redtext big'>The staff managed to stop the cult! Dark words and heresy are no match for Nanotrasen's finest!</span>"
+	if(!CONFIG_GET(flag/disable_greentext))
+		if(victory == CULT_NARSIE_KILLED) // Epic failure, you summoned your god and then someone killed it.
+			parts += "<span class='redtext big'>Nar'sie has been killed! The cult will haunt the universe no longer!</span>"
+		else if(victory)
+			parts += "<span class='greentext big'>The cult has succeeded! Nar'Sie has snuffed out another torch in the void!</span>"
+		else
+			parts += "<span class='redtext big'>The staff managed to stop the cult! Dark words and heresy are no match for Nanotrasen's finest!</span>"
 
 	if(objectives.len)
 		parts += "<b>The cultists' objectives were:</b>"
 		var/count = 1
 		for(var/datum/objective/objective in objectives)
 			if(objective.check_completion())
-				parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='greentext'>Success!</span>"
+				parts += "<b>Objective #[count]</b>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='greentext'>Success!</span>"]"
 			else
-				parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
+				parts += "<b>Objective #[count]</b>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='redtext'>Fail.</span>"]"
 			count++
 
 	if(members.len)

--- a/code/modules/antagonists/disease/disease_datum.dm
+++ b/code/modules/antagonists/disease/disease_datum.dm
@@ -46,20 +46,20 @@
 	var/count = 1
 	for(var/datum/objective/objective in objectives)
 		if(objective.check_completion())
-			objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <span class='greentext'>Success!</span>"
+			objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='greentext'>Success!</span>"]"
 		else
-			objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
+			objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='redtext'>Fail.</span>"]"
 			win = FALSE
 		count++
 
 	result += objectives_text
 
 	var/special_role_text = lowertext(name)
-
-	if(win)
-		result += "<span class='greentext'>The [special_role_text] was successful!</span>"
-	else
-		result += "<span class='redtext'>The [special_role_text] has failed!</span>"
+	if(!CONFIG_GET(flag/disable_greentext))
+		if(win)
+			result += "<span class='greentext'>The [special_role_text] was successful!</span>"
+		else
+			result += "<span class='redtext'>The [special_role_text] has failed!</span>"
 
 	if(istype(owner.current, /mob/camera/disease))
 		var/mob/camera/disease/D = owner.current

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -154,15 +154,16 @@
 		for(var/o in objectives)
 			var/datum/objective/objective = o
 			if(objective.check_completion())
-				parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='greentext'>Success!</b></span>"
+				parts += "<b>Objective #[count]</b>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='greentext'>Success!</span>"]"
 			else
-				parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
+				parts += "<b>Objective #[count]</b>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='redtext'>Fail.</span>"]"
 				cultiewin = FALSE
 			count++
-	if(ascended)
-		parts += "<span class='greentext big'>HERETIC HAS ASCENDED!</span>"
-	else
-		if(cultiewin)
+
+	if(!CONFIG_GET(flag/disable_greentext))
+		if(ascended)
+			parts += "<span class='greentext big'>HERETIC HAS ASCENDED!</span>"
+		else if(cultiewin)
 			parts += "<span class='greentext'>The heretic was successful!</span>"
 		else
 			parts += "<span class='redtext'>The heretic has failed.</span>"

--- a/code/modules/antagonists/fugitive/hunter.dm
+++ b/code/modules/antagonists/fugitive/hunter.dm
@@ -134,38 +134,38 @@
 
 	for(var/datum/mind/M in members)
 		result += "<b>[printplayer(M)]</b>"
-
-	switch(get_result())
-		if(FUGITIVE_RESULT_BADASS_HUNTER)//use defines
-			result += "<span class='greentext big'>Badass [capitalize(backstory)] Victory!</span>"
-			result += "<B>The [backstory]s managed to capture every fugitive, alive!</B>"
-		if(FUGITIVE_RESULT_POSTMORTEM_HUNTER)
-			result += "<span class='greentext big'>Postmortem [capitalize(backstory)] Victory!</span>"
-			result += "<B>The [backstory]s managed to capture every fugitive, but all of them died! Spooky!</B>"
-		if(FUGITIVE_RESULT_MAJOR_HUNTER)
-			result += "<span class='greentext big'>Major [capitalize(backstory)] Victory</span>"
-			result += "<B>The [backstory]s managed to capture every fugitive, dead or alive.</B>"
-		if(FUGITIVE_RESULT_HUNTER_VICTORY)
-			result += "<span class='greentext big'>[capitalize(backstory)] Victory</span>"
-			result += "<B>The [backstory]s managed to capture a fugitive, dead or alive.</B>"
-		if(FUGITIVE_RESULT_MINOR_HUNTER)
-			result += "<span class='greentext big'>Minor [capitalize(backstory)] Victory</span>"
-			result += "<B>All the [backstory]s died, but managed to capture a fugitive, dead or alive.</B>"
-		if(FUGITIVE_RESULT_STALEMATE)
-			result += "<span class='neutraltext big'>Bloody Stalemate</span>"
-			result += "<B>Everyone died, and no fugitives were recovered!</B>"
-		if(FUGITIVE_RESULT_MINOR_FUGITIVE)
-			result += "<span class='redtext big'>Minor Fugitive Victory</span>"
-			result += "<B>All the fugitives died, but none were recovered!</B>"
-		if(FUGITIVE_RESULT_FUGITIVE_VICTORY)
-			result += "<span class='redtext big'>Fugitive Victory</span>"
-			result += "<B>A fugitive survived, and no bodies were recovered by the [backstory]s.</B>"
-		if(FUGITIVE_RESULT_MAJOR_FUGITIVE)
-			result += "<span class='redtext big'>Major Fugitive Victory</span>"
-			result += "<B>All of the fugitives survived and avoided capture!</B>"
-		else //get_result returned null- either bugged or no fugitives showed
-			result += "<span class='neutraltext big'>Prank Call!</span>"
-			result += "<B>[capitalize(backstory)]s were called, yet there were no fugitives...?</B>"
+	if(!CONFIG_GET(flag/disable_greentext))
+		switch(get_result())
+			if(FUGITIVE_RESULT_BADASS_HUNTER)//use defines
+				result += "<span class='greentext big'>Badass [capitalize(backstory)] Victory!</span>"
+				result += "<B>The [backstory]s managed to capture every fugitive, alive!</B>"
+			if(FUGITIVE_RESULT_POSTMORTEM_HUNTER)
+				result += "<span class='greentext big'>Postmortem [capitalize(backstory)] Victory!</span>"
+				result += "<B>The [backstory]s managed to capture every fugitive, but all of them died! Spooky!</B>"
+			if(FUGITIVE_RESULT_MAJOR_HUNTER)
+				result += "<span class='greentext big'>Major [capitalize(backstory)] Victory</span>"
+				result += "<B>The [backstory]s managed to capture every fugitive, dead or alive.</B>"
+			if(FUGITIVE_RESULT_HUNTER_VICTORY)
+				result += "<span class='greentext big'>[capitalize(backstory)] Victory</span>"
+				result += "<B>The [backstory]s managed to capture a fugitive, dead or alive.</B>"
+			if(FUGITIVE_RESULT_MINOR_HUNTER)
+				result += "<span class='greentext big'>Minor [capitalize(backstory)] Victory</span>"
+				result += "<B>All the [backstory]s died, but managed to capture a fugitive, dead or alive.</B>"
+			if(FUGITIVE_RESULT_STALEMATE)
+				result += "<span class='neutraltext big'>Bloody Stalemate</span>"
+				result += "<B>Everyone died, and no fugitives were recovered!</B>"
+			if(FUGITIVE_RESULT_MINOR_FUGITIVE)
+				result += "<span class='redtext big'>Minor Fugitive Victory</span>"
+				result += "<B>All the fugitives died, but none were recovered!</B>"
+			if(FUGITIVE_RESULT_FUGITIVE_VICTORY)
+				result += "<span class='redtext big'>Fugitive Victory</span>"
+				result += "<B>A fugitive survived, and no bodies were recovered by the [backstory]s.</B>"
+			if(FUGITIVE_RESULT_MAJOR_FUGITIVE)
+				result += "<span class='redtext big'>Major Fugitive Victory</span>"
+				result += "<B>All of the fugitives survived and avoided capture!</B>"
+			else //get_result returned null- either bugged or no fugitives showed
+				result += "<span class='neutraltext big'>Prank Call!</span>"
+				result += "<B>[capitalize(backstory)]s were called, yet there were no fugitives...?</B>"
 
 	result += "</div>"
 

--- a/code/modules/antagonists/gang/gang.dm
+++ b/code/modules/antagonists/gang/gang.dm
@@ -156,10 +156,12 @@
 	report += "<span class='header'>[name]:</span>"
 	if(!members.len)
 		report += "<span class='redtext'>The family was wiped out!</span>"
-	else if(my_gang_datum.check_gang_objective())
-		report += "<span class='greentext'>The family completed their objective!</span>"
-	else
-		report += "<span class='redtext big'>The family failed their objective!</span>"
+
+	else if (!CONFIG_GET(flag/disable_greentext))
+		if(my_gang_datum.check_gang_objective())
+			report += "<span class='greentext'>The family completed their objective!</span>"
+		else
+			report += "<span class='redtext big'>The family failed their objective!</span>"
 	report += "Objective: [my_gang_datum.gang_objective]"
 	report += "Points: [points]"
 	if(members.len)

--- a/code/modules/antagonists/monkey/monkey.dm
+++ b/code/modules/antagonists/monkey/monkey.dm
@@ -188,19 +188,20 @@
 
 /datum/team/monkey/roundend_report()
 	var/list/parts = list()
-	switch(get_result())
-		if(MONKEYS_ESCAPED)
-			parts += "<span class='greentext big'><B>Monkey Major Victory!</B></span>"
-			parts += "<span class='greentext'><B>Central Command and [station_name()] were taken over by the monkeys! Ook ook!</B></span>"
-		if(MONKEYS_LIVED)
-			parts += "<FONT size = 3><B>Monkey Minor Victory!</B></FONT>"
-			parts += "<span class='greentext'><B>[station_name()] was taken over by the monkeys! Ook ook!</B></span>"
-		if(DISEASE_LIVED)
-			parts += "<span class='redtext big'><B>Monkey Minor Defeat!</B></span>"
-			parts += "<span class='redtext'><B>All the monkeys died, but the disease lives on! The future is uncertain.</B></span>"
-		if(MONKEYS_DIED)
-			parts += "<span class='redtext big'><B>Monkey Major Defeat!</B></span>"
-			parts += "<span class='redtext'><B>All the monkeys died, and Jungle Fever was wiped out!</B></span>"
+	if(!CONFIG_GET(flag/disable_greentext))
+		switch(get_result())
+			if(MONKEYS_ESCAPED)
+				parts += "<span class='greentext big'><B>Monkey Major Victory!</B></span>"
+				parts += "<span class='greentext'><B>Central Command and [station_name()] were taken over by the monkeys! Ook ook!</B></span>"
+			if(MONKEYS_LIVED)
+				parts += "<FONT size = 3><B>Monkey Minor Victory!</B></FONT>"
+				parts += "<span class='greentext'><B>[station_name()] was taken over by the monkeys! Ook ook!</B></span>"
+			if(DISEASE_LIVED)
+				parts += "<span class='redtext big'><B>Monkey Minor Defeat!</B></span>"
+				parts += "<span class='redtext'><B>All the monkeys died, but the disease lives on! The future is uncertain.</B></span>"
+			if(MONKEYS_DIED)
+				parts += "<span class='redtext big'><B>Monkey Major Defeat!</B></span>"
+				parts += "<span class='redtext'><B>All the monkeys died, and Jungle Fever was wiped out!</B></span>"
 	var/list/leaders = get_antag_minds(/datum/antagonist/monkey/leader, TRUE)
 	var/list/monkeys = get_antag_minds(/datum/antagonist/monkey, TRUE)
 

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -324,37 +324,38 @@
 	var/list/parts = list()
 	parts += "<span class='header'>[syndicate_name] Operatives:</span>"
 
-	switch(get_result())
-		if(NUKE_RESULT_FLUKE)
-			parts += "<span class='redtext big'>Humiliating Syndicate Defeat</span>"
-			parts += "<B>The crew of [station_name()] gave [syndicate_name] operatives back their bomb! The syndicate base was destroyed!</B> Next time, don't lose the nuke!"
-		if(NUKE_RESULT_NUKE_WIN)
-			parts += "<span class='greentext big'>Syndicate Major Victory!</span>"
-			parts += "<B>[syndicate_name] operatives have destroyed [station_name()]!</B>"
-		if(NUKE_RESULT_NOSURVIVORS)
-			parts += "<span class='neutraltext big'>Total Annihilation</span>"
-			parts +=  "<B>[syndicate_name] operatives destroyed [station_name()] but did not leave the area in time and got caught in the explosion.</B> Next time, don't lose the disk!"
-		if(NUKE_RESULT_WRONG_STATION)
-			parts += "<span class='redtext big'>Crew Minor Victory</span>"
-			parts += "<B>[syndicate_name] operatives secured the authentication disk but blew up something that wasn't [station_name()].</B> Next time, don't do that!"
-		if(NUKE_RESULT_WRONG_STATION_DEAD)
-			parts += "<span class='redtext big'>[syndicate_name] operatives have earned Darwin Award!</span>"
-			parts += "<B>[syndicate_name] operatives blew up something that wasn't [station_name()] and got caught in the explosion.</B> Next time, don't do that!"
-		if(NUKE_RESULT_CREW_WIN_SYNDIES_DEAD)
-			parts += "<span class='redtext big'>Crew Major Victory!</span>"
-			parts += "<B>The Research Staff has saved the disk and killed the [syndicate_name] Operatives</B>"
-		if(NUKE_RESULT_CREW_WIN)
-			parts += "<span class='redtext big'>Crew Major Victory</span>"
-			parts += "<B>The Research Staff has saved the disk and stopped the [syndicate_name] Operatives!</B>"
-		if(NUKE_RESULT_DISK_LOST)
-			parts += "<span class='neutraltext big'>Neutral Victory!</span>"
-			parts += "<B>The Research Staff failed to secure the authentication disk but did manage to kill most of the [syndicate_name] Operatives!</B>"
-		if(NUKE_RESULT_DISK_STOLEN)
-			parts += "<span class='greentext big'>Syndicate Minor Victory!</span>"
-			parts += "<B>[syndicate_name] operatives survived the assault but did not achieve the destruction of [station_name()].</B> Next time, don't lose the disk!"
-		else
-			parts += "<span class='neutraltext big'>Neutral Victory</span>"
-			parts += "<B>Mission aborted!</B>"
+	if(!CONFIG_GET(flag/disable_greentext))
+		switch(get_result())
+			if(NUKE_RESULT_FLUKE)
+				parts += "<span class='redtext big'>Humiliating Syndicate Defeat</span>"
+				parts += "<B>The crew of [station_name()] gave [syndicate_name] operatives back their bomb! The syndicate base was destroyed!</B> Next time, don't lose the nuke!"
+			if(NUKE_RESULT_NUKE_WIN)
+				parts += "<span class='greentext big'>Syndicate Major Victory!</span>"
+				parts += "<B>[syndicate_name] operatives have destroyed [station_name()]!</B>"
+			if(NUKE_RESULT_NOSURVIVORS)
+				parts += "<span class='neutraltext big'>Total Annihilation</span>"
+				parts +=  "<B>[syndicate_name] operatives destroyed [station_name()] but did not leave the area in time and got caught in the explosion.</B> Next time, don't lose the disk!"
+			if(NUKE_RESULT_WRONG_STATION)
+				parts += "<span class='redtext big'>Crew Minor Victory</span>"
+				parts += "<B>[syndicate_name] operatives secured the authentication disk but blew up something that wasn't [station_name()].</B> Next time, don't do that!"
+			if(NUKE_RESULT_WRONG_STATION_DEAD)
+				parts += "<span class='redtext big'>[syndicate_name] operatives have earned Darwin Award!</span>"
+				parts += "<B>[syndicate_name] operatives blew up something that wasn't [station_name()] and got caught in the explosion.</B> Next time, don't do that!"
+			if(NUKE_RESULT_CREW_WIN_SYNDIES_DEAD)
+				parts += "<span class='redtext big'>Crew Major Victory!</span>"
+				parts += "<B>The Research Staff has saved the disk and killed the [syndicate_name] Operatives</B>"
+			if(NUKE_RESULT_CREW_WIN)
+				parts += "<span class='redtext big'>Crew Major Victory</span>"
+				parts += "<B>The Research Staff has saved the disk and stopped the [syndicate_name] Operatives!</B>"
+			if(NUKE_RESULT_DISK_LOST)
+				parts += "<span class='neutraltext big'>Neutral Victory!</span>"
+				parts += "<B>The Research Staff failed to secure the authentication disk but did manage to kill most of the [syndicate_name] Operatives!</B>"
+			if(NUKE_RESULT_DISK_STOLEN)
+				parts += "<span class='greentext big'>Syndicate Minor Victory!</span>"
+				parts += "<B>[syndicate_name] operatives survived the assault but did not achieve the destruction of [station_name()].</B> Next time, don't lose the disk!"
+			else
+				parts += "<span class='neutraltext big'>Neutral Victory</span>"
+				parts += "<B>Mission aborted!</B>"
 
 	var/text = "<br><span class='header'>The syndicate operatives were:</span>"
 	var/purchases = ""

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -100,6 +100,9 @@
 	parts += L.loot_listing()
 	parts += "Total loot value : [L.get_loot_value()]/[L.target_value] credits"
 
+	if(CONFIG_GET(flag/disable_greentext))
+		return "<div class='panel redborder'>[parts.Join("<br>")]</div>"
+
 	if(L.check_completion() && !all_dead)
 		parts += "<span class='greentext big'>The pirate crew was successful!</span>"
 	else

--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -33,7 +33,7 @@
 /datum/antagonist/space_dragon/roundend_report()
 	var/list/parts = list()
 	var/datum/objective/summon_carp/S = locate() in objectives
-	if(S.check_completion())
+	if(S.check_completion() && !CONFIG_GET(flag/disable_greentext))
 		parts += "<span class='redtext big'>The [name] has succeeded! Station space has been reclaimed by the space carp!</span>"
 	parts += printplayer(owner)
 	var/objectives_complete = TRUE
@@ -43,10 +43,11 @@
 			if(!objective.check_completion())
 				objectives_complete = FALSE
 				break
-	if(objectives_complete)
-		parts += "<span class='greentext big'>The [name] was successful!</span>"
-	else
-		parts += "<span class='redtext big'>The [name] has failed!</span>"
+	if(!CONFIG_GET(flag/disable_greentext))
+		if(objectives_complete)
+			parts += "<span class='greentext big'>The [name] was successful!</span>"
+		else
+			parts += "<span class='redtext big'>The [name] has failed!</span>"
 	parts += "<span class='header'>The [name] was assisted by:</span>"
 	parts += printplayerlist(carp)
 	return "<div class='panel redborder'>[parts.Join("<br>")]</div>"

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -275,9 +275,9 @@
 		var/count = 1
 		for(var/datum/objective/objective in objectives)
 			if(objective.check_completion())
-				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <span class='greentext'>Success!</span>"
+				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='greentext'>Success!</span>"]"
 			else
-				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
+				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] [CONFIG_GET(flag/disable_greentext) ? "" : "<span class='redtext'>Fail.</span>"]"
 				traitorwin = FALSE
 			count++
 
@@ -295,6 +295,8 @@
 	if (contractor_hub)
 		result += contractor_round_end()
 
+	if(CONFIG_GET(flag/disable_greentext))
+		return result.Join("<br>")
 	if(traitorwin)
 		result += "<span class='greentext'>The [special_role_text] was successful!</span>"
 	else

--- a/code/modules/antagonists/valentines/valentine.dm
+++ b/code/modules/antagonists/valentines/valentine.dm
@@ -39,6 +39,7 @@
 				objectives_complete = FALSE
 				break
 
+	//Yes this isnt disabled by nogreentext config, but its not a *actual* antag
 	if(objectives_complete)
 		return "<span class='greentext big'>[owner.name] protected [owner.p_their()] date</span>"
 	else

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -288,16 +288,17 @@
 	var/wizardwin = 1
 	for(var/datum/objective/objective in objectives)
 		if(objective.check_completion())
-			parts += "<B>Objective #[count]</B>: [objective.explanation_text] <span class='greentext'>Success!</span>"
+			parts += "<B>Objective #[count]</B>: [objective.explanation_text] [!CONFIG_GET(flag/disable_greentext) ? "" : "<span class='greentext'>Success!</span>"]"
 		else
-			parts += "<B>Objective #[count]</B>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
+			parts += "<B>Objective #[count]</B>: [objective.explanation_text] [!CONFIG_GET(flag/disable_greentext) ? "" : "<span class='redtext'>Fail.</span>"]"
 			wizardwin = 0
 		count++
 
-	if(wizardwin)
-		parts += "<span class='greentext'>The wizard was successful!</span>"
-	else
-		parts += "<span class='redtext'>The wizard has failed!</span>"
+	if(!CONFIG_GET(flag/disable_greentext))
+		if(wizardwin)
+			parts += "<span class='greentext'>The wizard was successful!</span>"
+		else
+			parts += "<span class='redtext'>The wizard has failed!</span>"
 
 	if(owner.spell_list.len>0)
 		parts += "<B>[owner.name] used the following spells: </B>"

--- a/config/config.txt
+++ b/config/config.txt
@@ -373,6 +373,9 @@ MAPROTATION
 ## When it's set to zero, the map will be randomly picked each round
 PREFERENCE_MAP_VOTING 1
 
+## Disables greentext weithout disabling objective generation
+#DISABLE_GREENTEXT
+
 ## AUTOADMIN
 ## The default admin rank
 AUTOADMIN_RANK Game Master


### PR DESCRIPTION
## About The Pull Request

Does not prevent actual objective generation, just the text

## Why It's Good For The Game

Speedrunning a shuttle call after killing all the antags/doing steal objectives so they can see a red or green text at the end of the round isnt a good thing.

This arcade speedrun gameplay style is frankly,
shit.

It discourages RP and makes for a competitive play to win mentality instead of a play to have fun/create a good story mentality.

In particular this is seen on manuel where antags do _nothing_ all round only to silently do a steal objective 5 minutes before shuttle dock, which makes  for an abysmally boring round. LRP might want to keep this around(?) which is why it is a config option.

As some people are uncreative I also opted to leave objectives in.

## Changelog
:cl:
add:  Greentext can now be disabled through config
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
