### PR TITLE
Fixes crafting duplication bug/runtime and attempts to address destroying items in consumed containers

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -133,3 +133,26 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 
 /proc/cmp_mob_realname_dsc(mob/A,mob/B)
 	return sorttext(A.real_name,B.real_name)
+
+/**
+  * Sorts crafting recipe requirements before the crafting recipe is inserted into GLOB.crafting_recipes
+  *
+  * Prioritises [/datum/reagent] to ensure reagent requirements are always processed first when crafting.
+  * This prevents any reagent_containers from being consumed before the reagents they contain, which can
+  * lead to runtimes and item duplication when it happens.
+  */
+/proc/cmp_crafting_req_priority(var/A, var/B)
+	var/lhs
+	var/rhs
+
+	if(ispath(A, /datum/reagent))
+		lhs = 0
+	else
+		lhs = 1
+
+	if(ispath(B, /datum/reagent))
+		rhs = 0
+	else
+		rhs = 1
+
+	return lhs - rhs

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -145,14 +145,7 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 	var/lhs
 	var/rhs
 
-	if(ispath(A, /datum/reagent))
-		lhs = 0
-	else
-		lhs = 1
-
-	if(ispath(B, /datum/reagent))
-		rhs = 0
-	else
-		rhs = 1
+	lhs = ispath(A, /datum/reagent) ? 0 : 1
+	rhs = ispath(B, /datum/reagent) ? 0 : 1
 
 	return lhs - rhs

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -50,7 +50,17 @@
 
 	GLOB.emote_list = init_emote_list()
 
-	init_subtypes(/datum/crafting_recipe, GLOB.crafting_recipes)
+	init_crafting_recipes(GLOB.crafting_recipes)
+
+/// Inits the crafting recipe list, sorting crafting recipe requirements in the process.
+/proc/init_crafting_recipes(list/crafting_recipes)
+	if(!istype(crafting_recipes))
+		crafting_recipes = list()
+	for(var/path in subtypesof(/datum/crafting_recipe))
+		var/datum/crafting_recipe/recipe = new path()
+		recipe.reqs = sortList(recipe.reqs, /proc/cmp_crafting_req_priority)
+		crafting_recipes += recipe
+	return crafting_recipes
 
 //creates every subtype of prototype (excluding prototype) and adds it to list L.
 //if no list/L is provided, one is created.

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -54,8 +54,6 @@
 
 /// Inits the crafting recipe list, sorting crafting recipe requirements in the process.
 /proc/init_crafting_recipes(list/crafting_recipes)
-	if(!istype(crafting_recipes))
-		crafting_recipes = list()
 	for(var/path in subtypesof(/datum/crafting_recipe))
 		var/datum/crafting_recipe/recipe = new path()
 		recipe.reqs = sortList(recipe.reqs, /proc/cmp_crafting_req_priority)

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -311,6 +311,14 @@
 	while(Deletion.len)
 		var/DL = Deletion[Deletion.len]
 		Deletion.Cut(Deletion.len)
+		// Snowflake handling of reagent containers and storage atoms.
+		// If we consumed them in our crafting, we should dump their contents out before qdeling them.
+		if(istype(DL, /obj/item/reagent_containers))
+			var/obj/item/reagent_containers/container = DL
+			container.reagents.expose(container.loc, TOUCH)
+		else if(istype(DL, /obj/item/storage))
+			var/obj/item/storage/container = DL
+			container.emptyStorage()
 		qdel(DL)
 
 /datum/component/personal_crafting/proc/component_ui_interact(obj/screen/craft/image, location, control, params, user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #54300

First issue: Certain crafting recipes (for example, Hooch) require a bottle, 100u hooch and a paper bag. If the 100u of hooch is **in** the bottle, because the crafting recipe has the bottle before the hooch in the requirements list, the craft will runtime as the bottle is "consumed" along with all its reagents.

To remedy this, I've created a simple sorter proc that runs when the global recipe list is inited. Before each recipe is added to the global recipe list, it now sorts the crafting requirements so that reagents are always processed first.

It's not exactly pretty, but it solves having to either refactor crafting code (please God no) or to go through every recipe datum and manually reorder the req list or create a unit test to ensure all recipe reqs are in the appropriate order.

Second issue: When crafting consumes a container, it qdels it and thus qdels all the items inside of it.

I've added two snowflake checks to empty the contents of reagent_containers and storage items before they are qdel'd. No more accidentally deleting items through crafting.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I no longer get messages at 11pm on a Saturday night when I'm drunk as fuck asking me to investigate this bug.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Crafting recipes that require both bottles and reagents now craft properly when the bottle contains the reagent, without duplicating items.
fix: Crafting that consumes items that have some sort of inventory should now dump the inventory contents out instead of deleting them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
