### PR TITLE
[READY] Makes it so you need MOBILITY_USE flag to use direct radio implements

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -383,9 +383,9 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	return message
 
 /mob/living/proc/radio(message, list/message_mods = list(), list/spans, language)
-	if(!(mobility_flags & MOBILITY_USE)) // If can't use items, you can't press the button
-		to_chat(src, "<span class='warning'>You can't use the radio now!</span>")
-		return TRUE
+	if((message_mods[MODE_HEADSET] || message_mods[RADIO_EXTENSION]) && !(mobility_flags & MOBILITY_USE)) // If can't use items, you can't press the button
+		to_chat(src, "<span class='warning'>You can't use the radio right now!</span>")
+		return ITALICS | REDUCE_RANGE
 	var/obj/item/implant/radio/imp = locate() in src
 	if(imp && imp.radio.on)
 		if(message_mods[MODE_HEADSET])

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -384,6 +384,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 /mob/living/proc/radio(message, list/message_mods = list(), list/spans, language)
 	if(!(mobility_flags & MOBILITY_USE)) // If can't use items, you can't press the button
+		to_chat(src, "<span class='warning'>You can't use the radio now!</span>")
 		return TRUE
 	var/obj/item/implant/radio/imp = locate() in src
 	if(imp && imp.radio.on)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -383,6 +383,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	return message
 
 /mob/living/proc/radio(message, list/message_mods = list(), list/spans, language)
+	if(!(mobility_flags & MOBILITY_USE)) // If can't use items, you can't press the button
+		return TRUE
 	var/obj/item/implant/radio/imp = locate() in src
 	if(imp && imp.radio.on)
 		if(message_mods[MODE_HEADSET])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It will give the user a warning message if that's the case

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Discourages validhunting as calling out over on the radio will be harder.
Promotes more organised tactics for security, as once again, call outs may be harder.
You will no longer need to strip the radio really fast from people you handcuff to make sure they dont scream over radio

It also makes sense, you cant press the button if your hands are busy/incapable

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: You can no longer use direct radio implements (such as headsets) if you can't use items! (Being handcuffed, stunned etc.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
