### PR TITLE
Improve panicbunker interaction with hub status

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -284,6 +284,8 @@ GLOBAL_VAR(restart_counter)
 
 	if (!GLOB.enter_allowed)
 		features += "closed"
+	if (CONFIG_GET(flag/panic_bunker))
+		features += "closed to new accounts"
 
 	var/s = ""
 	var/hostedby

--- a/code/modules/admin/verbs/panicbunker.dm
+++ b/code/modules/admin/verbs/panicbunker.dm
@@ -7,7 +7,7 @@
 
 	var/new_pb = !CONFIG_GET(flag/panic_bunker)
 	CONFIG_SET(flag/panic_bunker, new_pb)
-
+	SSserver_maint.UpdateHubStatus()
 	log_admin("[key_name(usr)] has toggled the Panic Bunker, it is now [new_pb ? "on" : "off"]")
 	message_admins("[key_name_admin(usr)] has toggled the Panic Bunker, it is now [new_pb ? "enabled" : "disabled"].")
 	if (new_pb && !SSdbcore.Connect())


### PR DESCRIPTION
Toggling the panic bunker on will remove the servers from the hub,
preventing people from joining who don't know about panic bunker status.

I also added panic bunker status to the hub status message
