### PR TITLE
Fixes permanent stamina crit while in stasis

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -21,12 +21,6 @@
 			handle_blood()
 
 		if(stat != DEAD)
-			var/bprv = handle_bodyparts()
-			if(bprv & BODYPART_LIFE_UPDATE_HEALTH)
-				update_stamina() //needs to go before updatehealth to remove stamcrit
-				updatehealth()
-
-		if(stat != DEAD)
 			handle_brain_damage()
 
 	else
@@ -35,6 +29,11 @@
 	if(stat == DEAD)
 		stop_sound_channel(CHANNEL_HEARTBEAT)
 		LoadComponent(/datum/component/rot/corpse)
+	else
+		var/bprv = handle_bodyparts()
+		if(bprv & BODYPART_LIFE_UPDATE_HEALTH)
+			update_stamina() //needs to go before updatehealth to remove stamcrit
+			updatehealth()
 
 	check_cremation()
 


### PR DESCRIPTION
Stamina regeneration should happen regardless of if a mob is in stasis or not.
The alternative is having someone be permanently disabled by being stamcrit'ed and buckled to a stasis bed.
I feel that the other possible solution of allowing someone to unbuckle from a stasis bed while stunned is less ideal than this one.