### PR TITLE
Adds 👏 High 👏 Fives 👏

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -108,6 +108,8 @@
 #define STATUS_EFFECT_HELDUP /datum/status_effect/heldup // someone is currently pointing a gun at you
 
 #define STATUS_EFFECT_HOLDUP /datum/status_effect/holdup // you are currently pointing a gun at someone
+
+#define STATUS_EFFECT_HIGHFIVE /datum/status_effect/high_fiving // you are angling for a high five
 /////////////
 //  SLIME  //
 /////////////

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -315,6 +315,33 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	var/mob/living/carbon/C = owner
 	C.take(giver, receiving)
 
+/obj/screen/alert/highfive
+	icon_state = "default"
+	var/mob/living/carbon/giver
+	var/obj/item/receiving
+
+/obj/screen/alert/highfive/proc/setup(mob/living/carbon/taker, mob/living/carbon/giver, obj/item/receiving)
+	name = "[giver] is offering a high-five"
+	desc = "[giver] wants a high-five! Click this alert to take it."
+	icon_state = "template"
+	cut_overlays()
+	add_overlay(receiving)
+	src.receiving = receiving
+	src.giver = giver
+	RegisterSignal(taker, COMSIG_MOVABLE_MOVED, .proc/check_in_range, taker)
+
+/obj/screen/alert/highfive/proc/check_in_range(atom/taker)
+	SIGNAL_HANDLER
+
+	if (!giver.CanReach(taker))
+		to_chat(owner, "<span class='warning'>You left [giver] hanging!</span>")
+		owner.clear_alert("[giver]")
+
+/obj/screen/alert/highfive/Click(location, control, params)
+	. = ..()
+	var/mob/living/carbon/C = owner
+	C.take(giver, receiving)
+
 /// Gives the player the option to succumb while in critical condition
 /obj/screen/alert/succumb
 	name = "Succumb"

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -318,29 +318,22 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /obj/screen/alert/highfive
 	icon_state = "default"
 	var/mob/living/carbon/giver
-	var/obj/item/receiving
+	var/obj/item/slapper/slapper_item
 
-/obj/screen/alert/highfive/proc/setup(mob/living/carbon/taker, mob/living/carbon/giver, obj/item/receiving)
+/obj/screen/alert/highfive/proc/setup(mob/living/carbon/taker, mob/living/carbon/giver, obj/item/slapper/slap)
 	name = "[giver] is offering a high-five"
 	desc = "[giver] wants a high-five! Click this alert to take it."
 	icon_state = "template"
 	cut_overlays()
-	add_overlay(receiving)
-	src.receiving = receiving
+	add_overlay(slap)
+	src.slapper_item = slap
 	src.giver = giver
-	RegisterSignal(taker, COMSIG_MOVABLE_MOVED, .proc/check_in_range, taker)
-
-/obj/screen/alert/highfive/proc/check_in_range(atom/taker)
-	SIGNAL_HANDLER
-
-	if (!giver.CanReach(taker))
-		to_chat(owner, "<span class='warning'>You left [giver] hanging!</span>")
-		owner.clear_alert("[giver]")
 
 /obj/screen/alert/highfive/Click(location, control, params)
 	. = ..()
-	var/mob/living/carbon/C = owner
-	C.take(giver, receiving)
+	var/datum/status_effect/high_fiving/high_five_effect = giver.has_status_effect(STATUS_EFFECT_HIGHFIVE)
+	if(high_five_effect)
+		high_five_effect.we_did_it(owner)
 
 /// Gives the player the option to succumb while in critical condition
 /obj/screen/alert/succumb

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -239,6 +239,21 @@
 	mood_change = -25
 	timeout = 4 MINUTES
 
+/datum/mood_event/high_five_alone
+	description = "<span class='boldwarning'>I tried getting a high-five with no one around, how embarassing!</span>\n"
+	mood_change = -5
+	timeout = 1 MINUTES
+
+/datum/mood_event/high_five_full_hand
+	description = "<span class='boldwarning'>Oh God, I don't even know how to high-five correctly...</span>\n"
+	mood_change = -20
+	timeout = 2 MINUTES
+
+/datum/mood_event/left_hanging
+	description = "<span class='boldwarning'>But everyone loves high fives! Maybe people just... hate me?</span>\n"
+	mood_change = -10
+	timeout = 2 MINUTES
+
 //These are unused so far but I want to remember them to use them later
 /datum/mood_event/surgery
 	description = "<span class='boldwarning'>HE'S CUTTING ME OPEN!!</span>\n"

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -246,12 +246,17 @@
 
 /datum/mood_event/high_five_full_hand
 	description = "<span class='boldwarning'>Oh God, I don't even know how to high-five correctly...</span>\n"
-	mood_change = -20
+	mood_change = -15
 	timeout = 2 MINUTES
 
 /datum/mood_event/left_hanging
 	description = "<span class='boldwarning'>But everyone loves high fives! Maybe people just... hate me?</span>\n"
 	mood_change = -10
+	timeout = 2 MINUTES
+
+/datum/mood_event/too_slow
+	description = "<span class='boldwarning'>NO! HOW COULD I BE.... TOO SLOW???</span>\n"
+	mood_change = -20 // the ULTIMATE prank carries a lot of weight
 	timeout = 2 MINUTES
 
 //These are unused so far but I want to remember them to use them later

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -226,12 +226,12 @@
 
 /datum/mood_event/tripped
 	description = "<span class='boldwarning'>I can't believe I fell for the oldest trick in the book!</span>\n"
-	mood_change = -10
+	mood_change = -5
 	timeout = 2 MINUTES
 
 /datum/mood_event/untied
 	description = "<span class='boldwarning'>I hate when my shoes come untied!</span>\n"
-	mood_change = -5
+	mood_change = -3
 	timeout = 1 MINUTES
 
 /datum/mood_event/gates_of_mansus
@@ -241,23 +241,34 @@
 
 /datum/mood_event/high_five_alone
 	description = "<span class='boldwarning'>I tried getting a high-five with no one around, how embarassing!</span>\n"
-	mood_change = -5
+	mood_change = -2
 	timeout = 1 MINUTES
 
 /datum/mood_event/high_five_full_hand
 	description = "<span class='boldwarning'>Oh God, I don't even know how to high-five correctly...</span>\n"
-	mood_change = -15
-	timeout = 2 MINUTES
+	mood_change = -1
+	timeout = 45 SECONDS
 
 /datum/mood_event/left_hanging
 	description = "<span class='boldwarning'>But everyone loves high fives! Maybe people just... hate me?</span>\n"
-	mood_change = -10
-	timeout = 2 MINUTES
+	mood_change = -2
+	timeout = 1.5 MINUTES
 
 /datum/mood_event/too_slow
 	description = "<span class='boldwarning'>NO! HOW COULD I BE.... TOO SLOW???</span>\n"
-	mood_change = -20 // the ULTIMATE prank carries a lot of weight
+	mood_change = -2 // multiplied by how many people saw it happen, up to 8, so potentially massive. the ULTIMATE prank carries a lot of weight
 	timeout = 2 MINUTES
+
+/datum/mood_event/too_slow/add_effects(param)
+	var/people_laughing_at_you = 1 // start with 1 in case they're on the same tile or something
+	for(var/mob/living/carbon/iter_carbon in oview(owner, 7))
+		if(iter_carbon.stat == CONSCIOUS)
+			people_laughing_at_you++
+			if(people_laughing_at_you > 7)
+				break
+
+	mood_change *= people_laughing_at_you
+	return ..()
 
 //These are unused so far but I want to remember them to use them later
 /datum/mood_event/surgery

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -213,3 +213,8 @@
 	description = "<span class='nicegreen'>AMAZING! A HIGH-TEN!</span>\n"
 	mood_change = 10 // heh 10
 	timeout = 1.5 MINUTES
+
+/datum/mood_event/down_low
+	description = "<span class='nicegreen'>HA! What a rube, they never stood a chance...</span>\n"
+	mood_change = 20
+	timeout = 1.5 MINUTES

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -206,15 +206,15 @@
 
 /datum/mood_event/high_five
 	description = "<span class='nicegreen'>I love getting high fives!</span>\n"
-	mood_change = 5 // heh 5
-	timeout = 1 MINUTES
+	mood_change = 2
+	timeout = 45 SECONDS
 
 /datum/mood_event/high_ten
 	description = "<span class='nicegreen'>AMAZING! A HIGH-TEN!</span>\n"
-	mood_change = 10 // heh 10
-	timeout = 1.5 MINUTES
+	mood_change = 3
+	timeout = 45 SECONDS
 
 /datum/mood_event/down_low
 	description = "<span class='nicegreen'>HA! What a rube, they never stood a chance...</span>\n"
-	mood_change = 20
+	mood_change = 4
 	timeout = 1.5 MINUTES

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -203,3 +203,13 @@
 	description = "<span class='nicegreen'>Truly, that was the food of the Divine!</span>\n"
 	mood_change = 5
 	timeout = 3 MINUTES
+
+/datum/mood_event/high_five
+	description = "<span class='nicegreen'>I love getting high fives!</span>\n"
+	mood_change = 5 // heh 5
+	timeout = 1 MINUTES
+
+/datum/mood_event/high_ten
+	description = "<span class='nicegreen'>AMAZING! A HIGH-TEN!</span>\n"
+	mood_change = 10 // heh 10
+	timeout = 1.5 MINUTES

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -157,9 +157,8 @@
 	owner.visible_message("<span class='notice'>[owner] raises [owner.p_their()] arm, looking for a high-five!</span>", \
 		"<span class='notice'>You post up, looking for a high-five!</span>", null, 2)
 
-	for(var/i in orange(1, owner))
-		var/mob/living/carbon/possible_taker = i
-		if(!istype(possible_taker) || !owner.CanReach(possible_taker) || possible_taker.incapacitated())
+	for(var/mob/living/carbon/possible_taker in orange(1, owner))
+		if(!owner.CanReach(possible_taker) || possible_taker.incapacitated())
 			continue
 		register_candidate(possible_taker)
 
@@ -175,6 +174,7 @@
 	RegisterSignal(owner, COMSIG_PARENT_EXAMINE_MORE, .proc/check_fake_out)
 
 /datum/status_effect/high_fiving/Destroy()
+	QDEL_NULL(slap_item)
 	for(var/i in possible_takers)
 		var/mob/living/carbon/lost_hope = i
 		remove_candidate(lost_hope)

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -135,3 +135,128 @@
 	name = "Holding Up"
 	desc = "You're currently pointing a gun at someone."
 	icon_state = "aimed"
+
+// this status effect is used to negotiate the high-fiving capabilities of all concerned parties
+/datum/status_effect/high_fiving
+	id = "high_fiving"
+	duration = -1
+	tick_interval = -1
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = null
+	/// The carbons who were offered the ability to partake in the high-five
+	var/list/possible_takers
+	/// The actual slapper item
+	var/obj/item/slapper/slap_item
+
+/datum/status_effect/high_fiving/on_creation(mob/living/new_owner, obj/item/slap)
+	. = ..()
+	if(!.)
+		return
+
+	slap_item = slap
+	owner.visible_message("<span class='notice'>[owner] raises [owner.p_their()] arm, looking for a high-five!</span>", \
+		"<span class='notice'>You post up, looking for a high-five!</span>", null, 2)
+
+	for(var/i in orange(1, owner))
+		var/mob/living/carbon/possible_taker = i
+		if(!istype(possible_taker) || !owner.CanReach(possible_taker) || possible_taker.incapacitated())
+			continue
+		register_candidate(possible_taker)
+
+	if(!possible_takers) // in case we tried high-fiving with only a dead body around or something
+		owner.visible_message("<span class='danger'>[owner] realizes no one within range is actually capable of high-fiving, lowering [owner.p_their()] arm in shame...</span>", \
+			"<span class='warning'>You realize a moment too late that no one within range is actually capable of high-fiving you, oof...</span>", null, 2)
+		SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "high_five", /datum/mood_event/high_five_alone)
+		qdel(src)
+		return
+
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, .proc/check_owner_in_range)
+	RegisterSignal(slap_item, list(COMSIG_PARENT_QDELETING, COMSIG_ITEM_DROPPED), .proc/dropped_slap)
+
+/datum/status_effect/high_fiving/Destroy()
+	for(var/i in possible_takers)
+		var/mob/living/carbon/lost_hope = i
+		remove_candidate(lost_hope)
+	LAZYCLEARLIST(possible_takers)
+	return ..()
+
+/// Hook up the specified carbon mob for possible high-fiving, give them the alert and signals and all
+/datum/status_effect/high_fiving/proc/register_candidate(mob/living/carbon/possible_candidate)
+	var/obj/screen/alert/highfive/G = possible_candidate.throw_alert("[owner]", /obj/screen/alert/highfive)
+	if(!G)
+		return
+	LAZYADD(possible_takers, possible_candidate)
+	RegisterSignal(possible_candidate, COMSIG_MOVABLE_MOVED, .proc/check_taker_in_range)
+	G.setup(possible_candidate, owner, slap_item)
+
+/// Remove the alert and signals for the specified carbon mob
+/datum/status_effect/high_fiving/proc/remove_candidate(mob/living/carbon/removed_candidate)
+	removed_candidate.clear_alert("[owner]")
+	LAZYREMOVE(possible_takers, removed_candidate)
+	UnregisterSignal(removed_candidate, COMSIG_MOVABLE_MOVED)
+
+/// We failed to high-five broh, either because there's no one viable next to us anymore, or we lost the slapper, or what
+/datum/status_effect/high_fiving/proc/fail()
+	owner.visible_message("<span class='danger'>[owner] slowly lowers [owner.p_their()] arm, realizing no one will high-five [owner.p_them()]! How embarassing...</span>", \
+		"<span class='warning'>You realize the futility of continuing to wait for a high-five, and lower your arm...</span>", null, 2)
+	SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "high_five", /datum/mood_event/left_hanging)
+	qdel(src)
+
+/// Yeah broh! This is where we do the high-fiving (or high-tenning :o)
+/datum/status_effect/high_fiving/proc/we_did_it(mob/living/carbon/successful_taker)
+	var/open_hands_taker
+	var/slappers_owner
+	for(var/i in successful_taker.held_items) // see how many hands the taker has open for high'ing
+		if(isnull(i))
+			open_hands_taker++
+
+	if(!open_hands_taker)
+		to_chat(successful_taker, "<span class='warning'>You can't high-five [owner] with no open hands!</span>")
+		SEND_SIGNAL(successful_taker, COMSIG_ADD_MOOD_EVENT, "high_five", /datum/mood_event/high_five_full_hand) // not so successful now!
+		return
+	else if(open_hands_taker >= 2) // not gonna bother with high-15's and such
+		for(var/i in owner.held_items)
+			var/obj/item/slapper/slap_check = i
+			if(istype(slap_check))
+				slappers_owner++
+
+	if(slappers_owner >= 2) // we only check this if it's already established the taker has 2+ hands free
+		owner.visible_message("<span class='notice'>[successful_taker] enthusiastically high-tens [owner]!</span>", "<span class='nicegreen'>Wow! You're high-tenned [successful_taker]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", ignored_mobs=successful_taker)
+		to_chat(successful_taker, "<span class='nicegreen'>You give high-tenning [owner] your all!</span>")
+		playsound(owner, 'sound/weapons/slap.ogg', 100, TRUE, 1)
+		SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "high_five", /datum/mood_event/high_ten)
+		SEND_SIGNAL(successful_taker, COMSIG_ADD_MOOD_EVENT, "high_five", /datum/mood_event/high_ten)
+	else
+		owner.visible_message("<span class='notice'>[successful_taker] high-fives [owner]!</span>", "<span class='nicegreen'>All right! You're high-fived by [successful_taker]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", ignored_mobs=successful_taker)
+		to_chat(successful_taker, "<span class='nicegreen'>You high-five [owner]!</span>")
+		playsound(owner, 'sound/weapons/slap.ogg', 50, TRUE, -1)
+		SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "high_five", /datum/mood_event/high_five)
+		SEND_SIGNAL(successful_taker, COMSIG_ADD_MOOD_EVENT, "high_five", /datum/mood_event/high_five)
+	qdel(src)
+
+/// One of our possible takers moved, see if they left us hanging
+/datum/status_effect/high_fiving/proc/check_taker_in_range(mob/living/carbon/taker)
+	SIGNAL_HANDLER
+	if(owner.CanReach(taker) && !taker.incapacitated())
+		return
+
+	to_chat(taker, "<span class='warning'>You left [owner] hanging!</span>")
+	remove_candidate(taker)
+	if(!possible_takers)
+		fail()
+
+/// The propositioner moved, see if anyone is out of range now
+/datum/status_effect/high_fiving/proc/check_owner_in_range(mob/living/carbon/source)
+	SIGNAL_HANDLER
+
+	for(var/i in possible_takers)
+		var/mob/living/carbon/checking_taker = i
+		if(!istype(checking_taker) || !owner.CanReach(checking_taker) || checking_taker.incapacitated())
+			remove_candidate(checking_taker)
+
+	if(!possible_takers)
+		fail()
+
+/// Can't slap with no slapper
+/datum/status_effect/high_fiving/proc/dropped_slap(obj/item/source)
+	fail()

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -251,7 +251,8 @@
 		qdel(src)
 		return
 	owner.visible_message("<span class='danger'>[owner] pulls away from [rube]'s slap at the last second, dodging the high-five entirely!</span>", "<span class='nicegreen'>[rube] fails to make contact with your hand, making an utter fool of [rube.p_them()]self!</span>", "<span class='hear'>You hear a disappointing sound of flesh not hitting flesh!</span>", ignored_mobs=rube)
-	to_chat(rube, "<span class='userdanger'>NO! [owner] PULLS [owner.p_their()] HAND AWAY FROM YOURS! YOU'RE TOO SLOW!</span>")
+	var/all_caps_for_emphasis = uppertext("NO! [owner] PULLS [owner.p_their()] HAND AWAY FROM YOURS! YOU'RE TOO SLOW!")
+	to_chat(rube, "<span class='userdanger'>[all_caps_for_emphasis]</span>")
 	playsound(owner, 'sound/weapons/thudswoosh.ogg', 100, TRUE, 1)
 	rube.Knockdown(1 SECONDS)
 	SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "high_five", /datum/mood_event/down_low)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -619,9 +619,9 @@
   * Produces a signal [COMSIG_PARENT_EXAMINE_MORE]
   */
 /atom/proc/examine_more(mob/user)
-	. = list()
+	. = list("")
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE_MORE, user, .)
-	if(!LAZYLEN(.)) // lol ..length
+	if(. == list("")) // lol ..length
 		return list("<span class='notice'><i>You examine [src] closer, but find nothing of interest...</i></span>")
 
 /// Updates the icon of the atom

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -619,9 +619,9 @@
   * Produces a signal [COMSIG_PARENT_EXAMINE_MORE]
   */
 /atom/proc/examine_more(mob/user)
-	. = list("")
+	. = list()
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE_MORE, user, .)
-	if(. == list("")) // lol ..length
+	if(!LAZYLEN(.)) // lol ..length
 		return list("<span class='notice'><i>You examine [src] closer, but find nothing of interest...</i></span>")
 
 /// Updates the icon of the atom

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -215,7 +215,7 @@
 /mob/living/carbon/proc/offer_high_five(obj/item/slap)
 	if(has_status_effect(STATUS_EFFECT_HIGHFIVE))
 		return
-	if(!locate(/mob/living/carbon) in orange(1, src))
+	if(!(locate(/mob/living/carbon) in orange(1, src)))
 		visible_message("<span class='danger'>[src] raises [p_their()] arm, looking around for a high-five, but there's no one around! How embarassing...</span>", \
 			"<span class='warning'>You post up, looking for a high-five, but finding no one within range! How embarassing...</span>", null, 2)
 		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "high_five", /datum/mood_event/high_five_alone)

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -172,8 +172,8 @@
 		return
 
 	if(istype(receiving, /obj/item/slapper))
-		visible_message("<span class='notice'>[src] holds up [p_their()] hand, looking for a high-five!</span>", \
-							"<span class='notice'>You offer up a high-five.</span>")
+		offer_high_five(receiving)
+		return
 	visible_message("<span class='notice'>[src] is offering [receiving]</span>", \
 					"<span class='notice'>You offer [receiving]</span>", null, 2)
 	for(var/mob/living/carbon/C in orange(1, src))
@@ -210,3 +210,15 @@
 	visible_message("<span class='notice'>[src] takes [I] from [giver]</span>", \
 					"<span class='notice'>You take [I] from [giver]</span>")
 	put_in_hands(I)
+
+/// Spin-off of [/mob/living/carbon/proc/give] exclusively for high-fiving
+/mob/living/carbon/proc/offer_high_five(obj/item/slap)
+	if(has_status_effect(STATUS_EFFECT_HIGHFIVE))
+		return
+	if(!locate(/mob/living/carbon) in orange(1, src))
+		visible_message("<span class='danger'>[src] raises [p_their()] arm, looking around for a high-five, but there's no one around! How embarassing...</span>", \
+			"<span class='warning'>You post up, looking for a high-five, but finding no one within range! How embarassing...</span>", null, 2)
+		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "high_five", /datum/mood_event/high_five_alone)
+		return
+
+	apply_status_effect(STATUS_EFFECT_HIGHFIVE, slap)

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -170,6 +170,10 @@
 	if(!receiving)
 		to_chat(src, "<span class='warning'>You're not holding anything to give!</span>")
 		return
+
+	if(istype(receiving, /obj/item/slapper))
+		visible_message("<span class='notice'>[src] holds up [p_their()] hand, looking for a high-five!</span>", \
+							"<span class='notice'>You offer up a high-five.</span>")
 	visible_message("<span class='notice'>[src] is offering [receiving]</span>", \
 					"<span class='notice'>You offer [receiving]</span>", null, 2)
 	for(var/mob/living/carbon/C in orange(1, src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This was requested by my wonderful pal dezupher, who gave me the neat idea for implementing this with the offer item feature

[![dreamseeker_2020-10-20_23-18-56.png](https://i.imgur.com/LYF2Hnal.jpg)](https://i.imgur.com/LYF2Hna.png)

This PR lets you post up for high-fives with your buds so you can slap some skin and show off how well you vibe together. To initiate a high-five, simply stand next to another person with a slapper (the *slap emote one) in hand, and hit the offer item button (default G) to let the people adjacent to you know you're available. They'll get an alert that you're offering a high-five, and clicking it will follow through and award you both a small positive moodlet, or they can just walk away and leave you hanging, earning you a negative moodlet.

Is a high-five not enough to show the world how tight your crew is? Double the fun! If whoever initiates the high-five has a slapper in both hands, and the taker has two hands free, you'll go for the mythical high-ten for a louder slap and extra emphasis! Woo!

[![dreamseeker_2020-10-20_23-25-54.png](https://i.imgur.com/lcFitpMl.jpg)](https://i.imgur.com/lcFitpM.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is all NT has in the budget for team-building this year, sorry guys.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
add: You can now high-five your fellow crewmembers! Simply have a slapper in hand (emote *slap), walk up to someone, and press the "offer item" key (default G) to offer them a high-five! Show off how well you and your crew vibe today!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
