### PR TITLE
normal whips deal 2x damage to vampires too

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -60,7 +60,7 @@
 		C.IgniteMob()
 
 /datum/species/vampire/check_species_weakness(obj/item/weapon, mob/living/attacker)
-	if(istype(weapon, /obj/item/nullrod/whip))
+	if(istype(weapon, /obj/item/nullrod/whip) || istype(weapon, /obj/item/melee/curator_whip))
 		return 2 //Whips deal 2x damage to vampires. Vampire killer.
 	return 1
 


### PR DESCRIPTION
## About The Pull Request

Previously, the only whips that dealt double damage to vampires were null rods in whip form.

Now, curator whips will also deal double damage to vampires.

## Why It's Good For The Game

https://www.youtube.com/watch?v=cghpNmyrtSk

## Changelog
:cl: ATHATH
balance: The curator's whip is now twice as effective against vampires (to match the whip null rod form, which already dealt 2x its normal damage to vampires).
/:cl: