### PR TITLE
Skip app execution aliases when searching for Python

### DIFF
--- a/tools/hooks/python.sh
+++ b/tools/hooks/python.sh
@@ -1,15 +1,25 @@
 #!/bin/sh
 # `sh` must be used here instead of `bash` to support GitHub Desktop.
 set -e
+
+# Strip the "App Execution Aliases" from $PATH. Even if the user installed
+# Python using the Windows Store on purpose, these aliases always generate
+# "Permission denied" errors when sh.exe tries to invoke them.
+PATH=$(echo "$PATH" | tr ":" "\n" | grep -v "AppData/Local/Microsoft/WindowsApps" | tr "\n" ":")
+
+# Try to find a Python executable.
 if command -v python3 >/dev/null 2>&1; then
 	PY=python3
 elif command -v python >/dev/null 2>&1; then
 	PY=python
 elif command -v py >/dev/null 2>&1; then
-	PY=py
+	PY="py -3"
 else
-	echo "Please install Python 3.6 or later."
+	echo "Please install Python from https://www.python.org/downloads/"
+	exit 1
 fi
+
+# Deduce the path separator and add the mapmerge package to the search path.
 PATHSEP=$($PY - <<'EOF'
 import sys, os
 if sys.version_info.major != 3 or sys.version_info.minor < 6:


### PR DESCRIPTION
An attempt to finally solve this thorn in my side.

The issue: https://stackoverflow.com/questions/56974927/permission-denied-trying-to-run-python-on-windows-10