### PR TITLE
Fixes the attack chain

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -809,7 +809,7 @@
 	///Ends the attack chain. If sent early might cause posterior attacks not to happen.
 	#define COMPONENT_CANCEL_ATTACK_CHAIN (1<<0)
 	///Skips the specific attack step, continuing for the next one to happen.
-	#define COMPONENT_SKIP_ATTACK (1<<2)
+	#define COMPONENT_SKIP_ATTACK (1<<1)
 ///from base of atom/attack_ghost(): (mob/dead/observer/ghost)
 #define COMSIG_ATOM_ATTACK_GHOST "atom_attack_ghost"
 ///from base of atom/attack_hand(): (mob/user)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -805,7 +805,11 @@
 #define COMSIG_CONTAINER_TRY_ATTACH "container_try_attach"
 
 /* Attack signals. They should share the returned flags, to standardize the attack chain. */
+/// tool_act -> pre_attack -> target.attackby (item.attack) -> afterattack
+	///Ends the attack chain. If sent early might cause posterior attacks not to happen.
 	#define COMPONENT_CANCEL_ATTACK_CHAIN (1<<0)
+	///Skips the specific attack step, continuing for the next one to happen.
+	#define COMPONENT_SKIP_ATTACK (1<<2)
 ///from base of atom/attack_ghost(): (mob/dead/observer/ghost)
 #define COMSIG_ATOM_ATTACK_GHOST "atom_attack_ghost"
 ///from base of atom/attack_hand(): (mob/user)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -9,20 +9,20 @@
   */
 /obj/item/proc/melee_attack_chain(mob/user, atom/target, params)
 	if(tool_behaviour && target.tool_act(user, src, tool_behaviour))
-		return
+		return TRUE
 	if(pre_attack(target, user, params))
-		return
+		return TRUE
 	if(target.attackby(src,user, params))
-		return
+		return TRUE
 	if(QDELETED(src) || QDELETED(target))
 		attack_qdeleted(target, user, TRUE, params)
-		return
-	afterattack(target, user, TRUE, params)
+		return TRUE
+	return afterattack(target, user, TRUE, params)
 
 /// Called when the item is in the active hand, and clicked; alternately, there is an 'activate held object' verb or you can hit pagedown.
 /obj/item/proc/attack_self(mob/user)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
-		return
+		return TRUE
 	interact(user)
 
 /**
@@ -80,13 +80,13 @@
 
 	if(force && HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
-		return TRUE
+		return
 
 	if(item_flags & EYE_STAB && user.zone_selected == BODY_ZONE_PRECISE_EYES)
 		if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 			M = user
 		if(eyestab(M,user))
-			return TRUE
+			return
 	if(!force)
 		playsound(loc, 'sound/weapons/tap.ogg', get_clamped_volume(), TRUE, -1)
 	else if(hitsound)
@@ -103,7 +103,6 @@
 
 	log_combat(user, M, "attacked", src.name, "(INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
 	add_fingerprint(user)
-	return TRUE
 
 
 /// The equivalent of the standard version of [/obj/item/proc/attack] but for object targets.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -72,12 +72,14 @@
   * * mob/living/user - The mob hitting with this item
   */
 /obj/item/proc/attack(mob/living/M, mob/living/user)
-	switch(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, M, user))
-		if(COMPONENT_CANCEL_ATTACK_CHAIN)
-			return TRUE
-		if(COMPONENT_SKIP_ATTACK)
-			return
+	var/signal_return = SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, M, user)
+	if(signal_return & COMPONENT_CANCEL_ATTACK_CHAIN)
+		return TRUE
+	if(signal_return & COMPONENT_SKIP_ATTACK)
+		return
+
 	SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK, M, user)
+
 	if(item_flags & NOBLUDGEON)
 		return
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -72,8 +72,11 @@
   * * mob/living/user - The mob hitting with this item
   */
 /obj/item/proc/attack(mob/living/M, mob/living/user)
-	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, M, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
-		return TRUE
+	switch(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, M, user))
+		if(COMPONENT_CANCEL_ATTACK_CHAIN)
+			return TRUE
+		if(COMPONENT_SKIP_ATTACK)
+			return
 	SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK, M, user)
 	if(item_flags & NOBLUDGEON)
 		return


### PR DESCRIPTION
The attack chain is a mess, and giving it standardized functionality that makes sense and is consistent will take some time.
For now only the signal returns a value for item attacks, and we have a new signal return to distinguish between completely halting the attack chain and skipping a single step.

* Fixes #54638

:cl:
fix: Fixed an issue preventing afterattacks from happening, which broke regenerative crossbreeds, fulton packs and other interactions.
/:cl: