### PR TITLE
Yellow slime core nerfs and adjustments.

### DIFF
--- a/code/modules/cargo/exports/xenobio.dm
+++ b/code/modules/cargo/exports/xenobio.dm
@@ -20,15 +20,10 @@
 	unit_name = "rare slime core"
 	export_types = list(/obj/item/slime_extract/silver,/obj/item/slime_extract/darkblue,/obj/item/slime_extract/darkpurple,/obj/item/slime_extract/yellow)
 
-/datum/export/slime/charged
-	cost = 200
-	unit_name = "charged slime core"
-	export_types = list(/obj/item/stock_parts/cell/high/slime)
-
 /datum/export/slime/hypercharged
 	cost = 600
 	unit_name = "hypercharged slime core"
-	export_types = list(/obj/item/stock_parts/cell/high/slime/hypercharged)
+	export_types = list(/obj/item/stock_parts/cell/high/slime_hypercharged)
 
 /datum/export/slime/epic //EPIIIIIIC
 	cost = 220

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -22,7 +22,6 @@
 	var/rigged = FALSE	/// If the cell has been booby-trapped by injecting it with plasma. Chance on use() to explode.
 	var/corrupted = FALSE /// If the power cell was damaged by an explosion, chance for it to become corrupted and function the same as rigged.
 	var/chargerate = 100 //how much power is given every tick in a recharger
-	var/self_recharge = 0 //does it self recharge, over time, or not?
 	var/ratingdesc = TRUE
 	var/grown_battery = FALSE // If it's a grown that acts as a battery, add a wire overlay to it.
 
@@ -31,7 +30,6 @@
 
 /obj/item/stock_parts/cell/Initialize(mapload, override_maxcharge)
 	. = ..()
-	START_PROCESSING(SSobj, src)
 	create_reagents(5, INJECTABLE | DRAINABLE)
 	if (override_maxcharge)
 		maxcharge = override_maxcharge
@@ -39,25 +37,6 @@
 	if(ratingdesc)
 		desc += " This one has a rating of [DisplayEnergy(maxcharge)], and you should not swallow it."
 	update_icon()
-
-/obj/item/stock_parts/cell/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	return ..()
-
-/obj/item/stock_parts/cell/vv_edit_var(var_name, var_value)
-	switch(var_name)
-		if(NAMEOF(src, self_recharge))
-			if(var_value)
-				START_PROCESSING(SSobj, src)
-			else
-				STOP_PROCESSING(SSobj, src)
-	. = ..()
-
-/obj/item/stock_parts/cell/process(delta_time)
-	if(self_recharge)
-		give(chargerate * 0.125 * delta_time)
-	else
-		return PROCESS_KILL
 
 /obj/item/stock_parts/cell/update_overlays()
 	. = ..()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -346,18 +346,6 @@
 	custom_materials = null
 	grown_battery = TRUE //it has the overlays for wires
 
-/obj/item/stock_parts/cell/high/slime
-	name = "charged slime core"
-	desc = "A yellow slime core infused with plasma, it crackles with power."
-	icon = 'icons/mob/slimes.dmi'
-	icon_state = "yellow slime extract"
-	custom_materials = null
-	rating = 5 //self-recharge makes these desirable
-	self_recharge = 1 // Infused slime cores self-recharge, over time
-
-/*Hypercharged slime cell - located in /code/modules/research/xenobiology/crossbreeding/_misc.dm
-/obj/item/stock_parts/cell/high/slime/hypercharged */
-
 /obj/item/stock_parts/cell/emproof
 	name = "\improper EMP-proof cell"
 	desc = "An EMP-proof cell."

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -238,11 +238,6 @@
 	var/last_chrg = inputting
 	var/last_onln = outputting
 
-	//check for self-recharging cells in stock parts and use them to self-charge
-	for(var/obj/item/stock_parts/cell/C in component_parts)
-		if(C.self_recharge)
-			charge += min(capacity-charge, C.chargerate) // If capacity-charge is smaller than the attempted charge rate, this avoids overcharging
-
 	//inputting
 	if(terminal && input_attempt)
 		input_available = terminal.surplus()

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -266,10 +266,6 @@
 	required_container = /obj/item/slime_extract/yellow
 	required_other = TRUE
 
-/datum/chemical_reaction/slime/slimecell/on_reaction(datum/reagents/holder, created_volume)
-	new /obj/item/stock_parts/cell/high/slime(get_turf(holder.my_atom))
-	..()
-
 /datum/chemical_reaction/slime/slimeglow
 	required_reagents = list(/datum/reagent/water = 1)
 	required_container = /obj/item/slime_extract/yellow

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -89,14 +89,16 @@ Slimecrossing Items
 		desc = "This camera has seen better days."
 	. = ..()
 
-
 //Hypercharged slime cell - Charged Yellow
-/obj/item/stock_parts/cell/high/slime/hypercharged
+/obj/item/stock_parts/cell/high/slime_hypercharged
 	name = "hypercharged slime core"
 	desc = "A charged yellow slime extract, infused with even more plasma. It almost hurts to touch."
-	rating = 7 //Roughly 1.5 times the original.
-	maxcharge = 20000 //2 times the normal one.
-	chargerate = 2250 //1.5 times the normal rate.
+	icon = 'icons/mob/slimes.dmi'
+	icon_state = "yellow slime extract"
+	rating = 7
+	custom_materials = null
+	maxcharge = 50000
+	chargerate = 3500
 
 //Barrier cube - Chilling Grey
 /obj/item/barriercube

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -98,7 +98,7 @@ Slimecrossing Items
 	rating = 7
 	custom_materials = null
 	maxcharge = 50000
-	chargerate = 3500
+	chargerate = 2500
 
 //Barrier cube - Chilling Grey
 /obj/item/barriercube

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -92,7 +92,7 @@ Slimecrossing Items
 //Hypercharged slime cell - Charged Yellow
 /obj/item/stock_parts/cell/high/slime_hypercharged
 	name = "hypercharged slime core"
-	desc = "A charged yellow slime extract, infused with even more plasma. It almost hurts to touch."
+	desc = "A charged yellow slime extract, infused with plasma. It almost hurts to touch."
 	icon = 'icons/mob/slimes.dmi'
 	icon_state = "yellow slime extract"
 	rating = 7

--- a/code/modules/research/xenobiology/crossbreeding/charged.dm
+++ b/code/modules/research/xenobiology/crossbreeding/charged.dm
@@ -77,10 +77,10 @@ Charged extracts:
 
 /obj/item/slimecross/charged/yellow
 	colour = "yellow"
-	effect_desc = "Creates a hypercharged slime cell battery, which has high capacity and recharges constantly at a very fast rate."
+	effect_desc = "Creates a hypercharged slime cell battery, which has high capacity but takes longer to recharge."
 
 /obj/item/slimecross/charged/yellow/do_effect(mob/user)
-	new /obj/item/stock_parts/cell/high/slime/hypercharged(get_turf(user))
+	new /obj/item/stock_parts/cell/high/slime_hypercharged(get_turf(user))
 	user.visible_message("<span class='notice'>[src] sparks violently, and swells with electric power!</span>")
 	..()
 

--- a/code/modules/spells/spell_types/charge.dm
+++ b/code/modules/spells/spell_types/charge.dm
@@ -67,12 +67,11 @@
 				break
 			else if(istype(item, /obj/item/stock_parts/cell))
 				var/obj/item/stock_parts/cell/C = item
-				if(!C.self_recharge)
-					if(prob(80))
-						C.maxcharge -= 200
-					if(C.maxcharge <= 1) //Div by 0 protection
-						C.maxcharge = 1
-						burnt_out = TRUE
+				if(prob(80))
+					C.maxcharge -= 200
+				if(C.maxcharge <= 1) //Div by 0 protection
+					C.maxcharge = 1
+					burnt_out = TRUE
 				C.charge = C.maxcharge
 				charged_item = C
 				break
@@ -81,12 +80,11 @@
 				for(I in item.contents)
 					if(istype(I, /obj/item/stock_parts/cell/))
 						var/obj/item/stock_parts/cell/C = I
-						if(!C.self_recharge)
-							if(prob(80))
-								C.maxcharge -= 200
-							if(C.maxcharge <= 1) //Div by 0 protection
-								C.maxcharge = 1
-								burnt_out = TRUE
+						if(prob(80))
+							C.maxcharge -= 200
+						if(C.maxcharge <= 1) //Div by 0 protection
+							C.maxcharge = 1
+							burnt_out = TRUE
 						C.charge = C.maxcharge
 						if(istype(C.loc, /obj/item/gun))
 							var/obj/item/gun/G = C.loc

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -57,7 +57,7 @@
 			canmove = FALSE
 			addtimer(VARSET_CALLBACK(src, canmove, TRUE), 20)
 			return FALSE
-		power_cell.use(power_usage / max(power_efficiency, 1))
+		power_cell.use(power_usage / max(power_efficiency, 1) * 0.05)
 	return ..()
 
 /obj/vehicle/ridden/wheelchair/motorized/set_move_delay(mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Yellow slime extract can no longer turn into a self-charging yellow slime core. This functionality has been completely removed.

Hypercharged yellow slime cores no longer self-charge.
They now have a capacity of 50,000 (up from their previous 20,000). This is 10,000 more than a bluespace power cell.
Their recharge rate is 2500. This is relatively slow for the power capacity, as hyper and bluespace cells charge at 10% of their capacity respectively and this is 5%.

**Motorised wheelchairs have had their power usage reduced to 5% of their previous value since they were basically only usable with rechargable cells before**

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Self-charging cells from Xenobio were a mistake.

The breadth of uses they have includes mechs, silicons, APCs, a limited selection of weapons, portable defibs, chem dispensers, SMES and anything else that uses replaceable power cell.

I have considered reducing their recharge speed, but even that has arguments against it. Ions draining batteries have a significantly reduced effect against self-recharging cores as they never drop to 0% power. Mechs are almost universally imbalanced by having yellow cores inside them, giving them 24/7 uptime. Even slowly self-recharging cells in big enough numbers are still a balance nightmare.

Hypercharged cells are now a sidegrade to bluespace cells. They have a higher power capacity, lower charge speed. Their balance is much easier to argue and they're probably a bit underpowered overall, but can easily be tweaked should this be necessary.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Self-recharging basic yellow slime cores have been removed.
tweak: Self-recharging hypercharged yellow slime cores are no longer self-recharging. They are now a high capacity cell choice. Their capacity is above Bluespace Cells but they recharge slower than ordinary cells.
tweak: Motorised wheelchairs now use SIGNIFICANTLY less power and should last around 20 times as long before they run out of charge.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
