### PR TITLE
Edge's Explosive Balancing Patch [v4]

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -58,14 +58,15 @@
 	required_reagents = list(/datum/reagent/rdx = 1)
 	required_temp = 474
 	strengthdiv = 7
+	modifier = 2
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion2 //makes rdx unique , on its own it is a good bomb, but when combined with liquid electricity it becomes truly destructive
 	required_reagents = list(/datum/reagent/rdx = 1 , /datum/reagent/consumable/liquidelectricity = 1)
 	strengthdiv = 3.5 //actually a decrease of 1 becaused of how explosions are calculated. This is due to the fact we require 2 reagents
-	modifier = 2
+	modifier = 4
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion2/on_reaction(datum/reagents/holder, created_volume)
-	var/fire_range = round(created_volume/50)
+	var/fire_range = round(created_volume/30)
 	var/turf/T = get_turf(holder.my_atom)
 	for(var/turf/turf in range(fire_range,T))
 		new /obj/effect/hotspot(turf)
@@ -75,11 +76,11 @@
 /datum/chemical_reaction/reagent_explosion/rdx_explosion3
 	required_reagents = list(/datum/reagent/rdx = 1 , /datum/reagent/teslium = 1)
 	strengthdiv = 3.5 //actually a decrease of 1 becaused of how explosions are calculated. This is due to the fact we require 2 reagents
-	modifier = 4
+	modifier = 6
 
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion3/on_reaction(datum/reagents/holder, created_volume)
-	var/fire_range = round(created_volume/30)
+	var/fire_range = round(created_volume/20)
 	var/turf/T = get_turf(holder.my_atom)
 	for(var/turf/turf in range(fire_range,T))
 		new /obj/effect/hotspot(turf)
@@ -471,9 +472,20 @@
 
 /datum/chemical_reaction/reagent_explosion/nitrous_oxide
 	required_reagents = list(/datum/reagent/nitrous_oxide = 1)
-	strengthdiv = 7
+	strengthdiv = 9
 	required_temp = 575
 	modifier = 1
+
+/datum/chemical_reaction/reagent_explosion/nitrous_oxide/on_reaction(datum/reagents/holder, created_volume)
+	holder.remove_reagent(/datum/reagent/sorium, created_volume*2)
+	var/turf/T = get_turf(holder.my_atom)
+	//generally twice as weak as sorium.
+	var/range = clamp(sqrt(created_volume*2), 1, 6)
+	//This first throws people away and then it explodes
+	goonchem_vortex(T, 1, range)
+	T.atmos_spawn_air("o2=[created_volume/2];TEMP=[575]")
+	T.atmos_spawn_air("n2=[created_volume/2];TEMP=[575]")
+	return ..()
 
 /datum/chemical_reaction/firefighting_foam
 	results = list(/datum/reagent/firefighting_foam = 3)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -478,13 +478,13 @@
 
 /datum/chemical_reaction/reagent_explosion/nitrous_oxide/on_reaction(datum/reagents/holder, created_volume)
 	holder.remove_reagent(/datum/reagent/sorium, created_volume*2)
-	var/turf/T = get_turf(holder.my_atom)
+	var/turf/turfie_owo = get_turf(holder.my_atom)
 	//generally twice as weak as sorium.
 	var/range = clamp(sqrt(created_volume*2), 1, 6)
 	//This first throws people away and then it explodes
-	goonchem_vortex(T, 1, range)
-	T.atmos_spawn_air("o2=[created_volume/2];TEMP=[575]")
-	T.atmos_spawn_air("n2=[created_volume/2];TEMP=[575]")
+	goonchem_vortex(turfie_owo, 1, range)
+	turfie_owo.atmos_spawn_air("o2=[created_volume/2];TEMP=[575]")
+	turfie_owo.atmos_spawn_air("n2=[created_volume/2];TEMP=[575]")
 	return ..()
 
 /datum/chemical_reaction/firefighting_foam

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -478,13 +478,13 @@
 
 /datum/chemical_reaction/reagent_explosion/nitrous_oxide/on_reaction(datum/reagents/holder, created_volume)
 	holder.remove_reagent(/datum/reagent/sorium, created_volume*2)
-	var/turf/turfie_owo = get_turf(holder.my_atom)
+	var/turf/turfie = get_turf(holder.my_atom)
 	//generally twice as weak as sorium.
 	var/range = clamp(sqrt(created_volume*2), 1, 6)
 	//This first throws people away and then it explodes
-	goonchem_vortex(turfie_owo, 1, range)
-	turfie_owo.atmos_spawn_air("o2=[created_volume/2];TEMP=[575]")
-	turfie_owo.atmos_spawn_air("n2=[created_volume/2];TEMP=[575]")
+	goonchem_vortex(turfie, 1, range)
+	turfie.atmos_spawn_air("o2=[created_volume/2];TEMP=[575]")
+	turfie.atmos_spawn_air("n2=[created_volume/2];TEMP=[575]")
 	return ..()
 
 /datum/chemical_reaction/firefighting_foam

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -479,7 +479,7 @@
 /datum/chemical_reaction/reagent_explosion/nitrous_oxide/on_reaction(datum/reagents/holder, created_volume)
 	holder.remove_reagent(/datum/reagent/sorium, created_volume*2)
 	var/turf/turfie = get_turf(holder.my_atom)
-	//generally twice as weak as sorium.
+	//generally half as strong as sorium.
 	var/range = clamp(sqrt(created_volume*2), 1, 6)
 	//This first throws people away and then it explodes
 	goonchem_vortex(turfie, 1, range)


### PR DESCRIPTION
## About The Pull Request

Hello everybody! This is another batch of explosive balancing!. Today we have 2 balancing changes:

- Rework of N2O - Now it decomposes much less violently and sends people flying away with the pressure of the explosion!

- Buff to RDX - Increased it's modifiers and firerange, i dont see this chem used that often.

closes #53466

## Why It's Good For The Game

Why it's good for the game? Overuse of n2o, and underuse of other explosive. Honestly i have no clue how n2o ran under my radar last time. Time to fix my mistakes.

## Changelog
:cl:
balance: Reworks N2O - Now it is quasi-sorium that still explodes.
balance: Slightly Buffs RDX - It has a slightly bigger fire radius and explosive power in low quantities.
/:cl:
