### PR TITLE
NPC Simple Merchants with the Payment Component.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -447,9 +447,6 @@
 ///called when removing a given item from a mob, from mob/living/carbon/remove_embedded_object(mob/living/carbon/target, /obj/item)
 #define COMSIG_CARBON_EMBED_REMOVAL "item_embed_remove_safe"
 
-// /mob/living/simple_animal/merchant signals.
-///Called when a merchant NPC attempts to sell a product.
-#define COMSIG_MOB_ATTEMPT_SELL "mob_attempt_sell"
 
 // /mob/living/simple_animal/hostile signals
 #define COMSIG_HOSTILE_ATTACKINGTARGET "hostile_attackingtarget"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -447,6 +447,10 @@
 ///called when removing a given item from a mob, from mob/living/carbon/remove_embedded_object(mob/living/carbon/target, /obj/item)
 #define COMSIG_CARBON_EMBED_REMOVAL "item_embed_remove_safe"
 
+// /mob/living/simple_animal/merchant signals.
+///Called when a merchant NPC attempts to sell a product.
+#define COMSIG_MOB_ATTEMPT_SELL "mob_attempt_sell"
+
 // /mob/living/simple_animal/hostile signals
 #define COMSIG_HOSTILE_ATTACKINGTARGET "hostile_attackingtarget"
 	#define COMPONENT_HOSTILE_NO_ATTACK (1<<0)

--- a/code/datums/components/payment.dm
+++ b/code/datums/components/payment.dm
@@ -16,20 +16,15 @@
 	var/transaction_style = "Clinical"
 	///Who's getting paid?
 	var/datum/bank_account/target_acc
-	///Associated list of products if payment is setup on a mob.
-	var/list/products
 
-/datum/component/payment/Initialize(_cost, _target, _style, _products)
+/datum/component/payment/Initialize(_cost, _target, _style)
 	target_acc = _target
 	if(!target_acc)
 		target_acc = SSeconomy.get_dep_account(ACCOUNT_CIV)
-	if(_products)
-		products = _products
 	cost = _cost
 	transaction_style = _style
 	RegisterSignal(parent, COMSIG_OBJ_ATTEMPT_CHARGE, .proc/attempt_charge)
 	RegisterSignal(parent, COMSIG_OBJ_ATTEMPT_CHARGE_CHANGE, .proc/change_cost)
-	RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, .proc/purchase_item)
 
 /datum/component/payment/proc/attempt_charge(datum/source, atom/movable/target, extra_fees = 0)
 	SIGNAL_HANDLER
@@ -77,7 +72,22 @@
 		CRASH("change_cost called with variable new_cost as not a number.")
 	cost = new_cost
 
-/datum/component/payment/proc/purchase_item(datum/source, atom/movable/customer)
+
+/**
+  * Handles simple payment operations where the parent can handle buying and selling items from a given keyed list.
+  * Used on the merchant simplemob NPCs primarily.
+  **/
+/datum/component/payment/merchant
+	///Associated list of products if payment is setup on a mob.
+	var/list/products
+
+/datum/component/payment/merchant/Initialize(_cost, _target, _style, _products)
+	. = ..()
+	if(_products)
+		products = _products
+	RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, .proc/purchase_item)
+
+/datum/component/payment/merchant/proc/purchase_item(datum/source, atom/movable/customer)
 	SIGNAL_HANDLER
 	if(!LAZYLEN(products))
 		return

--- a/code/modules/mob/living/simple_animal/friendly/merchants.dm
+++ b/code/modules/mob/living/simple_animal/friendly/merchants.dm
@@ -1,0 +1,49 @@
+/mob/living/simple_animal/merchant
+	name = "Merchant?"
+	desc = "A rock. It seems to have... wares."
+	icon_state = "basalt"
+	icon = 'icons/obj/flora/rocks.dmi'
+	maxHealth = 200
+	health = 200
+	del_on_death = TRUE
+	stop_automated_movement = TRUE
+	loot = list(/obj/effect/decal/cleanable/dirt)
+	///What products are being assigned to the product list?
+	var/list/product_list = list(/obj/item/food/burger/plain = 1, /obj/item/gun/ballistic/automatic/pistol = 1, /obj/item/seeds/rainbow_bunch = 1)
+	///What is the base price for the products being offered?
+	var/product_cost = 100
+
+/mob/living/simple_animal/merchant/Initialize()
+	. = ..()
+	AddComponent(/datum/component/payment, product_cost, SSeconomy.get_dep_account(ACCOUNT_CIV), PAYMENT_FRIENDLY, product_list)
+
+/mob/living/simple_animal/merchant/attack_hand(mob/living/carbon/human/M)
+	if(M.a_intent == INTENT_HELP)
+		return SEND_SIGNAL(src, COMSIG_MOB_ATTEMPT_SELL, M)
+	return ..()
+
+/mob/living/simple_animal/merchant/gondola
+	name = "Gondola Merchant"
+	desc = "He speaks the language of green."
+	icon = 'icons/mob/pets.dmi'
+	icon = 'icons/mob/gondolas.dmi'
+	icon_state = "gondola"
+	icon_living = "gondola"
+	loot = list(/obj/effect/decal/cleanable/blood/gibs, /obj/item/stack/sheet/animalhide/gondola = 1, /obj/item/reagent_containers/food/snacks/meat/slab/gondola = 1)
+	///What products are being assigned to the product list?
+	product_list = list(/obj/item/stack/sheet/animalhide/gondola = 3, /obj/item/clothing/under/costume/gondola = 1, /obj/item/clothing/mask/gondola = 1)
+	///What is the base price for the products being offered?
+	product_cost = 300
+
+/mob/living/simple_animal/merchant/skeleton
+	name = "Skeleton Merchant"
+	desc = "Reanimated bones, with reanimated wares."
+	icon = 'icons/mob/simple_human.dmi'
+	icon_state = "skeleton"
+	icon_living = "skeleton"
+	icon_dead = "skeleton"
+	loot = list(/obj/effect/decal/cleanable/ash, /obj/item/stack/sheet/bone = 1)
+	///What products are being assigned to the product list?
+	product_list = list(/obj/item/reagent_containers/food/snacks/sugarcookie/spookyskull = 3, /obj/item/gun/ballistic/automatic/wt550 = 1, /obj/item/reagent_containers/food/condiment/milk = 1)
+	///What is the base price for the products being offered?
+	product_cost = 100

--- a/code/modules/mob/living/simple_animal/friendly/merchants.dm
+++ b/code/modules/mob/living/simple_animal/friendly/merchants.dm
@@ -19,7 +19,7 @@
 
 /mob/living/simple_animal/merchant/attack_hand(mob/living/carbon/human/M)
 	if(M.a_intent == INTENT_HELP)
-		return SEND_SIGNAL(src, COMSIG_MOB_ATTEMPT_SELL, M)
+		return SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_HAND, M)
 	return ..()
 
 /mob/living/simple_animal/merchant/gondola
@@ -30,9 +30,7 @@
 	icon_state = "gondola"
 	icon_living = "gondola"
 	loot = list(/obj/effect/decal/cleanable/blood/gibs, /obj/item/stack/sheet/animalhide/gondola = 1, /obj/item/reagent_containers/food/snacks/meat/slab/gondola = 1)
-	///What products are being assigned to the product list?
 	product_list = list(/obj/item/stack/sheet/animalhide/gondola = 3, /obj/item/clothing/under/costume/gondola = 1, /obj/item/clothing/mask/gondola = 1)
-	///What is the base price for the products being offered?
 	product_cost = 300
 
 /mob/living/simple_animal/merchant/skeleton
@@ -42,8 +40,6 @@
 	icon_state = "skeleton"
 	icon_living = "skeleton"
 	icon_dead = "skeleton"
-	loot = list(/obj/effect/decal/cleanable/ash, /obj/item/stack/sheet/bone = 1)
-	///What products are being assigned to the product list?
+	loot = list(/obj/effect/decal/remains/human, /obj/item/stack/sheet/bone = 1)
 	product_list = list(/obj/item/reagent_containers/food/snacks/sugarcookie/spookyskull = 3, /obj/item/gun/ballistic/automatic/wt550 = 1, /obj/item/reagent_containers/food/condiment/milk = 1)
-	///What is the base price for the products being offered?
 	product_cost = 100

--- a/code/modules/mob/living/simple_animal/friendly/merchants.dm
+++ b/code/modules/mob/living/simple_animal/friendly/merchants.dm
@@ -15,7 +15,7 @@
 
 /mob/living/simple_animal/merchant/Initialize()
 	. = ..()
-	AddComponent(/datum/component/payment, product_cost, SSeconomy.get_dep_account(ACCOUNT_CIV), PAYMENT_FRIENDLY, product_list)
+	AddComponent(/datum/component/payment/merchant, product_cost, SSeconomy.get_dep_account(ACCOUNT_CIV), PAYMENT_FRIENDLY, product_list)
 
 /mob/living/simple_animal/merchant/attack_hand(mob/living/carbon/human/M)
 	if(M.a_intent == INTENT_HELP)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -95,6 +95,7 @@
 	desc = "An outdated personal defence weapon. Uses 4.6x30mm rounds and is designated the WT-550 Automatic Rifle."
 	icon_state = "wt550"
 	inhand_icon_state = "arg"
+	custom_price = 1000
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_delay = 2
 	can_suppress = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2410,6 +2410,7 @@
 #include "code\modules\mob\living\simple_animal\friendly\fox.dm"
 #include "code\modules\mob\living\simple_animal\friendly\gondola.dm"
 #include "code\modules\mob\living\simple_animal\friendly\lizard.dm"
+#include "code\modules\mob\living\simple_animal\friendly\merchants.dm"
 #include "code\modules\mob\living\simple_animal\friendly\mouse.dm"
 #include "code\modules\mob\living\simple_animal\friendly\penguin.dm"
 #include "code\modules\mob\living\simple_animal\friendly\pet.dm"


### PR DESCRIPTION
## About The Pull Request

Adds simple, radial-based merchants using the payment component, as well as a merchant subtype simplemob.
When an empty hand is used on it, in help intent, you are given the choice to purchase objects from the assigned product list, at an assigned price PLUS that object's custom_price assignment.

Enables more methods for players to purchase things in-round, either as an admin event, or to enable events where merchants could arrive on-station with supplies dependent on the station's need.

![image](https://user-images.githubusercontent.com/41715314/93067735-9c16b200-f649-11ea-851f-2e9ad935229d.png)
_The Gondola Merchant, peddling his gondola-like wares. How DOES he find this stuff?_
## Why It's Good For The Game

The feedback to economy as of recent has been pretty uniform, players want more ways to spend their earned money that can affect their round without going through vending machines (basic loot) or cargo (specialized loot, but more expensive and slower). This sets up a basic framework to enable that going forward.

## Changelog
:cl:
add: The payment component can be added to a new merchant NPC type, to buy and sell objects.
/:cl: