### PR TITLE
Reduce maptick with this spicy one line change (warranty maybe included)

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -7,6 +7,7 @@
 /atom
 	layer = TURF_LAYER
 	plane = GAME_PLANE
+	appearance_flags = TILE_BOUND
 
 	///If non-null, overrides a/an/some in all cases
 	var/article
@@ -1559,7 +1560,7 @@
 
 /**
   * Recursive getter method to return a list of all ghosts orbitting this atom
-  * 
+  *
   * This will work fine without manually passing arguments.
   */
 /atom/proc/get_all_orbiters(list/processed, source = TRUE)


### PR DESCRIPTION
## About The Pull Request

Ok so 
The way appearance_flags works is it does extra calculations if it does NOT have the TILE_BOUND flag
Tile bound will make it avoid calculating pixel offset and large sprite render checks
This meant that for every turf and every area, it was doing extra calculations to see if it should render the sprite as it might be larger than 32x32.....despite no turf or area being larger than 32x32

I've been running this on tgmc through mass varedits and testmerges to no issue and a free ~7-10% decrease in maptick on 40-60 pop.

## Changelog
:cl:
code: Removed free lag from the renderer
/:cl:
