### PR TITLE
Fixes various shapeshifting-related runtimes and interactions

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -155,6 +155,13 @@
 	qdel(src)
 
 /proc/wabbajack(mob/living/M, randomize)
+	// If the mob has a shapeshifted form, we want to pull out the reference of the caster's original body from it.
+	// We then want to restore this original body through the shapeshift holder itself.
+	var/obj/shapeshift_holder/shapeshift = locate() in M
+	if(shapeshift)
+		M = shapeshift.stored
+		shapeshift.restore()
+
 	if(!istype(M) || M.stat == DEAD || M.notransform || (GODMODE & M.status_flags))
 		return
 

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -192,7 +192,7 @@
 		restore()
 
 /obj/shapeshift_holder/proc/restore(death=FALSE)
-	// Destroy() calls this if it hasn't been called and the prevents multiple qdel loops
+	// Destroy() calls this proc if it hasn't been called. Unregistering here prevents multiple qdel loops
 	// when caster and shape both die at the same time.
 	UnregisterSignal(shape, list(COMSIG_PARENT_QDELETING, COMSIG_MOB_DEATH))
 	UnregisterSignal(stored, list(COMSIG_PARENT_QDELETING, COMSIG_MOB_DEATH))

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -149,11 +149,12 @@
 		shape.apply_damage(damapply, source.convert_damage_type, forced = TRUE, wound_bonus=CANT_WOUND);
 		shape.blood_volume = stored.blood_volume;
 
-	stored.RegisterSignal(src, COMSIG_PARENT_QDELETING, .proc/shape_death)
-	stored.RegisterSignal(shape, list(COMSIG_PARENT_QDELETING, COMSIG_MOB_DEATH), .proc/shape_death)
-	shape.RegisterSignal(stored, list(COMSIG_PARENT_QDELETING, COMSIG_MOB_DEATH), .proc/shape_death)
+	RegisterSignal(shape, list(COMSIG_PARENT_QDELETING, COMSIG_MOB_DEATH), .proc/shape_death)
+	RegisterSignal(stored, list(COMSIG_PARENT_QDELETING, COMSIG_MOB_DEATH), .proc/caster_death)
 
 /obj/shapeshift_holder/Destroy()
+	// Restore manages signal unregistering. If restoring is TRUE, we've already unregistered the signals and we're here
+	// because restore() qdel'd src.
 	if(!restoring)
 		restore()
 	stored = null
@@ -191,6 +192,10 @@
 		restore()
 
 /obj/shapeshift_holder/proc/restore(death=FALSE)
+	// Destroy() calls this if it hasn't been called and the prevents multiple qdel loops
+	// when caster and shape both die at the same time.
+	UnregisterSignal(shape, list(COMSIG_PARENT_QDELETING, COMSIG_MOB_DEATH))
+	UnregisterSignal(stored, list(COMSIG_PARENT_QDELETING, COMSIG_MOB_DEATH))
 	restoring = TRUE
 	stored.forceMove(shape.loc)
 	stored.notransform = FALSE
@@ -207,5 +212,10 @@
 		stored.apply_damage(damapply, source.convert_damage_type, forced = TRUE, wound_bonus=CANT_WOUND)
 	if(source.convert_damage)
 		stored.blood_volume = shape.blood_volume;
-	QDEL_NULL(shape)
+
+	// This guard is important because restore() can also be called on COMSIG_PARENT_QDELETING for shape, as well as on death.
+	// This can happen in, for example, [/proc/wabbajack] where the mob hit is qdel'd.
+	if(!QDELETED(shape))
+		QDEL_NULL(shape)
+
 	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #54602

Fixes the RegisterSignal calls that Tivi must have written while high. They were runtiming because Tivi was registering signals on /mob/living and having them try to call procs attached to /obj/shapeshift_holder.

Wait, did I say procs? Because I actually meant proc. As proc/caster_death was never actually called. Now it is.

But wait, these signals were never Unregistered. Killing the caster will qdel the shapeshift_holder, which will kill the shapeshifted form, which will qdel the shapeshift_holder while it's already being qdel'd. So I now unregister the signals in the appropriate place to prevent the shapeshift_holder qdeling itself from qdel.

With THAT out of the way, I've also been able to fix the bug Ath brough up so long ago. Wabbajack effects leave behind a catatonic corpse of their old body when used on players who are in their shapeshift form. 

Wabbajack effects now appropriately check for a shapeshift holder and if one is present, they will forcefully restore them to their original caster form before applying the wabbajack effect to that caster form. No more weird bodies.

All of these changes also fix #54602 - When you die, you now properly revert to your caster form. No butchering your old transformed corpse for a full revive.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed various shapeshifting runtimes that would affect vampries in bat form and players in ash drake from in particular.
fix: Interactions with mobs in shapeshifted form and the Wabbajack force-tranformation effects (including the Staff of Change) should now make more sense and not leave behind random corpses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
