### PR TITLE
map_template load fix

### DIFF
--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -33,8 +33,6 @@
 
 	var/list/turfs = block(	locate(bounds[MAP_MINX], bounds[MAP_MINY], bounds[MAP_MINZ]),
 							locate(bounds[MAP_MAXX], bounds[MAP_MAXY], bounds[MAP_MAXZ]))
-	var/list/border = block(locate(max(bounds[MAP_MINX]-1, 1),			max(bounds[MAP_MINY]-1, 1),			 bounds[MAP_MINZ]),
-							locate(min(bounds[MAP_MAXX]+1, world.maxx),	min(bounds[MAP_MAXY]+1, world.maxy), bounds[MAP_MAXZ])) - turfs
 	for(var/L in turfs)
 		var/turf/B = L
 		atoms += B
@@ -46,14 +44,18 @@
 				continue
 			if(istype(A, /obj/machinery/atmospherics))
 				atmos_machines += A
-	for(var/L in border)
-		var/turf/T = L
-		T.air_update_turf(TRUE) //calculate adjacent turfs along the border to prevent runtimes
 
 	SSmapping.reg_in_areas_in_z(areas)
 	SSatoms.InitializeAtoms(atoms)
 	SSmachines.setup_template_powernets(cables)
 	SSair.setup_template_machinery(atmos_machines)
+
+	//calculate all turfs inside the border
+	var/list/border = block(locate(max(bounds[MAP_MINX]-1, 1),			max(bounds[MAP_MINY]-1, 1),			 bounds[MAP_MINZ]),
+							locate(min(bounds[MAP_MAXX]+1, world.maxx),	min(bounds[MAP_MAXY]+1, world.maxy), bounds[MAP_MAXZ]))
+	for(var/L in border)
+		var/turf/T = L
+		T.air_update_turf(TRUE)
 
 /datum/map_template/proc/load_new_z()
 	var/x = round((world.maxx - width)/2)

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -51,8 +51,18 @@
 	SSair.setup_template_machinery(atmos_machines)
 
 	//calculate all turfs inside the border
-	var/list/template_and_bordering_turfs = block(locate(max(bounds[MAP_MINX]-1, 1),			max(bounds[MAP_MINY]-1, 1),			 bounds[MAP_MINZ]),
-							locate(min(bounds[MAP_MAXX]+1, world.maxx),	min(bounds[MAP_MAXY]+1, world.maxy), bounds[MAP_MAXZ]))
+	var/list/template_and_bordering_turfs = block(
+		locate(
+			max(bounds[MAP_MINX]-1, 1),
+			max(bounds[MAP_MINY]-1, 1),
+			bounds[MAP_MINZ]
+			),
+		locate(
+			min(bounds[MAP_MAXX]+1, world.maxx),
+			min(bounds[MAP_MAXY]+1, world.maxy),
+			bounds[MAP_MAXZ]
+			)
+		)
 	for(var/t in template_and_bordering_turfs)
 		var/turf/affected_turf = t
 		affected_turf.air_update_turf(TRUE)

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -45,7 +45,6 @@
 		)
 	for(var/L in turfs)
 		var/turf/B = L
-		atoms += B
 		areas |= B.loc
 		for(var/A in B)
 			atoms += A
@@ -56,6 +55,7 @@
 				atmos_machines += A
 
 	SSmapping.reg_in_areas_in_z(areas)
+	SSatoms.InitializeAtoms(turfs)
 	SSatoms.InitializeAtoms(atoms)
 	SSmachines.setup_template_powernets(cables)
 	SSair.setup_template_machinery(atmos_machines)

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -31,8 +31,18 @@
 	var/list/atom/atoms = list()
 	var/list/area/areas = list()
 
-	var/list/turfs = block(	locate(bounds[MAP_MINX], bounds[MAP_MINY], bounds[MAP_MINZ]),
-							locate(bounds[MAP_MAXX], bounds[MAP_MAXY], bounds[MAP_MAXZ]))
+	var/list/turfs = block(
+		locate(
+			bounds[MAP_MINX],
+			bounds[MAP_MINY],
+			bounds[MAP_MINZ]
+			),
+		locate(
+			bounds[MAP_MAXX],
+			bounds[MAP_MAXY],
+			bounds[MAP_MAXZ]
+			)
+		)
 	for(var/L in turfs)
 		var/turf/B = L
 		atoms += B

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -51,11 +51,11 @@
 	SSair.setup_template_machinery(atmos_machines)
 
 	//calculate all turfs inside the border
-	var/list/border = block(locate(max(bounds[MAP_MINX]-1, 1),			max(bounds[MAP_MINY]-1, 1),			 bounds[MAP_MINZ]),
+	var/list/template_and_bordering_turfs = block(locate(max(bounds[MAP_MINX]-1, 1),			max(bounds[MAP_MINY]-1, 1),			 bounds[MAP_MINZ]),
 							locate(min(bounds[MAP_MAXX]+1, world.maxx),	min(bounds[MAP_MAXY]+1, world.maxy), bounds[MAP_MAXZ]))
-	for(var/L in border)
-		var/turf/T = L
-		T.air_update_turf(TRUE)
+	for(var/t in template_and_bordering_turfs)
+		var/turf/affected_turf = t
+		affected_turf.air_update_turf(TRUE)
 
 /datum/map_template/proc/load_new_z()
 	var/x = round((world.maxx - width)/2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

initTemplateBounds() No more try calculate border turfs before inner initialized
now it update air in all template turfs after init

Now template update air and air reacts.
If you want check, try place abandoned teleporter on station and see airless plating near aired turfs.

<details>
Green turfs - active

![image](https://user-images.githubusercontent.com/7734424/93669533-8ff18100-fa9d-11ea-859a-021fc30b6588.png)

</details>

Separate atom and turfs init on template load

In case of window that call `air_update_turf(1)` on `Initialize()`
`air_update_turf(1)` update adjacent turfs that can be uninitialized.

## Why It's Good For The Game

Less runtimes

## Changelog
:cl:
fix: Some fixes to map_template.load() to make it less runtime.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
