### PR TITLE
Chaplains should no longer experience invisible bibles.

### DIFF
--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -27,8 +27,11 @@
 			H.mind.holy_role = HOLY_ROLE_PRIEST
 		B.deity_name = GLOB.deity
 		B.name = GLOB.bible_name
-		B.icon_state = GLOB.bible_icon_state
-		B.inhand_icon_state = GLOB.bible_inhand_icon_state
+		// These checks are important as there's no guarantee the "HOLY_ROLE_HIGHPRIEST" chaplain has selected a bible skin.
+		if(GLOB.bible_icon_state)
+			B.icon_state = GLOB.bible_icon_state
+		if(GLOB.bible_inhand_icon_state)
+			B.inhand_icon_state = GLOB.bible_inhand_icon_state
 		to_chat(H, "<span class='boldnotice'>There is already an established religion onboard the station. You are an acolyte of [GLOB.deity]. Defer to the Chaplain.</span>")
 		H.equip_to_slot_or_del(B, ITEM_SLOT_BACKPACK)
 		var/nrt = GLOB.holy_weapon_type || /obj/item/nullrod


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Latejoin as Chaplain when there's already a Chaplain on the station.

If the OG Chappie hasn't selected a bible skin yet, you'll be given a bible with a broken icon_state as selecting a bible skin is what seeds the relevant GLOBs with values.

After the fix, we only overwrite the bible's icon_state if an existing bible skin has been selected by the station's main Chappie.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Keeps Fikou happy.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Latejoin chaplains should no longer have invisible bibles in certain circumstances.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
