### PR TITLE
Fixes food related runtime.

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -281,17 +281,25 @@ All foods are distributed among various categories. Use common sense.
 	add_overlay(filling)
 
 // initialize_cooked_food() is called when microwaving the food
-/obj/item/reagent_containers/food/snacks/proc/initialize_cooked_food(obj/item/reagent_containers/food/snacks/S, cooking_efficiency = 1)
-	S.create_reagents(S.volume)
-	if(reagents)
-		reagents.trans_to(S, reagents.total_volume)
-	if(S.bonus_reagents && S.bonus_reagents.len)
-		for(var/r_id in S.bonus_reagents)
-			var/amount = S.bonus_reagents[r_id] * cooking_efficiency
-			if(r_id == /datum/reagent/consumable/nutriment || r_id == /datum/reagent/consumable/nutriment/vitamin)
-				S.reagents.add_reagent(r_id, amount, tastes)
-			else
-				S.reagents.add_reagent(r_id, amount)
+/obj/item/reagent_containers/food/snacks/proc/initialize_cooked_food(obj/item/S, cooking_efficiency = 1)
+	if(istype(S, /obj/item/reagent_containers/food/snacks))
+		var/obj/item/reagent_containers/food/snacks/snackyfood = S
+		snackyfood.create_reagents(snackyfood.volume)
+		if(reagents)
+			reagents.trans_to(snackyfood, reagents.total_volume)
+		if(snackyfood.bonus_reagents && snackyfood.bonus_reagents.len)
+			for(var/r_id in snackyfood.bonus_reagents)
+				var/amount = snackyfood.bonus_reagents[r_id] * cooking_efficiency
+				if(r_id == /datum/reagent/consumable/nutriment || r_id == /datum/reagent/consumable/nutriment/vitamin)
+					snackyfood.reagents.add_reagent(r_id, amount, tastes)
+				else
+					snackyfood.reagents.add_reagent(r_id, amount)
+		return
+	if(istype(S, /obj/item/food))
+		var/obj/item/food/non_snackyfood = S
+		non_snackyfood.create_reagents(non_snackyfood.max_volume)
+		if(reagents)
+			reagents.trans_to(non_snackyfood, reagents.total_volume)
 
 /obj/item/reagent_containers/food/snacks/microwave_act(obj/machinery/microwave/M)
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/93029990-648f1200-f617-11ea-822b-344747680109.png)

#53316 either created or exposed a new runtime.

Microwaved snaccs expected snacc results. New caks are not snaccs but are caks.

Added branching code paths to handle both food typepaths while @Qustinnus finishes up his rework.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtime feex good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Microwaved cake batter and similar snack foods that create non-snack foods will no longer cause runtimes, meaning cakes now get filled with reagenty-goodness and are both delicious and nutritious.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
