### PR TITLE
[s] Reworks the sanitize_ooccolor proc

### DIFF
--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -79,20 +79,7 @@
 
 	return crunch + .
 
+/// Makes sure the input color is text with a # at the start followed by 6 hexadecimal characters. Examples: "#ff1234", "#A38321", COLOR_GREEN_GRAY
 /proc/sanitize_ooccolor(color)
-	if(!istext(color))
-		stack_trace("color ([color]) var is not text")
-		return GLOB.normal_ooc_colour
-	if(length(color) != length_char(color))
-		stack_trace("Unicode characters in color ([color])")
-		return GLOB.normal_ooc_colour
-	if(length(color) != 7)
-		stack_trace("Wrong number of characters in color ([color])")
-		return GLOB.normal_ooc_colour
-	if(copytext(color, 1, 2) != "#")
-		stack_trace("Wrong color format in color ([color])")
-		return GLOB.normal_ooc_colour
-	if(isnull(hex2num(copytext(color, 2, 8))))
-		stack_trace("Invalid hex number in color ([color])")
-		return GLOB.normal_ooc_colour
-	return color
+	var/static/regex/color_regex = regex(@"^#[0-9a-fA-F]{6}$")
+	return findtext(color, color_regex) ? color : GLOB.normal_ooc_colour

--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -80,9 +80,19 @@
 	return crunch + .
 
 /proc/sanitize_ooccolor(color)
+	if(!istext(color))
+		stack_trace("color ([color]) var is not text")
+		return GLOB.normal_ooc_colour
 	if(length(color) != length_char(color))
-		CRASH("Invalid characters in color '[color]'")
-	var/list/HSL = rgb2hsl(hex2num(copytext(color, 2, 4)), hex2num(copytext(color, 4, 6)), hex2num(copytext(color, 6, 8)))
-	HSL[3] = min(HSL[3],0.4)
-	var/list/RGB = hsl2rgb(arglist(HSL))
-	return "#[num2hex(RGB[1],2)][num2hex(RGB[2],2)][num2hex(RGB[3],2)]"
+		stack_trace("Unicode characters in color ([color])")
+		return GLOB.normal_ooc_colour
+	if(length(color) != 7)
+		stack_trace("Wrong number of characters in color ([color])")
+		return GLOB.normal_ooc_colour
+	if(copytext(color, 1, 2) != "#")
+		stack_trace("Wrong color format in color ([color])")
+		return GLOB.normal_ooc_colour
+	if(isnull(hex2num(copytext(color, 2, 8))))
+		stack_trace("Invalid hex number in color ([color])")
+		return GLOB.normal_ooc_colour
+	return color

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1495,12 +1495,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("ooccolor")
 					var/new_ooccolor = input(user, "Choose your OOC colour:", "Game Preference",ooccolor) as color|null
 					if(new_ooccolor)
-						ooccolor = new_ooccolor
+						ooccolor = sanitize_ooccolor(new_ooccolor)
 
 				if("asaycolor")
 					var/new_asaycolor = input(user, "Choose your ASAY color:", "Game Preference",asaycolor) as color|null
 					if(new_asaycolor)
-						asaycolor = new_asaycolor
+						asaycolor = sanitize_ooccolor(new_asaycolor)
 
 				if("bag")
 					var/new_backpack = input(user, "Choose your character's style of bag:", "Character Preference")  as null|anything in GLOB.backpacklist

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -119,7 +119,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		log_admin("[key_name(usr)] tried to set player ooc color without authorization.")
 		return
 	var/new_color = sanitize_ooccolor(newColor)
-	message_admins("[key_name_admin(usr)] has set the player's ooc color to [new_color].")
+	message_admins("[key_name_admin(usr)] has set the players' ooc color to [new_color].")
 	log_admin("[key_name_admin(usr)] has set the player ooc color to [new_color].")
 	GLOB.OOC_COLOR = new_color
 
@@ -136,7 +136,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		message_admins("[usr.key] has attempted to use the Reset Player OOC Color verb!")
 		log_admin("[key_name(usr)] tried to reset player ooc color without authorization.")
 		return
-	message_admins("[key_name_admin(usr)] has reset the player's ooc color.")
+	message_admins("[key_name_admin(usr)] has reset the players' ooc color.")
 	log_admin("[key_name_admin(usr)] has reset player ooc color.")
 	GLOB.OOC_COLOR = null
 

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -104,17 +104,42 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	else
 		GLOB.dooc_allowed = !GLOB.dooc_allowed
 
-/client/proc/set_ooc(newColor as color)
+
+/client/proc/set_ooc()
 	set name = "Set Player OOC Color"
 	set desc = "Modifies player OOC Color"
 	set category = "Server"
-	GLOB.OOC_COLOR = sanitize_ooccolor(newColor)
+	if(IsAdminAdvancedProcCall())
+		return
+	var/newColor = input(src, "Please select the new player OOC color.", "OOC color") as color|null
+	if(isnull(newColor))
+		return
+	if(!check_rights(R_FUN))
+		message_admins("[usr.key] has attempted to use the Set Player OOC Color verb!")
+		log_admin("[key_name(usr)] tried to set player ooc color without authorization.")
+		return
+	var/new_color = sanitize_ooccolor(newColor)
+	message_admins("[key_name_admin(usr)] has set the player's ooc color to [new_color].")
+	log_admin("[key_name_admin(usr)] has set the player ooc color to [new_color].")
+	GLOB.OOC_COLOR = new_color
+
 
 /client/proc/reset_ooc()
 	set name = "Reset Player OOC Color"
 	set desc = "Returns player OOC Color to default"
 	set category = "Server"
+	if(IsAdminAdvancedProcCall())
+		return
+	if(alert(usr, "Are you sure you want to reset the OOC color of all players?", "Reset Player OOC Color", "Yes", "No") != "Yes")
+		return
+	if(!check_rights(R_FUN))
+		message_admins("[usr.key] has attempted to use the Reset Player OOC Color verb!")
+		log_admin("[key_name(usr)] tried to reset player ooc color without authorization.")
+		return
+	message_admins("[key_name_admin(usr)] has reset the player's ooc color.")
+	log_admin("[key_name_admin(usr)] has reset player ooc color.")
 	GLOB.OOC_COLOR = null
+
 
 /client/verb/colorooc()
 	set name = "Set Your OOC Color"
@@ -125,11 +150,13 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 			return
 
 	var/new_ooccolor = input(src, "Please select your OOC color.", "OOC color", prefs.ooccolor) as color|null
-	if(new_ooccolor)
-		prefs.ooccolor = sanitize_ooccolor(new_ooccolor)
-		prefs.save_preferences()
+	if(isnull(new_ooccolor))
+		return
+	new_ooccolor = sanitize_ooccolor(new_ooccolor)
+	prefs.ooccolor = new_ooccolor
+	prefs.save_preferences()
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Set OOC Color") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	return
+
 
 /client/verb/resetcolorooc()
 	set name = "Reset Your OOC Color"


### PR DESCRIPTION
Added the [s] tag just because it adds a little bit more sanitization, but this is far from critical. The old santization could be bypassed through a single round by re-setting the invalid value each round, it just wouldn't save. Shouldn't be the case anymore with this.

Long ago we only had light mode, so we had to make sure the asay and ooc colors had a certain level of darkness to appear in the chat. Now, however, we have both dark and light mode.

This limit affects, in any case, only admins and byond donators, who can set their OOC and ASAY colors.
I pinged the headmins and they are in agreement with this, ooc color abuse is not deemed a big issue and they can handle it if it becomes one.

* Also adds a little sanitization and logging to some admin verbs, plus the chance to cancel the action.

## Changelog
:cl:
tweak: Admins and byond users can now set their OOC (and ASAY) color to light values and it will save in the preferences.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
