### PR TITLE
Adds Cross-Server Communication Network Option (PAID* CODE)

### DIFF
--- a/code/controllers/configuration/entries/comms.dm
+++ b/code/controllers/configuration/entries/comms.dm
@@ -21,3 +21,6 @@
 	return key_value != "byond:\\address:port" && ..()
 
 /datum/config_entry/string/cross_comms_name
+
+/datum/config_entry/string/cross_comms_network
+	protection = CONFIG_ENTRY_LOCKED

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -91,6 +91,12 @@
 	require_comms_key = TRUE
 
 /datum/world_topic/comms_console/Run(list/input)
+	// Reject comms messages from other servers that are not on our configured network,
+	// if this has been configured. (See CROSS_COMMS_NETWORK in comms.txt)
+	var/configured_network = CONFIG_GET(string/cross_comms_network)
+	if (configured_network && configured_network != input["network"])
+		return
+
 	minor_announce(input["message"], "Incoming message from [input["message_sender"]]")
 	for(var/obj/machinery/computer/communications/CM in GLOB.machines)
 		CM.overrideCooldown()

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -138,13 +138,14 @@
 				if(!input || !(usr in view(1,src)) || !checkCCcooldown())
 					return
 				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
-				if(dest == "all")
-					send2otherserver("[station_name()]", input,"Comms_Console")
-				else
-					send2otherserver("[station_name()]", input,"Comms_Console", list(dest))
+				var/payload = list()
+				var/network_name = CONFIG_GET(string/cross_comms_network)
+				if (network_name)
+					payload["network"] = network_name
+				send2otherserver("[station_name()]", input,"Comms_Console", dest == "all" ? null : list(dest), additional_data = payload)
 				minor_announce(input, title = "Outgoing message to allied station")
 				usr.log_talk(input, LOG_SAY, tag="message to the other server")
-				message_admins("[ADMIN_LOOKUPFLW(usr)] has sent a message to the other server.")
+				message_admins("[ADMIN_LOOKUPFLW(usr)] has sent a message to the other server\[s].")
 				deadchat_broadcast(" has sent an outgoing message to the other station(s).</span>", "<span class='bold'>[usr.real_name]", usr, message_type=DEADCHAT_ANNOUNCEMENT)
 				CM.lastTimeUsed = world.time
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -485,7 +485,7 @@
 						for(var/server in cross_servers)
 							if(server == our_id)
 								continue
-							dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=crossserver=all;cross_dest=[server]'>Send a message to station in [server] sector.</A> \]"
+							dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=crossserver;cross_dest=[server]'>Send a message to station in [server] sector.</A> \]"
 						if(cross_servers.len > 2)
 							dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=crossserver;cross_dest=all'>Send a message to all allied stations</A> \]"
 					if(SSmapping.config.allow_custom_shuttles)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -590,13 +590,13 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		send2otherserver(source,final)
 
 /// Sends a message to other servers.
-/proc/send2otherserver(source,msg,type = "Ahelp",target_servers)
+/proc/send2otherserver(source, msg, type = "Ahelp", target_servers, list/additional_data)
 	if(!CONFIG_GET(string/comms_key))
 		debug_world_log("Server cross-comms message not sent for lack of configured key")
 		return
 
 	var/our_id = CONFIG_GET(string/cross_comms_name)
-	var/list/message = list()
+	var/list/message = additional_data != null ? additional_data : list()
 	message["message_sender"] = source
 	message["message"] = msg
 	message["source"] = "([our_id])"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -590,13 +590,13 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		send2otherserver(source,final)
 
 /// Sends a message to other servers.
-/proc/send2otherserver(source, msg, type = "Ahelp", target_servers, list/additional_data)
+/proc/send2otherserver(source, msg, type = "Ahelp", target_servers, list/additional_data = list())
 	if(!CONFIG_GET(string/comms_key))
 		debug_world_log("Server cross-comms message not sent for lack of configured key")
 		return
 
 	var/our_id = CONFIG_GET(string/cross_comms_name)
-	var/list/message = additional_data != null ? additional_data : list()
+	var/list/message = additional_data
 	message["message_sender"] = source
 	message["message"] = msg
 	message["source"] = "([our_id])"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -589,18 +589,26 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		send2adminchat(source,final)
 		send2otherserver(source,final)
 
-/// Sends a message to other servers.
+/**
+  * Sends a message to a set of cross-communications-enabled servers using world topic calls
+  *
+  * Arguments:
+  * * source - Who sent this message
+  * * msg - The message body
+  * * type - The type of message, becomes the topic command under the hood
+  * * target_servers - A collection of servers to send the message to, defined in config
+  * * additional_data - An (optional) associated list of extra parameters and data to send with this world topic call
+  */
 /proc/send2otherserver(source, msg, type = "Ahelp", target_servers, list/additional_data = list())
 	if(!CONFIG_GET(string/comms_key))
 		debug_world_log("Server cross-comms message not sent for lack of configured key")
 		return
 
 	var/our_id = CONFIG_GET(string/cross_comms_name)
-	var/list/message = additional_data
-	message["message_sender"] = source
-	message["message"] = msg
-	message["source"] = "([our_id])"
-	message += type
+	additional_data["message_sender"] = source
+	additional_data["message"] = msg
+	additional_data["source"] = "([our_id])"
+	additional_data += type
 
 	var/list/servers = CONFIG_GET(keyed_list/cross_server)
 	for(var/I in servers)
@@ -608,7 +616,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			continue
 		if(target_servers && !(I in target_servers))
 			continue
-		world.send_cross_comms(I, message)
+		world.send_cross_comms(I, additional_data)
 
 /// Sends a message to a given cross comms server by name (by name for security).
 /world/proc/send_cross_comms(server_name, list/message, auth = TRUE)

--- a/config/comms.txt
+++ b/config/comms.txt
@@ -8,3 +8,8 @@
 
 ## Name that the server calls itself in communications
 #CROSS_COMMS_NAME
+
+## Network-name used for cross-server broadcasts made from communication consoles.
+## Servers that do not match this network-name will have their messages discarded.
+## Leaving this commented will allow all messages through, regardless of network.
+#CROSS_COMMS_NETWORK default_network


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a configurable network, just a string, wherein if set then only servers with matching networks will have their communications console's broadcasts accepted. If the network is not set the server accepts all broadcasts. If it is set and it does not match, the broadcast is discarded.

Also this fixes the ability to send a message to an individual server as it seems that was broken.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Adds ability to segregate the MRP servers from LRPs, [requested by head jannies](https://tgstation13.org/phpBB/viewtopic.php?f=41&t=27656#p577600)

To use this config option, set the value of ``CROSS_COMMS_NAME`` in the ``comms.txt`` configuration file. Cross-comms messages from servers that do not match the value set for ``CROSS_COMMS_NAME``, if set, will be rejected. If you do not set a network, then the server will accept cross-comms messages from all sources.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
add: Added a cross-server communication network setting to allow clustering servers into distinct groups for cross-server announcements
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
