### PR TITLE
Silver is a catalyst in formaldehyde reaction

### DIFF
--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -1,7 +1,8 @@
 
 /datum/chemical_reaction/formaldehyde
-	results = list(/datum/reagent/toxin/formaldehyde = 3)
-	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/oxygen = 1, /datum/reagent/silver = 1)
+	results = list(/datum/reagent/toxin/formaldehyde = 2)
+	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/oxygen = 1)
+	required_catalysts = list(/datum/reagent/silver = 5)
 	required_temp = 420
 
 /datum/chemical_reaction/fentanyl


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes silver a catalyst in formaldehyde reaction.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Formaldehyde formula is CH<sub>2</sub>O. Formaldehyde is produced industrially by the catalytic oxidation of methanol. The most common catalysts are silver metal ... [<sup>1</sup>](https://en.wikipedia.org/wiki/Formaldehyde).

Formaldehyde is basic reagent for many recipes and wasting expensive silver (which should have been a catalyst from start) does not make any sense. You still need to find silver and grind it, but it being a catalyst does not hinder building automatic factories.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Since silver was removed from chemical dispensers because of budget cuts, top NT chemists were looking another methods for synthesizing formaldehyde and they re-invented catalytic oxidation of ethanol. (Silver is now a catalyst in formaldehyde reaction)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
