### PR TITLE
Fix runtime when gun is destroyed with attached seclight

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -525,6 +525,8 @@
 			gun_light.forceMove(src)
 	else if(.)
 		var/obj/item/flashlight/seclite/old_gun_light = .
+		if(QDELETED(old_gun_light))
+			return
 		old_gun_light.set_light_flags(old_gun_light.light_flags & ~LIGHT_ATTACHED)
 		if(old_gun_light.loc == src)
 			old_gun_light.forceMove(get_turf(src))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -513,24 +513,30 @@
 	return TRUE
 
 
-///Called when gun_light value changes.
+/**
+  * Swaps the gun's seclight, dropping the old seclight if it has not been qdel'd.
+  *
+  * Arguments:
+  * * new_light - The new light to attach to the weapon. Can be null, which will mean the old light is removed with no replacement.
+  */
 /obj/item/gun/proc/set_gun_light(obj/item/flashlight/seclite/new_light)
+	// Doesn't look like this should ever happen? We're replacing our old light with our old light?
 	if(gun_light == new_light)
-		return
-	. = gun_light
-	gun_light = new_light
-	if(gun_light)
-		gun_light.set_light_flags(gun_light.light_flags | LIGHT_ATTACHED)
-		if(gun_light.loc != src)
-			gun_light.forceMove(src)
-	else if(.)
-		var/obj/item/flashlight/seclite/old_gun_light = .
-		if(QDELETED(old_gun_light))
-			return
-		old_gun_light.set_light_flags(old_gun_light.light_flags & ~LIGHT_ATTACHED)
-		if(old_gun_light.loc == src)
-			old_gun_light.forceMove(get_turf(src))
+		CRASH("Tried to set a new gun light when the old gun light was also the new gun light.")
 
+	// If there's an old gun light that isn't being QDELETED, detatch and drop it to the floor.
+	if(!QDELETED(gun_light))
+		gun_light.set_light_flags(gun_light.light_flags & ~LIGHT_ATTACHED)
+		if(gun_light.loc == src)
+			gun_light.forceMove(get_turf(src))
+
+	// If there's a new gun light to be added, attach and move it to the gun.
+	if(new_light)
+		new_light.set_light_flags(new_light.light_flags | LIGHT_ATTACHED)
+		if(new_light.loc != src)
+			new_light.forceMove(src)
+
+	gun_light = new_light
 
 /obj/item/gun/ui_action_click(mob/user, actiontype)
 	if(istype(actiontype, alight))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -516,6 +516,7 @@
 /**
   * Swaps the gun's seclight, dropping the old seclight if it has not been qdel'd.
   *
+  * Returns the former gun_light that has now been replaced by this proc.
   * Arguments:
   * * new_light - The new light to attach to the weapon. Can be null, which will mean the old light is removed with no replacement.
   */
@@ -523,6 +524,8 @@
 	// Doesn't look like this should ever happen? We're replacing our old light with our old light?
 	if(gun_light == new_light)
 		CRASH("Tried to set a new gun light when the old gun light was also the new gun light.")
+
+	. = gun_light
 
 	// If there's an old gun light that isn't being QDELETED, detatch and drop it to the floor.
 	if(!QDELETED(gun_light))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/93277126-6264b900-f7b9-11ea-9768-9520ab2d4336.png)

The lowdown is that when you have a gun with a seclight attached and throw it in lava, the gun will be destroyed, call QDEL_NULL on any seclight attached.

The attached seclight will be qdel'd. This will then call handle_atom_del() on the gun, which will call clear_gunlight() because the seclight hasn't been nulled on the gun yet, it's still in the middle of its own qdel.

clear_gunlight doesn't early return as gun_light on the gun itself isn't null yet, so set_gun_light(null) gets called. This eventually leads to the seclight being forceMove()ed to the turf the gun is on in the middle of the seclight's qdel. If that turf is, for instance, lava - The light will immediately start taking fire damage and thus the runtime happens.

I put a check in to make sure the forceMove logic is skipped if the seclight is being QDELETED. In testing, this was enough to guard against the runtime.

Basically - QDEL_NULL does what it says on the tin. qdels, then nulls after the qdel. Because of this, there's an oversight that allows a seclight to be forceMove()ed off the gun in the middle of the seclight's qdel and thus take damage while being qdel'd.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex runtimes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->