### PR TITLE
Rename orbiters list of orbiting orbiters var to something sane

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -875,7 +875,7 @@
 		var/atom/A = thing
 		A.transfer_observers_to(src)
 
-	for(var/i in orbiters?.orbiters)
+	for(var/i in orbiters?.orbiter_list)
 		if(!isobserver(i))
 			continue
 		var/mob/dead/observer/G = i

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -52,7 +52,7 @@
 			else if (M.mind == null)
 				npcs += list(serialized)
 			else
-				var/number_of_orbiters = M.orbiters?.orbiters?.len
+				var/number_of_orbiters = M.orbiters?.orbiter_list?.len
 				if (number_of_orbiters)
 					serialized["orbiters"] = number_of_orbiters
 
@@ -80,8 +80,7 @@
 	data["npcs"] = npcs
 
 	return data
-	
+
 /datum/orbit_menu/ui_assets()
 	. = ..() || list()
 	. += get_asset_datum(/datum/asset/simple/orbit)
-


### PR DESCRIPTION
## About The Pull Request

`var/list/orbiters` --> `var/list/orbiter_list`

## Why It's Good For The Game

More readable. More good.

## Changelog
:cl:
refactor: Orbiter components are a little easier to understand now.
/:cl: