### PR TITLE
turf open process_cell runtime fix/silent

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -197,6 +197,8 @@
 
 	for(var/t in adjacent_turfs)
 		var/turf/open/enemy_tile = t
+		if(!(istype(enemy_tile) && enemy_tile.air))
+			continue
 
 		if(fire_count <= enemy_tile.current_cycle)
 			continue


### PR DESCRIPTION

## About The Pull Request

Sometimes (find it on shuttle loading or shuttle moving) `atmos_adjacent_turfs` has closed turfs in self.
This check filter in out.

Maybe add some messages to show that something going wrong?

## Why It's Good For The Game

Less rintimes.
Make game not cry about our mistakes.
<!-- 
## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

 Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
