### PR TITLE
Adds Gibs That Don't Rot

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -10925,7 +10925,7 @@
 /area/wizard_station)
 "yI" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/blood/no_rot_gibs/body,
 /turf/open/floor/grass,
 /area/wizard_station)
 "yJ" = (

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -56,6 +56,15 @@
 
 	var/already_rotting = FALSE
 
+/obj/effect/decal/cleanable/blood/no_rot_gibs
+	name = "gibs"
+	desc = "They look bloody and gruesome."
+	icon = 'icons/effects/blood.dmi'
+	icon_state = "gib1"
+	layer = LOW_OBJ_LAYER
+	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6")
+	mergeable_decal = FALSE
+
 /obj/effect/decal/cleanable/blood/gibs/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()
 	reagents.add_reagent(/datum/reagent/liquidgibs, 5)
@@ -119,6 +128,35 @@
 	desc = "Space Jesus, why didn't anyone clean this up? They smell terrible."
 	bloodiness = 0
 	already_rotting = TRUE
+
+/obj/effect/decal/cleanable/blood/no_rot_gibs/up
+	icon_state = "gibup1"
+	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6","gibup1","gibup1","gibup1")
+
+/obj/effect/decal/cleanable/blood/no_rot_gibs/down
+	icon_state = "gibdown1"
+	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6","gibdown1","gibdown1","gibdown1")
+
+/obj/effect/decal/cleanable/blood/no_rot_gibs/body
+	icon_state = "gibtorso"
+	random_icon_states = list("gibhead", "gibtorso")
+
+/obj/effect/decal/cleanable/blood/no_rot_gibs/torso
+	icon_state = "gibtorso"
+	random_icon_states = null
+
+/obj/effect/decal/cleanable/blood/no_rot_gibs/limb
+	icon_state = "gibleg"
+	random_icon_states = list("gibleg", "gibarm")
+
+/obj/effect/decal/cleanable/blood/no_rot_gibs/core
+	icon_state = "gibmid1"
+	random_icon_states = list("gibmid1", "gibmid2", "gibmid3")
+
+/obj/effect/decal/cleanable/blood/no_rot_gibs/old
+	name = "old rotting gibs"
+	desc = "Space Jesus, why didn't anyone clean this up? They smell terrible."
+	bloodiness = 0
 
 /obj/effect/decal/cleanable/blood/gibs/old/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a subtype of cleanable/blood that is basically just gibs, but they don't rot. I've replaced the gibs on the wizard ship with these nonrot ones, but if other examples are brought to my attention, I'll gladly add them there as well. I have tested this and it works fine to my knowledge. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is mainly good for areas that were never meant to be accessible, since generating miasma there just puts unnecessary strain on the server. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a new type of gibs that don't rot
fix: Changes the rotting gibs on the wizard ship to no_rot_gibs

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
