### PR TITLE
The gem-encrusted hardsuit no longer slows you down while you wear it.

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -472,6 +472,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/wizard
 	cell = /obj/item/stock_parts/cell/hyper
+	slowdown = 0 //you're spending 2 wizard points on this thing, the least it could do is not make you a sitting duck
 
 /obj/item/clothing/suit/space/hardsuit/wizard/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

The gem-encrusted hardsuit that wizards can buy for 2 wizard points no longer slows you down while you wear it.

## Why It's Good For The Game

The gem-encrusted hardsuit is currently really, really bad, especially in comparison to battlemage armor. Wearing it currently actively HINDERS you more than it helps you, because even though it has some impressive armor stats, wearing it forces you to move at a snail's pace (or, to be more accurate, a gold golem's pace, if I'm reading this right). Meanwhile, battlemage armor, for the same price of 2 wizard points, ALSO provides protection against space, but it comes with NO slowdown AND a 16-hit (non-rechargeable) shield, making it superior to the gem-encrusted hardsuit in almost every way.

The slowdown of the gem-encrusted hardsuit currently makes it so bad that I wouldn't take it even if it was available for _0_ wizard points (unless I specifically needed antimagic for a gimmick). Carrying it around wouldn't be worth the risk of someone disarming me of it and gaining an antimagic source to use against me, and actually wearing it would make me LESS effective in combat (and outside of combat, as it'd take FOREVER to move anywhere), not more effective.

## Changelog
:cl: ATHATH
balance: The gem-encrusted hardsuit no longer slows you down while you wear it.
/:cl:
