### PR TITLE
Toolbox plushie

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -51,7 +51,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		/obj/item/toy/plush/goatplushie = 2,
 		/obj/item/toy/plush/moth = 2,
 		/obj/item/toy/plush/pkplush = 2,
-		/obj/item/toy/plush/toolboxplushie = 2,
+		/obj/item/toy/plush/toolboxplushie/random = 2,
 		/obj/item/storage/belt/military/snack = 2,
 		/obj/item/toy/brokenradio = 2,
 		/obj/item/toy/braintoy = 2,

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -51,6 +51,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		/obj/item/toy/plush/goatplushie = 2,
 		/obj/item/toy/plush/moth = 2,
 		/obj/item/toy/plush/pkplush = 2,
+		/obj/item/toy/plush/toolboxplushie = 2,
 		/obj/item/storage/belt/military/snack = 2,
 		/obj/item/toy/brokenradio = 2,
 		/obj/item/toy/braintoy = 2,

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -595,3 +595,46 @@
 	attack_verb_continuous = list("hugs", "squeezes")
 	attack_verb_simple = list("hug", "squeeze")
 	squeak_override = list('sound/weapons/thudswoosh.ogg'=1)
+
+/obj/item/toy/plush/toolboxplushie
+	name = "toolbox plushie"
+	desc = "A plush toolbox. Looks just like the real thing!"
+	icon_state = "toolbox_default"
+	inhand_icon_state = "toolbox_default"
+	icon = 'icons/obj/storage.dmi'
+	lefthand_file = 'icons/mob/inhands/equipment/toolbox_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'
+	var/latches = "single_latch"
+
+/obj/item/toy/plush/toolboxplushie/Initialize()
+	. = ..()
+
+	var/flavour = pick("toolbox_default", "red", "yellow", "blue", "green", "syndicate")
+	icon_state = flavour
+
+	switch(icon_state)
+		if("blue")
+			name = "mechanical toolbox plushie"
+			inhand_icon_state = "toolbox_blue"
+		if("red")
+			name = "emergency toolbox plushie"
+			inhand_icon_state = "toolbox_red"
+		if("yellow")
+			name = "electrical toolbox plushie"
+			inhand_icon_state = "toolbox_yellow"
+		if("green")
+			name = "artistic toolbox plushie"
+			inhand_icon_state = "artistic_toolbox"
+		if("syndicate")
+			name = "suspicious looking toolbox plushie"
+			inhand_icon_state = "toolbox_syndi"
+
+	if(prob(10))
+		latches = "double_latch"
+		if(prob(1))
+			latches = "triple_latch"
+	update_icon()
+
+/obj/item/toy/plush/toolboxplushie/update_overlays()
+	. = ..()
+		. += latches

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -637,4 +637,4 @@
 
 /obj/item/toy/plush/toolboxplushie/update_overlays()
 	. = ..()
-		. += latches
+	. += latches

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -609,26 +609,6 @@
 /obj/item/toy/plush/toolboxplushie/Initialize()
 	. = ..()
 
-	var/flavour = pick("toolbox_default", "red", "yellow", "blue", "green", "syndicate")
-	icon_state = flavour
-
-	switch(icon_state)
-		if("blue")
-			name = "mechanical toolbox plushie"
-			inhand_icon_state = "toolbox_blue"
-		if("red")
-			name = "emergency toolbox plushie"
-			inhand_icon_state = "toolbox_red"
-		if("yellow")
-			name = "electrical toolbox plushie"
-			inhand_icon_state = "toolbox_yellow"
-		if("green")
-			name = "artistic toolbox plushie"
-			inhand_icon_state = "artistic_toolbox"
-		if("syndicate")
-			name = "suspicious looking toolbox plushie"
-			inhand_icon_state = "toolbox_syndi"
-
 	if(prob(10))
 		latches = "double_latch"
 		if(prob(1))
@@ -638,3 +618,38 @@
 /obj/item/toy/plush/toolboxplushie/update_overlays()
 	. = ..()
 	. += latches
+
+/obj/item/toy/plush/toolboxplushie/emergency
+	name = "emergency toolbox plushie"
+	icon_state = "red"
+	inhand_icon_state = "toolbox_red"
+
+/obj/item/toy/plush/toolboxplushie/mechanical
+	name = "mechanical toolbox plushie"
+	icon_state = "blue"
+	inhand_icon_state = "toolbox_blue"
+
+/obj/item/toy/plush/toolboxplushie/electrical
+	name = "electrical toolbox plushie"
+	icon_state = "yellow"
+	inhand_icon_state = "toolbox_yellow"
+
+/obj/item/toy/plush/toolboxplushie/syndicate
+	name = "suspicious looking toolbox plushie"
+	icon_state = "syndicate"
+	inhand_icon_state = "toolbox_syndi"
+
+/obj/item/toy/plush/toolboxplushie/artistic
+	name = "artistic toolbox plushie"
+	icon_state = "green"
+	inhand_icon_state = "artistic_toolbox"
+
+/obj/item/toy/plush/toolboxplushie/random
+	name = "random toolbox plushie"
+	desc = "This should've vanished!"
+
+/obj/item/toy/plush/toolboxplushie/random/Initialize()
+	. = ..()
+	var/newbox = pick(subtypesof(/obj/item/toy/plush/toolboxplushie))
+	new newbox(get_turf(loc))
+	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a plushie in the style of the various latched toolboxes to the arcade prize pool.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This takes the iconic cold, hard toolbox and turns it into something soft and cuddly. It still looks like other toolboxes, so you can attack  unaware people. This results in a comedic squeak rather than blood. Like most plushies, it can have relations with other plushies and reproduce.

This is only in the arcade prize pool so it shouldn't appear too often. So the sprite being the same as regular toolboxes shouldn't get too annoying.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
add: There's another imitation toolbox in town: the toolbox plushie! Find it in the overly crowded arcade prize pool today!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
