### PR TITLE
Felinids can no longer contract organ failure by licking wounds

### DIFF
--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -161,8 +161,9 @@
 /// if a felinid is licking this cut to reduce bleeding
 /datum/wound/slash/proc/lick_wounds(mob/living/carbon/human/user)
 	// transmission is one way patient -> felinid since google said cat saliva is antiseptic or whatever, and also because felinids are already risking getting beaten for this even without people suspecting they're spreading a deathvirus
-	for(var/datum/disease/iter_disease in victim.diseases)
-		if((iter_disease.spread_flags & DISEASE_SPREAD_SPECIAL) || (iter_disease.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
+	for(var/i in victim.diseases)
+		var/datum/disease/iter_disease = i
+		if(iter_disease.spread_flags & (DISEASE_SPREAD_SPECIAL | DISEASE_SPREAD_NON_CONTAGIOUS))
 			continue
 		user.ForceContractDisease(iter_disease)
 

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -161,8 +161,10 @@
 /// if a felinid is licking this cut to reduce bleeding
 /datum/wound/slash/proc/lick_wounds(mob/living/carbon/human/user)
 	// transmission is one way patient -> felinid since google said cat saliva is antiseptic or whatever, and also because felinids are already risking getting beaten for this even without people suspecting they're spreading a deathvirus
-	for(var/datum/disease/D in victim.diseases)
-		user.ForceContractDisease(D)
+	for(var/datum/disease/iter_disease in victim.diseases)
+		if((iter_disease.spread_flags & DISEASE_SPREAD_SPECIAL) || (iter_disease.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
+			continue
+		user.ForceContractDisease(iter_disease)
 
 	user.visible_message("<span class='notice'>[user] begins licking the wounds on [victim]'s [limb.name].</span>", "<span class='notice'>You begin licking the wounds on [victim]'s [limb.name]...</span>", ignored_mobs=victim)
 	to_chat(victim, "<span class='notice'>[user] begins to lick the wounds on your [limb.name].</span")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This one's a simple goof on my part. Felinids licking wounds would forcibly contract every disease the patient had, which included things like appendicitis and myocardial infarction. This fixes that by adding the same checks that being exposed to someone's blood directly runs, filtering out diseases marked as DISEASE_SPREAD_SPECIAL or DISEASE_SPREAD_NON_CONTAGIOUS
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents an entire generation of youths from drastically misunderstanding how diseases work in real life
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Felinids can no longer contract heart attacks and appendicitis from licking the wounds of the injured.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
