### PR TITLE
C̶l̶o̶s̶e̶ ̶Q̶u̶a̶r̶t̶e̶r̶s̶ ̶C̶a̶p̶t̶a̶i̶n̶c̶y̶ Executive Option, CQC for the captain

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -230,3 +230,14 @@
 	if(!istype(get_area(H), /area/crew_quarters/kitchen))
 		return FALSE
 	return ..()
+
+/datum/martial_art/cqc/under_tide
+	name = "Close Quarters Captaincy"
+
+///Prevents use if the captain is not in their office or bedroom.
+/datum/martial_art/cqc/under_tide/can_use(mob/living/carbon/human/H) //this is used to make captain CQC only work in captain's office or bedroom
+	if(!istype(get_area(H), /area/crew_quarters/heads/captain))
+		return FALSE
+	if(!istype(get_area(H), /area/crew_quarters/heads/captain/private))
+		return FALSE
+	return ..()

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -238,6 +238,4 @@
 /datum/martial_art/cqc/under_tide/can_use(mob/living/carbon/human/H)
 	if(!istype(get_area(H), /area/crew_quarters/heads/captain))
 		return FALSE
-	if(!istype(get_area(H), /area/crew_quarters/heads/captain/private))
-		return FALSE
 	return ..()

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -235,7 +235,7 @@
 	name = "Close Quarters Captaincy"
 
 ///Prevents use if the captain is not in their office or bedroom.
-/datum/martial_art/cqc/under_tide/can_use(mob/living/carbon/human/H) //this is used to make captain CQC only work in captain's office or bedroom
+/datum/martial_art/cqc/under_tide/can_use(mob/living/carbon/human/H)
 	if(!istype(get_area(H), /area/crew_quarters/heads/captain))
 		return FALSE
 	if(!istype(get_area(H), /area/crew_quarters/heads/captain/private))

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -1,9 +1,7 @@
 /datum/job/captain
 	title = "Captain"
-	flag = CAPTAIN
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD|DEADMIN_POSITION_SECURITY
 	department_head = list("CentCom")
-	department_flag = ENGSEC
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
@@ -64,9 +62,9 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/swat/captain
 	suit_store = /obj/item/tank/internals/oxygen
 
-datum/outfit/job/cook/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+datum/outfit/job/captain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
 		return
-	var/datum/martial_art/cqc/under_siege/justacap = new
+	var/datum/martial_art/cqc/under_tide/justacap = new
 	justacap.teach(H)

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -62,9 +62,9 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/swat/captain
 	suit_store = /obj/item/tank/internals/oxygen
 
-datum/outfit/job/captain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/captain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
 		return
-	var/datum/martial_art/cqc/under_tide/justacap = new
+	var/datum/martial_art/cqc/under_t/justacap = new
 	justacap.teach(H)

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -66,5 +66,5 @@
 	..()
 	if(visualsOnly)
 		return
-	var/datum/martial_art/cqc/under_t/justacap = new
+	var/datum/martial_art/cqc/under_tide/justacap = new
 	justacap.teach(H)

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -1,7 +1,9 @@
 /datum/job/captain
 	title = "Captain"
+	flag = CAPTAIN
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD|DEADMIN_POSITION_SECURITY
 	department_head = list("CentCom")
+	department_flag = ENGSEC
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
@@ -61,3 +63,10 @@
 	mask = /obj/item/clothing/mask/gas/atmos/captain
 	suit = /obj/item/clothing/suit/space/hardsuit/swat/captain
 	suit_store = /obj/item/tank/internals/oxygen
+
+datum/outfit/job/cook/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	var/datum/martial_art/cqc/under_siege/justacap = new
+	justacap.teach(H)


### PR DESCRIPTION
## About The Pull Request

Executive Option. It's like the chef's Close Quarters Cooking but for the captain and their office. The captain has CQC when they're in their office, bedroom, and bathroom. This does not include the captain's office maintenance.

https://streamable.com/55sa7u Here's it in action.

## Why It's Good For The Game

Punishes raiding captain's office, to combat the shift start AA tide rush. Making the captain's office a no-go zone like the kitchen would be an interesting and funny change.

## Changelog
:cl:
add: Nanotrasen has begun teaching their captains how to kick ass.
/:cl: