### PR TITLE
No more free stuff in maint

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -90493,7 +90493,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/frame/machine,
+/obj/machinery/mecha_part_fabricator/maint,
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dus" = (
@@ -90502,7 +90502,6 @@
 /obj/item/stock_parts/micro_laser,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
-/obj/item/circuitboard/machine/mechfab,
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dut" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -18285,7 +18285,6 @@
 /area/space/nearstation)
 "aMQ" = (
 /obj/structure/table/wood,
-/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/abandoned_gambling_den/secondary)
 "aMR" = (
@@ -63518,11 +63517,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "crC" = (
-/obj/structure/closet/secure_closet/security/sec,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
+/obj/structure/closet/bombcloset/security,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "crD" = (
@@ -75061,8 +75060,8 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "cOs" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "cOt" = (
@@ -80467,7 +80466,6 @@
 /area/maintenance/department/electrical)
 "cYD" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/yellow,
 /obj/item/storage/toolbox/electrical,
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_y = -32
@@ -80515,7 +80513,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "cYJ" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "cYK" = (
@@ -88663,7 +88661,7 @@
 /area/maintenance/starboard/aft)
 "dpN" = (
 /obj/structure/table/wood/poker,
-/obj/item/clothing/glasses/sunglasses/big,
+/obj/item/toy/cards/deck,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/abandoned_gambling_den)
 "dpO" = (
@@ -88678,9 +88676,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dpP" = (
 /obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck/syndicate{
-	pixel_y = 6
-	},
+/obj/effect/spawner/lootdrop/gambling,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/abandoned_gambling_den)
 "dpQ" = (
@@ -92421,11 +92417,11 @@
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dzm" = (
-/obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_one_access_txt = "12;47"
 	},
+/obj/structure/barricade/wooden,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -92436,6 +92432,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4227,9 +4227,9 @@
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/donkpockets,
-/obj/item/kitchen/knife/butcher,
 /obj/item/stack/package_wrap,
 /obj/effect/turf_decal/bot,
+/obj/item/kitchen/knife,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "alM" = (
@@ -68274,9 +68274,9 @@
 /area/maintenance/port)
 "cAZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/turf_decal/delivery,
+/obj/structure/tank_holder/emergency_oxygen,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cBa" = (
@@ -69159,7 +69159,7 @@
 /area/maintenance/port)
 "cCF" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/tank_holder/emergency_oxygen,
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cCG" = (
@@ -71810,7 +71810,7 @@
 /area/maintenance/port)
 "cHy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
+/obj/structure/tank_holder/emergency_oxygen,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cHz" = (
@@ -87912,10 +87912,8 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dob" = (
 /obj/structure/table/wood/poker,
-/obj/item/stack/spacecash/c1000{
-	pixel_y = 8
-	},
 /obj/item/stack/spacecash/c500,
+/obj/item/storage/pill_bottle/dice,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/abandoned_gambling_den)
 "doc" = (
@@ -93463,7 +93461,6 @@
 "dBS" = (
 /obj/structure/table/wood/poker,
 /obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
@@ -93494,8 +93491,8 @@
 "dBX" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/head/welding,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/gloves/color/fyellow,
 /turf/open/floor/plating,
 /area/science/research/abandoned)
 "dBY" = (
@@ -114217,7 +114214,7 @@
 /area/science/research)
 "vec" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/tank_holder/emergency_oxygen,
+/obj/item/kirbyplants/random,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "vjn" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4723,7 +4723,6 @@
 /obj/structure/sign/barsign{
 	pixel_y = 32
 	},
-/obj/item/wirerod,
 /obj/item/wrench,
 /obj/item/clothing/under/suit/waiter,
 /obj/item/clothing/accessory/waistcoat,
@@ -85726,7 +85725,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/item/storage/secure/briefcase,
-/obj/item/restraints/handcuffs,
 /obj/item/grenade/smokebomb,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -85807,8 +85805,8 @@
 /area/crew_quarters/abandoned_gambling_den)
 "djn" = (
 /obj/structure/table/reinforced,
-/obj/item/multitool,
 /obj/item/screwdriver,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "djo" = (
@@ -87910,8 +87908,8 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dob" = (
 /obj/structure/table/wood/poker,
-/obj/item/stack/spacecash/c500,
 /obj/item/storage/pill_bottle/dice,
+/obj/effect/spawner/lootdrop/space/cashmoney,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/abandoned_gambling_den)
 "doc" = (
@@ -88666,11 +88664,6 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dpO" = (
 /obj/structure/table/wood/poker,
-/obj/item/stack/spacecash/c10{
-	pixel_x = -16;
-	pixel_y = 8
-	},
-/obj/item/stack/spacecash/c100,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/abandoned_gambling_den)
@@ -90499,10 +90492,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/mecha_part_fabricator/maint{
-	name = "forgotten exosuit fabricator"
-	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/frame/machine,
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dus" = (
@@ -90511,6 +90502,7 @@
 /obj/item/stock_parts/micro_laser,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
+/obj/item/circuitboard/machine/mechfab,
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dut" = (
@@ -92421,7 +92413,6 @@
 	name = "Maintenance Hatch";
 	req_one_access_txt = "12;47"
 	},
-/obj/structure/barricade/wooden,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -92432,10 +92423,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dzo" = (
@@ -93961,8 +93952,8 @@
 	amount = 23
 	},
 /obj/item/stack/cable_coil,
-/obj/item/flashlight/seclite,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/science/research/abandoned)
 "dDh" = (
@@ -102711,10 +102702,8 @@
 /turf/open/floor/plating,
 /area/library/abandoned)
 "dUW" = (
-/obj/structure/bookcase{
-	name = "Forbidden Knowledge"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bookcase/random/adult,
 /turf/open/floor/plasteel/dark,
 /area/library/abandoned)
 "dUX" = (
@@ -103007,8 +102996,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dVI" = (
-/obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/bookcase/random,
 /turf/open/floor/plating,
 /area/library/abandoned)
 "dVJ" = (
@@ -103379,7 +103368,9 @@
 /area/library/abandoned)
 "dWH" = (
 /obj/effect/decal/cleanable/blood/old,
-/obj/item/organ/tongue/bone,
+/obj/effect/spawner/lootdrop/memeorgans{
+	lootcount = 1
+	},
 /turf/open/floor/plating,
 /area/library/abandoned)
 "dWI" = (
@@ -107948,6 +107939,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"eui" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/bookcase/random,
+/turf/open/floor/wood,
+/area/library/abandoned)
 "exE" = (
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
@@ -110581,6 +110577,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"lUo" = (
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/wood,
+/area/library/abandoned)
 "lUX" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
@@ -114630,6 +114630,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"woC" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/wood,
+/area/library/abandoned)
 "wqd" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -144301,7 +144305,7 @@ dON
 dPv
 dQr
 dRp
-dSq
+lUo
 dTm
 dRr
 dSu
@@ -145332,7 +145336,7 @@ dRr
 dSu
 dSq
 dUe
-dSp
+eui
 dVJ
 dUf
 dXt
@@ -145847,7 +145851,7 @@ dSv
 dTq
 dSq
 dSu
-dSq
+lUo
 dWE
 dXv
 dYq
@@ -146102,7 +146106,7 @@ dQw
 dRu
 dPB
 dTr
-dSq
+woC
 dUU
 dRr
 dWF

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10400,6 +10400,7 @@
 "axg" = (
 /obj/structure/table/glass,
 /obj/item/storage/bag/trash,
+/obj/structure/bedsheetbin,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "axh" = (
@@ -30396,7 +30397,6 @@
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
 	},
-/obj/item/surgical_drapes,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bsV" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4597,7 +4597,6 @@
 /obj/item/bikehorn/rubberducky,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/item/clothing/gloves/color/fyellow,
-/obj/item/grenade/empgrenade,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "akq" = (
@@ -47445,6 +47444,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "clY" = (
@@ -47454,6 +47454,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "clZ" = (
@@ -47463,12 +47464,13 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "cma" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/apron,
 /obj/item/clothing/mask/surgical,
+/obj/item/clothing/suit/apron/chef,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "cmb" = (
@@ -49123,6 +49125,7 @@
 /area/maintenance/starboard/secondary)
 "cpI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -49174,14 +49177,13 @@
 /area/space/nearstation)
 "cpQ" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = 8;
 	pixel_y = 2
 	},
 /obj/item/reagent_containers/dropper,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "cpR" = (
@@ -49748,6 +49750,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "cqZ" = (
@@ -49756,6 +49759,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "cra" = (
@@ -49763,6 +49767,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "crb" = (
@@ -50100,7 +50105,7 @@
 "csa" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs/cable/white,
-/obj/item/gun/syringe,
+/obj/item/toy/plush/pkplush,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "csb" = (
@@ -57338,27 +57343,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cNj" = (
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/watermelon,
-/obj/item/reagent_containers/food/snacks/grown/watermelon,
-/obj/item/reagent_containers/food/snacks/grown/watermelon,
-/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
-/obj/item/reagent_containers/food/snacks/grown/grapes,
-/obj/item/reagent_containers/food/snacks/grown/cocoapod,
-/obj/structure/rack,
-/obj/item/seeds/wheat,
-/obj/item/seeds/watermelon,
-/obj/item/seeds/watermelon,
-/obj/item/seeds/grape,
-/obj/item/seeds/glowshroom,
 /obj/effect/turf_decal/stripes/line,
-/obj/item/seeds/cannabis/rainbow,
+/obj/machinery/seed_extractor,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cNk" = (
-/obj/item/storage/bag/plants/portaseeder,
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/plant_analyzer,
 /obj/item/cultivator,
@@ -57378,7 +57367,6 @@
 	},
 /obj/item/seeds/carrot,
 /obj/effect/turf_decal/stripes/line,
-/obj/item/seeds/cannabis/white,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cNm" = (
@@ -57957,7 +57945,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cOB" = (
-/obj/item/seeds/sunflower/moonflower,
+/obj/item/vending_refill/hydroseeds,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cOC" = (
@@ -57965,10 +57953,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOD" = (
-/obj/item/seeds/berry,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cOE" = (
@@ -58108,7 +58092,7 @@
 	},
 /obj/item/seeds/cannabis/ultimate,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/space)
 "cPg" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 8
@@ -63159,7 +63143,6 @@
 	pixel_y = 8
 	},
 /obj/item/seeds/glowshroom,
-/obj/item/seeds/corn,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -77194,6 +77177,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "uLZ" = (
@@ -77654,6 +77638,7 @@
 /obj/structure/girder,
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "vxU" = (
@@ -112453,7 +112438,7 @@ cPe
 dvY
 cNi
 cgs
-cOB
+ciL
 cPf
 dvY
 cRe
@@ -112966,7 +112951,7 @@ cIg
 dxQ
 dvY
 cNk
-ciL
+cOB
 ciL
 cPh
 dvY
@@ -113481,7 +113466,7 @@ cxM
 dvY
 cNl
 dAZ
-cOD
+ciL
 cPi
 dvY
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -45904,7 +45904,6 @@
 /obj/item/scalpel{
 	pixel_y = 12
 	},
-/obj/item/surgical_drapes,
 /obj/item/hemostat,
 /obj/item/cautery,
 /obj/item/hemostat,
@@ -48780,7 +48779,6 @@
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
 	},
-/obj/item/surgical_drapes,
 /obj/item/clothing/mask/surgical,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This pr removes some objects from maint on some maps that either don't make much sense being in maint like surgical drapes and stuff that makes maint free loot if maint loot needs to be buffed it should be through the helper not in maps.
-Putting this here instead of changelog to keep the pl*yers in the dark furthering coder superiority
<details>
<summary>Metastation</summary>

add:proper seed extractor to maint botany
add:cables into abandoned med to shock the grille akin to abandoned kitchen
add:seed vendor refill to maint botany
add:peacekeeper borg plushie in abandoned med
add:added chef's apron abandoned med
removed:growns from maint botany
removed:mutated seeds from maint botany
removed:one of the portaseeders from maint botany
removed:syringe gun in abandoned med
removed:cryoxadone beaker from abandoned bar
removed:regular apron from abandoned med
</details>
<details>
<summary>Deltastation</summary>

tweak:switched around tank holder and plants in atmos maint for better accessibility
add:kitchen knife to maint kitchen
add:budget insuls to maint robotics
add:random glowstick to maint robotics
add:empty machine frame to maint robotics
add:exosuit fab board to maint robotics
add:var edited meme organ spawner to abandoned library backroom with lootcount=1
add:plant in science maint
add:dice bag to gambling den
add:grille or trash spawner to maint robotics
add:tool closet in auxiliary engineering
add:tool closet in auxiliary atmos
add:sec bomb suit closet to where the maint nuke is
add:electrified grille into where the maint nuke is
add:regular deck of card to gambling den
add:gambling loot spawner to gambling den
add:money loot spawner to gambling den
add:two maint loot spawners to room next to maint robotics
tweak:changed some bookcases in abandoned library to spawners
removed:butcher knife from maint kitchen
removed:all money from gambling den
removed:cryoxadone beaker from maint bar
removed:welding helmet from maint robotics
removed:bone "tongue" from abandoned library backroom
removed:multitool in the room next to maint robotics
removed:wirerod from abandoned room next to sec with the waiter outfit
removed:cuffs from the room with owl costume
removed:exosuit fab from maint robotics
removed:seclite from maint robotics
removed:barricade in maint robotics
removed:emp grenade from abandoned storage (not sure what to call it)
removed:electrical supplies closet from auxiliary engineering
removed:electrical supplies closet from auxialiary atmos
removed:big sunglasses from gambling den
removed:regular sunglasses from gambling den
removed:officer closet from where the maint nuke is
removed:syndicate cards from gambling den
removed:insuls from auxiliary engineering
</details>
<details>
<summary>Icebox</summary>

add:bedsheet bin to maint surgery
removed:surgical drapes in maint surgery
</details>
<details>
<summary>Pubbystation</summary>

removed:surgical drapes in maint surgery
</details>
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As an assistant main this hurts me more than anyone but the cool thing about maint is having stuff be randomized instead of knowing the meta of the map. These changes are not all removals such as the addition of a proper seed extractor to the meta botany maint.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:PillowKakes
tweak: The rats have removed and added things to maintenance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
