### PR TITLE
Fix burning black crossbreed runtime on humanizing

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_mobs.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_mobs.dm
@@ -21,7 +21,7 @@ Slimecrossing Mobs
 	if(remove_on_restore)
 		if(M.mind)
 			M.mind.RemoveSpell(src)
-	..()
+	return ..()
 
 //Transformed slime - Burning Black
 /mob/living/simple_animal/slime/transformedslime


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When transforming back to a human, /obj/effect/proc_holder/spell/targeted/shapeshift/slimeform/Restore called the parent but didn't return it, instead returning nothing (always null).

It's used in /obj/effect/proc_holder/spell/targeted/shapeshift/cast when transforming back to human via the Burning Black crossbreed which expect Restore() to return a mob. The code would then go on to immediately runtime.

With the appropriate return, this runtime no longer happens as the value is no longer null.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Using a burning black crossbreed to transform into a slime, go ventcrawling, then transform back into a human while ventcrawling is now a lot more deadly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
