### PR TITLE
Lasergun resizing

### DIFF
--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -55,6 +55,7 @@
 	desc = "This is an expensive, modern recreation of an antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time."
 	cell_type = /obj/item/stock_parts/cell/hos_gun
 	icon_state = "hoslaser"
+	w_class = WEIGHT_CLASS_NORMAL
 	force = 10
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler/hos, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/ion/hos)
 	ammo_x_offset = 4

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -38,6 +38,7 @@
 /obj/item/gun/energy/laser/captain
 	name = "antique laser gun"
 	icon_state = "caplaser"
+	w_class = WEIGHT_CLASS_NORMAL
 	inhand_icon_state = null
 	desc = "This is an antique laser gun. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy. On the item is an image of Space Station 13. The station is exploding."
 	force = 10


### PR DESCRIPTION
## About The Pull Request

This PR is going to change X-01 MultiPhase Energy Gun and antique laser gun sizes from bulky to normal.

## Why It's Good For The Game

X-01 and Antique laser gun are one of the kind and they are supposed to be stronger than a regular laser/energy gun. What's more these items are traitor objectives and now they're hard to conceal, since you have to put them on the exo armor slot or carry them around in your hands.

## Changelog
:cl:
balance: HoS and Captain Laserguns are now normal sized. 
/:cl: