### PR TITLE
Malf AIs no longer fail their survive objective if piloting a shell when the round ends

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -486,15 +486,16 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 			return FALSE
 	return TRUE
 
-/datum/objective/survive/exist //Like survive, but works for silicons and zombies and such.
-	name = "survive nonhuman"
+/datum/objective/survive/malf //Like survive, but for Malf AIs
+	name = "survive AI"
+	explanation_text = "Prevent your own deactivation."
 
-/datum/objective/survive/exist/check_completion()
+/datum/objective/survive/malf/check_completion()
 	var/list/datum/mind/owners = get_owners()
-	for(var/datum/mind/M in owners)
-		if(!considered_alive(M, FALSE))
+	for(var/datum/mind/mindobj in owners)
+		if(!istype(mindobj, /mob/living/silicon/robot) && !considered_alive(mindobj, FALSE)) //Shells (and normal borgs for that matter) are considered alive for Malf
 			return FALSE
-	return TRUE
+		return TRUE
 
 /datum/objective/martyr
 	name = "martyr"

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -111,9 +111,9 @@
 		kill_objective.find_target()
 		add_objective(kill_objective)
 
-	var/datum/objective/survive/exist/exist_objective = new
-	exist_objective.owner = owner
-	add_objective(exist_objective)
+	var/datum/objective/survive/malf/dont_die_objective = new
+	dont_die_objective.owner = owner
+	add_objective(dont_die_objective)
 
 
 /datum/antagonist/traitor/proc/forge_single_objective()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the survive/exist objective type to survive/malf. In theory, survive/exist was supposed to also be used by other non-human antags, but in reality only AIs used it. The objective now returns a success if the mind is in a borg body as well as any body that considered_alive() passes.

Borgs in general are considered fine rather than just AI shells, because it seems thematically appropriate. If the AI gets staff-of-changed into a borg during a joint wizard/malf round, then sure, AI gets to greentext, why not.

Fixes #54317

While I was at it, I changed the text for the malf AI survive objective to `Prevent your own deactivation.` since it seems more fitting.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Malf AIs no longer fail their survive objective if piloting a shell when the round ends.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

ToDo:
- [x] Need to test to be doubly sure, as I slightly re-wrote part of it since the last test, but I don't have time right this moment.