### PR TITLE
Fixes for stomach edibility

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -264,7 +264,8 @@ Behavior that's still missing from this component that original food items had t
 
 	if(feeder.a_intent == INTENT_HARM)
 		return
-	if(!owner.reagents.total_volume)//Shouldn't be needed but it checks to see if it has anything left in it.
+	//If we had initial volume we should still have some until the last bite
+	if(volume > 0 && !owner.reagents.total_volume)
 		to_chat(feeder, "<span class='warning'>None of [owner] left, oh no!</span>")
 		if(isturf(parent))
 			var/turf/T = parent
@@ -331,8 +332,8 @@ Behavior that's still missing from this component that original food items had t
 	if(eater.satiety > -200)
 		eater.satiety -= junkiness
 	playsound(eater.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
+	SEND_SIGNAL(parent, COMSIG_FOOD_EATEN, eater, feeder, bitecount, bite_consumption)
 	if(owner.reagents.total_volume)
-		SEND_SIGNAL(parent, COMSIG_FOOD_EATEN, eater, feeder, bitecount, bite_consumption)
 		var/fraction = min(bite_consumption / owner.reagents.total_volume, 1)
 		owner.reagents.trans_to(eater, bite_consumption, transfered_by = feeder, methods = INGEST)
 		bitecount++

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -31,8 +31,6 @@
 
 	///Reagents when consumed
 	var/list/food_reagents = list(/datum/reagent/consumable/nutriment = 5)
-	///Volume of reagents as food
-	var/food_volume = 10
 
 /obj/item/organ/Initialize()
 	. = ..()
@@ -40,8 +38,8 @@
 		AddComponent(/datum/component/edible,\
 			initial_reagents = food_reagents,\
 			foodtypes = RAW | MEAT | GROSS,\
-			volume = food_volume,\
-			after_eat = CALLBACK(src, .proc/OnEatFrom))
+			volume = 10,\
+			before_eat = CALLBACK(src, .proc/OnEatFrom))
 
 /obj/item/organ/proc/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = TRUE)
 	if(!iscarbon(M) || owner == M)
@@ -145,8 +143,13 @@
 		STOP_PROCESSING(SSobj, src)
 	return ..()
 
+/**
+ * Callback when the item is being eaten
+ *
+ * Changes the usability of the organ as it is now being eaten.
+ */
 /obj/item/organ/proc/OnEatFrom(eater, feeder)
-	useable = FALSE //You can't use it anymore after eating it you spaztic
+	useable = FALSE
 
 /obj/item/organ/item_action_slot_check(slot,mob/user)
 	return //so we don't grant the organ's action to mobs who pick up the organ.

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -28,7 +28,11 @@
 
 	///When you take a bite you cant jam it in for surgery anymore.
 	var/useable = TRUE
+
+	///Reagents when consumed
 	var/list/food_reagents = list(/datum/reagent/consumable/nutriment = 5)
+	///Volume of reagents as food
+	var/food_volume = 10
 
 /obj/item/organ/Initialize()
 	. = ..()
@@ -36,7 +40,7 @@
 		AddComponent(/datum/component/edible,\
 			initial_reagents = food_reagents,\
 			foodtypes = RAW | MEAT | GROSS,\
-			volume = 10,\
+			volume = food_volume,\
 			after_eat = CALLBACK(src, .proc/OnEatFrom))
 
 /obj/item/organ/proc/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = TRUE)

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -16,11 +16,15 @@
 	high_threshold_cleared = "<span class='info'>The pain in your stomach dies down for now, but food still seems unappealing.</span>"
 	low_threshold_cleared = "<span class='info'>The last bouts of pain in your stomach have died out.</span>"
 
+	//manages it's own reagents, will inject food reagents on first bite.
+	food_volume = 0
+
 	var/disgust_metabolism = 1
 
 /obj/item/organ/stomach/Initialize()
 	. = ..()
 	create_reagents(1000)
+	RegisterSignal(src, COMSIG_FOOD_EATEN, .proc/on_bite)
 
 /obj/item/organ/stomach/on_life()
 	. = ..()
@@ -57,6 +61,19 @@
 
 /obj/item/organ/stomach/get_availability(datum/species/S)
 	return !(NOSTOMACH in S.inherent_traits)
+
+/**
+ * Triggers on bitting the food item before it is consumed.
+ *
+ * Checks if the stomach is useable, if so adds the food reagents.
+ */
+/obj/item/organ/stomach/proc/on_bite(datum/source, mob/living/target, mob/living/user, bitecount, bitesize)
+	SIGNAL_HANDLER
+
+	if(useable)
+		for(var/reag_id in food_reagents)
+			reagents.add_reagent(reag_id , food_reagents[reag_id])
+			useable = FALSE
 
 /obj/item/organ/stomach/proc/handle_disgust(mob/living/carbon/human/H)
 	if(H.disgust)

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -16,15 +16,11 @@
 	high_threshold_cleared = "<span class='info'>The pain in your stomach dies down for now, but food still seems unappealing.</span>"
 	low_threshold_cleared = "<span class='info'>The last bouts of pain in your stomach have died out.</span>"
 
-	//manages it's own reagents, will inject food reagents on first bite.
-	food_volume = 0
-
 	var/disgust_metabolism = 1
 
 /obj/item/organ/stomach/Initialize()
 	. = ..()
 	create_reagents(1000)
-	RegisterSignal(src, COMSIG_FOOD_EATEN, .proc/on_bite)
 
 /obj/item/organ/stomach/on_life()
 	. = ..()
@@ -62,18 +58,11 @@
 /obj/item/organ/stomach/get_availability(datum/species/S)
 	return !(NOSTOMACH in S.inherent_traits)
 
-/**
- * Triggers on bitting the food item before it is consumed.
- *
- * Checks if the stomach is useable, if so adds the food reagents.
- */
-/obj/item/organ/stomach/proc/on_bite(datum/source, mob/living/target, mob/living/user, bitecount, bitesize)
-	SIGNAL_HANDLER
-
+/obj/item/organ/stomach/OnEatFrom(mob/living/target, mob/living/user, bitecount, bitesize)
 	if(useable)
 		for(var/reag_id in food_reagents)
 			reagents.add_reagent(reag_id , food_reagents[reag_id])
-			useable = FALSE
+	return ..()
 
 /obj/item/organ/stomach/proc/handle_disgust(mob/living/carbon/human/H)
 	if(H.disgust)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The edible component has a check at the start of try to eat that qdels the item if it has no reagent volume, 
Then the component does a second reagent volume check gating all all logic for eating and activation of all signals.

This adds a new callback `before_eat` to the edible component.
The stomach will manage addition of reagents before the first bit happens.

Fixes #54118

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes organ edibility to work as expected

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Stomachs are now properly edible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
