### PR TITLE
Fixes pretty much all spells having 10 times longer cooldowns than intended.

### DIFF
--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -105,8 +105,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 	var/charge_type = "recharge" //can be recharge or charges, see charge_max and charge_counter descriptions; can also be based on the holder's vars now, use "holder_var" for that
 
-	var/charge_max = 10 //recharge time in seconds if charge_type = "recharge" or starting charges if charge_type = "charges"
-	var/charge_counter = 0 //can only cast spells if it equals recharge, ++ each second if charge_type = "recharge" or -- each cast if charge_type = "charges"
+	var/charge_max = 10 SECONDS //recharge time in deciseconds if charge_type = "recharge" or starting charges if charge_type = "charges"
+	var/charge_counter = 0 //can only cast spells if it equals recharge, ++ each decisecond if charge_type = "recharge" or -- each cast if charge_type = "charges"
 	var/still_recharging_msg = "<span class='notice'>The spell is still recharging.</span>"
 	var/recharging = TRUE
 

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -302,7 +302,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 /obj/effect/proc_holder/spell/process(delta_time)
 	if(recharging && charge_type == "recharge" && (charge_counter < charge_max))
-		charge_counter += delta_time
+		charge_counter += delta_time SECONDS
 		if(charge_counter >= charge_max)
 			action.UpdateButtonIcon()
 			charge_counter = charge_max

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -302,7 +302,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 /obj/effect/proc_holder/spell/process(delta_time)
 	if(recharging && charge_type == "recharge" && (charge_counter < charge_max))
-		charge_counter += delta_time SECONDS
+		charge_counter += delta_time * 10
 		if(charge_counter >= charge_max)
 			action.UpdateButtonIcon()
 			charge_counter = charge_max


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #53595
Fixes #53593

We're back again with my second fix related to #52981

This time spells! More specifically targetting wizard spells, but fixing anything that relies on proc_holder/spell in general - Including Revenants! How quaint! And heretics. Devil contracts and spells. Slaughter demon's blood crawl. Genetics powers. You know what? It just fixes everything. Ever. Oh yeah. And Santa's spell. Don't forget about Santa.

![image](https://user-images.githubusercontent.com/24975989/92678019-f7306800-f31c-11ea-8133-e32eec80486d.png)

So anyway. What broke?

![image](https://user-images.githubusercontent.com/24975989/92674707-c862c380-f315-11ea-8bcf-1620b601a474.png)

Spell proc_holders previously assumed a process() happened every 2 ticks and incremented charge_counter by 2.

They're now given a delta_time in seconds rather than in ticks.

![image](https://user-images.githubusercontent.com/24975989/92674806-02cc6080-f316-11ea-928b-84a13d7c84ce.png)

This causes them to increment charge_counter by 0.2 instead of 2.

As a result, they're charging 10 times slower.

I just added the SECONDS macro to delta_time's value when it's added to charge_counter which effectively converts delta_time to its representation in ticks.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## VV Workaround For Admins

For an antag type such as Wizard who is able to pick all their spells in advance, the following will prove exceedingly useful.

![image](https://user-images.githubusercontent.com/24975989/92679928-a96a2e80-f321-11ea-9bee-37374591cd42.png)

`UPDATE /obj/effect/proc_holder/spell SET charge_max = charge_max / 10`

Note that any spells chosen AFTER this will still need to be changed manually. Similarly, geneticists, heretics and any others that get their spells and abilities over time may still need manual changes.

A VV method to accomplish that is below.

VV the player. Under `actions`, there should be a list of various spells. Each of these spells should have a `target` which is an `/obj/effect/proc_holder/spell` of some sort.

Locate the `charge_max` in this proc_holder/spell and divide it by 10. This will effectively grant the spell an equivalent cooldown to what it should have. 

![image](https://user-images.githubusercontent.com/24975989/92676053-b46c9100-f318-11ea-9399-d0bc090fe00b.png)

## Why It's Good For The Game

Wizards are no longer useless with spells that have 10-fold increased cooldowns. Revenant spell cooldowns aren't 5 plus minutes. Basically, everyone gets happier except non-antags.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Various spells and abilities across reventants, wizards, genetics, heretics and others, no longer have cooldowns 10 times longer than expected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
