### PR TITLE
Fixes shuttle catastrophe triggering when Build Your Own Shuttle kit has been purchased

### DIFF
--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -5,7 +5,7 @@
 	max_occurrences = 1
 
 /datum/round_event_control/shuttle_catastrophe/canSpawnEvent(players, gamemode)
-	if(SSshuttle.emergency.name == "Build your own shuttle kit")
+	if(istype(SSshuttle.emergency, /obj/docking_port/mobile/emergency/shuttle_build))
 		return FALSE //don't undo manual player engineering, it also would unload people and ghost them, there's just a lot of problems
 	if(EMERGENCY_AT_LEAST_DOCKED)
 		return FALSE //don't remove all players when its already on station or going to centcom


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Shuttle Catastrophe event now checks for the `/obj/docking_port/mobile/emergency/shuttle_build` subtype rather than checking for a specific mobile docking port name when checking to see if it should spawn. This should keep Shuttle Catastrophe from triggering when Build Your Own Shuttle has been purchased and ghosting/qdeling everyone and everything onboard.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a pretty serious bug with the event so that it follows what was clearly the intended behavior. Fixes #53524 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: VexingRaven
fix: The Shuttle Catastrophe event can no longer occur to the Build Your Own Shuttle Kit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
