### PR TITLE
Pacifists now taunt secbots when attempting attacks with harm or disarm intent.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -203,6 +203,15 @@ Auto Patrol: []"},
 		if(special_retaliate_after_attack(H))
 			return
 
+		// Turns an oversight into a feature. Beepsky will now announce when pacifists taunt him over sec comms.
+		if(HAS_TRAIT(H, TRAIT_PACIFISM))
+			H.visible_message("<span class='notice'>[H] taunts [src], daring them to give chase!</span>", \
+				"<span class='notice'>You taunt [src], daring them to chase you!</span>", "<span class='hear'>You hear someone shout a daring taunt!</span>", DEFAULT_MESSAGE_RANGE, H)
+			speak("Taunted by pacifist scumbag <b>[H]</b> in [get_area(src)].", radio_channel)
+
+			// Interrupt the attack chain. We've already handled this scenario for pacifists.
+			return
+
 	return ..()
 
 /mob/living/simple_animal/bot/secbot/attackby(obj/item/W, mob/user, params)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -205,8 +205,8 @@ Auto Patrol: []"},
 
 		// Turns an oversight into a feature. Beepsky will now announce when pacifists taunt him over sec comms.
 		if(HAS_TRAIT(H, TRAIT_PACIFISM))
-			H.visible_message("<span class='notice'>[H] taunts [src], daring them to give chase!</span>", \
-				"<span class='notice'>You taunt [src], daring them to chase you!</span>", "<span class='hear'>You hear someone shout a daring taunt!</span>", DEFAULT_MESSAGE_RANGE, H)
+			H.visible_message("<span class='notice'>[H] taunts [src], daring [p_them()] to give chase!</span>", \
+				"<span class='notice'>You taunt [src], daring [p_them()] to chase you!</span>", "<span class='hear'>You hear someone shout a daring taunt!</span>", DEFAULT_MESSAGE_RANGE, H)
 			speak("Taunted by pacifist scumbag <b>[H]</b> in [get_area(src)].", radio_channel)
 
 			// Interrupt the attack chain. We've already handled this scenario for pacifists.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There exists an oversight where pacifists can attempt to attack Secbots such as Beepsky and there's no check for pacifism, only for the attack's intent. This causes Beepsky to get silently pissed off even though the player didn't attack them.

Instead of fixing this oversight, I've added additional feedback to turn this into a feature. Attacking Secbots as a pacifist in harm or disarm intent now taunts them instead. Beepsky will then vocally communicate to the security forces what's gotten him so rattled.

![image](https://user-images.githubusercontent.com/24975989/97040807-6e852880-1566-11eb-872e-942432819d36.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Secbots HATE pacifist scumbags and, when taunted, will chase them down without mercy. Gives a way for pacifists to distract security.

Turns an oversight into a minor feature.

Kinda fun meme PR?

Classic Timberpoes drunkcoding again?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Pacifists can now taunt secbots such as Beepsky. Secbots absolutely loathe pacifist scumbags and will chase down any pacifist who taunts them, informing security in the process.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
