### PR TITLE
Reactive Armors

### DIFF
--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -10,7 +10,9 @@
 	var/static/list/anomaly_armour_types = list(
 		/obj/effect/anomaly/grav	                = /obj/item/clothing/suit/armor/reactive/repulse,
 		/obj/effect/anomaly/flux 	           		= /obj/item/clothing/suit/armor/reactive/tesla,
-		/obj/effect/anomaly/bluespace 	            = /obj/item/clothing/suit/armor/reactive/teleport
+		/obj/effect/anomaly/bluespace 	            = /obj/item/clothing/suit/armor/reactive/teleport,
+		/obj/effect/anomaly/pyro					= /obj/item/clothing/suit/armor/reactive/fire,
+		/obj/effect/anomaly/bhole					= /obj/item/clothing/suit/armor/reactive/stealth
 		)
 
 	if(istype(I, /obj/item/assembly/signaler/anomaly))
@@ -112,11 +114,16 @@
 			owner.visible_message("<span class='danger'>The reactive incendiary armor on [owner] activates, but fails to send out flames as it is still recharging its flame jets!</span>")
 			return FALSE
 		owner.visible_message("<span class='danger'>[src] blocks [attack_text], sending out jets of flame!</span>")
-		playsound(get_turf(owner),'sound/magic/fireball.ogg', 100, TRUE)
-		for(var/mob/living/carbon/C in range(6, owner))
-			if(C != owner)
-				C.adjust_fire_stacks(8)
-				C.IgniteMob()
+		playsound(get_turf(src), 'sound/items/welder.ogg', 75, TRUE)
+		var/_range = 1
+		for(var/i = 0, i <= 2,i++)
+			for(var/turf/T in spiral_range_turfs(_range,get_turf(src)))
+				new /obj/effect/hotspot(T)
+				T.hotspot_expose(700,50,1)
+				for(var/mob/living/livies in T.contents - get_turf(src))
+					livies.adjustFireLoss(5)
+			_range++
+			sleep(3)
 		owner.set_fire_stacks(-20)
 		reactivearmor_cooldown = world.time + reactivearmor_cooldown_duration
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Now each anomaly gets it's own type of armor! Pyro gets a fire one with a reworked effect, while vortex gets stealth

## Why It's Good For The Game

Finally pyro reactive armor makes sense

## Changelog
:cl:
tweak: Pyro Reactive Armor now creates a ball of fire around the user while extinguishing them! Nice!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
