### PR TITLE
No more blobs after shuttle passes point of no return

### DIFF
--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -12,8 +12,8 @@
 
 #define EMERGENCY_IDLE_OR_RECALLED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_IDLE) || (SSshuttle.emergency.mode == SHUTTLE_RECALL)))
 #define EMERGENCY_ESCAPED_OR_ENDGAMED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_ESCAPE) || (SSshuttle.emergency.mode == SHUTTLE_ENDGAME)))
-#define EMERGENCY_PAST_POINT_OF_NO_RETURN (SSshuttle.emergency && SSshuttle.emergency.mode == SHUTTLE_CALL && !SSshuttle.canRecall())
 #define EMERGENCY_AT_LEAST_DOCKED (SSshuttle.emergency && SSshuttle.emergency.mode != SHUTTLE_IDLE && SSshuttle.emergency.mode != SHUTTLE_RECALL && SSshuttle.emergency.mode != SHUTTLE_CALL)
+#define EMERGENCY_PAST_POINT_OF_NO_RETURN ((SSshuttle.emergency && SSshuttle.emergency.mode == SHUTTLE_CALL && !SSshuttle.canRecall()) || EMERGENCY_AT_LEAST_DOCKED)
 
 // Shuttle return values
 #define SHUTTLE_CAN_DOCK "can_dock"

--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -12,6 +12,7 @@
 
 #define EMERGENCY_IDLE_OR_RECALLED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_IDLE) || (SSshuttle.emergency.mode == SHUTTLE_RECALL)))
 #define EMERGENCY_ESCAPED_OR_ENDGAMED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_ESCAPE) || (SSshuttle.emergency.mode == SHUTTLE_ENDGAME)))
+#define EMERGENCY_PAST_POINT_OF_NO_RETURN (SSshuttle.emergency && SSshuttle.emergency.mode == SHUTTLE_CALL && !SSshuttle.canRecall())
 #define EMERGENCY_AT_LEAST_DOCKED (SSshuttle.emergency && SSshuttle.emergency.mode != SHUTTLE_IDLE && SSshuttle.emergency.mode != SHUTTLE_RECALL && SSshuttle.emergency.mode != SHUTTLE_CALL)
 
 // Shuttle return values

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -8,11 +8,11 @@
 
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long
 
-/datum/round_event/control/blob/canSpawnEvent(players, gamemode)
-	if(!SSshuttle.emergency || SSshuttle.emergency.mode != SHUTTLE_CALL || SSshuttle.canRecall()) // no blobs if the shuttle is past the point of no return
+/datum/round_event_control/blob/canSpawnEvent(players, gamemode)
+	if(EMERGENCY_PAST_POINT_OF_NO_RETURN) // no blobs if the shuttle is past the point of no return
 		return FALSE
 
-	return TRUE
+	return ..()
 
 /datum/round_event/ghost_role/blob
 	announceChance	= 0

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -8,6 +8,12 @@
 
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long
 
+/datum/round_event/control/blob/canSpawnEvent(players, gamemode)
+	if(!SSshuttle.emergency || SSshuttle.emergency.mode != SHUTTLE_CALL || SSshuttle.canRecall()) // no blobs if the shuttle is past the point of no return
+		return FALSE
+
+	return TRUE
+
 /datum/round_event/ghost_role/blob
 	announceChance	= 0
 	role_name = "blob overmind"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Last second blobs that show up just as the crew is leaving can theoretically be a fun experience where the crew is forced to deal with a sudden threat so that they can wrap things up and go home. In practice though, it's usually a complete mess. Between high crew/player attrition and high time dilation, I've seen many rounds where things just end up in a boring deadlock between the few crew members left alive who care about fighting the blob, and the blob itself. While admins can choose to send pulse ERTs or even detonate the nuke to move things along, it's pretty rude towards the blob player to kick them aside just so we can move things along again (and sending 20 interns without space suits or effective anti-blob weapons is only funny for the first two waves), and limiting blobs to spawning before the very endgame seems like a good way to avoid that dilemma.

Mind this only prevents the event from triggering, it's still possible to get endgame blobs if they roll before the point of no return, so we can still have shuttle blocking blob scenarios
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Reduces one of the most frustrating parts of blobs
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
tweak: The blob random event can no longer occur after the shuttle has reached the point of no return
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
