### PR TITLE
Adds vox announcements to individual logging

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -123,6 +123,7 @@
 	announcing_vox = world.time + VOX_DELAY
 
 	log_game("[key_name(src)] made a vocal announcement with the following message: [message].")
+	log_talk(message, LOG_SAY, tag="VOX Announcement")
 
 	for(var/word in words)
 		play_vox_word(word, src.z, null)

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -123,7 +123,7 @@
 	announcing_vox = world.time + VOX_DELAY
 
 	log_game("[key_name(src)] made a vocal announcement with the following message: [message].")
-	ai.log_talk(message, LOG_SAY, tag="VOX Announcement")
+	log_talk(message, LOG_SAY, tag="VOX Announcement")
 
 	for(var/word in words)
 		play_vox_word(word, src.z, null)

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -123,7 +123,7 @@
 	announcing_vox = world.time + VOX_DELAY
 
 	log_game("[key_name(src)] made a vocal announcement with the following message: [message].")
-	src.log_talk(message, LOG_SAY, tag="VOX Announcement")
+	log_talk(message, LOG_SAY, tag="VOX Announcement")
 
 	for(var/word in words)
 		play_vox_word(word, src.z, null)

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -123,7 +123,7 @@
 	announcing_vox = world.time + VOX_DELAY
 
 	log_game("[key_name(src)] made a vocal announcement with the following message: [message].")
-	log_talk(message, LOG_SAY, tag="VOX Announcement")
+	ai.log_talk(message, LOG_SAY, tag="VOX Announcement")
 
 	for(var/word in words)
 		play_vox_word(word, src.z, null)

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -123,7 +123,7 @@
 	announcing_vox = world.time + VOX_DELAY
 
 	log_game("[key_name(src)] made a vocal announcement with the following message: [message].")
-	log_talk(message, LOG_SAY, tag="VOX Announcement")
+	src.log_talk(message, LOG_SAY, tag="VOX Announcement")
 
 	for(var/word in words)
 		play_vox_word(word, src.z, null)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds VOX announcement contents to the AI's individual say logs.

## Why It's Good For The Game
Announcement contents are in mobs' say logs, so it makes sense for VOX announcement contents to be in AIs' say logs.

## Changelog
:cl:
admin: Added vox announcements to individual say logs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
