### PR TITLE
Null rods no longer vanish when selecting a new holy weapon skin.

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -229,8 +229,8 @@
 		return
 	var/list/display_names = list()
 	var/list/nullrod_icons = list()
-	for(var/V in typesof(/obj/item/nullrod))
-		var/obj/item/nullrod/rodtype = V
+	for(var/rod in typesof(/obj/item/nullrod))
+		var/obj/item/nullrod/rodtype = rod
 		if(initial(rodtype.chaplain_spawnable))
 			display_names[initial(rodtype.name)] = rodtype
 			nullrod_icons += list(initial(rodtype.name) = image(icon = initial(rodtype.icon), icon_state = initial(rodtype.icon_state)))
@@ -240,8 +240,8 @@
 	if(!choice || !check_menu(M))
 		return
 
-	var/A = display_names[choice] // This needs to be on a separate var as list member access is not allowed for new
-	var/obj/item/nullrod/holy_weapon = new A
+	var/picked_rod_type = display_names[choice] // This needs to be on a separate var as list member access is not allowed for new
+	var/obj/item/nullrod/holy_weapon = new picked_rod_type(get_turf(src))
 	GLOB.holy_weapon_type = holy_weapon.type
 
 	SSblackbox.record_feedback("tally", "chaplain_weapon", 1, "[choice]")
@@ -249,7 +249,7 @@
 	if(holy_weapon)
 		holy_weapon.reskinned = TRUE
 		qdel(src)
-		M.put_in_active_hand(holy_weapon)
+		M.put_in_hands(holy_weapon)
 
 /**
   * check_menu: Checks if we are allowed to interact with a radial menu

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -241,7 +241,7 @@
 		return
 
 	var/picked_rod_type = display_names[choice] // This needs to be on a separate var as list member access is not allowed for new
-	var/obj/item/nullrod/holy_weapon = new picked_rod_type(get_turf(src))
+	var/obj/item/nullrod/holy_weapon = new picked_rod_type(drop_location())
 	GLOB.holy_weapon_type = holy_weapon.type
 
 	SSblackbox.record_feedback("tally", "chaplain_weapon", 1, "[choice]")

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -241,7 +241,7 @@
 		return
 
 	var/picked_rod_type = display_names[choice] // This needs to be on a separate var as list member access is not allowed for new
-	var/obj/item/nullrod/holy_weapon = new picked_rod_type(drop_location())
+	var/obj/item/nullrod/holy_weapon = new picked_rod_type(M.drop_location())
 	GLOB.holy_weapon_type = holy_weapon.type
 
 	SSblackbox.record_feedback("tally", "chaplain_weapon", 1, "[choice]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Put null rod in active hand > Bring up radial menu to select new skin > Swap active hands to hand that is full > Select new skin > Nullrod spawns in nullspace, can't be put in active hand, stays in nullspace, old rod deleted > Chaplain has no null rod.

Now we (redundantly) spawn the new null rod at the holder's drop_location instead of nullspace.

We use put_in_hands which will attempt to put it in the active hand, followed by any free hand, followed by the drop_location if all else failed (told you the above was redundant, probably good practice to do though)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I no longer get messages at 11pm on a Saturday night when I'm drunk as fuck asking me to investigate this bug.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Null rods will no longer banish themselves into the nether realms (never to be seen again) when you select a new null rod skin while your active hand contains anything but the null rod.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
