### PR TITLE
Fixes Pubbystation Monastery Shuttle not docking at centcom

### DIFF
--- a/_maps/shuttles/escape_pod_large.dmm
+++ b/_maps/shuttles/escape_pod_large.dmm
@@ -72,7 +72,6 @@
 /obj/docking_port/mobile/pod{
 	dwidth = 2;
 	height = 6;
-	id = "pod1";
 	port_direction = 2;
 	width = 5
 	},

--- a/code/modules/shuttle/monastery.dm
+++ b/code/modules/shuttle/monastery.dm
@@ -2,6 +2,6 @@
 	name = "monastery shuttle console"
 	desc = "Used to control the monastery shuttle."
 	circuit = /obj/item/circuitboard/computer/monastery_shuttle
-	shuttleId = "pod1"
+	shuttleId = "pod"
 	possible_destinations = "monastery_shuttle_asteroid;monastery_shuttle_station;lavaland_common_away;landing_zone_dock;mining_public"
 	no_destination_swap = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Pubby Monastery Shuttle currently does not dock at centcom even though it's meant to function as an escape pod. Seems this was broken in #46659. The pod is supposed to be named "pod", not "pod1" and there is no dock at centcom named "pod1". Fixes #53341 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a bug, bugfixes are good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The PubbyStation Monastery Shuttle will no longer maroon passengers in deep space when the emergency shuttle docks at centcom.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
