### PR TITLE
Adds backblast element, gives it to the rocket launcher

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -597,12 +597,14 @@
 
 ///called in /obj/item/gun/process_fire (user, target, params, zone_override)
 #define COMSIG_MOB_FIRED_GUN "mob_fired_gun"
+///called in /obj/item/gun/process_fire (user, target, params, zone_override)
+#define COMSIG_GUN_FIRED "gun_fired"
 
 // /obj/item/grenade signals
 
-///called in /obj/item/gun/process_fire (user, target, params, zone_override)
+///called in /obj/item/grenade/proc/prime(mob/living/lanced_by)
 #define COMSIG_GRENADE_PRIME "grenade_prime"
-///called in /obj/item/gun/process_fire (user, target, params, zone_override)
+///called in /obj/item/grenade/proc/preprime (det_time, delayoverride)
 #define COMSIG_GRENADE_ARMED "grenade_armed"
 
 // /obj/projectile signals (sent to the firer)

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -135,12 +135,12 @@
   * Note that grenades have extra handling for someone throwing themselves/being thrown on top of it, while landmines do not (obviously, it's a landmine!). See [/datum/component/pellet_cloud/proc/handle_martyrs]
   */
 /datum/component/pellet_cloud/proc/create_blast_pellets(obj/O, mob/living/lanced_by)
-	SIGNAL_HANDLER_DOES_SLEEP
+	SIGNAL_HANDLER
 
 	var/atom/A = parent
 
 	if(isgrenade(parent)) // handle_martyrs can reduce the radius and thus the number of pellets we produce if someone dives on top of a frag grenade
-		handle_martyrs(lanced_by) // note that we can modify radius in this proc
+		INVOKE_ASYNC(src, .proc/handle_martyrs, lanced_by) // note that we can modify radius in this proc
 
 	if(radius < 1)
 		return
@@ -150,7 +150,7 @@
 
 	for(var/T in all_the_turfs_were_gonna_lacerate)
 		var/turf/shootat_turf = T
-		pew(shootat_turf)
+		INVOKE_ASYNC(src, .proc/pew, shootat_turf)
 
 /**
   * handle_martyrs() is used for grenades that shoot shrapnel to check if anyone threw themselves/were thrown on top of the grenade, thus absorbing a good chunk of the shrapnel

--- a/code/datums/elements/backblast.dm
+++ b/code/datums/elements/backblast.dm
@@ -1,0 +1,74 @@
+/**
+  * When attached to a gun and the gun is successfully fired, this element creates a "backblast" of fire and pain, like you'd find in a rocket launcher or recoilless rifle
+  *
+  * The backblast is simulated by a number of fire plumes, or invisible incendiary rounds that will torch anything they come across for a short distance, as well as knocking
+  * back nearby items.
+  */
+/datum/element/backblast
+	element_flags = ELEMENT_BESPOKE
+	id_arg_index = 2
+
+	/// How many "pellets" of backblast we're shooting backwards, spread between the angle defined in angle_spread
+	var/plumes
+	/// Assuming we don't just have 1 plume, this is the total angle we'll cover with the plumes, split down the middle directly behind the angle we fired at
+	var/angle_spread
+	/// How far each plume of fire will fly, assuming it doesn't hit a mob
+	var/range
+
+/datum/element/backblast/Attach(datum/target, plumes = 4, angle_spread = 60, range = 10)
+	. = ..()
+	if(!isgun(target) || plumes < 1 || angle_spread < 1 || range < 1)
+		return ELEMENT_INCOMPATIBLE
+
+	src.plumes = plumes
+	src.angle_spread = angle_spread
+	src.range = range
+
+	if(plumes == 1)
+		RegisterSignal(target, COMSIG_GUN_FIRED, .proc/gun_fired_simple)
+	else
+		RegisterSignal(target, COMSIG_GUN_FIRED, .proc/gun_fired)
+
+/datum/element/backblast/Detach(datum/source, force)
+	if(source)
+		UnregisterSignal(source, COMSIG_GUN_FIRED)
+	. = ..()
+
+/// For firing multiple plumes behind us, we evenly spread out our projectiles based on the [angle_spread][/datum/element/backblast/var/angle_spread] and [number of plumes][/datum/element/backblast/var/plumes]
+/datum/element/backblast/proc/gun_fired(obj/item/gun/weapon, mob/living/user, atom/target, params, zone_override)
+	SIGNAL_HANDLER
+
+	if(!weapon.chambered || HAS_TRAIT(user, TRAIT_PACIFISM))
+		return
+
+	var/backwards_angle = Get_Angle(target, user)
+	var/starting_angle = SIMPLIFY_DEGREES(backwards_angle-(angle_spread * 0.5))
+	var/iter_offset = angle_spread / plumes // how much we increment the angle for each plume
+
+	for(var/i in 1 to plumes)
+		var/this_angle = SIMPLIFY_DEGREES(starting_angle + ((i - 1) * iter_offset))
+		var/turf/target_turf = get_turf_in_angle(this_angle, get_turf(user), 10)
+		pew(target_turf, weapon, user)
+
+/// If we're only firing one plume directly behind us, we don't need to bother with the loop or angles or anything
+/datum/element/backblast/proc/gun_fired_simple(obj/item/gun/weapon, mob/living/user, atom/target, params, zone_override)
+	SIGNAL_HANDLER
+
+	if(!weapon.chambered || HAS_TRAIT(user, TRAIT_PACIFISM))
+		return
+
+	var/backwards_angle = Get_Angle(target, user)
+	var/turf/target_turf = get_turf_in_angle(backwards_angle, get_turf(user), 10)
+	pew(target_turf, weapon, user)
+
+/// For firing an actual backblast pellet
+/datum/element/backblast/proc/pew(turf/target_turf, obj/item/gun/weapon, mob/living/user)
+	//Shooting Code:
+	var/obj/projectile/bullet/incendiary/backblast/P = new (get_turf(user))
+	P.original = target_turf
+	P.range = range
+	P.fired_from = weapon
+	P.firer = user // don't hit ourself that would be really annoying
+	P.permutated += user // don't hit the target we hit already with the flak
+	P.preparePixelProjectile(target_turf, weapon)
+	P.fire()

--- a/code/datums/elements/backblast.dm
+++ b/code/datums/elements/backblast.dm
@@ -15,7 +15,7 @@
 	/// How far each plume of fire will fly, assuming it doesn't hit a mob
 	var/range
 
-/datum/element/backblast/Attach(datum/target, plumes = 4, angle_spread = 60, range = 10)
+/datum/element/backblast/Attach(datum/target, plumes = 4, angle_spread = 48, range = 8)
 	. = ..()
 	if(!isgun(target) || plumes < 1 || angle_spread < 1 || range < 1)
 		return ELEMENT_INCOMPATIBLE
@@ -48,7 +48,7 @@
 	for(var/i in 1 to plumes)
 		var/this_angle = SIMPLIFY_DEGREES(starting_angle + ((i - 1) * iter_offset))
 		var/turf/target_turf = get_turf_in_angle(this_angle, get_turf(user), 10)
-		pew(target_turf, weapon, user)
+		INVOKE_ASYNC(src, .proc/pew, target_turf, weapon, user)
 
 /// If we're only firing one plume directly behind us, we don't need to bother with the loop or angles or anything
 /datum/element/backblast/proc/gun_fired_simple(obj/item/gun/weapon, mob/living/user, atom/target, params, zone_override)
@@ -59,7 +59,7 @@
 
 	var/backwards_angle = Get_Angle(target, user)
 	var/turf/target_turf = get_turf_in_angle(backwards_angle, get_turf(user), 10)
-	pew(target_turf, weapon, user)
+	INVOKE_ASYNC(src, .proc/pew, target_turf, weapon, user)
 
 /// For firing an actual backblast pellet
 /datum/element/backblast/proc/pew(turf/target_turf, obj/item/gun/weapon, mob/living/user)

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -240,9 +240,7 @@
 		var/mob/living/L = AM
 		L.fire_act(temperature, volume)
 
-/obj/effect/hotspot/backblast
-	volume = 250
-
+// for special backblast hotspots
 /obj/effect/hotspot/backblast/Crossed(atom/movable/AM, oldLoc)
 	..()
 	if(isliving(AM))

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -245,7 +245,7 @@
 	..()
 	if(isliving(AM))
 		var/mob/living/L = AM
-		L.adjust_fire_stacks(5) // +5 firestacks from normal
+		L.adjust_fire_stacks(3) // +3 firestacks on top of the normal +3
 
 /obj/effect/hotspot/singularity_pull()
 	return

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -240,6 +240,15 @@
 		var/mob/living/L = AM
 		L.fire_act(temperature, volume)
 
+/obj/effect/hotspot/backblast
+	volume = 250
+
+/obj/effect/hotspot/backblast/Crossed(atom/movable/AM, oldLoc)
+	..()
+	if(isliving(AM))
+		var/mob/living/L = AM
+		L.adjust_fire_stacks(5) // +5 firestacks from normal
+
 /obj/effect/hotspot/singularity_pull()
 	return
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -321,6 +321,8 @@
 	if(user)
 		SEND_SIGNAL(user, COMSIG_MOB_FIRED_GUN, user, target, params, zone_override)
 
+	SEND_SIGNAL(src, COMSIG_GUN_FIRED, user, target, params, zone_override)
+
 	add_fingerprint(user)
 
 	if(semicd)

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -62,6 +62,10 @@
 	empty_indicator = TRUE
 	tac_reloads = FALSE
 
+/obj/item/gun/ballistic/rocketlauncher/Initialize()
+	. = ..()
+	AddElement(/datum/element/backblast)
+
 /obj/item/gun/ballistic/rocketlauncher/unrestricted
 	pin = /obj/item/firing_pin
 

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -15,3 +15,48 @@
 	if(location)
 		new /obj/effect/hotspot(location)
 		location.hotspot_expose(700, 50, 1)
+
+/// Used in [the backblast element][/datum/element/backblast]
+/obj/projectile/bullet/incendiary/backblast
+	damage = 20
+	range = 10 // actually overwritten in the backblast element
+	alpha = 0
+	pass_flags = PASSMOB
+	sharpness = SHARP_NONE
+	shrapnel_type = null
+	embedding = null
+	ricochet_chance = 10000
+	ricochets_max = 4
+	ricochet_incidence_leeway = 0
+	suppressed = SUPPRESSED_VERY
+	damage_type = BURN
+	flag = BOMB
+	speed = 1.2
+	wound_bonus = 30
+	bare_wound_bonus = 30
+
+	/// Lazy attempt at knockback, any items this plume hits will be knocked back this far. Decrements with each tile passed.
+	var/knockback_range = 7
+	/// A lazylist of all the items we've already knocked back, so we don't do it again
+	var/list/launched_items
+
+/obj/projectile/bullet/incendiary/backblast/on_hit(atom/target, blocked = 0)
+	if(isliving(target))
+		var/mob/living/incineratee = target
+		incineratee.take_bodypart_damage(0, damage, wound_bonus=wound_bonus, bare_wound_bonus=bare_wound_bonus)
+		incineratee.adjust_fire_stacks(fire_stacks)
+	return ..()
+
+/obj/projectile/bullet/incendiary/backblast/Move()
+	. = ..()
+	if(knockback_range <= 0)
+		return
+	knockback_range--
+	var/turf/current_turf = get_turf(src)
+	var/turf/throw_at_turf = get_turf_in_angle(Angle, current_turf, 10)
+
+	for(var/obj/item/I in current_turf.contents)
+		if(I.anchored || LAZYFIND(launched_items, I))
+			continue
+		I.throw_at(throw_at_turf, knockback_range, knockback_range)
+		LAZYADD(launched_items, I)

--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -9,6 +9,7 @@
 	explosion(target, -1, 0, 2)
 	return BULLET_ACT_HIT
 
+/// PM9 HEDP rocket
 /obj/projectile/bullet/a84mm
 	name ="\improper HEDP rocket"
 	desc = "USE A WEEL GUN"
@@ -31,22 +32,24 @@
 		S.take_overall_damage(anti_armour_damage*0.75, anti_armour_damage*0.25)
 	return BULLET_ACT_HIT
 
+/// PM9 standard rocket
 /obj/projectile/bullet/a84mm_he
 	name ="\improper HE missile"
 	desc = "Boom."
 	icon_state = "missile"
-	damage = 30
+	damage = 50
 	ricochets_max = 0 //it's a MISSILE
 	embedding = null
 
 /obj/projectile/bullet/a84mm_he/on_hit(atom/target, blocked=0)
 	..()
 	if(!isliving(target)) //if the target isn't alive, so is a wall or something
-		explosion(target, 0, 1, 2, 4)
+		explosion(target, 0, 1, 2, 4, flame_range = 3)
 	else
-		explosion(target, 0, 0, 2, 4)
+		explosion(target, 0, 1, 2, 4, flame_range = 3)
 	return BULLET_ACT_HIT
 
+/// Mech BRM-6 missile
 /obj/projectile/bullet/a84mm_br
 	name ="\improper HE missile"
 	desc = "Boom."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -570,6 +570,7 @@
 #include "code\datums\diseases\advance\symptoms\weight.dm"
 #include "code\datums\diseases\advance\symptoms\youth.dm"
 #include "code\datums\elements\_element.dm"
+#include "code\datums\elements\backblast.dm"
 #include "code\datums\elements\bsa_blocker.dm"
 #include "code\datums\elements\cleaning.dm"
 #include "code\datums\elements\digitalcamo.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The PM9 rocket launcher is a really sad little thing, with its standard rockets doing a paltry 30 damage on impact and a (0, 0, 2, 4) explosion (no fire even) when hitting a living mob. This means even a direct hit may not be enough to crit an unarmored target. The HEDP is a little bit better, but it's still nowhere fun enough for a ROCKET LAUNCHER. So I finally got around to an old promise and wrote up a backblast element, and gave it to the rocket launcher. I also made the standard rockets for the rocket launcher do a bit more impact damage and have some flames in their explosion, to make them less terribly sad.

[![dreamseeker_2020-09-08_21-30-24.png](https://i.imgur.com/l53U6aXl.jpg)](https://i.imgur.com/l53U6aX.png)
_A screenshot of a backblast cloud midway through propagating, just after firing to the upper right_

This element can be attached to guns and causes a/several plumes of fire to go shooting out behind you when you fire said gun. These plumes of fire will bounce off any solid surface and burn any poor sap caught in its bullrush, as well as knocking any loose items left nearby away at high speeds. You can take a look at a WIP example here:

https://cdn.discordapp.com/attachments/326831214667235328/753059098550993056/backblast_Trim.mp4

I still have some neatening up and embellishing to do with the specifics of the plumes and the item knockbacks, and I definitely need to do some tweaking to the balance to make sure the backblast finds a nice level of power that makes it fun to use without being horribly OP. Stay tuned!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives nuke ops a reason to buy the rocket launcher, as well as a potential high-risk high-reward strategy of running up to a group of soft targets and firing directly away from them to scald them all with the backblast. Makes the rocket launcher more fun in general.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
add: The rocket launcher now creates a giant backblast of fire and pressure when fired, be sure that you don't shoot it off from a corner (unless you're fireproof)!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
