### PR TITLE
Changes the acronym of the Enhanced Interrogation Chamber

### DIFF
--- a/code/game/machinery/hypnochair.dm
+++ b/code/game/machinery/hypnochair.dm
@@ -1,5 +1,5 @@
 /obj/machinery/hypnochair
-	name = "enhanced interrogation chamber"
+	name = "enhanced prisoner interrogation chamber"
 	desc = "A device used to perform \"enhanced interrogation\" through invasive mental conditioning."
 	icon = 'icons/obj/machines/implantchair.dmi'
 	icon_state = "hypnochair"

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1195,7 +1195,7 @@
 		/obj/item/stock_parts/micro_laser = /obj/item/stock_parts/micro_laser/quadultra)
 
 /obj/item/circuitboard/machine/hypnochair
-	name = "Enhanced Interrogation Chamber (Machine Board)"
+	name = "Enhanced Prisoner Interrogation Chamber (Machine Board)"
 	icon_state = "security"
 	build_path = /obj/machinery/hypnochair
 	req_components = list(

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -169,8 +169,8 @@
 	category = list ("Medical Machinery")
 
 /datum/design/board/hypnochair
-	name = "Machine Design (Enhanced Interrogation Chamber)"
-	desc = "Allows for the construction of circuit boards used to build an Enhanced Interrogation Chamber."
+	name = "Machine Design (Enhanced Prisoner Interrogation Chamber)"
+	desc = "Allows for the construction of circuit boards used to build an Enhanced Prisoner Interrogation Chamber."
 	id = "hypnochair"
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 	build_path = /obj/item/circuitboard/machine/hypnochair

--- a/tgui/packages/tgui/interfaces/HypnoChair.js
+++ b/tgui/packages/tgui/interfaces/HypnoChair.js
@@ -12,7 +12,7 @@ export const HypnoChair = (props, context) => {
         <Section
           title="Information"
           backgroundColor="#450F44">
-          The Enhanced Interrogation Chamber is designed to induce a
+          The Enhanced Prisoner Interrogation Chamber is designed to induce a
           deep-rooted trance trigger into the subject. Once the procedure
           is complete, by using the implanted trigger phrase, the
           authorities are able to ensure immediate and complete obedience


### PR DESCRIPTION
## About The Pull Request

The Enhanced Interrogation Chamber's name has been changed. It is now the Enhanced Prisoner Interrogation Chamber.

## Why It's Good For The Game

Let's say, someone has added a machine to the game. Let's also say, hypothetically, that this machine's acronym was one letter off from being a very cool word. Okay, and if this machine's acronym went from not being a very cool word to being a very cool word, then that would improve the game that that machine was in, right? So, therefore, adding a letter to that machine's acronym by adding an extra word to its name would improve the game that that machine was in.

Logically, then, adding an extra word to the name of the Enhance Interrogation Chamber would improve SS13.

## Changelog
:cl: ATHATH
tweak: The Enhanced Interrogation Chamber's name has been changed. It is now the Enhanced Prisoner Interrogation Chamber.
/:cl:
