### PR TITLE
Minor tweaks and cleanup to mecha drill equipment's action code

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -25,38 +25,47 @@
 	AddComponent(/datum/component/butchering, 50, 100, null, null, TRUE)
 
 /obj/item/mecha_parts/mecha_equipment/drill/action(mob/source, atom/target, params)
+	// Check if we can even use the equipment to begin with.
 	if(!action_checks(target))
 		return
-	if(isspaceturf(target))
+
+	// We can only drill non-space turfs, living mobs and objects.
+	if(isspaceturf(target) || !isliving(target) || !isobj(target) || !isturf(target))
 		return
+
+	// For whatever reason we can't drill things that acid won't even stick too, and probably
+	// shouldn't waste our time drilling indestructible things.
 	if(isobj(target))
 		var/obj/target_obj = target
-		if(target_obj.resistance_flags & UNACIDABLE)
+		if(target_obj.resistance_flags & (UNACIDABLE | INDESTRUCTIBLE))
 			return
+
 	target.visible_message("<span class='warning'>[chassis] starts to drill [target].</span>", \
 					"<span class='userdanger'>[chassis] starts to drill [target]...</span>", \
 					 "<span class='hear'>You hear drilling.</span>")
 
 	if(do_after_cooldown(target, source))
 		log_message("Started drilling [target]", LOG_MECHA)
+		// Drilling a turf is a one-and-done procedure.
 		if(isturf(target))
 			var/turf/T = target
 			T.drill_act(src, source)
-			return
+			return ..()
+		// Drilling objects and mobs is a repeating procedure.
 		while(do_after_mecha(target, source, drill_delay))
 			if(isliving(target))
 				drill_mob(target, source)
 				playsound(src,'sound/weapons/drill.ogg',40,TRUE)
-				// If we gibbed the target by drilling them, we can stop drilling them.
-				// Prevents starting a do_after on a qdeleted target.
-				if(QDELETED(target))
-					break
 			else if(isobj(target))
 				var/obj/O = target
 				O.take_damage(15, BRUTE, 0, FALSE, get_dir(chassis, target))
 				playsound(src,'sound/weapons/drill.ogg',40,TRUE)
-			else
-				return
+
+			// If we caused a qdel drilling the target, we can stop drilling them.
+			// Prevents starting a do_after on a qdeleted target.
+			if(QDELETED(target))
+				break
+
 	return ..()
 
 /turf/proc/drill_act(obj/item/mecha_parts/mecha_equipment/drill/drill, mob/user)

--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -30,7 +30,7 @@
 		return
 
 	// We can only drill non-space turfs, living mobs and objects.
-	if(isspaceturf(target) || !isliving(target) || !isobj(target) || !isturf(target))
+	if(isspaceturf(target) || !(isliving(target) || isobj(target) || isturf(target)))
 		return
 
 	// For whatever reason we can't drill things that acid won't even stick too, and probably

--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -47,6 +47,10 @@
 			if(isliving(target))
 				drill_mob(target, source)
 				playsound(src,'sound/weapons/drill.ogg',40,TRUE)
+				// If we gibbed the target by drilling them, we can stop drilling them.
+				// Prevents starting a do_after on a qdeleted target.
+				if(QDELETED(target))
+					break
 			else if(isobj(target))
 				var/obj/O = target
 				O.take_damage(15, BRUTE, 0, FALSE, get_dir(chassis, target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mecha drilling can gib the target. Gibbing can qdel. The while loop will run one last time after the target is qdeleted, starting a final do_after that will not remove itself from the user's do_after list because the target is QDELETED.

This leaves a phantom do_after in the user's do_afters list.

Simplest fix is to accept this as a valid possibility and exit the while loop early if our target is QDELETED.

Also implements a few other early return code paths and ensure returns make sense, always returning the parent call when a drill action has been committed to.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Surgery cannot be performed if the target has any do_afters in their list, even if said do_afters are just a bunch of nulls.

Feex is good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Using mecha drills to turn living things into not living piles of gibs will no longer prevent you from doing surgery for the rest of the round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
