### PR TITLE
Remove travis CI status badge from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## /tg/station codebase
 
-[![Build Status](https://travis-ci.org/tgstation/tgstation.png)](https://travis-ci.org/tgstation/tgstation) 
+[![Build Status](https://github.com/tgstation/tgstation/workflows/Run%20tests/badge.svg)](https://github.com/tgstation/tgstation/actions?query=workflow%3A%22Run+tests%22) 
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/tgstation/tgstation.svg)](https://isitmaintained.com/project/tgstation/tgstation "Percentage of issues still open")
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/tgstation/tgstation.svg)](https://isitmaintained.com/project/tgstation/tgstation "Average time to resolve an issue")
 ![Coverage](https://img.shields.io/badge/coverage---3%25-red.svg)


### PR DESCRIPTION
Updates the old CI status badge from Travis to the status of the Run Tests workflow. 
Clicking the badge opens the test status page: https://github.com/tgstation/tgstation/actions?query=workflow%3A%22Run+tests%22

Relevant Github Documentation: https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/adding-a-workflow-status-badge

Thanks to @Jared-Fogle for the badge URL.
