### PR TITLE
Fixes NOBLOOD species having hearts

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -98,7 +98,7 @@
 		failed = TRUE
 
 /obj/item/organ/heart/get_availability(datum/species/S)
-	return !(NOBLOOD in S.inherent_traits)
+	return !(NOBLOOD in S.species_traits)
 
 /obj/item/organ/heart/cursed
 	name = "cursed heart"


### PR DESCRIPTION
## About The Pull Request

It was checking for `NOBLOOD` in the wrong place, which obviously means it was never found

## Why It's Good For The Game

I should be suffering more than I have been when I play as a plasmeme. I earned my death, not my revival, no easy defibbing.
Medstaff should either have to learn how to revive me or not revive me at all, no half measures of "just treat them like a human, but never take them off stasis."

## Changelog
:cl:
fix: Species without blood won't spawn with a vestigial heart any more
/:cl: