### PR TITLE
AIs can no longer gain ion laws compelling them to purge all the homosexuals.

### DIFF
--- a/strings/ion_laws.json
+++ b/strings/ion_laws.json
@@ -145,8 +145,6 @@
         "INVISIBLE",
         "PAINFUL",
         "HARMFUL",
-        "HOMOSEXUAL",
-        "HETEROSEXUAL",
         "SEXUAL",
         "BLOODY",
         "COLORFUL",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/94622399-09f9e500-02aa-11eb-8f1c-c41bc8a86fb0.png)

Yeets HOMOSEXUAL and HETEROSEXUAL out of the list of adjectives for AI ION laws.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Because it's going to trigger all the bigots to come out of their rotten woodworks defending why it's totally okay for the AI to get ion laws declaring it purge all the gays (or imprison all the gays or do anything to all the gays) because it's rare.

Seriously though. That the AI has a **chance** to roll ion laws like that just doesn't sit right with me.

HETEROSEXUAL has been removed for the same reason. Sexual orientation should in zero way factor into the AI's laws or law making decisions in any way, shape or form as far as randomly generated ion laws are concerned.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
