### PR TITLE
Add a confirmation for harvesting Replica Pods with associated ckeys/minds that aren't ready to be revived.

### DIFF
--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -101,28 +101,13 @@
 					ckey_holder = M.ckey
 					break
 
-	if(make_podman)	//all conditions met!
-		var/mob/living/carbon/human/podman = new /mob/living/carbon/human(parent.loc)
-		if(realName)
-			podman.real_name = realName
-		else
-			podman.real_name = "Pod Person ([rand(1,999)])"
-		mind.transfer_to(podman)
-		if(ckey)
-			podman.ckey = ckey
-		else
-			podman.ckey = ckey_holder
-		podman.gender = blood_gender
-		podman.faction |= factions
-		if(!features["mcolor"])
-			features["mcolor"] = "#59CE00"
-		for(var/V in quirks)
-			new V(podman)
-		podman.hardset_dna(null,null,null,podman.real_name,blood_type, new /datum/species/pod,features)//Discard SE's and UI's, podman cloning is inaccurate, and always make them a podman
-		podman.set_cloned_appearance()
-		log_cloning("[key_name(mind)] cloned as a podman via [src] in [parent] at [AREACOORD(parent)].")
+	// No podman player, give one or two seeds.
+	if(!make_podman)
+		// Prevent accidental harvesting. Make sure the user REALLY wants to do this.
+		var/choice = alert("The pod is currently devoid of soul. There is a possibility that a soul could claim this creature, or you could harvest it for seeds.", "Harvest Seeds?", "Harvest Seeds", "Cancel")
+		if(choice == "Cancel")
+			return result
 
-	else //else, one packet of seeds. maybe two
 		var/seed_count = 1
 		if(prob(getYield() * 20))
 			seed_count++
@@ -131,6 +116,30 @@
 			var/obj/item/seeds/replicapod/harvestseeds = src.Copy()
 			result.Add(harvestseeds)
 			harvestseeds.forceMove(output_loc)
+		parent.update_tray()
+		return result
+
+	// Congratulations! %Do you want to build a pod man?%
+	var/mob/living/carbon/human/podman = new /mob/living/carbon/human(parent.loc)
+
+	if(realName)
+		podman.real_name = realName
+	else
+		podman.real_name = "Pod Person ([rand(1,999)])"
+	mind.transfer_to(podman)
+	if(ckey)
+		podman.ckey = ckey
+	else
+		podman.ckey = ckey_holder
+	podman.gender = blood_gender
+	podman.faction |= factions
+	if(!features["mcolor"])
+		features["mcolor"] = "#59CE00"
+	for(var/V in quirks)
+		new V(podman)
+	podman.hardset_dna(null,null,null,podman.real_name,blood_type, new /datum/species/pod,features)//Discard SE's and UI's, podman cloning is inaccurate, and always make them a podman
+	podman.set_cloned_appearance()
+	log_cloning("[key_name(mind)] cloned as a podman via [src] in [parent] at [AREACOORD(parent)].")
 
 	parent.update_tray()
 	return result

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -116,6 +116,11 @@
 			to_chat(user, text = "This pod has already had its seeds harvested!", type = MESSAGE_TYPE_INFO)
 			return result
 
+		// Make sure they can still interact with the parent hydroponics tray.
+		if(!parent.can_interact(user))
+			to_chat(user, text = "You are no longer able to harvets the seeds from [parent]!", type = MESSAGE_TYPE_INFO)
+			return result
+
 		var/seed_count = 1
 		if(prob(getYield() * 20))
 			seed_count++

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -24,6 +24,7 @@
 	var/list/quirks
 	var/sampleDNA
 	var/contains_sample = FALSE
+	var/being_harvested = FALSE
 
 /obj/item/seeds/replicapod/Initialize()
 	. = ..()
@@ -103,10 +104,17 @@
 
 	// No podman player, give one or two seeds.
 	if(!make_podman)
-		// Prevent accidental harvesting. Make sure the user REALLY wants to do this.
-		var/choice = alert("The pod is currently devoid of soul. There is a possibility that a soul could claim this creature, or you could harvest it for seeds.", "Harvest Seeds?", "Harvest Seeds", "Cancel")
-		if(choice == "Cancel")
-			return result
+		// Prevent accidental harvesting. Make sure the user REALLY wants to do this if there's a chance of this coming from a living creature.
+		if(mind || ckey)
+			var/choice = alert("The pod is currently devoid of soul. There is a possibility that a soul could claim this creature, or you could harvest it for seeds.", "Harvest Seeds?", "Harvest Seeds", "Cancel")
+			if(choice == "Cancel")
+				return result
+
+		// If this plant has already been harvested, return early.
+		// parent.update_tray() qdels this seed.
+		if(QDELETED(src))
+			to_chat(user, text = "This pod has already had its seeds harvested!", type = MESSAGE_TYPE_INFO)
+			return list()
 
 		var/seed_count = 1
 		if(prob(getYield() * 20))

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -114,7 +114,7 @@
 		// parent.update_tray() qdels this seed.
 		if(QDELETED(src))
 			to_chat(user, text = "This pod has already had its seeds harvested!", type = MESSAGE_TYPE_INFO)
-			return list()
+			return result
 
 		var/seed_count = 1
 		if(prob(getYield() * 20))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tweak a code path to do an early return.

Add an alert box before the user harvests a Replica Pod if that Replica Pod is going to give you seeds but it has a mind or ckey associated with it.

![image](https://user-images.githubusercontent.com/24975989/92548238-68edb080-f24e-11ea-97e7-2144e80a1b99.png)

[Edit] - Additionally, I've protected against where two people try to harvest at once and spamming the crap outta the hydro trays to bring up a dozen prompts. A successful harvest will result in the seeds being qdel'd and thus a simple QDELETED check after the confirmation prompt is accepted should suffice to guard against any weirdness.

![image](https://user-images.githubusercontent.com/24975989/92623861-be61a600-f2be-11ea-8f89-8160d38cdff1.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Botanists gave me feedback that it sucks to harvest a replica pod of a person before they're dead, either through accidentally clicking, not realising the replica pod target is still alive or even though other well-meaning players harvesting them and thinking they're helping a revival.

Now there's no ambiguity. If these seeds have a mind or ckey associated with them, a simple confirmation box makes sure the player REALLY wants to harvest seeds instead of waiting for a fully formed pod person.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Added a confirmation prompt before harvesting a fully grown Replica Pod that has been associated with a player, but the player is not yet dead or ready to be revived. Gives you the choice of backing out or harvesting them for seeds. Functionality unchanged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
