### PR TITLE
Fixes pods not docking at centcomm

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -16714,7 +16714,7 @@
 /obj/docking_port/stationary{
 	dwidth = 1;
 	height = 4;
-	id = "pod4_away";
+	id = "pod_4_away";
 	name = "recovery ship";
 	width = 3
 	},
@@ -16724,7 +16724,7 @@
 /obj/docking_port/stationary{
 	dwidth = 1;
 	height = 4;
-	id = "pod3_away";
+	id = "pod_3_away";
 	name = "recovery ship";
 	width = 3
 	},
@@ -16908,7 +16908,7 @@
 	dir = 4;
 	dwidth = 1;
 	height = 4;
-	id = "pod2_away";
+	id = "pod_2_away";
 	name = "recovery ship";
 	width = 3
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pods don't dock at centcomm because #53993 changed the format of the mobile docking port names but did not change the format of the stationary ports at centcomm. This updates the stationary ports to match so the pods will dock again.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People usually prefer to get off their escape pod and not get sucked into the vacuum of space. Usually.
Fixes #54227
Fixes #54253
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: VexingRaven
fix: Nanotrasen has performed repairs on the escape pod navigation computers and they will once again dock at the CentComm recovery ship in the unlikely event of an evacuation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
