### PR TITLE
Disable TGS DMAPI Update Workflow while I'm away

### DIFF
--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -1,8 +1,6 @@
 name: Update TGS DMAPI
 
 on:
-  schedule:
-  - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
It's pinging maintainers and I'm not gonna fix it for like a week.