### PR TITLE
Fix two gas assertion runtimes

### DIFF
--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -92,6 +92,10 @@
 
 	var/datum/gas_mixture/env = L.return_air() //get air from the turf
 	var/datum/gas_mixture/removed = env.remove(0.1 * env.total_moles())
+
+	if(!removed)
+		return
+
 	removed.assert_gases(/datum/gas/water_vapor, /datum/gas/oxygen, /datum/gas/hydrogen)
 	var/proportion = min(removed.gases[/datum/gas/water_vapor][MOLES], (1.5 * delta_time * workingPower))//Works to max 12 moles at a time.
 	removed.gases[/datum/gas/water_vapor][MOLES] -= proportion * 2 * workingPower

--- a/code/modules/events/crystal_event.dm
+++ b/code/modules/events/crystal_event.dm
@@ -363,6 +363,10 @@ This section is for the destabilized SM
 	var/datum/gas_mixture/removed
 	var/gasefficency = 0.5
 	removed = env.remove(gasefficency * env.total_moles())
+
+	if(!removed)
+		return
+
 	removed.assert_gases(/datum/gas/bz, /datum/gas/miasma)
 	if(!removed || !removed.total_moles() || isspaceturf(loc_turf))
 		removed.gases[/datum/gas/bz][MOLES] += 0.5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/93106339-0f4f1100-f6a8-11ea-93e7-51f44db0747f.png)

/datum/gas_mixture/proc/remove(amount) has a code path that can return null.

All the code following the runtimes assume some bit of gas_mixture was actually removed at all. No need to trigger this code if there's no gas_mixture removed, can early return instead.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
~~:cl:~~
fix: Fixed runtimes when electrolyzers and the destabilized crystal attempted to remove air from a vacuum and then assert their dominance over it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
