### PR TITLE
Change "Hear Admin Triggered Sounds (Midis)" to "Hear Admin Triggered Music/Sounds"

### DIFF
--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -162,7 +162,7 @@ TOGGLE_CHECKBOX(/datum/verbs/menu/settings/sound, toggleendofroundsounds)()
 TOGGLE_CHECKBOX(/datum/verbs/menu/settings/sound, togglemidis)()
 	set name = "Hear/Silence Midis"
 	set category = "Preferences"
-	set desc = "Hear Admin Triggered Sounds (Midis)"
+	set desc = "Hear Admin Triggered Music/Sounds"
 	usr.client.prefs.toggles ^= SOUND_MIDI
 	usr.client.prefs.save_preferences()
 	if(usr.client.prefs.toggles & SOUND_MIDI)


### PR DESCRIPTION
## About The Pull Request

This toggle under settings > sounds is currently "Hear Admin Triggered Sounds (Midis)"
I think we should change it to "Hear Admin Triggered Music/Sounds"


## Why It's Good For The Game

I'd like to start with some simple facts:

- **"MIDI"** (/ˈmɪdi/; an acronym for Musical Instrument Digital Interface) is a technical standard that describes a communications protocol, digital interface, and electrical connectors that connect a wide variety of electronic musical instruments, computers, and related audio devices for playing, editing and recording music.
- ["Midis"](https://www.midisgroup.com/) is as far as I can tell some sort of Middle Eastern consulting company.
- I have never heard an actual MIDI played by an admin. Does Byond even still support it?
- I think this just makes what the setting is and does a little more obvious for new players.