### PR TITLE
Fix surgery initiation runtime.

### DIFF
--- a/code/modules/surgery/advanced/wingreconstruction.dm
+++ b/code/modules/surgery/advanced/wingreconstruction.dm
@@ -9,6 +9,8 @@
 	target_mobtypes = list(/mob/living/carbon/human)
 
 /datum/surgery/advanced/wing_reconstruction/can_start(mob/user, mob/living/carbon/target)
+	if(!istype(target))
+		return FALSE
 	return ..() && target.dna.features["moth_wings"] == "Burnt Off" && ismoth(target)
 
 /datum/surgery_step/wing_reconstruction

--- a/code/modules/surgery/bone_mending.dm
+++ b/code/modules/surgery/bone_mending.dm
@@ -28,11 +28,11 @@
 	targetable_wound = /datum/wound/blunt/critical
 
 /datum/surgery/repair_bone_compound/can_start(mob/living/user, mob/living/carbon/target)
+	if(!istype(target))
+		return FALSE
 	if(..())
 		var/obj/item/bodypart/targeted_bodypart = target.get_bodypart(user.zone_selected)
 		return(targeted_bodypart.get_wound_type(targetable_wound))
-
-
 
 //SURGERY STEPS
 

--- a/code/modules/surgery/bone_mending.dm
+++ b/code/modules/surgery/bone_mending.dm
@@ -11,6 +11,8 @@
 	targetable_wound = /datum/wound/blunt/severe
 
 /datum/surgery/repair_bone_hairline/can_start(mob/living/user, mob/living/carbon/target)
+	if(!istype(target))
+		return FALSE
 	if(..())
 		var/obj/item/bodypart/targeted_bodypart = target.get_bodypart(user.zone_selected)
 		return(targeted_bodypart.get_wound_type(targetable_wound))

--- a/code/modules/surgery/burn_dressing.dm
+++ b/code/modules/surgery/burn_dressing.dm
@@ -11,6 +11,8 @@
 	targetable_wound = /datum/wound/burn
 
 /datum/surgery/debride/can_start(mob/living/user, mob/living/carbon/target)
+	if(!istype(target))
+		return FALSE
 	if(..())
 		var/obj/item/bodypart/targeted_bodypart = target.get_bodypart(user.zone_selected)
 		var/datum/wound/burn/burn_wound = targeted_bodypart.get_wound_type(targetable_wound)

--- a/code/modules/surgery/repair_puncture.dm
+++ b/code/modules/surgery/repair_puncture.dm
@@ -15,6 +15,8 @@
 	targetable_wound = /datum/wound/pierce
 
 /datum/surgery/repair_puncture/can_start(mob/living/user, mob/living/carbon/target)
+	if(!istype(target))
+		return FALSE
 	. = ..()
 	if(.)
 		var/obj/item/bodypart/targeted_bodypart = target.get_bodypart(user.zone_selected)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/93033630-f6eee000-f62e-11ea-99a2-c85b686ae319.png)

```
src: Repair bone fracture (hairline... (/datum/surgery/repair_bone_hairline)
call stack:
Repair bone fracture (
  hairline... (
    /datum/surgery/repair_bone_hairline): can start(
    (/mob/living/carbon/human), 
    (/mob/living/simple_animal/hostile/regalrat
  )
)
```

Attempt to start wounds-mending surgery on simple_animal. Tries to find a body part. Runtimes.

I'm going to assume by the proc signature that we're not performing this kind of surgery on surgery on simple_animals. If the type doesn't match, we yeet outta there with an early FALSE.

Wing reconstruction also suffers from this except with DNA. Fixed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtime feez good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes runtime when attempting to start surgery on simple mobs and other non-humans/humanlikes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
