### PR TITLE
Fix chemicals not recognizing end of metabolization

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -618,9 +618,9 @@
 
 			if (isliving(my_atom))
 				mob_consumer = my_atom
-			else if (istype(my_atom, /obj/item/organ/stomach))
-				var/obj/item/organ/stomach/belly = my_atom
-				mob_consumer = belly.owner
+			else if (istype(my_atom, /obj/item/organ))
+				var/obj/item/organ/organ = my_atom
+				mob_consumer = organ.owner
 
 			if (mob_consumer)
 				if(R.metabolizing)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -614,12 +614,20 @@
 	for(var/_reagent in cached_reagents)
 		var/datum/reagent/R = _reagent
 		if(R.type == reagent)
-			if(my_atom && isliving(my_atom))
-				var/mob/living/M = my_atom
+			var/mob/living/mob_consumer
+
+			if (isliving(my_atom))
+				mob_consumer = my_atom
+			else if (istype(my_atom, /obj/item/organ/stomach))
+				var/obj/item/organ/stomach/belly = my_atom
+				mob_consumer = belly.owner
+
+			if (mob_consumer)
 				if(R.metabolizing)
 					R.metabolizing = FALSE
-					R.on_mob_end_metabolize(M)
-				R.on_mob_delete(M)
+					R.on_mob_end_metabolize(mob_consumer)
+				R.on_mob_delete(mob_consumer)
+
 			//Clear from relevant lists
 			addiction_list -= R
 			reagent_list -= R

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -2,6 +2,7 @@
 //Keep this sorted alphabetically
 
 #ifdef UNIT_TESTS
+
 /// Asserts that a condition is true
 /// If the condition is not true, fails the test
 #define TEST_ASSERT(assertion, reason) if (!(assertion)) { return Fail("Assertion failed: [reason || "No reason"]") }
@@ -13,6 +14,11 @@
 /// Asserts that the two parameters passed are not equal, fails otherwise
 /// Optionally allows an additional message in the case of a failure
 #define TEST_ASSERT_NOTEQUAL(a, b, message) if ((a) == (b)) { return Fail("Expected [isnull(a) ? "null" : a] to not be equal to [isnull(b) ? "null" : b].[message ? " [message]" : ""]") }
+
+/// *Only* run the test provided within the parentheses
+/// This is useful for debugging when you want to reduce noise, but should never be pushed
+/// Intended to be used in the manner of `TEST_FOCUS(/datum/unit_test/math)`
+#define TEST_FOCUS(test_path) ##test_path { focus = TRUE; }
 
 #include "anchored_mobs.dm"
 #include "bespoke_id.dm"

--- a/code/modules/unit_tests/metabolizing.dm
+++ b/code/modules/unit_tests/metabolizing.dm
@@ -17,3 +17,20 @@
 /datum/unit_test/metabolization/Destroy()
 	SSmobs.ignite()
 	return ..()
+
+/datum/unit_test/on_mob_end_metabolize/Run()
+	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
+	var/obj/item/reagent_containers/pill/pill = allocate(/obj/item/reagent_containers/pill)
+	var/datum/reagent/drug/methamphetamine/meth = /datum/reagent/drug/methamphetamine
+
+	// Give them enough meth to be consumed in 2 metabolizations
+	pill.reagents.add_reagent(meth, initial(meth.metabolization_rate) * 1.9)
+	pill.attack(user, user)
+	user.Life()
+
+	TEST_ASSERT(user.has_reagent(meth), "User does not have meth in their system after consuming it")
+	TEST_ASSERT(user.has_movespeed_modifier(/datum/movespeed_modifier/reagent/methamphetamine), "User consumed meth, but did not gain movespeed modifier")
+
+	user.Life()
+	TEST_ASSERT(!user.has_reagent(meth), "User still has meth in their system when it should've finished metabolizing")
+	TEST_ASSERT(!user.has_movespeed_modifier(/datum/movespeed_modifier/reagent/methamphetamine), "User still has movespeed modifier despite not containing any more meth")

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -24,6 +24,7 @@ GLOBAL_VAR(test_log)
 	var/turf/run_loc_top_right
 
 	//internal shit
+	var/focus = FALSE
 	var/succeeded = TRUE
 	var/list/allocated
 	var/list/fail_reasons
@@ -66,7 +67,14 @@ GLOBAL_VAR(test_log)
 /proc/RunUnitTests()
 	CHECK_TICK
 
-	for(var/I in subtypesof(/datum/unit_test))
+	var/tests_to_run = subtypesof(/datum/unit_test)
+	for (var/_test_to_run in tests_to_run)
+		var/datum/unit_test/test_to_run = _test_to_run
+		if (initial(test_to_run.focus))
+			tests_to_run = list(test_to_run)
+			break
+
+	for(var/I in tests_to_run)
 		var/datum/unit_test/test = new I
 
 		GLOB.current_test = test


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #53546.

Also as an aside thing, adds `TEST_FOCUS` to make it easy during debugging to focus just on the test you're writing rather than seeing all the extra noise.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A lot of chemicals do things when they're out of your system. These effects should work.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Chemicals now correctly do effects when they stop metabolizing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
