### PR TITLE
Borgs synced to an AI using Doomsday will have their lights force-set to red and enabled to at least level 1

### DIFF
--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -45,13 +45,6 @@
 
 /mob/living/silicon/ai/proc/ShutOffDoomsdayDevice()
 	if(nuking)
-		set_security_level("red")
 		nuking = FALSE
-		for(var/obj/item/pinpointer/nuke/P in GLOB.pinpointer_list)
-			P.switch_mode_to(TRACK_NUKE_DISK) //Party's over, back to work, everyone
-			P.alert = FALSE
-
 	if(doomsday_device)
-		doomsday_device.timing = FALSE
-		SSshuttle.clearHostileEnvironment(doomsday_device)
 		qdel(doomsday_device)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -555,8 +555,9 @@
 /mob/living/silicon/robot/proc/toggle_headlamp(turn_off = FALSE, update_color = FALSE)
 	//if both lamp is enabled AND the update_color flag is on, keep the lamp on. Otherwise, if anything listed is true, disable the lamp.
 	if(!(update_color && lamp_enabled) && (turn_off || lamp_enabled || update_color || !lamp_functional || stat || low_power_mode))
-		set_light_on(lamp_functional && lamp_doom) //If the lamp isn't broken, doomsday borgs cannot disable their light fully.
+		set_light_on(lamp_functional && stat != DEAD && lamp_doom) //If the lamp isn't broken and borg isn't dead, doomsday borgs cannot disable their light fully.
 		set_light_color(COLOR_RED) //This should only matter for doomsday borgs, as any other time the lamp will be off and the color not seen
+		set_light_range(1) //Again, like above, this only takes effect when the light is forced on by doomsday mode.
 		lamp_enabled = FALSE
 		lampButton.update_icon()
 		update_icons()
@@ -827,6 +828,7 @@
 			locked = TRUE
 		notify_ai(NEW_BORG)
 		. = TRUE
+		toggle_headlamp(FALSE, TRUE) //This will reenable borg headlamps if doomsday is currently going on still.
 
 /mob/living/silicon/robot/fully_replace_character_name(oldname, newname)
 	..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -84,6 +84,8 @@
 	var/lamp_enabled = FALSE
 	///Set lamp color
 	var/lamp_color = COLOR_WHITE
+	///Set to true if a doomsday event is locking our lamp to on and RED
+	var/lamp_doom = FALSE
 	///Lamp brightness. Starts at 3, but can be 1 - 5.
 	var/lamp_intensity = 3
 	///Lamp button reference
@@ -431,9 +433,9 @@
 	if(stat != DEAD && !(HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || IsStun() || IsParalyzed() || low_power_mode)) //Not dead, not stunned.
 		if(!eye_lights)
 			eye_lights = new()
-		if(lamp_enabled)
+		if(lamp_enabled || lamp_doom)
 			eye_lights.icon_state = "[module.special_light_key ? "[module.special_light_key]":"[module.cyborg_base_icon]"]_l"
-			eye_lights.color = lamp_color
+			eye_lights.color = lamp_doom? COLOR_RED : lamp_color
 			eye_lights.plane = 19 //glowy eyes
 		else
 			eye_lights.icon_state = "[module.special_light_key ? "[module.special_light_key]":"[module.cyborg_base_icon]"]_e"
@@ -553,13 +555,14 @@
 /mob/living/silicon/robot/proc/toggle_headlamp(turn_off = FALSE, update_color = FALSE)
 	//if both lamp is enabled AND the update_color flag is on, keep the lamp on. Otherwise, if anything listed is true, disable the lamp.
 	if(!(update_color && lamp_enabled) && (turn_off || lamp_enabled || update_color || !lamp_functional || stat || low_power_mode))
-		set_light_on(FALSE)
+		set_light_on(lamp_functional && lamp_doom) //If the lamp isn't broken, doomsday borgs cannot disable their light fully.
+		set_light_color(COLOR_RED) //This should only matter for doomsday borgs, as any other time the lamp will be off and the color not seen
 		lamp_enabled = FALSE
 		lampButton.update_icon()
 		update_icons()
 		return
 	set_light_range(lamp_intensity)
-	set_light_color(lamp_color)
+	set_light_color(lamp_doom? COLOR_RED : lamp_color) //Red for doomsday killborgs, borg's choice otherwise
 	set_light_on(TRUE)
 	lamp_enabled = TRUE
 	lampButton.update_icon()
@@ -1094,8 +1097,11 @@
 	if(.)
 		var/mob/living/silicon/ai/old_ai = .
 		old_ai.connected_robots -= src
+	lamp_doom = FALSE
 	if(connected_ai)
 		connected_ai.connected_robots |= src
+		lamp_doom = connected_ai.doomsday_device ? TRUE : FALSE
+	toggle_headlamp(FALSE, TRUE)
 
 /**
   * Records an IC event log entry in the cyborg's internal tablet.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Adds a variable for `lamp_doom` that keeps track of if the borg should be using doomsday lamp settings. Adds code that enables and disables this setting when the borg's AI activates doomsday, when doomsday is shut off for any reason, and if the borg syncs to (or loses sync with) an AI using doomsday. The `lamp_doom` var will override some things in `toggle_headlamp()`, forcing the lamp to be red and set to level one if it would be otherwise disabled. The only way for this light to shut off without affecting the doomsday or AI sync is for a nightmare to eat the bulb.

- Cleans up a small part of the doomsday code that is relevant to what I am changing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game


- Gives some feedback that the borgs are *certainly* not crew-aligned. This shouldn't be a secret once doomsday alerts are playing, but it helps re-enforce that idea with some spooky visuals.

- Crucially, allows non-synced borgs to show the crew that they are not synced; if a borg has any color light aside from red while the countdown is going, you can be sure they're not on the AI's side. Of course, this goes both ways, and the AI can send it's borgs after the one that's showing the wrong color. Not-synced borgs can manually set themselves to use red and blend in, of course, so the AI can't necessarily use a red color alone to tell friend from foe.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Cyborgs synced to a Malf AI that activates Doomsday will now have their lamps forced to a red color and enabled to at least light level one. Stealth is no longer an option. Lamp options return to normal upon Doomsday deactivation, no matter the reason, or if the borg somehow loses sync with the AI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

TODO:
- [x] Full testing on a better computer
- [x] Make dead doomsday borgs turn their light off

![image](https://user-images.githubusercontent.com/37497534/97531264-150b6800-1971-11eb-8f2e-7d745068af5e.png)