### PR TITLE
pressure and temperature gauges on canister examines

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -83,6 +83,12 @@
 	. = ..()
 	if(mode)
 		. += "<span class='notice'>This canister is [mode]. A sticker on its side says <b>MAX PRESSURE: [siunit(pressure_limit, "Pa", 0)]</b>.</span>"
+	if(!in_range(src, user) && !isobserver(user))
+		. += "<span class='notice'>If you want any more information you'll need to get closer.</span>"
+		return
+	. += "<span class='notice'>The pressure and temperature gauges read:</span>"
+	. += "<span class='notice'>- [round(air_contents.return_pressure(),0.01)] kPa.</span>"
+	. += "<span class='notice'>- [round(air_contents.return_temperature(),0.01)] K.</span>"
 
 /obj/machinery/portable_atmospherics/canister/nitrogen
 	name = "Nitrogen canister"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds pressure and temperature amounts on examine if the player is close to the canister, similar to how tanks work
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
QoL good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: pressure and temperature gauges on canisters examine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
