### PR TITLE
dmdoc now shows typepaths instead of names

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -4,3 +4,6 @@ dreamchecker = true
 [code_standards]
 disallow_relative_type_definitions = true
 disallow_relative_proc_definitions = true
+
+[dmdoc]
+use_typepath_names = true


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

dmdoc now shows the full paths instead of names for the last part
thanks to spacemaniac for telling me what to do

## Why It's Good For The Game

prevents this
![image](https://user-images.githubusercontent.com/23585223/93249389-89a79000-f791-11ea-8f53-2c72966ee7d2.png)
![image](https://user-images.githubusercontent.com/23585223/93249394-8b715380-f791-11ea-94e6-9f9326db5f59.png)



<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
