### PR TITLE
Adds a keybind for resting

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -43,6 +43,7 @@
 #define COMSIG_KB_LIVING_RESIST_DOWN "keybinding_living_resist_down"
 #define COMSIG_KB_LIVING_LOOKUP_DOWN "keybinding_living_lookup_down"
 #define COMSIG_KB_LIVING_LOOKDOWN_DOWN "keybinding_living_lookdown_down"
+#define COMSIG_KB_LIVING_REST_DOWN "keybinding_living_rest_down"
 
 //Mob
 #define COMSIG_KB_MOB_FACENORTH_DOWN "keybinding_mob_facenorth_down"

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -59,3 +59,18 @@
 	var/mob/living/L = user.mob
 	L.end_look_down()
 	return TRUE
+
+/datum/keybinding/living/rest
+	hotkey_keys = list("C")
+	name = "rest"
+	full_name = "Rest"
+	description = "Lay down, or get up."
+	keybind_signal = COMSIG_KB_LIVING_REST_DOWN
+
+/datum/keybinding/living/rest/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/L = user.mob
+	L.lay_down()
+	return TRUE

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -61,7 +61,7 @@
 	return TRUE
 
 /datum/keybinding/living/rest
-	hotkey_keys = list("C")
+	hotkey_keys = list("U")
 	name = "rest"
 	full_name = "Rest"
 	description = "Lay down, or get up."

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -71,6 +71,6 @@
 	. = ..()
 	if(.)
 		return
-	var/mob/living/L = user.mob
-	L.lay_down()
+	var/mob/living/living_mob = user.mob
+	living_mob.lay_down()
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a keybind for resting, it's odd that there's bind for all the UI buttons such as Resist, Throw, Drop but there isn't one for resting. The default key is ~~C, which I guess could be fatfingered if you're trying to swap hand by pressing X, so maybe not the best key choice, but im open for suggestions~~ The default key is now U !

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency with other buttons, and it's good to have around so people can rest comfortably (heh, get it)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a rest keybind! The default hotkey is U
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
