### PR TITLE
Dronespeak manual is once again infinite use, and can once again only be used on drones or silicons.

### DIFF
--- a/code/modules/language/language_manuals.dm
+++ b/code/modules/language/language_manuals.dm
@@ -91,7 +91,15 @@
 // So drones can teach borgs and AI dronespeak. For best effect, combine with mother drone lawset.
 /obj/item/language_manual/dronespeak_manual
 	name = "dronespeak manual"
-	desc = "The book's cover reads: \"Understanding Dronespeak - An exercise in futility.\""
+	desc = "The book's cover reads: \"Understanding Dronespeak - An exercise in futility.\" The book is written entirely in binary, non-silicons probably won't understand it."
 	language = /datum/language/drone
 	flavour_text = "suddenly the drone chittering makes sense"
 	charges = INFINITY
+
+/obj/item/language_manual/dronespeak_manual/attack(mob/living/M, mob/living/user)
+	// If they are not drone or silicon, we don't want them to learn this language.
+	if(!(isdrone(M) || issilicon(M)))
+		M.visible_message("<span class='danger'>[user] beats [M] over the head with [src]!</span>", "<span class='userdanger'>[user] beats you over the head with [src]!</span>", "<span class='hear'>You hear smacking.</span>")
+		return
+
+	return ..()

--- a/code/modules/language/language_manuals.dm
+++ b/code/modules/language/language_manuals.dm
@@ -94,3 +94,4 @@
 	desc = "The book's cover reads: \"Understanding Dronespeak - An exercise in futility.\""
 	language = /datum/language/drone
 	flavour_text = "suddenly the drone chittering makes sense"
+	charges = INFINITY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fix: Dronespeak manual on KS13 is once again infinite use, and can once again only be used on drones or silicons.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

AAAAA OVERSIGHT FROM https://github.com/tgstation/tgstation/pull/53916 REDOING LANGUAGE MANUALS.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Dronespeak manual on KS13 is once again infinite use, and can once again only be used on drones or silicons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
