### PR TITLE
Initialize and LateInitialize runs correctly at round start

### DIFF
--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -14,17 +14,22 @@ SUBSYSTEM_DEF(atoms)
 
 	var/list/BadInitializeCalls = list()
 
+	initialized = INITIALIZATION_INSSATOMS
+
 /datum/controller/subsystem/atoms/Initialize(timeofday)
 	GLOB.fire_overlay.appearance_flags = RESET_COLOR
 	setupGenetics() //to set the mutations' sequence
+
 	initialized = INITIALIZATION_INNEW_MAPLOAD
 	InitializeAtoms()
+	initialized = INITIALIZATION_INNEW_REGULAR
 	return ..()
 
 /datum/controller/subsystem/atoms/proc/InitializeAtoms(list/atoms)
 	if(initialized == INITIALIZATION_INSSATOMS)
 		return
 
+	old_initialized = initialized
 	initialized = INITIALIZATION_INNEW_MAPLOAD
 
 	var/count
@@ -47,7 +52,7 @@ SUBSYSTEM_DEF(atoms)
 	testing("Initialized [count] atoms")
 	pass(count)
 
-	initialized = INITIALIZATION_INNEW_REGULAR
+	initialized = old_initialized
 
 	if(late_loaders.len)
 		for(var/I in late_loaders)

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -55,8 +55,9 @@
 				atmos_machines += A
 
 	SSmapping.reg_in_areas_in_z(areas)
-	SSatoms.InitializeAtoms(turfs)
-	SSatoms.InitializeAtoms(atoms)
+	SSatoms.InitializeAtoms(areas + turfs + atoms)
+	// NOTE, now that Initialize and LateInitialize run correctly, do we really
+	// need these two below?
 	SSmachines.setup_template_powernets(cables)
 	SSair.setup_template_machinery(atmos_machines)
 


### PR DESCRIPTION
## About The Pull Request

I've been pulling my hair out on this one.  Ever since I started my ntnet project, I could never get LateInitalize to work right.  Apparently it has never worked right.  How it was set up before on server start
1. Station map loads, Does NOT run Initialize(mapload = TRUE)
2. Generates space, lavaland/icebox ruins
3. Loads a ruin, DOES run Initialize(mapload = TRUE) EXCEPT on areas
4. End of mapping system
5. Atom system Initialized and it checks and runs Initialize(mapload = TRUE) on world

You see the issue?  Initialize and by extension LateInitialize is run in blocks.  Worst, LateInitialize is run on turfs FIRST in ruins BEFORE Initialize is ever run on the other atoms.  While there isn't much in Area, there is map_generator so I am sure it caused some grief for map creators.

The NEW order now is
1. Station map loads, Does NOT run Initialize(mapload = TRUE)
2. Generates space, lavaland/icebox ruins
3. Loads a ruin, Does NOT run Initialize(mapload = TRUE)
4. End of mapping system
5. Atom system Initialized and it checks and runs Initialize(mapload = TRUE) on world

Also if you dynamicly load a map, like snowdin or such, it will Initialize all atoms at once and then run LateInitialize properly

## Why It's Good For The Game

People kept telling me "If you want late load, use LateInitialize" when I was pulling my hair out.  Now LateInitialize does what it says.
