### PR TITLE
Minor machine item dumping code cleanup and proc implementation.

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -164,7 +164,7 @@ Class Procs:
 /obj/machinery/Destroy()
 	GLOB.machines.Remove(src)
 	end_processing()
-	drop_contents()
+	dump_contents()
 	QDEL_LIST(component_parts)
 	QDEL_NULL(circuit)
 	return ..()
@@ -214,17 +214,17 @@ Class Procs:
 	state_open = TRUE
 	density = FALSE
 	if(drop)
-		drop_stored_items()
+		dump_inventory_contents()
 	update_icon()
 	updateUsrDialog()
 
 /**
-  * Drop every movable atom in the machine's contents list.
+  * Drop every movable atom in the machine's contents list, including any components and circuit.
   */
-/obj/machinery/proc/drop_contents()
-	// Start by calling the drop_stored_items proc. Will allow machines with special contents
+/obj/machinery/dump_contents()
+	// Start by calling the dump_inventory_contents proc. Will allow machines with special contents
 	// to handle their dropping.
-	drop_stored_items()
+	dump_inventory_contents()
 
 	// Then we can clean up and drop everything else.
 	var/turf/this_turf = get_turf(src)
@@ -237,14 +237,14 @@ Class Procs:
 	LAZYCLEARLIST(component_parts)
 
 /**
-  * Drop every movable atom in the machine's contents list.
+  * Drop every movable atom in the machine's contents list that is not a component_part.
   *
   * Proc does not drop components and will skip over anything in the component_parts list.
-  * Call drop_contents() to drop all contents including components.
+  * Call dump_contents() to drop all contents including components.
   * Arguments:
   * * subset - If this is not null, only atoms that are also contained within the subset list will be dropped.
   */
-/obj/machinery/proc/drop_stored_items(list/subset = null)
+/obj/machinery/proc/dump_inventory_contents(list/subset = null)
 	var/turf/this_turf = get_turf(src)
 	for(var/atom/movable/movable_atom in contents)
 		if(subset && !(movable_atom in subset))

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -187,7 +187,7 @@
 	. = ..()
 	if(!is_operational && state_open)
 		open_machine()
-		dump_contents()
+		drop_stored_items()
 	update_icon()
 
 /obj/machinery/suit_storage_unit/drop_stored_items()
@@ -201,8 +201,8 @@
 /obj/machinery/suit_storage_unit/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		open_machine()
-		dump_contents()
-		new /obj/item/stack/sheet/metal (loc, 2)
+		drop_stored_items()
+		new /obj/item/stack/sheet/metal(loc, 2)
 	qdel(src)
 
 /obj/machinery/suit_storage_unit/interact(mob/living/user)
@@ -258,7 +258,7 @@
 			if (!state_open)
 				open_machine(drop = FALSE)
 				if (occupant)
-					dump_contents()
+					drop_stored_items()
 		if ("close")
 			if (state_open)
 				close_machine()
@@ -407,7 +407,7 @@
 				dirty_movable.wash(CLEAN_ALL)
 		open_machine(FALSE)
 		if(occupant)
-			dump_contents()
+			drop_stored_items()
 
 /obj/machinery/suit_storage_unit/process(delta_time)
 	if(!suit)
@@ -436,12 +436,12 @@
 			to_chat(user, "<span class='warning'>[src]'s door won't budge!</span>")
 		return
 	open_machine()
-	dump_contents()
+	drop_stored_items()
 
 /obj/machinery/suit_storage_unit/container_resist_act(mob/living/user)
 	if(!locked)
 		open_machine()
-		dump_contents()
+		drop_stored_items()
 		return
 	user.changeNext_move(CLICK_CD_BREAKOUT)
 	user.last_special = world.time + CLICK_CD_BREAKOUT
@@ -454,7 +454,7 @@
 		user.visible_message("<span class='warning'>[user] successfully broke out of [src]!</span>", \
 			"<span class='notice'>You successfully break out of [src]!</span>")
 		open_machine()
-		dump_contents()
+		drop_stored_items()
 
 	add_fingerprint(user)
 	if(locked)
@@ -463,7 +463,7 @@
 		addtimer(CALLBACK(src, .proc/resist_open, user), 300)
 	else
 		open_machine()
-		dump_contents()
+		drop_stored_items()
 
 /obj/machinery/suit_storage_unit/proc/resist_open(mob/user)
 	if(!state_open && occupant && (user in src) && user.stat == CONSCIOUS) // Check they're still here.
@@ -513,7 +513,7 @@
 		if(default_deconstruction_screwdriver(user, "panel", "close", I))
 			return
 	if(default_pry_open(I))
-		dump_contents()
+		drop_stored_items()
 		return
 
 	return ..()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -187,10 +187,10 @@
 	. = ..()
 	if(!is_operational && state_open)
 		open_machine()
-		drop_stored_items()
+		dump_inventory_contents()
 	update_icon()
 
-/obj/machinery/suit_storage_unit/drop_stored_items()
+/obj/machinery/suit_storage_unit/dump_inventory_contents()
 	. = ..()
 	helmet = null
 	suit = null
@@ -201,7 +201,7 @@
 /obj/machinery/suit_storage_unit/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		open_machine()
-		drop_stored_items()
+		dump_inventory_contents()
 		new /obj/item/stack/sheet/metal(loc, 2)
 	qdel(src)
 
@@ -258,7 +258,7 @@
 			if (!state_open)
 				open_machine(drop = FALSE)
 				if (occupant)
-					drop_stored_items()
+					dump_inventory_contents()
 		if ("close")
 			if (state_open)
 				close_machine()
@@ -407,7 +407,7 @@
 				dirty_movable.wash(CLEAN_ALL)
 		open_machine(FALSE)
 		if(occupant)
-			drop_stored_items()
+			dump_inventory_contents()
 
 /obj/machinery/suit_storage_unit/process(delta_time)
 	if(!suit)
@@ -436,12 +436,12 @@
 			to_chat(user, "<span class='warning'>[src]'s door won't budge!</span>")
 		return
 	open_machine()
-	drop_stored_items()
+	dump_inventory_contents()
 
 /obj/machinery/suit_storage_unit/container_resist_act(mob/living/user)
 	if(!locked)
 		open_machine()
-		drop_stored_items()
+		dump_inventory_contents()
 		return
 	user.changeNext_move(CLICK_CD_BREAKOUT)
 	user.last_special = world.time + CLICK_CD_BREAKOUT
@@ -454,7 +454,7 @@
 		user.visible_message("<span class='warning'>[user] successfully broke out of [src]!</span>", \
 			"<span class='notice'>You successfully break out of [src]!</span>")
 		open_machine()
-		drop_stored_items()
+		dump_inventory_contents()
 
 	add_fingerprint(user)
 	if(locked)
@@ -463,7 +463,7 @@
 		addtimer(CALLBACK(src, .proc/resist_open, user), 300)
 	else
 		open_machine()
-		drop_stored_items()
+		dump_inventory_contents()
 
 /obj/machinery/suit_storage_unit/proc/resist_open(mob/user)
 	if(!state_open && occupant && (user in src) && user.stat == CONSCIOUS) // Check they're still here.
@@ -513,7 +513,7 @@
 		if(default_deconstruction_screwdriver(user, "panel", "close", I))
 			return
 	if(default_pry_open(I))
-		drop_stored_items()
+		dump_inventory_contents()
 		return
 
 	return ..()

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -132,7 +132,7 @@
 	return
 
 /obj/machinery/gibber/proc/go_out()
-	drop_stored_items()
+	dump_inventory_contents()
 	update_icon()
 
 /obj/machinery/gibber/proc/startgibbing(mob/user)

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -327,11 +327,11 @@
 		if(prob(max(metal / 2, 33)))
 			explosion(loc, 0, 1, 2)
 	else
-		drop_stored_items()
+		dump_inventory_contents()
 
 	after_finish_loop()
 
-/obj/machinery/microwave/drop_stored_items()
+/obj/machinery/microwave/dump_inventory_contents()
 	. = ..()
 	ingredients.Cut()
 

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -137,18 +137,12 @@
 		var/mob/living/L = usr
 		if(!(L.mobility_flags & MOBILITY_UI))
 			return
-	empty()
+	dump_inventory_contents()
 	add_fingerprint(usr)
 
 /obj/machinery/processor/container_resist_act(mob/living/user)
 	user.forceMove(drop_location())
 	user.visible_message("<span class='notice'>[user] crawls free of the processor!</span>")
-
-/obj/machinery/processor/proc/empty()
-	for (var/obj/O in src)
-		O.forceMove(drop_location())
-	for (var/mob/M in src)
-		M.forceMove(drop_location())
 
 /obj/machinery/processor/slime
 	name = "slime processor"

--- a/code/modules/library/skill_learning/skill_station.dm
+++ b/code/modules/library/skill_learning/skill_station.dm
@@ -92,13 +92,13 @@
 		return
 	return ..()
 
-/obj/machinery/skill_station/drop_contents()
+/obj/machinery/skill_station/dump_contents()
 	. = ..()
 	inserted_skillchip = null
 
-/obj/machinery/skill_station/drop_stored_items(list/subset = null)
+/obj/machinery/skill_station/dump_inventory_contents(list/subset = null)
 	// Don't drop the skillchip, it's directly inserted into the machine.
-	// drop_contents() will drop everything including the skillchip.
+	// dump_contents() will drop everything including the skillchip as an alternative to this.
 	subset = contents - inserted_skillchip
 	return ..()
 

--- a/code/modules/swarmers/swarmer.dm
+++ b/code/modules/swarmers/swarmer.dm
@@ -283,7 +283,7 @@
 		disintegration_effect.pixel_x = target.pixel_x
 		disintegration_effect.pixel_y = target.pixel_y
 		disintegration_effect.pixel_z = target.pixel_z
-		target.drop_contents()
+		target.dump_contents()
 		if(istype(target, /obj/machinery/computer))
 			var/obj/machinery/computer/computer_target = target
 			if(computer_target.circuit)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #54074

![image](https://user-images.githubusercontent.com/24975989/94540457-66bfb600-023e-11eb-8460-4c5d3aa751c5.png)

dump_contents was unimplemented for /obj/machine types. Instead we used a snowflake drop_contents proc.

drop_contents is renamed to dump_contents and now implements that intended behaviour for all /obj/machine types.

drop_stored_items is now renamed to dump_inventory_contents to match the dump_x nomenclature and also to hint that it drops all inventory-esque contents including non-items.

The suit storage unit doesn't dump_contents anymore and instead calls dump_inventory_contents instead, so the suit storage unit will now vomit out whatever the heck is in it when it should have before.

Removes snowflake empty proc from processing-type machines like the grinder and slime processor, now uses the newly renamed dump_inventory_content proc.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Code cleanup. Better named procs. Remove redundant procs.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Suit Storage Units will now correctly eject their contents in a variety of scenarios where previously they would refuse to do so.
fix: Grinders and Slime Processors no longer eject their own components.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
