### PR TITLE
Makes the syndicate syringe gun start with a syringe loaded.

### DIFF
--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -18,6 +18,7 @@
 /obj/item/gun/syringe/Initialize()
 	. = ..()
 	chambered = new /obj/item/ammo_casing/syringegun(src)
+	recharge_newshot()
 
 /obj/item/gun/syringe/handle_atom_del(atom/A)
 	. = ..()
@@ -95,6 +96,7 @@
 	force = 2 //Also very weak because it's smaller
 	suppressed = TRUE //Softer fire sound
 	can_unsuppress = FALSE //Permanently silenced
+	syringes = list(new /obj/item/reagent_containers/syringe())
 
 /obj/item/gun/syringe/dna
 	name = "modified syringe gun"


### PR DESCRIPTION
## About The Pull Request

The syndicate uplink dart gun doesn't start with a syringe.  Now it starts with an empty standard syringe loaded.

## Why It's Good For The Game

The dart gun right now is either incredibly powerful if you have access to a lot of syringes, or near worthless with a lack of available syringes.  This will hopefully raise it's power slightly in it's less useful cases, while not providing extra power when it was already very useful.

## Changelog
:cl:
balance: The syndicate now provides a single empty syringe with it's dart gun.
/:cl:
