### PR TITLE
Guide to Dank Mimery now uses a radial menu

### DIFF
--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -56,34 +56,41 @@
 
 /obj/item/book/mimery
 	name = "Guide to Dank Mimery"
-	desc = "A primer on basic pantomime."
-	icon_state ="bookmime"
+	desc = "Teaches one of three classic pantomime routines, allowing a practiced mime to conjure invisible objects into corporeal existence. One use only."
+	icon_state = "bookmime"
 
-/obj/item/book/mimery/attack_self(mob/user,)
-	user.set_machine(src)
-	var/dat = "<B>Guide to Dank Mimery</B><BR>"
-	dat += "Teaches one of three classic pantomime routines, allowing a practiced mime to conjure invisible objects into corporeal existence.<BR>"
-	dat += "Once you have mastered your routine, this book will have no more to say to you.<BR>"
-	dat += "<HR>"
-	dat += "<A href='byond://?src=[REF(src)];invisible_wall=1'>Invisible Wall</A><BR>"
-	dat += "<A href='byond://?src=[REF(src)];invisible_chair=1'>Invisible Chair</A><BR>"
-	dat += "<A href='byond://?src=[REF(src)];invisible_box=1'>Invisible Box</A><BR>"
-	user << browse(dat, "window=book")
-
-/obj/item/book/mimery/Topic(href, href_list)
-	..()
-	if (usr.stat || usr.restrained() || src.loc != usr)
-		return
-	if (!ishuman(usr))
-		return
-	var/mob/living/carbon/human/H = usr
-	if(H.is_holding(src) && H.mind)
-		H.set_machine(src)
-		if (href_list["invisible_wall"])
-			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall(null))
-		if (href_list["invisible_chair"])
-			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_chair(null))
-		if (href_list["invisible_box"])
-			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_box(null))
-	to_chat(usr, "<span class='notice'>The book disappears into thin air.</span>")
+/obj/item/book/mimery/attack_self(mob/user)
+	var/list/spell_icons = list(
+		"Invisible Wall" = image(icon = 'icons/mob/actions/actions_mime.dmi', icon_state = "invisible_wall"),
+		"Invisible Chair" = image(icon = 'icons/mob/actions/actions_mime.dmi', icon_state = "invisible_chair"),
+		"Invisible Box" = image(icon = 'icons/mob/actions/actions_mime.dmi', icon_state = "invisible_box")
+		)
+	var/picked_spell = show_radial_menu(user, src, spell_icons, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
+	switch(picked_spell)
+		if("Invisible Wall")
+			user.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall(null))
+		if("Invisible Chair")
+			user.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_chair(null))
+		if("Invisible Box")
+			user.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_box(null))
+		else
+			return
+	to_chat(user, "<span class='warning'>The book disappears into thin air.</span>")
 	qdel(src)
+
+/**
+  * Checks if we are allowed to interact with a radial menu
+  *
+  * Arguments:
+  * * user The human mob interacting with the menu
+  */
+/obj/item/book/mimery/proc/check_menu(mob/living/carbon/human/user)
+	if(!istype(user))
+		return FALSE
+	if(!user.is_holding(src))
+		return FALSE
+	if(user.incapacitated())
+		return FALSE
+	if(!user.mind)
+		return FALSE
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR makes Guides to Dank Mimery use a radial menu as a method for choosing mime spells, instead of using an outdated html browser menu. Old book text was moved to the item description instead to make it clear what it does.

**OLD:**

![DankMimeryOLD](https://user-images.githubusercontent.com/43862960/92782616-618ceb00-f3a5-11ea-9f99-08c642d9c148.png)

**NEW:**           

![MimeryRadial](https://user-images.githubusercontent.com/43862960/92782174-0ce97000-f3a5-11ea-9e04-934db500bee2.png)

## Why It's Good For The Game

Better spell selection method.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arkatos
add: Guide to Dank Mimery now uses a radial menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
