### PR TITLE
newly added keybinds no longer need savefile updates

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -116,12 +116,14 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			if(!addedbind)
 				notadded += kb
 	if(length(notadded))
-		to_chat(parent, "<span class='boldannounce'> KEYBINDING CONFLICT!!! </span>")
+		to_chat(parent, "<span class='userdanger'>KEYBINDING CONFLICT!!!</span>")
 		to_chat(parent, "<span class='userdanger'>There are new keybindings that have defaults bound to keys you already set, They will default to Unbound. You can bind them in Setup Character or Game Preferences</span>")
+		to_chat(parent, "<span class='userdanger'><a href='?_src_=prefs;preference=tab;tab=3'>Or you can click here to go straight to the keybindings page</a></span>")
 		for(var/item in notadded)
 			var/datum/keybinding/conflicted = item
 			to_chat(parent, "<span class='userdanger'>[conflicted.category]: [conflicted.full_name] needs updating")
 			LAZYADD(key_bindings["Unbound"], conflicted.name) // set it to unbound to prevent this from opening up again in the future
+
 
 
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -117,8 +117,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		if(!addedbind)
 			notadded += kb
 	if(length(notadded))
-		to_chat(parent, "<span class='userdanger'>KEYBINDING CONFLICT!!!\n
-		There are new keybindings that have defaults bound to keys you already set, They will default to Unbound. You can bind them in Setup Character or Game Preferences\n
+		to_chat(parent, "<span class='userdanger'>KEYBINDING CONFLICT!!!\n \
+		There are new keybindings that have defaults bound to keys you already set, They will default to Unbound. You can bind them in Setup Character or Game Preferences\n \
 		<a href='?_src_=prefs;preference=tab;tab=3'>Or you can click here to go straight to the keybindings page</a></span>")
 		for(var/item in notadded)
 			var/datum/keybinding/conflicted = item

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -101,24 +101,25 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	var/list/notadded = list()
 	for (var/name in GLOB.keybindings_by_name)
 		var/datum/keybinding/kb = GLOB.keybindings_by_name[name]
-		if(!length(user_binds[kb.name])) // key is not unbound and not bound to anything
-			var/addedbind = FALSE
-			if(hotkeys)
-				for(var/hotkeytobind in kb.classic_keys)
-					if(!length(key_bindings[hotkeytobind]))
-						LAZYADD(key_bindings[hotkeytobind], kb.name)
-						addedbind = TRUE
-			else
-				for(var/classickeytobind in kb.classic_keys)
-					if(!length(key_bindings[classickeytobind]))
-						LAZYADD(key_bindings[classickeytobind], kb.name)
-						addedbind = TRUE
-			if(!addedbind)
-				notadded += kb
+		if(length(user_binds[kb.name]))
+			continue // key is unbound and or bound to something
+		var/addedbind = FALSE
+		if(hotkeys)
+			for(var/hotkeytobind in kb.classic_keys)
+				if(!length(key_bindings[hotkeytobind]))
+					LAZYADD(key_bindings[hotkeytobind], kb.name)
+					addedbind = TRUE
+		else
+			for(var/classickeytobind in kb.classic_keys)
+				if(!length(key_bindings[classickeytobind]))
+					LAZYADD(key_bindings[classickeytobind], kb.name)
+					addedbind = TRUE
+		if(!addedbind)
+			notadded += kb
 	if(length(notadded))
-		to_chat(parent, "<span class='userdanger'>KEYBINDING CONFLICT!!!</span>")
-		to_chat(parent, "<span class='userdanger'>There are new keybindings that have defaults bound to keys you already set, They will default to Unbound. You can bind them in Setup Character or Game Preferences</span>")
-		to_chat(parent, "<span class='userdanger'><a href='?_src_=prefs;preference=tab;tab=3'>Or you can click here to go straight to the keybindings page</a></span>")
+		to_chat(parent, "<span class='userdanger'>KEYBINDING CONFLICT!!!\n
+		There are new keybindings that have defaults bound to keys you already set, They will default to Unbound. You can bind them in Setup Character or Game Preferences\n
+		<a href='?_src_=prefs;preference=tab;tab=3'>Or you can click here to go straight to the keybindings page</a></span>")
 		for(var/item in notadded)
 			var/datum/keybinding/conflicted = item
 			to_chat(parent, "<span class='userdanger'>[conflicted.category]: [conflicted.full_name] needs updating")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -90,6 +90,41 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 /datum/preferences/proc/update_character(current_version, savefile/S)
 	return
 
+/// checks through keybindings for outdated unbound keys and updates them
+/datum/preferences/proc/check_keybindings()
+	if(!parent)
+		return
+	var/list/user_binds = list()
+	for (var/key in key_bindings)
+		for(var/kb_name in key_bindings[key])
+			user_binds[kb_name] += list(key)
+	var/list/notadded = list()
+	for (var/name in GLOB.keybindings_by_name)
+		var/datum/keybinding/kb = GLOB.keybindings_by_name[name]
+		if(!length(user_binds[kb.name])) // key is not unbound and not bound to anything
+			var/addedbind = FALSE
+			if(hotkeys)
+				for(var/hotkeytobind in kb.classic_keys)
+					if(!length(key_bindings[hotkeytobind]))
+						LAZYADD(key_bindings[hotkeytobind], kb.name)
+						addedbind = TRUE
+			else
+				for(var/classickeytobind in kb.classic_keys)
+					if(!length(key_bindings[classickeytobind]))
+						LAZYADD(key_bindings[classickeytobind], kb.name)
+						addedbind = TRUE
+			if(!addedbind)
+				notadded += kb
+	if(length(notadded))
+		to_chat(parent, "<span class='boldannounce'> KEYBINDING CONFLICT!!! </span>")
+		to_chat(parent, "<span class='userdanger'>There are new keybindings that have defaults bound to keys you already set, They will default to Unbound. You can bind them in Setup Character or Game Preferences</span>")
+		for(var/item in notadded)
+			var/datum/keybinding/conflicted = item
+			to_chat(parent, "<span class='userdanger'>[conflicted.category]: [conflicted.full_name] needs updating")
+			LAZYADD(key_bindings["Unbound"], conflicted.name) // set it to unbound to prevent this from opening up again in the future
+
+
+
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
 	if(!ckey)
 		return
@@ -158,6 +193,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	// Custom hotkeys
 	READ_FILE(S["key_bindings"], key_bindings)
+	check_keybindings()
 	// hearted
 	READ_FILE(S["hearted_until"], hearted_until)
 	if(hearted_until > world.realtime)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Keybinds check if there are any new keybinds when loading preferences now
If there's a conflict it doesn't bind the key to anything
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes keybinds easier to work with, avoids frustrating players when new keybinds are added
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Newly added keybinds try to bind to their defaults when added and fail if the key is already taken
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
