### PR TITLE
Adds a visible effect to best hugs

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -472,6 +472,7 @@
 		if(HAS_TRAIT(M, TRAIT_FRIENDLY))
 			var/datum/component/mood/mood = M.GetComponent(/datum/component/mood)
 			if (mood.sanity >= SANITY_GREAT)
+				new /obj/effect/temp_visual/heart(loc)
 				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "friendly_hug", /datum/mood_event/besthug, M)
 			else if (mood.sanity >= SANITY_DISTURBED)
 				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "friendly_hug", /datum/mood_event/betterhug, M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hugging people while using the friendly quirk and having very high sanity will display the floating hearts effect typically used when petting animals

## Why It's Good For The Game

A small perk for a quirk that's entirely altruistic, now everyone can see how nice you are

![Screenshot_12](https://user-images.githubusercontent.com/38563876/96928896-86eb3980-14b9-11eb-9ab5-de0ecf548d1f.png)
## Changelog
:cl:
add: Added a visible effect to giving the best hugs while using the friendly quirk. Aww!
/:cl: