### PR TITLE
Fixes TRAIT_NOHUNGER on digestion and fat species that never stop being fat

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1082,7 +1082,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 //LIFE//
 ////////
 /datum/species/proc/handle_digestion(mob/living/carbon/human/H)
-	if(HAS_TRAIT(src, TRAIT_NOHUNGER))
+	if(HAS_TRAIT(H, TRAIT_NOHUNGER))
 		return //hunger is for BABIES
 
 	//The fucking TRAIT_FAT mutation is the dumbest shit ever. It makes the code so difficult to work with

--- a/code/modules/mob/living/carbon/human/species_types/abductors.dm
+++ b/code/modules/mob/living/carbon/human/species_types/abductors.dm
@@ -13,6 +13,8 @@
 	var/datum/atom_hud/abductor_hud = GLOB.huds[DATA_HUD_ABDUCTOR]
 	abductor_hud.add_hud_to(C)
 
+	C.set_safe_hunger_level()
+
 /datum/species/abductor/on_species_loss(mob/living/carbon/C)
 	. = ..()
 	var/datum/atom_hud/abductor_hud = GLOB.huds[DATA_HUD_ABDUCTOR]

--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -21,23 +21,7 @@
 		O.burn_reduction = 4
 
 	// Androids don't eat, hunger or metabolise foods. Let's do some cleanup.
-
-	// Nutrition reset and alert clearing.
-	C.nutrition = NUTRITION_LEVEL_FED
-	C.clear_alert("nutrition")
-
-	// Trait removal if obese
-	if(HAS_TRAIT_FROM(C, TRAIT_FAT, OBESITY))//I share your pain, past coder.
-		if(C.overeatduration >= 100)
-			to_chat(C, "<span class='notice'>Your android transformation restores your body's natural fitness!</span>")
-
-		REMOVE_TRAIT(C, TRAIT_FAT, OBESITY)
-		C.remove_movespeed_modifier(/datum/movespeed_modifier/obesity)
-		C.update_inv_w_uniform()
-		C.update_inv_wear_suit()
-
-	// Reset overeat duration.
-	C.overeatduration = 0
+	C.set_safe_hunger_level()
 
 /datum/species/android/on_species_loss(mob/living/carbon/C)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -20,6 +20,25 @@
 		O.brute_reduction = 5
 		O.burn_reduction = 4
 
+	// Androids don't eat, hunger or metabolise foods. Let's do some cleanup.
+
+	// Nutrition reset and alert clearing.
+	C.nutrition = NUTRITION_LEVEL_FED
+	C.clear_alert("nutrition")
+
+	// Trait removal if obese
+	if(HAS_TRAIT_FROM(C, TRAIT_FAT, OBESITY))//I share your pain, past coder.
+		if(C.overeatduration >= 100)
+			to_chat(C, "<span class='notice'>Your android transformation restores your body's natural fitness!</span>")
+
+		REMOVE_TRAIT(C, TRAIT_FAT, OBESITY)
+		C.remove_movespeed_modifier(/datum/movespeed_modifier/obesity)
+		C.update_inv_w_uniform()
+		C.update_inv_wear_suit()
+
+	// Reset overeat duration.
+	C.overeatduration = 0
+
 /datum/species/android/on_species_loss(mob/living/carbon/C)
 	. = ..()
 	for(var/X in C.bodyparts)

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -35,6 +35,7 @@
 			var/obj/item/organ/eyes/E = H.getorganslot(ORGAN_SLOT_EYES)
 			var/datum/action/item_action/organ_action/dullahan/D = locate() in E?.actions
 			D?.Trigger()
+	H.set_safe_hunger_level()
 
 /datum/species/dullahan/on_species_loss(mob/living/carbon/human/H)
 	H.flags_1 |= HEAR_1

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -61,7 +61,7 @@
 	RegisterSignal(ethereal, COMSIG_ATOM_EMP_ACT, .proc/on_emp_act)
 	ethereal_light = ethereal.mob_light()
 	spec_updatehealth(ethereal)
-
+	C.set_safe_hunger_level()
 
 /datum/species/ethereal/on_species_loss(mob/living/carbon/human/C, datum/species/new_species, pref_load)
 	UnregisterSignal(C, COMSIG_ATOM_EMAG_ACT)

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -34,6 +34,10 @@
 	// This effects how fast body temp stabilizes, also if cold resit is lost on the mob
 	bodytemp_cold_damage_limit = (BODYTEMP_COLD_DAMAGE_LIMIT - 50) // about -50c
 
+/datum/species/plasmaman/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
+	. = ..()
+	C.set_safe_hunger_level()
+
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H)
 	var/atmos_sealed = CanIgniteMob(H) && (isclothing(H.wear_suit) && H.wear_suit.clothing_flags & STOPSPRESSUREDAMAGE) && (isclothing(H.head) && H.head.clothing_flags & STOPSPRESSUREDAMAGE)
 	if(!atmos_sealed && (!istype(H.w_uniform, /obj/item/clothing/under/plasmaman) || !istype(H.head, /obj/item/clothing/head/helmet/space/plasmaman) || !istype(H.gloves, /obj/item/clothing/gloves)))

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -50,6 +50,7 @@
 	to_chat(C, "[info_text]")
 
 	C.fully_replace_character_name(null, pick(GLOB.nightmare_names))
+	C.set_safe_hunger_level()
 
 /datum/species/shadow/nightmare/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	var/turf/T = H.loc

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -18,6 +18,10 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN
 	species_language_holder = /datum/language_holder/skeleton
 
+/datum/species/skeleton/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
+	. = ..()
+	C.set_safe_hunger_level()
+
 /datum/species/skeleton/check_roundstart_eligible()
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
 		return TRUE

--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -36,6 +36,7 @@
 	..()
 	assume_disguise(old_species, H)
 	RegisterSignal(H, COMSIG_MOB_SAY, .proc/handle_speech)
+	H.set_safe_hunger_level()
 
 /datum/species/synth/on_species_loss(mob/living/carbon/human/H)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -16,9 +16,6 @@
 	var/info_text = "You are a <span class='danger'>Vampire</span>. You will slowly but constantly lose blood if outside of a coffin. If inside a coffin, you will slowly heal. You may gain more blood by grabbing a live victim and using your drain ability."
 	var/obj/effect/proc_holder/spell/targeted/shapeshift/bat/batform //attached to the datum itself to avoid cloning memes, and other duplicates
 
-
-
-
 /datum/species/vampire/check_roundstart_eligible()
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
 		return TRUE
@@ -32,6 +29,7 @@
 	if(isnull(batform))
 		batform = new
 		C.AddSpell(batform)
+	C.set_safe_hunger_level()
 
 /datum/species/vampire/on_species_loss(mob/living/carbon/C)
 	. = ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1766,3 +1766,23 @@
 /// Whether or not this mob will escape from storages while being picked up/held.
 /mob/living/proc/will_escape_storage()
 	return FALSE
+
+/// Sets the mob's hunger levels to a safe overall level. Useful for TRAIT_NOHUNGER species changes.
+/mob/living/proc/set_safe_hunger_level()
+	// Nutrition reset and alert clearing.
+	nutrition = NUTRITION_LEVEL_FED
+	clear_alert("nutrition")
+	satiety = 0
+
+	// Trait removal if obese
+	if(HAS_TRAIT_FROM(src, TRAIT_FAT, OBESITY))
+		if(overeatduration >= 100)
+			to_chat(src, "<span class='notice'>Your transformation restores your body's natural fitness!</span>")
+
+		REMOVE_TRAIT(src, TRAIT_FAT, OBESITY)
+		remove_movespeed_modifier(/datum/movespeed_modifier/obesity)
+		update_inv_w_uniform()
+		update_inv_wear_suit()
+
+	// Reset overeat duration.
+	overeatduration = 0

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -531,3 +531,23 @@
 ///Can the mob see reagents inside of containers?
 /mob/proc/can_see_reagents()
 	return stat == DEAD || has_unlimited_silicon_privilege //Dead guys and silicons can always see reagents
+
+/// Sets the mob's hunger levels to a safe overall level. Useful for TRAIT_NOHUNGER species changes.
+/mob/proc/set_safe_hunger_level(mob/target)
+	// Nutrition reset and alert clearing.
+	target.nutrition = NUTRITION_LEVEL_FED
+	target.clear_alert("nutrition")
+	target.satiety = 0
+
+	// Trait removal if obese
+	if(HAS_TRAIT_FROM(target, TRAIT_FAT, OBESITY))//I share your pain, past coder.
+		if(target.overeatduration >= 100)
+			to_chat(target, "<span class='notice'>Your transformation restores your body's natural fitness!</span>")
+
+		REMOVE_TRAIT(target, TRAIT_FAT, OBESITY)
+		target.remove_movespeed_modifier(/datum/movespeed_modifier/obesity)
+		target.update_inv_w_uniform()
+		target.update_inv_wear_suit()
+
+	// Reset overeat duration.
+	target.overeatduration = 0

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -531,23 +531,3 @@
 ///Can the mob see reagents inside of containers?
 /mob/proc/can_see_reagents()
 	return stat == DEAD || has_unlimited_silicon_privilege //Dead guys and silicons can always see reagents
-
-/// Sets the mob's hunger levels to a safe overall level. Useful for TRAIT_NOHUNGER species changes.
-/mob/proc/set_safe_hunger_level()
-	// Nutrition reset and alert clearing.
-	nutrition = NUTRITION_LEVEL_FED
-	clear_alert("nutrition")
-	satiety = 0
-
-	// Trait removal if obese
-	if(HAS_TRAIT_FROM(src, TRAIT_FAT, OBESITY))//I share your pain, past coder.
-		if(overeatduration >= 100)
-			to_chat(src, "<span class='notice'>Your transformation restores your body's natural fitness!</span>")
-
-		REMOVE_TRAIT(src, TRAIT_FAT, OBESITY)
-		remove_movespeed_modifier(/datum/movespeed_modifier/obesity)
-		update_inv_w_uniform()
-		update_inv_wear_suit()
-
-	// Reset overeat duration.
-	overeatduration = 0

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -533,21 +533,21 @@
 	return stat == DEAD || has_unlimited_silicon_privilege //Dead guys and silicons can always see reagents
 
 /// Sets the mob's hunger levels to a safe overall level. Useful for TRAIT_NOHUNGER species changes.
-/mob/proc/set_safe_hunger_level(mob/target)
+/mob/proc/set_safe_hunger_level()
 	// Nutrition reset and alert clearing.
-	target.nutrition = NUTRITION_LEVEL_FED
-	target.clear_alert("nutrition")
-	target.satiety = 0
+	nutrition = NUTRITION_LEVEL_FED
+	clear_alert("nutrition")
+	satiety = 0
 
 	// Trait removal if obese
-	if(HAS_TRAIT_FROM(target, TRAIT_FAT, OBESITY))//I share your pain, past coder.
-		if(target.overeatduration >= 100)
-			to_chat(target, "<span class='notice'>Your transformation restores your body's natural fitness!</span>")
+	if(HAS_TRAIT_FROM(src, TRAIT_FAT, OBESITY))//I share your pain, past coder.
+		if(overeatduration >= 100)
+			to_chat(src, "<span class='notice'>Your transformation restores your body's natural fitness!</span>")
 
-		REMOVE_TRAIT(target, TRAIT_FAT, OBESITY)
-		target.remove_movespeed_modifier(/datum/movespeed_modifier/obesity)
-		target.update_inv_w_uniform()
-		target.update_inv_wear_suit()
+		REMOVE_TRAIT(src, TRAIT_FAT, OBESITY)
+		remove_movespeed_modifier(/datum/movespeed_modifier/obesity)
+		update_inv_w_uniform()
+		update_inv_wear_suit()
 
 	// Reset overeat duration.
-	target.overeatduration = 0
+	overeatduration = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Issue was encountered during a Manuel round when a fatass became an Android.

Incorrect check for TRAIT_NOHUNGER in handle_digestion meant it was ignored and digestion code would always run.

Androids don't hunger, don't metabolise, don't eat. When a player turns into an android, if they were fat, they become a fat anrdroid. It then becomes incredibly difficult and annoying for admins to restore them back to normal. Admins trying to fix this manually can also create excess screen alerts, traits and moodlets as they triage the issue alongside the TRAIT_NOHUNGER bug that will constantly restore negative moodlets and throw screen alerts unless they set the status JUST RIGHT.

As a result, as well as fixing TRAIT_NOHUNGER I'm also hitting TRAIT_NOHUNGER species. I created a new proc to set hunger values to safe levels and call it on_species_gain for every TRAIT_NOHUNGER species.

Thanks to the Eric Fatsby who let me experiment on him to identify as many problem areas as I could.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes bugs and oversights.

Reduces admin workload when stuff like this happens in the future.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes issue where overweight characters would be eternally fat and starving characters would become eternally starving on changing species to one that doesn't eat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
