### PR TITLE
Makes freerunning quirk prevent falling damage from short falls

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -101,7 +101,7 @@
 
 /datum/quirk/freerunning
 	name = "Freerunning"
-	desc = "You're great at quick moves! You can climb tables more quickly."
+	desc = "You're great at quick moves! You can climb tables more quickly and take no damage from falling."
 	value = 2
 	mob_trait = TRAIT_FREERUNNING
 	gain_text = "<span class='notice'>You feel lithe on your feet!</span>"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -101,7 +101,7 @@
 
 /datum/quirk/freerunning
 	name = "Freerunning"
-	desc = "You're great at quick moves! You can climb tables more quickly and take no damage from falling."
+	desc = "You're great at quick moves! You can climb tables more quickly and take no damage from short falls."
 	value = 2
 	mob_trait = TRAIT_FREERUNNING
 	gain_text = "<span class='notice'>You feel lithe on your feet!</span>"

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -204,7 +204,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		prev_turf.visible_message("<span class='danger'>[mov_name] falls through [prev_turf]!</span>")
 	if(flags & FALL_INTERCEPTED)
 		return
-	if(zFall(A, ++levels))
+	if(zFall(A, levels + 1))
 		return FALSE
 	A.visible_message("<span class='danger'>[A] crashes into [src]!</span>")
 	A.onZImpact(src, levels)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -40,6 +40,13 @@
 	GLOB.human_list -= src
 	return ..()
 
+/mob/living/carbon/human/ZImpactDamage(turf/T, levels)
+	if(HAS_TRAIT(src, TRAIT_FREERUNNING))
+		visible_message("<span class='danger'>[src] makes a hard landing on [T] but remains unharmed from the fall.</span>", \
+						"<span class='userdanger'>You brace for the fall, making a hard landing on [T] but remaining unharmed from the fall.</span>")
+		Knockdown(levels * 50)
+		return
+	. = ..()
 
 /mob/living/carbon/human/prepare_data_huds()
 	//Update med hud images...

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -41,9 +41,9 @@
 	return ..()
 
 /mob/living/carbon/human/ZImpactDamage(turf/T, levels)
-	if(HAS_TRAIT(src, TRAIT_FREERUNNING))
+	if(HAS_TRAIT(src, TRAIT_FREERUNNING) && levels <= 2) // falling off one level
 		visible_message("<span class='danger'>[src] makes a hard landing on [T] but remains unharmed from the fall.</span>", \
-						"<span class='userdanger'>You brace for the fall, making a hard landing on [T] but remaining unharmed from the fall.</span>")
+						"<span class='userdanger'>You brace for the fall, making a hard landing on [T] but remaining unharmed.</span>")
 		Knockdown(levels * 50)
 		return
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -41,12 +41,11 @@
 	return ..()
 
 /mob/living/carbon/human/ZImpactDamage(turf/T, levels)
-	if(HAS_TRAIT(src, TRAIT_FREERUNNING) && levels <= 2) // falling off one level
-		visible_message("<span class='danger'>[src] makes a hard landing on [T] but remains unharmed from the fall.</span>", \
-						"<span class='userdanger'>You brace for the fall, making a hard landing on [T] but remaining unharmed.</span>")
-		Knockdown(levels * 50)
-		return
-	. = ..()
+	if(!HAS_TRAIT(src, TRAIT_FREERUNNING) || levels > 1) // falling off one level
+		return ..()
+	visible_message("<span class='danger'>[src] makes a hard landing on [T] but remains unharmed from the fall.</span>", \
+					"<span class='userdanger'>You brace for the fall. You make a hard landing on [T] but remain unharmed.</span>")
+	Knockdown(levels * 50)
 
 /mob/living/carbon/human/prepare_data_huds()
 	//Update med hud images...


### PR DESCRIPTION
This quirk is pretty terrible especially for a 2 pointer, now you can at least show off by jumping off of stairwells with impunity like the cool dude you are, you'll still get stunned but take no brute damage

:cl:
balance: The Freerunning quirk now lets you avoid brute damage from falling
fix: Fixed falling from z-levels causing more damage than intended
/:cl: