### PR TITLE
Wild Mutation crops now carry over traits from the parent plant.

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -222,7 +222,7 @@
 			t_prod.seed.desc = initial(new_prod.desc)
 			t_prod.seed.plantname = initial(new_prod.plantname)
 			for(var/datum/plant_gene/trait/trait in parent.myseed.genes)
-				if(trait.can_add(t_pod.seed))
+				if(trait.can_add(t_prod.seed))
 					t_prod.seed.genes += trait
 			t_prod.transform = initial(t_prod.transform)
 			t_prod.transform *= TRANSFORM_USING_VARIABLE(t_prod.seed.potency, 100) + 0.5

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -221,11 +221,13 @@
 			t_prod.seed.name = initial(new_prod.name)
 			t_prod.seed.desc = initial(new_prod.desc)
 			t_prod.seed.plantname = initial(new_prod.plantname)
+			for(var/datum/plant_gene/trait/trait in parent.myseed.genes)
+				if(trait.can_add(t_pod.seed))
+					t_prod.seed.genes += trait
 			t_prod.transform = initial(t_prod.transform)
 			t_prod.transform *= TRANSFORM_USING_VARIABLE(t_prod.seed.potency, 100) + 0.5
 			t_amount++
 			if(t_prod.seed)
-				//t_prod.seed = new new_prod
 				t_prod.seed.instability = round(instability * 0.5)
 			continue
 		else


### PR DESCRIPTION

## About The Pull Request

This results in wild mutation carrying over possible traits from parent to child, in a way that will also be displayed by the plant analyzer.

This means if you gene splice a parent plant and it wild mutates into a different species, the wild mutation will take the trait genes of the parent, with none of the reagents as reagents are specific to the species in most cases, but can be bred back in via cross-pollination. 

## Why It's Good For The Game

Fixes #53246, adds consistancy to wild mutations, and prevents ghost traits from being applied without warning.

## Changelog
:cl:
fix: Wild mutation crops now carry over the physical traits from their parents.
/:cl:

