### PR TITLE
Meta fixes for several locations

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -29518,6 +29518,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "brI" = (
@@ -30879,7 +30880,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment,
@@ -63453,14 +63453,6 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
-"dkq" = (
-/obj/structure/cable,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=13.2-Tcommstore";
-	location = "13.1-Engineering-Enter"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "dkR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -65003,6 +64995,13 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
+"dRL" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "dUu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -65264,15 +65263,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "elm" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "elp" = (
@@ -67502,11 +67499,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"hkq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "hkv" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -67981,6 +67973,7 @@
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/photocopier,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "hRK" = (
@@ -68441,10 +68434,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/filingcabinet,
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/filingcabinet,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "iJH" = (
@@ -69558,6 +69554,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"khK" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=13.2-Tcommstore";
+	location = "13.1-Engineering-Enter"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "kiy" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -70044,8 +70051,17 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kIL" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -70166,20 +70182,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"kRO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Engineering Desk";
-	req_one_access_txt = "24;32"
-	},
-/obj/item/folder/yellow,
-/obj/item/folder/yellow,
-/obj/item/pen,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "kSe" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -72383,6 +72385,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment,
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32;
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ogE" = (
@@ -72625,8 +72631,17 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ovx" = (
 /obj/structure/disposalpipe/segment{
@@ -74084,6 +74099,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32;
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qqg" = (
@@ -74369,6 +74388,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qEY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Engineering Desk";
+	req_one_access_txt = "24;32"
+	},
+/obj/item/folder/yellow,
+/obj/item/pen,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "qFk" = (
 /obj/structure/rack,
 /obj/item/book/manual/wiki/infections{
@@ -74810,7 +74843,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "riF" = (
-/obj/structure/cable,
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -74839,12 +74871,6 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "rjV" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/folder/yellow{
-	pixel_x = 4
-	},
-/obj/item/pen,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -74852,15 +74878,19 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/table/reinforced,
+/obj/item/clipboard{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/folder/yellow{
+	pixel_x = 4
+	},
 /obj/machinery/requests_console{
 	department = "Engineering";
 	departmentType = 3;
 	name = "Engineering RC";
 	pixel_x = -30
-	},
-/obj/item/clipboard{
-	pixel_x = 4;
-	pixel_y = -4
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -76001,10 +76031,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/photocopier,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/computer/station_alert{
+	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "sPc" = (
@@ -76132,10 +76162,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"tbp" = (
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "tbu" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -76996,15 +77022,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "usN" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/computer/station_alert{
-	dir = 4
+/obj/structure/chair/office{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -77226,8 +77251,17 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uJl" = (
 /obj/structure/cable,
@@ -77242,10 +77276,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uLp" = (
@@ -77751,15 +77785,16 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "vzO" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "vAj" = (
@@ -79677,8 +79712,17 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "yax" = (
 /obj/effect/turf_decal/tile/red,
@@ -116817,7 +116861,7 @@ bcx
 aZw
 aZw
 uuj
-gjw
+khK
 bkY
 alq
 boY
@@ -118616,7 +118660,7 @@ aWw
 aWw
 aWw
 bhQ
-dkq
+bjw
 lqU
 dhW
 dhW
@@ -120419,9 +120463,9 @@ wim
 blj
 bhT
 bhT
-bhT
 nde
-kRO
+qEY
+nde
 bhT
 bxc
 bAD
@@ -120933,8 +120977,8 @@ bjI
 ecs
 rxn
 djm
-sao
-hkq
+dRL
+rxn
 sao
 hRs
 bxc
@@ -121448,7 +121492,7 @@ blo
 grU
 rYV
 blk
-tbp
+bjL
 rWg
 oBU
 bxc

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -95,9 +95,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aap" = (
-/obj/machinery/newscaster{
-	pixel_x = -28
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -60822,12 +60819,12 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 1
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dbh" = (
 /obj/machinery/light{
 	dir = 1
 	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dbh" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
 	name = "Cooling Loop Bypass"
@@ -62360,9 +62357,6 @@
 /area/engine/engineering)
 "dfF" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/cable,
@@ -71807,9 +71801,6 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 8
 	},
@@ -74870,6 +74861,9 @@
 	name = "Service Shutter"
 	},
 /obj/item/pen,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "roZ" = (
@@ -77135,6 +77129,19 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/aft/secondary)
+"uIw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "uIS" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/structure/window/reinforced{
@@ -77697,6 +77704,9 @@
 	},
 /obj/structure/displaycase/forsale/kitchen{
 	pixel_y = 8
+	},
+/obj/machinery/newscaster{
+	pixel_x = -28
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -112629,13 +112639,13 @@ bjo
 bkT
 bmL
 bmP
-bmP
+bBS
 fGa
-bBS
-aEc
 bDC
+aEc
 bBS
 bBS
+bmP
 bmP
 bmP
 bmP
@@ -122637,7 +122647,7 @@ dfb
 dfj
 dlI
 deD
-dfE
+uIw
 dfT
 aVe
 alq

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -29421,6 +29421,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/newscaster{
+	pixel_x = 28
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "brn" = (
@@ -64574,10 +64577,6 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_x = -4;
-	pixel_y = 7
-	},
 /obj/machinery/navbeacon/wayfinding/bar,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -64585,6 +64584,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/item/reagent_containers/glass/rag,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "dDf" = (
@@ -65448,7 +65448,13 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/checker,
 /area/engine/atmos)
 "ezE" = (
 /obj/structure/disposalpipe/segment{
@@ -70868,7 +70874,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/rag,
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_x = -4;
+	pixel_y = 7
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "lWY" = (
@@ -79722,6 +79731,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "yax" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -34523,7 +34523,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen_counter";
-	name = "Service Shutter"
+	name = "Kitchen Counter Shutters"
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -34535,7 +34535,7 @@
 /obj/item/reagent_containers/food/snacks/pie/cream,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen_counter";
-	name = "Service Shutter"
+	name = "Kitchen Counter Shutters"
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -44800,7 +44800,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen_counter";
-	name = "Service Shutter"
+	name = "Kitchen Counter Shutters"
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -66807,7 +66807,7 @@
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen_counter";
-	name = "Service Shutter"
+	name = "Kitchen Counter Shutters"
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -68471,6 +68471,16 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"iLR" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "iMF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -71799,6 +71809,9 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
+	},
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/storage_shared)
@@ -76524,12 +76537,12 @@
 "tJz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/structure/displaycase/forsale/kitchen{
-	pixel_y = 8
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen_counter";
-	name = "Service Shutter"
+	name = "Kitchen Counter Shutters"
+	},
+/obj/structure/displaycase/forsale/kitchen{
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -115210,7 +115223,7 @@ scu
 bYh
 hhf
 duF
-ccw
+iLR
 bST
 ceZ
 cgq

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -32725,14 +32725,14 @@
 	icon_state = "map-left-MS";
 	pixel_y = 32
 	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics - Control Room"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/structure/tank_dispenser{
 	pixel_x = -1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
@@ -69346,7 +69346,7 @@
 	location = "Atmospherics"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "jTg" = (
 /obj/structure/disposalpipe/segment{
@@ -69537,7 +69537,9 @@
 	id = "atmos";
 	name = "Atmospherics Blast Door"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "kfZ" = (
@@ -72394,10 +72396,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32;
-	pixel_y = -32
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ogE" = (
@@ -79732,6 +79730,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32;
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "yax" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -89,8 +89,8 @@
 /area/hallway/secondary/command)
 "aao" = (
 /obj/machinery/vending/cigarette,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
+/obj/machinery/newscaster{
+	pixel_x = -28
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -15278,6 +15278,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -32027,6 +32030,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "byC" = (
@@ -33904,6 +33908,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDC" = (
@@ -33927,9 +33934,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "bDK" = (
-/obj/structure/sign/poster/random{
-	pixel_y = -32
-	},
 /obj/structure/chair/wood/wings{
 	dir = 8
 	},
@@ -33938,6 +33942,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/light_switch{
+	pixel_x = -26;
+	pixel_y = -26
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -34453,9 +34465,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -35045,8 +35054,6 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/rag,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
@@ -35055,6 +35062,11 @@
 	pixel_x = -28;
 	pixel_y = -28
 	},
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe"
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "bHc" = (
@@ -35094,11 +35106,14 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/processor,
+/obj/machinery/processor{
+	pixel_y = 12
+	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bHl" = (
@@ -35607,6 +35622,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bIB" = (
@@ -39285,10 +39301,6 @@
 "bRX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/item/radio/intercom{
-	pixel_x = -27;
-	pixel_y = -29
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -40118,23 +40130,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"bUn" = (
-/obj/structure/sink{
-	pixel_y = 22
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "bUq" = (
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 5
@@ -40526,6 +40521,11 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bVx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/structure/sink{
+	pixel_y = 22
+	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -40533,7 +40533,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bVy" = (
@@ -41874,7 +41873,6 @@
 /area/teleporter)
 "bYr" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bYu" = (
@@ -46628,9 +46626,6 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
@@ -63467,7 +63462,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "dkR" = (
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -64591,9 +64585,6 @@
 /obj/item/book/manual/wiki/barman_recipes{
 	pixel_x = -4;
 	pixel_y = 7
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
 	},
 /obj/machinery/navbeacon/wayfinding/bar,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -65733,6 +65724,9 @@
 	name = "Hipster Glasses"
 	},
 /obj/machinery/light/small,
+/obj/structure/sign/poster/random{
+	pixel_y = -32
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "eUZ" = (
@@ -66216,6 +66210,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"fCX" = (
+/obj/item/radio/intercom{
+	pixel_y = -25
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "fDB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
@@ -68230,6 +68234,17 @@
 /obj/machinery/gulag_teleporter,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"isV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/bar,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "itG" = (
 /obj/machinery/newscaster{
 	pixel_x = 1;
@@ -68439,9 +68454,6 @@
 	dir = 1
 	},
 /obj/item/clothing/head/that,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -69220,11 +69232,11 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
-	pixel_x = -6;
+	pixel_x = 6;
 	pixel_y = 6
 	},
 /obj/item/reagent_containers/food/drinks/shaker{
-	pixel_x = 6
+	pixel_x = -6
 	},
 /obj/machinery/camera{
 	c_tag = "Bar - Counter";
@@ -69452,11 +69464,13 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "jZS" = (
@@ -69562,6 +69576,18 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"kja" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Bar"
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "kjh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/vehicle/ridden/janicart,
@@ -70019,7 +70045,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/hallway/primary/starboard)
 "kIL" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -70746,6 +70772,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lOC" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "lOR" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Primary Treatment Maintenance";
@@ -70805,12 +70840,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
 "lUi" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "lUr" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -70834,10 +70865,8 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe"
-	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/rag,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "lWY" = (
@@ -71039,6 +71068,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "mfN" = (
@@ -71422,6 +71452,24 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard)
+"mGc" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "mHF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -72024,6 +72072,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"nLy" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "nLU" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -72113,6 +72170,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
+"nPl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "nPC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -72175,6 +72236,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
+"nVM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "nWN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed/roller,
@@ -72357,13 +72429,6 @@
 /turf/closed/wall,
 /area/science/misc_lab/range)
 "ojm" = (
-/obj/machinery/light_switch{
-	pixel_y = -28
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/structure/musician/piano,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -72561,7 +72626,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/hallway/primary/starboard)
 "ovx" = (
 /obj/structure/disposalpipe/segment{
@@ -73364,24 +73429,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
-"pzW" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "pAv" = (
 /obj/structure/table,
 /obj/structure/window,
@@ -73500,6 +73547,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74172,6 +74222,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qwO" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32;
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "qxe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel,
@@ -74277,6 +74339,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison/safe)
+"qCy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"qCJ" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "qEU" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/virology/glass{
@@ -74630,17 +74707,6 @@
 "rch" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/security/prison)
-"rcB" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "rcH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -77161,7 +77227,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/hallway/primary/starboard)
 "uJl" = (
 /obj/structure/cable,
@@ -77705,8 +77771,8 @@
 /obj/structure/displaycase/forsale/kitchen{
 	pixel_y = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = -28
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -77837,6 +77903,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vIc" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "vIO" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -79608,7 +79678,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/hallway/primary/starboard)
 "yax" = (
 /obj/effect/turf_decal/tile/red,
@@ -112384,7 +112454,7 @@ bmK
 boK
 brc
 qwx
-vPC
+isV
 fiI
 vPC
 byw
@@ -112641,13 +112711,13 @@ bmL
 bmP
 bBS
 fGa
-bDC
+kja
 aEc
 bBS
 bBS
 bmP
 bmP
-bmP
+bBS
 bmP
 bmP
 bmP
@@ -112898,13 +112968,13 @@ xKx
 aao
 aap
 qQP
-byC
-ldJ
+nPl
+qCy
 byC
 dbx
 vAj
+mGc
 bwO
-pzW
 bGZ
 aaF
 bmP
@@ -113158,7 +113228,7 @@ hMV
 aas
 aEq
 byy
-bBT
+lOC
 rtU
 pEb
 cjM
@@ -113921,9 +113991,9 @@ bdV
 aZt
 bhH
 bjp
-tFU
+nVM
 bDC
-byC
+nPl
 byC
 bto
 svt
@@ -114179,7 +114249,7 @@ aZt
 bhI
 bjC
 tFU
-bDC
+kja
 byC
 uyw
 btp
@@ -114443,7 +114513,7 @@ btq
 jux
 ldJ
 qQP
-iUy
+nLy
 cDQ
 bAo
 bmP
@@ -114458,7 +114528,7 @@ hqF
 rBy
 bUi
 qWw
-bYj
+vIc
 bYj
 bWT
 aQZ
@@ -114700,7 +114770,7 @@ byE
 dzh
 ldJ
 qQP
-rcB
+byz
 lUi
 jIE
 bFp
@@ -114970,7 +115040,7 @@ bOW
 bQH
 bRV
 xVl
-bUn
+bST
 bVx
 kBu
 bYj
@@ -115216,7 +115286,7 @@ pNO
 ltO
 fnI
 bwS
-bBT
+lOC
 bFr
 lJP
 bIy
@@ -115226,7 +115296,7 @@ qsx
 rnj
 bNx
 bRW
-xVl
+rWs
 xVl
 bVy
 scu
@@ -115472,7 +115542,7 @@ buQ
 efa
 aGk
 bAp
-bwS
+qCJ
 bBT
 bFs
 lJP
@@ -115483,7 +115553,7 @@ bND
 bKe
 bQI
 bRX
-rWs
+fCX
 xVl
 vPx
 uEi
@@ -116244,7 +116314,7 @@ ldJ
 rPb
 uLZ
 nMl
-bBT
+qwO
 tJz
 lcK
 fyu


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The console was deleted in a final fix up.
Also a newscaster.
And renamed the kitchen counter shutters.
Light in sm chamber moved
door to bar tweaked
another decal that bugged me
a light switch was just wrong
better bar flow
kitchen tweak
widened the hall in a notable way for like no loss
I will stop one day
but not today
some more decals
a waypoint was moved for better pathing
engineering lobby desk shifted


Fixes #53654

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Meta Engineering lobby fixes and tweaks, added missing machine, moved lights in SM
fix: Meta The bar and kitchen have had several updates to objects
fix: Meta The service hall was widened by one tile
fix: Meta Atmosia has a fancy new control room and a bigger storage room for projects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
