### PR TITLE
Adds some file helpers for working with byond file references in external systems

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -82,12 +82,15 @@
 /// Used because md5ing files stored in the rsc sometimes gives incorrect md5 results.
 /proc/md5asfile(file)
 	var/filename = file2filepath(file)
+	var/istmp = FALSE
 	if (!filename || length(filename) < 1)
 		// its importaint this code can handle md5filepath sleeping instead of hard blocking, if it's converted to use rust_g.
 		filename = generate_tmp_filepath("md5asfile")
 		fcopy(file, filename)
+		istmp = TRUE
 	. = md5filepath(filename)
-	fdel(filename)
+	if (istmp)
+		fdel(filename)
 
 /// Generate a unique filepath inside the tmp folder.
 /// namespace - a optional string to prepend to the filename, useful for knowing what isn't cleaning up their things in the tmp folder


### PR DESCRIPTION
file2filepath will convert icons and cache references into the filepath the file can be found at, or null if its a runtime created icon 

generate_tmp_filepath will return a filepath to a file in the tmp file that you can save a runtime created cache reference (like an icon) to before sending it to external tools. 

the asset cache's md5asfile will now use these systems to avoid saving files to the tmp that do not need to be saved to the tmp folder
