### PR TITLE
Fixes various immovable rod bugs, adds logging

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -1,4 +1,6 @@
 #define DEFAULT_METEOR_LIFETIME 1800
+#define MAP_EDGE_PAD 5
+
 GLOBAL_VAR_INIT(meteor_wave_delay, 625) //minimum wait between waves in tenths of seconds
 //set to at least 100 unless you want evarr ruining every round
 
@@ -46,17 +48,17 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 	var/startx
 	switch(startSide)
 		if(NORTH)
-			starty = world.maxy-(TRANSITIONEDGE+1)
-			startx = rand((TRANSITIONEDGE+1), world.maxx-(TRANSITIONEDGE+1))
+			starty = world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD)
+			startx = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD))
 		if(EAST)
-			starty = rand((TRANSITIONEDGE+1),world.maxy-(TRANSITIONEDGE+1))
-			startx = world.maxx-(TRANSITIONEDGE+1)
+			starty = rand((TRANSITIONEDGE + MAP_EDGE_PAD),world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD))
+			startx = world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD)
 		if(SOUTH)
-			starty = (TRANSITIONEDGE+1)
-			startx = rand((TRANSITIONEDGE+1), world.maxx-(TRANSITIONEDGE+1))
+			starty = (TRANSITIONEDGE + MAP_EDGE_PAD)
+			startx = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD))
 		if(WEST)
-			starty = rand((TRANSITIONEDGE+1), world.maxy-(TRANSITIONEDGE+1))
-			startx = (TRANSITIONEDGE+1)
+			starty = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD))
+			startx = (TRANSITIONEDGE + MAP_EDGE_PAD)
 	. = locate(startx, starty, Z)
 
 /proc/spaceDebrisFinishLoc(startSide, Z)
@@ -64,17 +66,17 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 	var/endx
 	switch(startSide)
 		if(NORTH)
-			endy = (TRANSITIONEDGE+1)
-			endx = rand((TRANSITIONEDGE+1), world.maxx-(TRANSITIONEDGE+1))
+			endy = (TRANSITIONEDGE + MAP_EDGE_PAD)
+			endx = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD))
 		if(EAST)
-			endy = rand((TRANSITIONEDGE+1), world.maxy-(TRANSITIONEDGE+1))
-			endx = (TRANSITIONEDGE+1)
+			endy = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD))
+			endx = (TRANSITIONEDGE + MAP_EDGE_PAD)
 		if(SOUTH)
-			endy = world.maxy-(TRANSITIONEDGE+1)
-			endx = rand((TRANSITIONEDGE+1), world.maxx-(TRANSITIONEDGE+1))
+			endy = world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD)
+			endx = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD))
 		if(WEST)
-			endy = rand((TRANSITIONEDGE+1),world.maxy-(TRANSITIONEDGE+1))
-			endx = world.maxx-(TRANSITIONEDGE+1)
+			endy = rand((TRANSITIONEDGE + MAP_EDGE_PAD),world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD))
+			endx = world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD)
 	. = locate(endx, endy, Z)
 
 ///////////////////////
@@ -381,3 +383,4 @@ GLOBAL_LIST_INIT(meteorsSPOOKY, list(/obj/effect/meteor/pumpkin))
 	meteorsound = pick('sound/hallucinations/im_here1.ogg','sound/hallucinations/im_here2.ogg')
 //////////////////////////
 #undef DEFAULT_METEOR_LIFETIME
+#undef MAP_EDGE_PAD

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -22,6 +22,8 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/aimed = alert("Aimed at current location?","Sniperod", "Yes", "No")
 	if(aimed == "Yes")
 		special_target = get_turf(usr)
+	message_admins("[key_name_admin(usr)] has aimed an immovable rod at [AREACOORD(special_target)].")
+	log_admin("[key_name_admin(usr)] has aimed an immovable rod at [AREACOORD(special_target)].")
 
 /datum/round_event/immovable_rod
 	announceWhen = 5
@@ -34,8 +36,9 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/startside = pick(GLOB.cardinals)
 	var/z = pick(SSmapping.levels_by_trait(ZTRAIT_STATION))
 	var/turf/startT = spaceDebrisStartLoc(startside, z)
-	var/turf/endT = spaceDebrisFinishLoc(startside, z)
+	var/turf/endT = get_edge_target_turf(get_random_station_turf(), turn(startside, 180))
 	var/atom/rod = new /obj/effect/immovablerod(startT, endT, C.special_target)
+	C.special_target = null //Cleanup for future event rolls.
 	announce_to_ghosts(rod)
 
 /obj/effect/immovablerod
@@ -106,7 +109,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	. = ..()
 
 /obj/effect/immovablerod/Moved()
-	if((z != z_original) || (loc == destination))
+	if((z != z_original))
 		qdel(src)
 	if(special_target && loc == get_turf(special_target))
 		complete_trajectory()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Immovable rods will 
- no longer instantly fly off z-level and despawn.
- no longer miss station completely as they aim at a station turf instead of an edge turf.
- now reset target when aimed.
- admin message and log when aimed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #48127
Fixes #49152
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Immovable rods should more consistently hit the station, will reset target if adminbused, and added more logs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
