### PR TITLE
[READY] Fixes being able to use items while inside a mech

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -394,8 +394,8 @@
 	return obscured
 
 
-/obj/item/proc/equip_to_best_slot(mob/M, swap=FALSE)
-	if(src != M.get_active_held_item())
+/obj/item/proc/equip_to_best_slot(mob/M, swap = FALSE, check_hand = TRUE)
+	if(check_hand && src != M.get_active_held_item())
 		to_chat(M, "<span class='warning'>You are not holding anything to equip!</span>")
 		return FALSE
 

--- a/code/modules/vehicles/cars/car.dm
+++ b/code/modules/vehicles/cars/car.dm
@@ -52,19 +52,10 @@
 	mob_exit(M, silent)
 	return TRUE
 
-/obj/vehicle/sealed/car/attacked_by(obj/item/I, mob/living/user)
-	if(!I.force)
-		return
-	if(occupants[user])
-		to_chat(user, "<span class='notice'>Your attack bounces off \the [src]'s padded interior.</span>")
-		return
-	return ..()
 
 /obj/vehicle/sealed/car/attack_hand(mob/living/user)
 	. = ..()
 	if(!(car_traits & CAN_KIDNAP))
-		return
-	if(occupants[user])
 		return
 	to_chat(user, "<span class='notice'>You start opening [src]'s trunk.</span>")
 	if(do_after(user, 30))

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -99,8 +99,12 @@
 		return
 	to_chat(user, "<span class='notice'>You remove [inserted_key] from [src].</span>")
 	inserted_key.forceMove(drop_location())
-	user.put_in_hands(inserted_key)
+	if(!HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+		user.put_in_hands(inserted_key)
+	else
+		inserted_key.equip_to_best_slot(user, check_hand = FALSE)
 	inserted_key = null
+
 
 /obj/vehicle/sealed/obj_destruction(damage_flag)
 	explosion(loc, 0, 1, 2, 3, 0)

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -24,6 +24,17 @@
 	if(ismob(AM))
 		remove_occupant(AM)
 
+
+/obj/vehicle/sealed/after_add_occupant(mob/M)
+	. = ..()
+	ADD_TRAIT(M, TRAIT_HANDS_BLOCKED, VEHICLE_TRAIT)
+
+
+/obj/vehicle/sealed/after_remove_occupant(mob/M)
+	. = ..()
+	REMOVE_TRAIT(M, TRAIT_HANDS_BLOCKED, VEHICLE_TRAIT)
+
+
 /obj/vehicle/sealed/proc/mob_try_enter(mob/M)
 	if(!istype(M))
 		return FALSE

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -98,6 +98,7 @@
 	var/obj/vehicle/vehicle_target
 
 /datum/action/vehicle/sealed
+	check_flags = AB_CHECK_IMMOBILE | AB_CHECK_CONSCIOUS
 	var/obj/vehicle/sealed/vehicle_entered_target
 
 /datum/action/vehicle/sealed/climb_out


### PR DESCRIPTION
* Fixes #54298
It was caused by the mech refactor, which removed less-than-ideal checks for whether the mob was inside a mech. This kind of functionality is better.