### PR TITLE
Fixes issue where self-resp and enabling Godmode may not clear the suffocating moodlet

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -10,10 +10,14 @@
 	usable_legs = 0 //Populated on init through list/bodyparts
 	num_hands = 0 //Populated on init through list/bodyparts
 	usable_hands = 0 //Populated on init through list/bodyparts
-	var/list/internal_organs		= list()	///List of [/obj/item/organ] in the mob. They don't go in the contents for some reason I don't want to know.
-	var/list/internal_organs_slot= list() ///Same as [above][/mob/living/carbon/var/internal_organs], but stores "slot ID" - "organ" pairs for easy access.
-	var/silent = 0 		///Can't talk. Value goes down every life proc. NOTE TO FUTURE CODERS: DO NOT INITIALIZE NUMERICAL VARS AS NULL OR I WILL MURDER YOU.
-	var/dreaming = 0 ///How many dream images we have left to send
+	//List of [/obj/item/organ] in the mob. They don't go in the contents for some reason I don't want to know.
+	var/list/internal_organs = list()
+	///Same as [above][/mob/living/carbon/var/internal_organs], but stores "slot ID" - "organ" pairs for easy access.
+	var/list/internal_organs_slot = list()
+	///Can't talk. Value goes down every life proc. NOTE TO FUTURE CODERS: DO NOT INITIALIZE NUMERICAL VARS AS NULL OR I WILL MURDER YOU.
+	var/silent = 0
+	///How many dream images we have left to send
+	var/dreaming = 0
 
 	var/obj/item/handcuffed = null///Whether or not the mob is handcuffed
 	var/obj/item/legcuffed = null  ///Same as handcuffs but for legs. Bear traps use this.
@@ -27,15 +31,22 @@
 	var/obj/item/tank/internal = null
 	var/obj/item/clothing/head = null
 
-	var/obj/item/clothing/gloves = null ///only used by humans
-	var/obj/item/clothing/shoes/shoes = null ///only used by humans.
-	var/obj/item/clothing/glasses/glasses = null ///only used by humans.
-	var/obj/item/clothing/ears = null ///only used by humans.
+	///only used by humans
+	var/obj/item/clothing/gloves = null
+	///only used by humans.
+	var/obj/item/clothing/shoes/shoes = null
+	///only used by humans.
+	var/obj/item/clothing/glasses/glasses = null
+	///only used by humans.
+	var/obj/item/clothing/ears = null
 
-	var/datum/dna/dna = null /// Carbon
-	var/datum/mind/last_mind = null ///last mind to control this mob, for blood-based cloning
+	/// Carbon
+	var/datum/dna/dna = null
+	///last mind to control this mob, for blood-based cloning
+	var/datum/mind/last_mind = null
 
-	var/failed_last_breath = 0 ///This is used to determine if the mob failed a breath. If they did fail a brath, they will attempt to breathe each tick, otherwise just once per 4 ticks.
+	///This is used to determine if the mob failed a breath. If they did fail a brath, they will attempt to breathe each tick, otherwise just once per 4 ticks.
+	var/failed_last_breath = FALSE
 
 	var/co2overloadtime = null
 	var/temperature_resistance = T0C+75
@@ -45,7 +56,8 @@
 
 	var/rotate_on_lying = 1
 
-	var/tinttotal = 0	/// Total level of visualy impairing items
+	/// Total level of visualy impairing items
+	var/tinttotal = 0
 
 	///Gets filled up in [create_bodyparts()][/mob/living/carbon/proc/create_bodyparts]
 	var/list/bodyparts = list(
@@ -57,7 +69,8 @@
 		/obj/item/bodypart/l_leg,
 		)
 
-	var/list/hand_bodyparts = list() ///a collection of arms (or actually whatever the fug /bodyparts you monsters use to wreck my systems)
+	/// A collection of arms (or actually whatever the fug /bodyparts you monsters use to wreck my systems)
+	var/list/hand_bodyparts = list()
 
 	var/icon_render_key = ""
 	var/static/list/limb_icon_cache = list()
@@ -70,8 +83,10 @@
 	var/next_hallucination = 0
 	var/damageoverlaytemp = 0
 
-	var/drunkenness = 0 ///Overall drunkenness
-	var/stam_regen_start_time = 0 ///used to halt stamina regen temporarily
+	///Overall drunkenness
+	var/drunkenness = 0
+	///used to halt stamina regen temporarily
+	var/stam_regen_start_time = 0
 
 	/// Protection (insulation) from the heat, Value 0-1 corresponding to the percentage of protection
 	var/heat_protection = 0 // No heat protection

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -10,7 +10,7 @@
 	usable_legs = 0 //Populated on init through list/bodyparts
 	num_hands = 0 //Populated on init through list/bodyparts
 	usable_hands = 0 //Populated on init through list/bodyparts
-	//List of [/obj/item/organ] in the mob. They don't go in the contents for some reason I don't want to know.
+	///List of [/obj/item/organ] in the mob. They don't go in the contents for some reason I don't want to know.
 	var/list/internal_organs = list()
 	///Same as [above][/mob/living/carbon/var/internal_organs], but stores "slot ID" - "organ" pairs for easy access.
 	var/list/internal_organs_slot = list()
@@ -19,8 +19,10 @@
 	///How many dream images we have left to send
 	var/dreaming = 0
 
-	var/obj/item/handcuffed = null///Whether or not the mob is handcuffed
-	var/obj/item/legcuffed = null  ///Same as handcuffs but for legs. Bear traps use this.
+	///Whether or not the mob is handcuffed
+	var/obj/item/handcuffed = null
+	///Same as handcuffs but for legs. Bear traps use this.
+	var/obj/item/legcuffed = null
 
 	var/disgust = 0
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -85,7 +85,7 @@
 		else if(!HAS_TRAIT(src, TRAIT_NOCRITDAMAGE))
 			adjustOxyLoss(HUMAN_CRIT_MAX_OXYLOSS)
 
-		failed_last_breath = 1
+		failed_last_breath = TRUE
 
 		var/datum/species/S = dna.species
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -136,11 +136,11 @@
 //Third link in a breath chain, calls handle_breath_temperature()
 /mob/living/carbon/proc/check_breath(datum/gas_mixture/breath)
 	if(status_flags & GODMODE)
-		failed_last_breath = 0
+		failed_last_breath = FALSE
 		clear_alert("not_enough_oxy")
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_NOBREATH))
-		failed_last_breath = 0
+		failed_last_breath = FALSE
 		clear_alert("not_enough_oxy")
 		return FALSE
 
@@ -154,7 +154,7 @@
 			return FALSE
 		adjustOxyLoss(1)
 
-		failed_last_breath = 1
+		failed_last_breath = TRUE
 		throw_alert("not_enough_oxy", /obj/screen/alert/not_enough_oxy)
 		return FALSE
 
@@ -180,15 +180,15 @@
 		if(O2_partialpressure > 0)
 			var/ratio = 1 - O2_partialpressure/safe_oxy_min
 			adjustOxyLoss(min(5*ratio, 3))
-			failed_last_breath = 1
+			failed_last_breath = TRUE
 			oxygen_used = breath_gases[/datum/gas/oxygen][MOLES]*ratio
 		else
 			adjustOxyLoss(3)
-			failed_last_breath = 1
+			failed_last_breath = TRUE
 		throw_alert("not_enough_oxy", /obj/screen/alert/not_enough_oxy)
 
 	else //Enough oxygen
-		failed_last_breath = 0
+		failed_last_breath = FALSE
 		if(health >= crit_threshold)
 			adjustOxyLoss(-5)
 		oxygen_used = breath_gases[/datum/gas/oxygen][MOLES]

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -136,8 +136,12 @@
 //Third link in a breath chain, calls handle_breath_temperature()
 /mob/living/carbon/proc/check_breath(datum/gas_mixture/breath)
 	if(status_flags & GODMODE)
+		failed_last_breath = 0
+		clear_alert("not_enough_oxy")
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_NOBREATH))
+		failed_last_breath = 0
+		clear_alert("not_enough_oxy")
 		return FALSE
 
 	var/obj/item/organ/lungs = getorganslot(ORGAN_SLOT_LUNGS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #53700

Clears suffocation-related flags while the user doesn't need to breathe due to the self-resp virus symptom or Godmode.

breathe() called check_breath() which returns early if you don't need to breathe, but never clears the failed_last_breath flag.

breathe() is immediately followed by:
![image](https://user-images.githubusercontent.com/24975989/93102669-99e14180-f6a3-11ea-8482-88b23cd0f51f.png)

You can see the problem.

Also correctly moves inline comments to their appropriate places for DMDocs to work and clears up some 0 instead of FALSE 1 instead of TRUE functionality

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes a simple oversight.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You will now no longer feel so eternally sad if you gain the a trait where you no longer need to breath or become a God while you are suffocating.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
