### PR TITLE
Fixes an issue with the sentient disease status panel, each letter was a new line

### DIFF
--- a/code/modules/antagonists/disease/disease_mob.dm
+++ b/code/modules/antagonists/disease/disease_mob.dm
@@ -88,7 +88,7 @@ the new instance inside the host to be updated to the template's stats.
 
 
 /mob/camera/disease/get_status_tab_items()
-	..()
+	. = ..()
 	if(freemove)
 		. += "Host Selection Time: [round((freemove_end - world.time)/10)]s"
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #54390

## Why It's Good For The Game
. isn't a list by default god fucking damn it

## Changelog
:cl:
fix: The sentient disease status panel is no longer a 1x1 line of letters, and works properly again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
