### PR TITLE
Fix erroneous logging of config errors for str_list configuration type

### DIFF
--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -130,6 +130,7 @@
 	str_val = trim(str_val)
 	if (str_val != "")
 		config_entry_value += str_val
+	return TRUE
 
 /datum/config_entry/number_list
 	abstract_type = /datum/config_entry/number_list


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed issue brought up by @Cyberboss wherein the new ``str_list`` config type doesn't properly return true after setting the values and as a result has an erroneous error pop up in the config error log.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No more fake errors.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
fix: Valid interview configurations no longer cause errors in the config error log
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
