### PR TITLE
[WIP] Alternative bluespace body bag nerf

### DIFF
--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -9,7 +9,7 @@
 		if(safety != "Proceed" || QDELETED(A) || QDELETED(W) || QDELETED(user) || !user.canUseTopic(A, BE_CLOSE, iscarbon(user)))
 			return
 		var/turf/loccheck = get_turf(A)
-		to_chat(user, "<span class='danger'>The Bluespace interfaces of the two devices catastrophically malfunction!</span>")
+		to_chat(user, "<span class='danger'>The bluespace interfaces of the two devices catastrophically malfunction!</span>")
 		qdel(W)
 		playsound(loccheck,'sound/effects/supermatter.ogg', 200, TRUE)
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -77,7 +77,7 @@
 	user.last_special = world.time + CLICK_CD_BREAKOUT
 	to_chat(user, "<span class='notice'>You claw at the fabric of [src], trying to tear it open...</span>")
 	to_chat(loc, "<span class='warning'>Someone starts trying to break free of [src]!</span>")
-	if(!do_after(user, 200, target = src))
+	if(!do_after(user, 10 SECONDS, target = src))
 		to_chat(loc, "<span class='warning'>The pressure subsides. It seems that they've stopped resisting...</span>")
 		return
 	loc.visible_message("<span class='warning'>[user] suddenly appears in front of [loc]!</span>", "<span class='userdanger'>[user] breaks free of [src]!</span>")

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -63,7 +63,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.allow_big_nesting = TRUE
-	STR.max_w_class = WEIGHT_CLASS_GIGANTIC
+	STR.max_w_class = WEIGHT_CLASS_BULKY
 	STR.max_combined_w_class = 35
 
 /obj/item/storage/backpack/holding/suicide_act(mob/living/user)

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -190,7 +190,6 @@
 	desc = "A toolbox painted bright green. Why anyone would store art supplies in a toolbox is beyond you, but it has plenty of extra space."
 	icon_state = "green"
 	inhand_icon_state = "artistic_toolbox"
-	w_class = WEIGHT_CLASS_GIGANTIC //Holds more than a regular toolbox!
 	material_flags = NONE
 
 /obj/item/storage/toolbox/artistic/ComponentInitialize()

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -37,7 +37,7 @@
 		if(!user.canUseTopic(src, BE_CLOSE))
 			return
 		if(t)
-			name = "body bag - [t]"
+			name = "[initial(name)] - [t]"
 			tagged = TRUE
 			update_icon()
 		else
@@ -45,7 +45,7 @@
 		return
 	else if(I.tool_behaviour == TOOL_WIRECUTTER)
 		to_chat(user, "<span class='notice'>You cut the tag off [src].</span>")
-		name = "body bag"
+		name = initial(name)
 		tagged = FALSE
 		update_icon()
 
@@ -84,7 +84,7 @@
 
 /obj/structure/closet/body_bag/bluespace
 	name = "bluespace body bag"
-	desc = "A bluespace body bag designed for the storage and transportation of cadavers."
+	desc = "A bluespace body bag designed for the storage and transportation of multiple cadavers. Cannot fit inside of most storage devices while something is stored inside of it."
 	icon = 'icons/obj/bodybag.dmi'
 	icon_state = "bluebodybag"
 	foldedbag_path = /obj/item/bodybag/bluespace
@@ -112,4 +112,8 @@
 			A.forceMove(B)
 			if(isliving(A))
 				to_chat(A, "<span class='userdanger'>You're suddenly forced into a tiny, compressed space!</span>")
+		if(B.contents.len)
+			B.w_class = WEIGHT_CLASS_GIGANTIC //you can't put a bluespace body bag into a backpack while it has items in it
+		else
+			B.w_class = WEIGHT_CLASS_SMALL
 		qdel(src)


### PR DESCRIPTION
## About The Pull Request

This PR is an alternative to https://github.com/tgstation/tgstation/pull/53747.

When folded with nothing inside of them, bluespace body bags are WEIGHT_CLASS_SMALL, as they were before. However, if they are folded with ANYTHING inside of them, they become WEIGHT_CLASS_GIGANTIC, which keeps them from being inserted into backpacks and such.

So that it won't be possible to get around this change by just using bags of holding instead of normal backpacks to store your bluespace body bags, bags of holding can now only hold items up to WEIGHT_CLASS_BULKY, not WEIGHT_CLASS GIGANTIC. This means that the following items can no longer fit inside of a bag of holding:
* Mecha parts. Sad, I know, but you can still store them inside of a bluespace body bag.
* His Grace. No mortal bag can contain Him.
* Cyborg modules (from Christmas presents or direct admin intervention), which are represented as gigantic items in the code for some reason.
* Artistic toolbo... what the hell? Why are artistic toolboxes WEIGHT_CLASS_GIGANTIC?!
![image](https://user-images.githubusercontent.com/42606352/93282092-30406080-f793-11ea-9023-88e8252c26c9.png)
:sigh:
Fuck it, artistic toolboxes are now the same size as the other toolboxes. Thus, they can still fit inside of a bag of holding.
* Nothing else (outside of some extreme edge cases, like secure safes that have somehow been unanchored).

Using a pen to label a bluespace body bag, then using wirecutters to remove said label will no longer change the name of the bluespace body bag to "body bag". Labeled bluespace body bags now mention that they're bluespace body bags in their names.

A capitalization error in one of the messages for detonating a bag of holding bomb has been fixed (this screenshot also proves that this PR doesn't break BoH bombing).
<img width="1438" alt="bohbombing" src="https://user-images.githubusercontent.com/42606352/93281328-7c8aa100-f791-11ea-86b1-6a63e6f2db6e.PNG">

The time required to break out of a folded bluespace body bag is now 10 seconds, not 20 seconds. Breaking out of an unfolded bluespace body bag (even one that's closed) is still instant, as it was before.
<img width="965" alt="slime7" src="https://user-images.githubusercontent.com/42606352/93281238-536a1080-f791-11ea-838b-4bb96c30e2d1.PNG">

## Why It's Good For The Game

This PR addresses (or will address, once it's done) most of the grievances from NecromancerAnne's PR, without nerfing them into being terrible.

> A) You could store toxins bombs into boxes using these. This lets you maxcap people with boxes, and hide maxcaps in plain sight.

You can now no longer fit bluespace body bags into cardboard boxes, backpacks, etc. I'll do some more testing to see if it's still possible to store them in lockers.

> B) You could abduct people in the blink of an eye and there is seemingly no way out in a reasonable time before you're deleted using various techniques. Mostly, throwing the bag into space or into the cremator. It's a pretty easy murderbone with it too since you need only shove someone for a few seconds to do it.

If I can, I'm going to try to make it so that you can't body bag people who are standing up. I'm also going to see if I can make it so that breaking out of a folded bluespace body bag that isn't on someone's person (in other words, it's on the ground) is instant. That way, you can still monologue to the abducted people in your bluespace body bag(s), but if your character isn't actively holding the bag closed, those people can just escape (which makes it harder to cremate them).

> C) You could put these in storage implants to haul massive amounts of machinery with you anywhere. This makes storage implants capable of some truly absurd things, like carrying an entire science department worth of stuff in a hidden compartment, or the aforementioned mechs. Nobody expects someone to make a durand in permabrig. (admittedly this is pretty dope but alas)

You can no longer fit bluespace body bags into storage implants.

> D) You could vore entire departments with them by putting someone into one and then putting the folded bag into your chest cavity.

That's pretty funny, IMO, and it's better than just straight up murdering everyone in those departments. Also, it's a bit difficult to fit two people into the same bag, as the first person can escape when you unfold the bag to capture the second person with it.

> E) They weren't being used as bodybags at all.

Fair point, but they definitely still can be used as body bags.

I understand that [WIP] PRs are generally frowned upon, but I fear that if I wait to post this PR until after it's finished, NecromancerAnne's PR would be merged before mine would even be posted.

## To-Do List

- [ ] Fix an existing oddity that's causing people in a folded bluespace body bag to suffocate if that body bag is being held by someone, but not if said folded bluespace body bag is on the ground.
- [ ] A bluespace body bag that becomes gigantic won't become small again, even if it's opened, everything is removed from it, and it's closed again. I need to figure out what's causing this bug and fix it.
- [ ] Add the bluespace body bag printing cost changes from NecromancerAnne's PR.
- [ ] Make sure that body bag tags on bluespace body bags still work right if you fold up the bag and then open it again.
- [ ] Check to see if it's possible to fit a gigantic item inside of a locker. If it is possible to fit a gigantic bluespace body bag inside of a locker, decide whether ot not it's okay to keep that in, as you can already fit TTVs and such inside of lockers anyway.
- [ ] Maybe remove that "feature" that makes it impossible to fold up a bluespace body bag if it's at half of its maximum capacity or greater (if balance is a concern, halve the maximum capacity of the bluespace body bag as well).
- [ ] Make it so that you can't bluespace body bag people who are standing up.
- [ ] Make breaking out of a folded bluespace body bag that's on the ground instant (like breaking out of an unfolded bluespace body bag is).
- [ ] Add bluespace body bags to the deep frying blacklist so that people don't use deep frying to get around the feature added by the previous checkbox.
- [ ] Check to see if you can fit a bluespace body bag inside of another bluespace body bag. If that can indeed happen, add a check to keep that from occurring.

## Changelog
:cl: ATHATH
balance: Folded bluespace body bags now can't fit inside of most storage items if they have something inside of them.
balance: The time required to break out of a folded bluespace body bag has been halved (it's now 10 seconds). Breaking out of an unfolded bluespace body bag (even one that's closed) is still instant, as it was before.
balance: Mecha parts, bluespace body bags that have something in them, and His Grace can no longer fit inside of bags of holding.
balance: Artistic toolboxes are now the same size as most other toolboxes, instead of being larger than backpacks.
fix: A capitalization error in one of the messages for detonating a bag of holding bomb has been fixed.
fix: Using a pen to label a bluespace body bag, then using wirecutters to remove said label will no longer change the name of the bluespace body bag to "body bag". Labeled bluespace body bags now mention that they're bluespace body bags in their names.
/:cl: