### PR TITLE
new chaplain sect, the Ever-Burning Candle sect

### DIFF
--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -196,7 +196,7 @@
 /datum/religion_sect/candle_sect
 	name = "Ever-Burning Candle"
 	desc = "A sect dedicated to candles."
-	convert_opener = "May you be the wax to keep the Ever-Burning Candle burning, acolyte.<br>Bibles now deal burn damage and double as a lighter. Sacrificing burning corpses with a lot of burn damage and candles grants you favor"
+	convert_opener = "May you be the wax to keep the Ever-Burning Candle burning, acolyte.<br>Sacrificing burning corpses with a lot of burn damage and candles grants you favor"
 	alignment = ALIGNMENT_NEUT
 	max_favor = 10000
 	desired_items = list(/obj/item/candle)

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -190,3 +190,29 @@
 	to_chat(L, "<span class='notice'>You offer [the_cell]'s power to [GLOB.deity], pleasing them.</span>")
 	qdel(I)
 	return TRUE
+
+/**** Ever-Burning Candle sect ****/
+
+/datum/religion_sect/candle_sect
+	name = "Ever-Burning Candle"
+	desc = "A sect dedicated to candles."
+	convert_opener = "May you be the wax to keep the Ever-Burning Candle burning, acolyte.<br>Bibles now deal burn damage and double as a lighter. Sacrificing burning corpses with a lot of burn damage and candles grants you favor"
+	alignment = ALIGNMENT_NEUT
+	desired_items = list(/obj/item/candle)
+	rites_list = list(/datum/religion_rites/fireproof, /datum/religion_rites/burning_sacrifice, /datum/religion_rites/infinite_candle)
+	altar_icon_state = "convertaltar-red"
+
+//candle sect bibles don't heal or do anything special but holy water blessings
+/datum/religion_sect/candle_sect/sect_bless(mob/living/blessed, mob/living/user)
+	return TRUE
+
+/datum/religion_sect/candle_sect/on_sacrifice(obj/item/candle/offering, mob/living/user)
+	if(!istype(offering))
+		return
+	if(!offering.lit)
+		to_chat(user, "<span class='notice'>The candle needs to be lit to be offered!</span>")
+		return
+	to_chat(user, "<span class='notice'>Another candle for [GLOB.deity]'s collection</span>")
+	adjust_favor(20, user) //it's not a lot but hey there's a pacifist favor option at least
+	qdel(offering)
+	return TRUE

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -198,11 +198,12 @@
 	desc = "A sect dedicated to candles."
 	convert_opener = "May you be the wax to keep the Ever-Burning Candle burning, acolyte.<br>Bibles now deal burn damage and double as a lighter. Sacrificing burning corpses with a lot of burn damage and candles grants you favor"
 	alignment = ALIGNMENT_NEUT
+	max_favor = 10000
 	desired_items = list(/obj/item/candle)
 	rites_list = list(/datum/religion_rites/fireproof, /datum/religion_rites/burning_sacrifice, /datum/religion_rites/infinite_candle)
 	altar_icon_state = "convertaltar-red"
 
-//candle sect bibles don't heal or do anything special but holy water blessings
+//candle sect bibles don't heal or do anything special apart from the standard holy water blessings
 /datum/religion_sect/candle_sect/sect_bless(mob/living/blessed, mob/living/user)
 	return TRUE
 

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -183,25 +183,26 @@
 		return ..()
 
 /datum/religion_rites/burning_sacrifice/invoke_effect(mob/living/user, atom/movable/religious_tool)
-	for(chosen_sacrifice in religious_tool.buckled_mobs) //checks one last time if the right corpse is still buckled
-		if(!chosen_sacrifice.on_fire)
-			to_chat(user, "<span class='warning'>The sacrifice is no longer on fire, it needs to burn until the end of the rite!</span>")
-			. = FALSE
-		else if(chosen_sacrifice.stat != DEAD)
-			to_chat(user, "<span class='warning'>The sacrifice has to stay dead for the rite to work!</span>")
-			. = FALSE
-		else
-			var/favor_gained = 100 + round(chosen_sacrifice.getFireLoss())
-			GLOB.religious_sect?.adjust_favor(favor_gained, user)
-			to_chat(user, "<span class='notice'>[GLOB.deity] absorb the burning corpse and any trace of fire with it. [GLOB.deity] rewards you with [favor_gained] favor.</span>")
-			chosen_sacrifice.dust(force = TRUE)
-			playsound(get_turf(religious_tool), 'sound/effects/supermatter.ogg', 50, TRUE)
-			. = TRUE
+	if(!(chosen_sacrifice in religious_tool.buckled_mobs)) //checks one last time if the right corpse is still buckled
+		to_chat(user, "<span class='warning'>The right sacrifice is no longer on the altar!</span>")
 		chosen_sacrifice = null
-		return
-	to_chat(user, "<span class='warning'>The sacrifice has been moved before you could finish the rite!</span>")
+		return FALSE
+	if(!chosen_sacrifice.on_fire)
+		to_chat(user, "<span class='warning'>The sacrifice is no longer on fire, it needs to burn until the end of the rite!</span>")
+		chosen_sacrifice = null
+		return FALSE
+	if(chosen_sacrifice.stat != DEAD)
+		to_chat(user, "<span class='warning'>The sacrifice has to stay dead for the rite to work!</span>")
+		chosen_sacrifice = null
+		return FALSE
+	var/favor_gained = 100 + round(chosen_sacrifice.getFireLoss())
+	GLOB.religious_sect?.adjust_favor(favor_gained, user)
+	to_chat(user, "<span class='notice'>[GLOB.deity] absorb the burning corpse and any trace of fire with it. [GLOB.deity] rewards you with [favor_gained] favor.</span>")
+	chosen_sacrifice.dust(force = TRUE)
+	playsound(get_turf(religious_tool), 'sound/effects/supermatter.ogg', 50, TRUE)
 	chosen_sacrifice = null
-	return FALSE
+	return TRUE
+
 
 
 /datum/religion_rites/infinite_candle

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -170,8 +170,8 @@
 		to_chat(user, "<span class='warning'>Nothing is buckled to the altar!</span>")
 		return FALSE
 	for(var/mob/living/corpse in movable_reltool.buckled_mobs)
-		if(!iscarbon(corpse))// only works with carbon corpse since normal mobs can't be set on fire.
-			to_chat(user, "<span class='warning'>This sacrifice cannot be set on fire!</span>")
+		if(!iscarbon(corpse))// only works with carbon corpse since most normal mobs can't be set on fire.
+			to_chat(user, "<span class='warning'>Only carbon lifeforms can be properly burned for the sacrifice!</span>")
 			return FALSE
 		chosen_sacrifice = corpse
 		if(chosen_sacrifice.stat != DEAD)

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -211,7 +211,7 @@
 
 /datum/religion_rites/infinite_candle/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	var/altar_turf = get_turf(religious_tool)
-	for(var/candle_count = 0, candle_count < 5, candle_count++)
+	for(var/i in 1 to 5)
 		new /obj/item/candle/infinite(altar_turf)
 	playsound(altar_turf, 'sound/magic/fireball.ogg', 50, TRUE)
 	return TRUE

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -130,7 +130,7 @@
 	for(chosen_clothing in get_turf(religious_tool))
 		chosen_clothing.name = "unmelting [chosen_clothing.name]"
 		chosen_clothing.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
-		chosen_clothing.add_atom_colour("#000080", FIXED_COLOUR_PRIORITY)
+		chosen_clothing.add_atom_colour("#FF0000", FIXED_COLOUR_PRIORITY)
 		chosen_clothing.max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 		chosen_clothing.heat_protection = chosen_clothing.body_parts_covered
 		chosen_clothing.resistance_flags |= FIRE_PROOF
@@ -144,7 +144,7 @@
 /datum/religion_rites/burning_sacrifice
 	name = "Candle Fuel"
 	desc = "Sacrifice a buckled burning corpse for favor, the more burn damage the corpse has the more favor you will receive."
-	ritual_length = 10 SECONDS
+	ritual_length = 20 SECONDS
 	ritual_invocations = list("To feed the fire of the one true flame ...",
 	"... to make it burn brighter ...",
 	"... so that it may consume all in its path ...",

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -106,6 +106,13 @@
 
 /*********Ever-Burning Candle**********/
 
+///apply a bunch of fire immunity effect to clothing
+/datum/religion_rites/fireproof/proc/apply_fireproof(obj/item/clothing/fireproofed)
+	fireproofed.name = "unmelting [fireproofed.name]"
+	fireproofed.max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
+	fireproofed.heat_protection = chosen_clothing.body_parts_covered
+	fireproofed.resistance_flags |= FIRE_PROOF
+
 /datum/religion_rites/fireproof
 	name = "Unmelting Wax"
 	desc = "Grants fire immunity to any piece of clothing."
@@ -128,12 +135,9 @@
 
 /datum/religion_rites/fireproof/invoke_effect(mob/living/user, atom/religious_tool)
 	for(chosen_clothing in get_turf(religious_tool))
-		chosen_clothing.name = "unmelting [chosen_clothing.name]"
-		chosen_clothing.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
-		chosen_clothing.add_atom_colour("#FF0000", FIXED_COLOUR_PRIORITY)
-		chosen_clothing.max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-		chosen_clothing.heat_protection = chosen_clothing.body_parts_covered
-		chosen_clothing.resistance_flags |= FIRE_PROOF
+		for(var/obj/item/clothing/head/integrated_clothing in chosen_clothing.contents) //check if the clothing has a hood/helmet integrated and fireproof that too
+			apply_fireproof(integrated_clothing)
+		apply_fireproof(chosen_clothing)
 		chosen_clothing = null //our lord and savior no longer cares about this apparel
 		return TRUE
 	chosen_clothing = null

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -169,7 +169,7 @@
 	if(!LAZYLEN(movable_reltool.buckled_mobs))
 		to_chat(user, "<span class='warning'>Nothing is buckled to the altar!</span>")
 		return FALSE
-	for(var/mob/living/corpse in movable_reltool.buckled_mobs)
+	for(var/corpse in movable_reltool.buckled_mobs)
 		if(!iscarbon(corpse))// only works with carbon corpse since most normal mobs can't be set on fire.
 			to_chat(user, "<span class='warning'>Only carbon lifeforms can be properly burned for the sacrifice!</span>")
 			return FALSE

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -134,7 +134,7 @@
 	return FALSE
 
 /datum/religion_rites/fireproof/invoke_effect(mob/living/user, atom/religious_tool)
-	for(chosen_clothing in get_turf(religious_tool))
+	if(!QDELETED(chosen_clothing) && get_turf(religious_tool) == chosen_clothing.loc) //check if the same clothing is still there
 		if(istype(chosen_clothing,/obj/item/clothing/suit/hooded) || istype(chosen_clothing,/obj/item/clothing/suit/space/hardsuit ))
 			for(var/obj/item/clothing/head/integrated_helmet in chosen_clothing.contents) //check if the clothing has a hood/helmet integrated and fireproof it if there is one.
 				apply_fireproof(integrated_helmet)
@@ -169,16 +169,18 @@
 	if(!LAZYLEN(movable_reltool.buckled_mobs))
 		to_chat(user, "<span class='warning'>Nothing is buckled to the altar!</span>")
 		return FALSE
-	for(var/mob/living/carbon/corpse in movable_reltool.buckled_mobs) //works with any carbon corpse,not just humans
-		if(corpse.stat != DEAD)
-			to_chat(user, "<span class='warning'>You can only sacrifice dead bodies, this one is still alive!</span>")
-			return FALSE
-		if(!corpse.on_fire)
-			to_chat(user, "<span class='warning'>This corpse needs to be on fire to be sacrificed!</span>")
+	for(var/mob/living/corpse in movable_reltool.buckled_mobs)
+		if(!iscarbon(corpse))// only works with carbon corpse since normal mobs can't be set on fire.
+			to_chat(user, "<span class='warning'>This sacrifice cannot be set on fire!</span>")
 			return FALSE
 		chosen_sacrifice = corpse
+		if(chosen_sacrifice.stat != DEAD)
+			to_chat(user, "<span class='warning'>You can only sacrifice dead bodies, this one is still alive!</span>")
+			return FALSE
+		if(!chosen_sacrifice.on_fire)
+			to_chat(user, "<span class='warning'>This corpse needs to be on fire to be sacrificed!</span>")
+			return FALSE
 		return ..()
-	return FALSE
 
 /datum/religion_rites/burning_sacrifice/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	for(chosen_sacrifice in religious_tool.buckled_mobs) //checks one last time if the right corpse is still buckled

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -135,9 +135,11 @@
 
 /datum/religion_rites/fireproof/invoke_effect(mob/living/user, atom/religious_tool)
 	for(chosen_clothing in get_turf(religious_tool))
-		for(var/obj/item/clothing/head/integrated_clothing in chosen_clothing.contents) //check if the clothing has a hood/helmet integrated and fireproof that too
-			apply_fireproof(integrated_clothing)
+		if(istype(chosen_clothing,/obj/item/clothing/suit/hooded) || istype(chosen_clothing,/obj/item/clothing/suit/space/hardsuit ))
+			for(var/obj/item/clothing/head/integrated_helmet in chosen_clothing.contents) //check if the clothing has a hood/helmet integrated and fireproof it if there is one.
+				apply_fireproof(integrated_helmet)
 		apply_fireproof(chosen_clothing)
+		playsound(get_turf(religious_tool), 'sound/magic/fireball.ogg', 50, TRUE)
 		chosen_clothing = null //our lord and savior no longer cares about this apparel
 		return TRUE
 	chosen_clothing = null
@@ -191,6 +193,7 @@
 			GLOB.religious_sect?.adjust_favor(favor_gained, user)
 			to_chat(user, "<span class='notice'>[GLOB.deity] absorb the burning corpse and any trace of fire with it. [GLOB.deity] rewards you with [favor_gained] favor.</span>")
 			chosen_sacrifice.dust(force = TRUE)
+			playsound(get_turf(religious_tool), 'sound/effects/supermatter.ogg', 50, TRUE)
 			. = TRUE
 		chosen_sacrifice = null
 		return
@@ -210,5 +213,5 @@
 	var/altar_turf = get_turf(religious_tool)
 	for(var/candle_count = 0, candle_count < 5, candle_count++)
 		new /obj/item/candle/infinite(altar_turf)
-	playsound(get_turf(altar_turf), 'sound/magic/charge.ogg', 50, TRUE)
+	playsound(altar_turf, 'sound/magic/fireball.ogg', 50, TRUE)
 	return TRUE

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -176,12 +176,20 @@
 
 /datum/religion_rites/burning_sacrifice/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	for(chosen_sacrifice in religious_tool.buckled_mobs) //checks one last time if the right corpse is still buckled
-		var/favor_gained = 100 + round(chosen_sacrifice.getFireLoss())
-		GLOB.religious_sect?.adjust_favor(favor_gained, user)
-		to_chat(user, "<span class='notice'>[GLOB.deity] absorb the burning corpse and any trace of fire with it. [GLOB.deity] rewards you with [favor_gained] favor.</span>")
-		chosen_sacrifice.dust(force = TRUE)
+		if(!chosen_sacrifice.on_fire)
+			to_chat(user, "<span class='warning'>The sacrifice is no longer on fire, it needs to burn until the end of the rite!</span>")
+			. = FALSE
+		else if(chosen_sacrifice.stat != DEAD)
+			to_chat(user, "<span class='warning'>The sacrifice has to stay dead for the rite to work!</span>")
+			. = FALSE
+		else
+			var/favor_gained = 100 + round(chosen_sacrifice.getFireLoss())
+			GLOB.religious_sect?.adjust_favor(favor_gained, user)
+			to_chat(user, "<span class='notice'>[GLOB.deity] absorb the burning corpse and any trace of fire with it. [GLOB.deity] rewards you with [favor_gained] favor.</span>")
+			chosen_sacrifice.dust(force = TRUE)
+			. = TRUE
 		chosen_sacrifice = null
-		return TRUE
+		return
 	to_chat(user, "<span class='warning'>The sacrifice has been moved before you could finish the rite!</span>")
 	chosen_sacrifice = null
 	return FALSE
@@ -191,7 +199,7 @@
 	name = "Immortal Candles"
 	desc = "Creates 5 candles that never run out of wax."
 	ritual_length = 10 SECONDS
-	invoke_msg = "please lend us five of your candles so we may bask in your Ever-Burning glory."
+	invoke_msg = "please lend us five of your candles so we may bask in your burning glory."
 	favor_cost = 200
 
 /datum/religion_rites/infinite_candle/invoke_effect(mob/living/user, atom/movable/religious_tool)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the Ever-Burning Candle sect, a sect that is about candles, and also fire, mainly fire.
The Ever-Burning Candle sect has 3 rites, but first let's talk about the most important one which is candle fuel

1. **Candle Fuel:**
Candle Fuel is a rite that consist of sacrificing a burning carbon corpse buckled to the altar for favor. the more burn damage the corpse has the more favor you'll get, although most human corpses will cap at around 600 burn damage, meaning that you'll generally get a maximum of 700 favor since the rite gives you 100 favor + the burn damage of the corpse. 
Now you may think this encourage people to put every corpse in medbay on fire, but it's actually very inefficient to do that since you can use monkeys for the sacrifices, it's supposed to encourage the chaplain to work with other departments for the sacrifices may it be botany, genetics or even medical if they have suicided corpses. And in exchange the chaplain will use the one rite that matters with this sect to help others, Sacrificing a corpse that can still be revived with this rite without a good reason is still antagging as it is dusted and can never come back and as such should be treated like a chaplain cremating someone for all intents and purposes.
It's REALLY easy to get the maximum amount of burn damage by just going to lavaland and dragging them back and forth in lava, or even just waiting for them to be crispy enough for a sacrifice by just setting them on fire and waiting for a minute, and as such burn damage is rarely a problem to max out, just keep a health analyzer to know when they are hot enough.

2. **Unmelting Wax:**
Makes a piece of clothing fireproof, that's it.
Now yes the fireproof potion from xenobio already does that, for less of a cost, with two charges. But xenobio is a balance mess and it's a gamble if they will ever help you for anything. While the chaplain is often wandering around the station asking people to join their religion or sell candy or whatever holy people do. 
This rite cost 1000 favor, aka : nearly two fully burned corpse. it only fireproofs ONE piece of clothing, meaning that for full fire protection you'll need to do the rite twice on both a hood and a jumpsuit/exosuit. unlike the fireproof potion the chaplain is the only one able to do the rite, so if he want he can only fireproof "holy" clothing so that only his followers get the "blessing"

3. **Immortal Candles:**
Immortal Candles spawn 5 candles that never melt
That's it there's no powergaming or big reveal that's all they do. It just wouldn't feel right to have a candle sect with at least SOME candles in there, and we already have infinite candles in game so eeeeeh. They are mainly here for fluff or decoration since it's pretty annoying to get a whole holy candle thing going only for them to run out after 5 minutes. The rite cost 200 favor, aka 1/3 of a burning corpse, burning corpse are the currency here.

not the only one actually, you _can_ sacrifice lit candles for 20 favor, which is jack shit, but hey you have a vegan option at least.

this sect does not have any blessing with the bible, since it already has the rites to make it useful. And keeping the default healing bless takes away the one thing normalcy is good at. Also the sect_bless proc is currently broken and only works half the time even for technophiles.

**_tldr : burn corpses > get favor > get fireproof clothing_**
## Why It's Good For The Game

We both need more sects and more reason for the chaplain to interact with the rest of the station that isn't just validing magic things. I do get that the chaplain is supposed to be an RP role, but we need to mix RP with mechanics for it to work, and giving the chaplain a reason to make weird burning monkey sacrifice makes it feel more natural and actually worth it since it mechanically does something. it also lets the chaplain put their own twist on why they are doing it and maybe invite people to their religion for religion perks (fireproof clothing).

## Changelog
:cl:
add: The sect of the Ever-Burning Candle has been officially recognised by NT and can now be practiced legally in the chapel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->