### PR TITLE
Clears up issues moods and alerts on gain of NOBREATH

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -21,11 +21,6 @@
 	QDEL_NULL(dna)
 	GLOB.carbon_list -= src
 
-/mob/living/carbon/register_init_signals()
-	. = ..()
-
-	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_NOBREATH), .proc/on_nobreath_trait_gain)
-
 /mob/living/carbon/swap_hand(held_index)
 	. = ..()
 	if(!.)
@@ -1286,23 +1281,3 @@
 		return
 
 	brain.update_skillchips()
-
-/**
- * On gain of TRAIT_NOBREATH
- *
- * This will clear all alerts and moods related to breathing.
- */
-/mob/living/carbon/proc/on_nobreath_trait_gain(datum/source)
-	failed_last_breath = FALSE
-	clear_alert("too_much_oxy")
-	clear_alert("not_enough_oxy")
-	clear_alert("too_much_tox")
-	clear_alert("not_enough_tox")
-	clear_alert("nitro")
-	clear_alert("too_much_nitro")
-	clear_alert("not_enough_nitro")
-	clear_alert("too_much_co2")
-	clear_alert("not_enough_co2")
-	SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "chemical_euphoria")
-	SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
-	SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "suffocation")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -21,6 +21,11 @@
 	QDEL_NULL(dna)
 	GLOB.carbon_list -= src
 
+/mob/living/carbon/register_init_signals()
+	. = ..()
+
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_NOBREATH), .proc/on_nobreath_trait_gain)
+
 /mob/living/carbon/swap_hand(held_index)
 	. = ..()
 	if(!.)
@@ -1281,3 +1286,23 @@
 		return
 
 	brain.update_skillchips()
+
+/**
+ * On gain of TRAIT_NOBREATH
+ *
+ * This will clear all alerts and moods related to breathing.
+ */
+/mob/living/carbon/proc/on_nobreath_trait_gain(datum/source)
+	failed_last_breath = FALSE
+	clear_alert("too_much_oxy")
+	clear_alert("not_enough_oxy")
+	clear_alert("too_much_tox")
+	clear_alert("not_enough_tox")
+	clear_alert("nitro")
+	clear_alert("too_much_nitro")
+	clear_alert("not_enough_nitro")
+	clear_alert("too_much_co2")
+	clear_alert("not_enough_co2")
+	SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "chemical_euphoria")
+	SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
+	SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "suffocation")

--- a/code/modules/mob/living/carbon/init_signals.dm
+++ b/code/modules/mob/living/carbon/init_signals.dm
@@ -1,0 +1,25 @@
+//Called on /mob/living/carbon/Initialize(), for the carbon mobs to register relevant signals.
+/mob/living/carbon/register_init_signals()
+	. = ..()
+
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_NOBREATH), .proc/on_nobreath_trait_gain)
+
+/**
+ * On gain of TRAIT_NOBREATH
+ *
+ * This will clear all alerts and moods related to breathing.
+ */
+/mob/living/carbon/proc/on_nobreath_trait_gain(datum/source)
+	failed_last_breath = FALSE
+	clear_alert("too_much_oxy")
+	clear_alert("not_enough_oxy")
+	clear_alert("too_much_tox")
+	clear_alert("not_enough_tox")
+	clear_alert("nitro")
+	clear_alert("too_much_nitro")
+	clear_alert("not_enough_nitro")
+	clear_alert("too_much_co2")
+	clear_alert("not_enough_co2")
+	SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "chemical_euphoria")
+	SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
+	SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "suffocation")

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -140,8 +140,6 @@
 		clear_alert("not_enough_oxy")
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_NOBREATH))
-		failed_last_breath = FALSE
-		clear_alert("not_enough_oxy")
 		return FALSE
 
 	var/obj/item/organ/lungs = getorganslot(ORGAN_SLOT_LUNGS)

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -76,6 +76,8 @@
 
 /obj/item/organ/lungs/proc/check_breath(datum/gas_mixture/breath, mob/living/carbon/human/H)
 	if(H.status_flags & GODMODE)
+		H.failed_last_breath = FALSE //clear oxy issues
+		H.clear_alert("not_enough_oxy")
 		return
 	if(HAS_TRAIT(H, TRAIT_NOBREATH))
 		return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2258,6 +2258,7 @@
 #include "code\modules\mob\living\carbon\death.dm"
 #include "code\modules\mob\living\carbon\emote.dm"
 #include "code\modules\mob\living\carbon\examine.dm"
+#include "code\modules\mob\living\carbon\init_signals.dm"
 #include "code\modules\mob\living\carbon\inventory.dm"
 #include "code\modules\mob\living\carbon\life.dm"
 #include "code\modules\mob\living\carbon\skillchip.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes up the gain of the NOBREATH trait to clear breath related moods and alerts.
Added a godmode fix up for humans also.

Fixes #53899 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gaining the trait should clear the alerts and moods
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cleaned up the gain of the no breath trait to clear moods and alerts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
