### PR TITLE
Ghost poly color value fix.

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -962,7 +962,7 @@
 /mob/living/simple_animal/parrot/poly/ghost
 	name = "The Ghost of Poly"
 	desc = "Doomed to squawk the Earth."
-	color = "#FFFFFF77"
+	color = "#FFFFFF"
 	speak_chance = 20
 	status_flags = GODMODE
 	incorporeal_move = INCORPOREAL_MOVE_BASIC

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -962,7 +962,8 @@
 /mob/living/simple_animal/parrot/poly/ghost
 	name = "The Ghost of Poly"
 	desc = "Doomed to squawk the Earth."
-	color = "#FFFFFF"
+	color = COLOR_WHITE
+	alpha = 77
 	speak_chance = 20
 	status_flags = GODMODE
 	incorporeal_move = INCORPOREAL_MOVE_BASIC


### PR DESCRIPTION

## About The Pull Request

Fresh from a downstream, we noticed there is a hex error with ghost poly's hex color that has been in the game for over 5 years. This fixes that. 

## Why It's Good For The Game

Fixes good

## Changelog
:cl: Tupinambis
fix: Ghost poly now has a hex color value instead of the forbidden oct color value.
/:cl:
