### PR TITLE
Add VSCode setting to ignore whitespace in git blame

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
 			"viewType": "imagePreview.previewEditor"
 		}
 	],
-	"files.eol": "\n"
+
+	"files.eol": "\n",
+
+	"gitlens.advanced.blame.customArguments": ["-w"],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,5 @@
 
 	"files.eol": "\n",
 
-	"gitlens.advanced.blame.customArguments": ["-w"],
+	"gitlens.advanced.blame.customArguments": ["-w"]
 }


### PR DESCRIPTION
Doesn't use `--ignore-revs-file` because it was added in a more recent Git version (2.23.0) than Ubuntu 18.04 ships (2.17.1)