### PR TITLE
Webedit fixing the logic of a statement about mecha armor plate overlays

### DIFF
--- a/code/datums/components/armor_plate.dm
+++ b/code/datums/components/armor_plate.dm
@@ -92,6 +92,6 @@
 		var/overlay_string = "ripley-g"
 		if(amount >= 3)
 			overlay_string += "-full"
-		if(LAZYLEN(mech.occupants))
+		if(!LAZYLEN(mech.occupants))
 			overlay_string += "-open"
 		overlays += overlay_string


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
This will close #54704.

## Changelog
:cl:
fix: Ripley mechas will now display the right overlays for their armor plates.
/:cl:
