### PR TITLE
Fixes scooter construction

### DIFF
--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -204,7 +204,7 @@
 		to_chat(user, "<span class='notice'>You begin to add wheels to [src].</span>")
 		if(I.use_tool(src, user, 80, volume=50, amount=5))
 			to_chat(user, "<span class='notice'>You finish making wheels for [src].</span>")
-			new /obj/vehicle/ridden/scooter/skateboard(user.loc)
+			new /obj/vehicle/ridden/scooter/skateboard/improvised(user.loc)
 			qdel(src)
 	else
 		return ..()


### PR DESCRIPTION
Fixes #53865

## About The Pull Request

You can properly build scooters again

## Why It's Good For The Game

Bugs are not radical

## Changelog
:cl:
fix: Fixed being unable to build scooters from manually crafted skateboards
/:cl: