### PR TITLE
[Ready] Changelings can no longer readapt while in stasis

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -207,6 +207,9 @@
 	if(!ishuman(owner.current))
 		to_chat(owner.current, "<span class='warning'>We can't remove our evolutions in this form!</span>")
 		return
+	if(HAS_TRAIT_FROM(owner.current, TRAIT_DEATHCOMA, CHANGELING_TRAIT))
+		to_chat(owner.current, "<span class='warning'>We are too busy reforming ourselves to readapt right now!</span>")
+		return
 	if(canrespec)
 		to_chat(owner.current, "<span class='notice'>We have removed our evolutions from this form, and are now ready to readapt.</span>")
 		reset_powers()


### PR DESCRIPTION
Atomizing #53986

* Fixes: #53191

## Changelog
:cl: Ryll/Shaps
fix: As a changeling, you can no longer readapt your mutations while in fakedeath stasis, which would cause you to stay in sleepies forever
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
