### PR TITLE
Excessive spinning makes you woozy

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,3 +1,10 @@
+#define BEYBLADE_PUKE_THRESHOLD 30 //How confused a carbon must be before they will vomit
+#define BEYBLADE_PUKE_NUTRIENT_LOSS 60 //How must nutrition is lost when a carbon pukes
+#define BEYBLADE_DIZZINESS_PROBABILITY 20 //How often a carbon becomes penalized
+#define BEYBLADE_DIZZINESS_VALUE 10 //How long the screenshake lasts
+#define BEYBLADE_CONFUSION_INCREMENT 10 //How much confusion a carbon gets when penalized
+#define BEYBLADE_CONFUSION_LIMIT 40 //A max for how penalized a carbon will be for beyblading
+
 //The code execution of the emote datum is located at code/datums/emotes.dm
 /mob/proc/emote(act, m_type = null, message = null, intentional = FALSE)
 	act = lowertext(act)
@@ -84,20 +91,28 @@
 			else
 				L.unbuckle_all_mobs()
 
-/datum/emote/spin/check_cooldown(mob/user, intentional)
+/datum/emote/spin/check_cooldown(mob/living/carbon/user, intentional)
 	. = ..()
 	if(.)
 		return
 	if(!can_run_emote(user, intentional=intentional))
 		return
-	if(iscarbon(user))
-		var/mob/living/carbon/spinner = user
-		var/current_confusion = spinner.get_confusion()
-		if(current_confusion > 30)
-			spinner.vomit(60, FALSE, TRUE, 0)
-			return
-		if(prob(20))
-			to_chat(spinner, "<span class='warning'>You feel woozy from spinning.</span>")
-			spinner.Dizzy(10)
-			if(current_confusion < 40)
-				spinner.add_confusion(10)
+	if(!iscarbon(user))
+		return
+	var/current_confusion = user.get_confusion()
+	if(current_confusion > BEYBLADE_PUKE_THRESHOLD)
+		user.vomit(BEYBLADE_PUKE_NUTRIENT_LOSS, FALSE, TRUE, 0)
+		return
+	if(prob(BEYBLADE_DIZZINESS_PROBABILITY))
+		to_chat(user, "<span class='warning'>You feel woozy from spinning.</span>")
+		user.Dizzy(BEYBLADE_DIZZINESS_VALUE)
+		if(current_confusion < BEYBLADE_CONFUSION_LIMIT)
+			user.add_confusion(BEYBLADE_CONFUSION_INCREMENT)
+
+
+#undef BEYBLADE_PUKE_THRESHOLD
+#undef BEYBLADE_PUKE_NUTRIENT_LOSS
+#undef BEYBLADE_DIZZINESS_PROBABILITY
+#undef BEYBLADE_DIZZINESS_VALUE
+#undef BEYBLADE_CONFUSION_INCREMENT
+#undef BEYBLADE_CONFUSION_LIMIT

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -83,3 +83,21 @@
 						riding_datum.force_dismount(M)
 			else
 				L.unbuckle_all_mobs()
+
+/datum/emote/spin/check_cooldown(mob/user, intentional)
+	. = ..()
+	if(.)
+		return
+	if(!can_run_emote(user, intentional=intentional))
+		return
+	if(iscarbon(user))
+		var/mob/living/carbon/spinner = user
+		var/current_confusion = spinner.get_confusion()
+		if(current_confusion > 30)
+			spinner.vomit(60, FALSE, TRUE, 0)
+			return
+		if(prob(20))
+			to_chat(spinner, "<span class='warning'>You feel woozy from spinning.</span>")
+			spinner.Dizzy(10)
+			if(current_confusion < 40)
+				spinner.add_confusion(10)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -101,7 +101,7 @@
 		return
 	var/current_confusion = user.get_confusion()
 	if(current_confusion > BEYBLADE_PUKE_THRESHOLD)
-		user.vomit(BEYBLADE_PUKE_NUTRIENT_LOSS, FALSE, TRUE, 0)
+		user.vomit(BEYBLADE_PUKE_NUTRIENT_LOSS, distance = 0)
 		return
 	if(prob(BEYBLADE_DIZZINESS_PROBABILITY))
 		to_chat(user, "<span class='warning'>You feel woozy from spinning.</span>")


### PR DESCRIPTION
## About The Pull Request

When attempting to spin while it's on cooldown carbons get a bit of dizziness and confusion in increments, and once it reaches a certain point they no longer get more confused, instead puking without purging their reagents.
This doesn't affect simplemobs, silicons, or using fists of the northstar to beyblade as a tot.

## Why It's Good For The Game

Funnee spessmans speen, get woozy, pukies, visit kitchen for more fuel for their next beyblade battle
https://youtu.be/WsOlT-q89f0

## Changelog
:cl:
add: Spinning while the emote is on cooldown will make you confused, dizzy, and eventually puke if you go too fast. 
/:cl: