### PR TITLE
Fix holopad runtime when speaking after placing call but before it's connected.

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -432,7 +432,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		if(HC.connected_holopad == src && speaker != HC.hologram)
 			HC.user.Hear(message, speaker, message_language, raw_message, radio_freq, spans, message_mods)
 
-	if(outgoing_call && speaker == outgoing_call.user)
+	if(outgoing_call?.hologram && speaker == outgoing_call.user)
 		outgoing_call.hologram.say(raw_message)
 
 	if(record_mode && speaker == record_user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/93032557-3535d080-f62a-11ea-95b0-d555b7709d26.png)

Activate holopad call. Speak. Instant runtime. Outgoing call may well be active, but if it's not picked up there's no hologram. Added logic to skip outgoing_call.hologram.say() if there's no hologram instead of if there's no outgoing call.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtime feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Non-gameplay impacting runtime on holopads when the user spoke after placing a call but before it has been connected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
