### PR TITLE
Fix shuttle loader big shuttle load issues.

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -697,6 +697,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/list/force_memory = preview_shuttle.movement_force
 	preview_shuttle.movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
+	preview_shuttle.mode = SHUTTLE_PREARRIVAL//No idle shuttle moving. Transit dock get removed if shuttle moves too long.	
 	preview_shuttle.initiate_docking(D)
 	preview_shuttle.movement_force = force_memory
 


### PR DESCRIPTION
## About The Pull Request

Set mode = SHUTTLE_PREARRIVAL to shuttle that initially placed to transit docking port.
No more SSshuttles delete transit for half loaded shuttle

Fix #54232

## Why It's Good For The Game

Deletion of transit with half placed shuttle is bad.

## Changelog
:cl:
fix: Shuttle loader no more lost big shuttles.
/:cl:
<!-- 
Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
