### PR TITLE
Various mech fixes

### DIFF
--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -172,8 +172,9 @@
 	. = ..()
 	if(emulate_door_bumps)
 		if(istype(A, /obj/machinery/door))
+			var/obj/machinery/door/conditionalwall = A
 			for(var/m in occupants)
-				A.Bumped(m)
+				conditionalwall.bumpopen(m)
 
 /obj/vehicle/Move(newloc, dir)
 	. = ..()

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -336,39 +336,39 @@
 		return FALSE
 	return TRUE
 
-/obj/item/mecha_parts/mecha_equipment/ripleyupgrade/attach(obj/vehicle/sealed/mecha/M)
-	var/obj/vehicle/sealed/mecha/working/ripley/mk2/N = new (get_turf(M),1)
-	if(!N)
+/obj/item/mecha_parts/mecha_equipment/ripleyupgrade/attach(obj/vehicle/sealed/mecha/markone)
+	var/obj/vehicle/sealed/mecha/working/ripley/mk2/marktwo = new (get_turf(markone),1)
+	if(!marktwo)
 		return
-	QDEL_NULL(N.cell)
-	if (M.cell)
-		N.cell = M.cell
-		M.cell.forceMove(N)
-		M.cell = null
-	QDEL_NULL(N.scanmod)
-	if (M.scanmod)
-		N.scanmod = M.scanmod
-		M.scanmod.forceMove(N)
-		M.scanmod = null
-	QDEL_NULL(N.capacitor)
-	if (M.capacitor)
-		N.capacitor = M.capacitor
-		M.capacitor.forceMove(N)
-		M.capacitor = null
-	N.update_part_values()
-	for(var/obj/item/mecha_parts/E in M.contents)
-		if(istype(E, /obj/item/mecha_parts/concealed_weapon_bay)) //why is the bay not just a variable change who did this
-			E.forceMove(N)
-	for(var/obj/item/mecha_parts/mecha_equipment/E in M.equipment) //Move the equipment over...
-		E.detach(M)
-		E.attach(N)
-	N.dna_lock = M.dna_lock
-	N.mecha_flags = M.mecha_flags
-	N.strafe = M.strafe
-	N.obj_integrity = M.obj_integrity //This is not a repair tool
-	if(M.name != initial(M.name))
-		N.name = M.name
-	M.wreckage = FALSE
-	qdel(M)
-	playsound(get_turf(N),'sound/items/ratchet.ogg',50,TRUE)
+	QDEL_NULL(marktwo.cell)
+	if (markone.cell)
+		marktwo.cell = markone.cell
+		markone.cell.forceMove(marktwo)
+		markone.cell = null
+	QDEL_NULL(marktwo.scanmod)
+	if (markone.scanmod)
+		marktwo.scanmod = markone.scanmod
+		markone.scanmod.forceMove(marktwo)
+		markone.scanmod = null
+	QDEL_NULL(marktwo.capacitor)
+	if (markone.capacitor)
+		marktwo.capacitor = markone.capacitor
+		markone.capacitor.forceMove(marktwo)
+		markone.capacitor = null
+	marktwo.update_part_values()
+	for(var/obj/item/mecha_parts/equipment in markone.contents)
+		if(istype(equipment, /obj/item/mecha_parts/concealed_weapon_bay)) //why is the bay not just a variable change who did this
+			equipment.forceMove(marktwo)
+	for(var/obj/item/mecha_parts/mecha_equipment/equipment in markone.equipment) //Move the equipment over...
+		equipment.detach(marktwo)
+		equipment.attach(marktwo)
+	marktwo.dna_lock = markone.dna_lock
+	marktwo.mecha_flags = markone.mecha_flags
+	marktwo.strafe = markone.strafe
+	marktwo.obj_integrity = round((markone.obj_integrity / markone.max_integrity) * marktwo.obj_integrity) //Integ set to the same percentage integ as the old mecha, rounded to be whole number
+	if(markone.name != initial(markone.name))
+		marktwo.name = markone.name
+	markone.wreckage = FALSE
+	qdel(markone)
+	playsound(get_turf(marktwo),'sound/items/ratchet.ogg',50,TRUE)
 	return

--- a/code/modules/vehicles/mecha/working/clarke.dm
+++ b/code/modules/vehicles/mecha/working/clarke.dm
@@ -18,6 +18,7 @@
 
 /obj/vehicle/sealed/mecha/working/clarke/Initialize()
 	. = ..()
+	box = new(src)
 	var/obj/item/mecha_parts/mecha_equipment/orebox_manager/ME = new(src)
 	ME.attach(src)
 

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -44,8 +44,6 @@
 
 /obj/vehicle/sealed/mecha/working/ripley/Initialize()
 	. = ..()
-	//Add ore box to cargo, here because the clarke has a unremovable box
-	LAZYADD(cargo, box)
 	AddComponent(/datum/component/armor_plate,3,/obj/item/stack/sheet/animalhide/goliath_hide,list(MELEE = 10, BULLET = 5, LASER = 5))
 
 

--- a/code/modules/vehicles/mecha/working/working.dm
+++ b/code/modules/vehicles/mecha/working/working.dm
@@ -4,10 +4,6 @@
 	/// Handles an internal ore box for working mechs
 	var/obj/structure/ore_box/box
 
-/obj/vehicle/sealed/mecha/working/Initialize()
-	. = ..()
-	box = new(src)
-
 /obj/vehicle/sealed/mecha/working/Destroy()
 	QDEL_NULL(box)
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Vehicle objects now call `bumpopen()` rather than `Bumped()` when moving into an airlock, and thus will once again open any door the pilot has access to. Closes #54480

- Fixes Ripley MK-I to MK-II conversions destroying equipment.

- MK-I to MK-II conversions now sets the MK-II's integrity to be same percentage as the MK-I's integrity. Thus, upgrading a full-health MK-I will no longer result in a damaged MK-II.

- Both Ripley types no longer start with an orebox, that function has been moved to the Clarke.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Being unable to open doors and losing equipment to an upgrade are unintended bugs. MK-II Ripleys starting at less than full health if upgraded from a full health MK-I was an oversight from the MK-II's health increase that came alongside the Firefighter's removal.
- Littering Robotics with oreboxes just leads to littering the hallways with oreboxes. The Clarke is the miner mech, let it have the orebox spawn code.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Mech pilots can once again open doors they have access to without exiting their mech.
fix: Upgrading a MK-I Ripley to MK-II no longer deletes the equipment, and will now match the same percentage integrity that the MK-I had before the upgrade.
balance: Ripleys no longer spawn with ore boxes. Go raid the mining outpost if you really need one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
