### PR TITLE
Fixes a map board that was oriented the wrong way

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -130,7 +130,7 @@
 	dir = 8
 	},
 /obj/machinery/bounty_board{
-	dir = 8;
+	dir = 4;
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel,

--- a/code/game/machinery/bounty_board.dm
+++ b/code/game/machinery/bounty_board.dm
@@ -6,7 +6,7 @@ GLOBAL_LIST_EMPTY(request_list)
   */
 /obj/machinery/bounty_board
 	name = "bounty board"
-	desc = "Alows you to place requests for goods and services across the station, as well as pay those who actually did it."
+	desc = "Allows you to place requests for goods and services across the station, as well as pay those who actually did it."
 	icon = 'icons/obj/terminals.dmi'
 	icon_state = "request_kiosk"
 	light_color = LIGHT_COLOR_GREEN


### PR DESCRIPTION
## About The Pull Request
Twists and turns are nice in a maze, but not on boards. And Allows is spelled with TWO L's

## Changelog
:cl:
fix: fixed the direction of that board
spellcheck: added another L.
/:cl: