### PR TITLE
Suit storage unit quality of life fixes

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -247,6 +247,7 @@
 		src,
 		choices,
 		custom_check = CALLBACK(src, .proc/check_interactable, user),
+		require_near = !issilicon(user),
 	)
 
 	if (!choice)
@@ -279,13 +280,14 @@
 			if (item_to_dispense)
 				vars[choice] = null
 				try_put_in_hand(item_to_dispense, user)
+			else
+				var/obj/item/in_hands = user.get_active_held_item()
+				if (in_hands)
+					attackby(in_hands, user)
 
 	interact(user)
 
 /obj/machinery/suit_storage_unit/proc/check_interactable(mob/user)
-	if (state_open && !powered())
-		return FALSE
-
 	if (!state_open && !can_interact(user))
 		return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Suit storage unit radials will now close when you walk away. 

You can now click an empty slot with an item will now put them inside.

You can now correctly use an already open suit storage unit when the power is out.

![2020-09-22T12-04-37](https://user-images.githubusercontent.com/35135081/93926778-cd882100-fccc-11ea-9979-146dce4921a3.gif)

Closes #53901.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Quality of life, makes the suit storage units more in line with existing radial menus.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Suit storage unit radial menus now close when you walk away.
add: Clicking a suit storage unit slot will try to put the item inside.
fix: You can now use suit storage units while the power is out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
