### PR TITLE
Fix shuttle_catastrophe shuttle replacing.

### DIFF
--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -34,5 +34,5 @@
 	SSshuttle.shuttle_purchased = SHUTTLEPURCHASE_FORCED
 	SSshuttle.unload_preview()
 	SSshuttle.existing_shuttle = SSshuttle.emergency
-	SSshuttle.action_load(new_shuttle)
+	SSshuttle.action_load(new_shuttle, replace = TRUE)
 	log_shuttle("Shuttle Catastrophe set a new shuttle, [new_shuttle.name].")


### PR DESCRIPTION
## About The Pull Request

Same as #54322 but for Shuttle Catastrophe

## Why It's Good For The Game

Bugs is bad.

## Changelog
:cl:
fix: CENTCOM cleaning staff remembered that it would be nice to clean hangars from remains of the catastrophed shuttles. Fixed shuttle catastrophe. Now shuttle catastrophes propertly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
