### PR TITLE
Improves cardboard box consistency.

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -622,6 +622,17 @@
 			return
 	return ..()
 
+/obj/item/storage/crayons/attack_self(mob/user)
+	. = ..()
+	if(contents.len > 0)
+		to_chat(user, "<span class='warning'>You can't fold down [src] with crayons inside!</span>")
+		return
+
+	var/obj/item/stack/sheet/cardboard/cardboard = new /obj/item/stack/sheet/cardboard(user.drop_location())
+	to_chat(user, "<span class='notice'>You fold the [src] into cardboard.</span>")
+	user.put_in_active_hand(cardboard)
+	qdel(src)
+
 //Spraycan stuff
 
 /obj/item/toy/crayon/spraycan

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -585,6 +585,7 @@
 	icon = 'icons/obj/crayons.dmi'
 	icon_state = "crayonbox"
 	w_class = WEIGHT_CLASS_SMALL
+	custom_materials = list(/datum/material/cardboard = 2000)
 
 /obj/item/storage/crayons/Initialize()
 	. = ..()

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -20,6 +20,7 @@
 	var/icon_type = "donut"
 	var/spawn_type = null
 	var/fancy_open = FALSE
+	var/obj/fold_result = /obj/item/stack/sheet/cardboard
 
 /obj/item/storage/fancy/PopulateContents()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
@@ -44,6 +45,11 @@
 	fancy_open = !fancy_open
 	update_icon()
 	. = ..()
+	if(!contents.len)
+		new fold_result(user.drop_location())
+		to_chat(user, "<span class='notice'>You fold the [src] into [initial(fold_result.name)].</span>")
+		user.put_in_active_hand(fold_result)
+		qdel(src)
 
 /obj/item/storage/fancy/Exited()
 	. = ..()
@@ -149,8 +155,12 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 5
 
-/obj/item/storage/fancy/candle_box/attack_self(mob_user)
-	return
+/obj/item/storage/fancy/candle_box/attack_self(mob/user)
+	if(!contents.len)
+		new fold_result(user.drop_location())
+		to_chat(user, "<span class='notice'>You fold the [src] into [initial(fold_result.name)].</span>")
+		user.put_in_active_hand(fold_result)
+		qdel(src)
 
 ////////////
 //CIG PACK//

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -17,6 +17,7 @@
 /obj/item/storage/fancy
 	icon = 'icons/obj/food/containers.dmi'
 	resistance_flags = FLAMMABLE
+	custom_materials = list(/datum/material/cardboard = 2000)
 	var/icon_type = "donut"
 	var/spawn_type = null
 	var/fancy_open = FALSE

--- a/code/modules/food_and_drinks/pizzabox.dm
+++ b/code/modules/food_and_drinks/pizzabox.dm
@@ -14,6 +14,7 @@
 	inhand_icon_state = "pizzabox"
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
+	custom_materials = list(/datum/material/cardboard = 2000)
 
 	var/open = FALSE
 	var/can_open_on_fall = TRUE //if FALSE, this pizza box will never open if it falls from a stack
@@ -106,6 +107,12 @@
 		audible_message("<span class='warning'>[icon2html(src, hearers(src))] *beep*</span>")
 		bomb_active = TRUE
 		START_PROCESSING(SSobj, src)
+	else if(!open && !pizza && !bomb)
+		var/obj/item/stack/sheet/cardboard/cardboard = new /obj/item/stack/sheet/cardboard(user.drop_location())
+		to_chat(user, "<span class='notice'>You fold [src] into [cardboard].</span>")
+		user.put_in_active_hand(cardboard)
+		qdel(src)
+		return
 	update_icon()
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE


### PR DESCRIPTION
@uomo91 

## About The Pull Request

This pr makes it so several types of fancy cardboard boxes, crayon boxes, cigarette boxes, etc, all break down into cardboard when they're left open and empty. This feels consistent with other boxes behaviors, and will improve consistency with what you can and cannot break down into cardboard.

I also gave those parent box types the cardboard datum material for consistency with this change.

## Why It's Good For The Game

Not really a bug per-say, but an annoying consistency issue that was pointed out to me.

## Changelog
:cl:
tweak: More cardboard box-adjacent things break down into cardboard, and are all made of cardboard.
/:cl:
