### PR TITLE
Buffs Anatomic Panacea and makes it depend less on reagents

### DIFF
--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -19,7 +19,6 @@
 		var/obj/item/organ/O = o
 		if(!istype(O))
 			continue
-
 		O.Remove(user)
 		if(iscarbon(user))
 			var/mob/living/carbon/C = user
@@ -33,8 +32,8 @@
 		C.drunkenness = 0
 		C.silent = 0
 		var/obj/item/organ/stomach/belly = C.getorganslot(ORGAN_SLOT_STOMACH)
-  		if(belly)
-    		belly.clear_reagents()
+		if(belly)
+			belly.clear_reagents()
 
     if(user.reagents)
 		user.reagents.clear_reagents()

--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -1,6 +1,6 @@
 /datum/action/changeling/panacea
 	name = "Anatomic Panacea"
-	desc = "Expels impurifications from our form; curing negative diseases, removing parasites, sobering us, purging radiation and all reagents, curing brain traumas and brain damage, breaking addictions, healing toxin damage, and resetting our genetic code completely. This power doesn't heal our non-brain organs, cure blindness, cure deafness, or restore our blood volume; for that, we should use the Regenerate power. Costs 20 chemicals."
+	desc = "Expels impurifications from our form; curing non-positive diseases, removing parasites, sobering us, purging radiation and all reagents, curing brain traumas and brain damage, breaking addictions, healing toxin damage, and resetting our genetic code completely. This power doesn't heal our non-brain organs, cure blindness, cure deafness, or restore our blood volume; for that, we should use the Regenerate power. Costs 20 chemicals."
 	helptext = "Can be used while unconscious."
 	button_icon_state = "panacea"
 	chemical_cost = 20

--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -34,8 +34,8 @@
 		var/obj/item/organ/stomach/belly = C.getorganslot(ORGAN_SLOT_STOMACH)
 		if(belly)
 			belly.clear_reagents()
-
-    if(user.reagents)
+	
+	if(user.reagents)
     	user.reagents.clear_reagents()
     	user.reagents.add_reagent(/datum/reagent/medicine/mutadone, 10) //I hate hate hate HATE this "solution", but I fear that just copy+pasting the code from mutadone here could cause an issue if that causes a monkey changeling to turn back into a human mid-power execution...
 

--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -46,6 +46,7 @@
 			if(D.severity == DISEASE_SEVERITY_POSITIVE)
 				continue
 			D.cure()
+		radiation = 0
 		L.clear_addictions()
 		L.dizziness = 0
 		L.drowsyness = 0

--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -1,6 +1,6 @@
 /datum/action/changeling/panacea
 	name = "Anatomic Panacea"
-	desc = "Expels impurifications from our form; curing diseases, removing parasites, sobering us, purging toxins and radiation, curing traumas and brain damage, and resetting our genetic code completely. Costs 20 chemicals."
+	desc = "Expels impurifications from our form; curing negative diseases, removing parasites, sobering us, purging radiation and all reagents, curing brain traumas and brain damage, breaking addictions, healing toxin damage, and resetting our genetic code completely. This power doesn't heal our non-brain organs, cure blindness, cure deafness, or restore our blood volume; for that, we should use the Regenerate power. Costs 20 chemicals."
 	helptext = "Can be used while unconscious."
 	button_icon_state = "panacea"
 	chemical_cost = 20
@@ -26,14 +26,18 @@
 			C.vomit(0, toxic = TRUE)
 		O.forceMove(get_turf(user))
 
-	user.reagents.add_reagent(/datum/reagent/medicine/mutadone, 10)
-	user.reagents.add_reagent(/datum/reagent/medicine/pen_acid, 20)
-	user.reagents.add_reagent(/datum/reagent/medicine/antihol, 10)
-	user.reagents.add_reagent(/datum/reagent/medicine/mannitol, 25)
-
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		C.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
+		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -200) //this is redundant with regenerate, but old!anatomic panacea gave you some mannitol and I want new!anatomic panacea to be consistent with that
+		C.drunkenness = 0
+		var/obj/item/organ/stomach/belly = C.getorganslot(ORGAN_SLOT_STOMACH)
+  		if(belly)
+    		belly.clear_reagents()
+
+    if(user.reagents)
+		user.reagents.clear_reagents()
+		user.reagents.add_reagent(/datum/reagent/medicine/mutadone, 10) //I hate hate hate HATE this "solution", but I fear that just copy+pasting the code from mutadone here could cause an issue if that causes a monkey changeling to turn back into a human mid-power execution...
 
 	if(isliving(user))
 		var/mob/living/L = user
@@ -42,4 +46,13 @@
 			if(D.severity == DISEASE_SEVERITY_POSITIVE)
 				continue
 			D.cure()
+		L.clear_addictions()
+		L.dizziness = 0
+		L.drowsyness = 0
+		L.slurring = 0
+		L.jitteriness = 0
+		L.set_confusion(0)
+		L.set_drugginess(amount)
+		L.set_disgust(amount)
+		L.adjustToxLoss(-50, TRUE, TRUE) //works even on toxinlovers, so a slimeperson changeling with anatomic panacea won't accidentally kill themselves with it
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -36,8 +36,8 @@
 			belly.clear_reagents()
 
     if(user.reagents)
-		user.reagents.clear_reagents()
-		user.reagents.add_reagent(/datum/reagent/medicine/mutadone, 10) //I hate hate hate HATE this "solution", but I fear that just copy+pasting the code from mutadone here could cause an issue if that causes a monkey changeling to turn back into a human mid-power execution...
+    	user.reagents.clear_reagents()
+    	user.reagents.add_reagent(/datum/reagent/medicine/mutadone, 10) //I hate hate hate HATE this "solution", but I fear that just copy+pasting the code from mutadone here could cause an issue if that causes a monkey changeling to turn back into a human mid-power execution...
 
 	if(isliving(user))
 		var/mob/living/L = user

--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -31,6 +31,7 @@
 		C.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
 		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -200) //this is redundant with regenerate, but old!anatomic panacea gave you some mannitol and I want new!anatomic panacea to be consistent with that
 		C.drunkenness = 0
+		C.silent = 0
 		var/obj/item/organ/stomach/belly = C.getorganslot(ORGAN_SLOT_STOMACH)
   		if(belly)
     		belly.clear_reagents()
@@ -46,12 +47,16 @@
 			if(D.severity == DISEASE_SEVERITY_POSITIVE)
 				continue
 			D.cure()
-		radiation = 0
+		L.radiation = 0
 		L.clear_addictions()
 		L.dizziness = 0
 		L.drowsyness = 0
-		L.slurring = 0
+		L.stuttering = 0
 		L.jitteriness = 0
+		L.hallucination = 0
+		L.slurring = 0
+		L.cultslurring = 0
+		L.derpspeech = 0
 		L.set_confusion(0)
 		L.set_drugginess(amount)
 		L.set_disgust(amount)

--- a/code/modules/antagonists/changeling/powers/regenerate.dm
+++ b/code/modules/antagonists/changeling/powers/regenerate.dm
@@ -1,6 +1,6 @@
 /datum/action/changeling/regenerate
 	name = "Regenerate"
-	desc = "Allows us to regrow and restore missing external limbs and vital internal organs, as well as removing shrapnel and restoring blood volume. Costs 10 chemicals."
+	desc = "Allows us to regrow and restore missing external limbs and vital internal organs, as well as curing all wounds (not to be confused with damage), removing shrapnel, and restoring blood volume. Costs 10 chemicals."
 	helptext = "Will alert nearby crew if any external limbs are regenerated. Can be used while unconscious."
 	button_icon_state = "regenerate"
 	chemical_cost = 10

--- a/code/modules/antagonists/changeling/powers/regenerate.dm
+++ b/code/modules/antagonists/changeling/powers/regenerate.dm
@@ -34,11 +34,18 @@
 			B.decoy_override = TRUE
 			B.Insert(C)
 		C.regenerate_organs()
+		for(var/organ in C.internal_organs)
+			var/obj/item/organ/O = organ
+			O.setOrganDamage(0) //this heals brain damage too!
+		var/obj/item/organ/ears/ears = C.getorganslot(ORGAN_SLOT_EARS)
+		if(istype(ears))
+			ears.deaf = 0 //because deafness isn't cured by just healing ear damage
+		C.set_blindness(0)
+		C.set_blurriness(0)
+		C.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
 		for(var/i in C.all_wounds)
 			var/datum/wound/iter_wound = i
 			iter_wound.remove_wound()
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		H.restore_blood()
-		H.remove_all_embedded_objects()
+		C.restore_blood()
+		C.remove_all_embedded_objects()
 	return TRUE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -59,7 +59,6 @@
 	M.reagents.remove_all_type(/datum/reagent/toxin, 5*REM, 0, 1)
 	M.setCloneLoss(0, 0)
 	M.setOxyLoss(0, 0)
-	M.radiation = 0
 	M.heal_bodypart_damage(5,5)
 	M.adjustToxLoss(-5, 0, TRUE)
 	M.hallucination = 0
@@ -71,27 +70,34 @@
 	M.SetUnconscious(0)
 	M.SetParalyzed(0)
 	M.SetImmobilized(0)
-	M.silent = FALSE
+	M.radiation = 0
 	M.dizziness = 0
 	M.disgust = 0
 	M.drowsyness = 0
 	M.stuttering = 0
 	M.slurring = 0
+	M.cultslurring = 0
+	M.derpspeech = 0
 	M.set_confusion(0)
 	M.SetSleeping(0)
 	M.jitteriness = 0
-	if(M.blood_volume < BLOOD_VOLUME_NORMAL)
-		M.blood_volume = BLOOD_VOLUME_NORMAL
+	if(istype(M))
+		M.silent = FALSE
+		if(M.blood_volume < BLOOD_VOLUME_NORMAL)
+			M.blood_volume = BLOOD_VOLUME_NORMAL
 
-	M.cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
-	for(var/organ in M.internal_organs)
-		var/obj/item/organ/O = organ
-		O.setOrganDamage(0)
-	for(var/thing in M.diseases)
-		var/datum/disease/D = thing
-		if(D.severity == DISEASE_SEVERITY_POSITIVE)
-			continue
-		D.cure()
+		M.cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
+		for(var/organ in M.internal_organs)
+			var/obj/item/organ/O = organ
+			O.setOrganDamage(0)
+		var/obj/item/organ/ears/ears = M.getorganslot(ORGAN_SLOT_EARS)
+		if(istype(ears))
+			ears.deaf = 0 //because deafness isn't cured by just healing ear damage
+		for(var/thing in M.diseases)
+			var/datum/disease/D = thing
+			if(D.severity == DISEASE_SEVERITY_POSITIVE)
+				continue
+			D.cure()
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -34,6 +34,7 @@
 	color = "#E0BB00" //golden for the gods
 	can_synth = FALSE
 	taste_description = "badmins"
+	self_consuming = TRUE //admin magic allows this to work on even races that normally can't metabolize reagents, like skeletons
 
 // The best stuff there is. For testing/debugging.
 /datum/reagent/medicine/adminordrazine/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray, mob/user)
@@ -856,9 +857,8 @@
 	M.set_confusion(0)
 	M.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 3*REM, 0, 1)
 	M.adjustToxLoss(-0.2*REM, 0)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.drunkenness = max(H.drunkenness - 10, 0)
+	if(istype(M))
+		M.drunkenness = max(M.drunkenness - 10, 0)
 	..()
 	. = 1
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -200,7 +200,6 @@
 	if(dna?.species)
 		dna.species.regenerate_organs(src)
 		return
-
 	else
 		var/obj/item/organ/lungs/L = getorganslot(ORGAN_SLOT_LUNGS)
 		if(!L)
@@ -231,6 +230,13 @@
 			ears = new()
 			ears.Insert(src)
 		ears.setOrganDamage(0)
+
+		var/obj/item/organ/stomach = getorganslot(ORGAN_SLOT_STOMACH)
+		if(!stomach)
+			stomach = new()
+			stomach.Insert(src)
+		stomach.setOrganDamage(0)
+
 
 
 /** get_availability


### PR DESCRIPTION
## About The Pull Request

The Anatomic Panacea changeling power no longer injects its user with pentetic acid, antihol, and mannitol. It still injects them with mutadone, however.

When used, the Anatomic Panacea power now does the following things:
* Causes you to vomit up any parasitic organs that are inside of you (it did this before).
* Cures all brain traumas of the lobotomy resilience tier or lower (it did this before) and immediately heals 200 brain damage.
* Sets the following values to 0: drunkenness, silent, radiation, dizziness, drowsyness [sic], stuttering, jitteriness, hallucination, slurring, cultslurring, derpspeech, confusion, drugginess, and disgust.
* **Purges all reagents from your body and stomach immediately.** I believe that most changeling players thought that old!Anatomic Panacea already did this, but it turns out that no, the chem-removal (and rad-removal) part of Anatomic Panacea actually came from the pentetic acid it gave you.
* Adds 10u of mutadone to your system. I'd really have loved to replace this with a direct mutation-clearing effect, but I fear that doing so could cause bugs with changelings who pop this power as a monkey or something.
* Clears all addictions.
* Heals 50 toxin damage, even if you have TRAIT_TOXINLOVER (before, changelings who popped Anatomic Panacea as a slime person would accidentally kill themselves with their own pentetic acid if they didn't change form, outheal the tox damage, or purge the pentetic acid somehow).
* Cures all non-positive diseases (and things that are technically treated as diseases by the game) that you're infected with (it did this before).

The Regenerate power was also slightly buffed to cover some of the things that Anatomic Panacea doesn't:
* Regenerate now sets the damage of all of your organs to 0.
* Regenerate now cures all brain traumas of the lobotomy resilience tier or lower. Yes, this makes Anatomic Panacea's ability to cure brain traumas somewhat redundant, but I believe that the ability to heal brain traumas could fall under the portfolio of either ability, and I'd rather not confuse or frustrate a new changeling player who activates an ability that logicially should heal their brain traumas, but doesn't because that actually falls under the domain of another ability. I'm considering adding Regenerate's wound healing to Fleshmend as well for a similar reason, but I'm stretching the scope of this PR already.
* Regenerate now cures blindness, deafness, and eye blurriness. I'm considering giving Anatomic Panacea the ability to cure eye blurriness as well, since it can come from multiple sources other than eye damage, but I'm still on the fence about that.
* Regenerate's blood restoration and embedded object removal functions now work on any carbon user of them, not just humanoids.

Adminordrazine is now self-consuming (skeletons and such can metabolize it and be healed by it now) and now cures cultslurring, deafness, and derpspeech. I think I also might have fixed a possible situation with the chem that could cause it to runtime when used by a non-carbon, but that was mostly an edge case anyway.

Antihol can now lower the drunkenness of monkeys and other nonhumanoid carbons.

The generic carbon regenerate_organs() proc now adds a stomach. Humans and such use a pseudo-override of the proc anyway, but monkey-form changelings should now be able to use the Regenerate to get their stomachs back (or heal their existing stomachs).

## Why It's Good For The Game

Making Anatomic Panacea less reliant on our medical chems means that we can rebalance or tweak those chems later without breaking/affecting the balance of Anatomic Panacea.

Anatomic Panacea is generally known as a "get that shit out of my body" ability, and especially as a "purge my body of reagents right now" ability, yet fails to fully deliver on either of those two fronts. This PR rectifies that issue and makes the power cover more things that it logically should cover.

## Changelog
:cl: ATHATH
balance: The Anatomic Panacea changeling power no longer injects its user with pentetic acid, antihol, or mannitol (it still injects them with mutadone, though), but treats MANY more ailments now (and treats the ailments it treated before much more immediately).
balance: The Anatomic Panacea changeling power now purges all chems from your body and your stomach immediately upon being used.
balance: The Anatomic Panacea changeling power now heals 50 toxin damage immediately upon being used.
balance: The Regenerate changeling power, like Anatomic Panacea, can now heal brain damage and cure brain traumas. In addition, it can cure some forms of blindness, eye blurriness, and some forms of deafness.
fix: The Regenerate changeling power's blood-restoring and embedded object-removal functions now affect monkeys and other nonhumanoid carbon users of the power.
fix: Adminordrazine is now self-consuming (skeletons and such can metabolize it and be healed by it now) and now cures cultslurring, deafness, and derpspeech.
fix: Antihol can now lower the drunkenness of monkeys and other nonhumanoid carbons.
fix: Regenerate can now give changelings in monkey form a replacement stomach (or heal a stomach that they already have).
/:cl: