### PR TITLE
internals scarcity

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -116,7 +116,7 @@
 // Ordinary survival box
 /obj/item/storage/box/survival
 	var/mask_type = /obj/item/clothing/mask/breath
-	var/internal_type = /obj/item/tank/internals/emergency_oxygen
+	var/internal_type = null
 	var/medipen_type = /obj/item/reagent_containers/hypospray/medipen
 
 /obj/item/storage/box/survival/PopulateContents()
@@ -124,10 +124,11 @@
 	if(!isnull(medipen_type))
 		new medipen_type(src)
 
-	if(!isplasmaman(loc))
-		new internal_type(src)
-	else
-		new /obj/item/tank/internals/plasmaman/belt(src)
+	if(!isnull(internal_type))
+		if(!isplasmaman(loc))
+			new internal_type(src)
+		else
+			new /obj/item/tank/internals/plasmaman/belt(src)
 
 /obj/item/storage/box/survival/radio/PopulateContents()
 	..() // we want the survival stuff too.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR removes internals from all roundstart boxes except engi and atmos since they are the job with the highest chance of dealing with hazardous atmospherics.
The goal is to make atmospheric hazards that aren't fires or pressure not get easily nullified by wearing internals, because getting oxigen is trivial as everyone spawn with a tank in their backpack.
Oxygen scarcity will make internals less forgettable, will make people use more the tanks in the closets (the station is filled with them) and make people go to atmos more to ~~steal~~ request a full tank
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Oxygen scarcity, more interesting hazards than fire/pressure
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: remove internals from jobs other than engi/atmos
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
