### PR TITLE
Nerfs Flashes [Edge Awards 2020]

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -145,7 +145,8 @@
 			else
 				to_chat(M, "<span class='userdanger'>You are flashed by [src]!</span>")
 			//easy way to make sure that you can only long stun someone who is facing in your direction
-			M.Paralyze(rand(60,80)*(1-deviation/2))
+			M.adjustStaminaLoss(rand(80,120)*(1-deviation/2))
+			M.Paralyze(rand(25,50)*(1-deviation/2))
 
 		else if(user)
 			visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>","<span class='danger'>[user] fails to blind you with the flash!</span>")

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -152,18 +152,21 @@
 			if(M.get_confusion() < power)
 				var/diff = power * CONFUSION_STACK_MAX_MULTIPLIER - M.get_confusion()
 				M.add_confusion(min(power, diff))
-			if(converter)
-				if(converter.owner.current.a_intent == INTENT_HELP && deviation == 2)
-					to_chat(user, "<span class='notice'>Your stance is too weak to flash [M] from behind!</span>")
-					visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>","<span class='danger'>[user] fails to blind you with the flash!</span>")
-					return
-				terrible_conversion_proc(M, user)
-				if(deviation == 2)
-					to_chat(user, "<span class='notice'>You use the tacticool tier, lean over the shoulder technique to blind [M] with a flash!</span>")
-					deviation = 1
-				visible_message("<span class='danger'>[user] blinds [M] with the flash!</span>","<span class='userdanger'>[user] blinds you with the flash!</span>")
-			else
-				to_chat(M, "<span class='userdanger'>You are flashed by [src]!</span>")
+			// Special check for if we're a revhead. Special cases to attempt conversion.
+				if(converter)
+					// Did we try to flash them from behind?
+					if(deviation == 2)
+						// If we did and we're on help intent, fail with a feedback message and return.
+						if(converter.owner.current.a_intent == INTENT_HELP)
+							to_chat(user, "<span class='notice'>You try to use the tacticool tier, lean over the shoulder technique to blind [M] from behind but your poor combat stance causes you to stumble!</span>")
+							visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>","<span class='danger'>[user] fails to blind you with the flash!</span>")
+							return
+						// Otherwise, tacticool leaning technique engaged for sideways-stun power.
+						to_chat(user, "<span class='notice'>You use the tacticool tier, lean over the shoulder technique to blind [M] with a flash!</span>")
+						deviation = 1
+					// Convert them. Terribly.
+					terrible_conversion_proc(M, user)
+					visible_message("<span class='danger'>[user] blinds [M] with the flash!</span>","<span class='userdanger'>[user] blinds you with the flash!</span>")
 			//easy way to make sure that you can only long stun someone who is facing in your direction
 			M.adjustStaminaLoss(rand(80,120)*(1-(deviation*0.5)))
 			M.Paralyze(rand(25,50)*(1-(deviation*0.5)))

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -155,7 +155,7 @@
 			else
 				to_chat(M, "<span class='userdanger'>You are flashed by [src]!</span>")
 			//easy way to make sure that you can only long stun someone who is facing in your direction
-			M.adjustStaminaLoss(rand(80,120)*(1-deviation/2))
+			M.adjustStaminaLoss(rand(80,120)*(1-(deviation*0.5)))
 			M.Paralyze(rand(25,50)*(1-(deviation*0.5)))
 
 		else if(user)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -154,6 +154,7 @@
 				M.add_confusion(min(power, diff))
 			if(converter)
 				if(converter.owner.current.a_intent == INTENT_HELP && deviation == 2)
+					to_chat(user, "<span class='notice'>Your stance is too weak to flash [M] from behind!</span>")
 					visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>","<span class='danger'>[user] fails to blind you with the flash!</span>")
 					return
 				terrible_conversion_proc(M, user)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -156,7 +156,7 @@
 				to_chat(M, "<span class='userdanger'>You are flashed by [src]!</span>")
 			//easy way to make sure that you can only long stun someone who is facing in your direction
 			M.adjustStaminaLoss(rand(80,120)*(1-deviation/2))
-			M.Paralyze(rand(25,50)*(1-deviation/2))
+			M.Paralyze(rand(25,50)*(1-(deviation*0.5)))
 
 		else if(user)
 			visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>","<span class='danger'>[user] fails to blind you with the flash!</span>")

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -152,7 +152,7 @@
 			if(M.get_confusion() < power)
 				var/diff = power * CONFUSION_STACK_MAX_MULTIPLIER - M.get_confusion()
 				M.add_confusion(min(power, diff))
-			// Special check for if we're a revhead. Special cases to attempt conversion.
+				// Special check for if we're a revhead. Special cases to attempt conversion.
 				if(converter)
 					// Did we try to flash them from behind?
 					if(deviation == 2)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -114,7 +114,17 @@
 /obj/item/assembly/flash/proc/flash_end()
 	set_light_on(FALSE)
 
-///Awfully bad proc that flashes carbons. this really fucking needs a refactor
+/**
+  * Handles actual flashing part of the attack
+  *
+  *	This proc is awful in every sense of the way, someone should definately refactor this whole code.
+  * Arguments:
+  * * M - Victim
+  * * user - Attacker
+  *	* power - handles the amount of confusion it gives you
+  * * targeted - determines if it was aoe or targeted
+  * * generic_message - checks if it should display default message.
+  */
 /obj/item/assembly/flash/proc/flash_carbon(mob/living/carbon/M, mob/user, power = 15, targeted = TRUE, generic_message = FALSE)
 	if(!istype(M))
 		return
@@ -157,7 +167,14 @@
 			var/diff = power * CONFUSION_STACK_MAX_MULTIPLIER - M.get_confusion()
 			M.add_confusion(min(power, diff))
 
-///Returns a value of deviation, 0 means they face the same direction, 2 means they face away from eachother.
+/**
+  * Handles the directionality of the attack
+  *
+  *	Returns the amount of 'deviation', 0 being facing eachother, 1 being sideways, 2 being facing away from eachother.
+  * Arguments:
+  * * M - Victim
+  * * user - Attacker
+  */
 /obj/item/assembly/flash/proc/calculate_deviation(mob/living/carbon/M, mob/user)
 	var/dir1 = M.dir
 	var/dir2 = turn(user.dir,180)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -114,6 +114,7 @@
 /obj/item/assembly/flash/proc/flash_end()
 	set_light_on(FALSE)
 
+///Awfully bad proc that flashes carbons. this really fucking needs a refactor
 /obj/item/assembly/flash/proc/flash_carbon(mob/living/carbon/M, mob/user, power = 15, targeted = TRUE, generic_message = FALSE)
 	if(!istype(M))
 		return

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -237,28 +237,28 @@
   * Converts the victim to revs
   *
   * Arguments:
-  * * M - Victim
-  * * user - Attacker
+  * * victim - Victim
+  * * aggressor - Attacker
   */
-/obj/item/assembly/flash/proc/terrible_conversion_proc(mob/living/carbon/H, mob/user)
-	if(!istype(H) || H.stat == DEAD)
+/obj/item/assembly/flash/proc/terrible_conversion_proc(mob/living/carbon/victim, mob/aggressor)
+	if(!istype(victim) || victim.stat == DEAD)
 		return
-	if(!user.mind)
+	if(!aggressor.mind)
 		return
-	if(!H.client)
-		to_chat(user, "<span class='warning'>This mind is so vacant that it is not susceptible to influence!</span>")
+	if(!victim.client)
+		to_chat(aggressor, "<span class='warning'>This mind is so vacant that it is not susceptible to influence!</span>")
 		return
-	if(H.stat != CONSCIOUS)
-		to_chat(user, "<span class='warning'>They must be conscious before you can convert [H.p_them()]!</span>")
+	if(victim.stat != CONSCIOUS)
+		to_chat(aggressor, "<span class='warning'>They must be conscious before you can convert [victim.p_them()]!</span>")
 		return
 	//If this proc fires the mob must be a revhead
-	var/datum/antagonist/rev/head/converter = user.mind.has_antag_datum(/datum/antagonist/rev/head)
-	if(converter.add_revolutionary(H.mind))
+	var/datum/antagonist/rev/head/converter = aggressor.mind.has_antag_datum(/datum/antagonist/rev/head)
+	if(converter.add_revolutionary(victim.mind))
 		if(prob(1) || SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
-			H.say("You son of a bitch! I'm in.", forced = "That son of a bitch! They're in.")
+			victim.say("You son of a bitch! I'm in.", forced = "That son of a bitch! They're in.")
 		times_used -- //Flashes less likely to burn out for headrevs when used for conversion
 	else
-		to_chat(user, "<span class='warning'>This mind seems resistant to the flash!</span>")
+		to_chat(aggressor, "<span class='warning'>This mind seems resistant to the flash!</span>")
 
 
 /obj/item/assembly/flash/cyborg

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -146,12 +146,16 @@
 	if(deviation == 2 && !converter)
 		return
 
+
 	if(targeted)
 		if(M.flash_act(1, 1))
 			if(M.get_confusion() < power)
 				var/diff = power * CONFUSION_STACK_MAX_MULTIPLIER - M.get_confusion()
 				M.add_confusion(min(power, diff))
 			if(converter)
+				if(converter.owner.current.a_intent == INTENT_HELP && deviation == 2)
+					visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>","<span class='danger'>[user] fails to blind you with the flash!</span>")
+					return
 				terrible_conversion_proc(M, user)
 				if(deviation == 2)
 					to_chat(user, "<span class='notice'>You use the tacticool tier, lean over the shoulder technique to blind [M] with a flash!</span>")


### PR DESCRIPTION
## About The Pull Request

Flashes now deal stamina damage and micro-stun, they deal higher damage than batons BUT they have a severe disadavntage in form of directionality. Stamina damage and the duration of the micro stun is determined by direction your enemy is facing.

Facing towards you - full stun

Facing perpendicular to you - half of stun

Facing away from you - nothing

## Why It's Good For The Game

Flashes are too op, especially since we are moving away from hardstuns and towards stamina based damage. With the overabundance of flashes this should be a good change

## Changelog
:cl:
balance: Flashes now stun for shorter and the duration of the stun is based on the direction of your enemy.
/:cl:

