### PR TITLE
Prevent inventory HUDs from overlapping multiple overlays

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -117,10 +117,14 @@
 	H.open_language_menu(usr)
 
 /obj/screen/inventory
-	var/slot_id	// The indentifier for the slot. It has nothing to do with ID cards.
-	var/icon_empty // Icon when empty. For now used only by humans.
-	var/icon_full  // Icon when contains an item. For now used only by humans.
-	var/list/object_overlays = list()
+	/// The identifier for the slot. It has nothing to do with ID cards.
+	var/slot_id
+	/// Icon when empty. For now used only by humans.
+	var/icon_empty
+	 /// Icon when contains an item. For now used only by humans.
+	var/icon_full
+	/// The overlay when hovering over with an item in your hand
+	var/image/object_overlay
 	layer = HUD_LAYER
 	plane = HUD_PLANE
 
@@ -150,8 +154,8 @@
 
 /obj/screen/inventory/MouseExited()
 	..()
-	cut_overlay(object_overlays)
-	object_overlays.Cut()
+	cut_overlay(object_overlay)
+	QDEL_NULL(object_overlay)
 
 /obj/screen/inventory/update_icon_state()
 	if(!icon_empty)
@@ -182,8 +186,9 @@
 	else
 		item_overlay.color = "#00ff00"
 
-	object_overlays += item_overlay
-	add_overlay(object_overlays)
+	cut_overlay(object_overlay)
+	object_overlay = item_overlay
+	add_overlay(object_overlay)
 
 /obj/screen/inventory/hand
 	var/mutable_appearance/handcuff_overlay


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently, when you drag your mouse off an inventory button while holding it down, it'll leave a permanent ghost image (#53950). This is because `MouseExited` is not being called properly. However, I couldn't reproduce this in a non-SS13 BYOND project, which makes it difficult for me to fix that.

This is a band-aid fix. It'll leave a ghost image, but then the next time you hover over and exit, it'll remove it, making it much less annoying.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The ghost images are really annoying, and this is better than nothing. I'm maintaining a feature I added 2 years ago.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: When you get ghost images on inventory buttons, you can now hover over and out to clear it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
