### PR TITLE
Fix advanced infiltrator

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -552,7 +552,7 @@
 	name = "basic syndicate infiltrator"
 
 /datum/map_template/shuttle/infiltrator/advanced
-	suffix = "basic"
+	suffix = "advanced"
 	name = "advanced syndicate infiltrator"
 
 /datum/map_template/shuttle/cargo/delta


### PR DESCRIPTION
## About The Pull Request

Someone set wrong suffix for advanced syndicate infiltrator.

Now advanced syndicate infiltrator available for badmintry.

Introduced in #43735

![image](https://user-images.githubusercontent.com/7734424/95604864-d6b11600-0a60-11eb-9a97-239141cdac0c.png)


## Why It's Good For The Game

Bugs is bad
Badmintry is great.

## Changelog
:cl:
fix: Fixed syndicate shuttle catalog entity, admins can now spawn the advanced syndicate infiltator during a round
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
