### PR TITLE
RPD unwrench upgrade

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -113,6 +113,8 @@
 #define RCD_UPGRADE_SILO_LINK (1<<2)
 #define RCD_UPGRADE_FURNISHING (1<<3)
 
+#define RPD_UPGRADE_UNWRENCH (1<<4)
+
 #define RCD_WINDOW_FULLTILE "full tile"
 #define RCD_WINDOW_DIRECTIONAL "directional"
 #define RCD_WINDOW_NORMAL "glass"

--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -113,7 +113,7 @@
 #define RCD_UPGRADE_SILO_LINK (1<<2)
 #define RCD_UPGRADE_FURNISHING (1<<3)
 
-#define RPD_UPGRADE_UNWRENCH (1<<4)
+#define RPD_UPGRADE_UNWRENCH (1<<0)
 
 #define RCD_WINDOW_FULLTILE "full tile"
 #define RCD_WINDOW_DIRECTIONAL "directional"

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -212,6 +212,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/static/datum/pipe_info/first_disposal
 	var/static/datum/pipe_info/first_transit
 	var/mode = BUILD_MODE | DESTROY_MODE | WRENCH_MODE
+	var/upgrade = FALSE
 
 /obj/item/pipe_dispenser/Initialize()
 	. = ..()
@@ -234,6 +235,16 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 /obj/item/pipe_dispenser/attack_self(mob/user)
 	ui_interact(user)
+
+/obj/item/construction/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/rpd_upgrade))
+		var/obj/item/rpd_upgrade/rpd_up = W
+		if(!(upgrade & rpd_up.upgrade))
+			upgrade |= rpd_up.upgrade
+			playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
+			qdel(W)
+	else
+		return ..()
 
 /obj/item/pipe_dispenser/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] points the end of the RPD down [user.p_their()] throat and presses a button! It looks like [user.p_theyre()] trying to commit suicide...</span>")

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -238,14 +238,13 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	ui_interact(user)
 
 /obj/item/pipe_dispenser/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/rpd_upgrade))
-		var/obj/item/rpd_upgrade/rpd_up = W
-		if(!(upgrade & rpd_up.upgrade))
-			upgrade |= rpd_up.upgrade
-			playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-			qdel(W)
-	else
-		return ..()
+	if(!istype(W, /obj/item/rpd_upgrade))
+		return ..()	
+	var/obj/item/rpd_upgrade/rpd_up = W
+	if(!(upgrade & rpd_up.upgrade))
+		upgrade |= rpd_up.upgrade
+		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
+		qdel(W)
 
 /obj/item/pipe_dispenser/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] points the end of the RPD down [user.p_their()] throat and presses a button! It looks like [user.p_theyre()] trying to commit suicide...</span>")
@@ -351,9 +350,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/queued_p_flipped = p_flipped
 
 	//Unwrench pipe before we build one over/paint it.
-	if((mode & DESTROY_MODE) && (upgrade & RPD_UPGRADE_UNWRENCH))
-		if(istype(A, /obj/machinery/atmospherics))
-			A = A.wrench_act(user, src)	
+	if((mode & DESTROY_MODE) && (upgrade & RPD_UPGRADE_UNWRENCH) && istype(A, /obj/machinery/atmospherics))
+		A = A.wrench_act(user, src)	
 
 	//make sure what we're clicking is valid for the current category
 	var/static/list/make_pipe_whitelist

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -212,7 +212,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/static/datum/pipe_info/first_disposal
 	var/static/datum/pipe_info/first_transit
 	var/mode = BUILD_MODE | DESTROY_MODE | WRENCH_MODE
-	var/upgrade = FALSE
+	///Hold upgrade flags
+	var/upgrade
 
 /obj/item/pipe_dispenser/Initialize()
 	. = ..()
@@ -359,7 +360,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 	. = TRUE
 
-	if((mode & DESTROY_MODE) && (upgrade & RPD_UPGRADE_UNWRENCH)
+	if((mode & DESTROY_MODE) && (upgrade & RPD_UPGRADE_UNWRENCH))
 		if(istype(A, /obj/machinery/atmospherics))
 			A = A.wrench_act(user, src)		
 
@@ -497,3 +498,14 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 #undef DESTROY_MODE
 #undef PAINT_MODE
 #undef WRENCH_MODE
+
+/obj/item/rpd_upgrade
+	name = "RPD advanced design disk"
+	desc = "It seems to be empty."
+	icon = 'icons/obj/module.dmi'
+	icon_state = "datadisk3"
+	var/upgrade
+
+/obj/item/rpd_upgrade/unwrench
+	desc = "Adds reverse wrench mode to the RPD. Attention, due to budget cuts, the mode is hard linked to the destroy mode control button."
+	upgrade = RPD_UPGRADE_UNWRENCH

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -348,6 +348,10 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 	. = TRUE
 
+	if((mode & DESTROY_MODE) && (upgrade & RPD_UPGRADE_UNWRENCH)
+		if(istype(A, /obj/machinery/atmospherics))
+			A = A.wrench_act(user, src)		
+
 	if((mode & DESTROY_MODE) && istype(A, /obj/item/pipe) || istype(A, /obj/structure/disposalconstruct) || istype(A, /obj/structure/c_transit_tube) || istype(A, /obj/structure/c_transit_tube_pod) || istype(A, /obj/item/pipe_meter))
 		to_chat(user, "<span class='notice'>You start destroying a pipe...</span>")
 		playsound(get_turf(src), 'sound/machines/click.ogg', 50, TRUE)

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -350,6 +350,11 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/queued_p_dir = p_dir
 	var/queued_p_flipped = p_flipped
 
+	//Unwrench pipe before we build one over/paint it.
+	if((mode & DESTROY_MODE) && (upgrade & RPD_UPGRADE_UNWRENCH))
+		if(istype(A, /obj/machinery/atmospherics))
+			A = A.wrench_act(user, src)	
+
 	//make sure what we're clicking is valid for the current category
 	var/static/list/make_pipe_whitelist
 	if(!make_pipe_whitelist)
@@ -359,10 +364,6 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/can_make_pipe = (isturf(A) || is_type_in_typecache(A, make_pipe_whitelist))
 
 	. = TRUE
-
-	if((mode & DESTROY_MODE) && (upgrade & RPD_UPGRADE_UNWRENCH))
-		if(istype(A, /obj/machinery/atmospherics))
-			A = A.wrench_act(user, src)		
 
 	if((mode & DESTROY_MODE) && istype(A, /obj/item/pipe) || istype(A, /obj/structure/disposalconstruct) || istype(A, /obj/structure/c_transit_tube) || istype(A, /obj/structure/c_transit_tube_pod) || istype(A, /obj/item/pipe_meter))
 		to_chat(user, "<span class='notice'>You start destroying a pipe...</span>")

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -213,7 +213,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/static/datum/pipe_info/first_transit
 	var/mode = BUILD_MODE | DESTROY_MODE | WRENCH_MODE
 	///Hold upgrade flags
-	var/upgrade
+	var/upgrade_flags
 
 /obj/item/pipe_dispenser/Initialize()
 	. = ..()
@@ -241,8 +241,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	if(!istype(W, /obj/item/rpd_upgrade))
 		return ..()	
 	var/obj/item/rpd_upgrade/rpd_up = W
-	if(!(upgrade & rpd_up.upgrade))
-		upgrade |= rpd_up.upgrade
+	if(!(upgrade_flags & rpd_up.upgrade_flags))
+		upgrade_flags |= rpd_up.upgrade_flags
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 		qdel(W)
 
@@ -350,7 +350,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/queued_p_flipped = p_flipped
 
 	//Unwrench pipe before we build one over/paint it.
-	if((mode & DESTROY_MODE) && (upgrade & RPD_UPGRADE_UNWRENCH) && istype(A, /obj/machinery/atmospherics))
+	if((mode & DESTROY_MODE) && (upgrade_flags & RPD_UPGRADE_UNWRENCH) && istype(A, /obj/machinery/atmospherics))
 		A = A.wrench_act(user, src)	
 
 	//make sure what we're clicking is valid for the current category
@@ -503,8 +503,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	desc = "It seems to be empty."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "datadisk3"
-	var/upgrade
+	var/upgrade_flags
 
 /obj/item/rpd_upgrade/unwrench
 	desc = "Adds reverse wrench mode to the RPD. Attention, due to budget cuts, the mode is hard linked to the destroy mode control button."
-	upgrade = RPD_UPGRADE_UNWRENCH
+	upgrade_flags = RPD_UPGRADE_UNWRENCH

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -237,7 +237,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /obj/item/pipe_dispenser/attack_self(mob/user)
 	ui_interact(user)
 
-/obj/item/construction/attackby(obj/item/W, mob/user, params)
+/obj/item/pipe_dispenser/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/rpd_upgrade))
 		var/obj/item/rpd_upgrade/rpd_up = W
 		if(!(upgrade & rpd_up.upgrade))

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -246,7 +246,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /**
   * Installs an upgrade into the RPD
   *
-  *  Installs an upgrade into the RPD checking if it is already installed
+  * Installs an upgrade into the RPD checking if it is already installed
   * Arguments:
   * * rpd_up - RPD upgrade
   * * user - mob that use upgrade on RPD

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -212,7 +212,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/static/datum/pipe_info/first_disposal
 	var/static/datum/pipe_info/first_transit
 	var/mode = BUILD_MODE | DESTROY_MODE | WRENCH_MODE
-	///Hold upgrade flags
+	/// Bitflags for upgrades
 	var/upgrade_flags
 
 /obj/item/pipe_dispenser/Initialize()
@@ -238,13 +238,19 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	ui_interact(user)
 
 /obj/item/pipe_dispenser/attackby(obj/item/W, mob/user, params)
-	if(!istype(W, /obj/item/rpd_upgrade))
-		return ..()	
-	var/obj/item/rpd_upgrade/rpd_up = W
-	if(!(upgrade_flags & rpd_up.upgrade_flags))
-		upgrade_flags |= rpd_up.upgrade_flags
-		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-		qdel(W)
+	if(istype(W, /obj/item/rpd_upgrade))
+		install_upgrade(W, user)
+		return TRUE
+	return ..()
+
+/// Installs an upgrade into the RPD checking if it is already installed
+/obj/item/pipe_dispenser/proc/install_upgrade(obj/item/rpd_upgrade/rpd_up, mob/user)
+	if(rpd_up.upgrade & upgrade_flags)
+		to_chat(user, "<span class='warning'>[src] has already installed this upgrade!</span>")
+		return
+	upgrade_flags |= rpd_up.upgrade
+	playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
+	qdel(rpd_up)
 
 /obj/item/pipe_dispenser/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] points the end of the RPD down [user.p_their()] throat and presses a button! It looks like [user.p_theyre()] trying to commit suicide...</span>")
@@ -503,6 +509,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	desc = "It seems to be empty."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "datadisk3"
+	/// Bitflags for upgrades
 	var/upgrade_flags
 
 /obj/item/rpd_upgrade/unwrench

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -245,10 +245,10 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 /// Installs an upgrade into the RPD checking if it is already installed
 /obj/item/pipe_dispenser/proc/install_upgrade(obj/item/rpd_upgrade/rpd_up, mob/user)
-	if(rpd_up.upgrade & upgrade_flags)
+	if(rpd_up.upgrade_flags& upgrade_flags)
 		to_chat(user, "<span class='warning'>[src] has already installed this upgrade!</span>")
 		return
-	upgrade_flags |= rpd_up.upgrade
+	upgrade_flags |= rpd_up.upgrade_flags
 	playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
 	qdel(rpd_up)
 

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -243,7 +243,14 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 		return TRUE
 	return ..()
 
-/// Installs an upgrade into the RPD checking if it is already installed
+/**
+  * Installs an upgrade into the RPD
+  *
+  *  Installs an upgrade into the RPD checking if it is already installed
+  * Arguments:
+  * * rpd_up - RPD upgrade
+  * * user - mob that use upgrade on RPD
+  */
 /obj/item/pipe_dispenser/proc/install_upgrade(obj/item/rpd_upgrade/rpd_up, mob/user)
 	if(rpd_up.upgrade_flags& upgrade_flags)
 		to_chat(user, "<span class='warning'>[src] has already installed this upgrade!</span>")

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -216,7 +216,7 @@
 		//You unwrenched a pipe full of pressure? Let's splat you into the wall, silly.
 		if(unsafe_wrenching)
 			unsafe_pressure_release(user, internal_pressure)
-		deconstruct(TRUE)
+		return deconstruct(TRUE)
 	return TRUE
 
 /obj/machinery/atmospherics/proc/can_unwrench(mob/user)
@@ -247,6 +247,7 @@
 			if(!disassembled)
 				stored.obj_integrity = stored.max_integrity * 0.5
 			transfer_fingerprints_to(stored)
+			. = stored
 	..()
 
 /obj/machinery/atmospherics/proc/getpipeimage(iconset, iconstate, direction, col=rgb(255,255,255), piping_layer=3, trinary = FALSE)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -239,6 +239,7 @@
 	// speed is pressures / 1250
 	user.throw_at(get_edge_target_turf(user, get_dir(src, user) || pick(GLOB.cardinals)), pressures / 250, pressures / 1250)
 
+/// Pipe deconstruction proc. Return created pipe fitting.
 /obj/machinery/atmospherics/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(can_unwrench)

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -93,6 +93,16 @@
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
+/datum/design/rpd_upgrade/unwrench
+	name = "RPD unwrenching upgrade"
+	desc = "Adds reverse wrench mode to the RPD. Attention, due to budget cuts, the mode is hard linked to the destroy mode control button."
+	id = "rpd_upgrade_unwrench"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 5000, /datum/material/glass = 2500)
+	build_path = /obj/item/rpd_upgrade/unwrench
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+
 /datum/design/rld_mini
 	name = "Mini Rapid Light Device (MRLD)"
 	desc = "A tool that can portable and standing lighting orbs and glowsticks."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -542,8 +542,6 @@
 	prereq_ids = list("rcd_upgrade", "bluespace_travel")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
-
-
 /////////////////////////weaponry tech/////////////////////////
 /datum/techweb_node/weaponry
 	id = "weaponry"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -528,9 +528,9 @@
 
 /datum/techweb_node/rcd_upgrade
 	id = "rcd_upgrade"
-	display_name = "RCD designs upgrade"
-	description = "Unlocks new RCD designs."
-	design_ids = list("rcd_upgrade_frames", "rcd_upgrade_simple_circuits", "rcd_upgrade_furnishing")
+	display_name = "RCD/RPD designs upgrade"
+	description = "Unlocks new RCD/RPD designs."
+	design_ids = list("rcd_upgrade_frames", "rcd_upgrade_simple_circuits", "rcd_upgrade_furnishing", "rpd_upgrade_unwrench")
 	prereq_ids = list("adv_engi")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
@@ -541,6 +541,8 @@
 	design_ids = list("rcd_upgrade_silo_link")
 	prereq_ids = list("rcd_upgrade", "bluespace_travel")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+
+
 
 /////////////////////////weaponry tech/////////////////////////
 /datum/techweb_node/weaponry

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -528,8 +528,8 @@
 
 /datum/techweb_node/rcd_upgrade
 	id = "rcd_upgrade"
-	display_name = "RCD/RPD designs upgrade"
-	description = "Unlocks new RCD/RPD designs."
+	display_name = "rapid device upgrade designs"
+	description = "Unlocks new designs that improve rapid devices."
 	design_ids = list("rcd_upgrade_frames", "rcd_upgrade_simple_circuits", "rcd_upgrade_furnishing", "rpd_upgrade_unwrench")
 	prereq_ids = list("adv_engi")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)


### PR DESCRIPTION
## About The Pull Request

Adds reverse wrench mode upgrade to the RPD.
Attention, due to budget cuts, the mode is hard linked to the destroy mode control button.
finished #53607

Now `/obj/machinery/atmospherics/deconstruct(disassembled = TRUE)` return created `obj/item/pipe`

## Why It's Good For The Game

OP atmostech is good

## Changelog
:cl:
add: Reverse wrench mode upgrade to the RPD. Attention, due to budget cuts, the mode is hard linked to the destroy mode control button.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
