### PR TITLE
Fixes split personality switching

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -71,7 +71,7 @@
 		current_backseat = owner_backseat
 		free_backseat = stranger_backseat
 
-	if(!free_backseat.client) //Make sure we never switch to a logged off mob.
+	if(!current_backseat.client) //Make sure we never switch to a logged off mob.
 		return
 
 	log_game("[key_name(current_backseat)] assumed control of [key_name(owner)] due to [src]. (Original owner: [current_controller == OWNER ? owner.key : current_backseat.key])")


### PR DESCRIPTION
:cl:
fix: Fixed an issue that prevented split personalities from switching control.
/:cl:
Fixes #54601

The code was checking the wrong mob for a client.