### PR TITLE
make overlay lists not persist when empty

### DIFF
--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -56,6 +56,8 @@ SUBSYSTEM_DEF(overlays)
 				continue
 			STAT_START_STOPWATCH
 			COMPILE_OVERLAYS(A)
+			UNSETEMPTY(A.add_overlays)
+			UNSETEMPTY(A.remove_overlays)
 			STAT_STOP_STOPWATCH
 			STAT_LOG_ENTRY(stats, A.type)
 		if(mc_check)
@@ -122,9 +124,8 @@ SUBSYSTEM_DEF(overlays)
 #define QUEUE_FOR_COMPILE flags_1 |= OVERLAY_QUEUED_1; SSoverlays.queue += src;
 /atom/proc/cut_overlays()
 	LAZYINITLIST(remove_overlays)
-	LAZYINITLIST(add_overlays)
 	remove_overlays = overlays.Copy()
-	add_overlays.Cut()
+	add_overlays = null
 
 	//If not already queued for work and there are overlays to remove
 	if(NOT_QUEUED_ALREADY && remove_overlays.len)
@@ -134,7 +135,7 @@ SUBSYSTEM_DEF(overlays)
 	if(!overlays)
 		return
 	overlays = build_appearance_list(overlays)
-	LAZYINITLIST(add_overlays) //always initialized after this point
+	LAZYINITLIST(add_overlays)
 	LAZYINITLIST(remove_overlays)
 	var/a_len = add_overlays.len
 	var/r_len = remove_overlays.len
@@ -147,6 +148,7 @@ SUBSYSTEM_DEF(overlays)
 	//If not already queued and there is work to be done
 	if(NOT_QUEUED_ALREADY && (fa_len != a_len || fr_len != r_len ))
 		QUEUE_FOR_COMPILE
+	UNSETEMPTY(add_overlays)
 
 /atom/proc/add_overlay(list/overlays)
 	if(!overlays)


### PR DESCRIPTION
an empty list uses 24 bytes of memory, plus what ever it still has in reserve since the list once contained items, and removing an item from a list doesn't free up the list's capacity.


