### PR TITLE
Fixes gondolas turning invisible when given a pet collar.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/gondola.dm
+++ b/code/modules/mob/living/simple_animal/friendly/gondola.dm
@@ -64,18 +64,9 @@
 /mob/living/simple_animal/pet/gondola/IsVocal() //Gondolas are the silent walker.
 	return FALSE
 
-/// Special handling for gondolas, as they don't use icon_states and instead rely on overlays, which the parent proc for this deletes.
-/mob/living/simple_animal/pet/gondola/add_collar(obj/item/clothing/neck/petcollar/P, mob/user)
-	if(QDELETED(P) || pcollar)
-		return
-	if(!user.transferItemToLoc(P, src))
-		return
-
-	pcollar = P
-
-	to_chat(user, "<span class='notice'>You put the [P] around [src]'s neck.</span>")
-	if(P.tagname && !unique_pet)
-		fully_replace_character_name(null, "\proper [P.tagname]")
+/// Special handling for gondolas, as they don't use icon_states and instead rely on overlays. The parent of this proc deletes all our overlays, so we're overriding it.
+/mob/living/simple_animal/pet/gondola/regenerate_icons()
+	return
 
 #undef GONDOLA_HEIGHT
 #undef GONDOLA_COLOR

--- a/code/modules/mob/living/simple_animal/friendly/gondola.dm
+++ b/code/modules/mob/living/simple_animal/friendly/gondola.dm
@@ -64,6 +64,18 @@
 /mob/living/simple_animal/pet/gondola/IsVocal() //Gondolas are the silent walker.
 	return FALSE
 
+/// Special handling for gondolas, as they don't use icon_states and instead rely on overlays, which the parent proc for this deletes.
+/mob/living/simple_animal/pet/gondola/add_collar(obj/item/clothing/neck/petcollar/P, mob/user)
+	if(QDELETED(P) || pcollar)
+		return
+	if(!user.transferItemToLoc(P, src))
+		return
+
+	pcollar = P
+
+	to_chat(user, "<span class='notice'>You put the [P] around [src]'s neck.</span>")
+	if(P.tagname && !unique_pet)
+		fully_replace_character_name(null, "\proper [P.tagname]")
 
 #undef GONDOLA_HEIGHT
 #undef GONDOLA_COLOR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gondolas exist as a composite of overlays with a null icon_state.

When you put a pet collar on a gondola, it deletes all the existing overlays, rendering the gondola invisible.

I just overrode the regenerate_icons proc to do nothing for gondolas, because the parent proc is utterly useless to us and we don't need its functionality.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Gondolas no longer turn invisible when given a pet collar.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
