### PR TITLE
[READY]Canisters no more give runtime error on shuttle loading

### DIFF
--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -14,15 +14,12 @@
 
 	var/maximum_pressure = 90 * ONE_ATMOSPHERE
 
-/obj/machinery/portable_atmospherics/New()
-	..()
-	SSair.atmos_machinery += src
-
 /obj/machinery/portable_atmospherics/Initialize()
 	. = ..()
 	air_contents = new
 	air_contents.volume = volume
 	air_contents.temperature = T20C
+	SSair.atmos_machinery += src
 
 /obj/machinery/portable_atmospherics/Destroy()
 	SSair.atmos_machinery -= src


### PR DESCRIPTION
## About The Pull Request

portable_atmospherics no more give runtime error on map loading

## Why It's Good For The Game

Runtime error is bad.

## Changelog
:cl:
fix: canisters no more give runtime error on shuttle loading
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
