### PR TITLE
Adds a cooldown to the jukebox's error sound

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -396,7 +396,7 @@
 		for(var/i in 1 to speed)
 			M.setDir(pick(GLOB.cardinals))
 			for(var/mob/living/carbon/NS in rangers)
-				NS.set_resting(!NS.resting, TRUE)
+				NS.set_resting(!NS.resting, TRUE, TRUE)
 		 time--
 
 /obj/machinery/jukebox/disco/proc/dance5(mob/living/M)

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -13,6 +13,7 @@
 	var/datum/track/selection = null
 	/// Volume of the songs played
 	var/volume = 100
+	COOLDOWN_DECLARE(jukebox_error_cd)
 
 /obj/machinery/jukebox/disco
 	name = "radiant dance machine mark IV"
@@ -94,7 +95,7 @@
 		return UI_CLOSE
 	if(!songs.len && !isobserver(user))
 		to_chat(user,"<span class='warning'>Error: No music tracks have been authorized for your station. Petition Central Command to resolve this issue.</span>")
-		playsound(src, 'sound/misc/compiler-failure.ogg', 25, TRUE)
+		user.playsound_local(src, 'sound/misc/compiler-failure.ogg', 25, TRUE)
 		return UI_CLOSE
 	return ..()
 
@@ -135,7 +136,10 @@
 			if(!active)
 				if(stop > world.time)
 					to_chat(usr, "<span class='warning'>Error: The device is still resetting from the last activation, it will be ready again in [DisplayTimeText(stop-world.time)].</span>")
+					if(!COOLDOWN_FINISHED(src, jukebox_error_cd))
+						return
 					playsound(src, 'sound/misc/compiler-failure.ogg', 50, TRUE)
+					COOLDOWN_START(src, jukebox_error_cd, 15 SECONDS)
 					return
 				activate_music()
 				START_PROCESSING(SSobj, src)
@@ -392,7 +396,7 @@
 		for(var/i in 1 to speed)
 			M.setDir(pick(GLOB.cardinals))
 			for(var/mob/living/carbon/NS in rangers)
-				NS.set_resting(!NS.resting, TRUE, TRUE)
+				NS.set_resting(!NS.resting, TRUE)
 		 time--
 
 /obj/machinery/jukebox/disco/proc/dance5(mob/living/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
THAT _FUCKING SOUND_ IS WORSE THAN CYBORG DEATHGASP

Also changes the access and lack of database errors to local sounds instead because that just makes more sense.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I WON'T HAVE TO REMOVE THE DISCO BALL FROM PETE'S ROLLERDOME
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
soundadd: It is no longer possible to rupture someone's eardrums by spam clicking on the Jukebox's music selection while the cooldown is active.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
