### PR TITLE
Rearranges the Science Department on IceBox Station for Toxins Gas Storage.

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -32277,18 +32277,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"bya" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/storage)
 "byb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -32405,18 +32393,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byo" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "byp" = (
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plasteel,
-/area/science/storage)
-"byq" = (
-/obj,
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bys" = (
@@ -34923,9 +34903,8 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "bED" = (
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
-/obj/machinery/camera/autoname,
+/obj/machinery/portable_atmospherics/canister/tier_1,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bEE" = (
@@ -35400,8 +35379,12 @@
 /area/science/mixing)
 "bFX" = (
 /obj/structure/cable,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
+/obj/machinery/power/apc{
+	areastring = "/area/science/mixing";
+	dir = 4;
+	name = "Toxins Lab APC";
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/white/telecomms,
 /area/science/mixing)
 "bFY" = (
@@ -35572,7 +35555,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGA" = (
-/obj,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
@@ -35751,8 +35733,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "bGY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/chair/office{
+	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
@@ -36847,12 +36830,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/power/apc{
-	areastring = "/area/science/mixing";
-	dir = 4;
-	name = "Toxins Lab APC";
-	pixel_x = 24
-	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bKb" = (
@@ -49861,7 +49838,8 @@
 	pixel_y = 2;
 	req_access_txt = "9"
 	},
-/turf/open/floor/grass,
+/mob/living/carbon/monkey,
+/turf/open/floor/engine,
 /area/science/genetics)
 "ddD" = (
 /obj/structure/disposalpipe/segment{
@@ -50205,7 +50183,8 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/mob/living/carbon/monkey,
+/turf/open/floor/engine,
 /area/science/genetics)
 "dYq" = (
 /turf/closed/wall,
@@ -50315,9 +50294,6 @@
 /obj/item/reagent_containers/food/drinks/waterbottle,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"eAc" = (
-/turf/open/floor/grass,
-/area/science/genetics)
 "eAi" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -50406,8 +50382,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "eRJ" = (
-/obj/machinery/portable_atmospherics/canister/tier_1,
 /obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "eSG" = (
@@ -50477,9 +50453,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "flN" = (
-/obj,
-/mob/living/carbon/monkey,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/white,
 /area/science/genetics)
 "fnC" = (
 /obj/effect/decal/cleanable/ash,
@@ -50792,12 +50768,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"ggS" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/science/genetics)
 "giT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -50842,6 +50812,9 @@
 /obj/structure/cable,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -51307,10 +51280,6 @@
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"hRm" = (
-/mob/living/carbon/monkey,
-/turf/open/floor/grass,
-/area/science/genetics)
 "hSa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/firecloset,
@@ -51558,13 +51527,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"iSM" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/mob/living/carbon/monkey,
-/turf/open/floor/grass,
-/area/science/genetics)
 "iTj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
@@ -51796,13 +51758,13 @@
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
 "jzb" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/delivery,
 /obj/structure/extinguisher_cabinet{
 	dir = 2;
 	pixel_x = 0;
 	pixel_y = -28
 	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "jBV" = (
@@ -53122,6 +53084,7 @@
 	pixel_x = 0;
 	pixel_y = 25
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "mSf" = (
@@ -53431,6 +53394,11 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"nQF" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/white,
+/area/science/genetics)
 "nQI" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -54123,7 +54091,12 @@
 /area/medical/medbay)
 "pBV" = (
 /obj,
-/turf/open/floor/grass,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/white,
 /area/science/genetics)
 "pCj" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -54461,8 +54434,9 @@
 	pixel_y = 2;
 	req_access_txt = "9"
 	},
+/obj/machinery/light,
 /mob/living/carbon/monkey,
-/turf/open/floor/grass,
+/turf/open/floor/engine,
 /area/science/genetics)
 "qrU" = (
 /obj/machinery/disposal/bin,
@@ -54535,7 +54509,9 @@
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "qQC" = (
-/obj,
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = -25
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "qQH" = (
@@ -54638,6 +54614,9 @@
 	pixel_y = -29
 	},
 /obj/effect/spawner/xmastree/rdrod,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "rzl" = (
@@ -54820,10 +54799,6 @@
 /obj/machinery/camera,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"rYJ" = (
-/obj,
-/turf/closed/wall/r_wall,
-/area/science/genetics)
 "rZR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -55079,11 +55054,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "sOU" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = -32
-	},
-/mob/living/carbon/monkey,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/tier_1,
+/turf/open/floor/plasteel/white,
 /area/science/genetics)
 "sUw" = (
 /obj/machinery/button/door{
@@ -55969,7 +55942,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "voe" = (
-/obj,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/white,
@@ -56303,6 +56275,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
+"wpg" = (
+/turf/open/floor/plating,
+/area/science/genetics)
 "wph" = (
 /obj/docking_port/stationary{
 	dheight = 4;
@@ -104348,7 +104323,7 @@ oMN
 ubw
 cas
 bCk
-byq
+byo
 bys
 bxP
 bIB
@@ -104864,7 +104839,7 @@ cas
 bIA
 bys
 bys
-bya
+bxP
 jzb
 dGF
 bMw
@@ -105886,9 +105861,9 @@ qrU
 kGS
 bzO
 taM
-dWG
-flN
 bon
+flN
+flN
 eRJ
 bFW
 wJG
@@ -106143,10 +106118,10 @@ gHj
 gHj
 xeP
 bAR
-iSM
-pBV
 bon
-eRJ
+pBV
+nQF
+bFU
 bEA
 voe
 bGA
@@ -106400,9 +106375,9 @@ bsL
 bsL
 rAv
 eFD
-dWG
+bon
 sOU
-rYJ
+sOU
 bED
 bFX
 glg
@@ -106657,8 +106632,8 @@ ifv
 ifv
 xkP
 cYY
-iSM
-ggS
+bon
+bon
 bon
 bEC
 bEC
@@ -106915,8 +106890,8 @@ bsL
 ink
 pSN
 ddy
-hRm
 bon
+wpg
 bEF
 bky
 bEO
@@ -107172,8 +107147,8 @@ bqe
 npF
 vPt
 qrH
-eAc
 bon
+wpg
 bEE
 bFY
 bKb
@@ -107429,8 +107404,8 @@ xXe
 lFP
 jyF
 dWG
-hRm
 bon
+wpg
 vqI
 bky
 bHs
@@ -107687,7 +107662,7 @@ bon
 bon
 bon
 bon
-bon
+wpg
 vqI
 bEs
 bEs

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -27280,6 +27280,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/bridge)
 "blP" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -51723,6 +51723,7 @@
 /area/medical/chemistry)
 "jtR" = (
 /obj/effect/landmark/start/research_director,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "juq" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -54831,7 +54831,7 @@
 	dir = 4;
 	name = "Misc Research APC";
 	pixel_x = 25;
-	step_x = 0
+	
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 9

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -27278,11 +27278,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/bridge)
 "blP" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1563,10 +1563,10 @@
 	},
 /obj/structure/cable,
 /obj/structure/bed/dogbed/lia,
-/mob/living/simple_animal/hostile/carp/cayenne/lia,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
+/mob/living/simple_animal/hostile/carp/cayenne/lia,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "adO" = (
@@ -12535,19 +12535,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aDH" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/pen,
-/obj/item/folder/white,
-/obj/item/stamp/rd{
-	pixel_x = 3;
-	pixel_y = -2
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
+/turf/open/floor/plasteel,
+/area/science/storage)
 "aDI" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -16969,11 +16965,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aNK" = (
-/mob/living/simple_animal/hostile/retaliate/goat{
-	name = "Pete"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/mob/living/simple_animal/hostile/retaliate/goat{
+	name = "Pete"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
@@ -20404,13 +20400,14 @@
 /turf/open/floor/carpet,
 /area/vacant_room/office)
 "aWt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/computer/card/minor/rd{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/science/storage)
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/hor)
 "aWu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -20455,14 +20452,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aWy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "aWz" = (
 /obj/machinery/power/apc{
 	areastring = "/area/storage/emergency/port";
@@ -27284,7 +27280,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/computer/rdconsole,
+/obj/structure/blob/core,
 /turf/open/floor/plasteel,
 /area/bridge)
 "blP" = (
@@ -28352,10 +28348,6 @@
 "bon" = (
 /turf/closed/wall/r_wall,
 /area/science/genetics)
-"bop" = (
-/obj/machinery/modular_computer/console/preset/civilian,
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
 "boq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30350,19 +30342,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "btj" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hor";
-	dir = 8;
-	name = "RD Office APC";
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light_switch{
 	pixel_x = -25
 	},
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/item/kirbyplants/dead,
-/obj/structure/cable,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
+/turf/open/floor/plasteel,
+/area/science/storage)
 "btk" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/closed/wall,
@@ -31869,10 +31855,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
-"bwR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
 "bwS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -32011,50 +31993,18 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bxi" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Research Director's Desk";
-	departmentType = 5;
-	name = "Research Director RC";
-	pixel_x = -2;
-	pixel_y = 30;
-	receive_ore_updates = 1
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/item/radio/intercom{
+	pixel_x = 0;
+	pixel_y = 29
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/computer/rdconsole{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
-"bxj" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen/rd,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "bxk" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"bxl" = (
-/obj/structure/rack,
-/obj/item/circuitboard/aicore{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
-"bxm" = (
-/obj/effect/spawner/xmastree/rdrod,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
 "bxn" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Turbine Access";
@@ -32241,18 +32191,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "bxP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "bxS" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -32300,13 +32247,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bxW" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Research Director";
-	req_access_txt = "30"
+/obj/machinery/door/airlock/research{
+	name = "Toxins Storage";
+	req_access_txt = "71"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -32314,46 +32259,48 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "bxX" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"bxY" = (
-/obj/structure/disposalpipe/segment{
+"bxZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/science/storage)
+"bya" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/science/storage)
+"byb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
-"bxZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
-"bya" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
-"byb" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
+/obj/structure/cable,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "byc" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/brown,
@@ -32458,64 +32405,34 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byo" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "Biohazard";
-	name = "Biohazard Shutter Control";
-	pixel_x = -5;
-	pixel_y = 5;
-	req_access_txt = "47"
-	},
-/obj/machinery/button/door{
-	id = "rnd2";
-	name = "Research Lab Shutter Control";
-	pixel_x = 5;
-	pixel_y = 5;
-	req_access_txt = "47"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "byp" = (
-/obj/machinery/computer/robotics{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "byq" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/effect/landmark/start/research_director,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
-"byr" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
+/obj,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "bys" = (
-/obj/structure/rack,
-/obj/item/aicard,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
-"byt" = (
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/hor)
+/obj,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "byu" = (
-/obj/structure/displaycase/labcage,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "byv" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Turbine Access";
@@ -32989,40 +32906,26 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bzJ" = (
-/obj/machinery/computer/mecha{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plasteel,
+/area/science/storage)
+"bzL" = (
+/obj,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plasteel,
+/area/science/storage)
+"bzN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
-"bzL" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
-"bzM" = (
-/obj/structure/rack,
-/obj/item/taperecorder{
-	pixel_x = -3
-	},
-/obj/item/paicard{
-	pixel_x = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
-"bzN" = (
-/obj/machinery/modular_computer/console/preset/research{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "bzO" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner{
@@ -34069,66 +33972,24 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "bCg" = (
-/obj/structure/table,
-/obj/item/cartridge/signal/toxins,
-/obj/item/cartridge/signal/toxins{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/cartridge/signal/toxins{
-	pixel_x = 4;
-	pixel_y = 6
-	},
+/obj,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/camera{
-	c_tag = "Research Director's Office";
-	dir = 1;
-	network = list("ss13","rd")
-	},
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
-"bCh" = (
-/obj/machinery/keycard_auth{
-	pixel_y = -24
-	},
-/obj/machinery/light,
-/obj/machinery/computer/card/minor/rd{
+	c_tag = "Security Checkpoint";
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
-"bCi" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "bCj" = (
 /obj/structure/closet/secure_closet/research_director,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bCk" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
-"bCl" = (
-/obj/machinery/camera{
-	c_tag = "Experimentor Lab Chamber";
-	dir = 1;
-	network = list("ss13","rd")
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = -32
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/mob/living/carbon/monkey,
-/turf/open/floor/engine,
-/area/science/genetics)
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "bCm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -34429,11 +34290,15 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/aft)
 "bCX" = (
-/obj/effect/decal/cleanable/oil,
-/obj/item/cigbutt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/science/storage)
+/obj,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "bCY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -34484,8 +34349,23 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "bDc" = (
-/turf/closed/wall,
-/area/science/storage)
+/obj/machinery/door/airlock/command/glass{
+	name = "Research Director";
+	req_access_txt = "30"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "bDd" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/airalarm{
@@ -34502,15 +34382,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bDf" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
-/obj/machinery/light/small{
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/science/storage)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "bDg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -34522,10 +34405,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bDj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel,
-/area/science/storage)
+/obj,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "bDk" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -34540,9 +34428,15 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bDl" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 5
@@ -34774,17 +34668,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "bDY" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/structure/blob/core{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/science/storage)
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "bDZ" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
@@ -34802,24 +34690,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "bEb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/storage)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "bEc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/science/storage)
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/hor)
 "bEd" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -34832,33 +34712,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
-"bEf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 5
-	},
-/area/science/research)
-"bEg" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Storage";
-	req_access_txt = "71"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/storage)
 "bEh" = (
 /obj/machinery/vending/medical{
 	pixel_x = -2
@@ -34952,38 +34805,39 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bEo" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/storage)
+/obj,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "bEp" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen/rd,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Research Director's Desk";
+	departmentType = 5;
+	name = "Research Director RC";
+	pixel_x = -2;
+	pixel_y = 30;
+	receive_ore_updates = 1
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/storage)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "bEq" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/research";
-	dir = 8;
-	name = "Misc Research APC";
-	pixel_x = -25
-	},
-/obj/structure/cable,
+/obj,
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
 /area/science/research)
 "bEr" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bEs" = (
@@ -35047,9 +34901,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bEA" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white/telecomms,
 /area/science/mixing)
 "bEB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -35063,8 +34922,12 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "bED" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plasteel,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bEE" = (
 /obj/structure/disposalpipe/segment{
@@ -35422,17 +35285,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/break_room)
-"bFI" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/science/storage)
 "bFL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
@@ -35509,14 +35361,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/break_room)
-"bFQ" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 5
-	},
-/area/science/research)
 "bFR" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -35546,23 +35390,20 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "bFW" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bFX" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/mixing";
-	dir = 4;
-	name = "Toxins Lab APC";
-	pixel_x = 24
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/white/telecomms,
 /area/science/mixing)
 "bFY" = (
 /obj/machinery/door/airlock/maintenance{
@@ -35732,13 +35573,17 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGA" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot,
+/obj,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGB" = (
 /obj/structure/table,
@@ -35766,6 +35611,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGD" = (
@@ -35781,12 +35632,17 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bGF" = (
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGG" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -35794,12 +35650,8 @@
 	sortType = 25
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bGI" = (
@@ -35825,6 +35677,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bGL" = (
@@ -35894,10 +35752,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "bGY" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/science/storage)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "bGZ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -35944,9 +35803,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/break_room)
 "bHc" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -35956,21 +35812,14 @@
 	},
 /area/science/research)
 "bHe" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/storage";
-	dir = 8;
-	name = "Toxins Storage APC";
-	pixel_x = -25
+/obj/machinery/modular_computer/console/preset/research{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Toxins Storage";
-	dir = 4;
-	network = list("ss13","rd")
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/science/storage)
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/hor)
 "bHf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/heavy,
@@ -36487,10 +36336,25 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bIz" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/storage)
+/obj/structure/table,
+/obj/item/cartridge/signal/toxins,
+/obj/item/cartridge/signal/toxins{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/cartridge/signal/toxins{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/hor)
 "bIA" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot,
@@ -36502,10 +36366,12 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bIC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plasteel,
-/area/science/storage)
+/obj,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "bID" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36980,8 +36846,15 @@
 /area/science/mixing)
 "bKa" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
+/obj/machinery/power/apc{
+	areastring = "/area/science/mixing";
+	dir = 4;
+	name = "Toxins Lab APC";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bKb" = (
 /obj/structure/disposalpipe/segment,
@@ -37324,8 +37197,8 @@
 /area/science/xenobiology)
 "bLh" = (
 /obj/structure/sign/warning/fire,
-/turf/closed/wall,
-/area/crew_quarters/heads/hor)
+/turf/closed/wall/r_wall,
+/area/science/storage)
 "bLi" = (
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/white,
@@ -39207,10 +39080,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/mob/living/carbon/monkey,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/mob/living/carbon/monkey,
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "bQK" = (
@@ -42226,6 +42099,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"cas" = (
+/turf/closed/wall/r_wall,
+/area/science/storage)
 "cau" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -43173,6 +43049,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"cdM" = (
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 25
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/science/research)
 "cdR" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
@@ -46624,9 +46508,9 @@
 	uses = 10
 	},
 /obj/structure/cable,
-/mob/living/simple_animal/bot/secbot/pingsky,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cuT" = (
@@ -46697,10 +46581,10 @@
 /area/ai_monitored/turret_protected/aisat/atmos)
 "cuZ" = (
 /obj/effect/turf_decal/tile/blue,
-/mob/living/simple_animal/bot/floorbot,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "cva" = (
@@ -46761,10 +46645,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/mob/living/simple_animal/bot/cleanbot,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
 "cvh" = (
@@ -46783,6 +46667,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
+"cvi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/hor)
 "cvj" = (
 /turf/closed/wall,
 /area/ai_monitored/turret_protected/aisat/hallway)
@@ -47782,9 +47673,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cAL" = (
-/mob/living/simple_animal/hostile/lizard/wags_his_tail,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/mob/living/simple_animal/hostile/lizard/wags_his_tail,
 /turf/open/floor/plasteel,
 /area/janitor)
 "cAN" = (
@@ -48015,16 +47906,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"cBu" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
 "cBw" = (
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/event_spawn,
@@ -49981,8 +49862,7 @@
 	pixel_y = 2;
 	req_access_txt = "9"
 	},
-/mob/living/carbon/monkey,
-/turf/open/floor/engine,
+/turf/open/floor/grass,
 /area/science/genetics)
 "ddD" = (
 /obj/structure/disposalpipe/segment{
@@ -50035,6 +49915,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
+"dnc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/displaycase/labcage,
+/obj/machinery/camera{
+	c_tag = "Research Director's Office";
+	dir = 1;
+	network = list("ss13","rd")
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/hor)
 "dni" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -50155,7 +50047,7 @@
 	name = "Toxins Chamber APC";
 	pixel_x = -25
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "dEq" = (
 /obj/effect/turf_decal/tile/green{
@@ -50207,6 +50099,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
+"dIF" = (
+/obj,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "dJx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50306,6 +50204,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"dWG" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/science/genetics)
 "dYq" = (
 /turf/closed/wall,
 /area/science/nanite)
@@ -50330,6 +50234,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"efX" = (
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "Biohazard";
+	name = "Biohazard Shutter Control";
+	pixel_x = -5;
+	pixel_y = 5;
+	req_access_txt = "47"
+	},
+/obj/machinery/button/door{
+	id = "rnd2";
+	name = "Research Lab Shutter Control";
+	pixel_x = 5;
+	pixel_y = 5;
+	req_access_txt = "47"
+	},
+/obj/machinery/light_switch{
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "egr" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
@@ -50382,6 +50307,9 @@
 /obj/item/reagent_containers/food/drinks/waterbottle,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"eAc" = (
+/turf/open/floor/grass,
+/area/science/genetics)
 "eAi" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -50469,6 +50397,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
+"eRJ" = (
+/obj/machinery/portable_atmospherics/canister/tier_1,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "eSG" = (
 /obj/machinery/light{
 	dir = 8
@@ -50536,10 +50469,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "flN" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel,
-/area/science/mixing)
+/obj,
+/mob/living/carbon/monkey,
+/turf/open/floor/grass,
+/area/science/genetics)
 "fnC" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating,
@@ -50664,14 +50597,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
-"fGF" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "fJT" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -50686,6 +50611,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"fKY" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/item/aicard,
+/obj/item/ai_module/core,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/hor)
 "fMP" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -50850,6 +50784,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"ggS" = (
+/obj/machinery/camera{
+	c_tag = "Experimentor Lab Chamber";
+	dir = 1;
+	network = list("ss13","rd")
+	},
+/turf/open/floor/grass,
+/area/science/genetics)
 "giT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -50892,8 +50834,10 @@
 /area/medical/virology)
 "glg" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "glY" = (
 /obj/machinery/power/tracker,
@@ -51175,6 +51119,18 @@
 "hjZ" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
+"hnE" = (
+/obj,
+/obj/structure/rack,
+/obj/item/paicard,
+/obj/item/taperecorder{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/hor)
 "hnW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/closed/wall,
@@ -51341,6 +51297,10 @@
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"hRm" = (
+/mob/living/carbon/monkey,
+/turf/open/floor/grass,
+/area/science/genetics)
 "hSa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/firecloset,
@@ -51588,6 +51548,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"iSM" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/mob/living/carbon/monkey,
+/turf/open/floor/grass,
+/area/science/genetics)
 "iTj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
@@ -51754,6 +51721,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"jtR" = (
+/obj/effect/landmark/start/research_director,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/hor)
 "juq" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -52345,9 +52316,6 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "kRC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -52408,13 +52376,6 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"kXf" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/mob/living/carbon/monkey,
-/turf/open/floor/engine,
-/area/science/genetics)
 "kXt" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white/side{
@@ -52453,6 +52414,10 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"lhZ" = (
+/obj,
+/turf/closed/wall/r_wall,
+/area/science/storage)
 "ljx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -52894,6 +52859,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"msr" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/science/research)
 "mtK" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
@@ -53111,6 +53086,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"mPs" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/obj/item/folder/white,
+/obj/item/stamp/rd{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/hor";
+	dir = 1;
+	name = "RD Office APC";
+	pixel_x = 0;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "mSf" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -53193,6 +53189,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"neV" = (
+/obj/machinery/computer/mecha{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "nlN" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -53380,6 +53388,22 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"nLS" = (
+/obj/machinery/door/airlock/research{
+	name = "Toxins Storage";
+	req_access_txt = "71"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "nPP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -53421,8 +53445,9 @@
 /area/storage/tools)
 "nWm" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "nWA" = (
 /obj/machinery/door/airlock/maintenance{
@@ -53893,12 +53918,6 @@
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
@@ -54080,13 +54099,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "pBV" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel,
-/area/science/mixing)
+/obj,
+/turf/open/floor/grass,
+/area/science/genetics)
 "pCj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -54333,6 +54348,19 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/aft)
+"qds" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "qea" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -54410,7 +54438,8 @@
 	pixel_y = 2;
 	req_access_txt = "9"
 	},
-/turf/open/floor/engine,
+/mob/living/carbon/monkey,
+/turf/open/floor/grass,
 /area/science/genetics)
 "qrU" = (
 /obj/machinery/disposal/bin,
@@ -54483,10 +54512,8 @@
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "qQC" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
+/obj,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "qQH" = (
 /obj/effect/spawner/lootdrop/minor/bowler_or_that,
@@ -54583,6 +54610,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"ruF" = (
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
+/obj/effect/spawner/xmastree/rdrod,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "rzl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -54764,10 +54798,9 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "rYJ" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/mixing)
+/obj,
+/turf/closed/wall/r_wall,
+/area/science/genetics)
 "rZR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -54790,6 +54823,19 @@
 /obj/item/stock_parts/cell/emproof,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"sbC" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/science/research";
+	dir = 4;
+	name = "Misc Research APC";
+	pixel_x = 25;
+	step_x = 0
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/science/research)
 "sgh" = (
 /obj/machinery/camera{
 	c_tag = "Holodeck - Aft";
@@ -55010,6 +55056,13 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"sOU" = (
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = -32
+	},
+/mob/living/carbon/monkey,
+/turf/open/floor/grass,
+/area/science/genetics)
 "sUw" = (
 /obj/machinery/button/door{
 	id = "xenobio4";
@@ -55413,9 +55466,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "tYi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -55423,6 +55473,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ubj" = (
@@ -55585,6 +55636,15 @@
 /obj/structure/altar_of_gods,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"uxs" = (
+/obj/machinery/computer/robotics{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "uyp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -55760,9 +55820,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/break_room)
-"uUy" = (
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "uVS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55890,9 +55947,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "voe" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "vof" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -56329,6 +56387,12 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"wJG" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "wJU" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/purple,
@@ -101417,7 +101481,7 @@ aYV
 bck
 aYV
 bfV
-bop
+biL
 cHM
 biL
 blB
@@ -101433,12 +101497,12 @@ byi
 bzz
 bAE
 bBY
-bDc
-bEo
-bFI
+bvK
+aGs
+bCj
 bHe
 bIz
-bIz
+fKY
 bJN
 bMl
 bIv
@@ -101690,12 +101754,12 @@ byi
 bwN
 bAG
 bCa
-bDc
+bvK
 bEo
 bIC
 bEc
-bIB
-bIB
+jtR
+hnE
 bJN
 bMo
 pnj
@@ -101947,12 +102011,12 @@ byj
 bwM
 aUs
 bBZ
-bDc
+bvK
 bEp
 bCX
 aWt
-bIA
-bIA
+cvi
+dnc
 bJN
 bMn
 bNp
@@ -102204,12 +102268,12 @@ byk
 bzD
 bxv
 bCc
-bDc
-bEo
+bvK
+efX
 bDj
 bDY
-bIA
-bIA
+uxs
+neV
 bJN
 bMq
 bNp
@@ -102461,12 +102525,12 @@ byk
 bzC
 bAH
 bCb
-bDc
-bEo
+bvK
+mPs
 bDf
 bEb
 bGY
-bGY
+ruF
 bJN
 bMp
 bNp
@@ -102718,12 +102782,12 @@ byk
 byk
 byk
 byk
+bvK
+bvJ
 bDc
-bDc
-bDc
-bEg
-bDc
-bDc
+bvJ
+bvJ
+bvJ
 bLe
 bMr
 bNr
@@ -102978,8 +103042,8 @@ bzE
 bDd
 bEq
 bDl
-bEf
-bFQ
+bzE
+bzE
 bHc
 bsX
 bzE
@@ -103234,7 +103298,7 @@ cBx
 bDm
 bAa
 bDm
-bDm
+qds
 bEr
 tYi
 bHf
@@ -103490,11 +103554,11 @@ bBD
 bBD
 bzA
 bzZ
-bBD
-bBD
-bBD
+sbC
+bsA
+cdM
 kRC
-bzZ
+msr
 bBD
 bBD
 bvH
@@ -103746,12 +103810,12 @@ wkN
 wkN
 wkN
 dYq
-bvK
-bvJ
-bvJ
-bvJ
+cas
+cas
+lhZ
+lhZ
 bxW
-bvK
+lhZ
 bLh
 bMs
 bMs
@@ -104003,13 +104067,13 @@ eja
 hAK
 ibG
 lQm
-bvK
+cas
 bCk
 byo
 aDH
 bxP
 btj
-bvK
+cas
 blq
 blq
 blq
@@ -104260,12 +104324,12 @@ tgl
 qGG
 oMN
 ubw
-bvK
-bxj
+cas
+bCk
 byq
-bwR
-bxY
-bCh
+bys
+bxP
+bIB
 dGF
 bMu
 bMu
@@ -104517,7 +104581,7 @@ hZk
 hZk
 icS
 uCO
-bvK
+cas
 bxi
 byp
 bzJ
@@ -104774,12 +104838,12 @@ hZk
 hZk
 icS
 bUq
-bvK
-bxl
+cas
+bIA
 bys
-bzM
+bys
 bya
-bCj
+dIF
 dGF
 bMw
 cBE
@@ -105031,12 +105095,12 @@ gnX
 epI
 uzl
 cbe
-bvK
-cBu
-byr
+cas
+bIA
+bys
 bzL
 bxZ
-bCi
+dIF
 aXE
 aXJ
 bNu
@@ -105288,12 +105352,12 @@ lcg
 xEM
 pKm
 pDu
-bvK
-bxm
+cas
+bIA
 byu
 bzN
 byb
-aGs
+dIF
 kzT
 bMx
 bNw
@@ -105545,12 +105609,12 @@ bpE
 bpE
 bon
 bon
-byt
-bvK
-bvK
-bvK
-bvK
-bvK
+bon
+lhZ
+nLS
+lhZ
+lhZ
+lhZ
 dGF
 bMv
 bNv
@@ -105800,12 +105864,12 @@ qrU
 kGS
 bzO
 taM
-bon
+dWG
 flN
 rYJ
-rYJ
+eRJ
 bFW
-rYJ
+wJG
 qQC
 dCN
 bLi
@@ -106057,10 +106121,10 @@ gHj
 gHj
 xeP
 bAR
-bon
+iSM
 pBV
-fGF
-bEA
+rYJ
+eRJ
 bEA
 voe
 bGA
@@ -106314,9 +106378,9 @@ bsL
 bsL
 rAv
 eFD
-bon
-bEC
-uUy
+dWG
+sOU
+rYJ
 bED
 bFX
 glg
@@ -106571,9 +106635,9 @@ ifv
 ifv
 xkP
 cYY
-bCl
+iSM
+ggS
 bon
-bEC
 bEC
 bEC
 bEC
@@ -106829,8 +106893,8 @@ bsL
 ink
 pSN
 ddy
+hRm
 bon
-btp
 bEF
 bky
 bEO
@@ -107086,8 +107150,8 @@ bqe
 npF
 vPt
 qrH
+eAc
 bon
-btp
 bEE
 bFY
 bKb
@@ -107342,9 +107406,9 @@ orP
 xXe
 lFP
 jyF
-kXf
+dWG
+hRm
 bon
-btp
 vqI
 bky
 bHs
@@ -107601,7 +107665,7 @@ bon
 bon
 bon
 bon
-btp
+bon
 vqI
 bEs
 bEs

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -27274,7 +27274,15 @@
 /area/science/robotics/lab)
 "blN" = (
 /obj/machinery/computer/rdconsole,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "blP" = (
@@ -53934,6 +53942,12 @@
 /area/maintenance/aft)
 "pjA" = (
 /obj/machinery/modular_computer/console/preset/civilian{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/corner{

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -27280,7 +27280,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/bridge)
 "blP" = (
@@ -33973,11 +33972,10 @@
 /area/maintenance/disposal/incinerator)
 "bCg" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/camera{
-	c_tag = "Security Checkpoint";
+/obj/effect/turf_decal/bot,
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bCj" = (
@@ -34925,10 +34923,8 @@
 /area/science/mixing)
 "bED" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway"
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bEE" = (
@@ -49922,10 +49918,8 @@
 	dir = 6
 	},
 /obj/structure/displaycase/labcage,
-/obj/machinery/camera{
-	c_tag = "Research Director's Office";
-	dir = 1;
-	network = list("ss13","rd")
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
@@ -50798,10 +50792,8 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "ggS" = (
-/obj/machinery/camera{
-	c_tag = "Experimentor Lab Chamber";
-	dir = 1;
-	network = list("ss13","rd")
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
 /turf/open/floor/grass,
 /area/science/genetics)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -33966,7 +33966,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "bCg" = (
-/obj,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/camera{
 	c_tag = "Security Checkpoint";
@@ -50231,6 +50230,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"edW" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Toxins Storage APC";
+	pixel_x = 25
+	},
+/turf/open/floor/plasteel,
+/area/science/storage)
 "efX" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -51786,6 +51796,16 @@
 /obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
+"jzb" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet{
+	dir = 2;
+	pixel_x = 0;
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel,
+/area/science/storage)
 "jBV" = (
 /obj/machinery/computer/warrant{
 	dir = 4
@@ -52416,10 +52436,6 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
-"lhZ" = (
-/obj,
-/turf/closed/wall/r_wall,
-/area/science/storage)
 "ljx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -103813,10 +103829,10 @@ wkN
 dYq
 cas
 cas
-lhZ
-lhZ
+cas
+cas
 bxW
-lhZ
+cas
 bLh
 bMs
 bMs
@@ -104844,7 +104860,7 @@ bIA
 bys
 bys
 bya
-dIF
+jzb
 dGF
 bMw
 cBE
@@ -105354,7 +105370,7 @@ xEM
 pKm
 pDu
 cas
-bIA
+edW
 byu
 bzN
 byb
@@ -105611,11 +105627,11 @@ bpE
 bon
 bon
 bon
-lhZ
+cas
 nLS
-lhZ
-lhZ
-lhZ
+cas
+cas
+cas
 dGF
 bMv
 bNv
@@ -105867,7 +105883,7 @@ bzO
 taM
 dWG
 flN
-rYJ
+bon
 eRJ
 bFW
 wJG
@@ -106124,7 +106140,7 @@ xeP
 bAR
 iSM
 pBV
-rYJ
+bon
 eRJ
 bEA
 voe

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -27274,6 +27274,7 @@
 /area/science/robotics/lab)
 "blN" = (
 /obj/machinery/computer/rdconsole,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/bridge)
 "blP" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -27273,14 +27273,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blN" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/blob/core,
+/obj/machinery/computer/rdconsole,
 /turf/open/floor/plasteel,
 /area/bridge)
 "blP" = (
@@ -34668,7 +34661,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "bDY" = (
-/obj/structure/blob/core{
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/computer/rdconsole{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -51290,6 +51286,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/virology)
+"hKu" = (
+/obj/machinery/modular_computer/console/preset/civilian,
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
 "hQK" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -54830,8 +54830,7 @@
 	areastring = "/area/science/research";
 	dir = 4;
 	name = "Misc Research APC";
-	pixel_x = 25;
-	
+	pixel_x = 25
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 9
@@ -101482,7 +101481,7 @@ aYV
 bck
 aYV
 bfV
-biL
+hKu
 cHM
 biL
 blB


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This map change seeks to resolve issues with IceBox Station that have been present for a very, very, long time.

On the maps currently in rotation, Toxins Gas Storage is connected to the actual Toxins mixing laboratory. This is true for all of them, except IceBox Station. Toxins is extremely discouraging to do when you have to waste precious time running outside of your lab to get your cans of Oxygen and Plasma. It makes no sense for IceBox to be so radically different than Meta or Delta Station's Toxins, where there is usually a hallway facing door and a door that connects right to the mixing lab. Also, for some reason, IceBox has always just had a shitload of empty t1 canisters and portable scrubbers, which were extremely useless in the scope of Toxins, and probably any other aspect in the game.

This PR seeks to accomplish this change by swapping around the RD's office with Toxin's storage. This does shrink the RD's office a teeny bit, but everything was carried over. In order to reduce the amount of empty space in the Toxins Mixing Lab, I decided to expand Genetics' Monkey Pen, and actually add grass. (i don't know how genetics work please tell me if this is a powercreep so i can just reduce the monkey spawns or something) It also does reduce a bit of maintenance as well, but i think it's not as clunky as it previously was, and feels a bit smoother.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

As stated above, IceBox Science is so much more different than the other stations, and for no real good reason at all (than what I can think of). This PR reworks that part of Science in order to make it more in form with the other stations currently in rotation, and not have trained bomb-makers pull out their hair when people vote for IceBox.

This PR also doesn't add any additional gas canisters to Toxins (in comparison to what was already there), it just shifts it to another place.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Bombmakers unite! Nanotrasen has recently retrofitted the Science department on the IceBox Station and made the Toxins Gas Storage room adjacent to... Toxins! They had to sell all of those scrubbers and gas canisters to pay for it though.
del: The RD however, is not too jazzed about his new office on IceBox, It's cut down by an incredibly slim margin, but...... What's the upside again?
add: Genetics Monkey Pen has shifted... Odd...
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Before:
![image](https://user-images.githubusercontent.com/34697715/92334241-62dab280-f049-11ea-9bea-100cea36e423.png)

After:
![image](https://user-images.githubusercontent.com/34697715/92334245-6a01c080-f049-11ea-98fa-ed0366443011.png)

Area Overlay:
![image](https://user-images.githubusercontent.com/34697715/92334248-70903800-f049-11ea-9925-154d3dd0ed0b.png)

(this is my first PR go easy on me)