### PR TITLE
Again crystal invasion fix, why edition (+ balancing because why not)

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -220,10 +220,4 @@
 #define DT_PROB(prob_per_second_percent, delta_time) (prob(100*DT_PROB_RATE(prob_per_second_percent/100, delta_time)))
 // )
 
-#define BETTER_DIST(dist, a, b)\
-	if (a == null || b == null) {\
-		dist = -1;\
-	}\
-	else{\
-		dist = max(abs(a.x-b.x), abs(a.y-b.y));\
-	}
+#define BETTER_DIST(a, b) (a == null || b == null) ? -1 : max(abs(a.x-b.x), abs(a.y-b.y))

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -219,3 +219,9 @@
 /// Like DT_PROB_RATE but easier to use, simply put `if(DT_PROB(10, 5))`
 #define DT_PROB(prob_per_second_percent, delta_time) (prob(100*DT_PROB_RATE(prob_per_second_percent/100, delta_time)))
 // )
+
+#define BETTER_DIST(dist, a, b)\
+	if (!a == null || b == null) {\
+		dist = -1;\
+	}\
+	dist = max(abs(a.x-b.x), abs(a.y-b.y));

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -220,4 +220,4 @@
 #define DT_PROB(prob_per_second_percent, delta_time) (prob(100*DT_PROB_RATE(prob_per_second_percent/100, delta_time)))
 // )
 
-#define BETTER_DIST(a, b) (a == null || b == null) ? -1 : max(abs(a.x-b.x), abs(a.y-b.y))
+#define BETTER_DIST(a, b) (a == null || b == null) ? -1 : max(abs(a.x -b.x), abs(a.y-b.y), abs(a.z-b.z))

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -220,4 +220,4 @@
 #define DT_PROB(prob_per_second_percent, delta_time) (prob(100*DT_PROB_RATE(prob_per_second_percent/100, delta_time)))
 // )
 
-#define BETTER_DIST(a, b) (a == null || b == null) ? -1 : max(abs(a.x -b.x), abs(a.y-b.y), abs(a.z-b.z))
+#define GET_TRUE_DIST(a, b) (a == null || b == null) ? -1 : max(abs(a.x -b.x), abs(a.y-b.y), abs(a.z-b.z))

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -221,7 +221,9 @@
 // )
 
 #define BETTER_DIST(dist, a, b)\
-	if (!a == null || b == null) {\
+	if (a == null || b == null) {\
 		dist = -1;\
 	}\
-	dist = max(abs(a.x-b.x), abs(a.y-b.y));
+	else{\
+		dist = max(abs(a.x-b.x), abs(a.y-b.y));\
+	}

--- a/code/modules/events/crystal_event.dm
+++ b/code/modules/events/crystal_event.dm
@@ -127,7 +127,7 @@ This section is for the event controller
 
 		for(var/t in RANGE_TURFS(5, center_turf))
 			var/turf/turf_loc = t
-			var/distance_from_center = BETTER_DIST(turf_loc, center_turf)
+			var/distance_from_center = GET_TRUE_DIST(turf_loc, center_turf)
 			switch(distance_from_center)
 				if(0)
 					distance_from_center = 1 //Same tile, let's avoid a division by zero.

--- a/code/modules/events/crystal_event.dm
+++ b/code/modules/events/crystal_event.dm
@@ -619,8 +619,8 @@ This section is for the crystal portals variations
 	name = "Huge Portal"
 	desc = "A huge portal to an unkown dimension!"
 	color = COLOR_BLACK
-	max_mobs = 5
-	spawn_time = 30 SECONDS
+	max_mobs = 2
+	spawn_time = 40 SECONDS
 	mob_types = list(
 		/mob/living/simple_animal/hostile/crystal_monster/boss
 		)
@@ -830,8 +830,8 @@ This section is for the crystal monsters variations
 		var/mob/living/mob = clong
 		if(mob.stat >= HARD_CRIT)
 			mob.dust()
-			if(health < 120)
-				health += 30
+			if(health < maxHealth)
+				health = min(health+30,maxHealth)
 	else if(isturf(clong))
 		var/turf/turf_bump = clong
 		turf_bump.Melt()
@@ -843,8 +843,8 @@ This section is for the crystal monsters variations
 		var/mob/living/mob = target
 		if(mob.stat >= HARD_CRIT)
 			mob.dust()
-			if(health < 120)
-				health += 30
+			if(health < maxHealth)
+				health = min(health+30,maxHealth)
 		else
 			var/obj/item/bodypart/body_part = mob.get_bodypart(pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
 			if(body_part)

--- a/code/modules/events/crystal_event.dm
+++ b/code/modules/events/crystal_event.dm
@@ -78,8 +78,7 @@ This section is for the event controller
 
 	for(var/t in RANGE_TURFS(8, dest_crystal.loc))
 		var/turf/turf_loc = t
-		var/distance_from_center
-		BETTER_DIST(distance_from_center, turf_loc, dest_crystal.loc)
+		var/distance_from_center = BETTER_DIST(turf_loc, dest_crystal.loc)
 		switch(distance_from_center)
 			if(0)
 				distance_from_center = 1 //Same tile, let's avoid a division by zero.
@@ -128,8 +127,7 @@ This section is for the event controller
 
 		for(var/t in RANGE_TURFS(5, center_turf))
 			var/turf/turf_loc = t
-			var/distance_from_center
-			BETTER_DIST(distance_from_center, turf_loc, center_turf)
+			var/distance_from_center = BETTER_DIST(turf_loc, center_turf)
 			switch(distance_from_center)
 				if(0)
 					distance_from_center = 1 //Same tile, let's avoid a division by zero.

--- a/code/modules/events/crystal_event.dm
+++ b/code/modules/events/crystal_event.dm
@@ -78,7 +78,7 @@ This section is for the event controller
 
 	for(var/t in RANGE_TURFS(8, dest_crystal.loc))
 		var/turf/turf_loc = t
-		var/distance_from_center = BETTER_DIST(turf_loc, dest_crystal.loc)
+		var/distance_from_center = get_dist(turf_loc, dest_crystal)
 		switch(distance_from_center)
 			if(0)
 				distance_from_center = 1 //Same tile, let's avoid a division by zero.

--- a/code/modules/events/crystal_event.dm
+++ b/code/modules/events/crystal_event.dm
@@ -79,12 +79,8 @@ This section is for the event controller
 	for(var/t in RANGE_TURFS(8, dest_crystal.loc))
 		var/turf/turf_loc = t
 		var/distance_from_center = get_dist(turf_loc, dest_crystal.loc)
-		switch(distance_from_center)
-			if(0)
-				distance_from_center = 1 //Same tile, let's avoid a division by zero.
-			if(-1)
-				kill()
-				CRASH("Negative distance measurement from the center turf detected, this should never happen")
+		if(distance_from_center == 0)
+			distance_from_center = 1 //Same tile, let's avoid a division by zero.
 		if(prob(325 / distance_from_center))
 			if(isopenturf(turf_loc) || isspaceturf(turf_loc))
 				turf_loc.ChangeTurf(/turf/open/indestructible/crystal_floor, flags = CHANGETURF_INHERIT_AIR)
@@ -128,12 +124,8 @@ This section is for the event controller
 		for(var/t in RANGE_TURFS(5, center_turf))
 			var/turf/turf_loc = t
 			var/distance_from_center = get_dist(turf_loc, center_turf)
-			switch(distance_from_center)
-				if(0)
-					distance_from_center = 1 //Same tile, let's avoid a division by zero.
-				if(-1)
-					kill()
-					CRASH("Negative distance error here")
+			if(distance_from_center == 0)
+				distance_from_center = 1 //Same tile, let's avoid a division by zero.
 			if(prob(250 / distance_from_center))
 				if(isopenturf(turf_loc) || isspaceturf(turf_loc))
 					turf_loc.ChangeTurf(/turf/open/indestructible/crystal_floor, flags = CHANGETURF_INHERIT_AIR)
@@ -619,12 +611,10 @@ This section is for the crystal portals variations
 	name = "Huge Portal"
 	desc = "A huge portal to an unkown dimension!"
 	color = COLOR_BLACK
-	max_mobs = 5
-	spawn_time = 20 SECONDS
+	max_mobs = 2
+	spawn_time = 45 SECONDS
 	mob_types = list(
-		/mob/living/simple_animal/hostile/crystal_monster/recruit,
-		/mob/living/simple_animal/hostile/crystal_monster/killer,
-		/mob/living/simple_animal/hostile/crystal_monster/boss,
+		/mob/living/simple_animal/hostile/crystal_monster/boss
 		)
 
 /obj/structure/crystal_portal/huge/Initialize()
@@ -686,8 +676,8 @@ This section is for the crystal monsters variations
 	health = 20
 	speed = 0.8
 	harm_intent_damage = 7
-	melee_damage_lower = 10
-	melee_damage_upper = 15
+	melee_damage_lower = 7
+	melee_damage_upper = 10
 	move_force = MOVE_FORCE_WEAK
 	move_resist = MOVE_FORCE_WEAK
 	pull_force = MOVE_FORCE_WEAK
@@ -713,9 +703,9 @@ This section is for the crystal monsters variations
 	maxHealth = 20
 	health = 20
 	speed = 0.9
-	harm_intent_damage = 11
-	melee_damage_lower = 10
-	melee_damage_upper = 15
+	harm_intent_damage = 8
+	melee_damage_lower = 8
+	melee_damage_upper = 11
 	move_force = MOVE_FORCE_NORMAL
 	move_resist = MOVE_FORCE_NORMAL
 	pull_force = MOVE_FORCE_NORMAL
@@ -745,9 +735,9 @@ This section is for the crystal monsters variations
 	maxHealth = 20
 	health = 20
 	speed = 1.2
-	harm_intent_damage = 11
-	melee_damage_lower = 15
-	melee_damage_upper = 20
+	harm_intent_damage = 9
+	melee_damage_lower = 10
+	melee_damage_upper = 15
 	move_force = MOVE_FORCE_STRONG
 	move_resist = MOVE_FORCE_STRONG
 	pull_force = MOVE_FORCE_STRONG
@@ -771,9 +761,9 @@ This section is for the crystal monsters variations
 	maxHealth = 35
 	health = 35
 	speed = 0.75
-	harm_intent_damage = 15
-	melee_damage_lower = 30
-	melee_damage_upper = 35
+	harm_intent_damage = 10
+	melee_damage_lower = 15
+	melee_damage_upper = 20
 	move_force = MOVE_FORCE_VERY_STRONG
 	move_resist = MOVE_FORCE_VERY_STRONG
 	pull_force = MOVE_FORCE_VERY_STRONG
@@ -810,12 +800,12 @@ This section is for the crystal monsters variations
 	icon_state = "crystal_boss"
 	icon_living = "crystal_boss"
 	icon_dead = "crystal_boss"
-	maxHealth = 300
-	health = 30
+	maxHealth = 150
+	health = 100
 	speed = 1.3
-	harm_intent_damage = 11
-	melee_damage_lower = 20
-	melee_damage_upper = 35
+	harm_intent_damage = 15
+	melee_damage_lower = 25
+	melee_damage_upper = 40
 	move_force = MOVE_FORCE_EXTREMELY_STRONG
 	move_resist = MOVE_FORCE_EXTREMELY_STRONG
 	pull_force = MOVE_FORCE_EXTREMELY_STRONG
@@ -832,7 +822,8 @@ This section is for the crystal monsters variations
 		var/mob/living/mob = clong
 		if(mob.stat >= HARD_CRIT)
 			mob.dust()
-			health += 35
+			if(health < 120)
+				health += 30
 	else if(isturf(clong))
 		var/turf/turf_bump = clong
 		turf_bump.Melt()
@@ -844,7 +835,8 @@ This section is for the crystal monsters variations
 		var/mob/living/mob = target
 		if(mob.stat >= HARD_CRIT)
 			mob.dust()
-			health += 35
+			if(health < 120)
+				health += 30
 		else
 			var/obj/item/bodypart/body_part = mob.get_bodypart(pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
 			if(body_part)

--- a/code/modules/events/crystal_event.dm
+++ b/code/modules/events/crystal_event.dm
@@ -78,9 +78,14 @@ This section is for the event controller
 
 	for(var/t in RANGE_TURFS(8, dest_crystal.loc))
 		var/turf/turf_loc = t
-		var/distance_from_center = get_dist(turf_loc, dest_crystal.loc)
-		if(distance_from_center == 0)
-			distance_from_center = 1 //Same tile, let's avoid a division by zero.
+		var/distance_from_center
+		BETTER_DIST(distance_from_center, turf_loc, dest_crystal.loc)
+		switch(distance_from_center)
+			if(0)
+				distance_from_center = 1 //Same tile, let's avoid a division by zero.
+			if(-1)
+				kill()
+				CRASH("Negative distance measurement from the center turf detected, this should never happen")
 		if(prob(325 / distance_from_center))
 			if(isopenturf(turf_loc) || isspaceturf(turf_loc))
 				turf_loc.ChangeTurf(/turf/open/indestructible/crystal_floor, flags = CHANGETURF_INHERIT_AIR)
@@ -123,9 +128,14 @@ This section is for the event controller
 
 		for(var/t in RANGE_TURFS(5, center_turf))
 			var/turf/turf_loc = t
-			var/distance_from_center = get_dist(turf_loc, center_turf)
-			if(distance_from_center == 0)
-				distance_from_center = 1 //Same tile, let's avoid a division by zero.
+			var/distance_from_center
+			BETTER_DIST(distance_from_center, turf_loc, center_turf)
+			switch(distance_from_center)
+				if(0)
+					distance_from_center = 1 //Same tile, let's avoid a division by zero.
+				if(-1)
+					kill()
+					CRASH("Negative distance measurement from the center turf detected, this should never happen")
 			if(prob(250 / distance_from_center))
 				if(isopenturf(turf_loc) || isspaceturf(turf_loc))
 					turf_loc.ChangeTurf(/turf/open/indestructible/crystal_floor, flags = CHANGETURF_INHERIT_AIR)
@@ -611,8 +621,8 @@ This section is for the crystal portals variations
 	name = "Huge Portal"
 	desc = "A huge portal to an unkown dimension!"
 	color = COLOR_BLACK
-	max_mobs = 2
-	spawn_time = 45 SECONDS
+	max_mobs = 5
+	spawn_time = 30 SECONDS
 	mob_types = list(
 		/mob/living/simple_animal/hostile/crystal_monster/boss
 		)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hating on get_dist() proc returning -1 if the two turfs are on the same spot
Using now BETTER_DIST() a define i added to replace the native proc, it takes 3 arguments the distance var, the first atom and the second atom to check. if one of those atoms is missing, it returns -1 as error.

Little bit of balancing on the overall mob damage, and boss spawning
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: BETTER_DIST define to replace the get_dist() native proc
fix: event crash fix by replacing the native proc with the define
tweak: monster damage overall reduced and boss spawning changed a bit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
