### PR TITLE
Fix two issues relating to stating laws

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -213,8 +213,18 @@
 
 	return
 
-
 /mob/living/silicon/proc/statelaws(force = 0)
+	// Create a cache of our laws and lawcheck flags before we do anything else.
+	// These are used to prevent weirdness when laws are changed when the AI is mid-stating.
+	var/lawcache_zeroth = laws.zeroth
+	var/list/lawcache_hacked = laws.hacked.Copy()
+	var/list/lawcache_ion = laws.ion.Copy()
+	var/list/lawcache_inherent = laws.inherent.Copy()
+	var/list/lawcache_supplied = laws.supplied.Copy()
+
+	var/list/lawcache_lawcheck = lawcheck.Copy()
+	var/list/lawcache_ioncheck = ioncheck.Copy()
+	var/list/lawcache_hackedcheck = hackedcheck.Copy()
 
 	//"radiomod" is inserted before a hardcoded message to change if and how it is handled by an internal radio.
 	say("[radiomod] Current Active Laws:")
@@ -223,42 +233,42 @@
 	var/number = 1
 	sleep(10)
 
-	if (laws.zeroth)
-		if (force || lawcheck[1] == "Yes")
-			say("[radiomod] 0. [laws.zeroth]")
+	if (lawcache_zeroth)
+		if (force || lawcache_lawcheck[1] == "Yes")
+			say("[radiomod] 0. [lawcache_zeroth]")
 			sleep(10)
 
-	for (var/index = 1, index <= laws.hacked.len, index++)
-		var/law = laws.hacked[index]
+	for (var/index = 1, index <= lawcache_hacked.len, index++)
+		var/law = lawcache_hacked[index]
 		var/num = ionnum()
 		if (length(law) > 0)
-			if (force || hackedcheck[index] == "Yes")
+			if (force || lawcache_hackedcheck[index] == "Yes")
 				say("[radiomod] [num]. [law]")
 				sleep(10)
 
-	for (var/index = 1, index <= laws.ion.len, index++)
-		var/law = laws.ion[index]
+	for (var/index = 1, index <= lawcache_ion.len, index++)
+		var/law = lawcache_ion[index]
 		var/num = ionnum()
 		if (length(law) > 0)
-			if (force || ioncheck[index] == "Yes")
+			if (force || lawcache_ioncheck[index] == "Yes")
 				say("[radiomod] [num]. [law]")
 				sleep(10)
 
-	for (var/index = 1, index <= laws.inherent.len, index++)
-		var/law = laws.inherent[index]
+	for (var/index = 1, index <= lawcache_inherent.len, index++)
+		var/law = lawcache_inherent[index]
 
 		if (length(law) > 0)
-			if (force || lawcheck[index+1] == "Yes")
+			if (force || lawcache_lawcheck[index+1] == "Yes")
 				say("[radiomod] [number]. [law]")
 				number++
 				sleep(10)
 
-	for (var/index = 1, index <= laws.supplied.len, index++)
-		var/law = laws.supplied[index]
+	for (var/index = 1, index <= lawcache_supplied.len, index++)
+		var/law = lawcache_supplied[index]
 
 		if (length(law) > 0)
-			if(lawcheck.len >= number+1)
-				if (force || lawcheck[number+1] == "Yes")
+			if(lawcache_lawcheck.len >= number+1)
+				if (force || lawcache_lawcheck[number+1] == "Yes")
 					say("[radiomod] [number]. [law]")
 					number++
 					sleep(10)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -238,7 +238,7 @@
 			say("[radiomod] 0. [lawcache_zeroth]")
 			sleep(10)
 
-	for (var/index = 1, index <= lawcache_hacked.len, index++)
+	for (var/index in 1 to length(lawcache_hacked))
 		var/law = lawcache_hacked[index]
 		var/num = ionnum()
 		if (length(law) > 0)
@@ -246,7 +246,7 @@
 				say("[radiomod] [num]. [law]")
 				sleep(10)
 
-	for (var/index = 1, index <= lawcache_ion.len, index++)
+	for (var/index in 1 to length(lawcache_ion))
 		var/law = lawcache_ion[index]
 		var/num = ionnum()
 		if (length(law) > 0)
@@ -254,7 +254,7 @@
 				say("[radiomod] [num]. [law]")
 				sleep(10)
 
-	for (var/index = 1, index <= lawcache_inherent.len, index++)
+	for (var/index in 1 to length(lawcache_inherent))
 		var/law = lawcache_inherent[index]
 
 		if (length(law) > 0)
@@ -263,7 +263,7 @@
 				number++
 				sleep(10)
 
-	for (var/index = 1, index <= lawcache_supplied.len, index++)
+	for (var/index in 1 to length(lawcache_supplied))
 		var/law = lawcache_supplied[index]
 
 		if (length(law) > 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Issue 1: When your laws change in the middle of stating laws, things can get weird due to this being a proc that sleeps and may end stating early or some other undesired behaviour.
Issue 2: Issue's 1 behaviour can also runtime.

This caches all relevant vars when a law state starts so that it can continue uninterrupted and as expected.

This seemed the simplest solution and was a concept suggested by a couple of other maintainers. My implementation may be utterly terrible though, so please review.

Testing to follow soon. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtime fix good. Knowing AI laws are being changed because they only partially state laws bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The AI will no longer partially state laws or potentially even state incorrect laws entirely whenever their lawset is changed in the middle of stating laws.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
