### PR TITLE
NODISMEMBER trait no longer applies to species with EASYDISMEMBER trait

### DIFF
--- a/code/datums/components/spooky.dm
+++ b/code/datums/components/spooky.dm
@@ -20,9 +20,9 @@
 
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
-		if(istype(H.dna.species, /datum/species/skeleton))
+		if(isskeleton(H))
 			return //undeads are unaffected by the spook-pocalypse.
-		if(istype(H.dna.species, /datum/species/zombie))
+		if(iszombie(H))
 			H.adjustStaminaLoss(25)
 			H.Paralyze(15) //zombies can't resist the doot
 		C.Jitter(35)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1314,6 +1314,9 @@
 /mob/living/carbon/human/species/ethereal
 	race = /datum/species/ethereal
 
+/mob/living/carbon/human/species/krokodil_addict
+	race = /datum/species/krokodil_addict
+
 /mob/living/carbon/human/species/lizard/ashwalker
 	race = /datum/species/lizard/ashwalker
 
@@ -1355,6 +1358,3 @@
 
 /mob/living/carbon/human/species/zombie/infectious
 	race = /datum/species/zombie/infectious
-
-/mob/living/carbon/human/species/zombie/krokodil_addict
-	race = /datum/species/krokodil_addict

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -26,7 +26,7 @@
 
 /datum/species/zombie/infectious
 	name = "Infectious Zombie"
-	id = "memezombies"
+	id = "romerolzombies"
 	limbs_id = "zombie"
 	mutanthands = /obj/item/zombie_hand
 	armor = 20 // 120 damage to KO a zombie, which kills it
@@ -90,10 +90,10 @@
 		infection = new()
 		infection.Insert(C)
 
-// Your skin falls off
+// Your skin falls off (NOT A REAL ZOMBIE JUST LOOKS LIKE ONE)
 /datum/species/krokodil_addict
 	name = "Human"
-	id = "goofzombies"
+	id = "krokaddicts"
 	limbs_id = "zombie" //They look like zombies
 	sexes = 0
 	meat = /obj/item/food/meat/slab/human/mutant/zombie

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -10,7 +10,7 @@
 	var/mob/living/carbon/C = owner
 	if(C.status_flags & GODMODE)
 		return FALSE
-	if(HAS_TRAIT(C, TRAIT_NODISMEMBER))
+	if(HAS_TRAIT(C, TRAIT_NODISMEMBER) && !HAS_TRAIT_FROM(C, TRAIT_EASYDISMEMBER, SPECIES_TRAIT))
 		return FALSE
 
 	var/obj/item/bodypart/affecting = C.get_bodypart(BODY_ZONE_CHEST)
@@ -54,7 +54,7 @@
 	var/mob/living/carbon/C = owner
 	if(!dismemberable)
 		return FALSE
-	if(HAS_TRAIT(C, TRAIT_NODISMEMBER))
+	if(HAS_TRAIT(C, TRAIT_NODISMEMBER) && !HAS_TRAIT_FROM(C, TRAIT_EASYDISMEMBER, SPECIES_TRAIT))
 		return FALSE
 	. = list()
 	var/turf/T = get_turf(C)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
During a recent round, I saw a romerol zombie get chopped in the head a million times by a bunch of people who couldn't decap it, despite having all the necessary wounds applied. It came out that the zombie had sleeping carp, which even as they were comatose, prevented the decapitation. This is a really niche edge case that caused everyone (including the zombie) to think dismemberment on zombies broke again, especially since there's no indication the zombie is undismemberable and thus unbeheadable, so I think the easiest way to resolve this is just making species EASYDISMEMBER traits take priority over NODISMEMBER traits (sleeping carp and reinforced ligaments).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes zombies more consistent, prevents someone from reporting this as a bug down the road
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Species with easily dismemberable limbs (zombies & skeletons) can no longer become undismemberable via sleeping carp or ligament reinforcement
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
