### PR TITLE
SQL Schema Version 5.11 / Add indices for ticket table to support Statbus operations

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,12 +1,24 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.10; The query to update the schema revision table is:
+The latest database version is 5.11; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 10);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 11);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 10);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 11);
 
 In any query remember to add a prefix to the table names if you use one.
+
+-----------------------------------------------------
+
+Version 5.11, 7 September 2020, by bobbahbrown and MrStonedOne
+
+Adds indices to support search operations on the adminhelp ticket tables. This is to support improved performance on Atlanta Ned's Statbus.
+
+CREATE INDEX idx_ticket_round_tid ON ticket (round_id, ticket);
+CREATE INDEX idx_ticket_act_recipient ON ticket (action, recipient);
+CREATE INDEX idx_ticket_act_sender ON ticket (action, sender);
+CREATE INDEX idx_ticket_recipient ON ticket (recipient);
+CREATE INDEX idx_ticket_sender ON ticket (sender);
 
 -----------------------------------------------------
 

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -10,15 +10,14 @@ In any query remember to add a prefix to the table names if you use one.
 
 -----------------------------------------------------
 
-Version 5.11, 7 September 2020, by bobbahbrown and MrStonedOne
+Version 5.11, 7 September 2020, by bobbahbrown, MrStonedOne, and Jordie0608
 
 Adds indices to support search operations on the adminhelp ticket tables. This is to support improved performance on Atlanta Ned's Statbus.
 
-CREATE INDEX idx_ticket_round_tid ON ticket (round_id, ticket);
-CREATE INDEX idx_ticket_act_recipient ON ticket (action, recipient);
-CREATE INDEX idx_ticket_act_sender ON ticket (action, sender);
-CREATE INDEX idx_ticket_recipient ON ticket (recipient);
-CREATE INDEX idx_ticket_sender ON ticket (sender);
+CREATE INDEX `idx_ticket_act_recip` (`action`, `recipient`)
+CREATE INDEX `idx_ticket_act_send` (`action`, `sender`)
+CREATE INDEX `idx_ticket_tic_rid` (`ticket`, `round_id`)
+CREATE INDEX `idx_ticket_act_time_rid` (`action`, `timestamp`, `round_id`)
 
 -----------------------------------------------------
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -548,11 +548,10 @@ CREATE TABLE `ticket` (
   `recipient` varchar(32) DEFAULT NULL,
   `sender` varchar(32) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `idx_ticket_round_tid` (round_id, ticket),
-  KEY `idx_ticket_act_recipient` (action, recipient),
-  KEY `idx_ticket_act_sender` (action, sender),
-  KEY `idx_ticket_recipient` (recipient),
-  KEY `idx_ticket_sender` (sender)
+  KEY `idx_ticket_act_recip` (`action`, `recipient`),
+  KEY `idx_ticket_act_send` (`action`, `sender`),
+  KEY `idx_ticket_tic_rid` (`ticket`, `round_id`),
+  KEY `idx_ticket_act_time_rid` (`action`, `timestamp`, `round_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DELIMITER $$

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -547,7 +547,12 @@ CREATE TABLE `ticket` (
   `timestamp` datetime NOT NULL,
   `recipient` varchar(32) DEFAULT NULL,
   `sender` varchar(32) DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `idx_ticket_round_tid` (round_id, ticket),
+  KEY `idx_ticket_act_recipient` (action, recipient),
+  KEY `idx_ticket_act_sender` (action, sender),
+  KEY `idx_ticket_recipient` (recipient),
+  KEY `idx_ticket_sender` (sender)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DELIMITER $$

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -547,7 +547,12 @@ CREATE TABLE `SS13_ticket` (
   `timestamp` datetime NOT NULL,
   `recipient` varchar(32) DEFAULT NULL,
   `sender` varchar(32) DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `idx_ticket_round_tid` (round_id, ticket),
+  KEY `idx_ticket_act_recipient` (action, recipient),
+  KEY `idx_ticket_act_sender` (action, sender),
+  KEY `idx_ticket_recipient` (recipient),
+  KEY `idx_ticket_sender` (sender)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DELIMITER $$

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -548,11 +548,10 @@ CREATE TABLE `SS13_ticket` (
   `recipient` varchar(32) DEFAULT NULL,
   `sender` varchar(32) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `idx_ticket_round_tid` (round_id, ticket),
-  KEY `idx_ticket_act_recipient` (action, recipient),
-  KEY `idx_ticket_act_sender` (action, sender),
-  KEY `idx_ticket_recipient` (recipient),
-  KEY `idx_ticket_sender` (sender)
+  KEY `idx_ticket_act_recip` (`action`, `recipient`),
+  KEY `idx_ticket_act_send` (`action`, `sender`),
+  KEY `idx_ticket_tic_rid` (`ticket`, `round_id`),
+  KEY `idx_ticket_act_time_rid` (`action`, `timestamp`, `round_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DELIMITER $$

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -20,7 +20,7 @@
   *
   * make sure you add an update to the schema_version stable in the db changelog
   */
-#define DB_MINOR_VERSION 10
+#define DB_MINOR_VERSION 11
 
 
 //! ## Timing subsystem


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds indices to support searches on the tickets table. Improves performance of operations that search them considerably.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We like performance.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown, MrStonedOne, Jordie0608
server: Added indices to improve support of searching through the tickets table, updated schema to 5.11.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
