### PR TITLE
Converts some unique and typelists into stringlists

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -115,10 +115,10 @@
 	can_hold_description = generate_hold_desc(can_hold_list)
 
 	if (can_hold_list != null)
-		can_hold = typecacheof(can_hold_list)
+		can_hold = string_list(typecacheof(can_hold_list))
 
 	if (cant_hold_list != null)
-		cant_hold = typecacheof(cant_hold_list)
+		cant_hold = string_list(typecacheof(cant_hold_list))
 
 /datum/component/storage/proc/generate_hold_desc(can_hold_list)
 	var/list/desc = list()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -190,9 +190,11 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 /obj/item/Initialize()
 
 	if(attack_verb_continuous)
-		attack_verb_continuous = typelist("attack_verb_continuous", attack_verb_continuous)
+		attack_verb_continuous = string_list(attack_verb_continuous)
 	if(attack_verb_simple)
-		attack_verb_simple = typelist("attack_verb_simple", attack_verb_simple)
+		attack_verb_simple = string_list(attack_verb_simple)
+	if(species_exception)
+		species_exception = string_list(species_exception)
 
 	. = ..()
 	for(var/path in actions_types)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -49,8 +49,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		inhand_icon_state = "cigon"
 		name = "lit [initial(name)]"
 		desc = "A [initial(name)]. This one is lit."
-		attack_verb_continuous = list("burns", "sings")
-		attack_verb_simple = list("burn", "sing")
+		attack_verb_continuous = string_list(list("burns", "sings"))
+		attack_verb_simple = string_list(list("burn", "sing"))
 		START_PROCESSING(SSobj, src)
 		update_icon()
 
@@ -64,8 +64,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		inhand_icon_state = "cigoff"
 		name = "burnt [initial(name)]"
 		desc = "A [initial(name)]. This one has seen better days."
-		attack_verb_continuous = list("flicks")
-		attack_verb_simple = list("flick")
+		attack_verb_continuous = string_list(list("flicks"))
+		attack_verb_simple = string_list(list("flick"))
 		STOP_PROCESSING(SSobj, src)
 
 /obj/item/match/extinguish()
@@ -188,8 +188,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	lit = TRUE
 	name = "lit [name]"
-	attack_verb_continuous = list("burns", "sings")
-	attack_verb_simple = list("burn", "sing")
+	attack_verb_continuous = string_list(list("burns", "sings"))
+	attack_verb_simple = string_list(list("burn", "sing"))
 	hitsound = 'sound/items/welder.ogg'
 	damtype = BURN
 	force = 4
@@ -680,8 +680,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		force = 5
 		damtype = BURN
 		hitsound = 'sound/items/welder.ogg'
-		attack_verb_continuous = list("burns", "sings")
-		attack_verb_simple = list("burn", "sing")
+		attack_verb_continuous = string_list(list("burns", "sings"))
+		attack_verb_simple = string_list(list("burn", "sing"))
 		START_PROCESSING(SSobj, src)
 	else
 		hitsound = "swing_hit"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -650,6 +650,15 @@
 	var/list/card_attack_verb_continuous = list("attacks")
 	var/list/card_attack_verb_simple = list("attack")
 
+
+/obj/item/toy/cards/Initialize()
+	. = ..()
+	if(card_attack_verb_continuous)
+		card_attack_verb_continuous = string_list(card_attack_verb_continuous)
+	if(card_attack_verb_simple)
+		card_attack_verb_simple = string_list(card_attack_verb_simple)
+
+
 /obj/item/toy/cards/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] is slitting [user.p_their()] wrists with \the [src]! It looks like [user.p_they()] [user.p_have()] a crummy hand!</span>")
 	playsound(src, 'sound/items/cardshuffle.ogg', 50, TRUE)
@@ -848,8 +857,8 @@
 	newobj.card_throwforce = sourceobj.card_throwforce
 	newobj.card_throw_speed = sourceobj.card_throw_speed
 	newobj.card_throw_range = sourceobj.card_throw_range
-	newobj.card_attack_verb_continuous = sourceobj.card_attack_verb_continuous
-	newobj.card_attack_verb_simple = sourceobj.card_attack_verb_simple
+	newobj.card_attack_verb_continuous = sourceobj.card_attack_verb_continuous //null or unique list made by string_list()
+	newobj.card_attack_verb_simple = sourceobj.card_attack_verb_simple //null or unique list made by string_list()
 	newobj.resistance_flags = sourceobj.resistance_flags
 
 /**
@@ -968,10 +977,8 @@
 	newobj.throw_speed = newobj.card_throw_speed
 	newobj.card_throw_range = sourceobj.card_throw_range
 	newobj.throw_range = newobj.card_throw_range
-	newobj.card_attack_verb_continuous = sourceobj.card_attack_verb_continuous
-	newobj.attack_verb_continuous = newobj.card_attack_verb_continuous
-	newobj.card_attack_verb_simple = sourceobj.card_attack_verb_simple
-	newobj.attack_verb_simple = newobj.card_attack_verb_simple
+	newobj.attack_verb_continuous = newobj.card_attack_verb_continuous = sourceobj.card_attack_verb_continuous //null or unique list made by string_list()
+	newobj.attack_verb_simple = newobj.card_attack_verb_simple = sourceobj.card_attack_verb_simple //null or unique list made by string_list()
 
 /*
 || Syndicate playing cards, for pretending you're Gambit and playing poker for the nuke disk. ||

--- a/code/modules/holodeck/holo_effect.dm
+++ b/code/modules/holodeck/holo_effect.dm
@@ -45,14 +45,14 @@
 		D.card_throwforce = 0
 		D.card_throw_speed = 3
 		D.card_throw_range = 7
-		D.card_attack_verb_continuous = list("attacks")
+		D.card_attack_verb_continuous = string_list(list("attacks"))
 	else
 		D.card_hitsound = 'sound/weapons/bladeslice.ogg'
 		D.card_force = 5
 		D.card_throwforce = 10
 		D.card_throw_speed = 3
 		D.card_throw_range = 7
-		D.card_attack_verb_continuous = list("attacks", "slices", "dices", "slashes", "cuts")
+		D.card_attack_verb_continuous = string_list(list("attacks", "slices", "dices", "slashes", "cuts"))
 
 
 /obj/effect/holodeck_effect/sparks/activate(obj/machinery/computer/holodeck/HC)

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -33,24 +33,24 @@ Slimecrossing Weapons
 	switch(damtype)
 		if(BRUTE)
 			hitsound = 'sound/weapons/bladeslice.ogg'
-			attack_verb_continuous = list("slashes", "slices", "cuts")
-			attack_verb_simple = list("slash", "slice", "cut")
+			attack_verb_continuous = string_list(list("slashes", "slices", "cuts"))
+			attack_verb_simple = string_list(list("slash", "slice", "cut"))
 		if(BURN)
 			hitsound = 'sound/weapons/sear.ogg'
-			attack_verb_continuous = list("burns", "sings", "heats")
-			attack_verb_simple = list("burn", "sing", "heat")
+			attack_verb_continuous = string_list(list("burns", "sings", "heats"))
+			attack_verb_simple = string_list(list("burn", "sing", "heat"))
 		if(TOX)
 			hitsound = 'sound/weapons/pierce.ogg'
-			attack_verb_continuous = list("poisons", "doses", "toxifies")
-			attack_verb_simple = list("poison", "dose", "toxify")
+			attack_verb_continuous = string_list(list("poisons", "doses", "toxifies"))
+			attack_verb_simple = string_list(list("poison", "dose", "toxify"))
 		if(OXY)
 			hitsound = 'sound/effects/space_wind.ogg'
-			attack_verb_continuous = list("suffocates", "winds", "vacuums")
-			attack_verb_simple = list("suffocate", "wind", "vacuum")
+			attack_verb_continuous = string_list(list("suffocates", "winds", "vacuums"))
+			attack_verb_simple = string_list(list("suffocate", "wind", "vacuum"))
 		if(CLONE)
 			hitsound = 'sound/items/geiger/ext1.ogg'
-			attack_verb_continuous = list("irradiates", "mutates", "maligns")
-			attack_verb_simple = list("irradiate", "mutate", "malign")
+			attack_verb_continuous = string_list(list("irradiates", "mutates", "maligns"))
+			attack_verb_simple = string_list(list("irradiate", "mutate", "malign"))
 	return ..()
 
 //Adamantine shield - Chilling Adamantine


### PR DESCRIPTION
String lists are cached unique lists, to diminish memory usage a bit. Like typelists, but the index is the actual content of the list, joined with a `"-"` glue.

* `card_attack_verb_continuous`, `card_attack_verb_simple`, `species_exception`, `can_hold` and `cant_hold` turned from unique lists into string lists.
* `attack_verb_continuous` and `attack_verb_simple` turned from type lists into string lists, because no reason not to.