### PR TITLE
Attn: Feature Freeze going into effect November first, ending december first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## /tg/station codebase
-
+asdfasdf
 [![Build Status](https://travis-ci.org/tgstation/tgstation.png)](https://travis-ci.org/tgstation/tgstation) 
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/tgstation/tgstation.svg)](https://isitmaintained.com/project/tgstation/tgstation "Percentage of issues still open")
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/tgstation/tgstation.svg)](https://isitmaintained.com/project/tgstation/tgstation "Average time to resolve an issue")


### PR DESCRIPTION
In honor of Nerf November, we will not be accepting new features, balance changes (unless strictly necessary to stop servers expoding) for all of November.

We will be accepting fixes and code refractors only.

The person who makes the best fix as determined by the maintainer team will get a prize, which I will make up later.