### PR TITLE
Skeletons and other bloodless creatures no longer suffer repeated heart attacks.

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -62,6 +62,11 @@
 
 /obj/item/organ/heart/on_life()
 	..()
+
+	// If the owner doesn't need a heart, we don't need to do anything with it.
+	if(!owner.needs_heart())
+		return
+
 	if(owner.client && beating)
 		failed = FALSE
 		var/sound/slowbeat = sound('sound/health/slowbeat.ogg', repeat = TRUE)
@@ -205,6 +210,11 @@
 
 /obj/item/organ/heart/cybernetic/emp_act(severity)
 	. = ..()
+
+	// If the owner doesn't need a heart, we don't need to do anything with it.
+	if(!owner.needs_heart())
+		return
+
 	if(. & EMP_PROTECT_SELF)
 		return
 	if(!COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ahelp from round 146599 - Skeleton chaining heart attacks.

Added simple code guards at the start of the two remaining peices of code that are responsible from spamming heart attack messages to early return if the owner doesn't actually use their heart.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

In-round bug reports good. Bugs bad. Bug feex good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Skeletons and other bloodless and/or heartless creatures should no longer suffer from heart attacks. This includes those whose hearts have been rendered obsolete via surgery.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
