### PR TITLE
Cleans up rat related features and makes Regal Ratking a rare spawn from mouse migration event.

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -125,6 +125,10 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 
 #define ishostile(A) (istype(A, /mob/living/simple_animal/hostile))
 
+#define israt(A) (istype(A, /mob/living/simple_animal/hostile/rat))
+
+#define isregalrat(A) (istype(A, /mob/living/simple_animal/hostile/regalrat))
+
 #define isswarmer(A) (istype(A, /mob/living/simple_animal/hostile/swarmer))
 
 #define isguardian(A) (istype(A, /mob/living/simple_animal/hostile/guardian))

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -1,3 +1,5 @@
+#define PROB_MOUSE_SPAWN 98
+
 SUBSYSTEM_DEF(minor_mapping)
 	name = "Minor Mapping"
 	init_order = INIT_ORDER_MINOR_MAPPING
@@ -16,7 +18,7 @@ SUBSYSTEM_DEF(minor_mapping)
 
 	while((num_mice > 0) && exposed_wires.len)
 		proposed_turf = pick_n_take(exposed_wires)
-		if(prob(98))
+		if(prob(PROB_MOUSE_SPAWN))
 			if(!M)
 				M = new(proposed_turf)
 			else

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(minor_mapping)
 
 	while((num_mice > 0) && exposed_wires.len)
 		proposed_turf = pick_n_take(exposed_wires)
-		if(prob(95))
+		if(prob(98))
 			if(!M)
 				M = new(proposed_turf)
 			else

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -16,10 +16,13 @@ SUBSYSTEM_DEF(minor_mapping)
 
 	while((num_mice > 0) && exposed_wires.len)
 		proposed_turf = pick_n_take(exposed_wires)
-		if(!M)
-			M = new(proposed_turf)
+		if(prob(95))
+			if(!M)
+				M = new(proposed_turf)
+			else
+				M.forceMove(proposed_turf)
 		else
-			M.forceMove(proposed_turf)
+			var/mob/living/simple_animal/hostile/regalrat/controlled/king = new /mob/living/simple_animal/hostile/regalrat/controlled(proposed_turf)
 		if(M.environment_air_is_safe())
 			num_mice -= 1
 			M = null

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -62,3 +62,5 @@ SUBSYSTEM_DEF(minor_mapping)
 				suitable += t
 
 	return shuffle(suitable)
+
+#undef PROB_MOUSE_SPAWN

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -11,7 +11,7 @@ SUBSYSTEM_DEF(minor_mapping)
 /datum/controller/subsystem/minor_mapping/proc/trigger_migration(num_mice=10)
 	var/list/exposed_wires = find_exposed_wires()
 
-	var/mob/living/simple_animal/mouse/M
+	var/mob/living/simple_animal/M
 	var/turf/proposed_turf
 
 	while((num_mice > 0) && exposed_wires.len)
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(minor_mapping)
 			else
 				M.forceMove(proposed_turf)
 		else
-			var/mob/living/simple_animal/hostile/regalrat/controlled/king = new /mob/living/simple_animal/hostile/regalrat/controlled(proposed_turf)
+			M = new /mob/living/simple_animal/hostile/regalrat/controlled(proposed_turf)
 		if(M.environment_air_is_safe())
 			num_mice -= 1
 			M = null

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -62,6 +62,13 @@
 		var/mob/living/simple_animal/mouse/M = target
 		visible_message("<span class='boldannounce'>SPLAT!</span>")
 		M.splat()
+	else if(israt(target))
+		var/mob/living/simple_animal/hostile/rat/ratt = target
+		visible_message("<span class='boldannounce'>Clink!</span>")
+		ratt.apply_damage(5) //Not lethal, but just enought to make a mark.
+		ratt.Stun(1 SECONDS)
+	else if(isregalrat(target))
+		visible_message("<span class='boldannounce'>Skreeeee!</span>") //He's simply too large to be affected by a tiny mouse trap.
 	playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
 	armed = FALSE
 	update_icon()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -136,7 +136,7 @@
   *Spawns a new regal rat, says some good jazz, and if sentient, transfers the relivant mind.
   */
 /mob/living/simple_animal/mouse/proc/evolve()
-	var/mob/living/simple_animal/hostile/regalrat = new /mob/living/simple_animal/hostile/regalrat(loc)
+	var/mob/living/simple_animal/hostile/regalrat/regalrat = new /mob/living/simple_animal/hostile/regalrat/controlled(loc)
 	visible_message("<span class='warning'>[src] devours the cheese! He morphs into something... greater!</span>")
 	regalrat.say("RISE, MY SUBJECTS! SCREEEEEEE!")
 	if(mind)

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -86,10 +86,17 @@
 		to_chat(src, "<span class='green'>You eat \the [src], restoring some health.</span>")
 		heal_bodypart_damage(10)
 		qdel(target)
+		return
+	if(istype(target, /obj/item/reagent_containers/food/snacks/store/cheesewheel))
+		to_chat(src, "<span class='green'>You eat \the [src], restoring some health.</span>")
+		heal_bodypart_damage(35)
+		qdel(target)
+		return
 	if(istype(target, /obj/item/reagent_containers/food/snacks/royalcheese))
 		to_chat(src, "<span class='green'>You eat \the [src], revitalizing your royal resolve completely.</span>")
 		heal_bodypart_damage(70)
 		qdel(target)
+		return
 
 /mob/living/simple_animal/hostile/regalrat/controlled
 	name = "regal rat"

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -228,7 +228,7 @@
 
 /mob/living/simple_animal/hostile/rat/death(gibbed)
 	if(!ckey)
-		..(1)
+		..(TRUE)
 		if(!gibbed)
 			var/obj/item/reagent_containers/food/snacks/deadmouse/mouse = new(loc)
 			mouse.icon_state = icon_dead

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -1,3 +1,7 @@
+#define MINOR_HEAL 10
+#define MEDIUM_HEAL 35
+#define MAJOR_HEAL 70
+
 /mob/living/simple_animal/hostile/regalrat
 	name = "feral regal rat"
 	desc = "An evolved rat, created through some strange science. It leads nearby rats with deadly efficiency to protect its kingdom. Not technically a king."
@@ -45,6 +49,7 @@
 		var/mob/dead/observer/C = pick(candidates)
 		key = C.key
 		notify_ghosts("All rise for the rat king, ascendant to the throne in \the [get_area(src)].", source = src, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Sentient Rat Created")
+	to_chat(src, "<span class='notice'>You are an independent, invasive force on the station! Horde coins, trash, cheese, and the like from the safety of darkness!</span>")
 
 /mob/living/simple_animal/hostile/regalrat/handle_automated_action()
 	if(prob(20))
@@ -83,18 +88,18 @@
 		to_chat(src, "<span class='warning'>You feel fine, no need to eat anything!</span>")
 		return
 	if(istype(target, /obj/item/reagent_containers/food/snacks/cheesewedge))
-		to_chat(src, "<span class='green'>You eat \the [src], restoring some health.</span>")
-		heal_bodypart_damage(10)
+		to_chat(src, "<span class='green'>You eat [src], restoring some health.</span>")
+		heal_bodypart_damage(MINOR_HEAL)
 		qdel(target)
 		return
 	if(istype(target, /obj/item/reagent_containers/food/snacks/store/cheesewheel))
-		to_chat(src, "<span class='green'>You eat \the [src], restoring some health.</span>")
-		heal_bodypart_damage(35)
+		to_chat(src, "<span class='green'>You eat [src], restoring some health.</span>")
+		heal_bodypart_damage(MEDIUM_HEAL)
 		qdel(target)
 		return
 	if(istype(target, /obj/item/reagent_containers/food/snacks/royalcheese))
-		to_chat(src, "<span class='green'>You eat \the [src], revitalizing your royal resolve completely.</span>")
-		heal_bodypart_damage(70)
+		to_chat(src, "<span class='green'>You eat [src], revitalizing your royal resolve completely.</span>")
+		heal_bodypart_damage(MAJOR_HEAL)
 		qdel(target)
 		return
 
@@ -225,9 +230,9 @@
 	if(!ckey)
 		..(1)
 		if(!gibbed)
-			var/obj/item/reagent_containers/food/snacks/deadmouse/M = new(loc)
-			M.icon_state = icon_dead
-			M.name = name
+			var/obj/item/reagent_containers/food/snacks/deadmouse/mouse = new(loc)
+			mouse.icon_state = icon_dead
+			mouse.name = name
 	SSmobs.cheeserats -= src // remove rats on death
 	return ..()
 
@@ -296,5 +301,9 @@
 			to_chat(src, "<span class='warning'>You feel fine, no need to eat anything!</span>")
 			return
 		to_chat(src, "<span class='green'>You eat \the [src], restoring some health.</span>")
-		heal_bodypart_damage(5)
+		heal_bodypart_damage(MINOR_HEAL)
 		qdel(target)
+
+#undef MINOR_HEAL
+#undef MEDIUM_HEAL
+#undef MAJOR_HEAL


### PR DESCRIPTION
Ratt

## About The Pull Request

This PR consists of several consistency changes for rats and regal rats and how they interact between types.

**Mousetraps:**
This adds interactions between rats and regal rats with mousetraps, dealing damage to rats crossing mousetraps, which would ordinarily kill a mouse.
If a regal rat crosses a mouse trap, he merely laughs it off, as they're far too large for that small of a trap.

**Healing off of cheese:**
A regal rat can now attack a wheel of royal cheese for a full heal, can eat a whole cheese wheel for a half heal, or a cheese wedge for the same 10 health heal.

**Rats dropping dead mice on death:**
When rats die (and aren't player controlled), they spawn a mouse object on death instead of a corpse, which can be used for cooking, eating, or other purposes, as well as being labeled as such.

**Mouse Migrations now have a rare chance of spawning a rat king:**
A mouse spawned by event has a rare chance (2%) of spawning a regal rat instead of a mouse, which will poll deadchat for players.

## Why It's Good For The Game

Improves the consistency of how the regal rat and it's minions interact with the crew, like by preventing dead rats from needing more effort to butcher than the slightly smaller mice mobs. The alternative leaves lots of tiny little rat bodies all around that should probably be treated like mice just for simplicity's sake. Additionally, regal rats could only interact with cheese wedges, now royal interact with cheese uniformly and properly. as they can properly use the more complete healing.

Lastly, adding a rare chance to bring a player into a round as a weaker antagonist is interesting, and during slower shifts I've seen that the amount of impact spawning a regal rat is is a nice change of pace.

## Changelog
:cl:
add: Regal rats can now heal off of cheese wheels as well as more royal cheese.
add: Royal rats can now occasionally appear during the mouse migration event.
tweak: Rats, when killed, spawn dead rat items that can be eaten or cooked, like dead mice..
tweak: Rats and mice now interact with mousetraps, albeit differently than mice do.
/:cl:


