### PR TITLE
Now hhmysteryRoomNumber generates only once.

### DIFF
--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -462,7 +462,8 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 
 /obj/item/paper/crumpled/docslogs/Initialize()
 	. = ..()
-	GLOB.hhmysteryRoomNumber = rand(1, SHORT_REAL_LIMIT)
+	if(!GLOB.hhmysteryRoomNumber)
+		GLOB.hhmysteryRoomNumber = rand(1, SHORT_REAL_LIMIT)
 	info = {"<h4><center>Research Logs</center></h4>
 	I might just be onto something here!<br>
 	The strange space-warping properties of bluespace have been known about for awhile now, but I might be on the verge of discovering a new way of harnessing it.<br>

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -1,5 +1,5 @@
 GLOBAL_VAR_INIT(hhStorageTurf, null)
-GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
+GLOBAL_VAR_INIT(hhmysteryRoomNumber, null)
 
 /obj/item/hilbertshotel
 	name = "Hilbert's Hotel"
@@ -21,6 +21,9 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 	. = ..()
 	//Load templates
 	INVOKE_ASYNC(src, .proc/prepare_rooms)
+	
+	if(!GLOB.hhmysteryRoomNumber)
+		GLOB.hhmysteryRoomNumber = rand(1, SHORT_REAL_LIMIT)
 
 /obj/item/hilbertshotel/proc/prepare_rooms()
 	hotelRoomTemp = new()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Now hhmysteryRoomNumber generates only once.
But in 2 places.
Fix #48527

Tested and work
![image](https://user-images.githubusercontent.com/7734424/93660946-97dd0100-fa5c-11ea-8a83-c5bdf7d510a8.png)
![image](https://user-images.githubusercontent.com/7734424/93660947-9f040f00-fa5c-11ea-9f26-5e4aa1c10cf7.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugs is bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
<!--
## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:
 -->
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
