### PR TITLE
Fixes processing of deleted objects in SSair

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -20,6 +20,7 @@ SUBSYSTEM_DEF(air)
 	var/list/hotspots = list()
 	var/list/networks = list()
 	var/list/pipenets_needing_rebuilt = list()
+	/// A list of machines that will be processed when currentpart == SSAIR_ATMOSMACHINERY. Use SSair.begin_processing_machine and SSair.stop_processing_machine to add and remove machines.
 	var/list/obj/machinery/atmos_machinery = list()
 	var/list/pipe_init_dirs_cache = list()
 
@@ -31,7 +32,7 @@ SUBSYSTEM_DEF(air)
 	var/list/turf/active_super_conductivity = list()
 	var/list/turf/open/high_pressure_delta = list()
 
-
+	/// A cache of objects that perisists between processing runs when resumed == TRUE. Dangerous, qdel'd objects not cleared from this may cause runtimes on processing.
 	var/list/currentrun = list()
 	var/currentpart = SSAIR_REBUILD_PIPENETS
 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -437,6 +437,36 @@ GLOBAL_LIST_EMPTY(colored_images)
 	var/datum/atmosphere/mix = atmos_gen[gas_string]
 	return mix.gas_string
 
+/**
+  * Adds a given machine to the processing system for SSAIR_ATMOSMACHINERY processing.
+  *
+  * This should be fast, so no error checking is done.
+  * If you start adding in things you shouldn't, you'll cause runtimes every 2 seconds for every
+  * object you added. Do not use irresponsibly.
+  * Arguments:
+  * * machine - The machine to start processing. Can be any /obj/machinery.
+  */
+/datum/controller/subsystem/air/proc/start_processing_machine(obj/machinery/machine)
+	atmos_machinery += machine
+
+/**
+  * Removes a given machine to the processing system for SSAIR_ATMOSMACHINERY processing.
+  *
+  * This should be fast, so no error checking is done.
+  * If you call this proc when your machine isn't processing, you're likely attempting to
+  * remove something that isn't in a list with over 1000 objects, twice. Do not use
+  * irresponsibly.
+  * Arguments:
+  * * machine - The machine to stop processing.
+  */
+/datum/controller/subsystem/air/proc/stop_processing_machine(obj/machinery/machine)
+	atmos_machinery -= machine
+
+	// If we're currently processing atmos machines, there's a chance this machine is in
+	// the currentrun list, which is a cache of atmos_machinery. Remove it from that list
+	// as well to prevent processing qdeleted objects in the cache.
+	if(currentpart == SSAIR_ATMOSMACHINERY)
+		currentrun -= machine
 
 /datum/controller/subsystem/air/ui_state(mob/user)
 	return GLOB.debug_state

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -73,11 +73,11 @@
 
 /obj/machinery/air_sensor/Initialize()
 	. = ..()
-	SSair.atmos_machinery += src
+	SSair.start_processing_machine(src)
 	set_frequency(frequency)
 
 /obj/machinery/air_sensor/Destroy()
-	SSair.atmos_machinery -= src
+	SSair.stop_processing_machine(src)
 	SSradio.remove_object(src, frequency)
 	return ..()
 

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -58,17 +58,15 @@
 		armor = list(MELEE = 25, BULLET = 10, LASER = 10, ENERGY = 100, BOMB = 0, BIO = 100, RAD = 100, FIRE = 100, ACID = 70)
 	..()
 	if(process)
-		SSair.atmos_machinery += src
+		SSair.start_processing_machine(src)
 	SetInitDirections()
 
 /obj/machinery/atmospherics/Destroy()
 	for(var/i in 1 to device_type)
 		nullifyNode(i)
 
-	SSair.atmos_machinery -= src
+	SSair.stop_processing_machine(src)
 	SSair.pipenets_needing_rebuilt -= src
-	if(SSair.currentpart == SSAIR_ATMOSMACHINERY)
-		SSair.currentrun -= src
 
 	dropContents()
 	if(pipe_vision_img)

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -33,14 +33,14 @@
 	id_tag = ATMOS_GAS_MONITOR_LOOP_DISTRIBUTION
 
 /obj/machinery/meter/Destroy()
-	SSair.atmos_machinery -= src
+	SSair.stop_processing_machine(src)
 	target = null
 	return ..()
 
 /obj/machinery/meter/Initialize(mapload, new_piping_layer)
 	if(!isnull(new_piping_layer))
 		target_layer = new_piping_layer
-	SSair.atmos_machinery += src
+	SSair.start_processing_machine(src)
 	if(!target)
 		reattach_to_layer()
 	return ..()

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -19,10 +19,10 @@
 	air_contents = new
 	air_contents.volume = volume
 	air_contents.temperature = T20C
-	SSair.atmos_machinery += src
+	SSair.start_processing_machine(src)
 
 /obj/machinery/portable_atmospherics/Destroy()
-	SSair.atmos_machinery -= src
+	SSair.stop_processing_machine(src)
 
 	disconnect()
 	qdel(air_contents)

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -17,7 +17,7 @@
 	. = ..()
 	find_circs()
 	connect_to_network()
-	SSair.atmos_machinery += src
+	SSair.start_processing_machine(src)
 	update_icon()
 	component_parts = list(new /obj/item/circuitboard/machine/generator)
 
@@ -27,7 +27,7 @@
 
 /obj/machinery/power/generator/Destroy()
 	kill_circs()
-	SSair.atmos_machinery -= src
+	SSair.stop_processing_machine(src)
 	return ..()
 
 /obj/machinery/power/generator/update_overlays()

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -308,7 +308,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 /obj/machinery/power/supermatter_crystal/Initialize()
 	. = ..()
 	uid = gl_uid++
-	SSair.atmos_machinery += src
+	SSair.start_processing_machine(src)
 	countdown = new(src)
 	countdown.start()
 	GLOB.poi_list |= src
@@ -332,7 +332,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 /obj/machinery/power/supermatter_crystal/Destroy()
 	investigate_log("has been destroyed.", INVESTIGATE_SUPERMATTER)
-	SSair.atmos_machinery -= src
+	SSair.stop_processing_machine(src)
 	QDEL_NULL(radio)
 	GLOB.poi_list -= src
 	QDEL_NULL(countdown)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/93164217-f0d13000-f710-11ea-9722-7e1fbb913f13.png)
![image](https://user-images.githubusercontent.com/24975989/93164225-f464b700-f710-11ea-9957-eedc25909436.png)

![image](https://user-images.githubusercontent.com/24975989/93164864-81f4d680-f712-11ea-8b16-a83469eb81fc.png)
![image](https://user-images.githubusercontent.com/24975989/93164868-84efc700-f712-11ea-890a-de6de084a3ee.png)

qdel'd objects could still process in SSair because SSair utilises a cache whenever it has to resume processing runs from a partially completed state from running out of processing time.

Of all the things that processed on SSair, only one thing actually took care to remove itself from the cache as well on deletion.

This is an important subsystem and the processing lists should not be public. Objects don't need to know how SSair works, they just call the proc to add when they start processing and call the proc to remove when they finish.

Thanks to @LemonInTheDark and @willox for spending a lot of time helping me track down a proper fix to this issue.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtimes bad. Apes having public access to processing subsystem vars is worse.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes a runtime in the air subsystem, where deleted objects were still processed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
