### PR TITLE
Miasma SM

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -45,6 +45,19 @@
 #define HYDROGEN_HEAT_RESISTANCE 2 // just a bit of heat resistance to spice it up
 #define PROTO_NITRATE_HEAT_RESISTANCE 5
 
+/// The minimum portion of the miasma in the air that will be consumed. Higher values mean more miasma will be consumed be default.
+#define MIASMA_CONSUMPTION_RATIO_MIN 0
+/// The maximum portion of the miasma in the air that will be consumed. Lower values mean the miasma consumption rate caps earlier.
+#define MIASMA_CONSUMPTION_RATIO_MAX 1
+/// The minimum pressure for a pure miasma atmosphere to begin being consumed. Higher values mean it takes more miasma pressure to make miasma start being consumed. Should be >= 0
+#define MIASMA_CONSUMPTION_PP (ONE_ATMOSPHERE*0.01)
+/// How the amount of miasma consumed per tick scales with partial pressure. Higher values decrease the rate miasma consumption scales with partial pressure. Should be >0
+#define MIASMA_PRESSURE_SCALING (ONE_ATMOSPHERE*0.5)
+/// How much the amount of miasma consumed per tick scales with gasmix power ratio. Higher values means gasmix has a greater effect on the miasma consumed.
+#define MIASMA_GASMIX_SCALING (0.3)
+/// The amount of matter power generated for every mole of miasma consumed. Higher values mean miasma generates more power.
+#define MIASMA_POWER_GAIN 10
+
 #define POWERLOSS_INHIBITION_GAS_THRESHOLD 0.20         //Higher == Higher percentage of inhibitor gas needed before the charge inertia chain reaction effect starts.
 #define POWERLOSS_INHIBITION_MOLE_THRESHOLD 20        //Higher == More moles of the gas are needed before the charge inertia chain reaction effect starts.        //Scales powerloss inhibition down until this amount of moles is reached
 #define POWERLOSS_INHIBITION_MOLE_BOOST_THRESHOLD 500  //bonus powerloss inhibition boost if this amount of moles is reached
@@ -172,6 +185,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		/datum/gas/healium,
 		/datum/gas/proto_nitrate,
 		/datum/gas/zauker,
+		/datum/gas/miasma
 	)
 	///The list of gases mapped against their current comp. We use this to calculate different values the supermatter uses, like power or heat resistance. It doesn't perfectly match the air around the sm, instead moving up at a rate determined by gas_change_rate per call. Ranges from 0 to 1
 	var/list/gas_comp = list(
@@ -240,6 +254,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		/datum/gas/healium = 1,
 		/datum/gas/proto_nitrate = 1,
 		/datum/gas/zauker = 1,
+		/datum/gas/miasma = 0.5,
 	)
 	///The last air sample's total molar count, will always be above or equal to 0
 	var/combined_gas = 0
@@ -629,6 +644,15 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		for(var/gasID in gas_trans)
 			power_transmission_bonus += gas_comp[gasID] * gas_trans[gasID] * (isnull(transit_mod[gasID]) ? 1 : transit_mod[gasID])
 		power_transmission_bonus *= h2obonus
+
+		//Miasma is really just microscopic particulate. It gets consumed like anything else that touches the crystal.
+		if(gas_comp[/datum/gas/miasma])
+			var/miasma_pp = env.return_pressure() * gas_comp[/datum/gas/miasma]
+			var/consumed_miasma = clamp(((miasma_pp - MIASMA_CONSUMPTION_PP) / (miasma_pp + MIASMA_PRESSURE_SCALING)) * (1 + (gasmix_power_ratio * MIASMA_GASMIX_SCALING)), MIASMA_CONSUMPTION_RATIO_MIN, MIASMA_CONSUMPTION_RATIO_MAX)
+			consumed_miasma *= gas_comp[/datum/gas/miasma] * combined_gas
+			if(consumed_miasma)
+				removed.gases[/datum/gas/miasma][MOLES] -= consumed_miasma
+				matter_power += consumed_miasma * MIASMA_POWER_GAIN
 
 		//more moles of gases are harder to heat than fewer, so let's scale heat damage around them
 		mole_heat_penalty = max(combined_gas / MOLE_HEAT_PENALTY, 0.25)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the supermatter crystal consume miasma in the air to power itself. The rate at which it consumes miasma scales with the partial pressure of the miasma and the gas mix of the surrounding air.

Miasma has no other effect on the supermatter crystal.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- More gas interactions with the supermatter
- Miasma SM memes

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The supermatter can now consume miasma in the air to power itself.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
