### PR TITLE
Make repository config default to HUMANS_NEED_SURNAMES 

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -50,7 +50,7 @@ MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal 0
 
 ## NAMES ###
 ## If uncommented this adds a random surname to a player's name if they only specify one name.
-#HUMANS_NEED_SURNAMES
+HUMANS_NEED_SURNAMES
 
 ## If uncommented, this forces all players to use random names !and appearances!.
 #FORCE_RANDOM_NAMES


### PR DESCRIPTION
Enables HUMANS_NEED_SURNAMES in the repository config by default, to be accurate to production.