### PR TITLE
BotKeeper (tablet app) list populates based on bot unlock access

### DIFF
--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -1,10 +1,10 @@
 
 /datum/computer_file/program/robocontrol
 	filename = "botkeeper"
-	filedesc = "Botkeeper"
+	filedesc = "BotKeeper"
 	program_icon_state = "robot"
 	extended_desc = "A remote controller used for giving basic commands to non-sentient robots."
-	transfer_access = ACCESS_ROBOTICS
+	transfer_access = ACCESS_ROBOTICS | ACCESS_HOS
 	requires_ntnet = TRUE
 	size = 12
 	tgui_id = "NtosRoboControl"

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -4,7 +4,7 @@
 	filedesc = "BotKeeper"
 	program_icon_state = "robot"
 	extended_desc = "A remote controller used for giving basic commands to non-sentient robots."
-	transfer_access = ACCESS_ROBOTICS | ACCESS_HOS
+	transfer_access = null
 	requires_ntnet = TRUE
 	size = 12
 	tgui_id = "NtosRoboControl"
@@ -37,7 +37,13 @@
 	for(var/B in GLOB.bots_list)
 		var/mob/living/simple_animal/bot/Bot = B
 		if(!Bot.on || Bot.z != zlevel || Bot.remote_disabled) //Only non-emagged bots on the same Z-level are detected!
-			continue //Also, the PDA must have access to the bot type.
+			continue
+		else if(computer) //Also, the inserted ID must have access to the bot type
+			var/obj/item/card/id/id_card = card_slot ? card_slot.stored_card : null
+			if(!id_card && !Bot.bot_core.allowed(current_user))
+				continue
+			else if(id_card && !Bot.bot_core.check_access(id_card))
+				continue
 		var/list/newbot = list("name" = Bot.name, "mode" = Bot.get_mode_ui(), "model" = Bot.model, "locat" = get_area(Bot), "bot_ref" = REF(Bot), "mule_check" = FALSE)
 		if(Bot.bot_type == MULE_BOT)
 			var/mob/living/simple_animal/bot/mulebot/MULE = Bot


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #54440
Anyone can now download BotKeeper. Only bots your current ID can unlock will be listed to control. Stylised Botkeeper as BotKeeper because it looks better.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's more consistent with PDA bot control.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
tweak: Anyone can now download BotKeeper (tablet app). Only bots your current ID can unlock will be listed to control.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
