### PR TITLE
Canisters can violently rupture now

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -457,8 +457,8 @@
 	if(our_pressure > pressure_limit + TANK_FRAGMENT_PRESSURE)
 		var/range = (our_pressure - (pressure_limit + TANK_FRAGMENT_PRESSURE)) / TANK_FRAGMENT_SCALE
 		var/turf/epicenter = get_turf(loc)
-		explosion(epicenter, round(range*0.25), round(range*0.5), round(range), round(range*1.5))
 		obj_break()
+		explosion(epicenter, round(range*0.25), round(range*0.5), round(range), round(range*1.5))
 		return
 
 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -436,7 +436,7 @@
 			investigate_log("[key_name(user)] started a transfer into [holding].", INVESTIGATE_ATMOS)
 
 /obj/machinery/portable_atmospherics/canister/process_atmos(delta_time)
-	..()
+	. = ..()
 	if(machine_stat & BROKEN)
 		return PROCESS_KILL
 	if(timing && valve_timer < world.time)
@@ -453,6 +453,14 @@
 
 	var/our_pressure = air_contents.return_pressure()
 	var/our_temperature = air_contents.return_temperature()
+
+	if(our_pressure > pressure_limit + TANK_FRAGMENT_PRESSURE)
+		var/range = (our_pressure - (pressure_limit + TANK_FRAGMENT_PRESSURE)) / TANK_FRAGMENT_SCALE
+		var/turf/epicenter = get_turf(loc)
+		explosion(epicenter, round(range*0.25), round(range*0.5), round(range), round(range*1.5))
+		obj_break()
+		return
+
 
 	///function used to check the limit of the canisters and also set the amount of damage that the canister can receive, if the heat and pressure are way higher than the limit the more damage will be done
 	if(our_temperature > heat_limit || our_pressure > pressure_limit)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is the start of a series of PRs aimed at reworking all kinds of bombs, from TTVs to singlecaps (i hate those)
In this PR i'll Introduce a basic but functioning canister explosion that follows the same rules of TTVs regarding range and maxcap. Those can be used to gain massive amount of sci points and for now are mostly doable by fusion heat only, this will surely change later on with the TTVs and singlecaps nerf and the rise of canister reaction bombs where you need to create a gas reaction inside the canister for the bomb to happen.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Start of a rework of bombs, more features and dangers to workplaces for players to explore
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Canisters can violently rupture now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
