### PR TITLE
Fixes bolt action guns getting phantom bullets chambered upon initialization.

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -98,7 +98,10 @@
 		return
 	if (!magazine)
 		magazine = new mag_type(src)
-	chamber_round(replace_new_round = TRUE)
+	if(bolt_type == BOLT_TYPE_STANDARD)
+		chamber_round()
+	else
+		chamber_round(replace_new_round = TRUE)
 	update_icon()
 
 /obj/item/gun/ballistic/vv_edit_var(vname, vval)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pr (https://github.com/tgstation/tgstation/pull/50410) broke mosins by jamming an extra bullet into their chamber when spawned. This basically breaks them A LITTLE. Not noticably but a little.

So I resolved that. Bolt action guns now just use the previous behaviour.

## Why It's Good For The Game

You see Ivan.

I put two bullet into chamber.

I shoot twice as fast.

It work.

## Changelog
:cl:
fix: Fixes bolt action guns having a mysterious additional bullet chambered upon initialization.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
