### PR TITLE
Refactors the keys_held rolling buffer

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -126,7 +126,7 @@
 #define MAX_KEYS_PER_KEYBIND 3
 ///Max amount of keypress messages per second over two seconds before client is autokicked
 #define MAX_KEYPRESS_AUTOKICK 50
-///Length of held key rolling buffer
+///Length of held key buffer
 #define HELD_KEY_BUFFER_LENGTH 15
 
 #define STICKYBAN_DB_CACHE_TIME 10 SECONDS

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -27,7 +27,8 @@ SUBSYSTEM_DEF(input)
 	"M" = "me",
 	"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
 	"Tab" = "\".winset \\\"input.focus=true?map.focus=true input.background-color=[COLOR_INPUT_DISABLED]:input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
-	"Escape" = "\".winset \\\"input.text=\\\"\\\"\\\"\"")
+	"Escape" = "Reset-Held-Keys",
+	)
 
 // Badmins just wanna have fun ♪
 /datum/controller/subsystem/input/proc/refresh_client_macro_sets()

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -192,3 +192,13 @@
 	/// rate limiting for the crew manifest
 	var/crew_manifest_delay
 
+	/// A buffer of currently held keys.
+	var/list/keys_held = list()
+	/*
+	** These next two vars are to apply movement for keypresses and releases made while move delayed.
+	** Because discarding that input makes the game less responsive.
+	*/
+ 	/// On next move, add this dir to the move that would otherwise be done
+	var/next_move_dir_add
+ 	/// On next move, subtract this dir from the move that would otherwise be done
+	var/next_move_dir_sub

--- a/code/modules/client/verbs/reset_held_keys.dm
+++ b/code/modules/client/verbs/reset_held_keys.dm
@@ -9,7 +9,3 @@
 
 	for(var/key in keys_held)
 		keyUp(key)
-
-	for(var/k in keybinds_held)
-		var/datum/keybinding/keybind = k
-		keybind.up(src)

--- a/code/modules/client/verbs/reset_held_keys.dm
+++ b/code/modules/client/verbs/reset_held_keys.dm
@@ -2,7 +2,6 @@
   * Manually clears any held keys, in case due to lag or other undefined behavior a key gets stuck.
   *
   * Hardcoded to the ESC key.
-  * Arguments:
   */
 /client/verb/reset_held_keys()
 	set name = "Reset Held Keys"
@@ -11,3 +10,6 @@
 	for(var/key in keys_held)
 		keyUp(key)
 
+	for(var/k in keybinds_held)
+		var/datum/keybinding/keybind = k
+		keybind.up(src)

--- a/code/modules/client/verbs/reset_held_keys.dm
+++ b/code/modules/client/verbs/reset_held_keys.dm
@@ -1,0 +1,14 @@
+/**
+  * Manually clears any held keys, in case due to lag or other undefined behavior a key gets stuck.
+  *
+  * Hardcoded to the ESC key.
+  * Arguments:
+  */
+/client/verb/reset_held_keys()
+	set name = "Reset Held Keys"
+	set category = "OOC"
+	set hidden = TRUE
+
+	for(var/key in keys_held)
+		keyUp(key)
+

--- a/code/modules/client/verbs/reset_held_keys.dm
+++ b/code/modules/client/verbs/reset_held_keys.dm
@@ -6,7 +6,6 @@
   */
 /client/verb/reset_held_keys()
 	set name = "Reset Held Keys"
-	set category = "OOC"
 	set hidden = TRUE
 
 	for(var/key in keys_held)

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -41,11 +41,11 @@
 		winset(src, null, "input.focus=true ; input.text=[url_encode(_key)]")
 		return
 
-	//offset by 1 because the buffer address is 0	 indexed because the math was simpler
-	keys_held[current_key_address + 1] = _key
+	if(length(keys_held) >= HELD_KEY_BUFFER_LENGTH && !keys_held[_key])
+		keyUp(keys_held[1]) //We are going over the number of possible held keys, so let's remove the first one.
+
 	//the time a key was pressed isn't actually used anywhere (as of 2019-9-10) but this allows easier access usage/checking
 	keys_held[_key] = world.time
-	current_key_address = ((current_key_address + 1) % HELD_KEY_BUFFER_LENGTH)
 	var/movement = movement_keys[_key]
 	if(!(next_move_dir_sub & movement) && !movement_locked)
 		next_move_dir_add |= movement
@@ -75,11 +75,9 @@
 	set instant = TRUE
 	set hidden = TRUE
 
-	//Can't just do a remove because it would alter the length of the rolling buffer, instead search for the key then null it out if it exists
-	for(var/i in 1 to HELD_KEY_BUFFER_LENGTH)
-		if(keys_held[i] == _key)
-			keys_held[i] = null
-			break
+	if(!keys_held[_key])
+		return
+	keys_held -= _key
 	var/movement = movement_keys[_key]
 	if(!(next_move_dir_add & movement))
 		next_move_dir_sub |= movement

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -1,15 +1,3 @@
-/client
-	/// A rolling buffer of any keys held currently
-	var/list/keys_held = list()
-	///used to keep track of the current rolling buffer position
-	var/current_key_address = 0
-	/// These next two vars are to apply movement for keypresses and releases made while move delayed.
-	/// Because discarding that input makes the game less responsive.
- 	/// On next move, add this dir to the move that would otherwise be done
-	var/next_move_dir_add
- 	/// On next move, subtract this dir from the move that would otherwise be done
-	var/next_move_dir_sub
-
 // Set a client's focus to an object and override these procs on that object to let it handle keypresses
 
 /datum/proc/key_down(key, client/user) // Called when a key is pressed down initially
@@ -33,10 +21,9 @@
 /client/proc/set_macros()
 	set waitfor = FALSE
 
-	//Reset and populate the rolling buffer
-	keys_held.Cut()
-	for(var/i in 1 to HELD_KEY_BUFFER_LENGTH)
-		keys_held += null
+	//Reset the buffer
+	for(var/key in keys_held)
+		keyUp(key)
 
 	erase_all_macros()
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1743,6 +1743,7 @@
 #include "code\modules\client\verbs\etips.dm"
 #include "code\modules\client\verbs\ooc.dm"
 #include "code\modules\client\verbs\ping.dm"
+#include "code\modules\client\verbs\reset_held_keys.dm"
 #include "code\modules\client\verbs\suicide.dm"
 #include "code\modules\client\verbs\who.dm"
 #include "code\modules\clothing\chameleon.dm"


### PR DESCRIPTION
* The buffer is no longer rolling.
* Client variables moved to the client definition.
* Fixes https://github.com/tgstation/tgstation/issues/47869
* Fixes https://github.com/tgstation/tgstation/issues/48070

## Changelog
:cl:
fix: Keys no longer have a lifetime of 15 keypresses, meaning you can ctrl+movement keys ad infinitum again.
add: Pressing Esc now has the same effect as releasing all held/pressed keys from the keyboard. Handy if one gets stuck.
tweak: Removed the old functionality in which Esc would delete what's on the input bar when not focused. Remove/backspace still does that.
/:cl: