### PR TITLE
Updates emagged borg's charged arm

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -9,6 +9,7 @@
 	name = "electrically-charged arm"
 	icon_state = "elecarm"
 	var/charge_cost = 30
+	var/stamina_loss_amt = 60
 
 /obj/item/borg/stun/attack(mob/living/M, mob/living/user)
 	if(ishuman(M))
@@ -22,7 +23,7 @@
 			return
 
 	user.do_attack_animation(M)
-	M.Paralyze(100)
+	M.apply_damage(stamina_loss_amt, STAMINA, BODY_ZONE_CHEST)
 	M.apply_effect(EFFECT_STUTTER, 5)
 
 	M.visible_message("<span class='danger'>[user] prods [M] with [src]!</span>", \


### PR DESCRIPTION
## About The Pull Request
Updates the electrically charged arm of an emagged borg. Replaces M.paralyze(100) with a stamina damage attack for 60, and makes the stamina damage a variable. Still strictly more powerful than the stun baton because it doesn't have any other of the stun baton's downsides like slowed attack rate, as it is a traitorous weapon.

## Why It's Good For The Game

Removes one of the few remaining hardstuns and brings it up to date

## Changelog
:cl:
fix: brought the electrically charged arm up to modern stunning standards
/:cl: