### PR TITLE
Fixes free Wizard spells

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -760,6 +760,18 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/enchanted/arcane_barrage/blood
 	fire_sound = 'sound/magic/wand_teleport.ogg'
 
+/obj/item/gun/ballistic/rifle/boltaction/enchanted/arcane_barrage/blood/can_trigger_gun(mob/living/user)
+	. = ..()
+	if(!iscultist(user))
+		to_chat(user, "<span class='cultlarge'>\"Did you truly think that you could channel MY blood without my approval? Amusing, but futile.\"</span>")
+		if(iscarbon(user))
+			var/mob/living/carbon/C = user
+			if(C.active_hand_index == 1)
+				C.apply_damage(20, BRUTE, BODY_ZONE_L_ARM, wound_bonus = 20, sharpness = SHARP_EDGED) //oof ouch
+			else
+				C.apply_damage(20, BRUTE, BODY_ZONE_R_ARM, wound_bonus = 20, sharpness = SHARP_EDGED)
+		qdel(src)
+		return FALSE
 
 /obj/item/ammo_box/magazine/internal/boltaction/enchanted/arcane_barrage/blood
 	ammo_type = /obj/item/ammo_casing/magic/arcane_barrage/blood

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -229,11 +229,23 @@
 	cost = 3
 	no_coexistance_typecache = /obj/effect/proc_holder/spell/targeted/infinite_guns/arcane_barrage
 
+/datum/spellbook_entry/infinite_guns/Refund(mob/living/carbon/human/user, obj/item/spellbook/book)
+	for (var/obj/item/currentItem in user.get_all_gear())
+		if (currentItem.type == /obj/item/gun/ballistic/rifle/boltaction/enchanted)
+			qdel(currentItem)
+	return ..()
+
 /datum/spellbook_entry/arcane_barrage
 	name = "Arcane Barrage"
 	spell_type = /obj/effect/proc_holder/spell/targeted/infinite_guns/arcane_barrage
 	cost = 3
 	no_coexistance_typecache = /obj/effect/proc_holder/spell/targeted/infinite_guns/gun
+
+/datum/spellbook_entry/arcane_barrage/Refund(mob/living/carbon/human/user, obj/item/spellbook/book)
+	for (var/obj/item/currentItem in user.get_all_gear())
+		if (currentItem.type == /obj/item/gun/ballistic/rifle/boltaction/enchanted/arcane_barrage)
+			qdel(currentItem)
+	return ..()
 
 /datum/spellbook_entry/barnyard
 	name = "Barnyard Curse"

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -102,6 +102,8 @@
 /obj/item/gun/ballistic/rifle/boltaction/enchanted/dropped()
 	. = ..()
 	guns_left = 0
+	magazine = null
+	chambered = null
 
 /obj/item/gun/ballistic/rifle/boltaction/enchanted/proc/discard_gun(mob/living/user)
 	user.throw_item(pick(oview(7,get_turf(user))))


### PR DESCRIPTION
## About The Pull Request

This PR is essentially a copy of what https://github.com/tgstation/tgstation/pull/54584 was before Rohesie told Gamer025 to turn it into a removal PR for a reason so flimsy that I can only interpret it as being a whim (or an expression of a dislike of wizards in general).

Fixes https://github.com/tgstation/tgstation/issues/48967 by making it so that any lesser summoned guns and arcane barrage hands in your inventory get deleted when you refund their corresponding spells. Since lesser summoned guns lose all of their ammo and become essentially decorations when dropped, and arcane barrage full-on deletes itself when dropped, this should fix the issue.

I've also added an extra fix to this PR: Non-cultists can no longer fire the blood bolts that remain in a blood barrage hand, and will be punished if they try to do so.

Closes: #54584

## Why It's Good For The Game

This is Rohesie's stated reason for turning https://github.com/tgstation/tgstation/pull/54584 into a removal PR:

> The correct fix here would be not to make these spells refundable, since you cannot guarantee their products will remain on the wizard's possessions.

EDIT: My bad, this was their reason to make these spells non-refundable, and they later changed their stance to suggest just removing those spells outright.

This is Rohesie's stated reason for asking for the removal of Lesser Summon Guns, Arcane Barrage, and Blood Barrage (the former two are 3 point wizard spells, the latter is one of the things you can do with Blood Rites charges as a cultist) is that we can't guarantee that this exploit won't crop up again if another exploit allows people to bypass dropped() effects in the future. And to that, I say this: Any exploit that allows you to bypass dropped() (like that item giving one) will ALREADY be a huge deal and need to be patched ASAP, regardless of the existence of these three spells. If people are able to bypass dropped(), being able to get a free 30 shots of a gun as a wizard will be the least of your worries.

Thus, it makes very little sense to panic and completely remove two interesting wizard spells (wizards who create new magically-created bolt-action rifles instead of reloading their old ones (Reaper-style) are cool as shit and you can't convince me otherwise, and there's an entire page on TV Tropes dedicated to the Hand Blast trope) and one of the main reasons to even bother making a setup for Blood Rites as a cultist (instead of just blitzkrieging the station) just because a bug (that would affect many more things than just this and thus get fixed ASAP anyway) MIGHT exist in the future. That'd be like removing wall-mounted defibs because of the various "use defib paddles out of range of their associated defibs" bugs that've cropped up over the course of their existence.

EDIT: The actual reason seems to be a belief that Summon Lesser Guns and Arcane Barrage aren't interesting, which is a matter of personal opinion, IMO, seeing as how myself and multiple other people DO find them interesting. As mentioned before, Reaper-ing guns or spamming energy blasts from your hands is cool (and hasn't proved to be a balance issue so far). Blood Barrage is an extension of Blood Rites, which is an interesting blood spell that's underused and underexplored, IMO. Removing Blood Barrage just turns Blood Rites into a blood spear factory+healing hand spell (the kamehameha is broken/bugged currently, and even if it wasn't, it takes such a hilariously long amount of time to charge up that it's actually better as a UTILITY spell (it's effectively a mass-twisted construction, and can turn iron (instead of just plasteel) into runed metal) than an attack spell), which is considerably less cool/worth making a good Blood Rites setup for.

## Changelog
:cl: Gamer025 and ATHATH
fix: Refunding Lesser Summon Guns or Arcane Barrage as a wizard will now remove any instances of that spell's associated kind of projectile weapon from your inventory.
add: Non-cultists who try to fire a blood bolt from a Blood Barrage "spell"'s hand will be in for a nasty surprise.
/:cl: