### PR TITLE
[READY] Buyable spare mining shuttle

### DIFF
--- a/_maps/shuttles/construction_mining.dmm
+++ b/_maps/shuttles/construction_mining.dmm
@@ -1,0 +1,128 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"b" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"c" = (
+/obj/machinery/computer/shuttle/mining{
+	possible_destinations = "mining_home;mining_away;landing_zone_dock;mining_public;construction_mining_custom";
+	shuttleId = "construction_mining"
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"d" = (
+/obj/structure/table,
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"e" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"f" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"g" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"h" = (
+/obj/docking_port/mobile{
+	dir = 8;
+	dwidth = 3;
+	height = 5;
+	id = "construction_mining";
+	name = "spare mining shuttle";
+	port_direction = 4;
+	width = 7
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"i" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"j" = (
+/obj/structure/shuttle/engine/heater,
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"k" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"l" = (
+/obj/structure/shuttle/engine/propulsion/burst,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"z" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"J" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker{
+	shuttleId = "construction_mining";
+	shuttlePortId = "construction_mining_custom"
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+"Q" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
+
+(1,1,1) = {"
+k
+k
+k
+k
+k
+k
+k
+"}
+(2,1,1) = {"
+k
+c
+k
+k
+k
+k
+k
+"}
+(3,1,1) = {"
+k
+d
+Q
+k
+k
+j
+l
+"}
+(4,1,1) = {"
+k
+J
+k
+k
+k
+k
+k
+"}
+(5,1,1) = {"
+k
+k
+k
+h
+k
+k
+k
+"}

--- a/_maps/shuttles/construction_mining.dmm
+++ b/_maps/shuttles/construction_mining.dmm
@@ -12,8 +12,8 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/mining)
 "c" = (
-/obj/machinery/computer/shuttle/mining{
-	possible_destinations = "mining_home;mining_away;landing_zone_dock;mining_public;construction_mining_custom";
+/obj/machinery/computer/shuttle{
+	possible_destinations = "construction_mining_custom";
 	shuttleId = "construction_mining"
 	},
 /turf/open/floor/plating/airless,
@@ -81,6 +81,7 @@
 /area/shuttle/mining)
 "J" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker{
+	jumpto_ports = list(mining_home = 1, mining_away = 1, landing_zone_dock = 1, mining_public = 1, construction_mining_custom = 1);
 	shuttleId = "construction_mining";
 	shuttlePortId = "construction_mining_custom"
 	},

--- a/_maps/shuttles/construction_mining.dmm
+++ b/_maps/shuttles/construction_mining.dmm
@@ -6,6 +6,9 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/mining)
 "b" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating/airless,
 /area/shuttle/mining)
 "c" = (
@@ -26,9 +29,15 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/mining)
 "f" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating/airless,
 /area/shuttle/mining)
 "g" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/shuttle/mining)
 "h" = (
@@ -40,6 +49,9 @@
 	name = "spare mining shuttle";
 	port_direction = 4;
 	width = 7
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/mining)
@@ -74,6 +86,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/mining)
+"L" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/mining)
 "Q" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -82,25 +98,25 @@
 /area/shuttle/mining)
 
 (1,1,1) = {"
-k
-k
-k
-k
-k
-k
-k
+a
+f
+f
+f
+f
+f
+i
 "}
 (2,1,1) = {"
-k
+b
 c
 k
 k
 k
 k
-k
+L
 "}
 (3,1,1) = {"
-k
+b
 d
 Q
 k
@@ -109,20 +125,20 @@ j
 l
 "}
 (4,1,1) = {"
-k
+b
 J
 k
 k
 k
 k
-k
+L
 "}
 (5,1,1) = {"
-k
-k
-k
+e
+g
+g
 h
-k
-k
-k
+g
+g
+z
 "}

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -127,6 +127,13 @@
 	port_id = "construction"
 	can_be_bought = FALSE
 
+/datum/map_template/shuttle/construction/New()
+	. = ..()
+	blacklisted_turfs = typecacheof(/turf/closed)
+	whitelisted_turfs = list()
+	banned_areas = typecacheof(/area/shuttle)
+	banned_objects = list()
+
 /datum/map_template/shuttle/mining
 	port_id = "mining"
 	can_be_bought = FALSE

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -123,6 +123,10 @@
 	port_id = "labour"
 	can_be_bought = FALSE
 
+/datum/map_template/shuttle/construction
+	port_id = "construction"
+	can_be_bought = FALSE
+
 /datum/map_template/shuttle/mining
 	port_id = "mining"
 	can_be_bought = FALSE
@@ -173,6 +177,12 @@
 	suffix = "backup"
 	name = "Backup Shuttle"
 	can_be_bought = FALSE
+
+/datum/map_template/shuttle/construction/mining
+	suffix = "mining"
+	can_be_bought = FALSE
+	name = "Build your own mining shuttle kit"
+	description = "For the beginning shuttle engineer! Comes stocked with base engine and consoles. Oxygen not included."
 
 /datum/map_template/shuttle/emergency/construction
 	suffix = "construction"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -220,6 +220,15 @@
 	crate_name = "space suit crate"
 	crate_type = /obj/structure/closet/crate/secure
 
+/datum/supply_pack/emergency/miningshuttlecapsule
+	name = "Spare Mining Shuttle Crate"
+	desc = "Contains bluespace shuttle capsule with mining shuttle empty shell. Oxygen not included. Requires AUX access to open."
+	cost = 2500
+	access = ACCESS_AUX_BASE 
+	contains = list(/obj/item/shuttlecapsule)
+	crate_name = "spare mining shuttle crate"
+	crate_type = /obj/structure/closet/crate/secure
+
 /datum/supply_pack/emergency/specialops
 	name = "Special Ops Supplies"
 	desc = "(*!&@#SAD ABOUT THAT NULL_ENTRY, HUH OPERATIVE? WELL, THIS LITTLE ORDER CAN STILL HELP YOU OUT IN A PINCH. CONTAINS A BOX OF FIVE EMP GRENADES, THREE SMOKEBOMBS, AN INCENDIARY GRENADE, AND A \"SLEEPY PEN\" FULL OF NICE TOXINS!#@*$"

--- a/code/modules/mining/constructed_shuttles.dm
+++ b/code/modules/mining/constructed_shuttles.dm
@@ -13,7 +13,7 @@
 		return
 	template = SSmapping.shuttle_templates[template_id]
 	if(!template)
-		loc.visible_message("<span class='warning'>Wrong template_id: [template_id]</span>")
+		loc.visible_message("<span class='warning'>Error in blurspace unfolding system. Please contact your Nanotrasen contractor.</span>")
 
 /obj/item/shuttlecapsule/Destroy()
 	template = null // without this, capsules would be one use. per round.
@@ -32,7 +32,7 @@
 		loc.visible_message("<span class='warning'>\The [src] begins to shake. Stand back!</span>")
 		used = TRUE
 		sleep(50)
-		/*var/turf/deploy_location = get_turf(src)
+		var/turf/deploy_location = get_turf(src)
 		var/status = template.check_deploy(deploy_location)
 		switch(status)
 			if(SHELTER_DEPLOY_BAD_AREA)
@@ -44,9 +44,7 @@
 
 		if(status != SHELTER_DEPLOY_ALLOWED)
 			used = FALSE
-			return*/
-
-		used = FALSE
+			return
 
 		playsound(src, 'sound/effects/phasein.ogg', 100, TRUE)
 

--- a/code/modules/mining/constructed_shuttles.dm
+++ b/code/modules/mining/constructed_shuttles.dm
@@ -1,0 +1,64 @@
+/obj/item/shuttlecapsule
+	name = "bluespace shuttle capsule"
+	desc = "An shuttle stored within a pocket of bluespace."
+	icon_state = "capsule"
+	icon = 'icons/obj/mining.dmi'
+	w_class = WEIGHT_CLASS_TINY
+	var/template_id = "construction_mining"
+	var/datum/map_template/shuttle/template
+	var/used = FALSE
+
+/obj/item/shuttlecapsule/proc/get_template()
+	if(template)
+		return
+	template = SSmapping.shuttle_templates[template_id]
+	if(!template)
+		loc.visible_message("<span class='warning'>Wrong template_id: [template_id]</span>")
+
+/obj/item/shuttlecapsule/Destroy()
+	template = null // without this, capsules would be one use. per round.
+	. = ..()
+
+/obj/item/shuttlecapsule/examine(mob/user)
+	. = ..()
+	get_template()
+	. += "This capsule has the [template.name] stored."
+	. += template.description
+
+/obj/item/shuttlecapsule/attack_self()
+	//Can't grab when capsule is New() because templates aren't loaded then
+	get_template()
+	if(!used)
+		loc.visible_message("<span class='warning'>\The [src] begins to shake. Stand back!</span>")
+		used = TRUE
+		sleep(50)
+		/*var/turf/deploy_location = get_turf(src)
+		var/status = template.check_deploy(deploy_location)
+		switch(status)
+			if(SHELTER_DEPLOY_BAD_AREA)
+				src.loc.visible_message("<span class='warning'>\The [src] will not function in this area.</span>")
+			if(SHELTER_DEPLOY_BAD_TURFS, SHELTER_DEPLOY_ANCHORED_OBJECTS)
+				var/width = template.width
+				var/height = template.height
+				src.loc.visible_message("<span class='warning'>\The [src] doesn't have room to deploy! You need to clear a [width]x[height] area!</span>")
+
+		if(status != SHELTER_DEPLOY_ALLOWED)
+			used = FALSE
+			return*/
+
+		used = FALSE
+
+		playsound(src, 'sound/effects/phasein.ogg', 100, TRUE)
+
+		if(!is_mining_level(deploy_location.z) && !isspaceturf(deploy_location)) //only report capsules away from the mining/lavaland level or not in space 
+			message_admins("[ADMIN_LOOKUPFLW(usr)] activated a bluespace shuttle capsule away from the mining level, and not in space! [ADMIN_VERBOSEJMP(deploy_location)]")
+			log_admin("[key_name(usr)] activated a bluespace shuttle capsule away from the mining level, or space, at [AREACOORD(deploy_location)]")
+		//Area saving docking_port
+		var/obj/docking_port/stationary/dock_port = new(deploy_location)
+		dock_port.unregister()
+		dock_port.delete_after = TRUE
+		template.load(deploy_location, centered = TRUE)
+		var/obj/docking_port/mobile/shuttle_port = SSshuttle.get_containing_shuttle(deploy_location)
+		dock_port.forceMove(shuttle_port.loc)
+		new /obj/effect/particle_effect/smoke(get_turf(src))
+		qdel(src)

--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -1,10 +1,6 @@
 /datum/map_template/shelter
 	var/shelter_id
 	var/description
-	var/blacklisted_turfs
-	var/whitelisted_turfs
-	var/banned_areas
-	var/banned_objects
 
 /datum/map_template/shelter/New()
 	. = ..()
@@ -12,23 +8,6 @@
 	whitelisted_turfs = list()
 	banned_areas = typecacheof(/area/shuttle)
 	banned_objects = list()
-
-/datum/map_template/shelter/proc/check_deploy(turf/deploy_location)
-	var/affected = get_affected_turfs(deploy_location, centered=TRUE)
-	for(var/turf/T in affected)
-		var/area/A = get_area(T)
-		if(is_type_in_typecache(A, banned_areas))
-			return SHELTER_DEPLOY_BAD_AREA
-
-		var/banned = is_type_in_typecache(T, blacklisted_turfs)
-		var/permitted = is_type_in_typecache(T, whitelisted_turfs)
-		if(banned && !permitted)
-			return SHELTER_DEPLOY_BAD_TURFS
-
-		for(var/obj/O in T)
-			if((O.density && O.anchored) || is_type_in_typecache(O, banned_objects))
-				return SHELTER_DEPLOY_ANCHORED_OBJECTS
-	return SHELTER_DEPLOY_ALLOWED
 
 /datum/map_template/shelter/alpha
 	name = "Shelter Alpha"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2159,6 +2159,7 @@
 #include "code\modules\mining\abandoned_crates.dm"
 #include "code\modules\mining\aux_base.dm"
 #include "code\modules\mining\aux_base_camera.dm"
+#include "code\modules\mining\constructed_shuttles.dm"
 #include "code\modules\mining\fulton.dm"
 #include "code\modules\mining\machine_processing.dm"
 #include "code\modules\mining\machine_redemption.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moved check_deploy to base map_template.

Add shuttlecapsule that can spawn empty mining shuttle shell.
Better implement this after #53993

![image](https://user-images.githubusercontent.com/7734424/94727110-e8126800-0366-11eb-9007-812ad591fb02.png)

Decals disappear until #54082 finished.

This shell has navigation and mining shuttle, console, so you can park shuttle on lavaland or near station. 
But shell don't has air from start.

Unpack restrictions same as for shelter capsules.

To prevent traffic jams this shuttle can fly only to self designed custom docking port.

I am so lazy to calculate and set the correct offsets for the shuttle docker console that I did #54274

## Why It's Good For The Game

More things to engineers to do.
Now, when your mining shuttle harassed by ashdrake or bubelgum, you can order new mining shuttle.

## Changelog
:cl:
add: Mining shuttlecapsule.  Now, when your mining shuttle harassed by ashdrake or bubelgum, you can order new mining shuttle.
/:cl:

