### PR TITLE
Hotspots fix

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -89,7 +89,7 @@
 		var/datum/gas_mixture/affected = location.air.remove_ratio(volume/location.air.volume)
 		if(affected) //in case volume is 0
 			affected.temperature = temperature
-			affected.react(src)
+			affected.react(src, TRUE, typecacheof(list(/datum/gas_reaction/tritfire, /datum/gas_reaction/plasmafire, /datum/gas_reaction/h2fire), only_root_path = TRUE))
 			temperature = affected.temperature
 			volume = affected.reaction_results["fire"]*FIRE_GROWTH_RATE
 			location.assume_air(affected)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -448,7 +448,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 			var/datum/gas_reaction/reaction = r
 
 			if(!is_type_in_typecache(reaction,reaction_whitelist) && have_whitelist == TRUE)
-				message_admins("continue")
 				continue
 
 			var/list/min_reqs = reaction.min_requirements

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -428,7 +428,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	///Performs various reactions such as combustion or fusion (LOL)
 	///Returns: 1 if any reaction took place; 0 otherwise
-/datum/gas_mixture/proc/react(datum/holder)
+/datum/gas_mixture/proc/react(datum/holder, have_whitelist = FALSE, reaction_whitelist = list())
 	. = NO_REACTION
 	var/list/cached_gases = gases
 	if(!length(cached_gases))
@@ -446,6 +446,10 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	reaction_loop:
 		for(var/r in reactions)
 			var/datum/gas_reaction/reaction = r
+
+			if(!is_type_in_typecache(reaction,reaction_whitelist) && have_whitelist == TRUE)
+				message_admins("continue")
+				continue
 
 			var/list/min_reqs = reaction.min_requirements
 			if(	(min_reqs["TEMP"] && temp < min_reqs["TEMP"]) || \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
affected.react() allows only fire to react inside the hotspot. Previously fires would make gases react twice, this is good for fires so that they have a normal behaviour, but for other reactions like fusion is a dreadful experience. This was leading to having weird behaviours in some reactions and open air fusion crashing the server if done in a big chamber (it became a radball party that killed the atmos system and crashed the servers).

Credit to @park66665 for the idea in [this PR](https://github.com/BeeStation/BeeStation-Hornet/pull/2649) and on discord
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
less bugs and less server ending glitches
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fix open air fusion crashing the server if on fire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
