### PR TITLE
Fixes the borg tablet being unusable without power, and borgs usually being unable to print pictures

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -379,6 +379,8 @@
 	return !cleared
 
 /mob/living/silicon/robot/can_interact_with(atom/A)
+	if (A == modularInterface)
+		return TRUE //bypass for borg tablets
 	if (low_power_mode)
 		return FALSE
 	var/turf/T0 = get_turf(src)

--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -52,7 +52,7 @@
 	data["integrity"] = ((borgo.health + 100) / 2) //Borgo health, as percentage
 	data["lampIntensity"] = borgo.lamp_intensity //Borgo lamp power setting
 	data["sensors"] = "[borgo.sensors_on?"ACTIVE":"DISABLED"]"
-	data["printerPictures"] = borgo.aicamera.stored.len //Number of pictures taken
+	data["printerPictures"] =  borgo.connected_ai? borgo.connected_ai.aicamera.stored.len : borgo.aicamera.stored.len //Number of pictures taken, synced to AI if available
 	data["printerToner"] = borgo.toner //amount of toner
 	data["printerTonerMax"] = borgo.tonermax //It's a variable, might as well use it
 	data["thrustersInstalled"] = borgo.ionpulse //If we have a thruster uprade
@@ -118,7 +118,10 @@
 			borgo.toggle_sensors()
 
 		if("viewImage")
-			borgo.aicamera?.viewpictures(usr)
+			if(borgo.connected_ai)
+				borgo.connected_ai.aicamera?.viewpictures(usr)
+			else
+				borgo.aicamera?.viewpictures(usr)
 
 		if("printImage")
 			var/obj/item/camera/siliconcam/robot_camera/borgcam = borgo.aicamera


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Fixes #54244. This was a bug, the tablet is meant to be usable at all times (except when the borg is unresponsive). As RoboTact takes the place of borg self status and management (viewing/stating laws, checking their master AI, diagnostics with wire issues, etc), borgs should not be locked away from using the tablet. The tablet antenna does get shut off when the borg loses power (or gets locked down), so outside RoboTact, the tablet is in a rather limited state of functionality.

- Fixes #54218. This was an oversight where I forgot that pictures taken while synced to an AI are synced and stored on the AI's camera.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes some bugs of my own design.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Borg tablets now correctly work when the borg is out of power (though you'll get no networking until you get that power issue sorted out).
fix: Borgs that are synced to AIs can correctly view and print photos once more.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
