### PR TITLE
Add Bluespace Navigation Gigabeacon to Lavaland

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -4556,6 +4556,10 @@
 /obj/machinery/mechpad,
 /turf/open/floor/plasteel,
 /area/mine/mechbay)
+"Ni" = (
+/obj/machinery/spaceship_navigation_beacon,
+/turf/open/floor/circuit,
+/area/mine/maintenance)
 "Nj" = (
 /obj/machinery/door/airlock{
 	name = "Restroom"
@@ -12685,7 +12689,7 @@ cC
 Pa
 zX
 cQ
-dg
+Ni
 dg
 cQ
 dZ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Add Bluespace Navigation Gigabeacon to Lavaland mining base.

## Why It's Good For The Game

Custom locations on Lavaland is great.

## Changelog
:cl:
add: Lavaland mining base now equipped by Bluespace Navigation Gigabeacon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
