### PR TITLE
nerfs nitrous oxide explosion 

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -471,7 +471,7 @@
 
 /datum/chemical_reaction/reagent_explosion/nitrous_oxide
 	required_reagents = list(/datum/reagent/nitrous_oxide = 1)
-	strengthdiv = 7
+	strengthdiv = 10
 	required_temp = 575
 	modifier = 1
 


### PR DESCRIPTION
:cl:
balance: nitrous oxide has strenght_div 10 (similar to bp) instead of 7 (similar to rdx)
/:cl:

nitrous oxide doesnt need anything other than clicking chem to make and has same explosion powder of rdx which takes more effort to make, so now there is a reason to those explosive chems instead of pressing 30 oxygen 30 hydrogen 25 nitrogen and weld 4 times the beaker for 3x3 gibbing
 



