### PR TITLE
Remove tab before names in Who for deadmins

### DIFF
--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -42,7 +42,7 @@
 				Lines += entry
 		else//If they don't have +ADMIN, only show hidden admins
 			for(var/client/C in GLOB.clients)
-				var/entry = "\t[C.key]"
+				var/entry = "[C.key]"
 				if(C.holder && C.holder.fakekey)
 					entry += " <i>(as [C.holder.fakekey])</i>"
 				entry += " ([round(C.avgping, 1)]ms)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Previously, names were prefixed with tabs for deadmins. This makes the output look significantly worse.


Before this PR:
![dreamseeker_2020-09-23T23-57-16](https://user-images.githubusercontent.com/35135081/94112060-c0b51b80-fdf9-11ea-86ac-abec4a44503f.png)

After this PR:
![dreamseeker_2020-09-23T23-58-12](https://user-images.githubusercontent.com/35135081/94112073-c448a280-fdf9-11ea-9299-6d60370dcda9.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes Who not ugly for deadmins.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Fixed deadmins getting a worse looking Who menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
