### PR TITLE
Lowers default instrument volume

### DIFF
--- a/code/modules/instruments/songs/_song.dm
+++ b/code/modules/instruments/songs/_song.dm
@@ -38,7 +38,7 @@
 	var/max_repeats = 10
 
 	/// Our volume
-	var/volume = 75
+	var/volume = 35
 	/// Max volume
 	var/max_volume = 75
 	/// Min volume - This is so someone doesn't decide it's funny to set it to 0 and play invisible songs.


### PR DESCRIPTION
Instruments are really loud, louder than any other sound in the game and I don't think many people realize you can change their volume. This sets their default volume to a saner level, it can still be increased manually to higher values if desired

## Changelog
:cl:
tweak: lowered default volume for musical instruments
/:cl: