### PR TITLE
Fixes borg flashlight color picker not working

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -346,6 +346,38 @@
 	enabled = 0
 	update_icon()
 
+/**
+  * Toggles the computer's flashlight, if it has one.
+  *
+  * Called from ui_act(), does as the name implies.
+  * It is seperated from ui_act() to be overwritten as needed.
+*/
+/obj/item/modular_computer/proc/toggle_flashlight()
+	if(!has_light)
+		return FALSE
+	set_light_on(!light_on)
+	if(light_on)
+		set_light(comp_light_luminosity, 1, comp_light_color)
+	else
+		set_light(0)
+	return TRUE
+
+/**
+  * Sets the computer's light color, if it has a light.
+  *
+  * Called from ui_act(), this proc takes a color string and applies it.
+  * It is seperated from ui_act() to be overwritten as needed.
+  * Arguments:
+  ** color is the string that holds the color value that we should use. Proc auto-fails if this is null.
+*/
+/obj/item/modular_computer/proc/set_flashlight_color(color)
+	if(!has_light || !color)
+		return FALSE
+	comp_light_color = color
+	set_light_color(color)
+	update_light()
+	return TRUE
+
 /obj/item/modular_computer/screwdriver_act(mob/user, obj/item/tool)
 	if(!all_components.len)
 		to_chat(user, "<span class='warning'>This device doesn't have any components installed.</span>")

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -167,12 +167,7 @@
 			return 1
 
 		if("PC_toggle_light")
-			set_light_on(!light_on)
-			if(light_on)
-				set_light(comp_light_luminosity, 1, comp_light_color)
-			else
-				set_light(0)
-			return TRUE
+			return toggle_flashlight()
 
 		if("PC_light_color")
 			var/mob/user = usr
@@ -184,10 +179,7 @@
 				if(color_hex2num(new_color) < 200) //Colors too dark are rejected
 					to_chat(user, "<span class='warning'>That color is too dark! Choose a lighter one.</span>")
 					new_color = null
-			comp_light_color = new_color
-			set_light_color(new_color)
-			update_light()
-			return TRUE
+			return set_flashlight_color(new_color)
 
 		if("PC_Eject_Disk")
 			var/param = params["name"]

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -114,12 +114,10 @@
 	.["light_on"] = borgo?.lamp_enabled
 	.["comp_light_color"] = borgo?.lamp_color
 
-//Overrides the ui_act to make the flashlight controls link to the borg instead
+//Overrides the ui_act to make the flashlight controls link to the borg instead.
+//No need to call parent, as this device is made inaccessable from anyone that shouldn't
+//be using it via other means (inaccessable to ghosts, shuts down while borg is offline, etc).
 /obj/item/modular_computer/tablet/integrated/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
-
 	switch(action)
 		if("PC_toggle_light")
 			if(!borgo)

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -114,33 +114,20 @@
 	.["light_on"] = borgo?.lamp_enabled
 	.["comp_light_color"] = borgo?.lamp_color
 
-//Overrides the ui_act to make the flashlight controls link to the borg instead.
-//No need to call parent, as this device is made inaccessable from anyone that shouldn't
-//be using it via other means (inaccessable to ghosts, shuts down while borg is offline, etc).
-/obj/item/modular_computer/tablet/integrated/ui_act(action, params)
-	switch(action)
-		if("PC_toggle_light")
-			if(!borgo)
-				return FALSE
-			borgo.toggle_headlamp()
-			return TRUE
+//Makes the flashlight button affect the borg rather than the tablet
+/obj/item/modular_computer/tablet/integrated/toggle_flashlight()
+	if(!borgo || QDELETED(borgo))
+		return FALSE
+	borgo.toggle_headlamp()
+	return TRUE
 
-		if("PC_light_color")
-			if(!borgo)
-				return FALSE
-			var/mob/user = usr
-			var/new_color
-			while(!new_color)
-				new_color = input(user, "Choose a new color for [src]'s flashlight.", "Light Color",light_color) as color|null
-				if(!new_color || QDELETED(borgo))
-					return
-				if(color_hex2num(new_color) < 200) //Colors too dark are rejected
-					to_chat(user, "<span class='warning'>That color is too dark! Choose a lighter one.</span>")
-					new_color = null
-			borgo.lamp_color = new_color
-			borgo.toggle_headlamp(FALSE, TRUE)
-			return TRUE
-	return ..()
+//Makes the flashlight color setting affect the borg rather than the tablet
+/obj/item/modular_computer/tablet/integrated/set_flashlight_color(color)
+	if(!borgo || QDELETED(borgo) || !color)
+		return FALSE
+	borgo.lamp_color = color
+	borgo.toggle_headlamp(FALSE, TRUE)
+	return TRUE
 
 /obj/item/modular_computer/tablet/integrated/syndicate
 	icon_state = "tablet-silicon-syndicate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added two new procs, `flashlight_toggle()` and `set_flashlight_color()` to modular computers, to handle their related functions after being called from `ui_act()`. Borg tablets now override these procs instead of `ui_act()`, which fixes borg not being able to change their lamp color (or use the tablet to toggle their lamp).

~~Removes the parent call for borg tablets ui_act() that was added in with the rest of #53964 and led to breaking the borg flashlight color picker (and tablet light button, though that one is less important). The borg tablet doesn't need this parent call to prevent ghosts from using the tablet because the tablet is not accessible to any ghost.~~
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix bug.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Borgs can choose their flashlight colors again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
