### PR TITLE
Undefine testing only define once tests are finished

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -54,4 +54,5 @@
 #undef TEST_ASSERT
 #undef TEST_ASSERT_EQUAL
 #undef TEST_ASSERT_NOTEQUAL
+#undef TEST_FOCUS
 #endif


### PR DESCRIPTION
Correctly undefines `TEST_FOCUS` after all test have concluded, just like `TEST_ASSERT` and friends.