### PR TITLE
Icebox multi-z mining now obeys the laws of gravity.

### DIFF
--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -41,7 +41,7 @@
          "Gravity":true,
          "Ice Ruins":true,
          "Weather_Snowstorm":true,
-         "Baseturf":"/turf/open/floor/plating/asteroid/snow/icemoon"
+         "Baseturf":"/turf/open/transparent/openspace/icemoon"
       }
    ],
    "minetype":"none"

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -287,6 +287,7 @@
 		/turf/closed/mineral/gibtonite/ice/icemoon = 4, /obj/item/stack/ore/bluespace_crystal = 1)
 
 /turf/closed/mineral/random/snow/underground
+	baseturfs = /turf/open/floor/plating/asteroid/snow/icemoon
 	// abundant ore and caves
 	mineralChance = 20
 	mineralSpawnChanceList = list(

--- a/code/game/turfs/open/floor/plating/asteroid.dm
+++ b/code/game/turfs/open/floor/plating/asteroid.dm
@@ -199,7 +199,7 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 	name = "snow"
 	desc = "Looks cold."
 	icon = 'icons/turf/snow.dmi'
-	baseturfs = /turf/open/floor/plating/asteroid/snow/icemoon
+	baseturfs = /turf/open/transparent/openspace/icemoon
 	icon_state = "snow"
 	icon_plating = "snow"
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
@@ -466,7 +466,7 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 	return FALSE
 
 /turf/open/floor/plating/asteroid/snow/icemoon
-	baseturfs = /turf/open/floor/plating/asteroid/snow/icemoon
+	baseturfs = /turf/open/transparent/openspace/icemoon
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
 	slowdown = 0
 

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -165,4 +165,5 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 	var/turf/closed/mineral/M = T
 	M.mineralAmt = 0
 	M.gets_drilled()
+	baseturfs = /turf/open/transparent/openspace/icemoon //This is to ensure that IF random turf generation produces a openturf, there won't be other turfs assigned other than openspace.
 


### PR DESCRIPTION
Okay, this one is a doozy.

## About The Pull Request

So, lets tell you the story of how we got here first, before we start writing any angry mining main letters.
So, there was a minor bug with icebox mining, where if you placed a lattice over openspace, it would place a snowturf, then then 
a lattice over-top the empty space.
Sounds like an easy fix, right?
Well, the multi-z map JSON file defaulted to any non-basement level defaulting to the regular snow turf. so I swapped that out for openspace. Didn't work.
Turns out, that snow turfs created by random mapgen would always place snow tiles overtop the randomly forming holes in the ground, and as a result could be abused to get both your lattice rods and the snow turf built, covering over that hole... forever. What's the point of a multi-z experience with depth if snow turfs can never be dug down into?
So, I did some quick changes and compiled about half a dozen times to make sure this all works properly because we all know how reliable the lavaland mapgen is, ya know?
(For Reference: I'll be referring to the levels as Level 1(Where the station is.), Level 2(Where mining department/public mining is), and Level 3(Where the lava spawns.)
Now: Levels 1 and 2 both have their baseturf set to whitespace. Particularly powerful explosions will now create a hole into the basement level. This is random and not a 100% chance to occur, but repeatedly bombing a single spot can easily create this as a hazard.
Level 3 remains the basement level, and still defaults to frozen plasma/just snow if bombed in a similar manner.
On levels 1 and 2, if you use an RCD to deconstruct the snow, you will break a manual hole into the lower z-level.

## Why It's Good For The Game

Well, uh, I fixed that tiny bug! /s
For real, having better integration between different z-levels, and forcing lower levels to interact with the higher levels of the station is a fun goal, and I'd like to see more situations where the station has to work out situations like a rescue mission for a crew-member whose fallen down a crater in the middle of the station.

## Changelog
:cl:
tweak: RCDing the top 2 levels of icebox's snow will create an open gap, where you can fall between z-levels.
tweak: Bombing an area heavily on icebox's top 2 floors can also result in chasms leading to the second level.
fix: Building atop openspace on icebox no longer produces magical snow under your lattices.
/:cl: