### PR TITLE
Adds Uncle Pete's Rollerdome, a replacement for Disco Inferno

### DIFF
--- a/_maps/shuttles/emergency_rollerdome.dmm
+++ b/_maps/shuttles/emergency_rollerdome.dmm
@@ -35,6 +35,12 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/escape)
+"hD" = (
+/obj/machinery/door/airlock/gold/glass{
+	req_access_txt = "19"
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
 "hF" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/escape)
@@ -459,7 +465,7 @@ wf
 wn
 Ky
 Ky
-QO
+hD
 Cg
 Cg
 ZN

--- a/_maps/shuttles/emergency_rollerdome.dmm
+++ b/_maps/shuttles/emergency_rollerdome.dmm
@@ -1,0 +1,576 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"cc" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"ce" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"cP" = (
+/obj/effect/spawner/randomarcade,
+/turf/open/floor/eighties,
+/area/shuttle/escape)
+"dJ" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"eR" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"fX" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"hF" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/escape)
+"im" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"ln" = (
+/obj/machinery/vending/games,
+/turf/open/floor/eighties,
+/area/shuttle/escape)
+"ns" = (
+/obj/structure/table/wood/bar,
+/obj/effect/fun_balloon/sentience/emergency_shuttle{
+	group_name = "snack bar drone at Uncle Pete's Rollerdome"
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"nw" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"nN" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"nT" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"od" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"pa" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"pj" = (
+/turf/template_noop,
+/area/template_noop)
+"pI" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"qU" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"ss" = (
+/obj/docking_port/mobile/emergency{
+	name = "Uncle Pete's Rollerdome"
+	},
+/obj/machinery/door/airlock/gold/glass,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"tG" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"uN" = (
+/obj/structure/table/wood/bar,
+/obj/item/storage/bag/tray,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"vq" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"wf" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/shuttle/escape)
+"wn" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"xK" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"ze" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"zs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"zt" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/lighter{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"zx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"zZ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"AT" = (
+/obj/structure/etherealball,
+/turf/open/floor/light,
+/area/shuttle/escape)
+"Cg" = (
+/turf/open/floor/eighties,
+/area/shuttle/escape)
+"Dh" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"DR" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Hi" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"HA" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"HS" = (
+/turf/open/floor/light,
+/area/shuttle/escape)
+"Jq" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"JR" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Ky" = (
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"KJ" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"Ow" = (
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Ox" = (
+/obj/structure/table/wood/bar,
+/obj/item/pizzabox/meat,
+/obj/item/pizzabox/meat,
+/obj/item/pizzabox/meat,
+/obj/item/pizzabox/mushroom,
+/obj/item/pizzabox/margherita,
+/obj/item/pizzabox/pineapple,
+/obj/item/pizzabox/vegetable,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"OG" = (
+/obj/machinery/computer/communications{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"ON" = (
+/obj/machinery/vending/donksofttoyvendor,
+/turf/open/floor/eighties,
+/area/shuttle/escape)
+"Qf" = (
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Qv" = (
+/mob/living/simple_animal/drone/snowflake/bardrone,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"QO" = (
+/obj/machinery/door/airlock/gold/glass,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Ry" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/railing,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"RN" = (
+/obj/machinery/jukebox/disco/indestructible,
+/turf/open/floor/light,
+/area/shuttle/escape)
+"TU" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"We" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Wg" = (
+/obj/structure/table/wood/bar,
+/obj/item/storage/bag/tray,
+/obj/item/food/cake/birthday,
+/obj/item/kitchen/knife,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Yr" = (
+/obj/structure/table/wood/poker,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Zo" = (
+/obj/structure/table/wood/bar,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"ZN" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+pj
+pj
+pj
+pj
+tG
+tG
+tG
+wf
+tG
+ss
+tG
+wf
+wf
+wf
+tG
+hF
+tG
+QO
+tG
+wf
+tG
+pj
+"}
+(2,1,1) = {"
+pj
+tG
+tG
+tG
+hF
+AT
+Cg
+Cg
+Cg
+Cg
+Cg
+Cg
+Cg
+Cg
+Cg
+AT
+ce
+Ky
+pI
+Ky
+tG
+tG
+"}
+(3,1,1) = {"
+tG
+tG
+nT
+Qf
+zx
+ln
+Cg
+vq
+zZ
+zZ
+zZ
+zZ
+zZ
+TU
+Cg
+Cg
+ce
+uN
+Ox
+Wg
+KJ
+od
+"}
+(4,1,1) = {"
+wf
+Hi
+We
+We
+zx
+cP
+Cg
+cc
+pa
+Ky
+Ky
+Ky
+pa
+ze
+Cg
+Cg
+ce
+Zo
+Ky
+eR
+KJ
+od
+"}
+(5,1,1) = {"
+wf
+wn
+Ky
+Ky
+zx
+cP
+Cg
+ZN
+pa
+HS
+HS
+HS
+pa
+Ry
+Cg
+Cg
+ce
+uN
+Ky
+fX
+KJ
+od
+"}
+(6,1,1) = {"
+wf
+im
+Ky
+Yr
+zx
+cP
+Cg
+ce
+pa
+HS
+RN
+HS
+pa
+dJ
+Cg
+Cg
+ce
+ns
+Qv
+JR
+KJ
+od
+"}
+(7,1,1) = {"
+wf
+wn
+Ky
+Ky
+QO
+Cg
+Cg
+ZN
+pa
+HS
+HS
+HS
+pa
+Ry
+Cg
+Cg
+ce
+Zo
+Ky
+nw
+KJ
+od
+"}
+(8,1,1) = {"
+wf
+zt
+xK
+xK
+zx
+ON
+Cg
+cc
+pa
+Ky
+Ky
+Ky
+pa
+ze
+Cg
+Cg
+ce
+uN
+Ky
+Ow
+KJ
+od
+"}
+(9,1,1) = {"
+tG
+tG
+Jq
+OG
+zx
+ln
+Cg
+nN
+zs
+zs
+zs
+zs
+zs
+DR
+Cg
+Cg
+ce
+Zo
+Dh
+HA
+KJ
+od
+"}
+(10,1,1) = {"
+pj
+tG
+tG
+tG
+hF
+AT
+Cg
+Cg
+Cg
+Cg
+Cg
+Cg
+Cg
+Cg
+Cg
+AT
+ce
+Ky
+qU
+Ky
+tG
+tG
+"}
+(11,1,1) = {"
+pj
+pj
+pj
+pj
+tG
+tG
+tG
+wf
+tG
+tG
+tG
+wf
+wf
+wf
+tG
+tG
+tG
+wf
+tG
+wf
+tG
+pj
+"}

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -372,6 +372,14 @@
 	description = "The Nanotrasen Emergency Shuttle Port(NES Port for short) is a shuttle used at other less known Nanotrasen facilities and has a more open inside for larger crowds, but fewer onboard shuttle facilities."
 	credit_cost = 500
 
+/datum/map_template/shuttle/emergency/rollerdome
+	suffix = "rollerdome"
+	name = "Uncle Pete's Rollerdome"
+	description = "Developed by a member of Nanotrasen's R&D crew that claims to have travelled from the year 2028. \
+	He says this shuttle is based off an old entertainment complex from the 1990s, though our database has no records on anything pertaining to that decade."
+	admin_notes = "ONLY NINETIES KIDS REMEMBER. Uses the fun balloon and drone from the Emergency Bar."
+	credit_cost = 2500
+
 /datum/map_template/shuttle/emergency/wabbajack
 	suffix = "wabbajack"
 	name = "NT Lepton Violet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There were a few folks who mentioned that they wanted to keep Disco Inferno for the dance stuff, not the fire hell stuff. I made it themed off of a 90s roller rink for giggles. Here's a version of Disco Inferno without the inferno.

![image](https://user-images.githubusercontent.com/7019927/94912445-46297300-046d-11eb-9eb5-9962239615c2.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's fun and people seem to like it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: A new dance-themed emergency shuttle has been added to the rotation. Buy it today!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
