### PR TITLE
For a exorbitant fee, you can purchase full machine beacons from cargo.

### DIFF
--- a/code/game/objects/items/beacons.dm
+++ b/code/game/objects/items/beacons.dm
@@ -1,0 +1,113 @@
+///The all new home for beacons that spawn objects, structures, atoms, whatever to the station via supply pods.
+/obj/item/sup_beacon
+	name = "beacon"
+	desc = "N.T. approved supply beacon, but this one shouldn't exist!"
+	icon = 'icons/obj/objects.dmi'
+	icon_state = "supply_beacon"
+	///Has the beacon been used already?
+	var/used
+	///What is the thing this beacon sends to the station?
+	var/obj/beacon_contents = /obj/item/reagent_containers/food/snacks/cookie
+
+/obj/item/sup_beacon/attack_self()
+	if(used)
+		return
+	loc.visible_message("<span class='warning'>\The [src] begins to beep loudly!</span>")
+	used = TRUE
+	addtimer(CALLBACK(src, .proc/launch_payload), 40)
+
+/**
+  * Creates a new beacon_contents object, shoves it in a supply pod, and launches it at the station from nullspace.
+  */
+/obj/item/sup_beacon/proc/launch_payload()
+	var/obj/structure/closet/supplypod/centcompod/toLaunch = new()
+	if(!beacon_contents)
+		return
+	new beacon_contents(toLaunch)
+	new /obj/effect/pod_landingzone(drop_location(), toLaunch)
+	qdel(src)
+
+//******SERVICE EQUIPMENT******
+
+///Roulette wheel
+/obj/item/sup_beacon/roulette
+	name = "roulette wheel beacon"
+	desc = "N.T. approved roulette wheel beacon, toss it down and you will have a complementary roulette wheel delivered to you."
+	beacon_contents = /obj/machinery/roulette
+
+///Beer Dispenser
+/obj/item/sup_beacon/beer_dispenser
+	name = "beer dispenser beacon"
+	desc = "N.T. approved alcohol dispenser beacon, toss it down and you'll have a fully ready bar in no time. Remember to ID everyone!"
+	beacon_contents = /obj/machinery/chem_dispenser/drinks/beer
+
+///Soda Dispenser
+/obj/item/sup_beacon/soda_dispenser
+	name = "soda dispenser beacon"
+	desc = "N.T. approved soda dispenser beacon, toss it down and you'll have a fully ready drink station. Drink cola to feel SUPER!"
+	beacon_contents = /obj/machinery/chem_dispenser/drinks
+
+///Microwave
+/obj/item/sup_beacon/microwave
+	name = "microwave beacon"
+	desc = "N.T. approved microwave beacon, toss it down and you'll have a fully ready kitchen. Okay, well not FULLY ready, but it worked in college, right?"
+	beacon_contents = /obj/machinery/microwave
+
+///Food processor
+/obj/item/sup_beacon/processor
+	name = "food processor beacon"
+	desc = "N.T. approved food processor beacon, toss it down and you'll have a fully ready food prep machine. It slices, it dices, it even makes julianne fries!"
+	beacon_contents = /obj/machinery/processor
+
+/obj/item/sup_beacon/hydroponics
+	name = "hydroponics tray beacon"
+	desc = "N.T. approved hydroponics tray beacon, toss it down and you'll have a fully ready hydroponics tray. Grow's just about anything the stomache desires."
+	beacon_contents = /obj/machinery/hydroponics
+
+//******Medical******
+
+///Statis Bed
+/obj/item/sup_beacon/stasis
+	name = "stasis bed beacon"
+	desc = "N.T. approved stasis bed beacon, toss it down and you'll have a fully ready statis bed. Turn anywhere into an operating theator! Or don't!"
+	beacon_contents = /obj/machinery/stasis
+
+/obj/item/sup_beacon/chem_dispenser
+	name = "chemistry dispenser beacon"
+	desc = "N.T. approved chemistry dispenser beacon, toss it down and you'll have a fully ready chemistry dispenser. Faster than starting an inter-departmental warzone!"
+	beacon_contents = /obj/machinery/chem_dispenser
+
+/obj/item/sup_beacon/chem_heater
+	name = "chemistry heater beacon"
+	desc = "N.T. approved chemistery heater beacon, toss it down and you'll have a fully ready chemistry heater. Infinitely safer than doing it on the stove."
+	beacon_contents = /obj/machinery/chem_heater
+
+/obj/item/sup_beacon/chem_master
+	name = "chemistry master beacon"
+	desc = "N.T. approved chemistry master beacon, toss it down and you'll have a fully ready chemistry master. Even we don't know where all those little bottles come from."
+	beacon_contents = /obj/machinery/chem_master
+
+//******Engineering******
+
+/obj/item/sup_beacon/emitter
+	name = "emitter beacon"
+	desc = "N.T. approved emitter beacon, toss it down and you'll have a fully ready laser emitter. Turn those rookie engine numbers into some BIG rookie numbers."
+	beacon_contents = /obj/machinery/power/emitter
+
+/obj/item/sup_beacon/freezer
+	name = "atmospherics freezer beacon"
+	desc = "N.T. approved freezer beacon, toss it down and you'll have a fully ready atmospherics freezer. Keep cool, "
+	beacon_contents = /obj/machinery/atmospherics/components/unary/thermomachine/freezer
+
+//******Security******
+
+/obj/item/sup_beacon/weapon_recharger
+	name = "weapon recharger beacon"
+	desc = "N.T. approved weapon recharger beacon, toss it down and you'll have a fully ready recharger. Makes short work of shorter stunpod cells."
+	beacon_contents = /obj/machinery/recharger
+
+/obj/item/sup_beacon/cameras
+	name = "camera console beacon"
+	desc = "N.T. approved camera console beacon, toss it down and you'll have a fully ready camera console. Home survailance... anywhere!"
+	beacon_contents = /obj/machinery/computer/security
+

--- a/code/game/objects/items/beacons.dm
+++ b/code/game/objects/items/beacons.dm
@@ -1,7 +1,7 @@
 ///The all new home for beacons that spawn objects, structures, atoms, whatever to the station via supply pods.
 /obj/item/sup_beacon
 	name = "beacon"
-	desc = "N.T. approved supply beacon, but this one shouldn't exist!"
+	desc = "N.T. approved supply beacon, but this one shouldn't exist! Use the 'Report Issue' button if you see this!"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "supply_beacon"
 	///Has the beacon been used already?
@@ -15,14 +15,15 @@
 	loc.visible_message("<span class='warning'>\The [src] begins to beep loudly!</span>")
 	used = TRUE
 	addtimer(CALLBACK(src, .proc/launch_payload), 40)
+	playsound(src,'sound/machines/triple_beep.ogg',50,FALSE)
 
 /**
-  * Creates a new beacon_contents object, shoves it in a supply pod, and launches it at the station from nullspace.
+  * Creates a new beacon_contents object, shoves it in a supply pod, and launches it at the station.
   */
 /obj/item/sup_beacon/proc/launch_payload()
 	var/obj/structure/closet/supplypod/centcompod/toLaunch = new()
 	if(!beacon_contents)
-		return
+		CRASH("Missing beacon_contents when calling launch_payload()!")
 	new beacon_contents(toLaunch)
 	new /obj/effect/pod_landingzone(drop_location(), toLaunch)
 	qdel(src)
@@ -61,7 +62,7 @@
 
 /obj/item/sup_beacon/hydroponics
 	name = "hydroponics tray beacon"
-	desc = "N.T. approved hydroponics tray beacon, toss it down and you'll have a fully ready hydroponics tray. Grow's just about anything the stomache desires."
+	desc = "N.T. approved hydroponics tray beacon, toss it down and you'll have a fully ready hydroponics tray. Grows just about anything the stomache desires."
 	beacon_contents = /obj/machinery/hydroponics
 
 //******Medical******
@@ -69,7 +70,7 @@
 ///Statis Bed
 /obj/item/sup_beacon/stasis
 	name = "stasis bed beacon"
-	desc = "N.T. approved stasis bed beacon, toss it down and you'll have a fully ready statis bed. Turn anywhere into an operating theator! Or don't!"
+	desc = "N.T. approved stasis bed beacon, toss it down and you'll have a fully ready stasis bed. Turn anywhere into an operating theatre! Or don't!"
 	beacon_contents = /obj/machinery/stasis
 
 /obj/item/sup_beacon/chem_dispenser
@@ -79,12 +80,12 @@
 
 /obj/item/sup_beacon/chem_heater
 	name = "chemistry heater beacon"
-	desc = "N.T. approved chemistery heater beacon, toss it down and you'll have a fully ready chemistry heater. Infinitely safer than doing it on the stove."
+	desc = "N.T. approved chemistry heater beacon, toss it down and you'll have a fully ready chemistry heater. Infinitely safer than doing it on the stove."
 	beacon_contents = /obj/machinery/chem_heater
 
 /obj/item/sup_beacon/chem_master
-	name = "chemistry master beacon"
-	desc = "N.T. approved chemistry master beacon, toss it down and you'll have a fully ready chemistry master. Even we don't know where all those little bottles come from."
+	name = "chem-master beacon"
+	desc = "N.T. approved chem-master beacon, toss it down and you'll have a fully ready ChemMaster 3000. Even we don't know where all those little bottles come from."
 	beacon_contents = /obj/machinery/chem_master
 
 //******Engineering******
@@ -96,18 +97,17 @@
 
 /obj/item/sup_beacon/freezer
 	name = "atmospherics freezer beacon"
-	desc = "N.T. approved freezer beacon, toss it down and you'll have a fully ready atmospherics freezer. Keep cool, "
+	desc = "N.T. approved freezer beacon, toss it down and you'll have a fully ready atmospherics freezer. Stay frosty. Note that with some simple user service, this machine can be turned into a heater."
 	beacon_contents = /obj/machinery/atmospherics/components/unary/thermomachine/freezer
 
 //******Security******
 
 /obj/item/sup_beacon/weapon_recharger
 	name = "weapon recharger beacon"
-	desc = "N.T. approved weapon recharger beacon, toss it down and you'll have a fully ready recharger. Makes short work of shorter stunpod cells."
+	desc = "N.T. approved weapon recharger beacon, toss it down and you'll have a fully ready recharger. Makes short work of shorter stunprod cells."
 	beacon_contents = /obj/machinery/recharger
 
 /obj/item/sup_beacon/cameras
 	name = "camera console beacon"
-	desc = "N.T. approved camera console beacon, toss it down and you'll have a fully ready camera console. Home survailance... anywhere!"
+	desc = "N.T. approved camera console beacon, toss it down and you'll have a fully ready camera console. Home surveillance... anywhere!"
 	beacon_contents = /obj/machinery/computer/security
-

--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -14,4 +14,4 @@
 	for(var/i in 1 to 10)
 		new /obj/item/reagent_containers/food/drinks/beer( src )
 	new /obj/item/etherealballdeployer(src)
-	new /obj/item/roulette_wheel_beacon(src)
+	new /obj/item/sup_beacon/roulette(src)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2419,6 +2419,102 @@
 		new cardpacktype(C)
 
 //////////////////////////////////////////////////////////////////////////////
+////////////////////////// Pre-Built Machines ////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/machine
+	group = "Pre-Built Machines"
+
+//******Service******
+/datum/supply_pack/machine/beer_dispenser
+	name = "Beer Dispenser Beacon"
+	desc = "Contains a beacon that will drop a finished beer dispenser to your location."
+	cost = 2500
+	contains = list(/obj/item/sup_beacon/beer_dispenser)
+	crate_name = "Beer Dispenser Beacon Crate"
+
+/datum/supply_pack/machine/soda_dispenser
+	name = "Soda Dispenser Beacon"
+	desc = "Contains a beacon that will drop a finished soda dispenser to your location."
+	cost = 2500
+	contains = list(/obj/item/sup_beacon/soda_dispenser)
+	crate_name = "Soda Dispenser Beacon Crate"
+
+/datum/supply_pack/machine/microwave
+	name = "Microwave Beacon"
+	desc = "Contains a beacon that will drop a finished microwave to your location."
+	cost = 4000
+	contains = list(/obj/item/sup_beacon/microwave)
+	crate_name = "Microwave Beacon Crate"
+
+/datum/supply_pack/machine/processor
+	name = "Food Processor Beacon"
+	desc = "Contains a beacon that will drop a finished food processor to your location."
+	cost = 4000
+	contains = list(/obj/item/sup_beacon/processor)
+	crate_name = "Food Processor Beacon Crate"
+
+//******Medical******
+/datum/supply_pack/machine/stasis
+	name = "Stasis Bed Beacon"
+	desc = "Contains a beacon that will drop a finished stasis bed to your location."
+	cost = 4000
+	contains = list(/obj/item/sup_beacon/stasis)
+	crate_name = "Stasis Bed Beacon Crate"
+
+/datum/supply_pack/machine/chem_dispenser
+	name = "Chemistry Dispenser Beacon"
+	desc = "Contains a beacon that will drop a finished chemistry dispenser to your location."
+	cost = 7500
+	contains = list(/obj/item/sup_beacon/chem_dispenser)
+	crate_name = "Chemistry Dispenser Beacon Crate"
+
+/datum/supply_pack/machine/chem_heater
+	name = "Chemistry Heater Beacon"
+	desc = "Contains a beacon that will drop a finished chemistry heater to your location."
+	cost = 2000
+	contains = list(/obj/item/sup_beacon/chem_heater)
+	crate_name = "Chemistry Heater Beacon Crate"
+
+/datum/supply_pack/machine/chem_master
+	name = "Chemistry Master Beacon"
+	desc = "Contains a beacon that will drop a finished chemistry master to your location."
+	cost = 3000
+	contains = list(/obj/item/sup_beacon/chem_master)
+	crate_name = "Chemistry Master Beacon Crate"
+
+//******Engineering******
+
+/datum/supply_pack/machine/emitter
+	name = "Emitter Beacon"
+	desc = "Contains a beacon that will drop a finished emitter to your location."
+	cost = 5000
+	contains = list(/obj/item/sup_beacon/emitter)
+	crate_name = "Emitter Beacon Crate"
+
+/datum/supply_pack/machine/freezer
+	name = "Atmospherics Freezer Beacon"
+	desc = "Contains a beacon that will drop a finished freezer to your location."
+	cost = 4000
+	contains = list(/obj/item/sup_beacon/freezer)
+	crate_name = "Atmospherics Freezer Beacon Crate"
+
+//******Security******
+/datum/supply_pack/machine/weapon_recharger
+	name = "Weapon Recharger Beacon"
+	desc = "Contains a beacon that will drop a finished recharger to your location."
+	cost = 6000
+	contains = list(/obj/item/sup_beacon/weapon_recharger)
+	crate_name = "Weapon Recharger Beacon Crate"
+
+/datum/supply_pack/machine/cameras
+	name = "Camera Console Beacon"
+	desc = "Contains a beacon that will drop a finished camera console to your location."
+	cost = 6000
+	contains = list(/obj/item/sup_beacon/cameras)
+	crate_name = "Camera Console Beacon Crate"
+
+//////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Miscellaneous ///////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -951,6 +951,7 @@
 #include "code\game\objects\items\AI_modules.dm"
 #include "code\game\objects\items\airlock_painter.dm"
 #include "code\game\objects\items\apc_frame.dm"
+#include "code\game\objects\items\beacons.dm"
 #include "code\game\objects\items\binoculars.dm"
 #include "code\game\objects\items\blueprints.dm"
 #include "code\game\objects\items\body_egg.dm"


### PR DESCRIPTION

## About The Pull Request

Cargo can now order supply beacons crates. Supply beacons are similar to the roulette beacon spawner, in that I refactored those into a base type that just spawns a certain type of object with them now to make everyone's life easier going forward.

The supply beacon packs allows you to purchase high use machinery directly from cargo, at the cost of being exceptionally expensive compared to their base cost and effort to just build one.  Currently, these are limited to being machinery that spawns somewhere on the map, and with a basic amount of effort you can already obtain these with minimal effort on station, but as it stands, sometimes it's just a pain in the ass as a doctor to drag the CMO to the bridge, get them to research biotech, drag a scientist to the desk, get them to print you the appropriate parts, then find the raw supplies and materials back to medbay to upgrade your department with 1-2 machines.

Now, can use your "overflowing" funds to buy replacements or spares of some of the most common machines on the station, within perfectly legal channels.

## Why It's Good For The Game

Average player finds at the end of a highpop shift trend to be about 1100 to 3000 credits if heads are involved in a round. This leaves most of the machines on this list as something a single player would need to bust ass to purchase within a 90 minute round, but serves as a nice suplementary goal for player funds. People want more ways to spend money, and in spite of the costs being exceptionally high, these make for acceptably difficult goals for players to strive towards using private funds to purchase.

Pairs well with departmental ordering in #53881, as each of these will need a departmental can_view variable assigned for each supply crate in order to prevent omni-department singularies from occurring more than they already do.

Original idea was from a discussion with maintainers, but the numbers are 100% subject to change and I'm more than willing to raise prices in areas if seen fit.

## Changelog
:cl:
add: The cargo department now offers supply beacons to be purchased, which will deploy fully built machines to the crew at a high cost.
/:cl:
