### PR TITLE
Hilbert's Hotel orb now has a bunch of checks to prevent users pulling shenanigans

### DIFF
--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -47,7 +47,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	promptAndCheckIn(user, user)
 
 /obj/item/hilbertshotel/attack_tk(mob/user)
-	to_chat(user, "<span class='notice'>Your telekinetic powers are not enough to activate \the [src].</span>")
+	to_chat(user, "<span class='notice'>\The [src] actively rejects your mind as the bluespace energies surrounding it disrupt your telekinesis.</span>")
 	return
 
 /obj/item/hilbertshotel/proc/promptAndCheckIn(mob/user, mob/target)
@@ -372,6 +372,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		qdel(H)
 		return
 
+	// Prepare for...
 	var/mob/unforeseen_consequences = get_atom_on_turf(H, /mob)
 
 	// Turns out giving anyone who grabs a Hilbert's Hotel a free, complementary warp whistle is probably bad.

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -74,7 +74,6 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		return
 	sendToNewRoom(chosenRoomNumber, user)
 
-
 /obj/item/hilbertshotel/proc/tryActiveRoom(roomNumber, mob/user)
 	if(activeRooms["[roomNumber]"])
 		var/datum/turf_reservation/roomReservation = activeRooms["[roomNumber]"]
@@ -338,6 +337,8 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		qdel(H)
 		return
 
+	// Turns out giving anyone who grabs a Hilbert's Hotel a free, complementary warp whistle is probably bad.
+	// Let's gib the last person to use it, which will be the first person after the
 	if(istype(H.last_user))
 		to_chat(H.last_user, "<span class='warning'>\The [H] starts to resonate. Forcing it to enter itself induces a bluespace paradox, violently tearing your body apart.</span>")
 		H.last_user.gib()

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -46,6 +46,10 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	. = ..()
 	promptAndCheckIn(user, user)
 
+/obj/item/hilbertshotel/attack_tk(mob/user)
+	to_chat(user, "<span class='notice'>Your telekinetic powers are not enough to activate \the [src].</span>")
+	return
+
 /obj/item/hilbertshotel/proc/promptAndCheckIn(mob/user, mob/target)
 	var/chosenRoomNumber
 

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -38,28 +38,59 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 /obj/item/hilbertshotel/attack(mob/living/M, mob/living/user)
 	if(M.mind)
 		to_chat(user, "<span class='notice'>You invite [M] to the hotel.</span>")
-		promptAndCheckIn(M)
+		promptAndCheckIn(user, M)
 	else
 		to_chat(user, "<span class='warning'>[M] is not intelligent enough to understand how to use this device!</span>")
 
 /obj/item/hilbertshotel/attack_self(mob/user)
 	. = ..()
-	promptAndCheckIn(user)
+	promptAndCheckIn(user, user)
 
-/obj/item/hilbertshotel/proc/promptAndCheckIn(mob/user)
-	var/chosenRoomNumber = input(user, "What number room will you be checking into?", "Room Number") as null|num
-	last_user = user
+/obj/item/hilbertshotel/proc/promptAndCheckIn(mob/user, mob/target)
+	var/chosenRoomNumber
+
+	// Input text changes depending on if you're using this in yourself or someone else.
+	if(user == target)
+		chosenRoomNumber = input(target, "What number room will you be checking into?", "Room Number") as null|num
+	else
+		chosenRoomNumber = input(target, "[user] is inviting you to enter \the [src]. What number room will you be checking into?", "Room Number") as null|num
+
 	if(!chosenRoomNumber)
 		return
 	if(chosenRoomNumber > SHORT_REAL_LIMIT)
-		to_chat(user, "<span class='warning'>You have to check out the first [SHORT_REAL_LIMIT] rooms before you can go to a higher numbered one!</span>")
+		to_chat(target, "<span class='warning'>You have to check out the first [SHORT_REAL_LIMIT] rooms before you can go to a higher numbered one!</span>")
 		return
 	if((chosenRoomNumber < 1) || (chosenRoomNumber != round(chosenRoomNumber)))
-		to_chat(user, "<span class='warning'>That is not a valid room number!</span>")
+		to_chat(target, "<span class='warning'>That is not a valid room number!</span>")
 		return
-	if(ismob(loc))
-		if(user == loc) //Not always the same as user
-			forceMove(get_turf(user))
+
+	// Orb is not adjacent to the target. No teleporties.
+	if(!src.Adjacent(target))
+		to_chat(target, "<span class='warning'>You too far away from \the [src] to enter it!</span>")
+
+	// If the target is incapacitated after selecting a room, they're not allowed to teleport.
+	if(target.incapacitated())
+		to_chat(target, "<span class='warning'>You aren't able to activate \the [src] anymore!</span>")
+
+	// Has the user thrown it away or otherwise disposed of it such that it's no longer in their hands or in some storage connected to them?
+	if(!(get_atom_on_turf(src, /mob) == user))
+		if(user == target)
+			to_chat(user, "<span class='warning'>\The [src] is no longer in your possession!</span>")
+		else
+			to_chat(target, "<span class='warning'>\The [src] is no longer in the possession of [user]!</span>")
+		return
+
+	// If the player is using it on themselves, we've got some logic to deal with.
+	// The user should drop the item before teleporting, but we're not going to force the item to be dropped if it can't be done normally...
+	if(user == target)
+		// The item should be on the user or in the user's inventory somewhere.
+		// However, if they're not holding it, it may be in a pocket? In a backpack? Who knows! Still, they can't just drop it to the floor anymore...
+		if(!user.get_held_index_of_item(src))
+			to_chat(user, "<span class='warning'>You try to drop \the [src], but it's too late! It's no longer in your hands! Prepare for unforeseen consequences...</span>")
+		// Okay, so they HAVE to be holding it here, because it's in their hand from the above check. Try to drop the item and if it fails, oh dear...
+		else if(!user.dropItemToGround(src))
+			to_chat(user, "<span class='warning'>You can't seem to drop \the [src]! It must be stuck to your hand somehow! Prepare for unforeseen consequences...</span>")
+
 	if(!storageTurf) //Blame subsystems for not allowing this to be in Initialize
 		if(!GLOB.hhStorageTurf)
 			var/datum/map_template/hilbertshotelstorage/storageTemp = new()
@@ -68,11 +99,11 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 			GLOB.hhStorageTurf = locate(storageReservation.bottom_left_coords[1]+1, storageReservation.bottom_left_coords[2]+1, storageReservation.bottom_left_coords[3])
 		else
 			storageTurf = GLOB.hhStorageTurf
-	if(tryActiveRoom(chosenRoomNumber, user))
+	if(tryActiveRoom(chosenRoomNumber, target))
 		return
-	if(tryStoredRoom(chosenRoomNumber, user))
+	if(tryStoredRoom(chosenRoomNumber, target))
 		return
-	sendToNewRoom(chosenRoomNumber, user)
+	sendToNewRoom(chosenRoomNumber, target)
 
 /obj/item/hilbertshotel/proc/tryActiveRoom(roomNumber, mob/user)
 	if(activeRooms["[roomNumber]"])
@@ -337,11 +368,13 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		qdel(H)
 		return
 
+	var/mob/unforeseen_consequences = get_atom_on_turf(H, /mob)
+
 	// Turns out giving anyone who grabs a Hilbert's Hotel a free, complementary warp whistle is probably bad.
-	// Let's gib the last person to use it, which will be the first person after the
-	if(istype(H.last_user))
-		to_chat(H.last_user, "<span class='warning'>\The [H] starts to resonate. Forcing it to enter itself induces a bluespace paradox, violently tearing your body apart.</span>")
-		H.last_user.gib()
+	// Let's gib the last person to have selected a room number in it.
+	if(unforeseen_consequences)
+		to_chat(unforeseen_consequences, "<span class='warning'>\The [H] starts to resonate. Forcing it to enter itself induces a bluespace paradox, violently tearing your body apart.</span>")
+		unforeseen_consequences.gib()
 
 	var/turf/targetturf = find_safe_turf()
 	if(!targetturf)

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -15,8 +15,6 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	var/storageTurf
 	//Lore Stuff
 	var/ruinSpawned = FALSE
-	/// The last mob to attempt to promptAndCheckIn()
-	var/mob/last_user = null
 
 /obj/item/hilbertshotel/Initialize()
 	. = ..()

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -15,6 +15,8 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	var/storageTurf
 	//Lore Stuff
 	var/ruinSpawned = FALSE
+	/// The last mob to attempt to promptAndCheckIn()
+	var/mob/last_user = null
 
 /obj/item/hilbertshotel/Initialize()
 	. = ..()
@@ -46,6 +48,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 
 /obj/item/hilbertshotel/proc/promptAndCheckIn(mob/user)
 	var/chosenRoomNumber = input(user, "What number room will you be checking into?", "Room Number") as null|num
+	last_user = user
 	if(!chosenRoomNumber)
 		return
 	if(chosenRoomNumber > SHORT_REAL_LIMIT)
@@ -334,6 +337,11 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	if(prob(0.135685)) //Because screw you
 		qdel(H)
 		return
+
+	if(istype(H.last_user))
+		to_chat(H.last_user, "<span class='warning'>\The [H] starts to resonate. Forcing it to enter itself induces a bluespace paradox, violently tearing your body apart.</span>")
+		H.last_user.gib()
+
 	var/turf/targetturf = find_safe_turf()
 	if(!targetturf)
 		if(GLOB.blobstart.len > 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This item is a pain in the ass to test all the edge cases for. Please review carefully.

An item that doesn't do ANY sanity checks at all after `input`? This should have never passed review.

Hilbert's Hotel now does some basic level of sanity checking after the `input` to cut down on a number of shenanigans.

The following are all the new changes:
* Hilbert's cannot be activated via telekinesis. It must be activated by direct player attack.
* If the item isn't adjacent to the target after their input, it aborts.
* If the player attempting to enter the hotel is incapacitated after their input, it aborts.
* If the user no longer has the item in their possession after their input, it aborts even if there is a different target.
* If the user is also the target, it will attempt to drop the item normally. If the item fails to drop, it may be teleported to the hotel with the user. The item can fail to drop when it is in the user's possession but not in their hands, or when it has TRAIT_NODROP.
* When the item enters a hotel room created by itself, it will now recursively check for the first mob in its loc stack. It will gib this mob before teleporting away.
* This prevents the warp-whistle effect where a user could put the item in their backpack at INCREDIBLY low risk to themselves (0.135685% chance of anything bad happening) to enter a hotel room and have the orb warped away at random. They could then immediately leave for a free warp whistle effect.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I'm less likely to remove Hilbert's Hotel from the game a SECOND time, this time for being poorly coded and poorly designed.

You can still teleport yourself and your buddies to hotel rooms, but you can't warp whistle around, throw the orb then teleport to its new location, tag a friend and then run away and allow them to teleport into the orb 3 minutes later, so on, so forth.

"Improve, don't remove"

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The Hilbert's orb Hotel can no longer be used via telekinesis, requires adjacency to teleport, will not teleport while incapacitated, requires you to have the item in your possession to teleport yourself and others and has new unforeseen consequences for attempting to transport the item into one of its own hotel rooms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
