### PR TITLE
Minor Pubby Map Fixes

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -27069,6 +27069,7 @@
 	name = "Recovery Ward";
 	req_access_txt = "5"
 	},
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bvi" = (
@@ -27573,19 +27574,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bwv" = (
-/obj/structure/table,
-/obj/item/storage/box/rxglasses,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/item/storage/box/syringes{
-	pixel_y = 2
-	},
-/obj/item/gun/syringe,
-/obj/item/gun/syringe,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bwx" = (
@@ -28174,16 +28169,19 @@
 	},
 /area/maintenance/department/engine)
 "byd" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/table,
+/obj/item/storage/box/rxglasses{
+	pixel_x = 4;
+	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
+	},
+/obj/item/storage/box/syringes,
+/obj/item/gun/syringe,
+/obj/item/gun/syringe,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -29717,12 +29715,12 @@
 "bCn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Lab";
-	req_access_txt = "33"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Pharmacy";
+	req_access_txt = "5; 69"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bCo" = (
@@ -48651,7 +48649,7 @@
 /obj/item/cautery,
 /obj/structure/table/glass,
 /obj/machinery/light{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -48660,9 +48658,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "hKm" = (
@@ -48685,6 +48680,15 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/item/stack/medical/bone_gel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = 28
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "hMa" = (
@@ -51921,7 +51925,7 @@
 /obj/item/cautery,
 /obj/structure/table/glass,
 /obj/machinery/light{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -7860,6 +7860,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/gateway)
 "aug" = (
@@ -8287,6 +8288,7 @@
 /obj/machinery/navbeacon/wayfinding/gateway,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/gateway)
 "avb" = (
@@ -9667,6 +9669,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/stairs,
 /area/hallway/primary/central)
 "ayi" = (
@@ -10138,6 +10141,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "azr" = (
@@ -14724,6 +14728,10 @@
 	},
 /obj/structure/filingcabinet/security,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aMm" = (
@@ -22540,7 +22548,7 @@
 	req_access_txt = "29"
 	},
 /obj/machinery/camera{
-	c_tag = "Mech Bay";
+	c_tag = "Robotics Mech Bay";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26658,11 +26666,10 @@
 "btW" = (
 /obj/machinery/camera{
 	c_tag = "Cryogenics";
-	dir = 10;
+	dir = 1;
 	network = list("ss13","medbay")
 	},
 /obj/structure/table/glass,
-/obj/machinery/light/small,
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "btY" = (
@@ -26764,6 +26771,10 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -31520,7 +31531,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bGO" = (
-/mob/living/carbon/monkey,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
@@ -45249,6 +45259,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/recycler,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cMJ" = (
@@ -47279,6 +47290,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"fMe" = (
+/obj/structure/cable,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "fMi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48250,10 +48269,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "hae" = (
-/obj/machinery/camera{
-	c_tag = "Holodeck Control";
-	name = "holodeck camera"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -48568,7 +48583,7 @@
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxiliary Base Construction";
-	req_one_access_txt = "72"
+	req_one_access_txt = "32;47;48"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -50540,6 +50555,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"kAo" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "atmospherics security door"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "kBu" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -52935,7 +52963,7 @@
 	layer = 2.9
 	},
 /obj/machinery/camera{
-	c_tag = "Xenobiology Slime Pen #3";
+	c_tag = "Xenobiology Slime Pen #5";
 	network = list("ss13","rd")
 	},
 /turf/open/floor/engine,
@@ -53208,7 +53236,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -53495,21 +53522,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
-"oFr" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbage"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/recycler,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "oFI" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/blood/old,
@@ -56281,6 +56293,10 @@
 	dir = 1;
 	light_color = "#c1caff"
 	},
+/obj/machinery/camera{
+	c_tag = "Holodeck Control";
+	name = "holodeck camera"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "sHH" = (
@@ -56759,7 +56775,7 @@
 	id = "aux_base_shutters";
 	name = "Public Shutters Control";
 	pixel_x = -26;
-	req_one_access_txt = "72"
+	req_one_access_txt = "32;47;48"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow,
@@ -58104,6 +58120,7 @@
 	dir = 1;
 	pixel_y = -26
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "uZJ" = (
@@ -94625,7 +94642,7 @@ bSP
 pps
 bUo
 bVc
-bUo
+kAo
 bTE
 bXk
 bTE
@@ -99198,7 +99215,7 @@ lAs
 lAs
 lAs
 aRl
-aVp
+fMe
 xau
 aVp
 aVv
@@ -111034,7 +111051,7 @@ aaa
 aaa
 aaa
 bbP
-oFr
+xbX
 eTw
 gBw
 hEc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR contains a large number of fixes for minor issues I found while working on Pubby's medbay. EOBGames requested that I put these in a seperate PR. This primarily addresses missing or misplaced bits of wire and piping, as well as number of floating and misnamed cameras. This also gets rid of a rogue monkey that map merge seems to have dumped in the middle of medbay.

Fixes #53668, by adding what should be the last two needed fire alarms to cargo
Fixes #53667, by moving the recycler in front of the stacker

## Why It's Good For The Game

Makes the map debugging tools happy. Air can get to the gateway again. Less space pollution.

## Changelog
:cl:
fix: The unattended monkey has been removed from Pubby's Medbay
fix: Pubby's disposals no longer jettisons recycled material into space
fix: Minor issues in Pubby's pipe, power and camera networks have been corrected
/:cl: