### PR TITLE
Basically, just makes genderswap potions an attack_self.

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -953,22 +953,18 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "potlightpink"
 
-/obj/item/slimepotion/genderchange/attack(mob/living/L, mob/user)
-	if(!istype(L) || L.stat == DEAD)
-		to_chat(user, "<span class='warning'>The potion can only be used on living things!</span>")
-		return
-
-	if(L.gender != MALE && L.gender != FEMALE)
+/obj/item/slimepotion/genderchange/attack_self(mob/user)
+	if(user.gender != MALE && user.gender != FEMALE)
 		to_chat(user, "<span class='warning'>The potion can only be used on gendered things!</span>")
 		return
 
-	if(L.gender == MALE)
-		L.gender = FEMALE
-		L.visible_message("<span class='boldnotice'>[L] suddenly looks more feminine!</span>", "<span class='boldwarning'>You suddenly feel more feminine!</span>")
+	if(user.gender == MALE)
+		user.gender = FEMALE
+		user.visible_message("<span class='boldnotice'>[user] suddenly looks more feminine!</span>", "<span class='boldwarning'>You suddenly feel more feminine!</span>")
 	else
-		L.gender = MALE
-		L.visible_message("<span class='boldnotice'>[L] suddenly looks more masculine!</span>", "<span class='boldwarning'>You suddenly feel more masculine!</span>")
-	L.regenerate_icons()
+		user.gender = MALE
+		user.visible_message("<span class='boldnotice'>[user] suddenly looks more masculine!</span>", "<span class='boldwarning'>You suddenly feel more masculine!</span>")
+	user.regenerate_icons()
 	qdel(src)
 
 /obj/item/slimepotion/slime/renaming


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can't use genderswap potions on other people. That's it.

## Why It's Good For The Game

Hey what if we re-added gender reassignment surgery, that thing people only used to grief and removed because it was creepy and only used for grief, but it's instant and correcting it is closely guarded inside of a fortress department, and also reliant on that same department not destroying any method of fixing it, since the aforementioned surgery no longer exists to do it outside of xenobiology. 

**This can only end well, I'm sure.**

## Changelog
:cl:
tweak: Genderswap potions can only be used willingly on yourself by clicking it in-hand, and not on other people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
