### PR TITLE
Fixes being able to bypass locks by breaking the container with lava, guns, or brute force.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -231,10 +231,13 @@
 		new material_drop(loc, material_drop_amount)
 	qdel(src)
 
+/obj/structure/closet/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", sound_effect = TRUE, attack_dir, armour_penetration = 0)
+	for(var/obj/O in src)
+		O.take_damage(damage_amount, damage_type, damage_flag, sound_effect = FALSE, attack_dir, armour_penetration)
+	..()
+	
 /obj/structure/closet/obj_break(damage_flag)
 	if(!broken && !(flags_1 & NODECONSTRUCT_1))
-		for(var/obj/O in src)
-			qdel(O)
 		bust_open()
 
 /obj/structure/closet/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -233,6 +233,8 @@
 
 /obj/structure/closet/obj_break(damage_flag)
 	if(!broken && !(flags_1 & NODECONSTRUCT_1))
+		for(var/obj/O in src)
+			qdel(O)
 		bust_open()
 
 /obj/structure/closet/attackby(obj/item/W, mob/user, params)


### PR DESCRIPTION
This is an extremely old bug I'm surprised nobody fixed.
![tumblr_ot46p81g3s1urjvsco1_500](https://user-images.githubusercontent.com/4081722/94803452-29723a00-039e-11eb-9ac6-d4c1d976a64f.png)

## About The Pull Request

See title.

## Why It's Good For The Game
Fixes #23473 

## Changelog
:cl:
fix: Fixes being able to bypass crate locks with brute force, lava, or guns.
/:cl:
