### PR TITLE
Fix issue with shuttle floors changing icon on land.

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -76,11 +76,21 @@ All ShuttleMove procs go here
 	var/shuttle_boundary = baseturfs.Find(/turf/baseturf_skipover/shuttle)
 	if(shuttle_boundary)
 		oldT.ScrapeAway(baseturfs.len - shuttle_boundary + 1)
+		if (isfloorturf(oldT))
+			var/turf/open/floor/oldFloor = oldT
+			oldFloor.icon_regular_floor = initial(oldFloor.icon_regular_floor)
 
 	if(rotation)
 		shuttleRotate(rotation) //see shuttle_rotate.dm
 
 	return TRUE
+
+/turf/open/floor/afterShuttleMove(turf/oldT, rotation)
+	if (isfloorturf(oldT))
+		var/turf/open/floor/floorTurf = oldT
+		icon_regular_floor = floorTurf.icon_regular_floor
+		update_icon()
+	return ..()
 
 /turf/proc/lateShuttleMove(turf/oldT)
 	blocks_air = initial(blocks_air)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -77,18 +77,18 @@ All ShuttleMove procs go here
 	if(shuttle_boundary)
 		oldT.ScrapeAway(baseturfs.len - shuttle_boundary + 1)
 		if (isfloorturf(oldT))
-			var/turf/open/floor/oldFloor = oldT
-			oldFloor.icon_regular_floor = initial(oldFloor.icon_regular_floor)
+			var/turf/open/floor/old_floor = oldT
+			old_floor.icon_regular_floor = initial(old_floor.icon_regular_floor)
 
 	if(rotation)
 		shuttleRotate(rotation) //see shuttle_rotate.dm
 
 	return TRUE
 
-/turf/open/floor/afterShuttleMove(turf/oldT, rotation)
-	if (isfloorturf(oldT))
-		var/turf/open/floor/floorTurf = oldT
-		icon_regular_floor = floorTurf.icon_regular_floor
+/turf/open/floor/afterShuttleMove(turf/old_turf, rotation)
+	if (isfloorturf(old_turf))
+		var/turf/open/floor/old_floor = old_turf
+		icon_regular_floor = old_floor.icon_regular_floor
 		update_icon()
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Fix #53134
Issue in `icon_regular_floor` var. It used to keep icon_state on floor damaging or crowbaring. 
And `copyTurf()` don't override `icon_regular_floor`. maybe it way, make it to override.
Another way, maybe best, make icon saved only in cases where we need it save, e.g. in `make_plating()`

I think this not best way to fix this issue but i cant find other way now.

Tested with #54082
![image](https://user-images.githubusercontent.com/7734424/94967489-d9af8200-0507-11eb-93a1-ad089796cae5.png)


## Why It's Good For The Game

Bugs is bad.

## Changelog
:cl:
fix: Shuttle floors no more unintentionally changes color when shuttle landing on something.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
