### PR TITLE
Makes highlander turn off pacifism

### DIFF
--- a/code/modules/antagonists/highlander/highlander.dm
+++ b/code/modules/antagonists/highlander/highlander.dm
@@ -9,12 +9,14 @@
 	var/mob/living/L = owner.current || mob_override
 	ADD_TRAIT(L, TRAIT_NOGUNS, "highlander")
 	ADD_TRAIT(L, TRAIT_NODISMEMBER, "highlander")
+	REMOVE_TRAIT(L, TRAIT_PACIFISM, ROUNDSTART_TRAIT)
 
 /datum/antagonist/highlander/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/L = owner.current || mob_override
 	REMOVE_TRAIT(L, TRAIT_NOGUNS, "highlander")
 	REMOVE_TRAIT(L, TRAIT_NODISMEMBER, "highlander")
-
+	if(L.has_quirk(/datum/quirk/nonviolent))
+		ADD_TRAIT(L, TRAIT_PACIFISM, ROUNDSTART_TRAIT)
 /datum/antagonist/highlander/proc/forge_objectives()
 	var/datum/objective/steal/steal_objective = new
 	steal_objective.owner = owner


### PR DESCRIPTION
## About The Pull Request

Makes gaining the highlander antagonist status turn disable the pacifism quirk. It will re-enable if you lose the status, although that doesn't happen often.
## Why It's Good For The Game

As it stands, Highlander is effective round removal for those with the pacifist quirk, as everyone gets an objective to cut you down, and you don't even have so much as your hands to defend yourself with. This enables more people to compete in the event, making for a better time.
## Changelog
:cl:
fix: Pacifists do not care about harm if it is for Scotland,
/:cl: