### PR TITLE
hexane refractor and rework

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1411,7 +1411,7 @@
 
 /datum/reagent/hexane/on_mob_life(mob/living/L)
 	. = ..()
-	L.hallucination += 150
+	L.hallucination += 10
 	if(prob(25))
 		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3, 150)
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1412,8 +1412,6 @@
 /datum/reagent/hexane/on_mob_life(mob/living/L)
 	. = ..()
 	L.hallucination += 10
-	if(prob(25))
-		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3, 150)
 
 /////////////////////////Colorful Powder////////////////////////////
 //For colouring in /proc/mix_color_from_reagents

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1401,13 +1401,19 @@
 	. = ..()
 	L.add_movespeed_modifier(/datum/movespeed_modifier/reagent/halon)
 	ADD_TRAIT(L, CHANGELING_HIVEMIND_MUTE, type)
-	ADD_TRAIT(L, TRAIT_SIXTHSENSE, type)
+	ADD_TRAIT(L, TRAIT_RESISTHEAT, type)
 
 /datum/reagent/hexane/on_mob_end_metabolize(mob/living/L)
 	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/halon)
 	REMOVE_TRAIT(L, CHANGELING_HIVEMIND_MUTE, type)
-	REMOVE_TRAIT(L, TRAIT_SIXTHSENSE, type)
+	REMOVE_TRAIT(L, TRAIT_RESISTHEAT, type)
 	return ..()
+
+/datum/reagent/hexane/on_mob_life(mob/living/L)
+	. = ..()
+	L.hallucination += 150
+	if(prob(25))
+		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3, 150)
 
 /////////////////////////Colorful Powder////////////////////////////
 //For colouring in /proc/mix_color_from_reagents

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -39,6 +39,8 @@
 	var/healium_para_min = 3
 	///Minimum amount of healium to knock you down for good
 	var/healium_sleep_min = 6
+	///Minimum amount of hexane needed to start having effect
+	var/hexane_min = 2
 
 	var/oxy_breath_dam_min = MIN_TOXIC_GAS_DAMAGE
 	var/oxy_breath_dam_max = MAX_TOXIC_GAS_DAMAGE
@@ -377,11 +379,9 @@
 
 	// Hexane
 		var/hexane_pp = breath.get_breath_partial_pressure(breath_gases[/datum/gas/hexane][MOLES])
-		if(hexane_pp > gas_stimulation_min)
-			H.hallucination += 50
-			H.reagents.add_reagent(/datum/reagent/hexane,5)
-			if(prob(33))
-				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3, 150)
+		if(hexane_pp > hexane_min)
+			var/existing = H.reagents.get_reagent_amount(/datum/reagent/hexane)
+			H.reagents.add_reagent(/datum/reagent/hexane,max(0, 5 - existing))
 
 	// Stimulum
 		gas_breathed = breath_gases[/datum/gas/stimulum][MOLES]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hexane no longer grant the ability to hear dchat (yep it was a bad idea)
Hexane now gives the resist heat trait to fight fires better but can give you brain damage (small amount behind a 25% chance) and a lot of hallucinations
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
hearing dchat bad + refractor good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
refractor: hexane properties are on the reagent and not the breathing
del: hexane no longer grand you dchat hearing
add: hexane makes you heat resistant (can still die due to pressure)
del: Hexane no longer deals brain damage 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
