### PR TITLE
Shuttle nav compuer docking cameras can no longer swap across z-levels.

### DIFF
--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -3,6 +3,11 @@
 	desc = "Used to designate a precise transit location for a spacecraft."
 	jump_action = null
 	should_supress_view_changes  = FALSE
+
+	// Docking cameras should only interact with their current z-level.
+	move_up_action = null
+	move_down_action = null
+
 	var/datum/action/innate/shuttledocker_rotate/rotate_action = new
 	var/datum/action/innate/shuttledocker_place/place_action = new
 	var/shuttleId = ""


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Shuttle docking nav computers can pick locations across z-levels. This is most likely an oversight, as shuttles should only be able to dock using this console on their own z-level.

Currently doesn't do anything bad as Icebox is the only map that supports this sort of multi-Z camera movement and has a distinct lack of pilotable shuttles, but patching this before it becomes an issue.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Oversight feex good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Shuttle navigation computers can no longer switch to z-levels the shuttle is not present on.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
