### PR TITLE
Add SpacemanDMM binaries to Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,9 @@ jobs:
     - name: "Generate Documentation"
       # Only run for non-PR commits to the real master branch.
       if: branch = master AND head_branch IS blank
+      cache:
+        directories:
+          - $HOME/SpacemanDMM
       install:
         - tools/travis/install_spaceman_dmm.sh dmdoc
       before_script:

--- a/tools/travis/install_spaceman_dmm.sh
+++ b/tools/travis/install_spaceman_dmm.sh
@@ -3,6 +3,17 @@ set -euo pipefail
 
 source dependencies.sh
 
-wget -O ~/$1 "https://github.com/SpaceManiac/SpacemanDMM/releases/download/$SPACEMAN_DMM_VERSION/$1"
-chmod +x ~/$1
+if [ ! -f ~/$1 ]; then
+	mkdir -p "$HOME/SpacemanDMM"
+	CACHEFILE="$HOME/SpacemanDMM/$1"
+
+	if ! [ -f "$CACHEFILE.version" ] || ! grep -Fxq "$SPACEMAN_DMM_VERSION" "$CACHEFILE.version"; then
+		wget -O "$CACHEFILE" "https://github.com/SpaceManiac/SpacemanDMM/releases/download/$SPACEMAN_DMM_VERSION/$1"
+		chmod +x "$CACHEFILE"
+		echo "$SPACEMAN_DMM_VERSION" >"$CACHEFILE.version"
+	fi
+
+	ln -s "$CACHEFILE" ~/$1
+fi
+
 ~/$1 --version


### PR DESCRIPTION
There have been a few CI failures due to GitHub ratelimiting the binary downloads from Travis servers. Let's fix that.

> --2020-09-17 20:53:05--  https://github.com/SpaceManiac/SpacemanDMM/releases/download/suite-1.4/dmdoc
Resolving github.com (github.com)... 140.82.114.4
Connecting to github.com (github.com)|140.82.114.4|:443... connected.
HTTP request sent, awaiting response... 429 too many requests
2020-09-17 20:53:05 ERROR 429: too many requests.

https://travis-ci.org/github/tgstation/tgstation/jobs/728147790