### PR TITLE
Fixes DNA console runtime

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -226,7 +226,10 @@
 		can_use_scanner = TRUE
 	else
 		can_use_scanner = FALSE
-		connected_scanner = null
+		if(connected_scanner)
+			if(connected_scanner.linked_console == src)
+				connected_scanner.linked_console = null
+			connected_scanner = null
 		is_viable_occupant = FALSE
 
 	// Check for a viable occupant in the scanner.
@@ -1607,10 +1610,7 @@
   * Checks if there is a connected DNA Scanner that is operational
   */
 /obj/machinery/computer/scan_consolenew/proc/scanner_operational()
-	if(!connected_scanner)
-		return FALSE
-
-	return (connected_scanner && connected_scanner.is_operational)
+	return connected_scanner?.is_operational
 
 /**
   * Checks if there is a valid DNA Scanner occupant for genetic modification


### PR DESCRIPTION
Closes #53692

:cl: ShizCalev
fix: Fixed a runtime caused by a DNA scanner's linked console var not being cleared properly.
/:cl:
