### PR TITLE
Eldritch Telepathy now has the same range as the raw prophet's other spells

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -423,6 +423,7 @@
 	invocation = ""
 	invocation_type = INVOCATION_WHISPER
 	clothes_req = FALSE
+	range = 10
 	action_background_icon_state = "bg_ecult"
 
 /obj/effect/proc_holder/spell/targeted/fire_sworn


### PR DESCRIPTION
## About The Pull Request

Eldritch Telepathy's range has been increased from 7 tiles to 10 tiles.

## Why It's Good For The Game

This was probably just an oversight. Currently, raw prophets can see 10 tiles away, blind people from 10 tiles away, and even link people into their special slime-like telepathy link thing from 10 tiles away, but can only send telepathic messages to specific people who are 7 tiles away.

## Changelog
:cl: ATHATH
balance: The raw prophet's Eldritch Telepathy spell's range has been increased from 7 tiles to 10 tiles, to match the ranges of the raw prophet's other spells.
/:cl: