### PR TITLE
[s] Don't allow sentient ice demons to teleport

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice demon.dm
@@ -50,6 +50,9 @@
 	temperature = -75
 
 /mob/living/simple_animal/hostile/asteroid/ice_demon/OpenFire()
+	// Sentient ice demons teleporting has been linked to server crashes
+	if(client)
+		return ..()
 	if(teleport_distance <= 0)
 		return ..()
 	var/list/possible_ends = list()


### PR DESCRIPTION
If you know, you know. I think this affects more than just teleporting, but hm.

## Changelog
:cl:
del: Sentient ice demons can no longer teleport.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
