### PR TITLE
Round end report cleanup

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -476,14 +476,14 @@
 		station_vault += current_acc.account_balance
 		if(!mr_moneybags || mr_moneybags.account_balance < current_acc.account_balance)
 			mr_moneybags = current_acc
-	parts += "<div class='panel stationborder'>There were [station_vault] credits collected by crew this shift.</div>"
+	parts += "<div class='panel stationborder'>There were [station_vault] credits collected by crew this shift.<br>"
 	if(total_players > 0)
-		parts += "<div class='panel stationborder'>An average of [station_vault/total_players] credits were collected.</div>"
+		parts += "An average of [station_vault/total_players] credits were collected.<br>"
 		log_econ("Roundend credit total: [station_vault] credits. Average Credits: [station_vault/total_players]")
 	if(mr_moneybags)
-		parts += "<div class='panel clockborder'>The most affulent crew member at shift end was <b>[mr_moneybags.account_holder] with [mr_moneybags.account_balance]</b> cr!</div>"
+		parts += "The most affulent crew member at shift end was <b>[mr_moneybags.account_holder] with [mr_moneybags.account_balance]</b> cr!</div>"
 	else
-		parts += "div class = panel redborder'>Somehow, nobody made any money this shift! This'll result in some budget cuts...</div>"
+		parts += "Somehow, nobody made any money this shift! This'll result in some budget cuts...</div>"
 	return parts
 
 /datum/controller/subsystem/ticker/proc/medal_report()
@@ -498,8 +498,7 @@
 ///Generate a report for all players who made it out alive with a hardcore random character and prints their final score
 /datum/controller/subsystem/ticker/proc/hardcore_random_report()
 	. = list()
-	. += "<span class='header'>The following people made it out as a random hardcore character:</span>"
-	. += "<ul class='playerlist'>"
+	var/list/hardcores = list()
 	for(var/i in GLOB.player_list)
 		if(!ishuman(i))
 			continue
@@ -508,8 +507,14 @@
 			continue
 		if(!human_player.mind)
 			continue
+		hardcores += human_player
+	if(!length(hardcores))
+		return
+	. += "<div class='panel stationborder'><span class='header'>The following people made it out as a random hardcore character:</span>"
+	. += "<ul class='playerlist'>"
+	for(var/mob/living/carbon/human/human_player in hardcores)
 		. += "<li>[printplayer(human_player.mind)] with a hardcore random score of [round(human_player.hardcore_survival_score)]</li>"
-	. += "</ul>"
+	. += "</ul></div>"
 
 /datum/controller/subsystem/ticker/proc/antag_report()
 	var/list/result = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Only prints the hardcore random section if there were hardcore random characters in the round.
Limits the economic report to a single panel instead of four.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl: Skoglol
tweak: Cleaned up roundend report somewhat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
