### PR TITLE
May i borrow some sugar? Nerfs free sugar(All aboard the nerf train).

### DIFF
--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -108,6 +108,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
 	list_reagents = list(/datum/reagent/consumable/sugar = 50)
 	fill_icon_thresholds = null
+	custom_premium_price = 100
 
 /obj/item/reagent_containers/food/condiment/saltshaker		//Separate from above since it's a small shaker rather then
 	name = "salt shaker"											//	a large one.

--- a/code/modules/plumbing/plumbers/synthesizer.dm
+++ b/code/modules/plumbing/plumbers/synthesizer.dm
@@ -35,7 +35,6 @@
 		/datum/reagent/silver,
 		/datum/reagent/sodium,
 		/datum/reagent/stable_plasma,
-		/datum/reagent/consumable/sugar,
 		/datum/reagent/sulfur,
 		/datum/reagent/toxin/acid,
 		/datum/reagent/water,

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -57,7 +57,6 @@
 		/datum/reagent/silver,
 		/datum/reagent/sodium,
 		/datum/reagent/stable_plasma,
-		/datum/reagent/consumable/sugar,
 		/datum/reagent/sulfur,
 		/datum/reagent/toxin/acid,
 		/datum/reagent/water,
@@ -473,7 +472,6 @@
 		/datum/reagent/consumable/lemon_lime,
 		/datum/reagent/consumable/pwr_game,
 		/datum/reagent/consumable/shamblers,
-		/datum/reagent/consumable/sugar,
 		/datum/reagent/consumable/pineapplejuice,
 		/datum/reagent/consumable/orangejuice,
 		/datum/reagent/consumable/grenadine,
@@ -487,7 +485,8 @@
 		/datum/reagent/consumable/ethanol/thirteenloko,
 		/datum/reagent/consumable/ethanol/whiskey_cola,
 		/datum/reagent/toxin/mindbreaker,
-		/datum/reagent/toxin/staminatoxin
+		/datum/reagent/toxin/staminatoxin,
+		/datum/reagent/consumable/sugar,
 	)
 
 /obj/machinery/chem_dispenser/drinks/fullupgrade //fully ugpraded stock parts, emagged

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -41,7 +41,8 @@
 					 /obj/item/reagent_containers/food/drinks/bottle/fernet = 5)
 	premium = list(/obj/item/reagent_containers/glass/bottle/ethanol = 4,
 				   /obj/item/reagent_containers/food/drinks/bottle/champagne = 5,
-				   /obj/item/reagent_containers/food/drinks/bottle/trappist = 5)
+				   /obj/item/reagent_containers/food/drinks/bottle/trappist = 5,
+				   /obj/item/reagent_containers/food/condiment/sugar = 5)
 
 	product_slogans = "I hope nobody asks me for a bloody cup o' tea...;Alcohol is humanity's friend. Would you abandon a friend?;Quite delighted to serve you!;Is nobody thirsty on this station?"
 	product_ads = "Drink up!;Booze is good for you!;Alcohol is humanity's best friend.;Quite delighted to serve you!;Care for a nice, cold beer?;Nothing cures you like booze!;Have a sip!;Have a drink!;Have a beer!;Beer is good for you!;Only the finest alcohol!;Best quality booze since 2053!;Award-winning wine!;Maximum alcohol!;Man loves beer.;A toast for progress!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR removes sugar from the synthesizer and dispenser. In addtion the ability of the soda dispenser to dispense pure sugar is locked behind the emag effect.

To compensate you will be able to buy sacks of sugar from the booze-o-mat for 100 credits each.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Infinite free sugar from these dispensers allows player to opt out of the hunger mechanic and it is also part of some popular chems, the most significant being smoke, meth and mannitol. I  think making these chems slightly harder/more expensive to make would be interesting.

It also makes sugarcane useful.

For small or average batch chemistry you can buy sugar, or find and grind various sugary snacks, but for big plumbing setups you might need to grow some sugarcane or emag a soda dispenser.

Sugarcane has a very high yield of sugar(25%) and decent stats, so this should not be too much of an impediment to plumbing setups since the grinding module does the annoying part for you.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The booze-o-mat now sells sacks of sugar.
del: The chemical dispenser no longer dispenses sugar.
del: The chemical synthesizer no longer synthesizes sugar.
del: The soda dispenser no longer dispenses sugar unless emagged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
