### PR TITLE
Scales ethereal power capacity and interactions upwards 

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -179,12 +179,12 @@
 
 //Charge levels for Ethereals
 #define ETHEREAL_CHARGE_NONE 0
-#define ETHEREAL_CHARGE_LOWPOWER 20
-#define ETHEREAL_CHARGE_NORMAL 50
-#define ETHEREAL_CHARGE_ALMOSTFULL 75
-#define ETHEREAL_CHARGE_FULL 100
-#define ETHEREAL_CHARGE_OVERLOAD 125
-#define ETHEREAL_CHARGE_DANGEROUS 150
+#define ETHEREAL_CHARGE_LOWPOWER 400
+#define ETHEREAL_CHARGE_NORMAL 1000
+#define ETHEREAL_CHARGE_ALMOSTFULL 1500
+#define ETHEREAL_CHARGE_FULL 2000
+#define ETHEREAL_CHARGE_OVERLOAD 2500
+#define ETHEREAL_CHARGE_DANGEROUS 3000
 
 //Slime evolution threshold. Controls how fast slimes can split/grow
 #define SLIME_EVOLUTION_THRESHOLD 10
@@ -290,7 +290,7 @@
 #define DOOR_CRUSH_DAMAGE	15	//the amount of damage that airlocks deal when they crush you
 
 #define	HUNGER_FACTOR		0.1	//factor at which mob nutrition decreases
-#define	ETHEREAL_CHARGE_FACTOR	0.08 //factor at which ethereal's charge decreases
+#define	ETHEREAL_CHARGE_FACTOR	1.6 //factor at which ethereal's charge decreases
 #define	REAGENTS_METABOLISM 0.4	//How many units of reagent are consumed per tick, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4)	// By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism
 

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -175,9 +175,9 @@
 		var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 		playsound(H, 'sound/magic/lightningshock.ogg', 100, TRUE, extrarange = 5)
 		H.cut_overlay(overcharge)
-		tesla_zap(H, 2, stomach.crystal_charge*50, ZAP_OBJ_DAMAGE | ZAP_ALLOW_DUPLICATES)
+		tesla_zap(H, 2, stomach.crystal_charge*2.5, ZAP_OBJ_DAMAGE | ZAP_ALLOW_DUPLICATES)
 		if(istype(stomach))
-			stomach.adjust_charge(100 - stomach.crystal_charge)
+			stomach.adjust_charge(ETHEREAL_CHARGE_FULL - stomach.crystal_charge)
 		to_chat(H, "<span class='warning'>You violently discharge energy!</span>")
 		H.visible_message("<span class='danger'>[H] violently discharges energy!</span>")
 		if(prob(10)) //chance of developing heart disease to dissuade overcharging oneself

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -39,7 +39,7 @@
 #define APC_FULLY_CHARGED 2
 
 #define APC_DRAIN_TIME 75
-#define APC_POWER_GAIN 10
+#define APC_POWER_GAIN 200
 
 // the Area Power Controller (APC), formerly Power Distribution Unit (PDU)
 // one per area, needs wire connection to power network through a terminal
@@ -819,7 +819,7 @@
 					to_chat(H, "<span class='warning'>You can't receive charge from the APC!</span>")
 			return
 		if((H.a_intent == INTENT_GRAB) && (E.drain_time < world.time))
-			if(cell.charge == cell.maxcharge)
+			if(cell.charge >= cell.maxcharge - APC_POWER_GAIN)
 				to_chat(H, "<span class='warning'>The APC is full!</span>")
 				return
 			var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -1,6 +1,6 @@
-#define CELL_DRAIN_TIME 20
-#define CELL_POWER_GAIN 3
-#define CELL_POWER_DRAIN 100
+#define CELL_DRAIN_TIME 35
+#define CELL_POWER_GAIN 60
+#define CELL_POWER_DRAIN 750
 
 /obj/item/stock_parts/cell
 	name = "power cell"
@@ -168,13 +168,13 @@
 		if(stomach.crystal_charge > charge_limit)
 			to_chat(H, "<span class='warning'>Your charge is full!</span>")
 			return
-		to_chat(H, "<span class='notice'>You clumsily channel power through [src] and into your body, wasting some in the process.</span>")
+		to_chat(H, "<span class='notice'>You begin clumsily channeling power from [src] into your body.</span>")
 		E.drain_time = world.time + CELL_DRAIN_TIME
 		if(do_after(user, CELL_DRAIN_TIME, target = src))
 			if((charge < CELL_POWER_DRAIN) || (stomach.crystal_charge > charge_limit))
 				return
 			if(istype(stomach))
-				to_chat(H, "<span class='notice'>You receive some charge from [src].</span>")
+				to_chat(H, "<span class='notice'>You receive some charge from [src], wasting some in the process.</span>")
 				stomach.adjust_charge(CELL_POWER_GAIN)
 				charge -= CELL_POWER_DRAIN //you waste way more than you receive, so that ethereals cant just steal one cell and forget about hunger
 			else

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -12,8 +12,8 @@
 #define BROKEN_SPARKS_MIN (30 SECONDS)
 #define BROKEN_SPARKS_MAX (90 SECONDS)
 
-#define LIGHT_DRAIN_TIME 30
-#define LIGHT_POWER_GAIN 2
+#define LIGHT_DRAIN_TIME 25
+#define LIGHT_POWER_GAIN 35
 
 /obj/item/wallframe/light_fixture
 	name = "light fixture frame"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -752,7 +752,7 @@
 	var/mob/living/carbon/exposed_carbon = exposed_mob
 	var/obj/item/organ/stomach/ethereal/stomach = exposed_carbon.getorganslot(ORGAN_SLOT_STOMACH)
 	if(istype(stomach))
-		stomach.adjust_charge(reac_volume * REM)
+		stomach.adjust_charge(reac_volume * REM * 20)
 
 /datum/reagent/consumable/liquidelectricity/on_mob_life(mob/living/carbon/M)
 	if(prob(25) && !isethereal(M))

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -154,7 +154,7 @@
 	var/did_we_charge = FALSE
 	var/obj/item/organ/stomach/ethereal/eth_stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 	if(istype(eth_stomach))
-		eth_stomach.adjust_charge(3)
+		eth_stomach.adjust_charge(60)
 		did_we_charge = TRUE
 
 	//if we're not targetting a robot part we stop early

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -157,7 +157,7 @@
 	..()
 
 /obj/item/organ/stomach/ethereal/proc/charge(datum/source, amount, repairs)
-	adjust_charge(amount / 70)
+	adjust_charge(amount / 3.5)
 
 /obj/item/organ/stomach/ethereal/proc/on_electrocute(datum/source, shock_damage, siemens_coeff = 1, flags = NONE)
 	if(flags & SHOCK_ILLUSION)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
The premise of this PR was approved by qustinnus, and due to that was approved by Jared-Fogle.  I made a couple extra, albeit minor, balance changes, and while I expect them to be fine with them, I encourage them to look at them.

## About The Pull Request

**Basically, all ethereal charge capacity and interactions have been scaled upwards by 20x.** 

Power wise, ethereals now hold up to 3000, with the max safe threshold being 2000. For reference, upgraded powercells can hold 2500, with high capacity holding 10K).

All appropriate values have been tweaked to match this change. **There shouldn't be ANY sort of noticeable difference in game, aside from power sources depleting faster, and a few values which I decided to tweak for balance reasons.** They are: power cell draining time is 1.5 seconds longer, and light draining time is 0.5 shorter. Also, draining cells has less of a punishment multiplier upon the cell now, (originally, the the cell lost 33x as much as you received. now its 12x). (to avoid returning to this in why its good, I did this because now that ethereals are capable of holding more, I can afford to have less of a punishment, while still maintaining a reasonable level of punishment). 

Also some minor code and grammar improvements.
## Why It's Good For The Game

Ethereals have almost 0 effect upon the power sources that they drain (which are capable of registering power loss. aka cells and apcs). If an ethereal were to drain from an APC, it would barely bring it down 1%. Now they actually have a significant effect upon these sources.

This is good because it actually requires ethereals to seek out new areas if they should deplete the charge of their current. Of course they could just stay and drain lights, but its inefficient compared to other methods. This holds true for power cells.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Ethereal power capacity and interactions with power sources has been scaled upwards. Ethereals will now have a more significant impact upon the sources they choose to receive power from.
balance: The time it takes for an ethereal to drain a power cell has been increased a little, and the time for lights has been decreased a little.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
