### PR TITLE
Enables a click cooldown on throws

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -81,6 +81,7 @@
 
 //click cooldowns, in tenths of a second, used for various combat actions
 #define CLICK_CD_MELEE 8
+#define CLICK_CD_THROW 8
 #define CLICK_CD_RANGE 4
 #define CLICK_CD_RAPID 2
 #define CLICK_CD_CLICK_ABILITY 6

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -115,6 +115,7 @@
 		return
 
 	if(in_throw_mode)
+		changeNext_move(CLICK_CD_THROW)
 		throw_item(A)
 		return
 


### PR DESCRIPTION
This counters the external macro that weaponizes throws a the cost of making the game slightly less responsive. The value can be tweaked if 0.8 seconds is deemed too high, but I feel that the same as the base melee click cooldown seems fair to me.