### PR TITLE
You can once again place hats on cyborgs without having to treat it as a party game.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -100,7 +100,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		return
 
 	if(W.slot_flags & ITEM_SLOT_HEAD && hat_offset != INFINITY && user.a_intent == INTENT_HELP && !is_type_in_typecache(W, GLOB.blacklisted_borg_hats))
-		if(HAS_TRAIT(hat, TRAIT_NODROP))
+		if(hat && HAS_TRAIT(hat, TRAIT_NODROP))
 			to_chat(user, "<span class='warn'>You can't seem to remove [src]'s existing headwear!</span>")
 			return
 		to_chat(user, "<span class='notice'>You begin to place [W] on [src]'s head...</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Someone decided to check the traits of a var that may very well be null. This led to the following runtime.

![image](https://user-images.githubusercontent.com/24975989/97775751-100a0c80-1b5b-11eb-9b04-ece48867f368.png)

A cyborg not having a hat is to be expected (and is the default state of all newly created cyborgs) so this isn't a runtime due to unexpected behaviour, just due to an oversight in coding for not guarding against a var where a valid state is null.

This PR makes sure there is actually a hat on the cyborg before attempting to check the hat's traits.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can once again place hats on the heads of cyborgs in an ordinary and everyday manner, without having to throw them like you're playing a drunken party game.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
