### PR TITLE
Adds icon_living states to cytology unique mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ooze.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ooze.dm
@@ -3,6 +3,7 @@
 	name = "Ooze"
 	icon = 'icons/mob/vatgrowing.dmi'
 	icon_state = "gelatinous"
+	icon_living = "gelatinous"
 	icon_dead = "gelatinous_dead"
 	mob_biotypes = MOB_ORGANIC
 	pass_flags = PASSTABLE | PASSGRILLE
@@ -276,6 +277,7 @@
 	name = "Sholean grapes"
 	desc = "A botryoidal ooze from Sholus VII.\nXenobiologists consider it to be one of the calmer and more agreeable species on the planet, but so far little is known about its behaviour in the wild.\nIt undulates in a comforting manner."
 	icon_state = "grapes"
+	icon_living = "grapes"
 	icon_dead = "grapes_dead"
 	speed = 1
 	health = 200

--- a/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
@@ -4,6 +4,7 @@
 	desc = "A strange molluscoidal creature carrying a busted growing vat.\nYou wonder if this burden is a voluntary undertaking in order to achieve comfort and protection, or simply because the creature is fused to its metal shell?"
 	icon = 'icons/mob/vatgrowing.dmi'
 	icon_state = "vat_beast"
+	icon_living = "vat_beast"
 	icon_dead = "vat_beast_dead"
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	mob_size = MOB_SIZE_LARGE


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin
Fixes: https://github.com/tgstation/tgstation/issues/53288

## Why It's Good For The Game

Makes these mobs visible when revived

## Changelog
:cl:
fix: Vatbeasts, gelatinous cubes, and sholean grapes are visible after being revived now
/:cl:
