### PR TITLE
Removes an unneeded piece of virology RNG

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -374,7 +374,7 @@
 	if(HasSymptom(S))
 		return
 
-	if(!(symptoms.len < (VIRUS_SYMPTOM_LIMIT - 1) + rand(-1, 1)))
+	if(symptoms.len >= VIRUS_SYMPTOM_LIMIT)
 		RemoveSymptom(pick(symptoms))
 	symptoms += S
 	S.OnAdd(src)


### PR DESCRIPTION
## About The Pull Request

Okay, so, this is gonna take a bit of explanation.

Under our current virology system, when you add a symptom to a virus that doesn't already have that symptom, the game chooses a number: either 4, 5, or 6. If the number of symptoms in that virus BEFORE adding that new symptom is NOT less than (apparently, >= was a foreign concept to the person who wrote this code) the number chosen, the virus loses a random symptom before the new one is added.

This changes that check to work much more sanely and with less RNG. Basically, the number of symptoms in your virus is capped at a flat 6 now, and a random symptom will be removed from your virus only if adding a new symptom would take you over that cap.

To put it more simply, this changes a `if(!(symptoms.len < (VIRUS_SYMPTOM_LIMIT - 1) + rand(-1, 1)))` check to be a `if(symptoms.len >= VIRUS_SYMPTOM_LIMIT)` check.

## Why It's Good For The Game

This is an incredibly weird and janky system to use for making a virus symptom cap. It's also mostly pointless, as you can easily get around it by just making two virus "halves" with 4 or fewer symptoms each and mixing samples of those two halves (and/or the virus(es) they make when mixed together) for a minute or two near the end of the virus creation process to get a 6 symptom virus with no real risk.

It adds nothing to the game except for confusion for newer viro players (who don't know the unintuitive meta tactic to reliably avoid symptom loss). If you can give me one good reason why the symptom "caps" for viruses should work this way, I'll close this PR on the spot.

## Changelog
:cl: ATHATH
balance: Adding a symptom to a virus that already has 4 or 5 symptoms in it no longer has a chance of removing a random symptom from that virus.
/:cl: