### PR TITLE
Brings back Daniel and Disco Inferno, makes them and Hyperfractal behind emag

### DIFF
--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -1,0 +1,485 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"b" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"c" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/shuttle/escape)
+"d" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape)
+"e" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape)
+"f" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape)
+"g" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/lighter{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape)
+"h" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 4
+	},
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape)
+"i" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape)
+"j" = (
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape)
+"k" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape)
+"l" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape)
+"m" = (
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape)
+"n" = (
+/obj/structure/table/wood/poker,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/machinery/light,
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape)
+"o" = (
+/obj/machinery/computer/communications{
+	dir = 8
+	},
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape)
+"p" = (
+/obj/machinery/door/airlock/gold{
+	req_access_txt = "19"
+	},
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape)
+"q" = (
+/obj/structure/statue/plasma/scientist{
+	anchored = 1;
+	custom_materials = list(/datum/material/plasma = 100000)
+	},
+/turf/open/floor/light/colour_cycle,
+/area/shuttle/escape)
+"r" = (
+/turf/open/floor/mineral/plasma/disco,
+/area/shuttle/escape)
+"s" = (
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"t" = (
+/turf/open/floor/light/colour_cycle,
+/area/shuttle/escape)
+"u" = (
+/obj/docking_port/mobile/emergency{
+	name = "Disco Inferno"
+	},
+/obj/machinery/door/airlock/gold{
+	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100);
+	heat_proof = 1;
+	resistance_flags = 2
+	},
+/turf/open/floor/mineral/plasma/disco,
+/area/shuttle/escape)
+"v" = (
+/obj/machinery/jukebox/disco/indestructible,
+/turf/open/floor/light/colour_cycle,
+/area/shuttle/escape)
+"w" = (
+/obj/machinery/door/airlock/gold,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"x" = (
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"y" = (
+/turf/open/floor/carpet,
+/area/shuttle/escape)
+"z" = (
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/carpet,
+/area/shuttle/escape)
+"A" = (
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/drinks/bottle/cognac,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"B" = (
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"C" = (
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"D" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"E" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/shuttle/escape)
+"F" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet,
+/area/shuttle/escape)
+"G" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/shuttle/escape)
+"H" = (
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/coin/plasma,
+/obj/item/coin/plasma,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"I" = (
+/obj/machinery/computer/slot_machine{
+	dir = 3
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"J" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/shuttle/escape)
+"K" = (
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/drinks/bottle/absinthe,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"L" = (
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"M" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/plasma/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"N" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"O" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+a
+a
+a
+a
+b
+b
+b
+c
+b
+u
+b
+c
+c
+c
+b
+O
+b
+w
+b
+c
+b
+a
+"}
+(2,1,1) = {"
+a
+b
+b
+b
+O
+q
+r
+r
+r
+r
+j
+r
+r
+r
+r
+q
+c
+x
+C
+I
+b
+b
+"}
+(3,1,1) = {"
+b
+b
+h
+m
+c
+r
+r
+r
+r
+s
+j
+s
+r
+r
+r
+r
+c
+x
+D
+D
+M
+N
+"}
+(4,1,1) = {"
+c
+d
+i
+i
+c
+r
+r
+r
+j
+j
+t
+j
+j
+r
+r
+r
+c
+x
+x
+x
+M
+N
+"}
+(5,1,1) = {"
+c
+e
+j
+j
+c
+r
+r
+s
+j
+t
+t
+t
+j
+s
+r
+r
+c
+y
+E
+y
+M
+N
+"}
+(6,1,1) = {"
+c
+f
+j
+n
+c
+r
+j
+j
+t
+t
+v
+t
+t
+j
+j
+r
+c
+z
+F
+J
+M
+N
+"}
+(7,1,1) = {"
+c
+e
+j
+j
+p
+r
+r
+s
+j
+t
+t
+t
+j
+s
+r
+r
+c
+y
+G
+y
+M
+N
+"}
+(8,1,1) = {"
+c
+g
+k
+k
+c
+r
+r
+r
+j
+j
+t
+j
+j
+r
+r
+r
+c
+x
+x
+x
+M
+N
+"}
+(9,1,1) = {"
+b
+b
+l
+o
+c
+r
+r
+r
+r
+s
+j
+s
+r
+r
+r
+r
+c
+A
+x
+K
+M
+N
+"}
+(10,1,1) = {"
+a
+b
+b
+b
+O
+q
+r
+r
+r
+r
+j
+r
+r
+r
+r
+q
+c
+B
+H
+L
+b
+b
+"}
+(11,1,1) = {"
+a
+a
+a
+a
+b
+b
+b
+c
+b
+b
+b
+c
+c
+c
+b
+b
+b
+c
+b
+c
+b
+a
+"}

--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -89,3 +89,4 @@
 //Shuttle unlocks
 #define SHUTTLE_UNLOCK_BUBBLEGUM "bubblegum"
 #define SHUTTLE_UNLOCK_ALIENTECH "abductor"
+#define SHUTTLE_UNLOCK_DISCOINFERNO "discoinferno"

--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -89,4 +89,4 @@
 //Shuttle unlocks
 #define SHUTTLE_UNLOCK_BUBBLEGUM "bubblegum"
 #define SHUTTLE_UNLOCK_ALIENTECH "abductor"
-#define SHUTTLE_UNLOCK_DISCOINFERNO "discoinferno"
+#define SHUTTLE_UNLOCK_EMAGGED "emagged"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -231,6 +231,13 @@
 	admin_notes = "Due to the limited space for non paying crew, this shuttle may cause a riot."
 	credit_cost = 10000
 
+/datum/map_template/shuttle/emergency/discoinferno
+	suffix = "discoinferno"
+	name = "Disco Inferno"
+	description = "The glorious results of centuries of plasma research done by Nanotrasen employees. This is the reason why you are here. Get on and dance like you're on fire, burn baby burn!"
+	admin_notes = "Flaming hot. The main area has a dance machine as well as plasma floor tiles that will be ignited by players every single time."
+	credit_cost = 10000
+
 /datum/map_template/shuttle/emergency/arena
 	suffix = "arena"
 	name = "The Arena"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -220,7 +220,7 @@
 	name = "Asteroid With Engines Strapped To It"
 	description = "A hollowed out asteroid with engines strapped to it, the hollowing procedure makes it very difficult to hijack but is very expensive. Due to its size and difficulty in steering it, this shuttle may damage the docking area."
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
-	credit_cost = 40000
+	credit_cost = 15000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/luxury

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -220,13 +220,8 @@
 	name = "Asteroid With Engines Strapped To It"
 	description = "A hollowed out asteroid with engines strapped to it, the hollowing procedure makes it very difficult to hijack but is very expensive. Due to its size and difficulty in steering it, this shuttle may damage the docking area."
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
-	credit_cost = 50000
+	credit_cost = 40000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
-
-/datum/map_template/shuttle/emergency/meteor/prerequisites_met()
-	if(SHUTTLE_UNLOCK_EMAGGED in SSshuttle.shuttle_purchase_requirements_met)
-		return TRUE
-	return FALSE
 
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"
@@ -241,7 +236,7 @@
 	name = "Disco Inferno"
 	description = "The glorious results of centuries of plasma research done by Nanotrasen employees. This is the reason why you are here. Get on and dance like you're on fire, burn baby burn!"
 	admin_notes = "Flaming hot. The main area has a dance machine as well as plasma floor tiles that will be ignited by players every single time."
-	credit_cost = 50000
+	credit_cost = 40000
 
 /datum/map_template/shuttle/emergency/discoinferno/prerequisites_met()
 	if(SHUTTLE_UNLOCK_EMAGGED in SSshuttle.shuttle_purchase_requirements_met)
@@ -371,7 +366,7 @@
 	Outside of admin intervention, it cannot explode. \
 	It does, however, still dust anything on contact, emits high levels of radiation, and induce hallucinations in anyone looking at it without protective goggles. \
 	Emitters spawn powered on, expect admin notices, they are harmless."
-	credit_cost = 50000
+	credit_cost = 40000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/supermatter/prerequisites_met()
@@ -385,7 +380,7 @@
 	description = "How was space work today? Oh, pretty good. We got a new space station and the company will make a lot of money. What space station? I cannot tell you; it's space confidential. \
 	Aw, come space on. Why not? No, I can't. Anyway, how is your space roleplay life?"
 	admin_notes = "Tiny, with a single airlock and wooden walls. What could go wrong?"
-	credit_cost = 50000
+	credit_cost = 40000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/imfedupwiththisworld/prerequisites_met()

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -239,7 +239,7 @@
 	credit_cost = 10000
 
 /datum/map_template/shuttle/emergency/discoinferno/prerequisites_met()
-	if(SHUTTLE_UNLOCK_DISCOINFERNO in SSshuttle.shuttle_purchase_requirements_met)
+	if(SHUTTLE_UNLOCK_EMAGGED in SSshuttle.shuttle_purchase_requirements_met)
 		return TRUE
 	return FALSE
 
@@ -369,14 +369,23 @@
 	credit_cost = 100000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
+/datum/map_template/shuttle/emergency/supermatter/prerequisites_met()
+	if(SHUTTLE_UNLOCK_EMAGGED in SSshuttle.shuttle_purchase_requirements_met)
+		return TRUE
+	return FALSE
+
 /datum/map_template/shuttle/emergency/imfedupwiththisworld
 	suffix = "imfedupwiththisworld"
 	name = "Oh, Hi Daniel"
 	description = "How was space work today? Oh, pretty good. We got a new space station and the company will make a lot of money. What space station? I cannot tell you; it's space confidential. \
 	Aw, come space on. Why not? No, I can't. Anyway, how is your space roleplay life?"
 	admin_notes = "Tiny, with a single airlock and wooden walls. What could go wrong?"
-	can_be_bought = FALSE
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
+
+/datum/map_template/shuttle/emergency/imfedupwiththisworld/prerequisites_met()
+	if(SHUTTLE_UNLOCK_EMAGGED in SSshuttle.shuttle_purchase_requirements_met)
+		return TRUE
+	return FALSE
 
 /datum/map_template/shuttle/emergency/goon
 	suffix = "goon"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -220,8 +220,13 @@
 	name = "Asteroid With Engines Strapped To It"
 	description = "A hollowed out asteroid with engines strapped to it, the hollowing procedure makes it very difficult to hijack but is very expensive. Due to its size and difficulty in steering it, this shuttle may damage the docking area."
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
-	credit_cost = 15000
+	credit_cost = 50000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
+
+/datum/map_template/shuttle/emergency/meteor/prerequisites_met()
+	if(SHUTTLE_UNLOCK_EMAGGED in SSshuttle.shuttle_purchase_requirements_met)
+		return TRUE
+	return FALSE
 
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"
@@ -236,7 +241,7 @@
 	name = "Disco Inferno"
 	description = "The glorious results of centuries of plasma research done by Nanotrasen employees. This is the reason why you are here. Get on and dance like you're on fire, burn baby burn!"
 	admin_notes = "Flaming hot. The main area has a dance machine as well as plasma floor tiles that will be ignited by players every single time."
-	credit_cost = 10000
+	credit_cost = 50000
 
 /datum/map_template/shuttle/emergency/discoinferno/prerequisites_met()
 	if(SHUTTLE_UNLOCK_EMAGGED in SSshuttle.shuttle_purchase_requirements_met)
@@ -366,7 +371,7 @@
 	Outside of admin intervention, it cannot explode. \
 	It does, however, still dust anything on contact, emits high levels of radiation, and induce hallucinations in anyone looking at it without protective goggles. \
 	Emitters spawn powered on, expect admin notices, they are harmless."
-	credit_cost = 100000
+	credit_cost = 50000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/supermatter/prerequisites_met()
@@ -380,6 +385,7 @@
 	description = "How was space work today? Oh, pretty good. We got a new space station and the company will make a lot of money. What space station? I cannot tell you; it's space confidential. \
 	Aw, come space on. Why not? No, I can't. Anyway, how is your space roleplay life?"
 	admin_notes = "Tiny, with a single airlock and wooden walls. What could go wrong?"
+	credit_cost = 50000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/imfedupwiththisworld/prerequisites_met()

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -238,6 +238,11 @@
 	admin_notes = "Flaming hot. The main area has a dance machine as well as plasma floor tiles that will be ignited by players every single time."
 	credit_cost = 10000
 
+/datum/map_template/shuttle/emergency/discoinferno/prerequisites_met()
+	if(SHUTTLE_UNLOCK_ALIENTECH in SSshuttle.shuttle_purchase_requirements_met)
+		return TRUE
+	return FALSE
+
 /datum/map_template/shuttle/emergency/arena
 	suffix = "arena"
 	name = "The Arena"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -239,7 +239,7 @@
 	credit_cost = 10000
 
 /datum/map_template/shuttle/emergency/discoinferno/prerequisites_met()
-	if(SHUTTLE_UNLOCK_ALIENTECH in SSshuttle.shuttle_purchase_requirements_met)
+	if(SHUTTLE_UNLOCK_DISCOINFERNO in SSshuttle.shuttle_purchase_requirements_met)
 		return TRUE
 	return FALSE
 

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -236,7 +236,7 @@
 	name = "Disco Inferno"
 	description = "The glorious results of centuries of plasma research done by Nanotrasen employees. This is the reason why you are here. Get on and dance like you're on fire, burn baby burn!"
 	admin_notes = "Flaming hot. The main area has a dance machine as well as plasma floor tiles that will be ignited by players every single time."
-	credit_cost = 40000
+	credit_cost = 20000
 
 /datum/map_template/shuttle/emergency/discoinferno/prerequisites_met()
 	if(SHUTTLE_UNLOCK_EMAGGED in SSshuttle.shuttle_purchase_requirements_met)
@@ -366,7 +366,7 @@
 	Outside of admin intervention, it cannot explode. \
 	It does, however, still dust anything on contact, emits high levels of radiation, and induce hallucinations in anyone looking at it without protective goggles. \
 	Emitters spawn powered on, expect admin notices, they are harmless."
-	credit_cost = 40000
+	credit_cost = 20000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/supermatter/prerequisites_met()
@@ -380,7 +380,7 @@
 	description = "How was space work today? Oh, pretty good. We got a new space station and the company will make a lot of money. What space station? I cannot tell you; it's space confidential. \
 	Aw, come space on. Why not? No, I can't. Anyway, how is your space roleplay life?"
 	admin_notes = "Tiny, with a single airlock and wooden walls. What could go wrong?"
-	credit_cost = 40000
+	credit_cost = 20000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/imfedupwiththisworld/prerequisites_met()

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -432,7 +432,7 @@
 		authenticated = 2
 	to_chat(user, "<span class='danger'>You scramble the communication routing circuits!</span>")
 	playsound(src, 'sound/machines/terminal_alert.ogg', 50, FALSE)
-	SSshuttle.shuttle_purchase_requirements_met |= SHUTTLE_UNLOCK_DISCOINFERNO
+	SSshuttle.shuttle_purchase_requirements_met |= SHUTTLE_UNLOCK_EMAGGED
 
 /obj/machinery/computer/communications/ui_interact(mob/user)
 	. = ..()

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -432,6 +432,7 @@
 		authenticated = 2
 	to_chat(user, "<span class='danger'>You scramble the communication routing circuits!</span>")
 	playsound(src, 'sound/machines/terminal_alert.ogg', 50, FALSE)
+	SSshuttle.shuttle_purchase_requirements_met |= SHUTTLE_UNLOCK_DISCOINFERNO
 
 /obj/machinery/computer/communications/ui_interact(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

It makes the Disco Inferno shuttle, and the Daniel shuttle purchasable again. The two, including the Gigafractal shuttles are all now 20,000Cr to buy, and require the communications console to be emagged to purchase. This makes all grief shuttles 20k credits and require the comms console to be emagged.

## Why It's Good For The Game

I feel as if this is a reasonable method of taking on grief shuttles. There is clearly a spot for them, although their implementation has been shaky. Shuttles have been taken out of rotation simply because some would frequently grief using them, and I feel like this helps. This essentially locks grief shuttles behind antagonist interference. The price change will also make the Hyperfractal see more use than before, and keep how often these grief shuttles show up low but reasonable with effort, proportional to their impact on the evacuation. To me this seems like a reasonable compromise between those who wish to see the funny kills you shuttle, and making it more of a direct influence by antagonists and not simply griefers.

## Changelog
:cl:
add: Disco Inferno and Daniel Shuttles are now purchaseable again.
tweak: Disco Inferno, Daniel, and Hyperfractal shuttles all require the comms console to be emagged to buy, and are 20k credits.
/:cl:
