### PR TITLE
Fixes infinite, (almost) free wound treatment with stacked medical items

### DIFF
--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -255,7 +255,7 @@
   */
 /datum/wound/proc/try_treating(obj/item/I, mob/user)
 	// first we weed out if we're not dealing with our wound's bodypart, or if it might be an attack
-	if(QDELETED(I)) || limb.body_zone != user.zone_selected || (I.force && user.a_intent != INTENT_HELP))
+	if(QDELETED(I) || limb.body_zone != user.zone_selected || (I.force && user.a_intent != INTENT_HELP))
 		return FALSE
 
 	var/allowed = FALSE

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -255,7 +255,7 @@
   */
 /datum/wound/proc/try_treating(obj/item/I, mob/user)
 	// first we weed out if we're not dealing with our wound's bodypart, or if it might be an attack
-	if(!I || limb.body_zone != user.zone_selected || (I.force && user.a_intent != INTENT_HELP))
+	if(QDELETED(I)) || limb.body_zone != user.zone_selected || (I.force && user.a_intent != INTENT_HELP))
 		return FALSE
 
 	var/allowed = FALSE


### PR DESCRIPTION
## About The Pull Request
Fixes a bug with stacked med items that allows you to treat wounds even after your stack runs out.

When a stack of medical items runs out, it gets deleted, but not fully deleted. So you can continue to use the 0 stack of sutures or meshes to tend a wound.

## Why It's Good For The Game
You can infinitely use a single suture to heal a bleeding wound (or a single mesh to heal a burn wound) if you lower your stack to 1 size before treating the wound. This also gives some free brute/burn healing. Probably not intended.

## Changelog
:cl: Melbert
fix: Fixes a bug with stacked medical items and wound treatment
/:cl:
