### PR TITLE
Fix bicon(icon2html) showing full dmis, fix asset cache hashes being incorrect.

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -73,3 +73,18 @@
 
 /proc/pathflatten(path)
 	return replacetext(path, "/", "_")
+
+/// Returns the md5 of a file at a given path.
+/proc/md5filepath(path)
+	. = md5(file(path))
+
+/// Save file as an external file then md5 it.
+/// Used because md5ing files stored in the rsc sometimes gives incorrect md5 results.
+/proc/md5asfile(file)
+	var/static/notch = 0
+	// its importaint this code can handle md5filepath sleeping instead of hard blocking, if it's converted to use rust_g.
+	var/filename = "tmp/md5asfile.[world.realtime].[world.timeofday].[world.time].[world.tick_usage].[notch]"
+	notch = WRAP(notch+1, 0, 2^15)
+	fcopy(file, filename)
+	. = md5filepath(filename)
+	fdel(filename)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1124,12 +1124,13 @@ GLOBAL_DATUM_INIT(dummySave, /savefile, new("tmp/dummySave.sav")) //Cache of ico
 	var/list/partial = splittext(iconData, "{")
 	return replacetext(copytext_char(partial[2], 3, -5), "\n", "")
 
-/proc/icon2html(thing, target, icon_state, dir, frame = 1, moving = FALSE, sourceonly = FALSE)
+/proc/icon2html(thing, target, icon_state, dir = SOUTH, frame = 1, moving = FALSE, sourceonly = FALSE)
 	if (!thing)
 		return
 
 	var/key
 	var/icon/I = thing
+
 	if (!target)
 		return
 	if (target == world)
@@ -1153,11 +1154,18 @@ GLOBAL_DATUM_INIT(dummySave, /savefile, new("tmp/dummySave.sav")) //Cache of ico
 				return SSassets.transport.get_asset_url(name)
 			return "<img class='icon icon-misc' src='[SSassets.transport.get_asset_url(name)]'>"
 		var/atom/A = thing
-		if (isnull(dir))
-			dir = A.dir
+		
+		I = A.icon
 		if (isnull(icon_state))
 			icon_state = A.icon_state
-		I = A.icon
+			if (!(icon_state in icon_states(I, 1)))
+				icon_state = initial(A.icon_state)
+				if (isnull(dir))
+					dir = initial(A.dir)
+		
+		if (isnull(dir))
+			dir = A.dir		
+		
 		if (ishuman(thing)) // Shitty workaround for a BYOND issue.
 			var/icon/temp = I
 			I = icon()

--- a/code/modules/asset_cache/asset_cache_item.dm
+++ b/code/modules/asset_cache/asset_cache_item.dm
@@ -24,12 +24,10 @@
 /datum/asset_cache_item/New(name, file)
 	if (!isfile(file))
 		file = fcopy_rsc(file)
-	hash = md5(file)
+		
+	hash = md5asfile(file) //icons sent to the rsc sometimes md5 incorrectly
 	if (!hash)
-		hash = md5(fcopy_rsc(file))
-		if (!hash)
-			CRASH("invalid asset sent to asset cache")
-		debug_world_log("asset cache unexpected success of second fcopy_rsc")
+		CRASH("invalid asset sent to asset cache")
 	src.name = name
 	var/extstart = findlasttext(name, ".")
 	if (extstart)


### PR DESCRIPTION
icon2html will now always show the south direction unless passed a specific direction to show. This is to work around icon() returning a blank icon if passed a direction that the icon doesn't define, instead of defaulting to south like the client does. This should also cut down on the number of assets generated by shift clicks

If icon2html is given an atom with an invalid icon state, it will use the atom's compile time icon_state, so smoothed icons can show their mapper's helper icon instead of the entire dmi.

Asset cache will now copy files to disk before md5ing them, to deal with byond not always returning the correct md5 for rsc references.