### PR TITLE
Syndrones no longer have references to eating weaker drones for health.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -15,8 +15,8 @@
 	icon_state = "drone_synd"
 	icon_living = "drone_synd"
 	picked = TRUE //the appearence of syndrones is static, you don't get to change it.
-	health = 30
-	maxHealth = 120 //If you murder other drones and cannibalize them you can get much stronger
+	health = 120
+	maxHealth = 120
 	initial_language_holder = /datum/language_holder/drone/syndicate
 	faction = list(ROLE_SYNDICATE)
 	speak_emote = list("hisses")
@@ -40,7 +40,7 @@
 	. = ..()
 	if(!. || !client)
 		return FALSE
-	to_chat(src, "<span class='notice'>You can kill and eat other drones to increase your health!</span>" )
+	to_chat(src, "<span class='notice'>You may resume your mission, operative!</span>" )
 
 /mob/living/simple_animal/drone/syndrone/badass
 	name = "Badass Syndrone"

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -36,12 +36,6 @@
 	var/datum/component/uplink/hidden_uplink = internal_storage.GetComponent(/datum/component/uplink)
 	hidden_uplink.telecrystals = 10
 
-/mob/living/simple_animal/drone/syndrone/Login()
-	. = ..()
-	if(!. || !client)
-		return FALSE
-	to_chat(src, "<span class='notice'>You may resume your mission, operative!</span>" )
-
 /mob/living/simple_animal/drone/syndrone/badass
 	name = "Badass Syndrone"
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi/elite


### PR DESCRIPTION
## About The Pull Request

Turns out that syndrones had an issue in 2 parts.
Previously they had a feature where they spawned with 30 health, and then if they found another drone, they would heal several points to health to get to their maximum of 120 points. However, due to an issue, they were spawning with 120 health regardless, and since they could just screwdriver themselves to full anyway, there wasn't any mechanical backing on that feature, and it was removed at some point.
In addition, when you rejoin as a syndrone if you went offline, you still got a line about being able to eat other drones for health.

The drone vore line has been replaced with some syndicate flavor, and their health has been set to 120 as is expected from them in modern balance.

Fixes #14923.

## Why It's Good For The Game

References to removed features and mechanics: Wack
Also, the variable assignment is now faithful to it's behavior in-game for code purposes.

## Changelog
:cl:
fix: Syndicate drones no longer have references to their removed mechanics.
/:cl:
