### PR TITLE
Use a more common documentation block standard.

### DIFF
--- a/.github/AUTODOC_GUIDE.md
+++ b/.github/AUTODOC_GUIDE.md
@@ -43,14 +43,14 @@ namespace), then a longer paragraph which will be shown when the user clicks on
 the proc to jump to it's definition
 ```
 /**
-  * Short description of the proc
-  *
-  * Longer detailed paragraph about the proc
-  * including any relevant detail
-  * Arguments:
-  * * arg1 - Relevance of this argument
-  * * arg2 - Relevance of this argument
-  */
+ * Short description of the proc
+ *
+ * Longer detailed paragraph about the proc
+ * including any relevant detail
+ * Arguments:
+ * * arg1 - Relevance of this argument
+ * * arg2 - Relevance of this argument
+ */
 ```
 
 ### Documenting a class
@@ -62,15 +62,15 @@ Then we give a short oneline description of the class
 Finally we give a longer multi paragraph description of the class and it's details
 ```
 /**
-  * # Classname (Can be omitted if it's just going to be the typepath)
-  *
-  * The short overview
-  *
-  * A longer
-  * paragraph of functionality about the class
-  * including any assumptions/special cases
-  *
-  */
+ * # Classname (Can be omitted if it's just going to be the typepath)
+ *
+ * The short overview
+ *
+ * A longer
+ * paragraph of functionality about the class
+ * including any assumptions/special cases
+ *
+ */
 ```
 
 ### Documenting a variable/define


### PR DESCRIPTION
## About The Pull Request

Related to #54604.

I propose use of a more common standard of documentation blocks instead of what we currently use. This new style of documentation block will allow easy adaptation of third-party documentation plugins for VSCode, because all common languages use this particular style of docblock, e.g. C, C++, C#, Go lang, Java, JavaScript, CSS, PHP... you name it.

DM shouldn't be a snowflake in that regard and adopt a proper standard.

[Auto Comment Blocks](https://marketplace.visualstudio.com/items?itemName=kevinkyang.auto-comment-blocks) - Reference VSCode Extension

![demo](https://raw.githubusercontent.com/kevinkyang/auto-comment-blocks/master/img/demo.gif)

## Good

```
/**
 * This proc adds two numbers together.
 *
 * Arguments:
 * - a - first number
 * - b - second number
 */
```

## Bad

```
/**
  * This proc adds two numbers together.
  *
  * Arguments:
  * - a - first number
  * - b - second number
  */
```

## Very Bad

```
/*
  * This proc adds two numbers together.
  *
  * Arguments:
  * - a - first number
  * - b - second number
*/
```