### PR TITLE
Barrels' O Mech Fixes

### DIFF
--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -206,5 +206,8 @@
 
 /obj/vehicle/sealed/car/clowncar/Destroy()
 	DumpMobs()
+	return ..()
+
+/obj/vehicle/sealed/car/clowncar/obj_destruction()
 	explosion(loc, 0, 1, 2, 3 , 0)
 	return ..()

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -202,3 +202,9 @@
 		for(var/i in return_drivers())
 			var/mob/busdriver = i
 			busdriver.client.give_award(/datum/award/achievement/misc/the_best_driver, busdriver)
+
+
+/obj/vehicle/sealed/car/clowncar/Destroy()
+	DumpMobs()
+	explosion(loc, 0, 1, 2, 3 , 0)
+	return ..()

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -1005,7 +1005,7 @@
 /obj/vehicle/sealed/mecha/container_resist_act(mob/living/user)
 	if(isAI(user))
 		var/mob/living/silicon/ai/AI = user
-		if(!AI.can_shunt)
+		if(AI.can_shunt)
 			to_chat(AI, "<span class='notice'>You can't leave a mech after dominating it!.</span>")
 			return FALSE
 	to_chat(user, "<span class='notice'>You begin the ejection procedure. Equipment is disabled during this process. Hold still to finish ejecting.</span>")

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -65,8 +65,6 @@
 	var/lights_power = 6
 	///Just stop the mech from doing anything
 	var/completely_disabled = FALSE
-	///Whether this mech is allowed to move diagonally
-	var/allow_diagonal_movement = FALSE
 	///Whether or not the mech destroys walls by running into it.
 	var/bumpsmash = FALSE
 
@@ -645,10 +643,6 @@
 
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
 		direction = pick(GLOB.alldirs)
-
-	//only mechs with diagonal movement may move diagonally
-	if(!allow_diagonal_movement && ISDIAGONALDIR(direction))
-		return TRUE
 
 	//if we're not facing the way we're going rotate us
 	if(dir != direction && !strafe || forcerotate)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -665,6 +665,8 @@
 		for(var/D in return_drivers())
 			var/mob/driver = D
 			if(driver.client?.keys_held["Alt"])
+				if(turnsound)
+					playsound(src,turnsound,40,TRUE)
 				return
 		setDir(olddir)
 

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -953,6 +953,7 @@
 	add_fingerprint(H)
 	log_message("[H] moved in as pilot.", LOG_MECHA)
 	setDir(dir_in)
+	update_icon()
 	playsound(src, 'sound/machines/windowdoor.ogg', 50, TRUE)
 	if(!internal_damage)
 		SEND_SOUND(H, sound('sound/mecha/nominal.ogg',volume=50))
@@ -1029,6 +1030,7 @@
 /obj/vehicle/sealed/mecha/mob_exit(mob/M, silent, forced)
 	var/newloc = get_turf(src)
 	var/atom/movable/mob_container
+	update_icon()
 	if(ishuman(M))
 		mob_container = M
 	else if(isbrain(M))

--- a/code/modules/vehicles/mecha/combat/gygax.dm
+++ b/code/modules/vehicles/mecha/combat/gygax.dm
@@ -2,7 +2,6 @@
 	desc = "A lightweight, security exosuit. Popular among private and corporate security."
 	name = "\improper Gygax"
 	icon_state = "gygax"
-	allow_diagonal_movement = TRUE
 	movedelay = 3
 	dir_in = 1 //Facing North.
 	max_integrity = 250

--- a/code/modules/vehicles/mecha/medical/odysseus.dm
+++ b/code/modules/vehicles/mecha/medical/odysseus.dm
@@ -2,7 +2,6 @@
 	desc = "These exosuits are developed and produced by Vey-Med. (&copy; All rights reserved)."
 	name = "\improper Odysseus"
 	icon_state = "odysseus"
-	allow_diagonal_movement = TRUE
 	movedelay = 2
 	max_temperature = 15000
 	max_integrity = 120

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -30,14 +30,6 @@
 	. = ..()
 	update_pressure()
 
-/obj/vehicle/sealed/mecha/working/ripley/mob_exit(mob/M, silent, forced)
-	..()
-	update_icon()
-
-/obj/vehicle/sealed/mecha/working/ripley/moved_inside(mob/living/carbon/human/H)
-	..()
-	update_icon()
-
 /obj/vehicle/sealed/mecha/working/ripley/check_for_internal_damage(list/possible_int_damage, ignore_threshold = FALSE)
 	if (!enclosed)
 		possible_int_damage -= (MECHA_INT_TEMP_CONTROL + MECHA_INT_TANK_BREACH) //if we don't even have an air tank, these two doesn't make a ton of sense.

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -91,11 +91,6 @@
 	user.put_in_hands(inserted_key)
 	inserted_key = null
 
-/obj/vehicle/sealed/Destroy()
-	DumpMobs()
-	explosion(loc, 0, 1, 2, 3, 0)
-	return ..()
-
 /obj/vehicle/sealed/proc/DumpMobs(randomstep = TRUE)
 	for(var/i in occupants)
 		mob_exit(i, null, randomstep)


### PR DESCRIPTION
Fixes #53415 
Fixes #53327 

## About The Pull Request

Mechs now have sounds when turning while strafing using the ALT key.

Also the Ripley MKII upgrade isnt made of C4 anymore.

Diagonal Movement is a thing again.

Mech sprites are no longer horribly broken for anything but Ripley.
## Why It's Good For The Game

BUGS BAD, FIXNG GRUG

GRUG DO CODE

## Changelog
:cl:
fix: Nanotrasen has removed the C4 from the Ripley MKII Upgrade Kits, alongside making their mech actuators more noisy. They also fixed interdimentional interference.
/:cl: