### PR TITLE
Countdowns now use the maptext class

### DIFF
--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -51,7 +51,7 @@
 	displayed_text = new_val
 
 	if(displayed_text)
-		maptext = "<font size = [text_size]>[displayed_text]</font>"
+		maptext = "<span class='maptext'><font size = [text_size]>[displayed_text]</font></span>"
 	else
 		maptext = null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I have no idea what this will do haha

![image](https://user-images.githubusercontent.com/40974010/92987343-7f765080-f476-11ea-94ca-fb22f1b73737.png)
![image](https://user-images.githubusercontent.com/40974010/92987403-e8f65f00-f476-11ea-99da-a4551cd35fad.png)


## Why It's Good For The Game

All maptext should use the maptext span, it's less blurry and really nice to look at.

## Changelog
:cl:
add: Countdowns use maptext.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
