### PR TITLE
Custodial Locator Tweaks

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -461,17 +461,17 @@ Code:
 			if (cl)
 				menu += "Current Orbital Location: <b>\[[cl.x],[cl.y]\]</b>"
 
-				menu += "<h4>Located Mops:</h4>"
+				menu += "<h4>Located Pimpin' Ride:</h4>"
 
 				var/ldat
-				for (var/obj/item/mop/M in world)
+				for (var/obj/vehicle/ridden/janicart/M in world)
 					var/turf/ml = get_turf(M)
 
 					if(ml)
 						if (ml.z != cl.z)
 							continue
 						var/direction = get_dir(src, M)
-						ldat += "Mop - <b>\[[ml.x],[ml.y] ([uppertext(dir2text(direction))])\]</b> - [M.reagents.total_volume ? "Wet" : "Dry"]<br>"
+						ldat += "Ride - <b>\[[ml.x],[ml.y] ([uppertext(dir2text(direction))])\]</b><br>"
 
 				if (!ldat)
 					menu += "None"
@@ -506,6 +506,23 @@ Code:
 							continue
 						var/direction = get_dir(src, B)
 						ldat += "Cleanbot - <b>\[[bl.x],[bl.y] ([uppertext(dir2text(direction))])\]</b> - [B.on ? "Online" : "Offline"]<br>"
+
+				if (!ldat)
+					menu += "None"
+				else
+					menu += "[ldat]"
+
+				menu += "<h4>Located Mops:</h4>"
+
+				ldat = null
+				for (var/obj/item/mop/M in world)
+					var/turf/ml = get_turf(M)
+
+					if(ml)
+						if (ml.z != cl.z)
+							continue
+						var/direction = get_dir(src, M)
+						ldat += "Mop - <b>\[[ml.x],[ml.y] ([uppertext(dir2text(direction))])\]</b> - [M.reagents.total_volume ? "Wet" : "Dry"]<br>"
 
 				if (!ldat)
 					menu += "None"


### PR DESCRIPTION
## About The Pull Request

Adds Pimpin Ride to the Custodial Locator

Moves mops to the bottom of custodial locator list. (You can print mops forever.)

![image](https://user-images.githubusercontent.com/7543955/97763838-3d1ad880-1ae3-11eb-8193-28a1167740e1.png)

## Why It's Good For The Game

It really sucks to have someone take off with the janicart and have no way to get it back. Now someone can jack the ride, and the janitor can find it, which is both a QoL feature, and a way to set up traps to gank the janitor.

I was going to add keys to the tracker, but I felt that'd be too silly. I may add some cargo orders for both stand-alone keys, and a janicart at some point instead, so they can be replaced.

## Changelog
:cl:
tweak: Custodial Locator now points out Pimpin Ride location.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
