### PR TITLE
Plasmamen psychologists now have an outfit.

### DIFF
--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -98,6 +98,13 @@
 	uniform = /obj/item/clothing/under/plasmaman/paramedic
 	gloves = /obj/item/clothing/gloves/color/plasmaman/white
 
+/datum/outfit/plasmaman/psychologist
+	name = "Psychologist Plasmaman"
+
+	head = /obj/item/clothing/head/helmet/space/plasmaman/medical
+	uniform = /obj/item/clothing/under/plasmaman/enviroslacks
+	gloves = /obj/item/clothing/gloves/color/plasmaman/white
+
 /datum/outfit/plasmaman/viro
 	name = "Virology Plasmaman"
 

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -82,6 +82,9 @@
 
 		if("Bartender", "Lawyer")
 			O = new /datum/outfit/plasmaman/bar
+		
+		if("Psychologist")
+			O = new /datum/outfit/plasmaman/psychologist
 
 		if("Cook")
 			O = new /datum/outfit/plasmaman/chef


### PR DESCRIPTION
## About The Pull Request

Not a _new_ outfit, mind you. But this gives plasmamen psychologists a more fitting outfit, until one specifically for them gets sprited.

## Why It's Good For The Game

![plasmeme](https://user-images.githubusercontent.com/51800976/93266037-1f7df380-f76f-11ea-88cf-89337ffaed2d.png)

I think giving them a medical plasmaman helmet, enviroslacks (as given to the bartender, lawyer, detective), and white envirogloves is better than them looking mostly like plasma assistants.

## Changelog
:cl:
tweak: Plasmamen psychologists will now wear enviroslacks and medical helmets.
/:cl:

