### PR TITLE
Adds a tiny define useful for downstreams

### DIFF
--- a/code/__DEFINES/icon_smoothing.dm
+++ b/code/__DEFINES/icon_smoothing.dm
@@ -125,3 +125,5 @@ DEFINE_BITFIELD(smoothing_flags, list(
 #define SMOOTH_GROUP_CLEANABLE_DIRT	S_OBJ(67)			///obj/effect/decal/cleanable/dirt
 
 #define SMOOTH_GROUP_INDUSTRIAL_LIFT S_OBJ(70)			///obj/structure/industrial_lift
+
+#define MAX_S_OBJ SMOOTH_GROUP_INDUSTRIAL_LIFT //Always match this value with the one above it.


### PR DESCRIPTION
This will affect us in no way, but it will make it easier for our downstreams to add their own custom smoothing groups without generating conflicts.
I know upstream support is not something we guarantee, but the cost here is really null.