### PR TITLE
Fix EMP-shielded camera runtime on destruction

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -105,7 +105,6 @@
 	if(isarea(myarea))
 		LAZYREMOVE(myarea.cameras, src)
 	QDEL_NULL(assembly)
-	QDEL_NULL(emp_component)
 	if(bug)
 		bug.bugged_cameras -= src.c_tag
 		if(bug.current == src)

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -92,7 +92,7 @@
 /obj/machinery/camera/proc/removeEmpProof(ignore_malf_upgrades)
 	if(ignore_malf_upgrades) //don't downgrade it if malf software is forced onto it.
 		return
-	emp_component.RemoveComponent()
+	QDEL_NULL(emp_component)
 	upgrades &= ~CAMERA_UPGRADE_EMP_PROOF
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/93170900-fbdf8c80-f71f-11ea-9684-0e39b6296ef4.png)
![image](https://user-images.githubusercontent.com/24975989/93171001-2c272b00-f720-11ea-81e5-7833d4944976.png)
![image](https://user-images.githubusercontent.com/24975989/93170922-09951200-f720-11ea-9632-e48a7ce31082.png)

Cameras delete their assemblies on Destroy(). The assembly calls RemoveComponent() on the Camera's emp component. This nulls the emp_component's parent. The camera itself then attempts to QDEL_NULL its emp component, which leads to the above image of a SEND_SIGNAL to a parent that's null.

Since the assembly manages it all for us, including calling the appropriate emp removal proc, we can remove QDEL_NULL in the camera Destroy() and instead QDEL_NULL the emp component where it once was simply RemoveComponent()'d.

This fixes the cause of the runtime.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: EMP-shielded cameras will no longer runtime when destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
