### PR TITLE
Fixes various do_after related issues from #54409

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -221,7 +221,7 @@ GLOBAL_LIST_EMPTY(species_list)
 			|| (!(timed_action_flags & IGNORE_USER_LOC_CHANGE) && !drifting && user.loc != user_loc) \
 			|| (!(timed_action_flags & IGNORE_TARGET_LOC_CHANGE) && target.loc != target_loc) \
 			|| (!(timed_action_flags & IGNORE_HELD_ITEM) && user.get_active_held_item() != holding) \
-			|| (!(timed_action_flags & IGNORE_INCAPACITATED) && user.incapacitated()) \
+			|| (!(timed_action_flags & IGNORE_INCAPACITATED) && HAS_TRAIT(user, TRAIT_INCAPACITATED)) \
 			|| (extra_checks && !extra_checks.Invoke()) \
 			)
 			. = FALSE
@@ -293,7 +293,7 @@ GLOBAL_LIST_EMPTY(species_list)
 			QDELETED(user) \
 			|| (!(timed_action_flags & IGNORE_USER_LOC_CHANGE) && !drifting && user.loc != user_loc) \
 			|| (!(timed_action_flags & IGNORE_HELD_ITEM) && user.get_active_held_item() != holding) \
-			|| (!(timed_action_flags & IGNORE_INCAPACITATED) && user.incapacitated()) \
+			|| (!(timed_action_flags & IGNORE_INCAPACITATED) && HAS_TRAIT(user, TRAIT_INCAPACITATED)) \
 			|| (extra_checks && !extra_checks.Invoke()) \
 		)
 			. = FALSE
@@ -367,7 +367,7 @@ GLOBAL_LIST_EMPTY(species_list)
 		if(
 			!((timed_action_flags & IGNORE_USER_LOC_CHANGE) && !drifting && user_loc != user.loc) \
 			|| (!(timed_action_flags & IGNORE_HELD_ITEM) && user.get_active_held_item() != holding) \
-			|| (!(timed_action_flags & IGNORE_INCAPACITATED) && user.incapacitated()) \
+			|| (!(timed_action_flags & IGNORE_INCAPACITATED) && HAS_TRAIT(user, TRAIT_INCAPACITATED)) \
 			|| (extra_checks && !extra_checks.Invoke()) \
 			)
 			. = FALSE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -396,7 +396,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 	var/list/things = src_object.contents()
 	var/datum/progressbar/progress = new(user, things.len, src)
-	while (do_after(usr, 10, TRUE, src, FALSE, CALLBACK(src_object, /datum/component/storage.proc/mass_remove_from_storage, src, things, progress)))
+	while (do_after(usr, 1 SECONDS, src, NONE, FALSE, CALLBACK(src_object, /datum/component/storage.proc/mass_remove_from_storage, src, things, progress)))
 		stoplag(1)
 	progress.end_progress()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #54502
Fixes #54494
Fixes #54491

https://github.com/tgstation/tgstation/pull/54409 replaced some snowflake checks with `user.incapacitated()` - However, this proc is an utter nightmare and considers handcuffs, aggro grabs and stasis to be incapacitations by default.

So when resisting out of cuffs is a do_after and do_afters cannot be used while cuffed, we have a problem.

Speaking with Rohesie, we opted for a quick fix solution so we can identify edge cases later on, replacing the incapacitated proc check with the trait check instead.

This means that in some situations where being cuffed prevented the user from initiating any do_thing procs in the past, they will now be able to do them. These will be addressed as they crop up.

That same PR also re-defined the proc signature for do_after, which dumping storage containers onto turfs got caught up in as their do_after was never updated, so it was passing TRUE as the target and getting this runtime when attempting to dump contents:
![image](https://user-images.githubusercontent.com/24975989/96656703-4ca65e80-1338-11eb-880f-029d56995720.png)

This has been fixed up too.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cuffs no longer prevent all actions that require a progress bar to complete. This includes cuffs preventing you from resisting out of cuffs (yikers!) and cuffs preventing you from standing up after resting.
fix: Container contents, including storage boxes and backpacks, can once again be dumped onto the floor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
