### PR TITLE
Reduces reinforced plunger price

### DIFF
--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -126,4 +126,4 @@
 	plunge_mod = 0.8
 	layer_mode_sprite = "reinforced_plunger_layer"
 
-	custom_premium_price = 1200
+	custom_premium_price = 800


### PR DESCRIPTION
Reinforced plunger price was untouched during all the economy reworks and just became too expensive. Now it should be somewhat more realisticaly attainable again through borrowing, waiting or doing bounties. 
(Especially with the cock and ball torture that poor metalgen went through, I really need to add more interesting geyser chems)

:cl:
tweak: Reinforced plunger is now 800cr, down from 1200
/:cl: