### PR TITLE
Bounty boards are now correctly dispersed and facing the correct directions.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2386,17 +2386,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"ahC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "ahD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster{
@@ -108554,6 +108543,17 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"gsX" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/item/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "gvO" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -168654,7 +168654,7 @@ cRw
 cTd
 cVc
 cWC
-ahC
+gsX
 dab
 dbF
 ddv

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -12359,7 +12359,7 @@
 /area/crew_quarters/toilet)
 "aBB" = (
 /obj/machinery/bounty_board{
-	dir = 4;
+	dir = 8;
 	pixel_x = 32
 	},
 /turf/open/floor/plastic,
@@ -19379,7 +19379,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/bounty_board{
-	dir = 4;
+	dir = 8;
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
@@ -30867,7 +30867,7 @@
 	dir = 1
 	},
 /obj/machinery/bounty_board{
-	dir = 8;
+	dir = 4;
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/white,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -64722,6 +64722,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"dLU" = (
+/obj/machinery/bounty_board{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "dMl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -72489,6 +72496,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/bounty_board{
+	dir = 1;
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
@@ -101037,7 +101048,7 @@ ayn
 aXr
 bmm
 baB
-bgQ
+dLU
 pXD
 bgY
 bgY

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -15892,7 +15892,7 @@
 /area/quartermaster/warehouse)
 "aPV" = (
 /obj/machinery/bounty_board{
-	dir = 4;
+	dir = 8;
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -26701,6 +26701,10 @@
 /obj/structure/table/glass,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/clothing/mask/surgical,
+/obj/machinery/bounty_board{
+	dir = 8;
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bub" = (
@@ -54379,6 +54383,10 @@
 "pYw" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-03"
+	},
+/obj/machinery/bounty_board{
+	dir = 4;
+	pixel_x = -28
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. Bounty boards now all face the correct direction, with the screen facing away from the wall and the keyboard not fused into the wall like a parasite.
Also, some departments lost theirs or had it disappear at some point. Now it's a uniform component of the map as intended.

## Why It's Good For The Game

Fixes #53280.

## Changelog
:cl:
fix: Bounty boards now face the correct direction and exist everywhere that they're intended to exist.
/:cl:

