### PR TITLE
Fix incorrect proc signature for /mob/living/proc/Life

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -1,7 +1,7 @@
 /// This divisor controls how fast body temperature changes to match the environment
 #define BODYTEMP_DIVISOR 8
 
-/mob/living/proc/Life(seconds, times_fired)
+/mob/living/proc/Life(times_fired)
 	set waitfor = FALSE
 
 	if((movement_type & FLYING) && !(movement_type & FLOATING))	//TODO: Better floating


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#52981 changed how Life() procs were called.

It also forgot to re-define the Life proc signature after doing so.

This gives Life the appropriate signature.

The part that changed which broke breathing via Life()
![image](https://user-images.githubusercontent.com/24975989/92547260-6427fd00-f24c-11ea-9a6d-83fb7aa0deea.png)

What we currently experience on live. `times_fired` is null and `null % anything` is always TRUE.
![image](https://user-images.githubusercontent.com/24975989/92547272-6f7b2880-f24c-11ea-807a-353a7abb2d09.png)

After the fix, expected behaviour restored.
![image](https://user-images.githubusercontent.com/24975989/92547357-9d606d00-f24c-11ea-8b84-cfae3f15ef1d.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Our intended breathing mechanic of once every 4 life ticks became every single life tick, effectively making mobs breathe 4 times as often as they should. Oh, my dear Atmos subsystem, how you must be crying in pain!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Living things should no longer hyperventilate 24/7 and will once again breathe at more leisurely pace.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
