### PR TITLE
Fixing cult turf overlays not showing under transparent tiles.

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -23,6 +23,7 @@
 
 #define SPACE_LAYER 1.8
 //#define TURF_LAYER 2 //For easy recordkeeping; this is a byond define
+#define CULT_OVERLAY_LAYER 2.01
 #define MID_TURF_LAYER 2.02
 #define HIGH_TURF_LAYER 2.03
 #define TURF_PLATING_DECAL_LAYER 2.031

--- a/code/modules/antagonists/cult/cult_turf_overlay.dm
+++ b/code/modules/antagonists/cult/cult_turf_overlay.dm
@@ -25,7 +25,7 @@
 /obj/effect/cult_turf/overlay/floor
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "clockwork_floor"
-	layer = TURF_DECAL_LAYER
+	layer = CULT_OVERLAY_LAYER
 
 /obj/effect/cult_turf/overlay/floor/bloodcult
 	icon_state = "cult"

--- a/code/modules/antagonists/cult/cult_turf_overlay.dm
+++ b/code/modules/antagonists/cult/cult_turf_overlay.dm
@@ -25,7 +25,7 @@
 /obj/effect/cult_turf/overlay/floor
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "clockwork_floor"
-	layer = TURF_LAYER
+	layer = TURF_DECAL_LAYER
 
 /obj/effect/cult_turf/overlay/floor/bloodcult
 	icon_state = "cult"


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
vis_contents always render the turf above other atoms of the same layer. This will close #54581.

By the by a holder atom should be made to contain the turf vis overlay, so mesons won't show its contents through walls and other dense objects.. but that's another issue.

## Changelog
N/A.