### PR TITLE
Rebalances pluox gen back to pre-newgas levels

### DIFF
--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -266,9 +266,9 @@
 	if (air.gases[/datum/gas/carbon_dioxide] && air.gases[/datum/gas/oxygen])
 		pulse_strength = min(pulse_strength, air.gases[/datum/gas/carbon_dioxide][MOLES] * 1000, air.gases[/datum/gas/oxygen][MOLES] * 2000) //Ensures matter is conserved properly
 		air.gases[/datum/gas/carbon_dioxide][MOLES] = max(air.gases[/datum/gas/carbon_dioxide][MOLES] - (pulse_strength * 0.001),0)
-		air.gases[/datum/gas/oxygen][MOLES] = max(air.gases[/datum/gas/oxygen][MOLES]-(pulse_strength * 0.002),0)
+		air.gases[/datum/gas/oxygen][MOLES] = max(air.gases[/datum/gas/oxygen][MOLES]-(pulse_strength * 0.0005),0)
 		air.assert_gas(/datum/gas/pluoxium)
-		air.gases[/datum/gas/pluoxium][MOLES] +=(pulse_strength * 0.004)
+		air.gases[/datum/gas/pluoxium][MOLES] +=(pulse_strength * 0.00025)
 		air.garbage_collect()
 		air_update_turf()
 	if (air.gases[/datum/gas/hydrogen])


### PR DESCRIPTION
## About The Pull Request

I have no idea if these balance changes were intentional. I'm porting stuff right now and noticed the funny math problem. Essentially, before this change, pluoxium was 4 : 2 CO2 : O2 making 1 pluox, but now it's 1 : 2 CO2 : O2 making 4 pluox. This reverts to the old numbers.

## Why It's Good For The Game

Honestly a bit questionable, but this looks like an arithmetic issue to me:

![image](https://user-images.githubusercontent.com/3927690/95264510-4ebed800-07e4-11eb-86e5-13b567cdfc16.png)


## Changelog
:cl:
balance: Pluoxium generation is back to normal.
/:cl: