### PR TITLE
New C2 Chem for Brain Damage

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -500,6 +500,26 @@
 	H.adjustOrganLoss(ORGAN_SLOT_HEART,10)
 	H.set_heartattack(TRUE)
 
+/*
+ *Proto-Neurite
+ *Does nothing below 30 brain damage. At or above, heals 3 brain damage.
+ *Deals 1 tox and 1 heart damage every tick, with a rare chance of seizure.
+*/
+/datum/reagent/medicine/c2/protoneurite
+	name = "Proto-Neurite"
+	description = "Prototype neurorestorative which rapidly heals brain damage, but causes toxic responses and cardiovascular stress within the body. Rarely causes seizures."
+	color = "#CCCCCC" //very light grey
+
+/datum/reagent/medicine/c2/protoneurite/on_mob_life(mob/living/carbon/M)
+	if(M.getOrganLoss(ORGAN_SLOT_BRAIN)>=30)
+		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -3*REM)
+	M.adjustToxLoss(1*REM,0)
+	M.adjustOrganLoss(ORGAN_SLOT_HEART,1*REM)
+	if(prob(1) && iscarbon(M))
+		M.visible_message("<span class='danger'>[M] starts having a seizure!</span>", "<span class='userdanger'>You have a seizure!</span>")
+		M.Unconscious(100)
+		M.Jitter(350)
+	..()
 
 /******NICHE******/
 //todo

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -179,3 +179,7 @@
 	var/location = get_turf(holder.my_atom)
 	for(var/i in 1 to created_volume)
 		new /obj/item/stack/medical/poultice(location)
+
+/datum/chemical_reaction/c2/protoneurite
+	results = list(/datum/reagent/medicine/c2/protoneurite = 3)
+	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/phenol = 1, /datum/reagent/consumable/sugar = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new chem to treat brain damage: Proto-Neurite. Made from equal parts phenol, stable plasma, and sugar. It heals three brain damage, down to 30, while dealing 1 toxin and 1 heart damage per tick, and has a small chance to give a seizure.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
After playing rounds on Manuel with a character who has Brain Tumor and Extreme Medicine Allergy, rolling a Mannitol allergy is great if you want to get to know your doctors in medbay. With brain death coming at sixteenish minutes, they need to do brain surgery every ten to fifteen minutes at most to keep you on this side of the grave. It's not so great if medbay is busy with patients who aren't total resource drains on the station. This adds a second chem to treat the brain damage. It does more raw brain healing than mannitol does with some pretty significant drawbacks. Unlike mannitol, it does not stop the brain tumor damage from ticking, nor will it completely heal the brain meaning that you can still accumulate traumas even if you had a thousand units of it in you (and some way of dealing with the toxin/heart damage). It is definitely not a chem to be used often, moreso just to keep you off death's door until medical can accommodate you.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: New C2 chem for brain damage. Proto-Neurite, made from phenol, stable plasma, and sugar.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
