### PR TITLE
Block movement now locks turning, migrate old save files to Ctrl

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -76,12 +76,13 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if (current_version < 38)
 		var/found_block_movement = FALSE
 
-		look_through_bindings:
-			for (var/list/key in key_bindings)
-				for (var/bind in key)
-					if (bind == "block_movement")
-						found_block_movement = TRUE
-						break look_through_bindings
+		for (var/list/key in key_bindings)
+			for (var/bind in key)
+				if (bind == "block_movement")
+					found_block_movement = TRUE
+					break
+			if (found_block_movement)
+				break
 
 		if (!found_block_movement)
 			LAZYADD(key_bindings["Ctrl"], "block_movement")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	37
+#define SAVEFILE_VERSION_MAX	38
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -72,6 +72,19 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(current_version < 37)
 		if(clientfps == 0)
 			clientfps = -1
+
+	if (current_version < 38)
+		var/found_block_movement = FALSE
+
+		look_through_bindings:
+			for (var/list/key in key_bindings)
+				for (var/bind in key)
+					if (bind == "block_movement")
+						found_block_movement = TRUE
+						break look_through_bindings
+
+		if (!found_block_movement)
+			LAZYADD(key_bindings["Ctrl"], "block_movement")
 
 /datum/preferences/proc/update_character(current_version, savefile/S)
 	return

--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -2,17 +2,20 @@
 // Only way to do that is to tie the behavior into the focus's keyLoop().
 
 /atom/movable/keyLoop(client/user)
-	if(!user.movement_locked)
-		var/movement_dir = NONE
-		for(var/_key in user.keys_held)
-			movement_dir = movement_dir | user.movement_keys[_key]
-		if(user.next_move_dir_add)
-			movement_dir |= user.next_move_dir_add
-		if(user.next_move_dir_sub)
-			movement_dir &= ~user.next_move_dir_sub
-		// Sanity checks in case you hold left and right and up to make sure you only go up
-		if((movement_dir & NORTH) && (movement_dir & SOUTH))
-			movement_dir &= ~(NORTH|SOUTH)
-		if((movement_dir & EAST) && (movement_dir & WEST))
-			movement_dir &= ~(EAST|WEST)
+	var/movement_dir = NONE
+	for(var/_key in user.keys_held)
+		movement_dir = movement_dir | user.movement_keys[_key]
+	if(user.next_move_dir_add)
+		movement_dir |= user.next_move_dir_add
+	if(user.next_move_dir_sub)
+		movement_dir &= ~user.next_move_dir_sub
+	// Sanity checks in case you hold left and right and up to make sure you only go up
+	if((movement_dir & NORTH) && (movement_dir & SOUTH))
+		movement_dir &= ~(NORTH|SOUTH)
+	if((movement_dir & EAST) && (movement_dir & WEST))
+		movement_dir &= ~(EAST|WEST)
+
+	if(user.movement_locked)
+		setDir(movement_dir)
+	else
 		user.Move(get_step(src, movement_dir), movement_dir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The block movement key now correctly locks turning like it used to.

Old save files are now migrated to Ctrl if they didn't bind it to anything before. This correctly replicates the old behavior.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It feels like we just removed a feature for people who don't follow the codebase. This is weird.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The block movement key now locks turning like it used to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
