### PR TITLE
Fixes infective nanite programs not syncing cloud id

### DIFF
--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -258,6 +258,7 @@
 		//this will potentially take over existing nanites!
 		infectee.AddComponent(/datum/component/nanites, 10)
 		SEND_SIGNAL(infectee, COMSIG_NANITE_SYNC, nanites)
+		SEND_SIGNAL(infectee, COMSIG_NANITE_SET_CLOUD, nanites.cloud_id)
 		infectee.investigate_log("was infected by spreading nanites by [key_name(host_mob)] at [AREACOORD(infectee)].", INVESTIGATE_NANITES)
 
 /datum/nanite_program/nanite_sting
@@ -282,6 +283,7 @@
 		//unlike with Infective Exo-Locomotion, this can't take over existing nanites, because Nanite Sting only targets non-hosts.
 		infectee.AddComponent(/datum/component/nanites, 5)
 		SEND_SIGNAL(infectee, COMSIG_NANITE_SYNC, nanites)
+		SEND_SIGNAL(infectee, COMSIG_NANITE_SET_CLOUD, nanites.cloud_id)
 		infectee.investigate_log("was infected by a nanite cluster by [key_name(host_mob)] at [AREACOORD(infectee)].", INVESTIGATE_NANITES)
 		to_chat(infectee, "<span class='warning'>You feel a tiny prick.</span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I have always meant to have infective programs copy over every property of the infector nanites, and i've only recently noticed from some log diving that this wasn't the case, and cloud IDs were defaulting to 0 (unsynced).
I probably never updated it since i made cloud nanites the default, assuming that the AddComponent handled it on its own.
Since an unsynced cloud ID causes constant software errors, this makes the infective programs much less useful than they're meant to be.

**Note: I'd also love to make the infectee's cloud ID a customizable parameter to allow for a wider range of possible uses, but avoided doing so to not violate the feature freeze. I'd gladly add that part if a maintainer gives the ok.**

## Why It's Good For The Game

Makes Viral Replica not obligatory for anyone who wants to use a spreading nanite program. Without it, the cloud IDs of infectees are defaulted to 0, causing degenerative software errors due to lack of cloud sync, which are likely to ruin any gimmick that involves infecting unsuspecting victims.

## Changelog
:cl: XDTM
fix: Spreading nanite programs (Exo-locomotion and Nanite Sting) now properly transfer the infector's cloud ID to the infectee.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
