### PR TITLE
Painkiller and miner's salve kills pain

### DIFF
--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -373,7 +373,7 @@
 			painkiller_bonus += 20
 
 		if(prob(25 + (20 * (severity - 2)) - painkiller_bonus)) // 25%/45% chance to fail self-applying with severe and critical wounds, modded by painkillers
-			victim.visible_message("<span class='danger'>[victim] fails to finish applying [I] to [victim.p_their()] [limb.name], passing out from the pain!</span>", "<span class='notice'>You black out from the pain of applying [I] to your [limb.name] before you can finish!</span>")
+			victim.visible_message("<span class='danger'>[victim] fails to finish applying [I] to [victim.p_their()] [limb.name], passing out from the pain!</span>", "<span class='notice'>You pass out from the pain of applying [I] to your [limb.name] before you can finish!</span>")
 			victim.AdjustUnconscious(5 SECONDS)
 			return
 		victim.visible_message("<span class='notice'>[victim] finishes applying [I] to [victim.p_their()] [limb.name], grimacing from the pain!</span>", "<span class='notice'>You finish applying [I] to your [limb.name], and your bones explode in pain!</span>")

--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -368,7 +368,9 @@
 		if(victim.has_reagent(/datum/reagent/determination))
 			painkiller_bonus += 10
 		if(victim.has.reagent(/datum/reagent/consumable/ethanol/painkiller))
-			painkiller_bonus += 10
+			painkiller_bonus += 5
+		if(victim.has.reagent(/datum/reagent/medicine/mine_salve))
+			painkiller_bonus += 20
 
 		if(prob(25 + (20 * (severity - 2)) - painkiller_bonus)) // 25%/45% chance to fail self-applying with severe and critical wounds, modded by painkillers
 			victim.visible_message("<span class='danger'>[victim] fails to finish applying [I] to [victim.p_their()] [limb.name], passing out from the pain!</span>", "<span class='notice'>You black out from the pain of applying [I] to your [limb.name] before you can finish!</span>")

--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -367,9 +367,9 @@
 			painkiller_bonus += 20
 		if(victim.has_reagent(/datum/reagent/determination))
 			painkiller_bonus += 10
-		if(victim.has.reagent(/datum/reagent/consumable/ethanol/painkiller))
+		if(victim.has_reagent(/datum/reagent/consumable/ethanol/painkiller))
 			painkiller_bonus += 5
-		if(victim.has.reagent(/datum/reagent/medicine/mine_salve))
+		if(victim.has_reagent(/datum/reagent/medicine/mine_salve))
 			painkiller_bonus += 20
 
 		if(prob(25 + (20 * (severity - 2)) - painkiller_bonus)) // 25%/45% chance to fail self-applying with severe and critical wounds, modded by painkillers

--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -367,6 +367,8 @@
 			painkiller_bonus += 20
 		if(victim.has_reagent(/datum/reagent/determination))
 			painkiller_bonus += 10
+		if(victim.has.reagent(/datum/reagent/consumable/ethanol/painkiller))
+			painkiller_bonus += 10
 
 		if(prob(25 + (20 * (severity - 2)) - painkiller_bonus)) // 25%/45% chance to fail self-applying with severe and critical wounds, modded by painkillers
 			victim.visible_message("<span class='danger'>[victim] fails to finish applying [I] to [victim.p_their()] [limb.name], passing out from the pain!</span>", "<span class='notice'>You black out from the pain of applying [I] to your [limb.name] before you can finish!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Painkiller (the drink) and miner's salve now add painkiller values in reference to bone gel application so they help prevent fainting when using it in a rush.
Also changes black out to pass out when you pass out due to pain.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The usage of painkiller as a placebo is an important one (though horribly ineffective). This PR will fix that by allowing for that drink to be unique and not useless.
Miner's salve is also referenced as a 'strong painkiller' so this now causes it to match morphine in effectiveness at killing pain.
![image](https://user-images.githubusercontent.com/68032262/94303629-08f14c80-ff66-11ea-9a10-a3346d2f41e3.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

balance: Painkiller (the drink) and miner's salve now kill pain as god intended! No more fainting during bonegel application.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
