### PR TITLE
Organ removal ends metabolizing reagents in the organ

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -60,6 +60,13 @@
 
 //Special is for instant replacement like autosurgeons
 /obj/item/organ/proc/Remove(mob/living/carbon/M, special = FALSE)
+	//Stop any reagent metabolizing on organ destruction
+	if(reagents && iscarbon(owner))
+		var/mob/living/carbon/body = owner
+		for(var/bit in reagents.reagent_list)
+			var/datum/reagent/_reagent = bit
+			_reagent.on_mob_end_metabolize(body)
+
 	owner = null
 	if(M)
 		M.internal_organs -= src

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -64,12 +64,12 @@
 	if(reagents && iscarbon(owner))
 		var/mob/living/carbon/body = owner
 		for(var/chem in reagents.reagent_list)
-			var/datum/reagent/_reagent = chem
-			if(!_reagent.metabolizing)
+			var/datum/reagent/reagent = chem
+			if(!reagent.metabolizing)
 				continue
-			_reagent.metabolizing = FALSE
-			_reagent.on_mob_end_metabolize(body)
-			_reagent.on_mob_delete(body) //It was removed from the body
+			reagent.metabolizing = FALSE
+			reagent.on_mob_end_metabolize(body)
+			reagent.on_mob_delete(body) //It was removed from the body
 
 	owner = null
 	if(M)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -63,9 +63,13 @@
 	//Stop any reagent metabolizing on organ destruction
 	if(reagents && iscarbon(owner))
 		var/mob/living/carbon/body = owner
-		for(var/bit in reagents.reagent_list)
-			var/datum/reagent/_reagent = bit
+		for(var/chem in reagents.reagent_list)
+			var/datum/reagent/_reagent = body
+			if(!_reagent.metabolizing)
+				continue
+			_reagent.metabolizing = FALSE
 			_reagent.on_mob_end_metabolize(body)
+			_reagent.on_mob_delete(body) //It was removed from the body
 
 	owner = null
 	if(M)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -64,7 +64,7 @@
 	if(reagents && iscarbon(owner))
 		var/mob/living/carbon/body = owner
 		for(var/chem in reagents.reagent_list)
-			var/datum/reagent/_reagent = body
+			var/datum/reagent/_reagent = chem
 			if(!_reagent.metabolizing)
 				continue
 			_reagent.metabolizing = FALSE

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -65,10 +65,9 @@
 		var/mob/living/carbon/body = owner
 		for(var/chem in reagents.reagent_list)
 			var/datum/reagent/reagent = chem
-			if(!reagent.metabolizing)
-				continue
-			reagent.metabolizing = FALSE
-			reagent.on_mob_end_metabolize(body)
+			if(reagent.metabolizing)
+				reagent.metabolizing = FALSE
+				reagent.on_mob_end_metabolize(body)
 			reagent.on_mob_delete(body) //It was removed from the body
 
 	owner = null

--- a/code/modules/unit_tests/stomach.dm
+++ b/code/modules/unit_tests/stomach.dm
@@ -2,6 +2,8 @@
 	var/mob/living/carbon/human/human = allocate(/mob/living/carbon/human)
 	var/obj/item/reagent_containers/food/snacks/hotdog/fooditem = allocate(/obj/item/reagent_containers/food/snacks/hotdog)
 	var/obj/item/organ/stomach/belly = human.getorganslot(ORGAN_SLOT_STOMACH)
+	var/obj/item/reagent_containers/pill/pill = allocate(/obj/item/reagent_containers/pill)
+	var/datum/reagent/drug/methamphetamine/meth = /datum/reagent/drug/methamphetamine
 
 	TEST_ASSERT_EQUAL(human.has_reagent(/datum/reagent/consumable/ketchup), FALSE, "Human somehow has ketchup before eating")
 
@@ -10,9 +12,19 @@
 	TEST_ASSERT(human.has_reagent(/datum/reagent/consumable/ketchup), "Human doesn't have ketchup after eating")
 	TEST_ASSERT(belly.reagents.has_reagent(/datum/reagent/consumable/ketchup), "Stomach doesn't have ketchup after eating")
 
-	qdel(belly)
+	//Give them meth and let it kick in
+	pill.reagents.add_reagent(meth, initial(meth.metabolization_rate) * 1.9)
+	pill.attack(human, human)
+	human.Life()
+
+	TEST_ASSERT(belly.reagents.has_reagent(/datum/reagent/consumable/ketchup), "Stomach doesn't have ketchup after eating")
+	TEST_ASSERT(human.has_reagent(meth), "Human does not have meth in their system after consuming it")
+	TEST_ASSERT(human.has_movespeed_modifier(/datum/movespeed_modifier/reagent/methamphetamine), "Human consumed meth, but did not gain movespeed modifier")
+
+	belly.Remove(human)
 
 	TEST_ASSERT_EQUAL(human.has_reagent(/datum/reagent/consumable/ketchup), FALSE, "Human still has ketchup after removal of stomach")
+	TEST_ASSERT(!human.has_movespeed_modifier(/datum/movespeed_modifier/reagent/methamphetamine), "Human still has movespeed modifier despite not containing any more meth")
 
 	fooditem.attack(human, human)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If an organ contains reagents it will end metabolizing them on removal.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more perma buffs for removal of an organ.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Organ removal stops reagent reactions on the host
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
