### PR TITLE
[WIP] players can possess only one spider per round

### DIFF
--- a/code/modules/client/player_details.dm
+++ b/code/modules/client/player_details.dm
@@ -6,6 +6,8 @@
 	var/list/played_names = list() //List of names this key played under this round
 	var/byond_version = "Unknown"
 	var/datum/achievement_data/achievements
+	var/ghost_role_respawn_timer = 1 MINUTES
+	var/can_ghost_role_respawn = TRUE
 
 /datum/player_details/New(key)
 	achievements = new(key)
@@ -21,3 +23,10 @@
 		for(var/name in names)
 			if(name)
 				P.played_names |= name
+
+/datum/player_details/proc/respawn_timer()
+	can_ghost_role_respawn = FALSE
+	addtimer(CALLBACK(src, .proc/allow_player_respawn), ghost_role_respawn_timer)
+
+/datum/player_details/proc/allow_player_respawn()
+	can_ghost_role_respawn = TRUE

--- a/code/modules/client/player_details.dm
+++ b/code/modules/client/player_details.dm
@@ -6,8 +6,10 @@
 	var/list/played_names = list() //List of names this key played under this round
 	var/byond_version = "Unknown"
 	var/datum/achievement_data/achievements
-	var/ghost_role_respawn_timer = 1 MINUTES
-	var/can_ghost_role_respawn = TRUE
+	var/list/ghost_roles_respawn_checks = list(/mob/living/simple_animal/hostile/poison/giant_spider = list("lives_available" = 5,
+																											"respawn_cooldown" = 3 MINUTES,
+																											"can_respawn" = TRUE
+																											))
 
 /datum/player_details/New(key)
 	achievements = new(key)
@@ -24,9 +26,14 @@
 			if(name)
 				P.played_names |= name
 
-/datum/player_details/proc/respawn_timer()
-	can_ghost_role_respawn = FALSE
-	addtimer(CALLBACK(src, .proc/allow_player_respawn), ghost_role_respawn_timer)
+/datum/player_details/proc/respawn_timer(mob_type)
+	ghost_roles_respawn_checks[mob_type]["can_respawn"] = FALSE
+	addtimer(CALLBACK(src, .proc/allow_player_respawn, mob_type), ghost_roles_respawn_checks[mob_type]["respawn_cooldown"])
 
-/datum/player_details/proc/allow_player_respawn()
-	can_ghost_role_respawn = TRUE
+/datum/player_details/proc/allow_player_respawn(mob_type)
+	ghost_roles_respawn_checks[mob_type]["can_respawn"] = TRUE
+
+/datum/player_details/proc/decrease_lives_available(mob_type)
+	ghost_roles_respawn_checks[mob_type]["lives_available"] -= 1
+	if(ghost_roles_respawn_checks[mob_type]["lives_available"] == 0)
+		ghost_roles_respawn_checks[mob_type]["can_respawn"] = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -1,3 +1,4 @@
+GLOBAL_LIST_EMPTY(users_played_spider)
 #define SPIDER_IDLE 0
 #define SPINNING_WEB 1
 #define LAYING_EGGS 2
@@ -86,6 +87,10 @@
 	. = ..()
 	if(.)
 		return
+	if(user.key in GLOB.users_played_spider)
+		to_chat(user, "<span class='warning'>You already took a spider and died!</span>")
+		return FALSE
+	GLOB.users_played_spider += user.key
 	humanize_spider(user)
 
 /mob/living/simple_animal/hostile/poison/giant_spider/proc/humanize_spider(mob/user)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -89,14 +89,10 @@ GLOBAL_LIST_EMPTY(users_played_spider)
 	if(.)
 		return
 	if(user.key in GLOB.users_played_spider)
-		to_chat(user, "<span class='warning'>You already took a spider role and died! Wait approximately 2 minutes before trying again!</span>")
+		to_chat(user, "<span class='warning'>You already took a spider role and died!</span>")
 		return FALSE
 	GLOB.users_played_spider += user.key
-	addtimer(CALLBACK(src, .proc/allow_player_respawn, user), 2 MINUTES)
 	humanize_spider(user)
-
-/mob/living/simple_animal/hostile/poison/giant_spider/proc/allow_player_respawn(mob/user)
-	GLOB.users_played_spider -= user.key
 
 /mob/living/simple_animal/hostile/poison/giant_spider/proc/humanize_spider(mob/user)
 	if(key || !playable_spider || stat)//Someone is in it, it's dead, or the fun police are shutting it down

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -1,5 +1,3 @@
-///Stores the users ckey that have already played as spiders
-GLOBAL_LIST_EMPTY(users_played_spider)
 #define SPIDER_IDLE 0
 #define SPINNING_WEB 1
 #define LAYING_EGGS 2
@@ -68,6 +66,11 @@ GLOBAL_LIST_EMPTY(users_played_spider)
 	QDEL_NULL(lay_web)
 	return ..()
 
+/mob/living/simple_animal/hostile/poison/giant_spider/death()
+	if(key)
+		client.player_details.respawn_timer()
+	return ..()
+
 /mob/living/simple_animal/hostile/poison/giant_spider/Topic(href, href_list)
 	if(href_list["activate"])
 		var/mob/dead/observer/ghost = usr
@@ -88,10 +91,9 @@ GLOBAL_LIST_EMPTY(users_played_spider)
 	. = ..()
 	if(.)
 		return
-	if(user.key in GLOB.users_played_spider)
+	if(!user.client.player_details.can_ghost_role_respawn)
 		to_chat(user, "<span class='warning'>You already took a spider role and died!</span>")
 		return FALSE
-	GLOB.users_played_spider += user.key
 	humanize_spider(user)
 
 /mob/living/simple_animal/hostile/poison/giant_spider/proc/humanize_spider(mob/user)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -89,10 +89,14 @@ GLOBAL_LIST_EMPTY(users_played_spider)
 	if(.)
 		return
 	if(user.key in GLOB.users_played_spider)
-		to_chat(user, "<span class='warning'>You already took a spider role and died!</span>")
+		to_chat(user, "<span class='warning'>You already took a spider role and died! Wait approximately 2 minutes before trying again!</span>")
 		return FALSE
 	GLOB.users_played_spider += user.key
+	addtimer(CALLBACK(src, .proc/allow_player_respawn, user), 2 MINUTES)
 	humanize_spider(user)
+
+/mob/living/simple_animal/hostile/poison/giant_spider/proc/allow_player_respawn(mob/user)
+	GLOB.users_played_spider -= user.key
 
 /mob/living/simple_animal/hostile/poison/giant_spider/proc/humanize_spider(mob/user)
 	if(key || !playable_spider || stat)//Someone is in it, it's dead, or the fun police are shutting it down

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -68,7 +68,8 @@
 
 /mob/living/simple_animal/hostile/poison/giant_spider/death()
 	if(key)
-		client.player_details.respawn_timer()
+		client.player_details.respawn_timer(type)
+		client.player_details.decrease_lives_available(type)
 	return ..()
 
 /mob/living/simple_animal/hostile/poison/giant_spider/Topic(href, href_list)
@@ -91,7 +92,7 @@
 	. = ..()
 	if(.)
 		return
-	if(!user.client.player_details.can_ghost_role_respawn)
+	if(!user.client.player_details.ghost_roles_respawn_checks[type]["can_respawn"])
 		to_chat(user, "<span class='warning'>You already took a spider role and died!</span>")
 		return FALSE
 	humanize_spider(user)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -1,3 +1,4 @@
+///Stores the users ckey that have already played as spiders
 GLOBAL_LIST_EMPTY(users_played_spider)
 #define SPIDER_IDLE 0
 #define SPINNING_WEB 1
@@ -88,7 +89,7 @@ GLOBAL_LIST_EMPTY(users_played_spider)
 	if(.)
 		return
 	if(user.key in GLOB.users_played_spider)
-		to_chat(user, "<span class='warning'>You already took a spider and died!</span>")
+		to_chat(user, "<span class='warning'>You already took a spider role and died!</span>")
 		return FALSE
 	GLOB.users_played_spider += user.key
 	humanize_spider(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### THE IDEA IS STILL GOING ON #53685 LEAVE FEEDBACKS THERE
The main scope of this PR is to stop people from abusing the spider ghost role as an easy way to re-enter the round multiple times with an easy antag role, to stop metagaming (many people after dying as spider take another one to go back and finish the job, sometimes even multiple times) and to give the station a chance to fight spiders without having an almost infinite number coming out of the pipes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
See above
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: users can play spiders ghost role only once per round
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
