### PR TITLE
Makes the Ghost Whispers pref. toggle work with or without Ghost Ears enabled

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -297,9 +297,10 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			if(M.stat != DEAD) //not dead, not important
 				continue
 			if(get_dist(M, src) > 7 || M.z != z) //they're out of range of normal hearing
-				if(eavesdrop_range && !(M.client.prefs.chat_toggles & CHAT_GHOSTWHISPER)) //they're whispering and we have hearing whispers at any range off
-					continue
-				if(!eavesdrop_range && !(M.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
+				if(eavesdrop_range)
+					if(!(M.client.prefs.chat_toggles & CHAT_GHOSTWHISPER)) //they're whispering and we have hearing whispers at any range off
+						continue
+				else if(!(M.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
 					continue
 			listening |= M
 			the_dead[M] = TRUE

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -299,7 +299,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			if(get_dist(M, src) > 7 || M.z != z) //they're out of range of normal hearing
 				if(eavesdrop_range && !(M.client.prefs.chat_toggles & CHAT_GHOSTWHISPER)) //they're whispering and we have hearing whispers at any range off
 					continue
-				if(!(M.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
+				if(!eavesdrop_range && !(M.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
 					continue
 			listening |= M
 			the_dead[M] = TRUE


### PR DESCRIPTION
## About The Pull Request

Adds the condition of `!eavesdrop_range` to the logic for determining weather or not a non-whispered speech message should be displayed based on our `CHAT_GHOSTEARS` preference. Making it so that the Ghost Ears setting is no longer checked if the message is whispered and therefore long distance whispers will no longer be suppressed if both preferences are not set to TRUE.

## Why It's Good For The Game

Whispers are much less common than normal speech, but I think are far more likely to contain some juicy scuttlebutt. I think we should be able to listen for them without needing to parse through all other speech in the world as a prerequisite.

Also ambiguous preference dependencies are bad. Options are good, and so is bringing this toggles functionality in-line with that of Ghost Sight which does not require Ghost Ears to likewise be informed about all emotes in the world.

## Changelog
:cl:
tweak: Ghost Whispers preference no longer requires Ghost Ears to be enabled to hear all whispers.
/:cl: