### PR TITLE
Tweaks Ice Box security desk

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -5718,7 +5718,9 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used to access the various cameras on the station.";
 	dir = 1;
+	layer = 3.1;
 	name = "Security Camera Monitor";
+	network = list("ss13");
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -4829,6 +4829,8 @@
 	name = "Brig Desk";
 	req_access_txt = "1"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "akV" = (
@@ -5092,9 +5094,13 @@
 	},
 /obj/machinery/button/flasher{
 	id = "brigentry";
-	pixel_x = -28;
+	pixel_x = -26;
 	pixel_y = -8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "alA" = (
@@ -5398,7 +5404,7 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
-	desc = "A remote control switch for the medbay foyer.";
+	desc = "A remote control switch for the brig exterior doors.";
 	id = "outerbrig";
 	name = "Brig Exterior Doors Control";
 	normaldoorcontrol = 1;
@@ -5407,13 +5413,16 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/button/door{
-	desc = "A remote control switch for the medbay foyer.";
+	desc = "A remote control switch for the brig interior doors.";
 	id = "innerbrig";
 	name = "Brig Interior Doors Control";
 	normaldoorcontrol = 1;
 	pixel_x = -26;
 	pixel_y = 5;
 	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -5434,6 +5443,10 @@
 "amn" = (
 /obj/structure/chair/office{
 	dir = 4
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -51549,6 +51562,15 @@
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"iMY" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "iNn" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room"
@@ -56954,6 +56976,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"yca" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "yce" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -86467,8 +86499,8 @@ ahz
 aie
 aIF
 ajc
-ajD
-akp
+yca
+iMY
 akU
 alz
 aml

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -5715,6 +5715,12 @@
 	name = "Brig Desk";
 	req_access_txt = "1"
 	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used to access the various cameras on the station.";
+	dir = 1;
+	name = "Security Camera Monitor";
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "amW" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds vents, a camera monitor, and a security officer spawn to the security desk on Ice Box. Also corrects the description of the door buttons to not say they operate the medbay doors.
![image](https://user-images.githubusercontent.com/1313921/92858492-b9cee780-f3bb-11ea-8d9e-fab0445bce8f.png)



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The security desk on Ice Box is underused, which is a shame because it's basically the only way for somebody to talk to sec that isn't over the radio or yelling at an officer as they run by. I hope that adding a spawn here may have a tiny chance of making sec realize this place exists. I added vents because enclosed areas with no vents are silly especially if we expect people to spend time there. And I fixed the description on those buttons because that was an obvious oversight from a copypasta.

## Changelog
:cl: VexingRaven
add: Ventilation and a security monitor have been added to the Ice Box Station security desk
add: A security officer may now spawn at the security desk on Ice Box Station.
spellcheck: Fixed the description of the door controls at the Ice Box Station security desk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
