### PR TITLE
light step buff

### DIFF
--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -48,11 +48,6 @@
 		if(!(flags & CALTROP_BYPASS_SHOES) && (H.shoes || feetCover))
 			return
 
-		var/damage = rand(min_damage, max_damage)
-		if(HAS_TRAIT(H, TRAIT_LIGHT_STEP))
-			damage *= 0.75
-
-
 		if(!(flags & CALTROP_SILENT) && COOLDOWN_FINISHED(src, caltrop_cooldown))
 			COOLDOWN_START(src, caltrop_cooldown, 1 SECONDS) //cooldown to avoid message spam.
 			var/atom/A = parent
@@ -63,5 +58,10 @@
 				H.visible_message("<span class='danger'>[H] slides on [A]!</span>", \
 						"<span class='userdanger'>You slide on [A]!</span>")
 
-		H.apply_damage(damage, BRUTE, picked_def_zone, wound_bonus = CANT_WOUND)
-		H.Paralyze(60)
+		var/damage = rand(min_damage, max_damage)
+		if(HAS_TRAIT(H, TRAIT_LIGHT_STEP))
+			H.apply_damage(damage*0.5, BRUTE, picked_def_zone, wound_bonus = CANT_WOUND) //halved damage
+			H.Paralyze(30) //halved stun length
+		else
+			H.apply_damage(damage, BRUTE, picked_def_zone, wound_bonus = CANT_WOUND)
+			H.Paralyze(60)


### PR DESCRIPTION
## About The Pull Request

The light step quirk now halves the damage and stun lengths of caltrop effects, instead of only reducing the damage from them by 1/4 (and doing nothing to their stun lengths).

## Why It's Good For The Game

One of the advertized benefits of the light step quirk is being less vulnerable to caltrops, but the perk actually does very little against them, especially against their nastiest effect: hardstunning.

I'd rather not touch the idea of turning the hardstun from stepping on a caltrop into a knockdown, as that'd signficantly affect the balance of ash walkers (and punji stick deathtraps). If the maintainers want me to do so, though, I could reluctantly change that hardstun into a knockdown.

## Changelog
:cl: ATHATH
balance: The light step quirk now halves the damage and stun lengths of caltrop effects, instead of only reducing the damage from them by 1/4 (and doing nothing to their stun lengths).
/:cl: