### PR TITLE
Atmospherics Map change + delta SM computer

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -14457,7 +14457,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aFH" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -14467,14 +14466,13 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aFI" = (
-/obj/structure/table/reinforced,
-/obj/item/crowbar/red,
-/obj/item/wrench,
-/obj/item/clothing/mask/gas,
 /obj/machinery/light/small,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
+	},
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
@@ -25720,10 +25718,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bad" = (
-/obj/machinery/pipedispenser/disposal/transit_tube,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bae" = (
@@ -26520,10 +26515,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bbI" = (
-/obj/machinery/pipedispenser/disposal,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/structure/table/reinforced,
+/obj/item/analyzer,
+/obj/item/analyzer,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bbJ" = (
@@ -27308,10 +27302,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bdj" = (
-/obj/machinery/pipedispenser,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bdk" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -25718,7 +25718,13 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bad" = (
-/obj/machinery/portable_atmospherics/canister/bz,
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bae" = (
@@ -26518,6 +26524,9 @@
 /obj/structure/table/reinforced,
 /obj/item/analyzer,
 /obj/item/analyzer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bbJ" = (
@@ -27303,6 +27312,9 @@
 /area/engine/atmos)
 "bdj" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bdk" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -36276,7 +36276,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bIH" = (
-/obj/machinery/pipedispenser/disposal,
+/obj/item/analyzer,
+/obj/item/analyzer,
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bIJ" = (
@@ -36578,7 +36583,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bJF" = (
-/obj/machinery/pipedispenser/disposal/transit_tube,
+/obj/machinery/portable_atmospherics/canister/bz,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bJG" = (
@@ -37671,12 +37679,15 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bMR" = (
-/obj/machinery/pipedispenser,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -36583,9 +36583,12 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bJF" = (
-/obj/machinery/portable_atmospherics/canister/bz,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -40203,10 +40203,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "bUA" = (
-/obj/machinery/pipedispenser,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUB" = (
@@ -40216,18 +40216,20 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/machinery/pipedispenser/disposal,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/table,
+/obj/item/analyzer,
+/obj/item/analyzer,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUC" = (
 /obj/item/radio/intercom{
 	pixel_y = 28
 	},
-/obj/machinery/pipedispenser/disposal/transit_tube,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUD" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -40229,7 +40229,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/portable_atmospherics/canister/bz,
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUD" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -36707,7 +36707,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQH" = (
-/obj/machinery/pipedispenser,
+/obj/machinery/portable_atmospherics/canister/bz,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQI" = (
@@ -36998,12 +37001,17 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRv" = (
-/obj/machinery/pipedispenser/disposal,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics Central";
+	dir = 4
+	},
+/obj/item/analyzer,
+/obj/item/analyzer,
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37307,7 +37315,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSe" = (
-/obj/machinery/pipedispenser/disposal/transit_tube,
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSf" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -36707,9 +36707,12 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQH" = (
-/obj/machinery/portable_atmospherics/canister/bz,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR removes from the atmospherics map the now useless Pipe dispenser and replace it with one h2o canister, 10 sheets of plasteel and a couple of analyzers. Those gases are chosen in light of the recent gas addition where both are used in many recipes as reagents or catalysts.
Also i added an engineering computer in the delta SM room similar to the one used in all the other stations to check on the SM gases and status.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Away useless, welcome useful
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: removed pipe dispensers from atmospherics room
add: replaced them with one canister of h2o, 10 sheets of plasteel and 2 analyzers
add: added an engineering computer in the delta station SM room
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
