### PR TITLE
Fixes whiteship console losing GPS signal

### DIFF
--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -258,6 +258,11 @@
 	icon_state = "generic"
 	build_path = /obj/machinery/computer/shuttle/white_ship
 
+/obj/item/circuitboard/computer/white_ship/bridge
+	name = "White Ship Bridge (Computer Board)"
+	icon_state = "generic"
+	build_path = /obj/machinery/computer/shuttle/white_ship/bridge
+
 /obj/item/circuitboard/computer/white_ship/pod
 	name = "Salvage Pod (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle/white_ship/pod

--- a/code/modules/shuttle/white_ship.dm
+++ b/code/modules/shuttle/white_ship.dm
@@ -7,6 +7,9 @@
 
 /// Console used on the whiteship bridge. Comes with GPS pre-baked.
 /obj/machinery/computer/shuttle/white_ship/bridge
+	name = "White Ship Bridge Console"
+	desc = "Used to control the White Ship from the bridge. Emits a faint GPS signal."
+	circuit = /obj/item/circuitboard/computer/white_ship/bridge
 
 /obj/machinery/computer/shuttle/white_ship/bridge/Initialize(mapload, obj/item/circuitboard/C)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Deconstructing and rebuilding the whiteship console will switch it back to the GPS-less subtype. Added a new board and assigned it to the whiteship bridge console to remedy this.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Oversight bad. Feex good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Whiteships no longer lose their GPS signal when their bridge consoles get deconstructed and rebuilt.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
