### PR TITLE
Fixes the supply console not inheriting contraband and emag status from its circuit

### DIFF
--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -40,6 +40,15 @@
 
 	return
 
+/**
+  * Used to allow the circuitboard to configure a machine in some way, shape or form.
+  *
+  * Arguments:
+  * * machine - The machine to attempt to configure.
+  */
+/obj/item/circuitboard/proc/configure_machine(obj/machinery/machine)
+	return
+
 // Circuitboard/machine
 /*Common Parts: Parts List: Ignitor, Timer, Infra-red laser, Infra-red sensor, t_scanner, Capacitor, Valve, sensor unit,
 micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -502,14 +502,13 @@
 
 /obj/item/circuitboard/computer/cargo/configure_machine(obj/machinery/computer/cargo/machine)
 	if(!istype(machine))
-		CRASH("Cargo board attempted to configure incorrect machine type: [machine] ([machine.type])")
+		CRASH("Cargo board attempted to configure incorrect machine type: [machine] ([machine?.type])")
 
 	machine.contraband = contraband
 	if (obj_flags & EMAGGED)
 		machine.obj_flags |= EMAGGED
 	else
 		machine.obj_flags &= ~EMAGGED
-	return
 
 /obj/item/circuitboard/computer/cargo/express
 	name = "Express Supply Console (Computer Board)"

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -500,6 +500,17 @@
 		obj_flags |= EMAGGED
 		to_chat(user, "<span class='notice'>You adjust [src]'s routing and receiver spectrum, unlocking special supplies and contraband.</span>")
 
+/obj/item/circuitboard/computer/cargo/configure_machine(obj/machinery/computer/cargo/machine)
+	if(!istype(machine))
+		CRASH("Cargo board attempted to configure incorrect machine type: [machine] ([machine.type])")
+
+	machine.contraband = contraband
+	if (obj_flags & EMAGGED)
+		machine.obj_flags |= EMAGGED
+	else
+		machine.obj_flags &= ~EMAGGED
+	return
+
 /obj/item/circuitboard/computer/cargo/express
 	name = "Express Supply Console (Computer Board)"
 	build_path = /obj/machinery/computer/cargo/express

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -29,12 +29,6 @@
 /obj/machinery/computer/cargo/Initialize()
 	. = ..()
 	radio = new /obj/item/radio/headset/headset_cargo(src)
-	var/obj/item/circuitboard/computer/cargo/board = circuit
-	contraband = board.contraband
-	if (board.obj_flags & EMAGGED)
-		obj_flags |= EMAGGED
-	else
-		obj_flags &= ~EMAGGED
 
 /obj/machinery/computer/cargo/Destroy()
 	QDEL_NULL(radio)
@@ -62,6 +56,10 @@
 	board.contraband = TRUE
 	board.obj_flags |= EMAGGED
 	update_static_data(user)
+
+/obj/machinery/computer/cargo/on_construction()
+	. = ..()
+	circuit.configure_machine(src)
 
 /obj/machinery/computer/cargo/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #54111

Added an abstract proc for circuits intended to be used to allow a circuit to configure a machine.

Overrode this proc for supply console boards (behaviour inherited by express boards)

Call this proc in supply console on_construction (behaviour inherited by express supply consoles)

Allows all supply consoles to inherit their circuit's emag and contraband status.

Doesn't look like any other circuits use this sort of functionality, but if they do I'll fix 'em up too.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex oversight.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Supply Consoles and Express Supply Consoles will once again be built pre-emagged if their boards used to build them are emagged.
fix: Supply Consoles will now once again allow Cargonia to buy contraband when their circuit boards are appropriately configured with a multitool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
