### PR TITLE
Fix Hilbert's Hotel on_unset_machine() runtime

### DIFF
--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -283,14 +283,13 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 	if(get_dist(get_turf(src), get_turf(user)) <= 1)
 		to_chat(user, "<span class='notice'>You peak through the door's bluespace peephole...</span>")
 		user.reset_perspective(parentSphere)
-		user.set_machine(src)
 		var/datum/action/peephole_cancel/PHC = new
 		user.overlay_fullscreen("remote_view", /obj/screen/fullscreen/impaired, 1)
 		PHC.Grant(user)
+		RegisterSignal(user, COMSIG_MOVABLE_MOVED, /atom/.proc/check_eye, user)
 
 /turf/closed/indestructible/hoteldoor/check_eye(mob/user)
 	if(get_dist(get_turf(src), get_turf(user)) >= 2)
-		user.unset_machine()
 		for(var/datum/action/peephole_cancel/PHC in user.actions)
 			PHC.Trigger()
 
@@ -304,6 +303,7 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 	to_chat(owner, "<span class='warning'>You move away from the peephole.</span>")
 	owner.reset_perspective()
 	owner.clear_fullscreen("remote_view", 0)
+	UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
 	qdel(src)
 
 /area/hilbertshotel


### PR DESCRIPTION
## About The Pull Request

Fix Hilbert's Hotel peephole runtime

related #53790

## Why It's Good For The Game

Runtimes id bad

<!-- 
## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:
 -->
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
