### PR TITLE
Mafia achievements can no longer be earned in debug games

### DIFF
--- a/code/modules/mafia/roles.dm
+++ b/code/modules/mafia/roles.dm
@@ -659,8 +659,7 @@
 	SIGNAL_HANDLER
 
 	if(game_status == MAFIA_ALIVE)
-		var/client/winner_client = GLOB.directory[player_key]
-		winner_client?.give_award(winner_award, body)
+		game.award_role(winner_award, src)
 		game.send_message("<span class='big comradio'>!! FUGITIVE VICTORY !!</span>")
 
 #undef FUGITIVE_NOT_PRESERVING
@@ -714,8 +713,7 @@
 		return
 	if(lynch)
 		game.send_message("<span class='big comradio'>!! OBSESSED VICTORY !!</span>")
-		var/client/winner_client = GLOB.directory[player_key]
-		winner_client?.give_award(winner_award, body)
+		game.award_role(winner_award, src)
 		reveal_role(game, FALSE)
 	else
 		to_chat(body, "<span class='userdanger'>You have failed your objective to lynch [obsession.body]!</span>")
@@ -744,6 +742,5 @@
 		var/datum/mafia_role/victim = pick(game.judgement_guilty_votes + game.judgement_abstain_votes)
 		game.send_message("<span class='big clown'>[body.real_name] WAS A CLOWN! HONK! They take down [victim.body.real_name] with their last prank.</span>")
 		game.send_message("<span class='big clown'>!! CLOWN VICTORY !!</span>")
-		var/client/winner_client = GLOB.directory[player_key]
-		winner_client?.give_award(winner_award, body)
+		game.award_role(winner_award, src)
 		victim.kill(game,FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If an admin sets up a non normal match, you cannot earn achivements.

## Why It's Good For The Game

I really love earning achievements, so if I have to debug something or run a goofy ass version, I don't want to unfairly give out achievements. The only way to prevent this is to nuke the game before it ends, and that is stupid.

## Changelog
:cl:
fix: You can no longer earn achievements in debug mafia games.
refactor: And the achievement code is much nicer :)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
