### PR TITLE
Dismemberment wounds

### DIFF
--- a/code/__DEFINES/wounds.dm
+++ b/code/__DEFINES/wounds.dm
@@ -118,6 +118,8 @@ GLOBAL_LIST_INIT(global_all_wound_types, list(/datum/wound/blunt/critical, /datu
 #define MANGLES_BONE	(1<<3)
 /// If this wound marks the limb as being allowed to have gauze applied
 #define ACCEPTS_GAUZE	(1<<4)
+/// If this wound ignores preexisting wounds of the same type when applying
+#define IGNORES_EXISTING_WOUNDS (1<<5)
 
 
 // ~scar persistence defines

--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -187,6 +187,8 @@
 	id = "laceration"
 /datum/status_effect/wound/slash/critical
 	id = "avulsion"
+/datum/status_effect/wound/slash/dismemberment
+	id = "dismemberment"
 // pierce
 /datum/status_effect/wound/pierce/moderate
 	id = "breakage"

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -317,7 +317,7 @@
   * * mob/user: The user examining the wound's owner, if that matters
   */
 /datum/wound/proc/get_examine_description(mob/user)
-	. = "[victim.p_their(TRUE)] [fake_body_zone ? parse_zone(fake_body_zone) : limb.name] [examine_desc]"
+	. = "[victim.p_their(TRUE)] [phantom_body_zone ? parse_zone(phantom_body_zone) : limb.name] [examine_desc]"
 	. = severity <= WOUND_SEVERITY_MODERATE ? "[.]." : "<B>[.]!</B>"
 
 /datum/wound/proc/get_scanner_description(mob/user)

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -43,7 +43,7 @@
 	/// The bodypart we're parented to
 	var/obj/item/bodypart/limb = null
 	/// A phantom body zone, for situations where the wound is tied to a bodypart that doesn't exist on the victim, like dismemberment
-	var/fake_body_zone
+	var/phantom_body_zone = null
 
 	/// Specific items such as bandages or sutures that can try directly treating this wound
 	var/list/treatable_by

--- a/code/datums/wounds/loss.dm
+++ b/code/datums/wounds/loss.dm
@@ -19,7 +19,7 @@
 
 	already_scarred = TRUE // so we don't scar a limb we don't have. If I add different levels of amputation desc, do it here
 	victim = dismembered_part.owner
-	fake_body_zone = dismembered_part.body_zone
+	phantom_body_zone = dismembered_part.body_zone
 
 	if(dismembered_part.body_zone == BODY_ZONE_CHEST)
 		occur_text = "is split open, causing [victim.p_their()] internals organs to spill out!"

--- a/code/datums/wounds/loss.dm
+++ b/code/datums/wounds/loss.dm
@@ -1,17 +1,18 @@
 
-/datum/wound/loss
-	name = "Dismemberment Wound"
-	desc = "oof ouch!!"
-
+/datum/wound/slash/critical/loss
+	name = "Dismembered stump"
+	desc = "Patient's limb has been violently dismembered, leaving only a severely damaged stump in it's place. Extreme blood loss will lead to quick death without intervention."
+	examine_desc = "has been violently severed from their chest"
 	sound_effect = 'sound/effects/dismember.ogg'
 	severity = WOUND_SEVERITY_LOSS
 	threshold_minimum = WOUND_DISMEMBER_OUTRIGHT_THRESH // not actually used since dismembering is handled differently, but may as well assign it since we got it
-	status_effect_type = null
+	status_effect_type = /datum/status_effect/wound/slash/dismemberment
 	scar_keyword = "dismember"
-	wound_flags = null
+	demotes_to = null
+	wound_flags = (FLESH_WOUND | ACCEPTS_GAUZE | IGNORES_EXISTING_WOUNDS)
 
 /// Our special proc for our special dismembering, the wounding type only matters for what text we have
-/datum/wound/loss/proc/apply_dismember(obj/item/bodypart/dismembered_part, wounding_type=WOUND_SLASH, outright = FALSE)
+/datum/wound/slash/critical/loss/proc/apply_dismember(obj/item/bodypart/dismembered_part, wounding_type=WOUND_SLASH, outright = FALSE)
 	if(!istype(dismembered_part) || !dismembered_part.owner || !(dismembered_part.body_zone in viable_zones) || isalien(dismembered_part.owner) || !dismembered_part.can_dismember())
 		qdel(src)
 		return
@@ -46,9 +47,21 @@
 
 	victim.visible_message(msg, "<span class='userdanger'>Your [dismembered_part.name] [occur_text]!</span>")
 
-	limb = dismembered_part
 	severity = WOUND_SEVERITY_LOSS
 	second_wind()
 	log_wound(victim, src)
-	dismembered_part.dismember(wounding_type == WOUND_BURN ? BURN : BRUTE)
-	qdel(src)
+	dismembered_part.dismember(wounding_type == WOUND_BURN ? BURN : BRUTE, silent = TRUE)
+
+	/// We apply ourselves to the chest now that we've ripped the bodypart off
+	name = "[capitalize(dismembered_part.name)] stump"
+	desc = "Patient's [capitalize(dismembered_part.name)] has been violently dismembered, leaving only a severely damaged stump in it's place."
+	var/obj/item/bodypart/chest/chest = victim.get_bodypart(BODY_ZONE_CHEST)
+	if((dismembered_part.body_zone != BODY_ZONE_CHEST) && chest)
+		apply_wound(chest, TRUE)
+	else
+		qdel(src)
+
+/datum/wound/slash/critical/loss/get_examine_description(mob/user)
+	. = ..()
+	if(fake_body_zone == BODY_ZONE_HEAD)
+		return "<span class='deadsay'>[..()]</span>"

--- a/code/datums/wounds/loss.dm
+++ b/code/datums/wounds/loss.dm
@@ -19,6 +19,7 @@
 
 	already_scarred = TRUE // so we don't scar a limb we don't have. If I add different levels of amputation desc, do it here
 	victim = dismembered_part.owner
+	fake_body_zone = dismembered_part.body_zone
 
 	if(dismembered_part.body_zone == BODY_ZONE_CHEST)
 		occur_text = "is split open, causing [victim.p_their()] internals organs to spill out!"
@@ -53,8 +54,8 @@
 	dismembered_part.dismember(wounding_type == WOUND_BURN ? BURN : BRUTE, silent = TRUE)
 
 	/// We apply ourselves to the chest now that we've ripped the bodypart off
-	name = "[capitalize(dismembered_part.name)] stump"
-	desc = "Patient's [capitalize(dismembered_part.name)] has been violently dismembered, leaving only a severely damaged stump in it's place."
+	name = "[parse_zone(dismembered_part.body_zone)] stump"
+	desc = "Patient's [parse_zone(dismembered_part.body_zone)] has been violently dismembered, leaving only a severely damaged stump in it's place."
 	var/obj/item/bodypart/chest/chest = victim.get_bodypart(BODY_ZONE_CHEST)
 	if((dismembered_part.body_zone != BODY_ZONE_CHEST) && chest)
 		apply_wound(chest, TRUE)

--- a/code/datums/wounds/loss.dm
+++ b/code/datums/wounds/loss.dm
@@ -65,4 +65,4 @@
 /datum/wound/slash/critical/loss/get_examine_description(mob/user)
 	. = ..()
 	if(fake_body_zone == BODY_ZONE_HEAD)
-		return "<span class='deadsay'>[..()]</span>"
+		return "<span class='deadsay'>[.]</span>"

--- a/code/datums/wounds/loss.dm
+++ b/code/datums/wounds/loss.dm
@@ -64,5 +64,5 @@
 
 /datum/wound/slash/critical/loss/get_examine_description(mob/user)
 	. = ..()
-	if(fake_body_zone == BODY_ZONE_HEAD)
+	if(phantom_body_zone == BODY_ZONE_HEAD)
 		return "<span class='deadsay'>[.]</span>"

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -49,8 +49,8 @@
 			var/datum/wound/W = i
 			msg += "[W.get_examine_description(user)]\n"
 			/// We don't count limbs that still have a fresh dismemberment wound as missing, that would be redundant
-			if((W.severity == WOUND_SEVERITY_LOSS) && (W.fake_body_zone))
-				missing -= W.fake_body_zone
+			if((W.severity == WOUND_SEVERITY_LOSS) && (W.phantom_body_zone))
+				missing -= W.phantom_body_zone
 
 	for(var/X in disabled)
 		var/obj/item/bodypart/BP = X

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -48,6 +48,9 @@
 		for(var/i in BP.wounds)
 			var/datum/wound/W = i
 			msg += "[W.get_examine_description(user)]\n"
+			/// We don't count limbs that still have a fresh dismemberment wound as missing, that would be redundant
+			if((W.severity == WOUND_SEVERITY_LOSS) && (W.fake_body_zone))
+				missing -= W.fake_body_zone
 
 	for(var/X in disabled)
 		var/obj/item/bodypart/BP = X

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -368,7 +368,7 @@
 	var/list/wounds_checking = GLOB.global_wound_types[woundtype]
 
 	if(injury_roll > WOUND_DISMEMBER_OUTRIGHT_THRESH && prob(get_damage() / max_damage * 100))
-		var/datum/wound/loss/dismembering = new
+		var/datum/wound/slash/critical/loss/dismembering = new
 		dismembering.apply_dismember(src, woundtype, outright=TRUE)
 		return
 

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -370,7 +370,8 @@
 
 	/// Reattaching a limb fixes dismemberment wounds
 	var/obj/item/bodypart/chest/chest = C.get_bodypart(BODY_ZONE_CHEST)
-	for(var/datum/wound/woundie in chest.wounds)
+	for(var/w in chest.wounds)
+		var/datum/wound/woundie = w
 		if((woundie.severity == WOUND_SEVERITY_LOSS) && (woundie.fake_body_zone == body_zone))
 			woundie.remove_wound()
 

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -35,7 +35,7 @@
 		burn()
 		return TRUE
 	add_mob_blood(C)
-	C.bleed(rand(20, 40))
+	C.bleed(rand(8, 12))
 	var/direction = pick(GLOB.cardinals)
 	var/t_range = rand(2,max(throw_range/2, 2))
 	var/turf/target_turf = get_turf(src)
@@ -50,7 +50,7 @@
 	return TRUE
 
 
-/obj/item/bodypart/chest/dismember()
+/obj/item/bodypart/chest/dismember(dam_type = BRUTE, silent=TRUE)
 	if(!owner)
 		return FALSE
 	var/mob/living/carbon/C = owner
@@ -192,7 +192,7 @@
 		base_chance += 15
 
 	if(prob(base_chance))
-		var/datum/wound/loss/dismembering = new
+		var/datum/wound/slash/critical/loss/dismembering = new
 		dismembering.apply_dismember(src, wounding_type)
 		return TRUE
 
@@ -464,6 +464,6 @@
 			qdel(L)
 			return FALSE
 		var/datum/scar/scaries = new
-		var/datum/wound/loss/phantom_loss = new // stolen valor, really
+		var/datum/wound/slash/critical/loss/phantom_loss = new // stolen valor, really
 		scaries.generate(L, phantom_loss)
 		return TRUE

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -368,6 +368,12 @@
 		var/datum/wound/W = i
 		W.apply_wound(src, TRUE)
 
+	/// Reattaching a limb fixes dismemberment wounds
+	var/obj/item/bodypart/chest/chest = C.get_bodypart(BODY_ZONE_CHEST)
+	for(var/datum/wound/woundie in chest.wounds)
+		if((woundie.severity == WOUND_SEVERITY_LOSS) && (woundie.fake_body_zone == body_zone))
+			woundie.remove_wound()
+
 	update_bodypart_damage_state()
 
 	C.updatehealth()

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -372,7 +372,7 @@
 	var/obj/item/bodypart/chest/chest = C.get_bodypart(BODY_ZONE_CHEST)
 	for(var/w in chest.wounds)
 		var/datum/wound/woundie = w
-		if((woundie.severity == WOUND_SEVERITY_LOSS) && (woundie.fake_body_zone == body_zone))
+		if((woundie.severity == WOUND_SEVERITY_LOSS) && (woundie.phantom_body_zone == body_zone))
 			woundie.remove_wound()
 
 	update_bodypart_damage_state()


### PR DESCRIPTION
## About The Pull Request

Dismembering a limb causes a wound equivalent to a weeping avulsion on the chest.

## Why It's Good For The Game

Dismemberment should be lethal, not something preferrable to having a severely damaged limb - This makes dismemberment scary and very likely to kill you if left untreated.

## Changelog
:cl:
balance: When a limb gets dismembered, it now causes a critical slash wound on the chest.
/:cl:
