### PR TITLE
Adds basic game logging to Protolathe-variant construction and deconstruction

### DIFF
--- a/code/modules/research/machinery/protolathe.dm
+++ b/code/modules/research/machinery/protolathe.dm
@@ -19,3 +19,14 @@
 								)
 	production_animation = "protolathe_n"
 	allowed_buildtypes = PROTOLATHE
+
+/obj/machinery/rnd/production/protolathe/deconstruct(disassembled)
+	log_game("Protolathe of type [type] [disassembled ? "disassembled" : "deconstructed"] by [key_name(usr)] at [get_area_name(src, TRUE)]")
+
+	return ..()
+
+/obj/machinery/rnd/production/protolathe/Initialize(mapload)
+	if(!mapload)
+		log_game("Protolathe of type [type] constructed by [key_name(usr)] at [get_area_name(src, TRUE)]")
+
+	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds basic logging to Protolathe-variant construction and deconstruction, indicating ckeys, areas deconstructed and areas constructed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I'm gathering data on protolathe and departmental lathe construction and deconstruction in general. I want to see which protolathes are unbuilt, rebuilt, built in general and where they're built.

I also want to look closely at what is happening with ghost ruins and their protolathes, and how often they're getting deconstructed and where they're being rebuilt.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
