### PR TITLE
makes it possible for admins to edit under siege cqc valid areas

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -224,9 +224,10 @@
 ///Subtype of CQC. Only used for the chef.
 /datum/martial_art/cqc/under_siege
 	name = "Close Quarters Cooking"
+	var/list/valid_areas = list(/area/crew_quarters/kitchen)
 
 ///Prevents use if the cook is not in the kitchen.
 /datum/martial_art/cqc/under_siege/can_use(mob/living/carbon/human/H) //this is used to make chef CQC only work in kitchen
-	if(!istype(get_area(H), /area/crew_quarters/kitchen))
+	if(!is_type_in_list(get_area(H), valid_areas))
 		return FALSE
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

what the title says, its now a list var so an admin can just var edit to get their close quarter captaining or whatever
inspired by bad code in #53469

## Why It's Good For The Game

something editable is probably better than a strict check

## Changelog
:cl:
admin: admins can now edit the valid areas of close quarters cooking, become the next star of the close quarters cleaning!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
