### PR TITLE
icebox's second level counts as station too

### DIFF
--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -29,7 +29,6 @@
 			"Down": -1,
 			"Up": 1,
 			"Mining": true,
-			"Station": false,
 			"Linkage": null,
 			"Gravity": true,
 			"Ice Ruins Underground": true,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
removes the line of code that makes ice box's second level not be a station level

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
prevents
![image](https://user-images.githubusercontent.com/23585223/97962629-e3056600-1db5-11eb-8626-b195a3823b32.png)


## Changelog
:cl:
fix: You will no longer lose the mission if you go to water plants on Ice Box, comrade.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
