### PR TITLE
Fixes a rare interaction between mice by assigning a proper subtype.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -263,7 +263,7 @@
 				stop_automated_movement = 1
 				walk_to(src,movement_target,0,3)
 
-/mob/living/simple_animal/pet/cat/jerry //Holy shit we left jerry on pubby ~ Arcane
+/mob/living/simple_animal/pet/cat/jerry //Holy shit we left jerry on donut ~ Arcane ~Fikou
 	name = "Jerry"
 	desc = "Tom is VERY amused."
 	inept_hunter = TRUE

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -34,6 +34,8 @@
 	var/mob/living/simple_animal/mouse/movement_target
 	///Limits how often cats can spam chasing mice.
 	var/emote_cooldown = 0
+	///Can this cat catch special mice?
+	var/inept_hunter = FALSE
 	gold_core_spawnable = FRIENDLY_SPAWN
 	collar_type = "cat"
 	can_be_held = TRUE
@@ -221,7 +223,7 @@
 	if((src.loc) && isturf(src.loc))
 		if(!stat && !resting && !buckled)
 			for(var/mob/living/simple_animal/mouse/M in view(1,src))
-				if(istype(M, /mob/living/simple_animal/mouse/brown/tom) && (name == "Jerry")) //Turns out there's no jerry subtype.
+				if(istype(M, /mob/living/simple_animal/mouse/brown/tom) && inept_hunter) //We have a jerry subtype now.
 					if (emote_cooldown < (world.time - 600))
 						visible_message("<span class='warning'>[src] chases [M] around, to no avail!</span>")
 						step(M, pick(GLOB.cardinals))
@@ -260,6 +262,11 @@
 			if(movement_target)
 				stop_automated_movement = 1
 				walk_to(src,movement_target,0,3)
+
+/mob/living/simple_animal/pet/cat/jerry //Holy shit we left jerry on pubby ~ Arcane
+	name = "Jerry"
+	desc = "Tom is VERY amused."
+	inept_hunter = TRUE
 
 /mob/living/simple_animal/pet/cat/cak //I told you I'd do it, Remie
 	name = "Keeki"

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -223,7 +223,7 @@
 	if((src.loc) && isturf(src.loc))
 		if(!stat && !resting && !buckled)
 			for(var/mob/living/simple_animal/mouse/M in view(1,src))
-				if(istype(M, /mob/living/simple_animal/mouse/brown/tom) && inept_hunter) //We have a jerry subtype now.
+				if(istype(M, /mob/living/simple_animal/mouse/brown/tom) && inept_hunter)
 					if (emote_cooldown < (world.time - 600))
 						visible_message("<span class='warning'>[src] chases [M] around, to no avail!</span>")
 						step(M, pick(GLOB.cardinals))


### PR DESCRIPTION
...Oh fuck, we left Jerry on donut.

## About The Pull Request

Cats named Jerry can't catch mice named Tom. This is known. However, there was only one distinct instance of jerry, and that was on DonutStation in the permabrig. ...And we don't have donutstation in the rotation anymore, so this interaction was pretty rare and now basically impossible to pull off.

This PR finally makes Jerry his own subtype, and throws the ability to catch mice onto an `inept_hunter` var, so it can be varedited or adjusted in the future.

## Why It's Good For The Game

Effectively a tiny code clean up on a meme feature that might see some use now that it's now literally the most obscure ever.

## Changelog
:cl:
add: Jerry the cat is now his own subtype, and cannot catch Tom the Mouse.
/:cl: