### PR TITLE
Fixes oversight with "tactical combat spinning" and flashes

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -46,6 +46,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ALLOW_DARK_PAINTS_1 (1 << 19)
 /// Should this object be unpaintable?
 #define UNPAINTABLE_1 (1 << 20)
+/// Is the thing currently spinning?
+#define IS_SPINNING_1 (1 << 21)
 
 /// If the thing can reflect light (lasers/energy)
 #define RICOCHET_SHINY			(1<<0)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -152,7 +152,6 @@
 	if(deviation == DEVIATION_FULL && !converter)
 		return
 
-
 	if(targeted)
 		if(M.flash_act(1, 1))
 			if(M.get_confusion() < power)
@@ -199,6 +198,10 @@
 	// or flashing someone they're stood on the same turf as, or a borg flashing someone buckled to them.
 	if(victim.loc == attacker.loc)
 		return DEVIATION_PARTIAL
+
+	// Tactical combat emote-spinning should not counter intended gameplay mechanics.
+	if(victim.is_spinning)
+		return DEVIATION_NONE
 
 	// If the victim was looking at the attacker, this is the direction they'd have to be facing.
 	var/victim_to_attacker = get_dir(victim, attacker)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -194,14 +194,16 @@
   * * attacker - Attacker
   */
 /obj/item/assembly/flash/proc/calculate_deviation(mob/victim, atom/attacker)
+	// Tactical combat emote-spinning should not counter intended gameplay mechanics.
+	// This trumps same-loc checks to discourage floor spinning in general to counter flashes.
+	// In short, combat spinning is silly and you should feel silly for doing it.
+	if(victim.flags_1 & IS_SPINNING_1)
+		return DEVIATION_NONE
+
 	// Are they on the same tile? We'll return partial deviation. This may be someone flashing while lying down
 	// or flashing someone they're stood on the same turf as, or a borg flashing someone buckled to them.
 	if(victim.loc == attacker.loc)
 		return DEVIATION_PARTIAL
-
-	// Tactical combat emote-spinning should not counter intended gameplay mechanics.
-	if(victim.is_spinning)
-		return DEVIATION_NONE
 
 	// If the victim was looking at the attacker, this is the direction they'd have to be facing.
 	var/victim_to_attacker = get_dir(victim, attacker)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -599,6 +599,8 @@
 	var/D = dir
 	if((spintime < 1)||(speed < 1)||!spintime||!speed)
 		return
+
+	is_spinning = TRUE
 	while(spintime >= speed)
 		sleep(speed)
 		switch(D)
@@ -612,6 +614,7 @@
 				D = NORTH
 		setDir(D)
 		spintime -= speed
+	is_spinning = FALSE
 
 ///Update the pulling hud icon
 /mob/proc/update_pull_hud_icon()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -600,7 +600,7 @@
 	if((spintime < 1)||(speed < 1)||!spintime||!speed)
 		return
 
-	is_spinning = TRUE
+	flags_1 |= IS_SPINNING_1
 	while(spintime >= speed)
 		sleep(speed)
 		switch(D)
@@ -614,7 +614,7 @@
 				D = NORTH
 		setDir(D)
 		spintime -= speed
-	is_spinning = FALSE
+	flags_1 &= ~IS_SPINNING_1
 
 ///Update the pulling hud icon
 /mob/proc/update_pull_hud_icon()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -221,3 +221,6 @@
 
 	///Whether the mob is updating glide size when movespeed updates or not
 	var/updating_glide_size = TRUE
+
+	/// Is the mob currently spinning with the spin emote or some other thing that forces a mob.spin()? Useful to counter tactical combat spinning.
+	var/is_spinning = FALSE

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -221,6 +221,3 @@
 
 	///Whether the mob is updating glide size when movespeed updates or not
 	var/updating_glide_size = TRUE
-
-	/// Is the mob currently spinning with the spin emote or some other thing that forces a mob.spin()? Useful to counter tactical combat spinning.
-	var/is_spinning = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Using the spin emote can no longer let you RNG your way out of new flash mechanics.

Mobs have a new flag that is set to when they start spinning and unset when they stop.

Flashes now use this new flag when calcing deviation.

Tactical combat spinning using the spin emote now results in a full deviation flash when it may previously have resulted in a failure or half-deviation flash.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Emotes should either not influence combat at all (spin on floor when both players share the same loc, this was already handled by same-loc code), or negatively influence combat for the emote user (spin in all other circumtances, which is what this PR addresses).

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Spamming the spin emote, also known as tactical combat spinning, no longer counters new flash mechanics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
