### PR TITLE
Fix flash runtime, improve flash logic

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -133,8 +133,6 @@
 	else //caused by emp/remote signal
 		M.log_message("was [targeted? "flashed(targeted)" : "flashed(AOE)"]",LOG_ATTACK)
 
-
-
 	if(generic_message && M != user)
 		to_chat(M, "<span class='danger'>[src] emits a blinding light!</span>")
 
@@ -189,41 +187,27 @@
   * * attacker - Attacker
   */
 /obj/item/assembly/flash/proc/calculate_deviation(mob/victim, atom/attacker)
-	var/victim_dir = victim.dir
-	var/inverse_attacker_dir
-
-	// If the victim was looking at the attacker, this is the direction they'd be facing.
+	// If the victim was looking at the attacker, this is the direction they'd have to be facing.
 	var/victim_to_attacker = get_dir(victim, attacker)
-
-	// Imagine 2 vectors coming from both mobs, they represent the direction the mob is currently looking towards,
-	// What we actually check is we check if the inverted vector of the second mob is equal to the vector of the
-	// first. The more deviated the vectors, the less powerful the flash.
-	if(ismob(attacker))
-		inverse_attacker_dir = turn(attacker.dir,180)
-	else
-		inverse_attacker_dir = get_dir(victim, src)
+	var/victim_dir = victim.dir
 
 	// Are they on the same tile? We'll return partial deviation. This may be someone flashing while lying down
 	// or flashing someone they're stood on the same turf as, or a borg flashing someone buckled to them.
 	if(victim.loc == attacker.loc)
 		return 1
-	// Are they looking in opposite directions or within 45 degrees of this?
-	if(victim_dir == inverse_attacker_dir || turn(victim_dir, 45) == inverse_attacker_dir || turn(victim_dir, -45) == inverse_attacker_dir )
-		// Now we get the dir as if the victim was looking at the attacker. If this matches up properly
-		// or is within 45 degrees of one, they were infront of eachother and this is a frontal flash.
-		if(victim_to_attacker == inverse_attacker_dir || victim_to_attacker == turn(inverse_attacker_dir, 45) || victim_to_attacker == turn(inverse_attacker_dir, -45))
-			return 0
-		// Otherwise, they were behind eachother. You know, standing back-to-back.
-		return 2
-	// If they're directly to the side, we look to do a side flash.
-	if(turn(victim_dir,90) == inverse_attacker_dir || turn(victim_dir,-90) == inverse_attacker_dir)
-		// Now what matters is where our attacker was looking. We can use victim_to_attacker again.
-		// We take that attack's inverse direction, this is the opposite of where they are looking.
-		// We take the direction as if the victim was looking at the attacker.
-		if(victim_to_attacker == inverse_attacker_dir)
-			return 1
 
-	// If we got here, they weren't facing eachother, facing within 45 degrees of eachother or facing within 90 degrees of eachother.
+	// Is the victim looking directly at the attacker? and is the attacker looking at the victim?
+	if(victim_dir == victim_to_attacker)
+		return 0
+
+	// Is the victim looking at the attacker within 45 degrees?
+	if(victim_dir == turn(victim_to_attacker, 45) || victim_dir == turn(victim_to_attacker, -45))
+		return 0
+
+	// Is the is the victim looking perpendicular to the attacker?
+	if(victim_dir == turn(victim_to_attacker, 90) || victim_dir == turn(victim_to_attacker, -90))
+		return 1
+
 	// This only leaves directions from directly behind and diagonal-behind. No flash bueno.
 	return 2
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -195,29 +195,35 @@
   * * attacker - Attacker
   */
 /obj/item/assembly/flash/proc/calculate_deviation(mob/victim, atom/attacker)
-	// If the victim was looking at the attacker, this is the direction they'd have to be facing.
-	var/victim_to_attacker = get_dir(victim, attacker)
-	var/victim_dir = victim.dir
-
 	// Are they on the same tile? We'll return partial deviation. This may be someone flashing while lying down
 	// or flashing someone they're stood on the same turf as, or a borg flashing someone buckled to them.
 	if(victim.loc == attacker.loc)
 		return DEVIATION_PARTIAL
 
-	// Is the victim looking directly at the attacker? and is the attacker looking at the victim?
-	if(victim_dir == victim_to_attacker)
+	// If the victim was looking at the attacker, this is the direction they'd have to be facing.
+	var/victim_to_attacker = get_dir(victim, attacker)
+	// The victim's dir is necessarily a cardinal value.
+	var/victim_dir = victim.dir
+
+	// - - -
+	// - V - Victim facing south
+	// # # #
+	// Attacker within 45 degrees of where the victim is facing.
+	if(victim_dir & victim_to_attacker)
 		return DEVIATION_NONE
 
-	// Is the victim looking at the attacker within 45 degrees?
-	if(victim_dir == turn(victim_to_attacker, 45) || victim_dir == turn(victim_to_attacker, -45))
-		return DEVIATION_NONE
+	// # # #
+	// - V - Victim facing south
+	// - - -
+	// Attacker at 135 or more degrees of where the victim is facing.
+	if(victim_dir & REVERSE_DIR(victim_to_attacker))
+		return DEVIATION_FULL
 
-	// Is the is the victim looking perpendicular to the attacker?
-	if(victim_dir == turn(victim_to_attacker, 90) || victim_dir == turn(victim_to_attacker, -90))
-		return DEVIATION_PARTIAL
-
-	// This only leaves directions from directly behind and diagonal-behind. No flash bueno.
-	return DEVIATION_FULL
+	// - - -
+	// # V # Victim facing south
+	// - - -
+	// Attacker lateral to the victim.
+	return DEVIATION_PARTIAL
 
 /obj/item/assembly/flash/attack(mob/living/M, mob/user)
 	if(!try_use_flash(user))

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -1,4 +1,12 @@
 #define CONFUSION_STACK_MAX_MULTIPLIER 2
+
+/// No deviation at all. Flashed from the front or front-left/front-right. Alternatively, flashed in direct view.
+#define DEVIATION_NONE 0
+/// Partial deviation. Flashed from the side. Alternatively, flashed out the corner of your eyes.
+#define DEVIATION_PARTIAL 1
+/// Full deviation. Flashed from directly behind or behind-left/behind-rack. Not flashed at all.
+#define DEVIATION_FULL 2
+
 /obj/item/assembly/flash
 	name = "flash"
 	desc = "A powerful and versatile flashbulb device, with applications ranging from disorienting attackers to acting as visual receptors in robot production."
@@ -141,7 +149,7 @@
 	var/datum/antagonist/rev/head/converter = user?.mind?.has_antag_datum(/datum/antagonist/rev/head)
 
 	//If you face away from someone they shouldnt notice any effects.
-	if(deviation == 2 && !converter)
+	if(deviation == DEVIATION_FULL && !converter)
 		return
 
 
@@ -153,7 +161,7 @@
 				// Special check for if we're a revhead. Special cases to attempt conversion.
 				if(converter)
 					// Did we try to flash them from behind?
-					if(deviation == 2)
+					if(deviation == DEVIATION_FULL)
 						// If we did and we're on help intent, fail with a feedback message and return.
 						if(converter.owner.current.a_intent == INTENT_HELP)
 							to_chat(user, "<span class='notice'>You try to use the tacticool tier, lean over the shoulder technique to blind [M] from behind but your poor combat stance causes you to stumble!</span>")
@@ -161,7 +169,7 @@
 							return
 						// Otherwise, tacticool leaning technique engaged for sideways-stun power.
 						to_chat(user, "<span class='notice'>You use the tacticool tier, lean over the shoulder technique to blind [M] with a flash!</span>")
-						deviation = 1
+						deviation = DEVIATION_PARTIAL
 					// Convert them. Terribly.
 					terrible_conversion_proc(M, user)
 					visible_message("<span class='danger'>[user] blinds [M] with the flash!</span>","<span class='userdanger'>[user] blinds you with the flash!</span>")
@@ -194,22 +202,22 @@
 	// Are they on the same tile? We'll return partial deviation. This may be someone flashing while lying down
 	// or flashing someone they're stood on the same turf as, or a borg flashing someone buckled to them.
 	if(victim.loc == attacker.loc)
-		return 1
+		return DEVIATION_PARTIAL
 
 	// Is the victim looking directly at the attacker? and is the attacker looking at the victim?
 	if(victim_dir == victim_to_attacker)
-		return 0
+		return DEVIATION_NONE
 
 	// Is the victim looking at the attacker within 45 degrees?
 	if(victim_dir == turn(victim_to_attacker, 45) || victim_dir == turn(victim_to_attacker, -45))
-		return 0
+		return DEVIATION_NONE
 
 	// Is the is the victim looking perpendicular to the attacker?
 	if(victim_dir == turn(victim_to_attacker, 90) || victim_dir == turn(victim_to_attacker, -90))
-		return 1
+		return DEVIATION_PARTIAL
 
 	// This only leaves directions from directly behind and diagonal-behind. No flash bueno.
-	return 2
+	return DEVIATION_FULL
 
 /obj/item/assembly/flash/attack(mob/living/M, mob/user)
 	if(!try_use_flash(user))
@@ -378,3 +386,8 @@
 		M.dizziness += min(M.dizziness + 4, 20)
 		M.drowsyness += min(M.drowsyness + 4, 20)
 		M.apply_status_effect(STATUS_EFFECT_PACIFY, 40)
+
+#undef CONFUSION_STACK_MAX_MULTIPLIER
+#undef DEVIATION_NONE
+#undef DEVIATION_PARTIAL
+#undef DEVIATION_FULL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/93388291-67ca0e00-f862-11ea-9476-77c255b9b86f.png)

Flash + Emp = Flash with no user = Runtime.

Additional logic has been put in place to handle this.

I've also robustified the calculate_deviation proc to have explicit returns in every code path and simplified it to only care about the direction the victim is facing compared to the attacker's position.

The end result for a Victim facing south is this:

```
2 2 2
1 V 1
0 0 0
```

This has been fully tested in-game.

![pPC8e9DUwF](https://user-images.githubusercontent.com/24975989/93389110-972d4a80-f863-11ea-9a92-f62454ce4318.gif)
![image](https://user-images.githubusercontent.com/24975989/93389055-85e43e00-f863-11ea-9d62-3c02dfac6f7b.png)

2x side, 3x front, 3x behind

Similarly, EMPing a flash works as expected and does not runtime.

![xpPO9d755E](https://user-images.githubusercontent.com/24975989/93389260-d065ba80-f863-11ea-8eaa-bfbb48eff916.gif)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Flashes are now more reliable and flashes hit by EMP will appropriately blind or not blind people based on whether they are facing the flash or not.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
