### PR TITLE
Airlock painter runtime fix

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1565,7 +1565,7 @@
   */
 /obj/machinery/door/airlock/proc/set_wires()
 	var/area/source_area = get_area(src)
-	return source_area?.airlock_wires ? new source_area.airlock_wires : new /datum/wires/airlock
+	return source_area?.airlock_wires ? new source_area.airlock_wires(src) : new /datum/wires/airlock(src)
 
 #undef AIRLOCK_CLOSED
 #undef AIRLOCK_CLOSING

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1210,22 +1210,19 @@
 		return
 
 	var/airlock_type = painter.available_paint_jobs["[current_paintjob]"] // get the airlock type path associated with the airlock name the user just chose
-	var/obj/machinery/door/airlock/airlock = new airlock_type // we need to create a new instance of the airlock and assembly to read vars from them
-	var/obj/structure/door_assembly/assembly = new airlock.assemblytype
+	var/obj/machinery/door/airlock/airlock = airlock_type // we need to create a new instance of the airlock and assembly to read vars from them
+	var/obj/structure/door_assembly/assembly = initial(airlock.assemblytype)
 
-	if(airlock_material == "glass" && assembly.noglass) // prevents painting glass airlocks with a paint job that doesn't have a glass version, such as the freezer
+	if(airlock_material == "glass" && initial(assembly.noglass)) // prevents painting glass airlocks with a paint job that doesn't have a glass version, such as the freezer
 		to_chat(user, "<span class='warning'>This paint job can only be applied to non-glass airlocks.</span>")
-	else
-		// applies the user-chosen airlock's icon, overlays and assemblytype to the src airlock
-		painter.use_paint(user)
-		icon = airlock.icon
-		overlays_file = airlock.overlays_file
-		assemblytype = airlock.assemblytype
-		update_icon()
+		return
 
-	// these are just hanging around but are never placed, we need to delete them
-	qdel(airlock)
-	qdel(assembly)
+	// applies the user-chosen airlock's icon, overlays and assemblytype to the src airlock
+	painter.use_paint(user)
+	icon = initial(airlock.icon)
+	overlays_file = initial(airlock.overlays_file)
+	assemblytype = initial(airlock.assemblytype)
+	update_icon()
 
 /obj/machinery/door/airlock/CanAStarPass(obj/item/card/id/ID)
 //Airlock is passable if it is open (!density), bot has access, and is not bolted shut or powered off)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1565,7 +1565,7 @@
   */
 /obj/machinery/door/airlock/proc/set_wires()
 	var/area/source_area = get_area(src)
-	return new source_area.airlock_wires(src)
+	return source_area?.airlock_wires ? new source_area.airlock_wires : new /datum/wires/airlock
 
 #undef AIRLOCK_CLOSED
 #undef AIRLOCK_CLOSING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

[08:04:50] Runtime in airlock.dm, line 1566: Cannot read null.airlock_wires
```
proc name: set wires (/obj/machinery/door/airlock/proc/set_wires)
usr: ---/(---)
usr.loc: (Fore Primary Hallway (120,164,4))
src: the airlock (/obj/machinery/door/airlock/public)
src.loc: null
call stack:
the airlock (/obj/machinery/door/airlock/public): set wires()
the airlock (/obj/machinery/door/airlock/public): Initialize(0)
Atoms (/datum/controller/subsystem/atoms): InitAtom(the airlock (/obj/machinery/door/airlock/public), /list (/list))
the airlock (/obj/machinery/door/airlock/public): New(0)
Brig (/obj/machinery/door/airlock/security/glass): change paintjob(the airlock painter (/obj/item/airlock_painter), --- (/mob/living/carbon/human))
Brig (/obj/machinery/door/airlock/security/glass): attackby(the airlock painter (/obj/item/airlock_painter), --- (/mob/living/carbon/human), "icon-x=21;icon-y=12;left=1;scr...")
the airlock painter (/obj/item/airlock_painter): melee attack chain(--- (/mob/living/carbon/human), Brig (/obj/machinery/door/airlock/security/glass), "icon-x=21;icon-y=12;left=1;scr...")
--- (/mob/living/carbon/human): ClickOn(Brig (/obj/machinery/door/airlock/security/glass), "icon-x=21;icon-y=12;left=1;scr...")
Brig (/obj/machinery/door/airlock/security/glass): Click(the floor (120,165,4) (/turf/open/floor/plasteel), "mapwindow.map", "icon-x=21;icon-y=12;left=1;scr...")
```

Painting airlocks creates a new airlock in nullspace or something. Somewhere that doesn't have an area. Doors get their wire layout from the area they're built in. Do the math. The answer is null.

There's no getting around this as a concept. At some point a door is going to built where there's no area. Wire assignment logic made more robust. If there's no area or wire assignments available, it just returns a generic door wire assignment.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtime feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The Airlock Painter should now paint airlocks in all appropriate scenarios where it failed to do so before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
