### PR TITLE
Fixes cases of held keys getting stuck

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -194,6 +194,8 @@
 
 	/// A buffer of currently held keys.
 	var/list/keys_held = list()
+	/// A buffer for combinations such of modifiers + keys (ex: CtrlD, AltE, ShiftT). Format: ["key"] -> ["combo"] (ex: ["D"] -> ["CtrlD"])
+	var/list/key_combos_held = list()
 	/*
 	** These next two vars are to apply movement for keypresses and releases made while move delayed.
 	** Because discarding that input makes the game less responsive.

--- a/code/modules/client/verbs/reset_held_keys.dm
+++ b/code/modules/client/verbs/reset_held_keys.dm
@@ -9,3 +9,7 @@
 
 	for(var/key in keys_held)
 		keyUp(key)
+
+	//In case one got stuck and the previous loop didn't clean it, somehow.
+	for(var/key in key_combos_held)
+		keyUp(key_combos_held[key])

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -61,7 +61,11 @@
 		if("Alt", "Ctrl", "Shift")
 			full_key = "[AltMod][CtrlMod][ShiftMod]"
 		else
-			full_key = "[AltMod][CtrlMod][ShiftMod][_key]"
+			if(AltMod || CtrlMod || ShiftMod)
+				full_key = "[AltMod][CtrlMod][ShiftMod][_key]"
+				key_combos_held[_key] = full_key
+			else
+				full_key = _key
 	var/keycount = 0
 	for(var/kb_name in prefs.key_bindings[full_key])
 		keycount++
@@ -72,13 +76,21 @@
 	holder?.key_down(_key, src)
 	mob.focus?.key_down(_key, src)
 
+
 /client/verb/keyUp(_key as text)
 	set instant = TRUE
 	set hidden = TRUE
 
+	var/key_combo = key_combos_held[_key]
+	if(key_combo)
+		key_combos_held -= _key
+		keyUp(key_combo)
+
 	if(!keys_held[_key])
 		return
+
 	keys_held -= _key
+
 	if(!movement_locked)
 		var/movement = movement_keys[_key]
 		if(!(next_move_dir_add & movement))
@@ -92,6 +104,7 @@
 			break
 	holder?.key_up(_key, src)
 	mob.focus?.key_up(_key, src)
+
 
 // Called every game tick
 /client/keyLoop()

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -22,8 +22,7 @@
 	set waitfor = FALSE
 
 	//Reset the buffer
-	for(var/key in keys_held)
-		keyUp(key)
+	reset_held_keys()
 
 	erase_all_macros()
 


### PR DESCRIPTION
What we stored in `keys_held` on `keyDown()` didn't necessarily match what we got on `keyUp()`, particularly key combos (ex: `CtrlT`, `ShiftE`, etc), which would never trigger a key-up event.

Hopefully it fixes the fixable cases of #52706 and #48031