### PR TITLE
Adds Shuttle 667 as a buyable shuttle for dispelling a cult rune

### DIFF
--- a/_maps/shuttles/emergency_narnar.dmm
+++ b/_maps/shuttles/emergency_narnar.dmm
@@ -262,6 +262,10 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"X" = (
+/obj/machinery/stasis,
+/turf/open/floor/plasteel/cult,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 a
@@ -473,9 +477,9 @@ j
 j
 j
 c
+X
 j
-j
-j
+X
 U
 V
 "}

--- a/_maps/shuttles/emergency_narnar.dmm
+++ b/_maps/shuttles/emergency_narnar.dmm
@@ -6,7 +6,9 @@
 /turf/closed/wall/mineral/cult,
 /area/shuttle/escape)
 "c" = (
-/obj/effect/forcefield/cult,
+/obj/effect/forcefield/cult{
+	timeleft = 0
+	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "d" = (
@@ -262,7 +264,7 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
-"X" = (
+"Z" = (
 /obj/machinery/stasis,
 /turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
@@ -477,9 +479,9 @@ j
 j
 j
 c
-X
+Z
 j
-X
+Z
 U
 V
 "}

--- a/_maps/shuttles/emergency_narnar.dmm
+++ b/_maps/shuttles/emergency_narnar.dmm
@@ -6,9 +6,7 @@
 /turf/closed/wall/mineral/cult,
 /area/shuttle/escape)
 "c" = (
-/obj/effect/forcefield/cult{
-	timeleft = 0
-	},
+/obj/effect/forcefield/cult/permanent,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "d" = (

--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -86,5 +86,6 @@
 #define SHUTTLE_DEFAULT_UNDERLYING_AREA /area/space
 
 //Shuttle unlocks
-#define SHUTTLE_UNLOCK_BUBBLEGUM "bubblegum"
 #define SHUTTLE_UNLOCK_ALIENTECH "abductor"
+#define SHUTTLE_UNLOCK_BUBBLEGUM "bubblegum"
+#define SHUTTLE_UNLOCK_NARNAR "narnar"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -248,9 +248,7 @@
 	var/arena_loaded = FALSE
 
 /datum/map_template/shuttle/emergency/arena/prerequisites_met()
-	if(SHUTTLE_UNLOCK_BUBBLEGUM in SSshuttle.shuttle_purchase_requirements_met)
-		return TRUE
-	return FALSE
+	return SHUTTLE_UNLOCK_BUBBLEGUM in SSshuttle.shuttle_purchase_requirements_met
 
 /datum/map_template/shuttle/emergency/arena/post_load(obj/docking_port/mobile/M)
 	. = ..()
@@ -334,6 +332,10 @@
 	description = "Looks like this shuttle may have wandered into the darkness between the stars on route to the station. Let's not think too hard about where all the bodies came from."
 	admin_notes = "Contains real cult ruins, mob eyeballs, and inactive constructs. Cult mobs will automatically be sentienced by fun balloon. \
 	Cloning pods in 'medbay' area are showcases and nonfunctional."
+	credit_cost = 6667
+
+/datum/map_template/shuttle/emergency/narnar/prerequisites_met()
+	return SHUTTLE_UNLOCK_NARNAR in SSshuttle.shuttle_purchase_requirements_met
 
 /datum/map_template/shuttle/emergency/pubby
 	suffix = "pubby"
@@ -513,9 +515,7 @@
 	credit_cost = 8000
 
 /datum/map_template/shuttle/emergency/zeta/prerequisites_met()
-	if(SHUTTLE_UNLOCK_ALIENTECH in SSshuttle.shuttle_purchase_requirements_met)
-		return TRUE
-	return FALSE
+	return SHUTTLE_UNLOCK_ALIENTECH in SSshuttle.shuttle_purchase_requirements_met
 
 /datum/map_template/shuttle/arrival/box
 	suffix = "box"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -248,7 +248,7 @@
 	var/arena_loaded = FALSE
 
 /datum/map_template/shuttle/emergency/arena/prerequisites_met()
-	return SHUTTLE_UNLOCK_BUBBLEGUM in SSshuttle.shuttle_purchase_requirements_met
+	return SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_BUBBLEGUM]
 
 /datum/map_template/shuttle/emergency/arena/post_load(obj/docking_port/mobile/M)
 	. = ..()
@@ -335,7 +335,7 @@
 	credit_cost = 6667
 
 /datum/map_template/shuttle/emergency/narnar/prerequisites_met()
-	return SHUTTLE_UNLOCK_NARNAR in SSshuttle.shuttle_purchase_requirements_met
+	return SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_NARNAR]
 
 /datum/map_template/shuttle/emergency/pubby
 	suffix = "pubby"
@@ -515,7 +515,7 @@
 	credit_cost = 8000
 
 /datum/map_template/shuttle/emergency/zeta/prerequisites_met()
-	return SHUTTLE_UNLOCK_ALIENTECH in SSshuttle.shuttle_purchase_requirements_met
+	return SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_ALIENTECH]
 
 /datum/map_template/shuttle/arrival/box
 	suffix = "box"

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -24,6 +24,11 @@
 	CanAtmosPass = ATMOS_PASS_NO
 	timeleft = 200
 
+/// A form of the cult forcefield that lasts permanently.
+/// Used on the Shuttle 667.
+/obj/effect/forcefield/cult/permanent
+	timeleft = 0
+
 ///////////Mimewalls///////////
 
 /obj/effect/forcefield/mime

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -64,6 +64,7 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 	else if(istype(I, /obj/item/nullrod))
 		user.say("BEGONE FOUL MAGIKS!!", forced = "nullrod")
 		to_chat(user, "<span class='danger'>You disrupt the magic of [src] with [I].</span>")
+		SSshuttle.shuttle_purchase_requirements_met |= SHUTTLE_UNLOCK_NARNAR
 		qdel(src)
 
 /obj/effect/rune/attack_hand(mob/living/user)

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -64,7 +64,7 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 	else if(istype(I, /obj/item/nullrod))
 		user.say("BEGONE FOUL MAGIKS!!", forced = "nullrod")
 		to_chat(user, "<span class='danger'>You disrupt the magic of [src] with [I].</span>")
-		SSshuttle.shuttle_purchase_requirements_met |= SHUTTLE_UNLOCK_NARNAR
+		SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_NARNAR] = TRUE
 		qdel(src)
 
 /obj/effect/rune/attack_hand(mob/living/user)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -419,7 +419,7 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/bubblegum/grant_achievement(medaltype,scoretype)
 	. = ..()
 	if(.)
-		SSshuttle.shuttle_purchase_requirements_met |= SHUTTLE_UNLOCK_BUBBLEGUM
+		SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_BUBBLEGUM] = TRUE
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/do_attack_animation(atom/A, visual_effect_icon)
 	if(!charging)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -920,7 +920,7 @@
 	hidden = TRUE
 
 /datum/techweb_node/alientech/on_research() //Unlocks the Zeta shuttle for purchase
-		SSshuttle.shuttle_purchase_requirements_met |= SHUTTLE_UNLOCK_ALIENTECH
+		SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_ALIENTECH] = TRUE
 
 /datum/techweb_node/alien_bio
 	id = "alien_bio"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Shuttle 667 (the "Nar Nar" shuttle) as a purchasable shuttle. You can buy it once a cult rune is dispelled through a null rod.

Also adds two stasis beds in the medbay part.

![image](https://user-images.githubusercontent.com/35135081/94310444-7da89480-ff2e-11ea-8292-361b5eb2c4d9.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds more novelty to shuttle purchasing. Plus, who doesn't want to see a cult attempt to hijack the emergency shuttle to use the summon rune on it?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now buy the Shuttle 667 when a cult rune is dispelled with a null rod.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
