### PR TITLE
Activate Held Object and Drop hotkeys (Z and Q by default) now activate and store arm implant tools

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1074,6 +1074,11 @@
 	else if(can_be_firemanned(target))
 		fireman_carry(target)
 
+/mob/living/carbon/human/limb_attack_self()
+	var/obj/item/bodypart/arm = hand_bodyparts[active_hand_index]
+	if(arm)
+		arm.attack_self(src)
+
 
 //src is the user that will be carrying, target is the mob to be carried
 /mob/living/carbon/human/proc/can_piggyback(mob/living/carbon/target)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1078,6 +1078,7 @@
 	var/obj/item/bodypart/arm = hand_bodyparts[active_hand_index]
 	if(arm)
 		arm.attack_self(src)
+	return ..()
 
 
 //src is the user that will be carrying, target is the mob to be carried

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -589,6 +589,16 @@
 
 	return TRUE
 
+/**
+  * Called by using Activate Held Object with an empty hand/limb
+  *
+  * Does nothing by default. The intended use is to allow limbs to call their
+  * own attack_self procs. It is up to the individual mob to override this
+  * parent and actually use it.
+  */
+/mob/proc/limb_attack_self()
+	return
+
 ///Can this mob resist (default FALSE)
 /mob/proc/can_resist()
 	return FALSE		//overridden in living.dm
@@ -644,6 +654,10 @@
 	if(I)
 		I.attack_self(src)
 		update_inv_hands()
+		return
+
+	limb_attack_self()
+
 
 /**
   * Get the notes of this mob

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -178,7 +178,7 @@
 /obj/item/organ/cyberimp/arm/gun/laser/l
 	zone = BODY_ZONE_L_ARM
 
-/obj/item/organ/cyberimp/arm/gun/laser/Initialize
+/obj/item/organ/cyberimp/arm/gun/laser/Initialize()
 	. = ..()
 	var/obj/item/organ/cyberimp/arm/gun/laser/laserphasergun = locate(/obj/item/organ/cyberimp/arm/gun/laser) in contents
 	laserphasergun.icon = icon //No invisible laser guns kthx

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -84,10 +84,6 @@
 		"<span class='notice'>[holder] snaps back into your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
 		"<span class='hear'>You hear a short mechanical noise.</span>")
 
-	if(istype(holder, /obj/item/assembly/flash/armimplant))
-		var/obj/item/assembly/flash/F = holder
-		F.set_light(0)
-
 	owner.transferItemToLoc(holder, src, TRUE)
 	UnregisterSignal(holder, COMSIG_ITEM_DROPPED)
 	holder = null
@@ -103,10 +99,6 @@
 	holder.resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	holder.slot_flags = null
 	holder.set_custom_materials(null)
-
-	if(istype(holder, /obj/item/assembly/flash/armimplant))
-		var/obj/item/assembly/flash/F = holder
-		F.set_light(7)
 
 	var/side = zone == BODY_ZONE_R_ARM? RIGHT_HANDS : LEFT_HANDS
 	var/hand = owner.get_empty_held_index_for_side(side)
@@ -180,9 +172,9 @@
 
 /obj/item/organ/cyberimp/arm/gun/laser/Initialize()
 	. = ..()
-	var/obj/item/organ/cyberimp/arm/gun/laser/laserphasergun = locate(/obj/item/organ/cyberimp/arm/gun/laser) in contents
+	var/obj/item/organ/cyberimp/arm/gun/laser/laserphasergun = locate(/obj/item/gun/energy/laser/mounted) in contents
 	laserphasergun.icon = icon //No invisible laser guns kthx
-	laserphasergun.icon_state = icon
+	laserphasergun.icon_state = icon_state
 
 /obj/item/organ/cyberimp/arm/gun/taser
 	name = "arm-mounted taser implant"
@@ -230,6 +222,15 @@
 	if(locate(/obj/item/assembly/flash/armimplant) in items_list)
 		var/obj/item/assembly/flash/armimplant/F = locate(/obj/item/assembly/flash/armimplant) in items_list
 		F.I = src
+
+/obj/item/organ/cyberimp/arm/flash/Extend()
+	. = ..()
+	holder.set_light_range(7)
+	holder.set_light_on(TRUE)
+
+/obj/item/organ/cyberimp/arm/flash/Retract()
+	holder.set_light_on(FALSE)
+	..()
 
 /obj/item/organ/cyberimp/arm/baton
 	name = "arm electrification implant"

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -5,13 +5,12 @@
 	icon_state = "implant-toolkit"
 	w_class = WEIGHT_CLASS_SMALL
 	actions_types = list(/datum/action/item_action/organ_action/toggle)
-	var/obj/hand //A ref for the arm we're taking up. Mostly for the unregister signal upon removal
-	var/list/items_list = list()
-	// Used to store a list of all items inside, for multi-item implants.
-	// I would use contents, but they shuffle on every activation/deactivation leading to interface inconsistencies.
-
-	var/obj/item/active_item = null
-	// You can use this var for item path, it would be converted into an item on New()
+	///A ref for the arm we're taking up. Mostly for the unregister signal upon removal
+	var/obj/hand
+	/// Used to store a list of all items inside, for multi-item implants.
+	var/list/items_list = list()// I would use contents, but they shuffle on every activation/deactivation leading to interface inconsistencies.
+	/// You can use this var for item path, it would be converted into an item on New().
+	var/obj/item/active_item
 
 /obj/item/organ/cyberimp/arm/Initialize()
 	. = ..()

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -230,7 +230,7 @@
 
 /obj/item/organ/cyberimp/arm/flash/Retract()
 	holder.set_light_on(FALSE)
-	..()
+	return ..()
 
 /obj/item/organ/cyberimp/arm/baton
 	name = "arm electrification implant"

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -10,13 +10,13 @@
 	// Used to store a list of all items inside, for multi-item implants.
 	// I would use contents, but they shuffle on every activation/deactivation leading to interface inconsistencies.
 
-	var/obj/item/holder = null
+	var/obj/item/active_item = null
 	// You can use this var for item path, it would be converted into an item on New()
 
 /obj/item/organ/cyberimp/arm/Initialize()
 	. = ..()
-	if(ispath(holder))
-		holder = new holder(src)
+	if(ispath(active_item))
+		active_item = new active_item(src)
 
 	update_icon()
 	SetSlotFromZone()
@@ -77,33 +77,33 @@
 		Retract()
 
 /obj/item/organ/cyberimp/arm/proc/Retract()
-	if(!holder || (holder in src))
+	if(!active_item || (active_item in src))
 		return
 
-	owner.visible_message("<span class='notice'>[owner] retracts [holder] back into [owner.p_their()] [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
-		"<span class='notice'>[holder] snaps back into your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
+	owner.visible_message("<span class='notice'>[owner] retracts [active_item] back into [owner.p_their()] [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
+		"<span class='notice'>[active_item] snaps back into your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
 		"<span class='hear'>You hear a short mechanical noise.</span>")
 
-	owner.transferItemToLoc(holder, src, TRUE)
-	UnregisterSignal(holder, COMSIG_ITEM_DROPPED)
-	holder = null
+	owner.transferItemToLoc(active_item, src, TRUE)
+	UnregisterSignal(active_item, COMSIG_ITEM_DROPPED)
+	active_item = null
 	playsound(get_turf(owner), 'sound/mecha/mechmove03.ogg', 50, TRUE)
 
 /obj/item/organ/cyberimp/arm/proc/Extend(obj/item/item)
 	if(!(item in src))
 		return
 
-	holder = item
-	RegisterSignal(holder, COMSIG_ITEM_DROPPED, .proc/Retract) //Drop it to put away.
+	active_item = item
+	RegisterSignal(active_item, COMSIG_ITEM_DROPPED, .proc/Retract) //Drop it to put away.
 
-	holder.resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	holder.slot_flags = null
-	holder.set_custom_materials(null)
+	active_item.resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	active_item.slot_flags = null
+	active_item.set_custom_materials(null)
 
 	var/side = zone == BODY_ZONE_R_ARM? RIGHT_HANDS : LEFT_HANDS
 	var/hand = owner.get_empty_held_index_for_side(side)
 	if(hand)
-		owner.put_in_hand(holder, hand)
+		owner.put_in_hand(active_item, hand)
 	else
 		var/list/hand_items = owner.get_held_items_for_side(side, all = TRUE)
 		var/success = FALSE
@@ -114,24 +114,24 @@
 				failure_message += "<span class='warning'>Your [I] interferes with [src]!</span>"
 				continue
 			to_chat(owner, "<span class='notice'>You drop [I] to activate [src]!</span>")
-			success = owner.put_in_hand(holder, owner.get_empty_held_index_for_side(side))
+			success = owner.put_in_hand(active_item, owner.get_empty_held_index_for_side(side))
 			break
 		if(!success)
 			for(var/i in failure_message)
 				to_chat(owner, i)
 			return
-	owner.visible_message("<span class='notice'>[owner] extends [holder] from [owner.p_their()] [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
-		"<span class='notice'>You extend [holder] from your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
+	owner.visible_message("<span class='notice'>[owner] extends [active_item] from [owner.p_their()] [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
+		"<span class='notice'>You extend [active_item] from your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
 		"<span class='hear'>You hear a short mechanical noise.</span>")
 	playsound(get_turf(owner), 'sound/mecha/mechmove03.ogg', 50, TRUE)
 
 /obj/item/organ/cyberimp/arm/ui_action_click()
-	if((organ_flags & ORGAN_FAILING) || (!holder && !contents.len))
+	if((organ_flags & ORGAN_FAILING) || (!active_item && !contents.len))
 		to_chat(owner, "<span class='warning'>The implant doesn't respond. It seems to be broken...</span>")
 		return
 
-	if(!holder || (holder in src))
-		holder = null
+	if(!active_item || (active_item in src))
+		active_item = null
 		if(contents.len == 1)
 			Extend(contents[1])
 		else
@@ -139,7 +139,7 @@
 			for(var/obj/item/I in items_list)
 				choice_list[I] = image(I)
 			var/obj/item/choice = show_radial_menu(owner, owner, choice_list)
-			if(owner && owner == usr && owner.stat != DEAD && (src in owner.internal_organs) && !holder && (choice in contents))
+			if(owner && owner == usr && owner.stat != DEAD && (src in owner.internal_organs) && !active_item && (choice in contents))
 				// This monster sanity check is a nice example of how bad input is.
 				Extend(choice)
 	else
@@ -225,11 +225,11 @@
 
 /obj/item/organ/cyberimp/arm/flash/Extend()
 	. = ..()
-	holder.set_light_range(7)
-	holder.set_light_on(TRUE)
+	active_item.set_light_range(7)
+	active_item.set_light_on(TRUE)
 
 /obj/item/organ/cyberimp/arm/flash/Retract()
-	holder.set_light_on(FALSE)
+	active_item.set_light_on(FALSE)
 	return ..()
 
 /obj/item/organ/cyberimp/arm/baton


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- The Activate Held Object verb (and by extension, hotkey) will now call limb_attack_self() on the mob if the selected hand is empty.

- Added limb_attack_self() as a base mob-level proc. It is empty by default, as it is up to the mob to use this proc.

- Human mobs override limb_attack_self() to call attack_self() on their selected arm (if the arm exists).

- Arm implants now register a signal for COMSIG_ATTACK_SELF on the arm that they are installed for, which calls the ui_action_click() proc (action button proc). They also register one for COMSIG_DROPPED on any item they have extended into the mob's hand, which calls the retract() proc.

- Arm implant tools are no longer nodrop, and instead retract back to the implant when dropped.

- Fixed the arm-mounted laser implant having no in-hand sprite (due to incorrect icon and state settings).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Action buttons are clunky, so let's add some hotkey support.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now use the Activate Held Object and Drop Object hotkeys (default Z and Q, respectively) to activate arm-implanted tools and put objects away. You must have the hand free before you can activate it this way.
balance: Arm implant tools are no longer no-drop, and instead simply snap back if they get dropped. Don't sweat it, if you slip just press Z again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
