### PR TITLE
Fixes mapstart and random arcade machines

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1686,7 +1686,7 @@
 /turf/open/floor/plating/airless,
 /area/awaymission/bmpship/midship)
 "gz" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /turf/open/floor/plasteel,
 /area/awaymission/bmpship/aft)
 "gA" = (

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1686,7 +1686,7 @@
 /turf/open/floor/plating/airless,
 /area/awaymission/bmpship/midship)
 "gz" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/plasteel,
 /area/awaymission/bmpship/aft)
 "gA" = (

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -1155,7 +1155,7 @@
 /area/ruin/space/has_grav/deepstorage/storage)
 "cR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage)
@@ -1276,7 +1276,7 @@
 /area/ruin/space/has_grav/deepstorage/storage)
 "dh" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage)

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -1155,7 +1155,7 @@
 /area/ruin/space/has_grav/deepstorage/storage)
 "cR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage)
@@ -1276,7 +1276,7 @@
 /area/ruin/space/has_grav/deepstorage/storage)
 "dh" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage)

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -3173,7 +3173,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)
 "jS" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)
 "jT" = (
@@ -3211,7 +3211,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)
 "ka" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -3173,7 +3173,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)
 "jS" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)
 "jT" = (
@@ -3211,7 +3211,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)
 "ka" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -5812,7 +5812,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "mB" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/moonoutpost19/arrivals)
 "mC" = (

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -5812,7 +5812,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "mB" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/moonoutpost19/arrivals)
 "mC" = (

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -5399,7 +5399,7 @@
 /turf/open/floor/wood,
 /area/awaymission/research/interior/dorm)
 "lU" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 4
 	},
@@ -5486,7 +5486,7 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/research/interior/escapepods)
 "mk" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -5399,7 +5399,7 @@
 /turf/open/floor/wood,
 /area/awaymission/research/interior/dorm)
 "lU" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 4
 	},
@@ -5486,7 +5486,7 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/research/interior/escapepods)
 "mk" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5044,7 +5044,7 @@
 /area/maintenance/starboard/fore)
 "anz" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/machinery/computer/arcade{
+/obj/machinery/computer/arcade/random{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -5595,7 +5595,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "aox" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -5609,7 +5609,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "aoy" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -7280,7 +7280,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arX" = (
-/obj/machinery/computer/arcade{
+/obj/machinery/computer/arcade/random{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -7317,7 +7317,7 @@
 /area/maintenance/starboard/fore)
 "asa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/arcade{
+/obj/machinery/computer/arcade/random{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -18630,7 +18630,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aND" = (
-/obj/machinery/computer/arcade{
+/obj/machinery/computer/arcade/random{
 	dir = 8
 	},
 /obj/machinery/status_display/evac{
@@ -19532,7 +19532,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aPl" = (
-/obj/machinery/computer/arcade{
+/obj/machinery/computer/arcade/random{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -108539,7 +108539,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/computer/arcade{
+/obj/machinery/computer/arcade/random{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -113382,7 +113382,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/computer/arcade{
+/obj/machinery/computer/arcade/random{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -114919,7 +114919,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/computer/arcade{
+/obj/machinery/computer/arcade/random{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5044,7 +5044,7 @@
 /area/maintenance/starboard/fore)
 "anz" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/machinery/computer/arcade/random{
+/obj/effect/spawner/randomarcade{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -5595,7 +5595,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "aox" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -5609,7 +5609,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "aoy" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -7280,7 +7280,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arX" = (
-/obj/machinery/computer/arcade/random{
+/obj/effect/spawner/randomarcade{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -7317,7 +7317,7 @@
 /area/maintenance/starboard/fore)
 "asa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/arcade/random{
+/obj/effect/spawner/randomarcade{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -18630,7 +18630,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aND" = (
-/obj/machinery/computer/arcade/random{
+/obj/effect/spawner/randomarcade{
 	dir = 8
 	},
 /obj/machinery/status_display/evac{
@@ -19532,7 +19532,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aPl" = (
-/obj/machinery/computer/arcade/random{
+/obj/effect/spawner/randomarcade{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -108539,7 +108539,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/computer/arcade/random{
+/obj/effect/spawner/randomarcade{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -113382,7 +113382,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/computer/arcade/random{
+/obj/effect/spawner/randomarcade{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -114919,7 +114919,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/computer/arcade/random{
+/obj/effect/spawner/randomarcade{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -200,7 +200,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaA" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -20216,7 +20216,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/computer/arcade/random{
+/obj/effect/spawner/randomarcade{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -22531,7 +22531,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/computer/arcade/random{
+/obj/effect/spawner/randomarcade{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23763,7 +23763,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "bdi" = (
-/obj/machinery/computer/arcade/random{
+/obj/effect/spawner/randomarcade{
 	dir = 4
 	},
 /turf/open/floor/wood,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -200,7 +200,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaA" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -20216,7 +20216,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/computer/arcade{
+/obj/machinery/computer/arcade/random{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -22531,7 +22531,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/computer/arcade{
+/obj/machinery/computer/arcade/random{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23763,7 +23763,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "bdi" = (
-/obj/machinery/computer/arcade{
+/obj/machinery/computer/arcade/random{
 	dir = 4
 	},
 /turf/open/floor/wood,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1202,7 +1202,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "acK" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -2395,7 +2395,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "afB" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -30827,7 +30827,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "buR" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/machinery/camera{
 	c_tag = "Bar - Starboard"
 	},
@@ -50854,7 +50854,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "ctn" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -55919,7 +55919,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "cJA" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1202,7 +1202,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "acK" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -2395,7 +2395,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "afB" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -30827,7 +30827,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "buR" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/machinery/camera{
 	c_tag = "Bar - Starboard"
 	},
@@ -50854,7 +50854,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "ctn" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -55919,7 +55919,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "cJA" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1986,7 +1986,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "afI" = (
-/obj/machinery/computer/arcade{
+/obj/machinery/computer/arcade/random{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -6452,7 +6452,7 @@
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "aqT" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -12894,7 +12894,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/computer/arcade{
+/obj/machinery/computer/arcade/random{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -13119,7 +13119,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "aHb" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -19892,7 +19892,7 @@
 	},
 /area/crew_quarters/bar)
 "baq" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
@@ -36630,7 +36630,7 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQz" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -55181,7 +55181,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library/artgallery)
 "riF" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1986,7 +1986,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "afI" = (
-/obj/machinery/computer/arcade/random{
+/obj/effect/spawner/randomarcade{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -6452,7 +6452,7 @@
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "aqT" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -12894,7 +12894,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/computer/arcade/random{
+/obj/effect/spawner/randomarcade{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -13119,7 +13119,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "aHb" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -19892,7 +19892,7 @@
 	},
 /area/crew_quarters/bar)
 "baq" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
@@ -36630,7 +36630,7 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQz" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -55181,7 +55181,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library/artgallery)
 "riF" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/debug/multiz.dmm
+++ b/_maps/map_files/debug/multiz.dmm
@@ -486,7 +486,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bT" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bU" = (

--- a/_maps/map_files/debug/multiz.dmm
+++ b/_maps/map_files/debug/multiz.dmm
@@ -486,7 +486,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bT" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bU" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -18872,7 +18872,7 @@
 /turf/open/floor/wood,
 /area/centcom/holding)
 "UV" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "UY" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -18872,7 +18872,7 @@
 /turf/open/floor/wood,
 /area/centcom/holding)
 "UV" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "UY" = (

--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -24,7 +24,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "g" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/machinery/light{
 	dir = 1
 	},

--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -24,7 +24,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "g" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/machinery/light{
 	dir = 1
 	},

--- a/_maps/shuttles/arrival_donut.dmm
+++ b/_maps/shuttles/arrival_donut.dmm
@@ -23,7 +23,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/arrival)
 "f" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "g" = (

--- a/_maps/shuttles/arrival_donut.dmm
+++ b/_maps/shuttles/arrival_donut.dmm
@@ -23,7 +23,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/arrival)
 "f" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "g" = (

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -1176,7 +1176,7 @@
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "cz" = (
-/obj/machinery/computer/arcade/random,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -1176,7 +1176,7 @@
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "cz" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/random,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -134,32 +134,6 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		to_chat(user, "<span class='notice'>You turn in 2 tickets to the [src] and claim a prize!</span>")
 		return
 
-/obj/machinery/computer/arcade/random
-	name = "random arcade machine"
-	desc = "Automagically transforms into a random arcade machine. If you see this, please create a bug report."
-
-/obj/machinery/computer/arcade/random/Initialize()
-	// This is just a shell for a random arcade machine. We're not going to do anything
-	// with it, so don't call parent.
-	SHOULD_CALL_PARENT(FALSE)
-
-	var/list/gameodds = list(
-		/obj/item/circuitboard/computer/arcade/battle = 49,
-		/obj/item/circuitboard/computer/arcade/orion_trail = 49,
-		/obj/item/circuitboard/computer/arcade/amputation = 2)
-	circuit = pickweight(gameodds)
-	var/new_build_path = initial(circuit.build_path)
-
-	if(!ispath(new_build_path))
-		stack_trace("Circuit with incorrect build path: [circuit]")
-		return INITIALIZE_HINT_QDEL
-
-	// Create a new machine.
-	new new_build_path(loc)
-
-	// And request a qdel.
-	return INITIALIZE_HINT_QDEL
-
 // ** BATTLE ** //
 /obj/machinery/computer/arcade/battle
 	name = "arcade machine"

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -69,14 +69,6 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	return
 
 /obj/machinery/computer/arcade/Initialize()
-	// If it's a generic arcade machine, pick a random arcade
-	// circuit board for it
-	if(!circuit)
-		var/list/gameodds = list(/obj/item/circuitboard/computer/arcade/battle = 49,
-							/obj/item/circuitboard/computer/arcade/orion_trail = 49,
-							/obj/item/circuitboard/computer/arcade/amputation = 2)
-		circuit = pickweight(gameodds)
-
 	. = ..()
 
 	Reset()
@@ -142,10 +134,33 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		to_chat(user, "<span class='notice'>You turn in 2 tickets to the [src] and claim a prize!</span>")
 		return
 
+/obj/machinery/computer/arcade/random
+	name = "random arcade machine"
+	desc = "Automagically transforms into a random arcade machine. If you see this, please create a bug report."
+
+/obj/machinery/computer/arcade/random/Initialize()
+	// This is just a shell for a random arcade machine. We're not going to do anything
+	// with it, so don't call parent.
+	SHOULD_CALL_PARENT(FALSE)
+
+	var/list/gameodds = list(
+		/obj/item/circuitboard/computer/arcade/battle = 49,
+		/obj/item/circuitboard/computer/arcade/orion_trail = 49,
+		/obj/item/circuitboard/computer/arcade/amputation = 2)
+	circuit = pickweight(gameodds)
+	var/new_build_path = initial(circuit.build_path)
+
+	if(!ispath(new_build_path))
+		stack_trace("Circuit with incorrect build path: [circuit]")
+		return INITIALIZE_HINT_QDEL
+
+	// Create a new machine.
+	new new_build_path(loc)
+
+	// And request a qdel.
+	return INITIALIZE_HINT_QDEL
 
 // ** BATTLE ** //
-
-
 /obj/machinery/computer/arcade/battle
 	name = "arcade machine"
 	desc = "Does not support Pinball."

--- a/code/game/objects/effects/spawners/arcade.dm
+++ b/code/game/objects/effects/spawners/arcade.dm
@@ -1,0 +1,25 @@
+/obj/effect/spawner/randomarcade
+	icon = 'icons/obj/computer.dmi'
+	icon_state = "arcade"
+	name = "spawn random arcade machine"
+	desc = "Automagically transforms into a random arcade machine. If you see this while in a shift, please create a bug report."
+
+/obj/effect/spawner/randomarcade/Initialize(mapload)
+	..()
+
+	var/static/list/gameodds = list(
+		/obj/item/circuitboard/computer/arcade/battle = 49,
+		/obj/item/circuitboard/computer/arcade/orion_trail = 49,
+		/obj/item/circuitboard/computer/arcade/amputation = 2)
+	var/obj/item/circuitboard/circuit = pickweight(gameodds)
+	var/new_build_path = initial(circuit.build_path)
+
+	if(!ispath(new_build_path))
+		stack_trace("Circuit with incorrect build path: [circuit]")
+		return INITIALIZE_HINT_QDEL
+
+	var/obj/arcade = new new_build_path(loc)
+	arcade.setDir(dir)
+
+	// And request a qdel.
+	return INITIALIZE_HINT_QDEL

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -929,6 +929,7 @@
 #include "code\game\objects\effects\effect_system\effects_smoke.dm"
 #include "code\game\objects\effects\effect_system\effects_sparks.dm"
 #include "code\game\objects\effects\effect_system\effects_water.dm"
+#include "code\game\objects\effects\spawners\arcade.dm"
 #include "code\game\objects\effects\spawners\bombspawner.dm"
 #include "code\game\objects\effects\spawners\bundle.dm"
 #include "code\game\objects\effects\spawners\decals.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #53951

Randomly generated arcade machines were getting random boards and initing properly, but they weren't re-built as the appropriate subtype.

This oversight has been remedied. A new subtype has been created for random arcade machines which exists purely to pick a random circuit then create a machine from that circuit's build path before returning that it should be qdel'd.

This new subtype has been appropriately regex find-and-replaced into all maps.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Pinball. Lizard.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Arcade machines no longer require deconstructing and reconstructing in order to work.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
