### PR TITLE
Assistants no longer spawn in the chapel on Pubby

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -42937,20 +42937,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"crL" = (
-/obj/structure/chair/wood,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/chapel{
-	dir = 4
-	},
-/area/chapel/main/monastery)
-"crM" = (
-/obj/structure/chair/wood,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/chapel{
-	dir = 1
-	},
-/area/chapel/main/monastery)
 "crN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -74846,7 +74832,7 @@ bXJ
 bXJ
 bZm
 bYB
-crL
+bZm
 caV
 cbM
 ccH
@@ -75617,7 +75603,7 @@ bXJ
 bXJ
 bZl
 bYA
-crM
+bZl
 caW
 cbP
 cdu


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Assistants no longer spawn in the chapel on Pubby.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Assistant spawns as vampire. Spawns in chapel spawn. RIP vampire if they don't know exactly how to play vampire.

Fixes #54664

Yeah, it's an edge case, but there's no reason assistants have to spawn there so may as well remove those spawns just to help somebody out on rare occasion.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: VexingRaven
tweak: Assistants no longer spawn in the chapel on Pubby
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
