### PR TITLE
Fixes heretic giving you both hijack and dagd, fixes protection objective.

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -296,7 +296,7 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 	if(human_check)
 		brain_target = target.current.getorganslot(ORGAN_SLOT_BRAIN)
 	//Protect will always suceed when someone suicides
-	return !target || considered_alive(target, enforce_human = human_check) || (human_check == TRUE && brain_target)? !brain_target.suicided : FALSE
+	return !target || considered_alive(target, enforce_human = human_check) || (human_check == TRUE && brain_target) ? brain_target.suicided : FALSE
 
 /datum/objective/protect/update_explanation_text()
 	..()

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -92,41 +92,45 @@
 /datum/antagonist/heretic/proc/forge_primary_objectives()
 	var/list/assasination = list()
 	var/list/protection = list()
-	var/choose_list = list("assasinate","hjiack","protect","glory")
-	for(var/i in 1 to 2)
-		var/pck = pick(choose_list)
-		switch(pck)
-			if("assasinate")
-				var/datum/objective/assassinate/A = new
-				A.owner = owner
-				var/list/owners = A.get_owners()
-				A.find_target(owners,protection)
-				assasination += A.target
-				objectives += A
-			if("hjiack")
-				var/datum/objective/hijack/hijack = new
-				hijack.owner = owner
-				objectives += hijack
-				choose_list -= "hijack"
-				choose_list -=  "glory"
-			if("glory")
-				var/datum/objective/martyr/martyrdom = new
-				martyrdom.owner = owner
-				objectives += martyrdom
-				choose_list -= "hijack"
-				choose_list -=  "glory"
-			if("protect")
-				var/datum/objective/protect/P = new
-				P.owner = owner
-				var/list/owners = P.get_owners()
-				P.find_target(owners,assasination)
-				protection += P.target
-				objectives += P
+
+	var/choose_list_begin = list("assasinate","protect")
+	var/choose_list_end = list("assasinate","hjiack","protect","glory")
+
+	var/pck1 = pick(choose_list_begin)
+	var/pck2 = pick(choose_list_end)
+
+	forge_objective(pck1,assasination,protection)
+	forge_objective(pck2,assasination,protection)
 
 	var/datum/objective/sacrifice_ecult/SE = new
 	SE.owner = owner
 	SE.update_explanation_text()
 	objectives += SE
+
+/datum/antagonist/heretic/proc/forge_objective(string,assasination,protection)
+	switch(pck1)
+		if("assasinate")
+			var/datum/objective/assassinate/A = new
+			A.owner = owner
+			var/list/owners = A.get_owners()
+			A.find_target(owners,protection)
+			assasination += A.target
+			objectives += A
+		if("hjiack")
+			var/datum/objective/hijack/hijack = new
+			hijack.owner = owner
+			objectives += hijack
+		if("glory")
+			var/datum/objective/martyr/martyrdom = new
+			martyrdom.owner = owner
+			objectives += martyrdom
+		if("protect")
+			var/datum/objective/protect/P = new
+			P.owner = owner
+			var/list/owners = P.get_owners()
+			P.find_target(owners,assasination)
+			protection += P.target
+			objectives += P
 
 /datum/antagonist/heretic/apply_innate_effects(mob/living/mob_override)
 	. = ..()

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -94,7 +94,7 @@
 	var/list/protection = list()
 
 	var/choose_list_begin = list("assassinate","protect")
-	var/choose_list_end = list("assassinate","hjiack","protect","glory")
+	var/choose_list_end = list("assassinate","hijack","protect","glory")
 
 	var/pck1 = pick(choose_list_begin)
 	var/pck2 = pick(choose_list_end)
@@ -116,7 +116,7 @@
 			A.find_target(owners,protection)
 			assasination += A.target
 			objectives += A
-		if("hjiack")
+		if("hijack")
 			var/datum/objective/hijack/hijack = new
 			hijack.owner = owner
 			objectives += hijack

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -93,8 +93,8 @@
 	var/list/assasination = list()
 	var/list/protection = list()
 
-	var/choose_list_begin = list("assasinate","protect")
-	var/choose_list_end = list("assasinate","hjiack","protect","glory")
+	var/choose_list_begin = list("assassinate","protect")
+	var/choose_list_end = list("assassinate","hjiack","protect","glory")
 
 	var/pck1 = pick(choose_list_begin)
 	var/pck2 = pick(choose_list_end)
@@ -108,8 +108,8 @@
 	objectives += SE
 
 /datum/antagonist/heretic/proc/forge_objective(string,assasination,protection)
-	switch(pck1)
-		if("assasinate")
+	switch(string)
+		if("assassinate")
 			var/datum/objective/assassinate/A = new
 			A.owner = owner
 			var/list/owners = A.get_owners()


### PR DESCRIPTION
## About The Pull Request

Heretic can no longer give you both hijack AND die a glorius death objective.

Protection objective was broken for some time, it always suceeded. It should be fixed now.

## Why It's Good For The Game

Fixing good.

## Changelog
:cl:
fix: Heretics can no longer get dagd and hijack at the same time.
fix: Protection objective now works as it should.
/:cl:

