### PR TITLE
Attempted fix at dismemberment runtime

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1409,9 +1409,10 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		Iwound_bonus = CANT_WOUND
 
 	var/weakness = H.check_weakness(I, user)
-	apply_damage(I.force * weakness, I.damtype, def_zone, armor_block, H, wound_bonus = Iwound_bonus, bare_wound_bonus = I.bare_wound_bonus, sharpness = I.get_sharpness())
 
 	H.send_item_attack_message(I, user, hit_area, affecting)
+
+	apply_damage(I.force * weakness, I.damtype, def_zone, armor_block, H, wound_bonus = Iwound_bonus, bare_wound_bonus = I.bare_wound_bonus, sharpness = I.get_sharpness())
 
 	if(!I.force)
 		return FALSE //item force is zero


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/93030745-4debb980-f61d-11ea-8fb9-fe1fcff8d74b.png)

Bunch of undocumented procs relating to wounds.

can_dismember is being called on the head from send_item_attack_message after the head is dismembered. At that point is has no owner and we get ourselves a bit of juicy runtime.

I suspect it's an order-of-operations issue. The wording of the text messages in send_item_attack_message seem to indicate that it's warning about the attack that is just about to happen. In /mob/living/attacked_by() the very first thing it does is call send_item_attack_message(), before apply_damage.

As such, I've made sure send_item_attack_message() is called before apply_damage in this instance too.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtime feex good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Severing and almost severing a body part should now always display the proper gruesome wounds messages instead of occasionally runtiming.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
