### PR TITLE
Hilbert's Hotel Bag of Holding is now a raw bluespace anomaly core with an accompanying inert bag.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
@@ -226,6 +226,15 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/unpowered/no_grav)
+"Q" = (
+/obj/structure/table/glass,
+/obj/item/bag_of_holding_inert{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/grimy{
+	icon_state = "engine"
+	},
+/area/ruin/space/has_grav/hilbertresearchfacility)
 "U" = (
 /turf/open/floor/plasteel/stairs/medium{
 	initial_gas_mix = "TEMP=2.7"
@@ -778,7 +787,7 @@ e
 f
 q
 g
-g
+Q
 y
 g
 f

--- a/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
@@ -36,7 +36,9 @@
 "h" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/bluespace_crystal{
-	amount = 37
+	amount = 37;
+	pixel_x = 2;
+	pixel_y = 1
 	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
@@ -44,7 +46,9 @@
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "i" = (
 /obj/structure/table/glass,
-/obj/item/bodybag/bluespace,
+/obj/item/bodybag/bluespace{
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
@@ -60,14 +64,18 @@
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "m" = (
 /obj/structure/table/glass,
-/obj/item/reagent_containers/syringe/bluespace,
+/obj/item/reagent_containers/syringe/bluespace{
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "n" = (
 /obj/structure/table/glass,
-/obj/item/stock_parts/matter_bin/bluespace,
+/obj/item/stock_parts/matter_bin/bluespace{
+	pixel_y = 7
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
@@ -84,22 +92,30 @@
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "q" = (
 /obj/structure/table/glass,
-/obj/item/storage/backpack/holding,
+/obj/item/raw_anomaly_core/bluespace{
+	pixel_y = 7
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "r" = (
 /obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace{
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "s" = (
 /obj/structure/table/glass,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/crystal{
+	pixel_y = 3
+	},
+/obj/item/stock_parts/subspace/transmitter{
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
@@ -112,14 +128,19 @@
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "u" = (
 /obj/structure/table/glass,
-/obj/item/analyzer,
+/obj/item/analyzer{
+	pixel_x = 2;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "v" = (
 /obj/structure/table/glass,
-/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier{
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
@@ -131,14 +152,18 @@
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "x" = (
 /obj/structure/table/glass,
-/obj/item/assembly/signaler,
+/obj/item/assembly/signaler{
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "y" = (
 /obj/structure/table/glass,
-/obj/item/slimecross/industrial/bluespace,
+/obj/item/slimecross/industrial/bluespace{
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
@@ -751,8 +776,8 @@ b
 c
 e
 f
-g
 q
+g
 g
 y
 g


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Swaps out Hilbert's Hotel Bag of Holding with a raw bluespace anomaly core with a matching inert bag of holding.

Tweaks various pixel_x and pixel_y values to place items more aesthetically on the tables.

![screenie](https://user-images.githubusercontent.com/24975989/95088978-83b32800-071b-11eb-9847-ad7face7cf81.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Hilbert's Hotel was out of comission during my space loot sweep. Now it's back, it doesn't get to bypass it untouched either.

We added raw anomaly cores as a gating mechanic for certain items for good reason. Hilbert's Hotel doesn't get to bypass this by injecting a bonus activated anomaly core item into the shift. 

The raw anomaly core can be activated like any other anomaly core and counts towards the hard cap of anomaly core items in the round. It can then be used to create any of a Reactive Teleport Armour, Wormhole Projector, Phazon or Bag of Holding.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Hilbert's Hotel Bag of Holding has been replaced with a raw bluespace anomaly core and inert bag of holding. For flavour.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
