### PR TITLE
Conveyor switch tool interaction

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -340,14 +340,28 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 
 /obj/machinery/conveyor_switch/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_CROWBAR)
+		I.play_tool_sound(src, 50)
 		var/obj/item/conveyor_switch_construct/C = new/obj/item/conveyor_switch_construct(src.loc)
 		C.id = id
 		transfer_fingerprints_to(C)
 		to_chat(user, "<span class='notice'>You detach the conveyor switch.</span>")
 		qdel(src)
+	else if(I.tool_behaviour == TOOL_SCREWDRIVER)
+		I.play_tool_sound(src, 50)
+		oneway = !oneway
+		to_chat(user, "<span class='notice'>You set conveyor switch to [oneway ? "one way" : "default"] configuration.</span>")
+	else if(I.tool_behaviour == TOOL_WRENCH)
+		I.play_tool_sound(src, 50)
+		invert_icon = !invert_icon
+		to_chat(user, "<span class='notice'>You set conveyor switch to [invert_icon ? "inverted": "normal"] position.</span>")
 	if(is_wire_tool(I))
 		wires.interact(user)
 		return TRUE
+
+/obj/machinery/conveyor_switch/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>[src] is set to [oneway ? "one way" : "default"] configuration. It can be changed with <b>screwdriver</b>.</span>"
+	. += "<span class='notice'>[src] is set to [invert_icon ? "inverted": "normal"] position. It can be rotated with <b>wrench</b>.</span>"
 
 /obj/machinery/conveyor_switch/oneway
 	icon_state = "conveyor_switch_oneway"

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -339,24 +339,31 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 
 
 /obj/machinery/conveyor_switch/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_CROWBAR)
-		I.play_tool_sound(src, 50)
-		var/obj/item/conveyor_switch_construct/C = new/obj/item/conveyor_switch_construct(src.loc)
-		C.id = id
-		transfer_fingerprints_to(C)
-		to_chat(user, "<span class='notice'>You detach the conveyor switch.</span>")
-		qdel(src)
-	else if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		I.play_tool_sound(src, 50)
-		oneway = !oneway
-		to_chat(user, "<span class='notice'>You set conveyor switch to [oneway ? "one way" : "default"] configuration.</span>")
-	else if(I.tool_behaviour == TOOL_WRENCH)
-		I.play_tool_sound(src, 50)
-		invert_icon = !invert_icon
-		to_chat(user, "<span class='notice'>You set conveyor switch to [invert_icon ? "inverted": "normal"] position.</span>")
 	if(is_wire_tool(I))
 		wires.interact(user)
 		return TRUE
+
+/obj/machinery/conveyor_switch/crowbar_act(mob/user, obj/item/I)
+	I.play_tool_sound(src, 50)
+	var/obj/item/conveyor_switch_construct/C = new/obj/item/conveyor_switch_construct(src.loc)
+	C.id = id
+	transfer_fingerprints_to(C)
+	to_chat(user, "<span class='notice'>You detach the conveyor switch.</span>")
+	qdel(src)
+	return TRUE
+
+/obj/machinery/conveyor_switch/screwdriver_act(mob/user, obj/item/I)
+	I.play_tool_sound(src, 50)
+	oneway = !oneway
+	to_chat(user, "<span class='notice'>You set conveyor switch to [oneway ? "one way" : "default"] configuration.</span>")
+	return TRUE
+
+/obj/machinery/conveyor_switch/wrench_act(mob/user, obj/item/I)
+	I.play_tool_sound(src, 50)
+	invert_icon = !invert_icon
+	update_icon()
+	to_chat(user, "<span class='notice'>You set conveyor switch to [invert_icon ? "inverted": "normal"] position.</span>")
+	return TRUE
 
 /obj/machinery/conveyor_switch/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Adds conveyor belt switch interaction with screwdriver allowing to construct one way conveyor belt switches
and interaction with wrench allowing to reverse direction of conveyor belt switches.
Those options were available only in map editor, now you can use them in game.
Examine message is adjusted to show which tools you can use.

## Why It's Good For The Game

You can now build things that were only available in map editor, for example, extend cargo conveyor belts.

## Changelog
:cl:
add: Conveyor belt switches can now interact with screwdriver and wrench.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
