### PR TITLE
Fixes shuttle call text

### DIFF
--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -277,7 +277,7 @@
 "aW" = (
 /obj/docking_port/mobile/emergency{
 	height = 15;
-	name = "Box emergency shuttle"
+	name = "Mother Russia Bleeds"
 	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Emergency Shuttle Airlock"


### PR DESCRIPTION
## About The Pull Request
Shuttle call text for Mother Russia Bleeds read as the Box Emergency Shuttle, this fixes it by making it read properly. This fixes #51602

## Why It's Good For The Game
The announcement is actually right and follows expected behavior
## Changelog
:cl:
fix: Announcements now correctly read Mother Russia Bleeds
/:cl: