### PR TITLE
Medical kiosks now properly show brain trauma to others.

### DIFF
--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -211,7 +211,7 @@
 	var/clone_loss = altPatient.getCloneLoss()
 	var/brain_loss = altPatient.getOrganLoss(ORGAN_SLOT_BRAIN)
 	var/brain_status = "Brain patterns normal."
-	if(LAZYLEN(user.get_traumas()))
+	if(LAZYLEN(altPatient.get_traumas()))
 		var/list/trauma_text = list()
 		for(var/datum/brain_trauma/B in altPatient.get_traumas())
 			var/trauma_desc = ""


### PR DESCRIPTION
## About The Pull Request

If someone with a brain trauma is scanned by a medical kiosk, and then the kiosk is examined by someone else (who does not have a brain trauma), the kiosk would incorrectly show them that the patient has no traumas.

## Why It's Good For The Game

Tiny bug fix.
