### PR TITLE
Fixes bonesetter material duplication

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -526,7 +526,7 @@
 	name = "Bonesetter"
 	id = "bonesetter"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 1000)
+	materials = list(/datum/material/iron = 5000,  /datum/material/glass = 2500)
 	build_path = /obj/item/bonesetter
 	category = list("initial", "Medical", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE


### PR DESCRIPTION
## About The Pull Request

You can no longer duplicate metal and glass by printing and recycling bonesetters

## Why It's Good For The Game

Infinite materials bad

## Changelog
:cl: Bumtickley00
fix: Printing and recycling bonesetters no longer creates materials from nothing
/:cl: