### PR TITLE
Bumps the damage of disabler beams up to 35.

### DIFF
--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -18,7 +18,7 @@
 /obj/item/ammo_casing/energy/disabler
 	projectile_type = /obj/projectile/beam/disabler
 	select_name  = "disable"
-	e_cost = 100
+	e_cost = 50
 	fire_sound = 'sound/weapons/taser2.ogg'
 	harmful = FALSE
 

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -18,7 +18,7 @@
 /obj/item/ammo_casing/energy/disabler
 	projectile_type = /obj/projectile/beam/disabler
 	select_name  = "disable"
-	e_cost = 50
+	e_cost = 100
 	fire_sound = 'sound/weapons/taser2.ogg'
 	harmful = FALSE
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -88,7 +88,7 @@
 /obj/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 30
+	damage = 35
 	damage_type = STAMINA
 	flag = ENERGY
 	hitsound = 'sound/weapons/tap.ogg'


### PR DESCRIPTION
## About The Pull Request

This PR just bumps up the damage of disablers beams to 35, an improvement of 5 damage. This means it requires only 3 shots to down a target instead of 4.

## Why It's Good For The Game

Right now disablers feel rather weak, and security should feel a lot more like an unstoppable force that requires stealth and subterfuge to beat. Why not buff their main weapon to actually be a main weapon?

## Changelog
:cl:
balance: The Nanotrasen Weapons Research Lab has upgraded all the disablers on the station, making them deal 5 more "stamina damage". This makes their damage 35.
/:cl: