### PR TITLE
[WIP] [Draft] Functionality to restrict ghost selection of non spawn menu roles on a per-whatever basis.

### DIFF
--- a/code/modules/client/player_details.dm
+++ b/code/modules/client/player_details.dm
@@ -7,6 +7,9 @@
 	var/byond_version = "Unknown"
 	var/datum/achievement_data/achievements
 
+	/// Associated list. Keys are type paths. Values are lists of strings and restrictions associated with them. Lazylist as most players never accept ghost roles.
+	var/list/ghost_roles_respawn_checks
+
 /datum/player_details/New(key)
 	achievements = new(key)
 
@@ -21,3 +24,53 @@
 		for(var/name in names)
 			if(name)
 				P.played_names |= name
+
+/**
+  * Checks the ghost_roles_respawn_checks for whether a player can spawn as a type of mob, and returns
+  * an error message if relevant.
+  *
+  * Returns a specific error message string if the player cannot respawn as this mob type, FALSE if they can.
+  * Arguments:
+  * * mob_type - Type path to the mob the user is attempting to spawn as.
+  * * max_lives - The maximum number of lives to check against.
+  */
+/datum/player_details/proc/get_respawn_error(mob_type, max_lives = 0)
+	var/lives_used = LAZYACCESSASSOC(ghost_roles_respawn_checks, mob_type, "lives_lost")
+	if(lives_used > max_lives)
+		return "You have used all available lives for this role and cannot spawn as it."
+
+	var/respawn_at = LAZYACCESSASSOC(ghost_roles_respawn_checks, mob_type, "respawn_at")
+	if(respawn_at > world.time)
+		return "You must wait [respawn_at - world.time * 0.1] seconds before you can spawn as this role again."
+
+/**
+  * Modifies the lives lost counter for the mob_type by the amount in life_change.
+  *
+  * Arguments:
+  * * mob_type - Type path to the mob the user is attempting to spawn as.
+  * * life_change - Number of lives to lose. If negative, number of lives to gain.
+  */
+/datum/player_details/proc/modify_lost_lives(mob_type, life_change)
+	// if we've not got a list, init it. This also handles all of our checks for the lists existing.
+	LAZYINITLIST(ghost_roles_respawn_checks)
+	LAZYINITLIST(ghost_roles_respawn_checks[mob_type])
+
+	if(ghost_roles_respawn_checks[mob_type]["lives_lost"])
+		ghost_roles_respawn_checks[mob_type]["lives_lost"] += life_change
+	else
+		ghost_roles_respawn_checks[mob_type]["lives_lost"] = life_change
+
+/datum/player_details/proc/set_respawn_in(mob_type, respawn_time)
+	// if we've not got a list, init it. This also handles all of our checks for the lists existing.
+	LAZYINITLIST(ghost_roles_respawn_checks)
+	LAZYINITLIST(ghost_roles_respawn_checks[mob_type])
+
+	ghost_roles_respawn_checks[mob_type]["respawn_at"] = world.time + respawn_time
+
+/datum/player_details/proc/get_lost_lives(mob_type)
+	return LAZYACCESSASSOC(ghost_roles_respawn_checks, mob_type, "lives_lost")
+
+/datum/player_details/proc/get_respawn_in(mob_type)
+	var/respawn_at = LAZYACCESSASSOC(ghost_roles_respawn_checks, mob_type, "respawn_at")
+	var/respawn_in = max(respawn_at - world.time, 0)
+	return respawn_in


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alternative to #53662

Implemented some discussion points from https://tgstation13.org/phpBB/viewtopic.php?f=9&t=23649

Adds a new set of stuff to the `player_details` (Is there are better place for this?) on the `client`.

Allows for either/or tracking of persistent lives per key (key is arbitrary. Uses type paths. Can use strings. Or anything else) and cooldown times.

Example used on spiders is purely for example purposes of implementation and is not the final implementation (Only applies to a single type of spider ghost role)

If you want swarmers, can set a low (or no) cooldown and have a maximum number of lives a player can churn through in a round.

If you want to limit certain suicide-spawn abuses, you can set an infinite number of lives while giving a cooldown timer for deaths. Posibrains? Golem shells?

If you just really want to carefully tune an antag for swarm and power, you can set both (Xenos?)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

See #53662 for arguments. See https://tgstation13.org/phpBB/viewtopic.php?f=9&t=23649 for arguments.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
[TODO] - Make the changelog when code is finalised.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
