### PR TITLE
Re-adds the grinder to Pubbystation's xenobiology wing

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -26593,15 +26593,15 @@
 "bqE" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/glasses/science,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = 8
+/obj/item/paper_bin{
+	layer = 2.9
 	},
+/obj/item/folder/blue,
+/obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bqF" = (
@@ -53428,6 +53428,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/closet/firecloset{
+	name = "fire extinguishers"
+	},
+/obj/item/extinguisher{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/extinguisher{
+	pixel_x = 6;
+	pixel_y = 7
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "ofX" = (
@@ -53586,13 +53597,13 @@
 /area/engine/engineering)
 "ost" = (
 /obj/structure/table/glass,
-/obj/item/paper_bin{
-	layer = 2.9
-	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/window/reinforced,
-/obj/item/folder/blue,
-/obj/item/pen,
+/obj/item/reagent_containers/dropper{
+	pixel_y = 8
+	},
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/glasses/science,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "ots" = (
@@ -57283,14 +57294,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/item/extinguisher{
-	pixel_x = -7;
-	pixel_y = 4
-	},
-/obj/item/extinguisher{
-	pixel_x = 6;
-	pixel_y = 7
-	},
+/obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "wfO" = (
@@ -58308,6 +58312,10 @@
 /obj/structure/table/glass,
 /obj/structure/noticeboard{
 	pixel_y = 32
+	},
+/obj/item/clothing/glasses/science,
+/obj/item/reagent_containers/dropper{
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Someone removed it at some point, possibly when vat growing was added since I remember it being where the microscope is now.

I also moved a few things around for the sake of appearances
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Job critical hardware being removed is bad and wrong. Badong.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Re-adds the reagent grinder to Pubbystation's xenobiology wing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
