### PR TITLE
Pea Soup Now Requires a Bowl (THE ECONOMY IS SAVED!)

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_soup.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_soup.dm
@@ -300,7 +300,8 @@
 		/datum/reagent/water = 10,
 		/obj/item/reagent_containers/food/snacks/grown/peas = 2,
 		/obj/item/reagent_containers/food/snacks/grown/parsnip = 1,
-		/obj/item/reagent_containers/food/snacks/grown/carrot = 1
+		/obj/item/reagent_containers/food/snacks/grown/carrot = 1,
+		/obj/item/reagent_containers/glass/bowl = 1
 	)
 	result = /obj/item/food/soup/peasoup
 	subcategory = CAT_SOUP


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #54678.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dear god, imagine what people could do with infinite bowls... in fact, I'd rather not.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: 
fix: pea soup now requires a bowl, and obeys the laws of conservation of kitchenware
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
