### PR TITLE
ChemMaster does not need beaker to destroy chems

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -1,5 +1,5 @@
 /obj/machinery/chem_master
-	name = "ChemMaster 3001"
+	name = "ChemMaster 3000"
 	desc = "Used to separate chemicals and distribute them in a variety of forms."
 	density = TRUE
 	layer = BELOW_OBJ_LAYER

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -1,5 +1,5 @@
 /obj/machinery/chem_master
-	name = "ChemMaster 3000"
+	name = "ChemMaster 3001"
 	desc = "Used to separate chemicals and distribute them in a variety of forms."
 	density = TRUE
 	layer = BELOW_OBJ_LAYER
@@ -210,8 +210,6 @@
 		return TRUE
 
 	if(action == "transfer")
-		if(!beaker)
-			return FALSE
 		var/reagent = GLOB.name2reagent[params["id"]]
 		var/amount = text2num(params["amount"])
 		var/to_container = params["to"]
@@ -220,16 +218,16 @@
 			amount = text2num(input(
 				"Enter the amount you want to transfer:",
 				name, ""))
-		if (amount == null || amount <= 0)
+		if (to_container == "beaker" && !mode)
+			reagents.remove_reagent(reagent, amount)
+			return TRUE
+		if (!beaker || amount == null || amount <= 0)
 			return FALSE
 		if (to_container == "buffer")
 			beaker.reagents.trans_id_to(src, reagent, amount)
 			return TRUE
 		if (to_container == "beaker" && mode)
 			reagents.trans_id_to(beaker, reagent, amount)
-			return TRUE
-		if (to_container == "beaker" && !mode)
-			reagents.remove_reagent(reagent, amount)
 			return TRUE
 		return FALSE
 

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -218,10 +218,12 @@
 			amount = text2num(input(
 				"Enter the amount you want to transfer:",
 				name, ""))
+		if (amount == null || amount <= 0)
+			return FALSE
 		if (to_container == "beaker" && !mode)
 			reagents.remove_reagent(reagent, amount)
 			return TRUE
-		if (!beaker || amount == null || amount <= 0)
+		if (!beaker)
 			return FALSE
 		if (to_container == "buffer")
 			beaker.reagents.trans_id_to(src, reagent, amount)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


You do not need to have a beaker in the Chemmaster to destroy items in the buffer.
Fixes #53977 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

it is good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: ChemMaster got an update and the beaker is not needed to clear the buffer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
