### PR TITLE
[WIP]Some shuttes rework. Returned second fighter to syndicate ambush.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -390,6 +390,17 @@
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/caravan/freighter3)
+"gh" = (
+/obj/docking_port/stationary{
+	dwidth = 4;
+	height = 5;
+	id = "caravansyndicate1_ambush";
+	name = "Trade Route";
+	roundstart_template = /datum/map_template/shuttle/ruin/syndicate_fighter_shiv;
+	width = 9
+	},
+/turf/template_noop,
+/area/template_noop)
 "gk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3902,7 +3913,7 @@ aa
 aa
 aa
 aa
-aa
+gh
 aa
 aa
 aa

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -948,6 +948,13 @@
 /obj/machinery/gulag_teleporter,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"df" = (
+/obj/machinery/camera/autoname,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "dg" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
@@ -1577,13 +1584,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ff" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 11;
-	height = 15;
-	id = "whiteship_home";
-	name = "SS13: Auxiliary Dock, Station-Port";
-	width = 28
+/obj/docking_port/stationary/public_mining_dock{
+	dir = 2
 	},
 /turf/open/space/basic,
 /area/space)
@@ -1919,20 +1921,22 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "gc" = (
-/obj/machinery/door/airlock/external{
-	name = "Auxiliary Airlock"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "gd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science)
 "ge" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/hallway/secondary/entry)
+/obj/machinery/door/airlock,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "gf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2141,6 +2145,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science)
+"hl" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "hD" = (
 /obj/structure/closet/secure_closet/chemical/heisenberg{
 	locked = 0
@@ -2156,6 +2166,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction)
+"iZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "jb" = (
 /obj/machinery/door/airlock,
 /obj/structure/cable,
@@ -2256,6 +2272,18 @@
 "qQ" = (
 /turf/open/floor/engine,
 /area/quartermaster/miningoffice)
+"rk" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 3;
+	height = 5;
+	id = "mining_home";
+	name = "mining shuttle bay";
+	roundstart_template = /datum/map_template/shuttle/mining/box;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space)
 "rK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2267,6 +2295,21 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"rM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
+"sb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "sE" = (
 /obj/machinery/power/rtg/advanced,
 /obj/structure/cable,
@@ -2314,6 +2357,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"vj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "vm" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/aft)
@@ -2381,6 +2431,17 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"Ao" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 11;
+	height = 22;
+	id = "whiteship_home";
+	name = "SS13: Auxiliary Dock, Station-Port";
+	width = 35
+	},
+/turf/open/space/basic,
+/area/space)
 "AP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -2422,6 +2483,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"Dd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "DW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -2475,10 +2543,37 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"Fh" = (
+/obj/machinery/door/airlock/external{
+	name = "Auxiliary Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"FW" = (
+/obj/structure/sign/warning/docking,
+/turf/closed/wall/r_wall,
+/area/maintenance/aft)
+"Hn" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
+"HM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "If" = (
 /obj/machinery/rnd/production/techfab/department,
 /turf/open/floor/plasteel,
 /area/science)
+"Ih" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "Iy" = (
 /obj/structure/closet/secure_closet/research_director{
 	locked = 0
@@ -2524,10 +2619,20 @@
 /obj/machinery/chem_dispenser/chem_synthesizer,
 /turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
+"LK" = (
+/obj/machinery/door/airlock/external{
+	name = "Auxiliary Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "LW" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"LZ" = (
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "Mh" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel,
@@ -2548,6 +2653,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/medical/medbay)
+"NS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "NZ" = (
 /obj/machinery/rnd/production/protolathe/department,
 /turf/open/floor/plasteel,
@@ -2573,6 +2685,13 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"Rf" = (
+/obj/machinery/door/airlock/external{
+	name = "Transport Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "RM" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -2606,6 +2725,11 @@
 "Tt" = (
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"Ty" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "TV" = (
 /obj/machinery/door/airlock,
 /obj/structure/cable,
@@ -2623,6 +2747,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"Vr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "Vy" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel,
@@ -3745,7 +3873,7 @@ rK
 rK
 vy
 em
-eh
+ej
 eh
 LW
 lc
@@ -3757,7 +3885,7 @@ lc
 lc
 wB
 eh
-eh
+gv
 dY
 aa
 aa
@@ -3942,8 +4070,8 @@ lc
 wB
 eh
 eh
-en
-aa
+fs
+ff
 aa
 aa
 aa
@@ -4021,7 +4149,7 @@ qQ
 qQ
 CQ
 em
-eh
+ej
 eh
 LW
 lc
@@ -4034,7 +4162,7 @@ lc
 wB
 eh
 eh
-dY
+en
 aa
 aa
 aa
@@ -4125,8 +4253,8 @@ lc
 lc
 wB
 eh
-eh
-en
+gv
+dY
 aa
 aa
 aa
@@ -4342,10 +4470,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+vm
+vm
+vm
+vm
 aa
 aa
 aa
@@ -4389,7 +4517,7 @@ gi
 gm
 go
 gp
-eL
+NS
 gr
 LW
 lc
@@ -4401,7 +4529,7 @@ lc
 lc
 wB
 eh
-eh
+gv
 dY
 aa
 aa
@@ -4434,10 +4562,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+vm
+LZ
+LZ
+vm
 aa
 aa
 aa
@@ -4503,7 +4631,7 @@ aa
 en
 eh
 eh
-gc
+en
 aa
 aa
 aa
@@ -4526,10 +4654,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+Rb
+LZ
+LZ
+Rb
 aa
 aa
 aa
@@ -4595,8 +4723,7 @@ aa
 en
 eh
 eh
-gc
-ff
+en
 aa
 aa
 aa
@@ -4619,9 +4746,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+Rb
+LZ
+LZ
+Rb
 aa
 aa
 aa
@@ -4710,10 +4838,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+vm
+df
+LZ
+vm
 aa
 aa
 aa
@@ -4779,7 +4907,7 @@ aa
 en
 eh
 eh
-en
+LK
 aa
 aa
 aa
@@ -4802,10 +4930,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+Fh
+LZ
+LZ
+Fh
 aa
 aa
 aa
@@ -4871,7 +4999,8 @@ aa
 fj
 eh
 eh
-en
+LK
+Ao
 aa
 aa
 aa
@@ -4893,12 +5022,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+Fh
+LZ
+LZ
+Fh
+rk
 aa
 aa
 aa
@@ -4986,10 +5114,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+FW
+LZ
+Hn
+FW
 aa
 aa
 aa
@@ -5078,10 +5206,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+vm
+Ih
+LZ
+Rb
 aa
 aa
 aa
@@ -5147,7 +5275,7 @@ aa
 en
 ek
 eh
-dY
+en
 aa
 aa
 aa
@@ -5170,10 +5298,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+Rb
+iZ
+LZ
+Rb
 aa
 aa
 aa
@@ -5262,10 +5390,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+Rb
+iZ
+LZ
+Rb
 aa
 aa
 aa
@@ -5354,10 +5482,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+Rb
+iZ
+LZ
+vm
 aa
 aa
 aa
@@ -5446,10 +5574,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+vm
+rM
+LZ
+vm
 aa
 aa
 aa
@@ -5515,7 +5643,7 @@ aa
 en
 ek
 eh
-dY
+en
 aa
 aa
 aa
@@ -5538,10 +5666,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+Rb
+iZ
+LZ
+Rb
 aa
 aa
 aa
@@ -5607,7 +5735,7 @@ dY
 dY
 ek
 eh
-dY
+en
 aa
 aa
 aa
@@ -5630,11 +5758,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+Rb
+iZ
+LZ
+Rf
+ff
 aa
 aa
 aa
@@ -5699,7 +5827,7 @@ eV
 eh
 ek
 eh
-dY
+en
 aa
 aa
 aa
@@ -5722,10 +5850,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+vm
+iZ
+LZ
+Rb
 aa
 aa
 aa
@@ -5788,7 +5916,7 @@ eL
 eL
 eL
 eL
-eL
+gc
 fZ
 eh
 dY
@@ -5814,10 +5942,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+vm
+iZ
+LZ
+vm
 aa
 aa
 aa
@@ -5880,10 +6008,10 @@ eh
 eh
 eh
 eh
+ek
 eh
 eh
-eh
-ge
+dY
 aa
 aa
 aa
@@ -5906,10 +6034,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+vm
+iZ
+Hn
+vm
 aa
 aa
 aa
@@ -5972,36 +6100,36 @@ cN
 cN
 cN
 cN
-fI
-dY
-dY
 ge
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+dY
+dY
+dY
+vm
+Rb
+Rb
+vm
+Rb
+Rb
+vm
+Rb
+Rb
+vm
+Rb
+Rb
+vm
+Rb
+Rb
+vm
+Rb
+Rb
+vm
+Rb
+Rb
+vm
+vm
+Dd
+fI
+vm
 aa
 aa
 aa
@@ -6064,36 +6192,36 @@ dy
 dm
 dM
 cN
+HM
+Vr
+Vr
+Ty
+vj
+Vr
+Vr
+Vr
+Vr
+Vr
+vj
+Vr
+Vr
+Vr
+Vr
+Vr
+vj
+Vr
+Vr
+Vr
+Vr
+Vr
+vj
+Vr
+Vr
+Vr
+Vr
+sb
 Tt
-vm
-fg
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Rb
 aa
 aa
 aa
@@ -6157,35 +6285,35 @@ dn
 dL
 cN
 Tt
-vm
-fg
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Tt
+Tt
+fI
+Tt
+Tt
+Tt
+hl
+Tt
+Tt
+Tt
+Tt
+Tt
+hl
+Tt
+Tt
+Tt
+Tt
+Tt
+hl
+Tt
+Tt
+Tt
+Tt
+Tt
+hl
+Tt
+Tt
+Tt
+Rb
 aa
 aa
 aa
@@ -6248,36 +6376,36 @@ dn
 dn
 dL
 cN
-Tt
+fI
 vm
-fg
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+vm
+vm
+vm
+Rb
+Rb
+vm
+Rb
+Rb
+vm
+Rb
+Rb
+vm
+Rb
+Rb
+vm
+Rb
+Rb
+vm
+Rb
+Rb
+vm
+Rb
+Rb
+vm
+vm
+Rb
+Rb
+vm
 aa
 aa
 aa
@@ -8456,7 +8584,7 @@ cS
 cS
 cS
 cS
-ga
+fI
 ga
 ga
 ga
@@ -8547,9 +8675,9 @@ fr
 eu
 eu
 eu
-et
-aa
-aa
+fI
+Tt
+Rb
 aa
 aa
 aa
@@ -8640,8 +8768,8 @@ fo
 eu
 eu
 et
-aa
-aa
+Rb
+Rb
 aa
 aa
 aa

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -7,7 +7,9 @@ SUBSYSTEM_DEF(shuttle)
 	flags = SS_KEEP_TIMING|SS_NO_TICK_CHECK
 	runlevels = RUNLEVEL_SETUP | RUNLEVEL_GAME
 
+	// associated list(u_id = shuttle)
 	var/list/mobile = list()
+	// associated list(u_id = dock)
 	var/list/stationary = list()
 	var/list/beacons = list()
 	var/list/transit = list()
@@ -83,20 +85,23 @@ SUBSYSTEM_DEF(shuttle)
 	return ..()
 
 /datum/controller/subsystem/shuttle/proc/initial_load()
-	for(var/s in stationary)
-		var/obj/docking_port/stationary/S = s
-		S.load_roundstart()
+	for(var/dock_u_id in stationary)
+		var/obj/docking_port/stationary/dock = stationary[dock_u_id]
+		dock.load_roundstart()
 		CHECK_TICK
 
 /datum/controller/subsystem/shuttle/fire()
-	for(var/thing in mobile)
-		if(!thing)
-			mobile.Remove(thing)
+	for(var/shuttle_u_id in mobile)
+		if(!shuttle_u_id)
+			mobile.Remove(shuttle_u_id)
 			continue
-		var/obj/docking_port/mobile/P = thing
-		P.check()
-	for(var/thing in transit)
-		var/obj/docking_port/stationary/transit/T = thing
+		var/obj/docking_port/mobile/shuttle_port = mobile[shuttle_u_id]
+		if(!shuttle_port)
+			mobile.Remove(shuttle_u_id)
+			continue
+		shuttle_port.check()
+	for(var/transit_dock in transit)
+		var/obj/docking_port/stationary/transit/T = transit_dock
 		if(!T.owner)
 			qdel(T, force=TRUE)
 		// This next one removes transit docks/zones that aren't
@@ -159,17 +164,25 @@ SUBSYSTEM_DEF(shuttle)
 /datum/controller/subsystem/shuttle/proc/unblock_recall()
 	emergencyNoRecall = FALSE
 
-/datum/controller/subsystem/shuttle/proc/getShuttle(id)
-	for(var/obj/docking_port/mobile/M in mobile)
-		if(M.id == id)
-			return M
-	WARNING("couldn't find shuttle with id: [id]")
+/datum/controller/subsystem/shuttle/proc/getShuttle(u_id)
+	if(mobile[u_id])
+		return mobile[u_id]
+	WARNING("couldn't find shuttle with unique u_id: [u_id]. try to find match id")
+	for(var/port in mobile)
+		var/obj/docking_port/mobile/shuttle_port = mobile[port]
+		if(shuttle_port.id == u_id)
+			return shuttle_port
+	WARNING("couldn't find shuttle with id: [u_id]")
 
-/datum/controller/subsystem/shuttle/proc/getDock(id)
-	for(var/obj/docking_port/stationary/S in stationary)
-		if(S.id == id)
-			return S
-	WARNING("couldn't find dock with id: [id]")
+/datum/controller/subsystem/shuttle/proc/getDock(u_id)
+	if(stationary[u_id])
+		return stationary[u_id]
+	WARNING("couldn't find dock with unique u_id: [u_id]. try to find match id")
+	for(var/port in stationary)
+		var/obj/docking_port/stationary/dock_port = stationary[port]
+		if(dock_port.id == u_id)
+			return dock_port
+	WARNING("couldn't find dock with id: [u_id]")
 
 /datum/controller/subsystem/shuttle/proc/canEvac(mob/user)
 	var/srd = CONFIG_GET(number/shuttle_refuel_delay)
@@ -387,7 +400,7 @@ SUBSYSTEM_DEF(shuttle)
 		return 1
 	var/obj/docking_port/stationary/dockedAt = M.get_docked()
 	var/destination = dockHome
-	if(dockedAt && dockedAt.id == dockHome)
+	if(dockedAt && dockedAt.u_id == dockHome)
 		destination = dockAway
 	if(timed)
 		if(M.request(getDock(destination)))
@@ -496,7 +509,7 @@ SUBSYSTEM_DEF(shuttle)
 	A.contents = proposal.reserved_turfs
 	var/obj/docking_port/stationary/transit/new_transit_dock = new(midpoint)
 	new_transit_dock.reserved_area = proposal
-	new_transit_dock.name = "Transit for [M.id]/[M.name]"
+	new_transit_dock.name = "Transit for [M.u_id]/[M.name]"
 	new_transit_dock.owner = M
 	new_transit_dock.assigned_area = A
 
@@ -572,38 +585,36 @@ SUBSYSTEM_DEF(shuttle)
 	var/area/current = get_area(A)
 	if(istype(current, /area/shuttle) && !istype(current, /area/shuttle/transit))
 		return TRUE
-	for(var/obj/docking_port/mobile/M in mobile)
+	for(var/port in mobile)
+		var/obj/docking_port/mobile/M = mobile[port]
 		if(M.is_in_shuttle_bounds(A))
 			return TRUE
 
 /datum/controller/subsystem/shuttle/proc/get_containing_shuttle(atom/A)
-	var/list/mobile_cache = mobile
-	for(var/i in 1 to mobile_cache.len)
-		var/obj/docking_port/port = mobile_cache[i]
-		if(port.is_in_shuttle_bounds(A))
-			return port
+	for(var/port in mobile)
+		var/obj/docking_port/dock = mobile[port]
+		if(dock.is_in_shuttle_bounds(A))
+			return dock
 
 /datum/controller/subsystem/shuttle/proc/get_containing_dock(atom/A)
 	. = list()
-	var/list/stationary_cache = stationary
-	for(var/i in 1 to stationary_cache.len)
-		var/obj/docking_port/port = stationary_cache[i]
-		if(port.is_in_shuttle_bounds(A))
-			. += port
+	for(var/port in stationary)
+		var/obj/docking_port/dock = stationary[port]
+		if(dock.is_in_shuttle_bounds(A))
+			. += dock
 
 /datum/controller/subsystem/shuttle/proc/get_dock_overlap(x0, y0, x1, y1, z)
 	. = list()
-	var/list/stationary_cache = stationary
-	for(var/i in 1 to stationary_cache.len)
-		var/obj/docking_port/port = stationary_cache[i]
-		if(!port || port.z != z)
+	for(var/port in stationary)
+		var/obj/docking_port/dock = stationary[port]
+		if(!dock || dock.z != z)
 			continue
-		var/list/bounds = port.return_coords()
+		var/list/bounds = dock.return_coords()
 		var/list/overlap = get_overlap(x0, y0, x1, y1, bounds[1], bounds[2], bounds[3], bounds[4])
 		var/list/xs = overlap[1]
 		var/list/ys = overlap[2]
 		if(xs.len && ys.len)
-			.[port] = overlap
+			.[dock] = overlap
 
 /datum/controller/subsystem/shuttle/proc/update_hidden_docking_ports(list/remove_turfs, list/add_turfs)
 	var/list/remove_images = list()
@@ -651,8 +662,9 @@ SUBSYSTEM_DEF(shuttle)
 		QDEL_NULL(preview_reservation)
 
 	if(!preview_shuttle)
-		if(load_template(loading_template))
-			preview_shuttle.linkup(loading_template, destination_port)
+		//if(load_template(loading_template))
+			//preview_shuttle.linkup(loading_template, destination_port)
+		load_template(loading_template)
 		preview_template = loading_template
 
 	// get the existing shuttle information, if any
@@ -662,10 +674,10 @@ SUBSYSTEM_DEF(shuttle)
 
 	if(istype(destination_port))
 		D = destination_port
-	else if(existing_shuttle)
-		timer = existing_shuttle.timer
-		mode = existing_shuttle.mode
-		D = existing_shuttle.get_docked()
+	//else if(existing_shuttle)
+	//	timer = existing_shuttle.timer
+	//	mode = existing_shuttle.mode
+	//	D = existing_shuttle.get_docked()
 
 	if(!D)
 		D = generate_transit_dock(preview_shuttle)
@@ -681,8 +693,8 @@ SUBSYSTEM_DEF(shuttle)
 		WARNING("Template shuttle [preview_shuttle] cannot dock at [D] ([result]).")
 		return
 
-	if(existing_shuttle)
-		existing_shuttle.jumpToNullSpace()
+	//if(existing_shuttle)
+	//	existing_shuttle.jumpToNullSpace()
 
 	var/list/force_memory = preview_shuttle.movement_force
 	preview_shuttle.movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
@@ -799,11 +811,11 @@ SUBSYSTEM_DEF(shuttle)
 	// Status panel
 	data["shuttles"] = list()
 	for(var/i in mobile)
-		var/obj/docking_port/mobile/M = i
+		var/obj/docking_port/mobile/M = mobile[i]
 		var/timeleft = M.timeLeft(1)
 		var/list/L = list()
 		L["name"] = M.name
-		L["id"] = M.id
+		L["id"] = M.u_id
 		L["timer"] = M.timer
 		L["timeleft"] = M.getTimerStr()
 		if (timeleft > 1 HOURS)
@@ -842,31 +854,25 @@ SUBSYSTEM_DEF(shuttle)
 				. = TRUE
 		if("jump_to")
 			if(params["type"] == "mobile")
-				for(var/i in mobile)
-					var/obj/docking_port/mobile/M = i
-					if(M.id == params["id"])
-						user.forceMove(get_turf(M))
-						. = TRUE
-						break
+				var/obj/docking_port/mobile/M = getShuttle(params["id"])
+				if(M)
+					user.forceMove(get_turf(M))
+					. = TRUE
 
 		if("fly")
-			for(var/i in mobile)
-				var/obj/docking_port/mobile/M = i
-				if(M.id == params["id"])
-					. = TRUE
-					M.admin_fly_shuttle(user)
-					break
+			var/obj/docking_port/mobile/M = getShuttle(params["id"])
+			if(M)
+				. = TRUE
+				M.admin_fly_shuttle(user)
 
 		if("fast_travel")
-			for(var/i in mobile)
-				var/obj/docking_port/mobile/M = i
-				if(M.id == params["id"] && M.timer && M.timeLeft(1) >= 50)
-					M.setTimer(50)
-					. = TRUE
-					message_admins("[key_name_admin(usr)] fast travelled [M]")
-					log_admin("[key_name(usr)] fast travelled [M]")
-					SSblackbox.record_feedback("text", "shuttle_manipulator", 1, "[M.name]")
-					break
+			var/obj/docking_port/mobile/M = getShuttle(params["id"])
+			if(M && M.timer && M.timeLeft(1) >= 50)
+				M.setTimer(50)
+				. = TRUE
+				message_admins("[key_name_admin(usr)] fast travelled [M]")
+				log_admin("[key_name(usr)] fast travelled [M]")
+				SSblackbox.record_feedback("text", "shuttle_manipulator", 1, "[M.name]")
 
 		if("preview")
 			if(S)

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -98,9 +98,10 @@
 					port.dheight = width - port_x_offset
 
 //Whatever special stuff you want
-/datum/map_template/shuttle/proc/post_load(obj/docking_port/mobile/M)
+/datum/map_template/shuttle/post_load(obj/docking_port/mobile/M)
 	if(movement_force)
 		M.movement_force = movement_force.Copy()
+	M.linkup(src)
 
 /datum/map_template/shuttle/emergency
 	port_id = "emergency"

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -21,6 +21,13 @@
 	images += preview
 	if(alert(src,"Confirm location.","Template Confirm","Yes","No") == "Yes")
 		if(template.load(T, centered = TRUE))
+			var/affected = template.get_affected_turfs(T, centered=TRUE)
+			for(var/AT in affected)
+				for(var/obj/docking_port/mobile/P in AT)
+					if(istype(P, /obj/docking_port/mobile))
+						template.post_load(P)
+						break
+
 			message_admins("<span class='adminnotice'>[key_name_admin(src)] has placed a map template ([template.name]) at [ADMIN_COORDJMP(T)]</span>")
 		else
 			to_chat(src, "Failed to place map", confidential = TRUE)

--- a/code/modules/admin/verbs/shuttlepanel.dm
+++ b/code/modules/admin/verbs/shuttlepanel.dm
@@ -12,12 +12,12 @@
 /obj/docking_port/mobile/proc/admin_fly_shuttle(mob/user)
 	var/list/options = list()
 
-	for(var/port in SSshuttle.stationary)
-		if (istype(port, /obj/docking_port/stationary/transit))
+	for(var/port_u_id in SSshuttle.stationary)
+		var/obj/docking_port/stationary/S = SSshuttle.stationary[port_u_id]
+		if (istype(S, /obj/docking_port/stationary/transit))
 			continue  // please don't do this
-		var/obj/docking_port/stationary/S = port
 		if (canDock(S) == SHUTTLE_CAN_DOCK)
-			options[S.name || S.id] = S
+			options[S.name || S.u_id] = S
 
 	options += "--------"
 	options += "Infinite Transit"
@@ -60,10 +60,10 @@
 
 	var/list/options = list()
 
-	for(var/port in SSshuttle.stationary)
-		if (istype(port, /obj/docking_port/stationary/transit))
+	for(var/port_u_id in SSshuttle.stationary)
+		var/obj/docking_port/stationary/S = SSshuttle.stationary[port_u_id]
+		if (istype(S, /obj/docking_port/stationary/transit))
 			continue  // please don't do this
-		var/obj/docking_port/stationary/S = port
 		if (canDock(S) == SHUTTLE_CAN_DOCK)
 			options[S.name || S.id] = S
 

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -110,6 +110,9 @@
 	log_game("[name] loaded at [T.x],[T.y],[T.z]")
 	return bounds
 
+/datum/map_template/proc/post_load()
+	return
+
 /datum/map_template/proc/get_affected_turfs(turf/T, centered = FALSE)
 	var/turf/placement = T
 	if(centered)

--- a/code/modules/shuttle/arrivals.dm
+++ b/code/modules/shuttle/arrivals.dm
@@ -33,6 +33,8 @@
 		WARNING("More than one arrivals docking_port placed on map! Ignoring duplicates.")
 	SSshuttle.arrivals = src
 
+	target_dock = locate(/obj/docking_port/stationary) in loc
+
 /obj/docking_port/mobile/arrivals/LateInitialize()
 	areas = list()
 
@@ -179,10 +181,12 @@
 	if(mode == SHUTTLE_IDLE)
 		if(console)
 			console.say(pickingup ? "Departing immediately for new employee pickup." : "Shuttle departing.")
-		var/obj/docking_port/stationary/target = target_dock
-		if(QDELETED(target))
-			target = SSshuttle.getDock("arrivals_stationary")
-		request(target)		//we will intentionally never return SHUTTLE_ALREADY_DOCKED
+		if(QDELETED(target_dock))
+			console.say("Error in flight targeting system!")
+			message_admins("Arrival shuttle [src] dont have arrival dock.")
+			target_dock = SSshuttle.getDock("arrivals_stationary")
+			return
+		request(target_dock)		//we will intentionally never return SHUTTLE_ALREADY_DOCKED
 
 /obj/docking_port/mobile/arrivals/proc/RequireUndocked(mob/user)
 	if(mode == SHUTTLE_CALL || damaged)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -343,7 +343,7 @@
 				if(mode == SHUTTLE_STRANDED)
 					return
 				for(var/A in SSshuttle.mobile)
-					var/obj/docking_port/mobile/M = A
+					var/obj/docking_port/mobile/M = SSshuttle.mobile[A]
 					if(M.launch_status == UNLAUNCHED) //Pods will not launch from the mine/planet, and other ships won't launch unless we tell them to.
 						M.check_transit_zone()
 
@@ -355,7 +355,7 @@
 
 			success &= (check_transit_zone() == TRANSIT_READY)
 			for(var/A in SSshuttle.mobile)
-				var/obj/docking_port/mobile/M = A
+				var/obj/docking_port/mobile/M = SSshuttle.mobile[A]
 				if(M.launch_status == UNLAUNCHED)
 					success &= (M.check_transit_zone() == TRANSIT_READY)
 			if(!success)
@@ -371,7 +371,7 @@
 			if(time_left <= 0 && !SSshuttle.emergencyNoEscape)
 				//move each escape pod (or applicable spaceship) to its corresponding transit dock
 				for(var/A in SSshuttle.mobile)
-					var/obj/docking_port/mobile/M = A
+					var/obj/docking_port/mobile/M = SSshuttle.mobile[A]
 					M.on_emergency_launch()
 
 				//now move the actual emergency shuttle to its transit dock
@@ -406,7 +406,7 @@
 				if(area_parallax)
 					parallax_slowdown()
 					for(var/A in SSshuttle.mobile)
-						var/obj/docking_port/mobile/M = A
+						var/obj/docking_port/mobile/M = SSshuttle.mobile[A]
 						if(M.launch_status == ENDGAME_LAUNCHED)
 							if(istype(M, /obj/docking_port/mobile/pod))
 								M.parallax_slowdown()
@@ -414,7 +414,7 @@
 			if(time_left <= 0)
 				//move each escape pod to its corresponding escape dock
 				for(var/A in SSshuttle.mobile)
-					var/obj/docking_port/mobile/M = A
+					var/obj/docking_port/mobile/M = SSshuttle.mobile[A]
 					M.on_emergency_dock()
 
 				// now move the actual emergency shuttle to centcom

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -33,7 +33,7 @@
 		for(var/port_u_id in SSshuttle.stationary)
 			var/obj/docking_port/stationary/S = SSshuttle.stationary[port_u_id]
 			if(S.id == shuttleId)
-				jumpto_ports[S.u_id] = TRUE
+				jumpto_ports[S.id] = TRUE
 
 	for(var/V in SSshuttle.stationary)
 		if(!V)
@@ -351,7 +351,7 @@
 		if(!V)
 			stack_trace("SSshuttle.stationary have null entry!")
 			continue
-		var/obj/docking_port/stationary/S = V
+		var/obj/docking_port/stationary/S = SSshuttle.stationary[V]
 		if(console.z_lock.len && !(S.z in console.z_lock))
 			continue
 		if(console.jumpto_ports[S.id])

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -377,7 +377,7 @@ All ShuttleMove procs go here
 	. = ..()
 
 /obj/docking_port/stationary/public_mining_dock/onShuttleMove(turf/newT, turf/oldT, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
-	id = "mining_public" //It will not move with the base, but will become enabled as a docking point.
+	hidden = FALSE //It will not move with the base, but will become enabled as a docking point.
 
 /obj/effect/abstract/proximity_checker/onShuttleMove(turf/newT, turf/oldT, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
 	//timer so it only happens once


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Make additional docking_port gen id and name.
This allow creating and working of many shuttles created from single template.

Added u_id that works like id before, bit unique. You can set many docks of one id but all it have different u_id's. you can send shuttle to docks u_id.

SSshuttle stationary and mobile now associated lists(id = shuttle/dock).

Some change shuttle panel work to not replace old shuttles. Now it always place new shuttle.

Rework of #45024

## Why It's Good For The Game
Now we don't need code new areas, consoles, docking ports to create new shuttles from single template.
If you need second whiteship, just place it.
If you want new docking port just place it,
For whiteship's Deep Space just place whiteship dock template.

## Changelog
:cl:
add: Make many single template shuttles work at the same time.
add: Returned second fighter to syndicate ambush.
/:cl:

TODO:
- [x] Make SSshuttle.mobile and SSshuttle.stationary asociative list's. `list( u_id = docking_port )`
     - [ ] Add list(`destination_type` = list(docking_port_1,docking_port_2, ...)
- [ ] Change using shuttles.len in id to something another, to dont get messed after deliting shuttles/docks.
- [ ] Move `possible_destinations` from shuttle console to `docking_port/mobile`
- [ ] Rename `id` to `destination_type` (?)
     - [ ] Replace all starting 'id' to `destination_type` in `obj/docking_port`
- [ ] Give shuttle manipulator variant to load addition shuttles, instead of replacing.
     - [x] Removed replace. Just place new shuttles.
     - [ ] Add place button, and return replace.