### PR TITLE
Re-enables ghost role events

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -53,7 +53,7 @@
 		return FALSE
 	if(EMERGENCY_ESCAPED_OR_ENDGAMED)
 		return FALSE
-	if(ispath(typepath, /datum/round_event/ghost_role) && GHOSTROLE_MIDROUND_EVENT)
+	if(ispath(typepath, /datum/round_event/ghost_role) && !(GLOB.ghost_role_flags & GHOSTROLE_MIDROUND_EVENT))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

so the proc that checks if a random event is allowed to trigger (`/datum/round_event_control/proc/canSpawnEvent`) returns `FALSE` if this check is true:
>`(ispath(typepath, /datum/round_event/ghost_role) && GHOSTROLE_MIDROUND_EVENT)`

hmmm that's interesting, I wonder what GHOSTROLE_MIDROUND_EVENT is?

>`#define GHOSTROLE_MIDROUND_EVENT	(1<<0)`

oh
well that explains why I haven't been getting midround antag lately

## Why It's Good For The Game

Basically, a messed-up bitflag check has been stopping all event ghostroles from spawning for the last two months (outside of dynamic mode).

## Changelog
🆑
fix: Midround events that require ghosts should be able to trigger again
/🆑