### PR TITLE
Fix pai emitter regen rate that was incorrectly modified by delta_time changes.

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -75,7 +75,7 @@
 
 	var/emitterhealth = 20
 	var/emittermaxhealth = 20
-	var/emitterregen = 0.125
+	var/emitter_regen_per_second = 1.25
 	var/emittercd = 50
 	var/emitteroverloadcd = 100
 	var/emittersemicd = FALSE
@@ -311,7 +311,7 @@
 	update_stat()
 
 /mob/living/silicon/pai/process(delta_time)
-	emitterhealth = clamp((emitterhealth + emitterregen * delta_time), -50, emittermaxhealth)
+	emitterhealth = clamp((emitterhealth + emitter_regen_per_second * delta_time), -50, emittermaxhealth)
 
 /obj/item/paicard/attackby(obj/item/W, mob/user, params)
 	if(pai && (istype(W, /obj/item/encryptionkey) || W.tool_behaviour == TOOL_SCREWDRIVER))

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -311,7 +311,7 @@
 	update_stat()
 
 /mob/living/silicon/pai/process(delta_time)
-	emitterhealth = clamp((emitterhealth + emitter_regen_per_second * delta_time), -50, emittermaxhealth)
+	emitterhealth = clamp((emitterhealth + (emitter_regen_per_second * delta_time)), -50, emittermaxhealth)
 
 /obj/item/paicard/attackby(obj/item/W, mob/user, params)
 	if(pai && (istype(W, /obj/item/encryptionkey) || W.tool_behaviour == TOOL_SCREWDRIVER))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Another casualty of #52981

![image](https://user-images.githubusercontent.com/24975989/97923336-b7eb2a00-1d55-11eb-9b27-1b3c7e24cf55.png)

Old behaviour - 0.25 regen 5 times per second for 1.25 per second.

delta_time PR behaviour - 0.125 regen multiplied by delta_time value of 0.2 per processing tick, intended to be run 5 times per second, for 0.125 regen per second.

Fixed behaviour - 1.25 regen multiplied by delta_time value of 0.2 per processing tick, intended to be run 5 times per second, for 1.25 per second.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex coding oversight from delta_time changes, restore previous behaviour with delta_time support.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Personal AI emitters now regenerate at their properly intended speed instead of 1/10th of that speed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
