### PR TITLE
Makes dressers not drop wood when they have the NODECONSTRUCT flag

### DIFF
--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -16,7 +16,8 @@
 		return ..()
 
 /obj/structure/dresser/deconstruct(disassembled = TRUE)
-	new /obj/item/stack/sheet/mineral/wood(drop_location(), 10)
+	if(!(flags_1 & NODECONSTRUCT_1))
+		new /obj/item/stack/sheet/mineral/wood(drop_location(), 10)
 	qdel(src)
 
 /obj/structure/dresser/attack_hand(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
technically this is a holodeck nerf, might also find other things that dont check for nodeconstruct later idk
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
cant get infinite wood via holodeck dressers
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: dressers are allowed to cease existing without needless littering 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
