### PR TITLE
Adds a living time config to the panic bunker

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -312,6 +312,8 @@
 
 /datum/config_entry/flag/panic_bunker	// prevents people the server hasn't seen before from connecting
 
+/datum/config_entry/number/panic_bunker_living // living time in minutes that a player needs to pass the panic bunker
+
 /datum/config_entry/string/panic_bunker_message
 	config_entry_value = "Sorry but the server is currently not accepting connections from never before seen players."
 

--- a/code/modules/admin/verbs/panicbunker.dm
+++ b/code/modules/admin/verbs/panicbunker.dm
@@ -6,10 +6,18 @@
 		return
 
 	var/new_pb = !CONFIG_GET(flag/panic_bunker)
+	var/time_rec = 0
+	var/message = ""
+	if(new_pb)
+		time_rec = input(src, "How many living minutes should they need to play?", "Shit's fucked isn't it", CONFIG_GET(number/panic_bunker_living)) as num
+		message = input(src, "What should they see when they log in?", "MMM", CONFIG_GET(string/panic_bunker_message)) as text
+		message = replacetext(message, "%minutes%", time_rec)
+		CONFIG_SET(number/panic_bunker_living, time_rec)
+		CONFIG_SET(string/panic_bunker_message, message)
+		
 	CONFIG_SET(flag/panic_bunker, new_pb)
-
-	log_admin("[key_name(usr)] has toggled the Panic Bunker, it is now [new_pb ? "on" : "off"]")
-	message_admins("[key_name_admin(usr)] has toggled the Panic Bunker, it is now [new_pb ? "enabled" : "disabled"].")
+	log_admin("[key_name(usr)] has toggled the Panic Bunker, it is now [new_pb ? "on and set to [time_rec] with a message of [message]" : "off"]")
+	message_admins("[key_name_admin(usr)] has toggled the Panic Bunker, it is now [new_pb ? "enabled with a living minutes requirement of [time_rec]" : "disabled"].")
 	if (new_pb && !SSdbcore.Connect())
 		message_admins("The Database is not connected! Panic bunker will not work until the connection is reestablished.")
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Panic Bunker", "[new_pb ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -554,7 +554,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			var/reject_message = "Failed Login: [key] - Account attempting to connect during panic bunker, but they do not have the required living time [minutes]/[living_recs]"
 			log_access(reject_message)
 			message_admins("<span class='adminnotice'>[reject_message]</span>")
-			to_chat(src, CONFIG_GET(string/panic_bunker_message))
+			var/message = CONFIG_GET(string/panic_bunker_message)
+			message = replacetext(message, "%minutes%", living_recs)
+			to_chat(src, message)
 			var/list/connectiontopic_a = params2list(connectiontopic)
 			var/list/panic_addr = CONFIG_GET(string/panic_server_address)
 			if(panic_addr && !connectiontopic_a["redirect"])

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -549,7 +549,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(CONFIG_GET(flag/panic_bunker) && !holder && !GLOB.deadmins[ckey])
 		var/living_recs = CONFIG_GET(number/panic_bunker_living)
 		//Relies on pref existing, but this proc is only called after that occurs, so we're fine.
-		var/minutes = get_exp_living(TRUE)
+		var/minutes = get_exp_living(pure_numeric = TRUE)
 		if(minutes <= living_recs)
 			var/reject_message = "Failed Login: [key] - Account attempting to connect during panic bunker, but they do not have the required living time [minutes]/[living_recs]"
 			log_access(reject_message)

--- a/config/config.txt
+++ b/config/config.txt
@@ -346,8 +346,8 @@ NOTIFY_NEW_PLAYER_ACCOUNT_AGE 1
 #PANIC_BUNKER_LIVING 90
 
 ## The message the Panic Bunker gives when someone is rejected by it
-## %minutes% is replaced with PANIC_BUNKER_LIVING on runtime, remove it if you don't want htis
-#PANIC_BUNKER_MESSAGE Sorry, but the server is currently not accepting connections from players with less then %minutes% minutes of living time.
+## %minutes% is replaced with PANIC_BUNKER_LIVING on runtime, remove it if you don't want this
+#PANIC_BUNKER_MESSAGE Sorry, but the server is currently not accepting connections from players with less than %minutes% minutes of living time.
 
 ## If panic bunker is on and a player is rejected (see above), attempt to send them to this connected server (see below) instead.
 ##	You probably want this to be the same as CROSS_SERVER_ADDRESS

--- a/config/config.txt
+++ b/config/config.txt
@@ -342,8 +342,11 @@ NOTIFY_NEW_PLAYER_ACCOUNT_AGE 1
 ##	Requires database
 #PANIC_BUNKER
 
+## If a player connects during a bunker with less then or this amount of living time (Minutes), we deny the connection
+#PANIC_BUNKER_LIVING 90
+
 ## The message the Panic Bunker gives when someone is rejected by it
-#PANIC_BUNKER_MESSAGE Sorry, but the server is currently not accepting connections from never before seen players.
+#PANIC_BUNKER_MESSAGE Sorry, but the server is currently not accepting connections from players with less then 90 minutes of living time.
 
 ## If panic bunker is on and a player is rejected (see above), attempt to send them to this connected server (see below) instead.
 ##	You probably want this to be the same as CROSS_SERVER_ADDRESS

--- a/config/config.txt
+++ b/config/config.txt
@@ -346,7 +346,8 @@ NOTIFY_NEW_PLAYER_ACCOUNT_AGE 1
 #PANIC_BUNKER_LIVING 90
 
 ## The message the Panic Bunker gives when someone is rejected by it
-#PANIC_BUNKER_MESSAGE Sorry, but the server is currently not accepting connections from players with less then 90 minutes of living time.
+## %minutes% is replaced with PANIC_BUNKER_LIVING on runtime, remove it if you don't want htis
+#PANIC_BUNKER_MESSAGE Sorry, but the server is currently not accepting connections from players with less then %minutes% minutes of living time.
 
 ## If panic bunker is on and a player is rejected (see above), attempt to send them to this connected server (see below) instead.
 ##	You probably want this to be the same as CROSS_SERVER_ADDRESS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I've added a living time config option to the panic bunker, so you can set it to block people with less then a year of in game time to weed out the casuals, etc.
@MrStonedOne Touches config, consider yourself pinged.

## Why It's Good For The Game

Gives more fine control over the panic bunker, might be useful in future.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: The panic bunker now supports living time, set it to 100000000 minutes today! 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
