### PR TITLE
Fix loading templates in new z-levels being off by one turf.

### DIFF
--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -79,8 +79,8 @@
 		affected_turf.levelupdate()
 
 /datum/map_template/proc/load_new_z()
-	var/x = round((world.maxx - width)/2) + 1
-	var/y = round((world.maxy - height)/2) + 1
+	var/x = round((world.maxx - width) * 0.5) + 1
+	var/y = round((world.maxy - height) * 0.5) + 1
 
 	var/datum/space_level/level = SSmapping.add_new_zlevel(name, list(ZTRAIT_AWAY = TRUE))
 	var/datum/parsed_map/parsed = load_map(file(mappath), x, y, level.z_value, no_changeturf=(SSatoms.initialized == INITIALIZATION_INSSATOMS), placeOnTop=TRUE)

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -79,8 +79,8 @@
 		affected_turf.levelupdate()
 
 /datum/map_template/proc/load_new_z()
-	var/x = round((world.maxx - width)/2)
-	var/y = round((world.maxy - height)/2)
+	var/x = round((world.maxx - width)/2) + 1
+	var/y = round((world.maxy - height)/2) + 1
 
 	var/datum/space_level/level = SSmapping.add_new_zlevel(name, list(ZTRAIT_AWAY = TRUE))
 	var/datum/parsed_map/parsed = load_map(file(mappath), x, y, level.z_value, no_changeturf=(SSatoms.initialized == INITIALIZATION_INSSATOMS), placeOnTop=TRUE)


### PR DESCRIPTION
## About The Pull Request

Fixes loading templates on new z-levels being off by one turf.
Due to how byond maps start at 1,1 and not 0,0 when loading a map that is the same size as the world the map will start loading at 0,0 in the world which is outside the map.
load_map defaults the x and y offsets to 1 for a reason!

Though you can load a map that is larger (257 x 257) than the world as a band aid for issue.

## Why It's Good For The Game
Fixes a bug.

## Changelog
:cl:
fix: fixed loading map templates on new z-levels causing them to be off by one turf in the x/y axes.
/:cl:
