### PR TITLE
Biogen dispenses botany chems in more user-friendly volumes.

### DIFF
--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -67,67 +67,67 @@
 	category = list("initial","Food")
 
 /datum/design/ez_nut   //easy nut :)
-	name = "30u E-Z Nutrient"
+	name = "25u E-Z Nutrient"
 	id = "ez_nut"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 10)
-	make_reagents = list(/datum/reagent/plantnutriment/eznutriment = 30)
+	make_reagents = list(/datum/reagent/plantnutriment/eznutriment = 25)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/l4z_nut
-	name = "30u Left 4 Zed"
+	name = "25u Left 4 Zed"
 	id = "l4z_nut"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 20)
-	make_reagents = list(/datum/reagent/plantnutriment/left4zednutriment = 30)
+	make_reagents = list(/datum/reagent/plantnutriment/left4zednutriment = 25)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/rh_nut
-	name = "30u Robust Harvest"
+	name = "25u Robust Harvest"
 	id = "rh_nut"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 25)
-	make_reagents = list(/datum/reagent/plantnutriment/robustharvestnutriment = 30)
+	make_reagents = list(/datum/reagent/plantnutriment/robustharvestnutriment = 25)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/end_gro
-	name = "30u Enduro Grow"
+	name = "25u Enduro Grow"
 	id = "end_gro"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 30)
-	make_reagents = list(/datum/reagent/plantnutriment/endurogrow = 30)
+	make_reagents = list(/datum/reagent/plantnutriment/endurogrow = 25)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/liq_earth
-	name = "30u Liquid Earthquake"
+	name = "25u Liquid Earthquake"
 	id = "liq_earth"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 30)
-	make_reagents = list(/datum/reagent/plantnutriment/liquidearthquake = 30)
+	make_reagents = list(/datum/reagent/plantnutriment/liquidearthquake = 25)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/weed_killer
-	name = "30u Weed Killer"
+	name = "25u Weed Killer"
 	id = "weed_killer"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 50)
-	make_reagents = list(/datum/reagent/toxin/plantbgone/weedkiller = 30)
+	make_reagents = list(/datum/reagent/toxin/plantbgone/weedkiller = 25)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/pest_spray
-	name = "30u Pest Killer"
+	name = "25u Pest Killer"
 	id = "pest_spray"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 50)
-	make_reagents = list(/datum/reagent/toxin/pestkiller = 30)
+	make_reagents = list(/datum/reagent/toxin/pestkiller = 25)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/org_pest_spray
-	name = "30u Organic Pest Killer"
+	name = "25u Organic Pest Killer"
 	id = "org_pest_spray"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 80)
-	make_reagents = list(/datum/reagent/toxin/pestkiller/organic = 30)
+	make_reagents = list(/datum/reagent/toxin/pestkiller/organic = 25)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/cloth

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -2623,69 +2623,6 @@
 			<ul class="changes bgimages16">
 				<li class="bugfix">Titanium does not devolve in to iron when it rusts</li>
 			</ul>
-
-			<h2 class="date">24 July 2020</h2>
-			<h3 class="author">ArcaneMusic updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="tweak">The BEPIS has been moved to the Cargo Bay from Science, and it's prices have been adjusted to roughly late-game proportions for most players.</li>
-				<li class="balance">The Rolling Tables and Mauna Mug BEPIS techs have been merged into one.</li>
-			</ul>
-			<h3 class="author">EdgeLordExe updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Ash ascension no longer kills user.</li>
-			</ul>
-			<h3 class="author">Galdar02 updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">Winter Boots and Coats can now be acquired from Clothesmates</li>
-			</ul>
-			<h3 class="author">Jared-Fogle updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">You can now take off clothes while in stasis.</li>
-			</ul>
-			<h3 class="author">Maurukas updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="tweak">All maps now receive a blood crate and surplus limb crate in Medical.</li>
-				<li class="tweak">All maps now have a chemical locker in the Pharmacy or in Plumbing.</li>
-				<li class="rscdel">The last chemistry wardrobe locker has been removed from DeltaStation.</li>
-				<li class="bugfix">IceBox blood freezer not spawning the correct number of blood bags.</li>
-			</ul>
-			<h3 class="author">MrDoomBringer updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Routing protocols for contractor pods have been fixed - they should no longer send victims to mysterious crystal filled rooms</li>
-			</ul>
-			<h3 class="author">Ryll/Shaps updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="tweak">Licking wounds on other people will automatically contract any diseases they're carrying. This is a one way transmission vector, you cannot contract disease from a felinid doctor in this way due to the partially antiseptic nature of cat saliva or whatever</li>
-				<li class="tweak">You also cannot lick wounds if your mouth is covered or if you do not, in fact, possess a tongue</li>
-				<li class="bugfix">Your clothes and items will no longer be covered in distressingly human looking blood when bashing borgs to bits</li>
-				<li class="rscadd">Introduces piercing wounds, a new type of wound mostly related to pointy things like bullets. Piercing wounds cause bleeding that does not clot over time, as well as when that limb is hit.</li>
-				<li class="rscadd">Skeletons and plasmamen can now suffer bone wounds!</li>
-				<li class="tweak">Dismemberment is now integrated with wounds! Simply apply a critical bleeding wound and a severe bone wound, keep whacking, and pop! Sharp weapons will cut through to bones on limbs with critical bleeding wounds, allowing you to still dismember with just a sword or axe.</li>
-				<li class="tweak">A few projectile types, namely buckshot and shotgun slugs, have had their damage reduced slightly to account for their new wounding abilities. Buckshot may take three shots to crit now, but you can also blast peoples limbs off! Cool!</li>
-				<li class="rscadd">Health analyzers now tell you if a humanoid is missing a heart, lungs, liver, or stomach (and they need them to survive)</li>
-				<li class="tweak">Formaldehyde replaces calomel in paramedic belts</li>
-				<li class="bugfix">Having brute damage on a limb no longer causes bleeding. Bandages now apply to all wounds on a limb, rather than be applied per-wound. Gauze also stops bleeding from dragging, but this wears out the gauze faster</li>
-				<li class="tweak">Wounds that have their removal requirements met while the patient is on a stasis bed will now be cured of their wounds as expected. In addition, burn wounds will slowly recover while stasis'd if they have flesh regen/sanitizer applied</li>
-				<li class="bugfix">Examining a bleeding dead body now reflects that dead bodies don't actually bleed, saying their blood is pooling instead</li>
-				<li class="tweak">Coagulant is now slightly less effective per bleeding wound for each bleed wound on a patient</li>
-			</ul>
-			<h3 class="author">Sirich96 updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="imageadd">new stunbaton sprites</li>
-			</ul>
-			<h3 class="author">YPOQ updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Fixed an issue that prevented throwing hats onto heads.</li>
-			</ul>
-			<h3 class="author">nightred updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Only living mobs can buckle to borgs</li>
-				<li class="bugfix">The golden bike horn now works after round end,</li>
-			</ul>
-			<h3 class="author">zxaber updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="tweak">AIs disconnecting from a shell will be left looking at the shell rather than their core.</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -2686,46 +2686,6 @@
 			<ul class="changes bgimages16">
 				<li class="tweak">AIs disconnecting from a shell will be left looking at the shell rather than their core.</li>
 			</ul>
-
-			<h2 class="date">23 July 2020</h2>
-			<h3 class="author">ArcaneMusic updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Civilian bounty pads, when submitting a bounty that the department can't pay for, will allow you to submit it later.</li>
-				<li class="bugfix">Fixes 2 duplicate bounties between security/assistants.</li>
-			</ul>
-			<h3 class="author">Coul updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="code_imp">All keybinds send signals when pressed</li>
-			</ul>
-			<h3 class="author">Melbert updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Fixes cyborg slot cycling (and a runtime)</li>
-			</ul>
-			<h3 class="author">Nebulacrity updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="imageadd">Updated the reality fractures (Heretic influences) to have nicer sprites.</li>
-			</ul>
-			<h3 class="author">ShizCalev updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Fixed display cases going invisible when you put things inside of them.</li>
-				<li class="bugfix">Fixed the pedestal for open display cases being glass colored.</li>
-			</ul>
-			<h3 class="author">Skoglol updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="balance">electrolysis reaction now outputs 4.5u of reagents instead of 30u.</li>
-				<li class="rscdel">Removed forcesay on getting hit in classic mode.</li>
-			</ul>
-			<h3 class="author">nightred updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Fixed medical records for quirks.</li>
-				<li class="bugfix">Quirks settings trigger after spawn now.</li>
-			</ul>
-			<h3 class="author">tralezab updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">More roles added for mafia!</li>
-				<li class="balance">Should have (outside of adminbus) way more balanced role lists in mafia now.</li>
-				<li class="bugfix">general improvements to the game have been made as well :)</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You know what's super fun? When you want to fill a hydro nutrient bottle from the bio generator, and it only produces the stuff 30 units at a time, and the container you're using can only hold 50 units, and the generator won't overfill the container, so you can't fill the container completely without removing the container, removing 10 units from it by some means, then putting it back in and clicking the button again.

I love that.

## Changelog
:cl:
tweak: The biogenerator in hydroponics will now dispense botany chemicals in volumes that aren't specifically designed to upset the user.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
