### PR TITLE
Fixes deathnettle and nova flower. Third time is the charm.

### DIFF
--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -257,18 +257,15 @@
 	..()
 	force = round((5 + seed.potency / 5), 1)
 
-/obj/item/grown/novaflower/attack(mob/living/carbon/M, mob/user)
-	if(!..())
-		return
-	if(isliving(M))
-		to_chat(M, "<span class='danger'>You are lit on fire from the intense heat of the [name]!</span>")
-		M.adjust_fire_stacks(seed.potency / 20)
-		if(M.IgniteMob())
-			message_admins("[ADMIN_LOOKUPFLW(user)] set [ADMIN_LOOKUPFLW(M)] on fire with [src] at [AREACOORD(user)]")
-			log_game("[key_name(user)] set [key_name(M)] on fire with [src] at [AREACOORD(user)]")
 
-/obj/item/grown/novaflower/afterattack(atom/A as mob|obj, mob/user,proximity)
+/obj/item/grown/novaflower/afterattack(atom/target as mob|obj, mob/user,proximity)
 	. = ..()
+	if(isliving(target))
+		var/mob/living/target_mob = target
+		to_chat(target_mob, "<span class='danger'>You are lit on fire from the intense heat of the [name]!</span>")
+		target_mob.adjust_fire_stacks(seed.potency / 20)
+		if(target_mob.IgniteMob())
+			log_combat("[key_name(user)] set [key_name(target_mob)] on fire with [src] at [AREACOORD(user)]")
 	if(!proximity)
 		return
 	if(force > 0)

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -106,15 +106,14 @@
 			user.Paralyze(100)
 			to_chat(user, "<span class='userdanger'>You are stunned by [src] as you try picking it up!</span>")
 
-/obj/item/reagent_containers/food/snacks/grown/nettle/death/attack(mob/living/carbon/M, mob/user)
-	if(!..())
-		return
-	if(isliving(M))
-		to_chat(M, "<span class='danger'>You are stunned by the powerful acid of [src]!</span>")
-		log_combat(user, M, "attacked", src)
-
-		M.adjust_blurriness(force/7)
+/obj/item/reagent_containers/food/snacks/grown/nettle/death/afterattack(atom/target as mob|obj, mob/user, proximity)
+	. = ..()
+	if(isliving(target))
+		var/mob/living/target_mob = target
+		to_chat(target_mob, "<span class='danger'>You are stunned by the powerful acid of [src]!</span>")
+		target_mob.adjust_blurriness(force/7)
 		if(prob(20))
-			M.Unconscious(force / 0.3)
-			M.Paralyze(force / 0.75)
-		M.drop_all_held_items()
+			target_mob.Unconscious(force / 0.3)
+			target_mob.Paralyze(force / 0.75)
+			log_combat("[key_name(user)] painfully stunned [key_name(target)] with [src] at [AREACOORD(user)]")
+		target_mob.drop_all_held_items()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes the long broken nova flower and deathnettle special attack effects work again by moving them to afterattack as was suggest in review of my last attempt to fix this.

I have also improved logging by moving the logging of their special effects to the combat log and removing the message to admins every time someone is hit with a nova flower.

Fixes: https://github.com/tgstation/tgstation/issues/51143
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugs are bad and these items, especially the nova flowers, are in a sorry state.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Novaflowers and deathnettles apply their special on hit effects again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
