### PR TITLE
makes psychotic brawling not show up twice in the pool of special traumas

### DIFF
--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -222,7 +222,8 @@
 	QDEL_NULL(psychotic_brawling)
 
 /datum/brain_trauma/special/psychotic_brawling/bath_salts
-	name = "Chemical Violent Psychosis"
+	name = "Chemical Violent Psychosis" //note that this DOESN'T change scan_desc, so this won't change what health analyzers refer to this brain trauma as (in comparison to non-chemical violent psychosis)
+	random_gain = FALSE
 
 /datum/brain_trauma/special/tenacity
 	name = "Tenacity"


### PR DESCRIPTION
## About The Pull Request

The psychotic brawling brain trauma has a subtype that's only supposed to be used by bath salts. This PR removes that subtype from the list of randomly-obtainable (from brain damage, lobotomies, and the like) special traumas, but does NOT remove normal psychotic brawling from that list.

## Why It's Good For The Game

There might be some special logic or something in the code for gaining random special traumas that would keep deeper subtypes from being randomly selected, but we might as well set random_gain to FALSE, just in case.

## Changelog
:cl: ATHATH
fix: Psychotic brawling now definitely won't show up twice in the pool of special traumas that can be obtained from brain damage, lobotomies, etc.
/:cl: