### PR TITLE
Fixes AI upgrades not being applied correctly

### DIFF
--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -9,11 +9,12 @@
 	icon_state = "datadisk3"
 
 
-/obj/item/malf_upgrade/pre_attack(mob/living/silicon/ai/AI, mob/user, proximity)
+/obj/item/malf_upgrade/pre_attack(atom/A, mob/living/user, proximity)
 	if(!proximity)
 		return ..()
-	if(!istype(AI))
+	if(!isAI(A))
 		return ..()
+	var/mob/living/silicon/ai/AI = A
 	if(AI.malf_picker)
 		AI.malf_picker.processing_time += 50
 		to_chat(AI, "<span class='userdanger'>[user] has attempted to upgrade you with combat software that you already possess. You gain 50 points to spend on Malfunction Modules instead.</span>")
@@ -36,11 +37,12 @@
 	icon = 'icons/obj/module.dmi'
 	icon_state = "datadisk3"
 
-/obj/item/surveillance_upgrade/pre_attack(mob/living/silicon/ai/AI, mob/user, proximity)
+/obj/item/surveillance_upgrade/pre_attack(atom/A, mob/living/user, proximity)
 	if(!proximity)
 		return ..()
-	if(!istype(AI))
+	if(!isAI(A))
 		return ..()
+	var/mob/living/silicon/ai/AI = A
 	if(AI.eyeobj)
 		AI.eyeobj.relay_speech = TRUE
 		to_chat(AI, "<span class='userdanger'>[user] has upgraded you with surveillance software!</span>")

--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -9,12 +9,11 @@
 	icon_state = "datadisk3"
 
 
-/obj/item/malf_upgrade/afterattack(mob/living/silicon/ai/AI, mob/user, proximity)
-	. = ..()
+/obj/item/malf_upgrade/pre_attack(mob/living/silicon/ai/AI, mob/user, proximity)
 	if(!proximity)
-		return
+		return ..()
 	if(!istype(AI))
-		return
+		return ..()
 	if(AI.malf_picker)
 		AI.malf_picker.processing_time += 50
 		to_chat(AI, "<span class='userdanger'>[user] has attempted to upgrade you with combat software that you already possess. You gain 50 points to spend on Malfunction Modules instead.</span>")
@@ -27,6 +26,7 @@
 		message_admins("[ADMIN_LOOKUPFLW(user)] has upgraded [ADMIN_LOOKUPFLW(AI)] with a [src].")
 	to_chat(user, "<span class='notice'>You upgrade [AI]. [src] is consumed in the process.</span>")
 	qdel(src)
+	return TRUE
 
 
 //Lipreading
@@ -36,12 +36,11 @@
 	icon = 'icons/obj/module.dmi'
 	icon_state = "datadisk3"
 
-/obj/item/surveillance_upgrade/afterattack(mob/living/silicon/ai/AI, mob/user, proximity)
-	. = ..()
+/obj/item/surveillance_upgrade/pre_attack(mob/living/silicon/ai/AI, mob/user, proximity)
 	if(!proximity)
-		return
+		return ..()
 	if(!istype(AI))
-		return
+		return ..()
 	if(AI.eyeobj)
 		AI.eyeobj.relay_speech = TRUE
 		to_chat(AI, "<span class='userdanger'>[user] has upgraded you with surveillance software!</span>")
@@ -50,3 +49,4 @@
 	log_game("[key_name(user)] has upgraded [key_name(AI)] with a [src].")
 	message_admins("[ADMIN_LOOKUPFLW(user)] has upgraded [ADMIN_LOOKUPFLW(AI)] with a [src].")
 	qdel(src)
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes AI upgrades not applying:
 - due to the item's `afterattack()` proc never being called
 - - due to the attack chain ending early
 - - - due to the AI's `attackby()` proc returning true
 - - - - seemingly due to an unintended side effect of #54475 

Anyway, easiest way to fix it was to change the item to use `pre_attack()` instead. 
Closes #54585
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: AI combat and surveillance upgrades work properly again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
