### PR TITLE
[s]Showers now properly react with 10u per tick instead of 1000u.

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -4,6 +4,7 @@
 #define SHOWER_NORMAL_TEMP 300
 #define SHOWER_BOILING "boiling"
 #define SHOWER_BOILING_TEMP 400
+#define SHOWER_REACTION_MULTIPLIER 0.05
 
 
 /obj/machinery/shower
@@ -130,7 +131,7 @@
 		wash_atom(loc)
 		for(var/am in loc)
 			var/atom/movable/movable_content = am
-			reagents.expose(movable_content, TOUCH, 0.05) //There's not many reagents leaving the sink at once! This should make for a 10 unit reaction
+			reagents.expose(movable_content, TOUCH, SHOWER_REACTION_MULTIPLIER) //There's not many reagents leaving the sink at once! This should make for a 10 unit reaction
 			if(!ismopable(movable_content)) // Mopables will be cleaned anyways by the turf wash above
 				wash_atom(movable_content)
 	else
@@ -192,3 +193,5 @@
 	layer = FLY_LAYER
 	anchored = TRUE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+#undef SHOWER_REACTION_MULTIPLIER

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -130,7 +130,7 @@
 		wash_atom(loc)
 		for(var/am in loc)
 			var/atom/movable/movable_content = am
-			reagents.expose(movable_content, TOUCH, 5) //There's not many reagents leaving the sink at once!
+			reagents.expose(movable_content, TOUCH, 0.05) //There's not many reagents leaving the sink at once! This should make for a 10 unit reaction
 			if(!ismopable(movable_content)) // Mopables will be cleaned anyways by the turf wash above
 				wash_atom(movable_content)
 	else

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -663,6 +663,12 @@
   * * [/datum/reagent/proc/expose_mob]
   * * [/datum/reagent/proc/expose_turf]
   * * [/datum/reagent/proc/expose_obj]
+  *
+  * Arguments
+  * - Atom/A: What mob/turf/object is being exposed to reagents? This is your reaction target.
+  * - Methods: What reaction type is the reagent itself going to call on the reaction target? Types are TOUCH, INGEST, VAPOR, PATCH, and INJECT.
+  * - Volume_modifier: What is the reagent volume multiplied by when exposed? Note that this is called on the volume of EVERY reagent in the base body, so factor in your Maximum_Volume if necessary!
+  * - Show_message: Whether to display anything to mobs when they are exposed.
   */
 /datum/reagents/proc/expose(atom/A, methods = TOUCH, volume_modifier = 1, show_message = 1)
 	if(isnull(A))


### PR DESCRIPTION
Whoops.

## About The Pull Request

Turns out what I thought was reagent units used per reaction was actually reaction multiplier in #53377, and it flew under the radar until literally 15 minutes ago.

This adjusted the reaction quantity down to 0.05, which with the 200 unit reagent volume of the showers, equates to about a 10u reaction per tick, ya know, rather high but reasonable considering that before it was mistakenly set to *5 instead, which meant you could de-husk a patient in a literal single tick with 1 unit of synthflesh.

## Why It's Good For The Game

Jeopardizes medical difficulty due to a poorly labeled variable.

## Changelog
:cl:
fix: Showers once again react with a 10u reaction quantity per tick instead of... 1000u.
/:cl: