### PR TITLE
Improves morph shapeshifting

### DIFF
--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -1,5 +1,3 @@
-#define MORPH_COOLDOWN 50
-
 /mob/living/simple_animal/hostile/morph
 	name = "morph"
 	real_name = "morph"
@@ -37,7 +35,6 @@
 	var/melee_damage_disguised = 0
 	var/eat_while_disguised = FALSE
 	var/atom/movable/form = null
-	var/morph_time = 0
 	var/static/list/blacklist_typecache = typecacheof(list(
 	/obj/screen,
 	/obj/singularity,
@@ -87,7 +84,7 @@
 	return FALSE
 
 /mob/living/simple_animal/hostile/morph/ShiftClickOn(atom/movable/A)
-	if(morph_time <= world.time && !stat)
+	if(!stat)
 		if(A == src)
 			restore()
 			return
@@ -118,7 +115,6 @@
 	melee_damage_upper = melee_damage_disguised
 	set_varspeed(0)
 
-	morph_time = world.time + MORPH_COOLDOWN
 	med_hud_set_health()
 	med_hud_set_status() //we're an object honest
 	return
@@ -147,7 +143,6 @@
 	melee_damage_upper = initial(melee_damage_upper)
 	set_varspeed(initial(speed))
 
-	morph_time = world.time + MORPH_COOLDOWN
 	med_hud_set_health()
 	med_hud_set_status() //we are not an object
 

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -41,13 +41,6 @@
 	/mob/living/simple_animal/hostile/morph,
 	/obj/effect))
 
-	var/playstyle_string = "<span class='big bold'>You are a morph,</span></b> an abomination of science created primarily with changeling cells. \
-							You may take the form of anything you can see by shift-clicking it. This process will alert any nearby \
-							observers. While morphed, you move faster, but deal no damage to living creatures.\
-							In addition, anyone within three tiles will note an uncanny wrongness if examining you. \
-							You can attack any item or dead creature to consume it - creatures will restore your health. \
-							Finally, you can restore yourself to your original form while morphed by shift-clicking yourself.</b>"
-
 /mob/living/simple_animal/hostile/morph/examine(mob/user)
 	if(morphed)
 		. = form.examine(user)
@@ -75,7 +68,7 @@
 
 /mob/living/simple_animal/hostile/morph/proc/eat(atom/movable/A)
 	if(morphed && !eat_while_disguised)
-		to_chat(src, "<span class='warning'>You can not eat anything while you are disguised!</span>")
+		to_chat(src, "<span class='warning'>You cannot eat anything while you are disguised!</span>")
 		return FALSE
 	if(A && A.loc != src)
 		visible_message("<span class='warning'>[src] swallows [A] whole!</span>")
@@ -91,7 +84,7 @@
 		if(istype(A) && allowed(A))
 			assume(A)
 	else
-		to_chat(src, "<span class='warning'>Your chameleon skin is still repairing itself!</span>")
+		to_chat(src, "<span class='warning'>You need to be conscious to transform!</span>")
 		..()
 
 /mob/living/simple_animal/hostile/morph/proc/assume(atom/movable/target)
@@ -230,7 +223,6 @@
 	player_mind.assigned_role = "Morph"
 	player_mind.special_role = "Morph"
 	player_mind.add_antag_datum(/datum/antagonist/morph)
-	to_chat(S, S.playstyle_string)
 	SEND_SOUND(S, sound('sound/magic/mutate.ogg'))
 	message_admins("[ADMIN_LOOKUPFLW(S)] has been made into a morph by an event.")
 	log_game("[key_name(S)] was spawned as a morph by an event.")

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -95,9 +95,6 @@
 		..()
 
 /mob/living/simple_animal/hostile/morph/proc/assume(atom/movable/target)
-	if(morphed)
-		to_chat(src, "<span class='warning'>You must restore to your original form first!</span>")
-		return
 	morphed = TRUE
 	form = target
 

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -43,7 +43,7 @@
 
 	var/playstyle_string = "<span class='big bold'>You are a morph,</span></b> an abomination of science created primarily with changeling cells. \
 							You may take the form of anything you can see by shift-clicking it. This process will alert any nearby \
-							observers. While morphed, you move faster, but deal [melee_damage_disguised <= 0 ? "no" : "less"] damage to living creatures.\
+							observers. While morphed, you move faster, but deal no damage to living creatures.\
 							In addition, anyone within three tiles will note an uncanny wrongness if examining you. \
 							You can attack any item or dead creature to consume it - creatures will restore your health. \
 							Finally, you can restore yourself to your original form while morphed by shift-clicking yourself.</b>"

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -42,9 +42,9 @@
 	/obj/effect))
 
 	var/playstyle_string = "<span class='big bold'>You are a morph,</span></b> an abomination of science created primarily with changeling cells. \
-							You may take the form of anything nearby by shift-clicking it. This process will alert any nearby \
-							observers, and can only be performed once every five seconds. While morphed, you move faster, but do \
-							less damage. In addition, anyone within three tiles will note an uncanny wrongness if examining you. \
+							You may take the form of anything you can see by shift-clicking it. This process will alert any nearby \
+							observers. While morphed, you move faster, but deal [melee_damage_disguised <= 0 ? "no" : "less"] damage to living creatures.\
+							In addition, anyone within three tiles will note an uncanny wrongness if examining you. \
 							You can attack any item or dead creature to consume it - creatures will restore your health. \
 							Finally, you can restore yourself to your original form while morphed by shift-clicking yourself.</b>"
 

--- a/code/modules/antagonists/morph/morph_antag.dm
+++ b/code/modules/antagonists/morph/morph_antag.dm
@@ -2,5 +2,15 @@
 	name = "Morph"
 	show_name_in_check_antagonists = TRUE
 	show_in_antagpanel = FALSE
+	var/playstyle_string = "<span class='big bold'>You are a morph,</span> a shapeshifting abomination that can eat almost anything. \
+							You may take the form of anything you can see by shift-clicking it. This process will alert any nearby \
+							observers. While morphed, you move faster, but are unable to attack creatures or eat anything.\
+							In addition, anyone within three tiles will note an uncanny wrongness if examining you. \
+							You can attack any item or dead creature to consume it - creatures will restore your health. \
+							Finally, you can restore yourself to your original form while morphed by shift-clicking yourself."
 
-//It does nothing! (Besides tracking)
+/datum/antagonist/morph/on_gain()
+	to_chat(owner.current, playstyle_string)
+	antag_memory += playstyle_string
+	..()
+


### PR DESCRIPTION
## About The Pull Request

Morphs no longer have to wait 5 seconds between disguising themselves and undisguising themselves (or vice versa).

Morphs can now change the form they're disguised as without needing to return to their true form first.

Morphs created by Gluttony's Blessing now actually receive the helpful paragraph that explains their powers that they're supposed to receive. This paragraph has been updated and is now displayed both in the text log and in the new morph's IC notes. The morph fluff mentioned in the paragraph has also been changed to reflect the gluttony ruin, not admin-only event spawns, being the usual source of player-controlled morphs.

## Why It's Good For The Game

Morph disguising is cool, but pretty impractical due to the long cooldown timer for disguising/undisguising and the awkwardness of the current form switching mechanics.

I think that this change will also make combat as a morph a bit more interesting than just running up to someone and clicking on them a bunch, as you can alternate between your disguised form for speed and your true form for damage once you've caught up to your tagret without having to worry about being stuck in your disguised form (which can't damage creatures) for too long.

Also, reflexively shift-clicking something to examine it and being forced into staying in squeaky toy mode for the next five seconds is pretty annoying. I'd rebind it to alt+click, but now that alt is the default "stop moving" key, I feel like that would make rebinding "stop moving" to another key near-necessary to play morph at full effectiveness.

Being able to change your disguise on the fly as a morph without having to awkwardly wait around in your natural form for 5 seconds makes blending in much easier and smoother as a morph. It also lets them live up to the "proto-changeling" side of their antag identity, instead of just being "a green thing that ventcrawls into the armory and eats everything".

## Changelog
:cl: ATHATH
balance: Morphs no longer have to wait 5 seconds between disguising themselves and undisguising themselves (or vice versa).
/:cl: