### PR TITLE
Reinforces HoP and Captain's airlock wire panels

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -45337,10 +45337,9 @@
 /area/crew_quarters/heads/cmo)
 "bIX" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Captain's Office";
 	req_access_txt = "20";
-	security_level = 6
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -51899,10 +51898,9 @@
 /area/crew_quarters/heads/hop)
 "bUC" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/iron{
 	name = "Head of Personnel's Office";
 	req_access_txt = "57";
-	security_level = 1
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -54641,10 +54639,9 @@
 /area/tcommsat/server)
 "bZm" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Captain's Quarters";
 	req_access_txt = "20";
-	security_level = 6
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -59116,10 +59113,9 @@
 /area/tcommsat/server)
 "cij" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Emergency Escape";
 	req_access_txt = "20";
-	security_level = 6
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -63246,10 +63242,9 @@
 	id = "hopblast";
 	name = "HoP Blast door"
 	},
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Head of Personnel's Office";
 	req_access_txt = "57";
-	security_level = 6
 	},
 /obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -45339,7 +45339,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Captain's Office";
-	req_access_txt = "20"
+	req_access_txt = "20";
+	security_level = 6
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -51900,7 +51901,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel's Office";
-	req_access_txt = "57"
+	req_access_txt = "57";
+	security_level = 1
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -54641,7 +54643,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
-	req_access_txt = "20"
+	req_access_txt = "20";
+	security_level = 6
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -59115,7 +59118,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Emergency Escape";
-	req_access_txt = "20"
+	req_access_txt = "20";
+	security_level = 6
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -63244,7 +63248,8 @@
 	},
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel's Office";
-	req_access_txt = "57"
+	req_access_txt = "57";
+	security_level = 6
 	},
 /obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -22107,7 +22107,8 @@
 "aZX" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Office";
-	req_access_txt = "20"
+	req_access_txt = "20";
+	security_level = 6
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -26926,7 +26927,8 @@
 "blb" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
-	req_access_txt = "20"
+	req_access_txt = "20";
+	security_level = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -26947,7 +26949,8 @@
 "bld" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Captain's Office Maintenance";
-	req_access_txt = "20"
+	req_access_txt = "20";
+	security_level = 6
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
@@ -27492,7 +27495,8 @@
 "bms" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
-	req_access_txt = "57"
+	req_access_txt = "57";
+	security_level = 1
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -32178,7 +32182,8 @@
 "bxG" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
-	req_access_txt = "57"
+	req_access_txt = "57";
+	security_level = 6
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -22105,10 +22105,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aZX" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Captain's Office";
 	req_access_txt = "20";
-	security_level = 6
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -26925,10 +26924,9 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "blb" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Captain's Quarters";
 	req_access_txt = "20";
-	security_level = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -26947,10 +26945,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "bld" = (
-/obj/machinery/door/airlock/maintenance{
+/obj/machinery/door/airlock/maintenance/reinforced/plasteel{
 	name = "Captain's Office Maintenance";
 	req_access_txt = "20";
-	security_level = 6
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
@@ -27493,10 +27490,9 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hop)
 "bms" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/iron{
 	name = "Head of Personnel";
 	req_access_txt = "57";
-	security_level = 1
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -32180,10 +32176,9 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bxG" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Head of Personnel";
 	req_access_txt = "57";
-	security_level = 6
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -13651,10 +13651,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Captain's Quarters";
 	req_access_txt = "20";
-	security_level = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain/private)
@@ -27588,10 +27587,9 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bmI" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Captain's Quarters";
 	req_access_txt = "20";
-	security_level = 6
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -30710,10 +30708,9 @@
 /area/hallway/primary/central)
 "bum" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Head of Personnel";
 	req_access_txt = "57";
-	security_level = 6
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30782,10 +30779,9 @@
 /area/crew_quarters/heads/hop)
 "buu" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/iron{
 	name = "Head of Personnel";
 	req_access_txt = "57";
-	security_level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -31556,10 +31552,9 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bwG" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Emergency Escape";
 	req_access_txt = "20";
-	security_level = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32145,10 +32140,9 @@
 /area/bridge)
 "byo" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Captain's Quarters";
 	req_access_txt = "20";
-	security_level = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain/private)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -13648,12 +13648,13 @@
 /area/engine/engineering)
 "aFs" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "Captain's Quarters";
-	req_access_txt = "20"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters";
+	req_access_txt = "20";
+	security_level = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain/private)
@@ -27589,7 +27590,8 @@
 "bmI" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
-	req_access_txt = "20"
+	req_access_txt = "20";
+	security_level = 6
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -30710,7 +30712,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
-	req_access_txt = "57"
+	req_access_txt = "57";
+	security_level = 6
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30781,7 +30784,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
-	req_access_txt = "57"
+	req_access_txt = "57";
+	security_level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -31554,7 +31558,8 @@
 "bwG" = (
 /obj/machinery/door/airlock/command{
 	name = "Emergency Escape";
-	req_access_txt = "20"
+	req_access_txt = "20";
+	security_level = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32142,7 +32147,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
-	req_access_txt = "20"
+	req_access_txt = "20";
+	security_level = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain/private)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -9213,7 +9213,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/command{
 	name = "Captain's Office Access";
-	req_access_txt = "20"
+	req_access_txt = "20";
+	security_level = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -9975,7 +9976,8 @@
 "ayW" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
-	req_access_txt = "20"
+	req_access_txt = "20";
+	security_level = 6
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -11470,7 +11472,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
-	req_access_txt = "57"
+	req_access_txt = "57";
+	security_level = 6
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11779,7 +11782,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Captain's Office";
-	req_access_txt = "20"
+	req_access_txt = "20";
+	security_level = 6
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11881,7 +11885,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
-	req_access_txt = "57"
+	req_access_txt = "57";
+	security_level = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -9211,10 +9211,9 @@
 /area/crew_quarters/heads/captain)
 "awT" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Captain's Office Access";
 	req_access_txt = "20";
-	security_level = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -9974,10 +9973,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
 "ayW" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Captain's Quarters";
 	req_access_txt = "20";
-	security_level = 6
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -11470,10 +11468,9 @@
 /area/crew_quarters/heads/hop)
 "aCV" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Head of Personnel";
 	req_access_txt = "57";
-	security_level = 6
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11780,10 +11777,9 @@
 /area/crew_quarters/heads/captain)
 "aDH" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/plasteel{
 	name = "Captain's Office";
 	req_access_txt = "20";
-	security_level = 6
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11883,10 +11879,9 @@
 /area/bridge)
 "aDQ" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/reinforced/iron{
 	name = "Head of Personnel";
 	req_access_txt = "57";
-	security_level = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -7,6 +7,18 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_com
 	normal_integrity = 450
 
+/obj/machinery/door/airlock/command/reinforced/iron
+	icon = 'icons/obj/doors/airlocks/station/command.dmi'
+	assemblytype = /obj/structure/door_assembly/door_assembly_com
+	normal_integrity = 450
+	security_level = 1
+
+/obj/machinery/door/airlock/command/reinforced/plasteel
+	icon = 'icons/obj/doors/airlocks/station/command.dmi'
+	assemblytype = /obj/structure/door_assembly/door_assembly_com
+	normal_integrity = 450
+	security_level = 6
+
 /obj/machinery/door/airlock/security
 	icon = 'icons/obj/doors/airlocks/station/security.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_sec


### PR DESCRIPTION
## About The Pull Request

Introduces reinforced command airlock subtypes, which are used to reinforce the Captain's Command Airlocks and the front entrance to the HoP's office with plasteel airlock wire panel reinforcements, and the HoP's command entrance with iron.

## Why It's Good For The Game

Valuable equipment, namely All Access, is easily acquirable with a small amount of know-how, and a small amount of prep time. This helps to combat shift-start rushing of valuable items with little prep work. This does not greatly alter the skill required to steal these items, only increases the gear requirement.

## Changelog
:cl:
balance: New models of Captain and Head of Personnel airlock wire panels have been reinforced.
/:cl:
