### PR TITLE
Breathing changes

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -40,7 +40,7 @@
 /// liters in a cell
 #define CELL_VOLUME				2500
 
-/// liters in a normal breath. note that breaths are taken every 8 seconds
+/// liters in a normal breath. note that breaths are taken once every 4 life ticks, which is 8 seconds
 #define BREATH_VOLUME			2
 /// Amount of air to take a from a tile
 #define BREATH_PERCENTAGE		(BREATH_VOLUME/CELL_VOLUME)

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -40,8 +40,8 @@
 /// liters in a cell
 #define CELL_VOLUME				2500
 
-/// liters in a normal breath
-#define BREATH_VOLUME			0.5
+/// liters in a normal breath. note that breaths are taken every 8 seconds
+#define BREATH_VOLUME			2
 /// Amount of air to take a from a tile
 #define BREATH_PERCENTAGE		(BREATH_VOLUME/CELL_VOLUME)
 

--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -182,7 +182,7 @@
 	desc = "A generic tank used for storing and transporting gasses. Can be used for internals."
 	icon_state = "generic"
 	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
-	force = 20
+	force = 10
 	dog_fashion = /datum/dog_fashion/back
 
 /obj/item/tank/internals/generic/populate_gas()

--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -118,7 +118,7 @@
 	worn_icon = null
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
-	volume = 6
+	volume = 24	//enough so they need to refill but not that often to be a chore
 	w_class = WEIGHT_CLASS_SMALL //thanks i forgot this
 
 /obj/item/tank/internals/plasmaman/belt/full/populate_gas()
@@ -144,7 +144,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	force = 4
 	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
-	volume = 1 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
+	volume = 3 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
 
 
 /obj/item/tank/internals/emergency_oxygen/populate_gas()
@@ -160,7 +160,7 @@
 	icon_state = "emergency_engi"
 	worn_icon_state = "emergency_engi"
 	worn_icon = null
-	volume = 2 // should last a bit over 30 minutes if full
+	volume = 6 // should last a bit over 30 minutes if full
 
 /obj/item/tank/internals/emergency_oxygen/engi/empty/populate_gas()
 	return
@@ -168,7 +168,7 @@
 /obj/item/tank/internals/emergency_oxygen/double
 	name = "double emergency oxygen tank"
 	icon_state = "emergency_double"
-	volume = 8
+	volume = 24
 
 /obj/item/tank/internals/emergency_oxygen/double/empty/populate_gas()
 	return
@@ -182,7 +182,7 @@
 	desc = "A generic tank used for storing and transporting gasses. Can be used for internals."
 	icon_state = "generic"
 	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
-	force = 10
+	force = 20
 	dog_fashion = /datum/dog_fashion/back
 
 /obj/item/tank/internals/generic/populate_gas()

--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -160,7 +160,7 @@
 	icon_state = "emergency_engi"
 	worn_icon_state = "emergency_engi"
 	worn_icon = null
-	volume = 6 // should last a bit over 30 minutes if full
+	volume = 6 // should last 24 minutes if full
 
 /obj/item/tank/internals/emergency_oxygen/engi/empty/populate_gas()
 	return


### PR DESCRIPTION
## About The Pull Request

According to math done by Timberpoes and myself, air on a 1x1 square will last you ~3 hours, a emergency air tank ~17 minutes, and the large tanks 17 hours.

With the new changes a turf will last about 45 minutes, an emergency tank ~13 minutes and a large tank 4.25 hours

Plasmaman tanks will last the same amount of time as before

## Why It's Good For The Game

As it stands our rounds are too short for breathing atmos to really make a difference and this opens new interactions and generally makes it matter more.

Also opens the door towards making atmosia matter more beyond "The antag/fusion subdepartment"

## Changelog
:cl:
balance: Spacemen will now take 4x larger breaths
balance: Various pocket and belt-sized internals tanks have had their capacities increased 3x to 4x to account for the new breathing changes
/:cl:
