### PR TITLE
Buffs Gravitokinetic Stands a bit

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/types/gravitokinetic.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/gravitokinetic.dm
@@ -46,6 +46,7 @@
 	. = ..()
 	//just make sure to reapply a gravity immunity wherever you summon. it can be overridden but not by you at least
 	summoner.AddElement(/datum/element/forced_gravity, 1)
+	AddElement(/datum/element/forced_gravity, 1)
 
 /mob/living/simple_animal/hostile/guardian/gravitokinetic/Moved(oldLoc, dir)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/guardian/types/gravitokinetic.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/gravitokinetic.dm
@@ -19,9 +19,9 @@
 
 /mob/living/simple_animal/hostile/guardian/gravitokinetic/AttackingTarget()
 	. = ..()
-	if(isliving(target) && target != src)
+	if(isliving(target) && target != src && target != summoner)
 		to_chat(src, "<span class='danger'><B>Your punch has applied heavy gravity to [target]!</span></B>")
-		add_gravity(target, 2)
+		add_gravity(target, 5)
 		to_chat(target, "<span class='userdanger'>Everything feels really heavy!</span>")
 
 /mob/living/simple_animal/hostile/guardian/gravitokinetic/AltClickOn(atom/A)
@@ -32,7 +32,7 @@
 			return
 		visible_message("<span class='danger'>[src] slams their fist into the [T]!</span>", "<span class='notice'>You modify the gravity of the [T].</span>")
 		do_attack_animation(T)
-		add_gravity(T, 4)
+		add_gravity(T, 3)
 		return
 	return ..()
 
@@ -42,13 +42,18 @@
 	for(var/i in gravito_targets)
 		remove_gravity(i)
 
+/mob/living/simple_animal/hostile/guardian/gravitokinetic/Manifest(forced)
+	. = ..()
+	//just make sure to reapply a gravity immunity wherever you summon. it can be overridden but not by you at least
+	summoner.AddElement(/datum/element/forced_gravity, 1)
+
 /mob/living/simple_animal/hostile/guardian/gravitokinetic/Moved(oldLoc, dir)
 	. = ..()
 	for(var/i in gravito_targets)
 		if(get_dist(src, i) > gravity_power_range)
 			remove_gravity(i)
 
-/mob/living/simple_animal/hostile/guardian/gravitokinetic/proc/add_gravity(atom/A, new_gravity = 2)
+/mob/living/simple_animal/hostile/guardian/gravitokinetic/proc/add_gravity(atom/A, new_gravity = 3)
 	if(gravito_targets[A])
 		return
 	A.AddElement(/datum/element/forced_gravity, new_gravity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gravitokinetic stands now give their user an immunity to their own gravity, and cannot apply it to their user.

Gravitokinetic stands now send out heavier gravity. Gravity applied to turfs will now damage lightly, gravity applied to people will damage twice as fast.

## Why It's Good For The Game

Gravitokinetic stands are super cool but like, kind of a deathwish to use even with the best holoparasite player

## Changelog
:cl:
balance: Buffed gravitokinetic stands, and they can't hurt their user anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
