### PR TITLE
Cyborg inventory runtime fix.

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -93,7 +93,7 @@
 
 /datum/hud/robot/New(mob/owner)
 	..()
-	var/mob/living/silicon/robot/mymobR = mymob
+	var/mob/living/silicon/robot/robit = mymob
 	var/obj/screen/using
 
 	using = new/obj/screen/language_menu
@@ -107,23 +107,26 @@
 	static_inventory += using
 
 //Module select
-	using = new /obj/screen/robot/module1()
-	using.screen_loc = ui_inv1
-	using.hud = src
-	static_inventory += using
-	mymobR.inv1 = using
+	if(!robit.inv1)
+		robit.inv1 = new /obj/screen/robot/module1()
 
-	using = new /obj/screen/robot/module2()
-	using.screen_loc = ui_inv2
-	using.hud = src
-	static_inventory += using
-	mymobR.inv2 = using
+	robit.inv1.screen_loc = ui_inv1
+	robit.inv1.hud = src
+	static_inventory += robit.inv1
 
-	using = new /obj/screen/robot/module3()
-	using.screen_loc = ui_inv3
-	using.hud = src
-	static_inventory += using
-	mymobR.inv3 = using
+	if(!robit.inv2)
+		robit.inv2 = new /obj/screen/robot/module1()
+
+	robit.inv2.screen_loc = ui_inv2
+	robit.inv2.hud = src
+	static_inventory += robit.inv2
+
+	if(!robit.inv3)
+		robit.inv3 = new /obj/screen/robot/module1()
+
+	robit.inv3.screen_loc = ui_inv3
+	robit.inv3.hud = src
+	static_inventory += robit.inv3
 
 //End of module select
 
@@ -149,14 +152,14 @@
 	using.screen_loc = ui_borg_lamp
 	using.hud = src
 	static_inventory += using
-	mymobR.lamp_button = using
+	robit.lamp_button = using
 
 //Thrusters
 	using = new /obj/screen/robot/thrusters()
 	using.screen_loc = ui_borg_thrusters
 	using.hud = src
 	static_inventory += using
-	mymobR.thruster_button = using
+	robit.thruster_button = using
 
 //Intent
 	action_intent = new /obj/screen/act_intent/robot()
@@ -170,10 +173,10 @@
 	infodisplay += healths
 
 //Installed Module
-	mymobR.hands = new /obj/screen/robot/module()
-	mymobR.hands.screen_loc = ui_borg_module
-	mymobR.hands.hud = src
-	static_inventory += mymobR.hands
+	robit.hands = new /obj/screen/robot/module()
+	robit.hands.screen_loc = ui_borg_module
+	robit.hands.hud = src
+	static_inventory += robit.hands
 
 //Store
 	module_store_icon = new /obj/screen/robot/store()

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -93,6 +93,7 @@
 
 /datum/hud/robot/New(mob/owner)
 	..()
+	// i, Robit
 	var/mob/living/silicon/robot/robit = mymob
 	var/obj/screen/using
 

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -116,14 +116,14 @@
 	static_inventory += robit.inv1
 
 	if(!robit.inv2)
-		robit.inv2 = new /obj/screen/robot/module1()
+		robit.inv2 = new /obj/screen/robot/module2()
 
 	robit.inv2.screen_loc = ui_inv2
 	robit.inv2.hud = src
 	static_inventory += robit.inv2
 
 	if(!robit.inv3)
-		robit.inv3 = new /obj/screen/robot/module1()
+		robit.inv3 = new /obj/screen/robot/module3()
 
 	robit.inv3.screen_loc = ui_inv3
 	robit.inv3.hud = src

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -114,6 +114,10 @@
 	robot_modules_background.layer = HUD_LAYER	//Objects that appear on screen are on layer ABOVE_HUD_LAYER, UI should be just below it.
 	robot_modules_background.plane = HUD_PLANE
 
+	inv1 = new /obj/screen/robot/module1()
+	inv2 = new /obj/screen/robot/module2()
+	inv3 = new /obj/screen/robot/module3()
+
 	ident = rand(1, 999)
 
 	previous_health = health
@@ -188,12 +192,12 @@
 		if(T && istype(radio) && istype(radio.keyslot))
 			radio.keyslot.forceMove(T)
 			radio.keyslot = null
-	qdel(wires)
-	qdel(module)
-	qdel(eye_lights)
-	wires = null
-	module = null
-	eye_lights = null
+	QDEL_NULL(wires)
+	QDEL_NULL(module)
+	QDEL_NULL(eye_lights)
+	QDEL_NULL(inv1)
+	QDEL_NULL(inv2)
+	QDEL_NULL(inv3)
 	cell = null
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/93186243-4e2ba800-f736-11ea-9007-c6cd57fffc4f.png)

Following the cyborg inventory refactor, code changed a bit.

Cyborg inventory screens are inited in the HUD, however AI Shells don't generate a HUD until an AI assumes direct control.

Damaging an AI shell before the AI created a HUD in it would cause runtimes as modules disabled and enabled.

To remedy this, we now initialize the core inventory slots on the robit Init() and then update them as necessary in the HUD code later on if an AI ever deigns to grace your shell with their exalted presence instead of asking for it and then never using it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtime feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: AIs should no longer experience weird interface disparities or module selection issues when assuming direct control over a shell for the first time when said shell is damaged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
