### PR TITLE
Remove monkey1 icon rendering as it is hiding limb loss

### DIFF
--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -2,8 +2,6 @@
 	name = "monkey"
 	verb_say = "chimpers"
 	initial_language_holder = /datum/language_holder/monkey
-	icon = 'icons/mob/monkey.dmi'
-	icon_state = "monkey1"
 	gender = NEUTER
 	pass_flags = PASSTABLE
 	ventcrawler = VENTCRAWLER_NUDE


### PR DESCRIPTION
## About The Pull Request

Dismemberment of monkey limbs was not showing on the monkey itself.

`/mob/living/carbon/proc/update_body_parts()` is working correctly for monkeys but the `monkey1`  icon was convering up the absence of limbs.

This is on master:
![image](https://user-images.githubusercontent.com/32263167/95671156-5affb800-0b8b-11eb-9a12-dbfd193a5f6d.png)

My changes:
![image](https://user-images.githubusercontent.com/32263167/95670890-00fdf300-0b89-11eb-99b8-ee159da82e2c.png)



## Why It's Good For The Game
No need to examine monkeys for missing limbs.
Also duplicate monkey rendering was effectively occurring.

## Changelog
:cl:
fix: Monkeys will once again show missing limbs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
