### PR TITLE
Adds a mood penalty to wearing internal masks

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -285,3 +285,7 @@
 /datum/mood_event/bald
 	description ="<span class='warning'>I need something to cover my head...</span>\n"
 	mood_change = -3
+
+/datum/mood_event/mask
+	description ="<span class='warning'>Plasma gas is an hoax and even if it wasn't there's no evidence to suggest that masks even help at all. Having to wear a mask goes against my personal freedom, we live in a free country I should be able to do whatever the hell I want I don't have to listen and I don't have to listen to anything anyone says.</span>\n"
+	mood_change = -50

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -32,6 +32,15 @@
 	. = ..()
 	. += "<span class='notice'>Alt-click [src] to adjust it.</span>"
 
+/obj/item/clothing/mask/breath/equipped(mob/user, slot)
+	. = ..()
+	if(slot == ITEM_SLOT_MASK)
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "anti_mask", /datum/mood_event/mask)
+
+/obj/item/clothing/mask/breath/dropped(mob/user)
+	. = ..()
+	SEND_SIGNAL(user, COMSIG_CLEAR_MOOD_EVENT, "anti_mask")
+
 /obj/item/clothing/mask/breath/medical
 	desc = "A close-fitting sterile mask that can be connected to an air supply."
 	name = "medical mask"


### PR DESCRIPTION
## About The Pull Request
Alternative to #54689

## Why It's Good For The Game
Having a mood penalty to breath masks will make people less likely to use them unless they're really needed, I think this is a more elegant solution to the alternative of removing internal tanks altogether

## Changelog
:cl:
balance: wearing breath masks now incurs a mood penalty
/:cl:
