### PR TITLE
Fixes a runtime for ModPCs running Plexagon Access Management without a secondary card slot

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -103,7 +103,6 @@
 	var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
 	var/obj/item/computer_hardware/card_slot/card_slot2 = all_components[MC_CARD2]
 	if(!(card_slot || card_slot2))
-		//to_chat(user, "<span class='warning'>There isn't anywhere you can fit a card into on this computer.</span>")
 		return FALSE
 
 	var/obj/item/card/inserting_id = inserting_item.RemoveID()
@@ -112,7 +111,6 @@
 
 	if((card_slot?.try_insert(inserting_id)) || (card_slot2?.try_insert(inserting_id)))
 		return TRUE
-	//to_chat(user, "<span class='warning'>This computer doesn't have an open card slot.</span>")
 	return FALSE
 
 /obj/item/modular_computer/MouseDrop(obj/over_object, src_location, over_location)
@@ -350,6 +348,11 @@
 
 
 /obj/item/modular_computer/attackby(obj/item/W as obj, mob/user as mob)
+	// Check for ID first
+	if(istype(W, /obj/item/card/id))
+		if(InsertID(W))
+			return
+
 	// Insert items into the components
 	for(var/h in all_components)
 		var/obj/item/computer_hardware/H = all_components[h]

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -349,9 +349,8 @@
 
 /obj/item/modular_computer/attackby(obj/item/W as obj, mob/user as mob)
 	// Check for ID first
-	if(istype(W, /obj/item/card/id))
-		if(InsertID(W))
-			return
+	if(istype(W, /obj/item/card/id) && InsertID(W))
+		return
 
 	// Insert items into the components
 	for(var/h in all_components)

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -320,32 +320,31 @@
 /datum/computer_file/program/card_mod/ui_data(mob/user)
 	var/list/data = get_header_data()
 
+	data["station_name"] = station_name()
+
 	var/obj/item/computer_hardware/card_slot/card_slot2
 	var/obj/item/computer_hardware/printer/printer
 
 	if(computer)
 		card_slot2 = computer.all_components[MC_CARD2]
 		printer = computer.all_components[MC_PRINT]
-
-	data["station_name"] = station_name()
-
-	if(computer)
 		data["have_id_slot"] = !!(card_slot2)
-		data["have_printer"] = !!printer
+		data["have_printer"] = !!(printer)
 	else
 		data["have_id_slot"] = FALSE
 		data["have_printer"] = FALSE
 
 	data["authenticated"] = authenticated
+	if(!card_slot2)
+		return data //We're just gonna error out on the js side at this point anyway
 
-	if(computer)
-		var/obj/item/card/id/id_card = card_slot2.stored_card
-		data["has_id"] = !!id_card
-		data["id_name"] = id_card ? id_card.name : "-----"
-		if(id_card)
-			data["id_rank"] = id_card.assignment ? id_card.assignment : "Unassigned"
-			data["id_owner"] = id_card.registered_name ? id_card.registered_name : "-----"
-			data["access_on_card"] = id_card.access
+	var/obj/item/card/id/id_card = card_slot2.stored_card
+	data["has_id"] = !!id_card
+	data["id_name"] = id_card ? id_card.name : "-----"
+	if(id_card)
+		data["id_rank"] = id_card.assignment ? id_card.assignment : "Unassigned"
+		data["id_owner"] = id_card.registered_name ? id_card.registered_name : "-----"
+		data["access_on_card"] = id_card.access
 
 	return data
 

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -52,14 +52,10 @@
 	if(..())
 		return
 
-	var/authed = FALSE
-	var/mob/user = usr
-	var/obj/item/card/id/user_id = user.get_idcard()
-	if(user_id)
-		if(ACCESS_CHANGE_IDS in user_id.access)
-			authed = TRUE
+	var/obj/item/computer_hardware/card_slot/card_slot = computer.all_components[MC_CARD]
+	var/obj/item/card/id/user_id = card_slot?.stored_card
 
-	if(!authed)
+	if(!user_id || !(ACCESS_CHANGE_IDS in user_id.access))
 		return
 
 	switch(action)
@@ -107,10 +103,10 @@
 	var/list/data = get_header_data()
 
 	var/authed = FALSE
-	var/obj/item/card/id/user_id = user.get_idcard(FALSE)
-	if(user_id)
-		if(ACCESS_CHANGE_IDS in user_id.access)
-			authed = TRUE
+	var/obj/item/computer_hardware/card_slot/card_slot = computer.all_components[MC_CARD]
+	var/obj/item/card/id/user_id = card_slot?.stored_card
+	if(user_id && (ACCESS_CHANGE_IDS in user_id.access))
+		authed = TRUE
 
 	data["authed"] = authed
 

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -1,5 +1,5 @@
 /obj/item/computer_hardware/card_slot
-	name = "identification card authentication module"	// \improper breaks the find_hardware_by_name proc
+	name = "primary RFID card module"	// \improper breaks the find_hardware_by_name proc
 	desc = "A module allowing this computer to read or write data on ID cards. Necessary for some programs to run properly."
 	power_usage = 10 //W
 	icon_state = "card_mini"
@@ -106,8 +106,10 @@
 	expansion_hw = !expansion_hw
 	if(expansion_hw)
 		device_type = MC_CARD2
+		name = "secondary RFID card module"
 	else
 		device_type = MC_CARD
+		name = "primary RFID card module"
 
 /obj/item/computer_hardware/card_slot/examine(mob/user)
 	. = ..()
@@ -116,5 +118,6 @@
 		. += "There appears to be something loaded in the card slots."
 
 /obj/item/computer_hardware/card_slot/secondary
+	name = "secondary RFID card module"
 	device_type = MC_CARD2
 	expansion_hw = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As said by the title.

Also fixes an oversight where the Plexagon HR Core app (job management) was reading worn ID rather than inserted ID.

Also adds names to differentiate between primary and secondary card readers so both show on the screwdriver remove menu.

Also makes using IDs on a modPC actually call the InsertID proc, so that having the secondary ID come first in the list of parts doesn't give it priority.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtimes are rude.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed a runtime with Plexagon Access Management when the second ID slot is missing.
fix: Plexagon Access Management now follows the standard for ID reading and requires you to insert your card.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
~~Since this computer takes so long to set up test servers I'm just gonna PR this now and fix the PR if the code isn't correct.~~ Works as intended