### PR TITLE
removes astplate flooring, adds it to turfs2decals script

### DIFF
--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -35,13 +35,6 @@
 /turf/open/floor/plating/abductor2/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
 	return
 
-/turf/open/floor/plating/astplate
-	icon_state = "asteroidplating"
-
-/turf/open/floor/plating/airless/astplate
-	icon_state = "asteroidplating"
-
-
 /turf/open/floor/plating/ashplanet
 	icon = 'icons/turf/mining.dmi'
 	gender = PLURAL

--- a/tools/mapmerge2/map_scripts/turfs2decals.txt
+++ b/tools/mapmerge2/map_scripts/turfs2decals.txt
@@ -463,3 +463,5 @@
 /turf/open/floor/plasteel/yellow/side {dir=9} : /obj/effect/turf_decal/tile/yellow {dir=1} , /obj/effect/turf_decal/tile/yellow {dir=4} , /obj/effect/turf_decal/tile/yellow {dir=8} , /turf/open/floor/plasteel {@OLD;dir=@SKIP}
 /turf/open/floor/plasteel/yellow/side {dir=10} : /obj/effect/turf_decal/tile/yellow {dir=1} , /obj/effect/turf_decal/tile/yellow , /obj/effect/turf_decal/tile/yellow {dir=8} , /turf/open/floor/plasteel {@OLD;dir=@SKIP}
 /turf/open/floor/plasteel/yellow/corner : /obj/effect/turf_decal/tile/yellow {dir=@OLD} , /turf/open/floor/plasteel {@OLD;dir=@SKIP}
+/turf/open/floor/plating/airless/astplate : /obj/effect/turf_decal/sand/plating , /turf/open/floor/plating/airless  {@OLD;dir=@SKIP}
+/turf/open/floor/plating/astplate : /obj/effect/turf_decal/sand/plating , /turf/open/floor/plating  {@OLD;dir=@SKIP}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

what the title says, wjohn forgot to remove it when adding the decal for sandy plating so we have this pink black thing

## Why It's Good For The Game

its been a pink/black sprite for like 3 years or something


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
