### PR TITLE
Cleans up try_eject proc prototype and various proc usages to fix some runtimes

### DIFF
--- a/code/modules/modular_computers/file_system/programs/cargoship.dm
+++ b/code/modules/modular_computers/file_system/programs/cargoship.dm
@@ -42,7 +42,7 @@
 	switch(action)
 		if("ejectid")
 			if(id_card)
-				card_slot.try_eject(TRUE, usr)
+				card_slot.try_eject(usr, TRUE)
 		if("selectid")
 			if(!id_card)
 				return

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -94,12 +94,20 @@
 
 // Called when component is removed from PC.
 /obj/item/computer_hardware/proc/on_remove(obj/item/modular_computer/M, mob/living/user = null)
-	try_eject(forced = 1)
+	try_eject(forced = TRUE)
 
 // Called when someone tries to insert something in it - paper in printer, card in card reader, etc.
 /obj/item/computer_hardware/proc/try_insert(obj/item/I, mob/living/user = null)
 	return FALSE
 
-// Called when someone tries to eject something from it - card from card reader, etc.
-/obj/item/computer_hardware/proc/try_eject(slot=0, mob/living/user = null, forced = 0)
+/**
+  * Implement this when your hardware contains an object that the user can eject.
+  *
+  * Examples include ejecting cells from battery modules, ejecting an ID card from a card reader
+  * or ejecting an Intellicard from an AI card slot.
+  * Arguments:
+  * * user - The mob requesting the eject.
+  * * forced - Whether this action should be forced in some way.
+  */
+/obj/item/computer_hardware/proc/try_eject(mob/living/user = null, forced = FALSE)
 	return FALSE

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -12,7 +12,7 @@
 
 /obj/item/computer_hardware/ai_slot/handle_atom_del(atom/A)
 	if(A == stored_card)
-		try_eject(0, null, TRUE)
+		try_eject(forced = TRUE)
 	. = ..()
 
 /obj/item/computer_hardware/ai_slot/examine(mob/user)
@@ -39,7 +39,7 @@
 	return TRUE
 
 
-/obj/item/computer_hardware/ai_slot/try_eject(mob/living/user = null,forced = FALSE)
+/obj/item/computer_hardware/ai_slot/try_eject(mob/living/user = null, forced = FALSE)
 	if(!stored_card)
 		to_chat(user, "<span class='warning'>There is no card in \the [src].</span>")
 		return FALSE
@@ -65,5 +65,5 @@
 		return
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
 		to_chat(user, "<span class='notice'>You press down on the manual eject button with \the [I].</span>")
-		try_eject(,user,1)
+		try_eject(user, TRUE)
 		return

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -14,7 +14,7 @@
 	. = ..()
 
 /obj/item/computer_hardware/card_slot/Destroy()
-	try_eject()
+	try_eject(forced = TRUE)
 	return ..()
 
 /obj/item/computer_hardware/card_slot/GetAccess()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

`[09:18:04] Runtime in card_slot.dm, line 72: Cannot execute 1.put in hands().`

Usage of the try_eject proc is an eclectic mix of unimplemented behaviour and incorrect argument order, with behaviour that can cause runtimes. 

Prototype for the try_eject proc wasn't even implemented properly by children. Nothing implemented it used the slots arg, so I modified the base prototype. Cleaned up various proc calls. Should no longer have incorrect arg-based runtimes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
