### PR TITLE
Allow AI camera to move up Z-levels as well as down.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -134,7 +134,7 @@
 		target = get_step_multiz(source, direction)
 		if(!target)
 			return FALSE
-	return !(movement_type & FLYING) && has_gravity(source) && !throwing && !isAI(src)
+	return !(movement_type & FLYING) && has_gravity(source) && !throwing
 
 /atom/movable/proc/onZImpact(turf/T, levels)
 	var/atom/highest = T

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -134,7 +134,7 @@
 		target = get_step_multiz(source, direction)
 		if(!target)
 			return FALSE
-	return !(movement_type & FLYING) && has_gravity(source) && !throwing
+	return !(movement_type & FLYING) && has_gravity(source) && !throwing && !isAI(src)
 
 /atom/movable/proc/onZImpact(turf/T, levels)
 	var/atom/highest = T

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1015,5 +1015,12 @@
 	if(.)
 		end_multicam()
 
+/mob/living/silicon/ai/verb/up()
+	set name = "Move Upwards"
+	set category = "IC"
+
+	if(zMove(UP, TRUE))
+		to_chat(src, "<span class='notice'>You move upwards.</span>")
+
 /mob/living/silicon/ai/zMove(dir, feedback = FALSE)
 	. = eyeobj.zMove(dir, feedback)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1015,7 +1015,7 @@
 	if(.)
 		end_multicam()
 
-/mob/living/silicon/ai/verb/up()
+/mob/living/silicon/ai/up()
 	set name = "Move Upwards"
 	set category = "IC"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This was from being called into servers on a few occasions to help fix AIs that can't see anything on Icebox.

Looks like AIs are dropping down to lower Z-levels (like Botany's lower floor) and getting their cameras stuck there. It's not readily apparent what's going on because there are NO cameras on those lower Z-levels. It just looks like everything is static to the AI.

The current fix is asking them to zap their camera back to their core. However, letting them move up Z-levels at will should lower the number of times players get caught out with this if they go down a Z-level.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Little QoL fix.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The AI can now move its camera up z-levels as well as down by using the option in the IC tab. If you're an AI and you can't see anything, your camera may be on the wrong Z-level. Try moving it up or returning hitting the button to return to your core.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
