### PR TITLE
Fly people eating fixed up

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -554,13 +554,11 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	else if (toxvomit == VOMIT_TOXIC)
 		V.icon_state = "vomittox_[pick(1,4)]"
 	if (iscarbon(M))
-		var/mob/living/carbon/C = M
-		if(C.reagents)
-			clear_reagents_to_vomit_pool(C, V, purge)
+		clear_reagents_to_vomit_pool(M, V, purge)
 
 /proc/clear_reagents_to_vomit_pool(mob/living/carbon/M, obj/effect/decal/cleanable/vomit/V, purge = FALSE)
 	var/obj/item/organ/stomach/belly = M.getorganslot(ORGAN_SLOT_STOMACH)
-	if(!belly)
+	if(!belly?.reagents.total_volume)
 		return
 	var/chemicals_lost = belly.reagents.total_volume * 0.1
 	if(purge)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -459,7 +459,7 @@
 	if((HAS_TRAIT(src, TRAIT_NOHUNGER) || HAS_TRAIT(src, TRAIT_TOXINLOVER)) && !force)
 		return TRUE
 
-	if(nutrition < 100 && !blood)
+	if(nutrition < 100 && !blood && !force)
 		if(message)
 			visible_message("<span class='warning'>[src] dry heaves!</span>", \
 							"<span class='userdanger'>You try to throw up, but there's nothing in your stomach!</span>")

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -78,7 +78,8 @@
 			continue
 		var/mob/living/carbon/body = owner
 		var/turf/pos = get_turf(owner)
-		body.vomit(reagents.total_volume, FALSE, FALSE, 2, TRUE)
+		// we do not loss any nutrition as a fly when vomiting out food
+		body.vomit(0, FALSE, FALSE, 2, TRUE, force=TRUE, purge=TRUE)
 		playsound(pos, 'sound/effects/splat.ogg', 50, TRUE)
 		body.visible_message("<span class='danger'>[body] vomits on the floor!</span>", \
 					"<span class='userdanger'>You throw up on the floor!</span>")

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -70,17 +70,11 @@
 	icon_state = pick("brain-x-d", "liver-x", "kidneys-x", "stomach-x", "lungs-x", "random_fly_1", "random_fly_2", "random_fly_3", "random_fly_4", "random_fly_5")
 
 /obj/item/organ/stomach/fly/on_life()
-	for(var/bile in reagents.reagent_list)
-		if(!istype(bile, /datum/reagent/consumable))
-			continue
-		var/datum/reagent/consumable/chunk = bile
-		if(chunk.nutriment_factor <= 0)
-			continue
+	if(locate(/datum/reagent/consumable) in reagents.reagent_list)
 		var/mob/living/carbon/body = owner
-		var/turf/pos = get_turf(owner)
 		// we do not loss any nutrition as a fly when vomiting out food
 		body.vomit(0, FALSE, FALSE, 2, TRUE, force=TRUE, purge=TRUE)
-		playsound(pos, 'sound/effects/splat.ogg', 50, TRUE)
+		playsound(get_turf(owner), 'sound/effects/splat.ogg', 50, TRUE)
 		body.visible_message("<span class='danger'>[body] vomits on the floor!</span>", \
 					"<span class='userdanger'>You throw up on the floor!</span>")
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When a fly person vomited up food the nutrition was not added properly.
Also the amount of nutrition that was lost to the vomit was 90%, this changes flyperson vomit to transfer ~67% of the nutrition to the vomit, this changes fly people from eating 10 hotdogs to just 1-2 for the same nutrition. Fly people were a drain on the food supply.
This also fixed the issue that fly people would loss nutrition on vomit where that was not intended.

Fixes #54510

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fly people can now eat.
Vomiting now transfers reagents as expected.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fly people will not become full on eating that vomit
fix: Vomiting now removes reagents properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
