### PR TITLE
Add test for emotes

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -17,6 +17,7 @@
 #include "chain_pull_through_space.dm"
 #include "component_tests.dm"
 #include "confusion.dm"
+#include "emoting.dm"
 #include "keybinding_init.dm"
 #include "machine_disassembly.dm"
 #include "medical_wounds.dm"

--- a/code/modules/unit_tests/emoting.dm
+++ b/code/modules/unit_tests/emoting.dm
@@ -1,0 +1,25 @@
+/datum/unit_test/emoting
+	var/emotes_used = 0
+
+/datum/unit_test/emoting/Run()
+	var/mob/living/carbon/human/human = allocate(/mob/living/carbon/human)
+	RegisterSignal(human, COMSIG_MOB_EMOTE, .proc/on_emote_used)
+
+	human.say("*shrug")
+	TEST_ASSERT_EQUAL(emotes_used, 1, "Human did not shrug")
+
+	human.say("*beep")
+	TEST_ASSERT_EQUAL(emotes_used, 1, "Human beeped, when that should be restricted to silicons")
+
+	human.setOxyLoss(140)
+
+	TEST_ASSERT(human.stat != CONSCIOUS, "Human is somehow conscious after receiving suffocation damage")
+
+	human.say("*shrug")
+	TEST_ASSERT_EQUAL(emotes_used, 1, "Human shrugged while unconscious")
+
+	human.say("*deathgasp")
+	TEST_ASSERT_EQUAL(emotes_used, 2, "Human could not deathgasp while unconscious")
+
+/datum/unit_test/emoting/proc/on_emote_used()
+	emotes_used += 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tests normal emotes being usable while conscious, but not unconscious.
Tests emotes that can only be used on certain mobs.
Tests deathgasp.

Emotes have broken twice this week--ensures those don't regress.