### PR TITLE
Turns simple mob vars into string lists and fixes string assoc lists

### DIFF
--- a/code/__HELPERS/string_assoc_lists.dm
+++ b/code/__HELPERS/string_assoc_lists.dm
@@ -7,7 +7,7 @@ GLOBAL_LIST_EMPTY(string_assoc_lists)
 	var/list/string_id = list()
 	for(var/val in values)
 		string_id += "[val]_[values[val]]"
-	string_id.Join("-")
+	string_id = string_id.Join("-")
 
 	. = GLOB.string_assoc_lists[string_id]
 

--- a/code/__HELPERS/string_assoc_lists.dm
+++ b/code/__HELPERS/string_assoc_lists.dm
@@ -1,18 +1,17 @@
 GLOBAL_LIST_EMPTY(string_assoc_lists)
 
-
 /**
   * Caches associative lists with non-numeric stringify-able index keys and stringify-able values (text/typepath -> text/path/number).
   */
 /datum/proc/string_assoc_list(list/values)
-  var/list/string_id = list()
-  for(var/val in values)
-    string_id += "[val]_[values[val]]"
-  string_id.Join("-")
+	var/list/string_id = list()
+	for(var/val in values)
+		string_id += "[val]_[values[val]]"
+	string_id.Join("-")
 
-  . = GLOB.string_assoc_lists[string_id]
+	. = GLOB.string_assoc_lists[string_id]
 
-  if(.)
-    return
+	if(.)
+		return
 
-  return GLOB.string_assoc_lists[string_id] = values
+	return GLOB.string_assoc_lists[string_id] = values

--- a/code/__HELPERS/string_lists.dm
+++ b/code/__HELPERS/string_lists.dm
@@ -4,11 +4,11 @@ GLOBAL_LIST_EMPTY(string_lists)
   * Caches lists with non-numeric stringify-able values (text or typepath).
   */
 /datum/proc/string_list(list/values)
-  var/string_id = values.Join("-")
+	var/string_id = values.Join("-")
 
-  . = GLOB.string_lists[string_id]
+	. = GLOB.string_lists[string_id]
 
-  if(.)
-    return
+	if(.)
+		return
 
-  return GLOB.string_lists[string_id] = values
+	return GLOB.string_lists[string_id] = values

--- a/code/datums/dog_fashion.dm
+++ b/code/datums/dog_fashion.dm
@@ -23,13 +23,13 @@
 	if(desc)
 		D.desc = desc
 	if(emote_see)
-		D.emote_see = emote_see
+		D.emote_see = string_list(emote_see)
 	if(emote_hear)
-		D.emote_hear = emote_hear
+		D.emote_hear = string_list(emote_hear)
 	if(speak)
-		D.speak = speak
+		D.speak = string_list(speak)
 	if(speak_emote)
-		D.speak_emote = speak_emote
+		D.speak_emote = string_list(speak_emote)
 
 /datum/dog_fashion/proc/get_overlay(dir)
 	if(icon_file && obj_icon_state)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -59,7 +59,7 @@
 			if(prob(70) && !QDELETED(upriser))
 				var/mob/living/simple_animal/hostile/mimic/copy/M = new(upriser.loc, upriser, null, 1) // it will delete upriser on creation and override any machine checks
 				M.faction = list("profit")
-				M.speak = rampant_speeches.Copy()
+				M.speak = string_list(rampant_speeches.Copy())
 				M.speak_chance = 7
 			else
 				explosion(upriser.loc, -1, 1, 2, 4, 0)

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -120,7 +120,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 			icon_state = "holocarp"
 			icon_living = "holocarp"
 			icon_dead = "holocarp"
-			speak_emote = list("gnashes")
+			speak_emote = string_list(list("gnashes"))
 			desc = "A mysterious fish that stands by its charge, ever vigilant."
 			attack_verb_continuous = "bites"
 			attack_verb_simple = "bite"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -182,7 +182,7 @@
 	if(emote_see)
 		emote_see = string_list(emote_hear)
 	if(atmos_requirements)
-		atmos_requirements = string_assoc_list(damage_coeff)
+		atmos_requirements = string_assoc_list(atmos_requirements)
 	if(damage_coeff)
 		damage_coeff = string_assoc_list(damage_coeff)
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -172,8 +172,19 @@
 	update_simplemob_varspeed()
 	if(dextrous)
 		AddComponent(/datum/component/personal_crafting)
+
+	if(speak)
+		speak = string_list(speak)
+	if(speak_emote)
+		speak_emote = string_list(speak_emote)
+	if(emote_hear)
+		emote_hear = string_list(emote_hear)
+	if(emote_see)
+		emote_see = string_list(emote_hear)
+	if(atmos_requirements)
+		atmos_requirements = string_assoc_list(damage_coeff)
 	if(damage_coeff)
-		damage_coeff = string_list(damage_coeff)
+		damage_coeff = string_assoc_list(damage_coeff)
 
 
 /mob/living/simple_animal/Destroy()
@@ -388,10 +399,12 @@
 	if(icon_gib)
 		new /obj/effect/temp_visual/gib_animation/animal(loc, icon_gib)
 
+
 /mob/living/simple_animal/say_mod(input, list/message_mods = list())
-	if(speak_emote && speak_emote.len)
+	if(length(speak_emote))
 		verb_say = pick(speak_emote)
-	. = ..()
+	return ..()
+
 
 /mob/living/simple_animal/emote(act, m_type=1, message = null, intentional = FALSE)
 	if(stat)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -172,6 +172,9 @@
 	update_simplemob_varspeed()
 	if(dextrous)
 		AddComponent(/datum/component/personal_crafting)
+	if(damage_coeff)
+		damage_coeff = string_list(damage_coeff)
+
 
 /mob/living/simple_animal/Destroy()
 	GLOB.simple_animals[AIStatus] -= src
@@ -187,6 +190,7 @@
 		SSidlenpcpool.idle_mobs_by_zlevel[T.z] -= src
 
 	return ..()
+
 
 /mob/living/simple_animal/attackby(obj/item/O, mob/user, params)
 	if(!is_type_in_list(O, food_type))


### PR DESCRIPTION
Like typelist, this system caches repeated values to diminish the memory footprint of lists.
Instead of one unique list per simple mob we get one list per unique entry.

This fixes the associative version of the proc, which wasn't properly storing unique identities.
Also makes both files use tabs for indentation as per the contribution guidelines.

This PR turns around 2000ish unique lists into under 70.