### PR TITLE
After 2 long years, shades are zoomers again

### DIFF
--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -26,6 +26,7 @@
 	minbodytemp = 0
 	maxbodytemp = INFINITY
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
+	speed = -1 //they don't have to lug a body made of runed metal around
 	stop_automated_movement = 1
 	faction = list("cult")
 	status_flags = CANPUSH


### PR DESCRIPTION
## About The Pull Request

Shades now move faster than the other cult constructs, undoing the change to their movement speed made all the way back in 2018: https://github.com/tgstation/tgstation/pull/36092.

## Why It's Good For The Game

Fikou's PR (https://github.com/tgstation/tgstation/pull/53862) gave shades the ability to ventcrawl to give them some form of purpose (they can be scouts now), but I don't think it went far enough. Now shades should be able to actually keep up with masters who release them from their soulstones (!), and life in vent-less areas is a little less miserable for them.

Also, now the shade that the chaplain usually makes with their soulstone can make itself useful by dragging crates and bodies and stuff at a non-abysmal pace (and cult-aligned shades can drag corpses back to runes more effectively).

## Changelog
:cl: ATHATH
balance: Because they don't have to drag around a heavy body made of runed metal, shades now move faster than the other cult constructs.
/:cl: