### PR TITLE
Adds a minor SM interaction with water vapor.

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -703,7 +703,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		//Aboce certain power thresholds the supermatter crystal can electrolyze water vapor.
 		if(power > POWER_PENALTY_THRESHOLD)
 			var/h2o_moles = removed.gases[/datum/gas/water_vapor][MOLES]
-			var/electrolysis_moles = max(h2o_moles * (power - POWER_PENALTY_THRESHOLD)/(power + WATER_ELECTROLYSIS_MODIFIER), 0)
+			var/electrolysis_moles = clamp(h2o_moles * (power - POWER_PENALTY_THRESHOLD)/(power + WATER_ELECTROLYSIS_MODIFIER), 0, h2o_moles)
 			if(electrolysis_moles)
 				removed.gases[/datum/gas/water_vapor][MOLES] -= electrolysis_moles
 				removed.gases[/datum/gas/hydrogen][MOLES] += electrolysis_moles


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the supermatter crystal split water vapor into hydrogen and oxygen above the power level it starts shocking things at. The efficiency increases with the crystals power.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Makes the spicy crystal a little more spicy.
- At high powers the supermatter starts launching lightning bolts. It just makes sense.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The supermatter now splits water molecules at high power levels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
