### PR TITLE
Increases large toner cartridge capacity, adds a supply pack containing them

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2453,8 +2453,8 @@
 
 /datum/supply_pack/misc/toner_large
 	name = "Toner Crate (Large)"
-	desc = "Tired of changing toner cartridges? These six extra heavy duty refills contain roughly ten times as much toner as the base model!"
-	cost = 5000
+	desc = "Tired of changing toner cartridges? These six extra heavy duty refills contain roughly five times as much toner as the base model!"
+	cost = 3000
 	contains = list(/obj/item/toner/large,
 					/obj/item/toner/large,
 					/obj/item/toner/large,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2451,6 +2451,18 @@
 					/obj/item/toner)
 	crate_name = "toner crate"
 
+/datum/supply_pack/misc/toner_large
+	name = "Toner Crate (Large)"
+	desc = "Tired of changing toner cartridges? These six extra heavy duty refills contain roughly ten times as much toner as the base model!"
+	cost = 5000
+	contains = list(/obj/item/toner/large,
+					/obj/item/toner/large,
+					/obj/item/toner/large,
+					/obj/item/toner/large,
+					/obj/item/toner/large,
+					/obj/item/toner/large)
+	crate_name = "large toner crate"
+
 /datum/supply_pack/misc/training_toolbox
 	name = "Training Toolbox Crate"
 	desc = "Hone your combat abiltities with two AURUMILL-Brand Training Toolboxes! Guarenteed to count hits made against living beings!"

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -486,8 +486,8 @@
 	name = "large toner cartridge"
 	desc = "A hefty cartridge of NanoTrasen ValueBrand toner. Fits photocopiers and autopainters alike."
 	grind_results = list(/datum/reagent/iodine = 90, /datum/reagent/iron = 10)
-	charges = 50
-	max_charges = 50
+	charges = 25
+	max_charges = 25
 
 /obj/item/toner/extreme
 	name = "extremely large toner cartridge"

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -475,6 +475,7 @@
  */
 /obj/item/toner
 	name = "toner cartridge"
+	desc = "A small, lightweight cartridge of NanoTrasen ValueBrand toner. Fits photocopiers and autopainters alike."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "tonercartridge"
 	grind_results = list(/datum/reagent/iodine = 40, /datum/reagent/iron = 10)
@@ -483,9 +484,10 @@
 
 /obj/item/toner/large
 	name = "large toner cartridge"
+	desc = "A hefty cartridge of NanoTrasen ValueBrand toner. Fits photocopiers and autopainters alike."
 	grind_results = list(/datum/reagent/iodine = 90, /datum/reagent/iron = 10)
-	charges = 15
-	max_charges = 15
+	charges = 50
+	max_charges = 50
 
 /obj/item/toner/extreme
 	name = "extremely large toner cartridge"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR does two things:
1) The capacity of large toner cartridges is increased from 15 to 25.
2) It adds a supply pack containing large cartridges; so far the game only has a single large cartridge available on one map.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
While our base toner capacity is alright for photocopiers, it's absolutely dreadful for decal/airlock painters, which use toner as ammo. 
Right now, only 5 capacity cartridges are available for painting - try redecorating an area while having to swap cartridges every five decals, it's nuts.
Right now, you can only find a single large toner cartridge on one map (Icebox) either.

With this PR, cargo can order 25 capacity large toners (pack of six for 5000 credits), which will be useful for anyone trying to decorate new or existing areas. 
I'd honestly even lower the price because hey, it's toner for a paint gun.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
add: Added a large toner pack to cargo - six cartridges for 3000 credits.
tweak: Increased the capacity of large toner cartridges from 15 to 25. This should make decal/airlock painting less frustrating.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
