### PR TITLE
You can shake people up again

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -482,6 +482,8 @@
 	AdjustParalyzed(-60)
 	AdjustImmobilized(-60)
 	set_resting(FALSE)
+	if(body_position != STANDING_UP && !resting && !buckled && !HAS_TRAIT(src, TRAIT_FLOORED))
+		get_up(TRUE)
 
 	playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
 


### PR DESCRIPTION
This was an unintended mechanical change of the mobility refactor.
You can once again shake people to help them (or force them to) instantly stand up.
If this is a good thing or not, I don't really have opinions, but this is how things behaved before and I've seen a complaint about it.