### PR TITLE
Fixes up addictions reporting on scanners, and admin full heal

### DIFF
--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -243,8 +243,9 @@
 			chemical_list += list(list("name" = bit.name, "volume" = round(bit.volume, 0.01)))
 			if(bit.overdosed)
 				overdose_list += list(list("name" = bit.name))
-	if(altPatient.reagents.addiction_list.len)
-		for(var/datum/reagent/R in altPatient.reagents.addiction_list)
+	var/list/addictions = altPatient.get_addiction_list()
+	if(addictions.len)
+		for(var/datum/reagent/R in addictions)
 			addict_list += list(list("name" = R.name))
 	if (altPatient.hallucinating())
 		hallucination_status = "Subject appears to be hallucinating. Suggested treatments: bedrest, mannitol or psicodine."

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -429,10 +429,12 @@ GENE SCANNER
 					render_list += "<span class='notice ml-2'>[round(bit.volume, 0.001)] units of [bit.name][bit.overdosed ? "</span> - <span class='boldannounce'>OVERDOSING</span>" : ".</span>"]\n"
 			else
 				render_list += "<span class='notice ml-1'>Subject contains no reagents in their stomach.</span>\n"
-		if(M.reagents.addiction_list.len)
+
+		var/list/addictions = M.get_addiction_list()
+		if(addictions.len)
 			render_list += "<span class='boldannounce ml-1'>Subject is addicted to the following reagents:</span>\n"
-			for(var/datum/reagent/R in M.reagents.addiction_list)
-				render_list += "<span class='alert ml-2'>[R.name]</span>\n"
+			for(var/datum/reagent/reagent in addictions)
+				render_list += "<span class='alert ml-2'>[reagent.name]</span>\n"
 		else
 			render_list += "<span class='notice ml-1'>Subject is not addicted to any reagents.</span>\n"
 

--- a/code/modules/antagonists/gang/gang.dm
+++ b/code/modules/antagonists/gang/gang.dm
@@ -423,7 +423,8 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			people_on_station++
-			for(var/R in H.reagents.addiction_list)
+			var/list/addictions = H.get_addiction_list()
+			for(var/R in addictions)
 				if(istype(R, /datum/reagent/drug/methamphetamine))
 					people_on_crack++
 	if(0.25*people_on_station > people_on_crack)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -862,10 +862,6 @@
 	update_mobility()
 
 /mob/living/carbon/fully_heal(admin_revive = FALSE)
-	if(reagents)
-		reagents.clear_reagents()
-		for(var/addi in reagents.addiction_list)
-			reagents.remove_addiction(addi)
 	for(var/O in internal_organs)
 		var/obj/item/organ/organ = O
 		organ.setOrganDamage(0)
@@ -884,8 +880,7 @@
 		for(var/obj/item/restraints/R in contents) //actually remove cuffs from inventory
 			qdel(R)
 		update_handcuffed()
-		if(reagents)
-			reagents.addiction_list = list()
+	clear_addictions()
 	cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
 	..()
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -168,6 +168,46 @@
 /mob/living/proc/get_reagent_amount(reagent)
 	return reagents.get_reagent_amount(reagent)
 
+/**
+ * Get a list of all chems the mob has that they are addicted to.
+ *
+ * This creates a ist of all chems the mob has within its body that it is addicted to.
+ * Returns list of reagents
+ */
+/mob/living/proc/get_addiction_list()
+	var/list/addictions = list()
+	var/obj/item/organ/stomach/belly = getorganslot(ORGAN_SLOT_STOMACH)
+	if(reagents.addiction_list.len)
+		for(var/datum/reagent/reagent in reagents.addiction_list)
+			addictions += reagent
+	if(belly?.reagents.addiction_list.len)
+		for(var/bile in belly.reagents.addiction_list)
+			addictions += bile
+	return addictions
+
+/**
+ * Removes an addiction from the mob
+ *
+ * This will remove addiction to the passeed in chem from the mob
+ * vars:
+ * * addiction (reagent) the reagent to remove
+ */
+/mob/living/proc/remove_addiction(addiction)
+	reagents.remove_addiction(addiction)
+	var/obj/item/organ/stomach/belly = getorganslot(ORGAN_SLOT_STOMACH)
+	if(belly)
+		belly.reagents.remove_addiction(addiction)
+
+/**
+ * Removes all addictions from the mob
+ *
+ * This will remove all addictions from the mob
+ */
+/mob/living/proc/clear_addictions()
+	var/list/addictions = get_addiction_list()
+	for(var/reagent in addictions)
+		remove_addiction(reagent)
+
 //this updates all special effects: knockdown, druggy, stuttering, etc..
 /mob/living/proc/handle_status_effects()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Addictions now account for organs
This means the medical scanners, and kiosk now show addictions
Admin full heal/revival now clears addictions as intended.
Meth users are reported in families properly.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Addicts need to be addicts

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Medical scanners, and kiosk now show all addictions
fix: Admin full heal/revival now clears addictions as intended
fix: Families checks addicts fully now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
