### PR TITLE
Adds layer switching with mouse wheel to the RPD.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -220,7 +220,7 @@
 ///from base of atom/MouseDrop_T: (/atom/from, /mob/user)
 #define COMSIG_MOUSEDROPPED_ONTO "mousedropped_onto"
 ///from base of mob/MouseWheelOn(): (/atom, delta_x, delta_y, params)
-#define COMSIG_MOUSE_SCROLL "mousescroll"
+#define COMSIG_MOUSE_SCROLL_ON "mousescroll_on"
 
 // /area signals
 

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -219,6 +219,8 @@
 	#define COMPONENT_NO_MOUSEDROP (1<<0)
 ///from base of atom/MouseDrop_T: (/atom/from, /mob/user)
 #define COMSIG_MOUSEDROPPED_ONTO "mousedropped_onto"
+///from base of mob/MouseWheelOn(): (delta_x, delta_y, params)
+#define COMSIG_MOUSE_SCROLL "mousescroll"
 
 // /area signals
 

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -219,7 +219,7 @@
 	#define COMPONENT_NO_MOUSEDROP (1<<0)
 ///from base of atom/MouseDrop_T: (/atom/from, /mob/user)
 #define COMSIG_MOUSEDROPPED_ONTO "mousedropped_onto"
-///from base of mob/MouseWheelOn(): (delta_x, delta_y, params)
+///from base of mob/MouseWheelOn(): (/atom, delta_x, delta_y, params)
 #define COMSIG_MOUSE_SCROLL "mousescroll"
 
 // /area signals

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -446,7 +446,12 @@
 
 /// MouseWheelOn
 /mob/proc/MouseWheelOn(atom/A, delta_x, delta_y, params)
-	return
+	if(incapacitated(ignore_restraints = TRUE, ignore_stasis = TRUE))
+		return
+
+	var/obj/item/I = get_active_held_item()
+	if (I)
+		SEND_SIGNAL(I, COMSIG_MOUSE_SCROLL, src, delta_x, delta_y, params)
 
 /mob/dead/observer/MouseWheelOn(atom/A, delta_x, delta_y, params)
 	var/list/modifier = params2list(params)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -446,7 +446,7 @@
 
 /// MouseWheelOn
 /mob/proc/MouseWheelOn(atom/A, delta_x, delta_y, params)
-	SEND_SIGNAL(src, COMSIG_MOUSE_SCROLL, A, delta_x, delta_y, params)
+	SEND_SIGNAL(src, COMSIG_MOUSE_SCROLL_ON, A, delta_x, delta_y, params)
 
 /mob/dead/observer/MouseWheelOn(atom/A, delta_x, delta_y, params)
 	var/list/modifier = params2list(params)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -449,9 +449,7 @@
 	if(incapacitated(ignore_restraints = TRUE, ignore_stasis = TRUE))
 		return
 
-	var/obj/item/I = get_active_held_item()
-	if (I)
-		SEND_SIGNAL(I, COMSIG_MOUSE_SCROLL, src, delta_x, delta_y, params)
+	SEND_SIGNAL(src, COMSIG_MOUSE_SCROLL, delta_x, delta_y, params)
 
 /mob/dead/observer/MouseWheelOn(atom/A, delta_x, delta_y, params)
 	var/list/modifier = params2list(params)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -446,10 +446,7 @@
 
 /// MouseWheelOn
 /mob/proc/MouseWheelOn(atom/A, delta_x, delta_y, params)
-	if(incapacitated(ignore_restraints = TRUE, ignore_stasis = TRUE))
-		return
-
-	SEND_SIGNAL(src, COMSIG_MOUSE_SCROLL, delta_x, delta_y, params)
+	SEND_SIGNAL(src, COMSIG_MOUSE_SCROLL, A, delta_x, delta_y, params)
 
 /mob/dead/observer/MouseWheelOn(atom/A, delta_x, delta_y, params)
 	var/list/modifier = params2list(params)

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -230,6 +230,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 	recipe = first_atmos
 
+	RegisterSignal(src, COMSIG_MOUSE_SCROLL, .proc/mouse_wheeled)
+
 /obj/item/pipe_dispenser/Destroy()
 	qdel(spark_system)
 	spark_system = null
@@ -478,6 +480,15 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 /obj/item/pipe_dispenser/proc/activate()
 	playsound(get_turf(src), 'sound/items/deconstruct.ogg', 50, TRUE)
+
+/obj/item/pipe_dispenser/proc/mouse_wheeled(datum/source, mob/user, delta_x, delta_y, params)
+	SIGNAL_HANDLER
+
+	if(delta_y > 0)
+		piping_layer = min(PIPING_LAYER_MAX, piping_layer + 1)
+	else
+		piping_layer = max(PIPING_LAYER_MIN, piping_layer - 1)
+	to_chat(user, "<span class='notice'>You set the layer to [piping_layer].</span>")
 
 #undef ATMOS_CATEGORY
 #undef DISPOSALS_CATEGORY

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -241,10 +241,10 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 /obj/item/pipe_dispenser/equipped(mob/user, slot, initial)
 	. = ..()
-	RegisterSignal(user, COMSIG_MOUSE_SCROLL, .proc/mouse_wheeled)
+	RegisterSignal(user, COMSIG_MOUSE_SCROLL_ON, .proc/mouse_wheeled)
 
 /obj/item/pipe_dispenser/dropped(mob/user, silent)
-	UnregisterSignal(user, COMSIG_MOUSE_SCROLL)
+	UnregisterSignal(user, COMSIG_MOUSE_SCROLL_ON)
 	return ..()
 
 /obj/item/pipe_dispenser/attack_self(mob/user)

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -230,12 +230,18 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 	recipe = first_atmos
 
-	RegisterSignal(src, COMSIG_MOUSE_SCROLL, .proc/mouse_wheeled)
-
 /obj/item/pipe_dispenser/Destroy()
 	qdel(spark_system)
 	spark_system = null
 	return ..()
+
+/obj/item/pipe_dispenser/equipped(mob/user, slot, initial)
+	. = ..()
+	RegisterSignal(user, COMSIG_MOUSE_SCROLL, .proc/mouse_wheeled)
+
+/obj/item/pipe_dispenser/dropped(mob/user, silent)
+	. = ..()
+	UnregisterSignal(user, COMSIG_MOUSE_SCROLL)
 
 /obj/item/pipe_dispenser/attack_self(mob/user)
 	ui_interact(user)
@@ -481,14 +487,14 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /obj/item/pipe_dispenser/proc/activate()
 	playsound(get_turf(src), 'sound/items/deconstruct.ogg', 50, TRUE)
 
-/obj/item/pipe_dispenser/proc/mouse_wheeled(datum/source, mob/user, delta_x, delta_y, params)
+/obj/item/pipe_dispenser/proc/mouse_wheeled(datum/source, delta_x, delta_y, params)
 	SIGNAL_HANDLER
 
 	if(delta_y > 0)
 		piping_layer = min(PIPING_LAYER_MAX, piping_layer + 1)
-	else
+	else if(delta_y < 0)
 		piping_layer = max(PIPING_LAYER_MIN, piping_layer - 1)
-	to_chat(user, "<span class='notice'>You set the layer to [piping_layer].</span>")
+	to_chat(source, "<span class='notice'>You set the layer to [piping_layer].</span>")
 
 #undef ATMOS_CATEGORY
 #undef DISPOSALS_CATEGORY

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -235,13 +235,17 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	spark_system = null
 	return ..()
 
+/obj/item/pipe_dispenser/examine(mob/user)
+	. = ..()
+	. += "You can scroll your mouse wheel to change the piping layer."
+
 /obj/item/pipe_dispenser/equipped(mob/user, slot, initial)
 	. = ..()
 	RegisterSignal(user, COMSIG_MOUSE_SCROLL, .proc/mouse_wheeled)
 
 /obj/item/pipe_dispenser/dropped(mob/user, silent)
-	. = ..()
 	UnregisterSignal(user, COMSIG_MOUSE_SCROLL)
+	return ..()
 
 /obj/item/pipe_dispenser/attack_self(mob/user)
 	ui_interact(user)
@@ -487,13 +491,17 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /obj/item/pipe_dispenser/proc/activate()
 	playsound(get_turf(src), 'sound/items/deconstruct.ogg', 50, TRUE)
 
-/obj/item/pipe_dispenser/proc/mouse_wheeled(datum/source, delta_x, delta_y, params)
+/obj/item/pipe_dispenser/proc/mouse_wheeled(mob/source, atom/A, delta_x, delta_y, params)
 	SIGNAL_HANDLER
+	if(source.incapacitated(ignore_restraints = TRUE, ignore_stasis = TRUE))
+		return
 
 	if(delta_y > 0)
 		piping_layer = min(PIPING_LAYER_MAX, piping_layer + 1)
 	else if(delta_y < 0)
 		piping_layer = max(PIPING_LAYER_MIN, piping_layer - 1)
+	else
+		return
 	to_chat(source, "<span class='notice'>You set the layer to [piping_layer].</span>")
 
 #undef ATMOS_CATEGORY


### PR DESCRIPTION
## About The Pull Request
Adds a signal that gets sent to items in currently active hand on mouse scroll
and makes RPD listen to this and change the piping layer accordingly.

I don't really like what I called the signal so if someone has a better idea for it please do tell.

## Why It's Good For The Game
Having a fast way to switch between layers is useful now that there are five layers and adds a possibility for more functionality to be added for other items. (also I were wondering why nothing uses the mouse wheel for anything and at some point thought BYOND just couldn't do anything with the mouse wheel)

## Changelog
:cl:
add: You can now change piping layers on the RPD by scrolling with the mouse wheel.
/:cl: