### PR TITLE
HARS no longer cures brain traumas, it moves your brain to your chest

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -463,7 +463,7 @@
 
 /datum/mutation/human/headless
 	name = "H.A.R.S."
-	desc = "A mutation that makes the body reject the head. Stands for Head Allergic Rejection Syndrome. Warning: Removing this mutation is very dangerous, though it will regenerate head organs."
+	desc = "A mutation that makes the body reject the head, the brain receding into the chest. Stands for Head Allergic Rejection Syndrome. Warning: Removing this mutation is very dangerous, though it will regenerate non-vital head organs."
 	difficulty = 12 //pretty good for traitors
 	quality = NEGATIVE //holy shit no eyes or tongue or ears
 	text_gain_indication = "<span class='warning'>Something feels off.</span>"
@@ -473,9 +473,8 @@
 	if(.)//cant add
 		return TRUE
 	var/obj/item/organ/brain/brain = owner.getorganslot(ORGAN_SLOT_BRAIN)
-	if(brain) //so this doesn't instantly kill you
-		brain.organ_flags &= ~ORGAN_VITAL
-		qdel(brain)
+	if(brain)
+		brain.zone = BODY_ZONE_CHEST
 
 	var/obj/item/bodypart/head/head = owner.get_bodypart(BODY_ZONE_HEAD)
 	if(head)
@@ -491,6 +490,9 @@
 	. = ..()
 	if(.)
 		return TRUE
+	var/obj/item/organ/brain/brain = owner.getorganslot(ORGAN_SLOT_BRAIN)
+	if(brain) //so this doesn't instantly kill you. we could delete the brain, but it lets people cure brain issues they /really/ shouldn't be
+		brain.zone = BODY_ZONE_HEAD
 	UnregisterSignal(owner, COMSIG_CARBON_ATTACH_LIMB)
 	var/successful = owner.regenerate_limb(BODY_ZONE_HEAD, noheal = TRUE) //noheal needs to be TRUE to prevent weird adding and removing mutation healing
 	if(!successful)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #51841

Instead of deleting your brain, your brain will be stored in your stomach. Obviously this means that your brain is now a chest organ until the hars mutation is removed, which has some weird parts when removed and inserted into other people but i'm sure it's honestly no issue since you'll still be killing people by removing the brain.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/40974010/95256404-9ee36d80-07d7-11eb-9fff-bcc82df8a3a5.png)

No but really, while I'd love to keep "the secret hars technique" it removes roundstart quirks and admin traumas and other things that shouldn't be removed.

## Changelog
:cl:
tweak: HARS moves your brain to your chest instead of deleting it
fix: This does in fact mean you can no longer heal admin traumas, roundstart quirks, and other brain oddities
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
