### PR TITLE
/obj/effect/spawner -> /atom/movable/spawner

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
@@ -188,12 +188,12 @@
 /turf/open/floor/plasteel/icemoon,
 /area/icemoon/surface/outdoors)
 "aM" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/engine/airless,
 /area/icemoon/surface/outdoors)
 "aN" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/engine/airless,
 /area/icemoon/surface/outdoors)
@@ -216,7 +216,7 @@
 /turf/open/floor/plasteel/icemoon,
 /area/icemoon/surface/outdoors)
 "aQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/icemoon,
 /area/icemoon/surface/outdoors)
 "aR" = (
@@ -677,7 +677,7 @@
 /turf/open/floor/plasteel/icemoon,
 /area/icemoon/surface/outdoors)
 "bR" = (
-/obj/effect/spawner/structure/window/plasma,
+/atom/movable/spawner/structure/window/plasma,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bS" = (
@@ -1085,17 +1085,17 @@
 /turf/open/floor/plasteel/icemoon,
 /area/icemoon/surface/outdoors)
 "cZ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/engine/airless,
 /area/icemoon/surface/outdoors)
 "da" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/brown/visible,
 /turf/open/floor/engine/airless,
 /area/icemoon/surface/outdoors)
 "db" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/engine/airless,
 /area/icemoon/surface/outdoors)

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -1579,7 +1579,7 @@
 "ZA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/structure/curtain,
 /turf/open/floor/plating,
 /area/ruin/powered/beach)

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -393,7 +393,7 @@
 /turf/open/indestructible/permalube,
 /area/ruin/powered/clownplanet)
 "aU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/powered/clownplanet)
 "aV" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
@@ -384,7 +384,7 @@
 /turf/open/floor/pod/dark,
 /area/ruin/powered/snow_biodome)
 "QN" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/ruin/powered/snow_biodome)
 "Sj" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_elephant_graveyard.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_elephant_graveyard.dmm
@@ -159,14 +159,14 @@
 /area/ruin/unpowered/elephant_graveyard)
 "aG" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/glowstick,
+/atom/movable/spawner/lootdrop/glowstick,
 /turf/open/floor/plating/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "aH" = (
 /turf/closed/wall/mineral/titanium,
 /area/ruin/powered/graveyard_shuttle)
 "aI" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/structure/grille,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/powered/graveyard_shuttle)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -164,7 +164,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/ruin/powered)
 "J" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating{
 	initial_gas_mix = "LAVALAND_ATMOS"
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
@@ -57,7 +57,7 @@
 /area/ruin/unpowered)
 "k" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/pizzaparty,
+/atom/movable/spawner/lootdrop/pizzaparty,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{
 	initial_gas_mix = "LAVALAND_ATMOS"
@@ -68,7 +68,7 @@
 	dir = 4
 	},
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/pizzaparty,
+/atom/movable/spawner/lootdrop/pizzaparty,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood{
@@ -153,7 +153,7 @@
 /area/ruin/unpowered)
 "x" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/pizzaparty,
+/atom/movable/spawner/lootdrop/pizzaparty,
 /turf/open/floor/wood{
 	initial_gas_mix = "LAVALAND_ATMOS"
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -185,10 +185,10 @@
 /turf/open/floor/vault,
 /area/ruin/powered/seedvault)
 "aB" = (
-/obj/effect/spawner/lootdrop/seed_vault,
+/atom/movable/spawner/lootdrop/seed_vault,
 /obj/structure/closet/crate/hydroponics,
-/obj/effect/spawner/lootdrop/seed_vault,
-/obj/effect/spawner/lootdrop/seed_vault,
+/atom/movable/spawner/lootdrop/seed_vault,
+/atom/movable/spawner/lootdrop/seed_vault,
 /obj/item/vending_refill/hydronutrients,
 /obj/item/vending_refill/hydroseeds,
 /turf/open/floor/vault,

--- a/_maps/RandomRuins/SpaceRuins/DJstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation.dmm
@@ -21,7 +21,7 @@
 /turf/closed/wall,
 /area/ruin/space/djstation)
 "ag" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/djstation)
 "ah" = (
@@ -72,7 +72,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/space/syndiecosmetic,
+/atom/movable/spawner/lootdrop/space/syndiecosmetic,
 /turf/open/floor/plating,
 /area/ruin/space/djstation)
 "aq" = (
@@ -137,7 +137,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/djstation)
 "aB" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/djstation)
 "aC" = (
@@ -230,7 +230,7 @@
 /area/ruin/space/djstation)
 "aP" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/djstation)
 "aQ" = (

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -42,7 +42,7 @@
 /turf/closed/wall,
 /area/ruin/space/derelict/solar_control)
 "at" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/solar_control)
 "au" = (
@@ -77,7 +77,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
 "aF" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
@@ -165,7 +165,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
 "bc" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -208,7 +208,7 @@
 /area/ruin/space/derelict/bridge/ai_upload)
 "bk" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
 "bl" = (
@@ -281,7 +281,7 @@
 /area/ruin/space/derelict/bridge/ai_upload)
 "bA" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
@@ -321,7 +321,7 @@
 /area/ruin/space/derelict/bridge/ai_upload)
 "bH" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
@@ -427,7 +427,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
 "cb" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged4"
 	},
@@ -519,7 +519,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/access)
 "cA" = (
@@ -529,7 +529,7 @@
 /area/ruin/space/derelict/bridge/access)
 "cB" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/access)
 "cC" = (
@@ -607,11 +607,11 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/access)
 "cT" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/bridge/access)
 "cU" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -637,13 +637,13 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/access)
 "cY" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 10
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/gravity_generator)
 "cZ" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -656,13 +656,13 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/gravity_generator)
 "db" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/gravity_generator)
 "dc" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 5
 	},
 /turf/open/floor/plating/airless,
@@ -671,7 +671,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/derelict/bridge/access)
 "de" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/template_noop)
 "df" = (
@@ -784,7 +784,7 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/gravity_generator)
 "dE" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/template_noop,
 /area/template_noop)
 "dF" = (
@@ -799,7 +799,7 @@
 /area/ruin/space/derelict/bridge)
 "dI" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
@@ -851,7 +851,7 @@
 	},
 /area/ruin/space/derelict/singularity_engine)
 "dQ" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged5"
 	},
@@ -914,7 +914,7 @@
 /area/ruin/space/derelict/singularity_engine)
 "eg" = (
 /obj/structure/window/reinforced,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged4"
 	},
@@ -977,17 +977,17 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "ev" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional,
+/atom/movable/spawner/structure/window/hollow/reinforced/directional,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "ew" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 6
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "ex" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
@@ -1074,7 +1074,7 @@
 /area/ruin/space/derelict/bridge)
 "eQ" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge)
 "eS" = (
@@ -1099,7 +1099,7 @@
 /turf/template_noop,
 /area/template_noop)
 "eW" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 9
 	},
 /turf/open/floor/plating/airless,
@@ -1134,13 +1134,13 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "fc" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "fd" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 5
 	},
 /turf/open/floor/plating/airless,
@@ -1160,7 +1160,7 @@
 	name = "Worn-out APC";
 	pixel_y = -23
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge)
@@ -1174,7 +1174,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge)
 "fj" = (
@@ -1222,7 +1222,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/bridge)
 "fq" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
@@ -1248,7 +1248,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "ft" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -1260,7 +1260,7 @@
 	},
 /area/ruin/space/derelict/singularity_engine)
 "fv" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/bridge/access)
 "fw" = (
@@ -1327,7 +1327,7 @@
 	},
 /area/ruin/space/derelict/singularity_engine)
 "fI" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 10
 	},
 /turf/open/floor/plasteel/airless{
@@ -1349,7 +1349,7 @@
 /area/ruin/space/derelict/bridge/access)
 "fL" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged2"
 	},
@@ -1390,7 +1390,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/bridge/access)
 "fS" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/bridge/access)
 "fT" = (
@@ -1427,7 +1427,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged2"
 	},
@@ -1514,7 +1514,7 @@
 	},
 /area/ruin/space/derelict/singularity_engine)
 "gt" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 9
 	},
 /obj/item/shard{
@@ -1523,7 +1523,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "gw" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
@@ -1556,7 +1556,7 @@
 	},
 /area/ruin/unpowered/no_grav)
 "gE" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -1566,7 +1566,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/primary)
 "gG" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "gH" = (
@@ -1615,7 +1615,7 @@
 	},
 /area/ruin/unpowered/no_grav)
 "gQ" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/airless,
 /area/ruin/unpowered/no_grav)
 "gR" = (
@@ -1632,7 +1632,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "gT" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end,
+/atom/movable/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "gV" = (
@@ -1648,7 +1648,7 @@
 /turf/closed/wall,
 /area/ruin/space/derelict/singularity_engine)
 "gZ" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 10
 	},
 /turf/open/floor/plating/airless,
@@ -1736,7 +1736,7 @@
 /area/ruin/space/derelict/arrival)
 "hs" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/arrival)
 "ht" = (
@@ -1754,11 +1754,11 @@
 /turf/closed/wall,
 /area/ruin/space/derelict/medical)
 "hw" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/medical)
 "hx" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
@@ -1826,7 +1826,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged2"
 	},
@@ -1867,7 +1867,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
@@ -1943,7 +1943,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
@@ -1956,7 +1956,7 @@
 /area/ruin/space/derelict/medical/chapel)
 "ig" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
@@ -1977,7 +1977,7 @@
 /area/ruin/space/derelict/medical)
 "il" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/medical)
 "im" = (
@@ -1989,7 +1989,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "io" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "ip" = (
@@ -2023,7 +2023,7 @@
 /turf/template_noop,
 /area/template_noop)
 "iu" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 6
 	},
 /turf/template_noop,
@@ -2034,7 +2034,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
@@ -2167,7 +2167,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
@@ -2250,7 +2250,7 @@
 /area/ruin/space/derelict/medical)
 "jl" = (
 /obj/structure/closet/wardrobe/genetics_white,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
@@ -2382,11 +2382,11 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/arrival)
 "jJ" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/arrival)
 "jK" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -2448,7 +2448,7 @@
 /area/ruin/unpowered/no_grav)
 "jW" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
@@ -2485,7 +2485,7 @@
 /area/ruin/unpowered/no_grav)
 "ke" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
@@ -2608,17 +2608,17 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "kO" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/primary)
 "kP" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/primary)
 "kQ" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
@@ -2651,7 +2651,7 @@
 /area/ruin/space/derelict/arrival)
 "kW" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "kX" = (
@@ -2677,7 +2677,7 @@
 /area/ruin/space/derelict/hallway/primary)
 "lb" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary/port)
 "lc" = (
@@ -2724,7 +2724,7 @@
 /area/ruin/space/derelict/hallway/primary/port)
 "lk" = (
 /obj/structure/closet/wardrobe/orange,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
@@ -2738,7 +2738,7 @@
 /area/ruin/space/derelict/arrival)
 "lm" = (
 /obj/structure/closet/wardrobe,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
@@ -2754,7 +2754,7 @@
 /area/ruin/space/derelict/hallway/primary)
 "lo" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
@@ -2824,7 +2824,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary/port)
 "lD" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -2894,7 +2894,7 @@
 /area/ruin/space/derelict/hallway/primary/port)
 "lS" = (
 /obj/structure/closet/wardrobe/mixed,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
@@ -2919,11 +2919,11 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/atmospherics)
 "lX" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end,
+/atom/movable/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/primary/port)
 "lY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/arrival)
 "lZ" = (
@@ -3012,7 +3012,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "mn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "mo" = (
@@ -3102,7 +3102,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "mD" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -3119,7 +3119,7 @@
 	},
 /area/ruin/space/derelict/atmospherics)
 "mH" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged2"
 	},
@@ -3148,7 +3148,7 @@
 	},
 /area/ruin/space/derelict/atmospherics)
 "mO" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/template_noop,
 /area/ruin/space/derelict/hallway/primary/port)
 "mP" = (
@@ -3157,14 +3157,14 @@
 /area/ruin/space/derelict/atmospherics)
 "mQ" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 8;
 	name = "8maintenance loot spawner"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/atmospherics)
 "mR" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/primary)
 "mT" = (
@@ -3197,7 +3197,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "mY" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
@@ -3332,15 +3332,15 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "ny" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional,
+/atom/movable/spawner/structure/window/hollow/reinforced/directional,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "nz" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "nA" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end,
+/atom/movable/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "nB" = (
@@ -3362,7 +3362,7 @@
 /area/ruin/space/derelict/hallway/secondary)
 "nE" = (
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "nF" = (
@@ -3375,7 +3375,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "nH" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
@@ -3389,7 +3389,7 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/se_solar)
 "nM" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/se_solar)
 "nN" = (
@@ -3666,7 +3666,7 @@
 	},
 /area/template_noop)
 "ES" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -3817,7 +3817,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/atmospherics)
 "Qt" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /obj/structure/grille,
 /turf/open/floor/plating/airless,

--- a/_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
@@ -36,13 +36,13 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/abandoned_tele)
 "j" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/abandoned_tele)
 "k" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -60,7 +60,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/abandoned_tele)
 "o" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plating/airless,
 /area/ruin/space/abandoned_tele)
 "p" = (

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -8,12 +8,12 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
 "ac" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/abandonedzoo)
 "ag" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/abandonedzoo)
 "ah" = (
@@ -247,7 +247,7 @@
 	},
 /obj/structure/rack,
 /obj/item/melee/baton/cattleprod,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -187,7 +187,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
 "aK" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost)
 "aL" = (
@@ -787,7 +787,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
 "cc" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "cd" = (
@@ -1877,7 +1877,7 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/effect/spawner/lootdrop/space/fancytool,
+/atom/movable/spawner/lootdrop/space/fancytool,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargostorage)
 "er" = (
@@ -1959,7 +1959,7 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/delivery,
-/obj/effect/spawner/lootdrop/space/fancytech,
+/atom/movable/spawner/lootdrop/space/fancytech,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargostorage)
 "eC" = (

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -387,7 +387,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter3)
 "gd" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/caravan/freighter3)
 "gk" = (
@@ -588,7 +588,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter2)
 "ht" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/caravan/freighter2)
 "hu" = (
@@ -618,8 +618,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/secure/engineering,
-/obj/effect/spawner/lootdrop/space/fancytech,
-/obj/effect/spawner/lootdrop/space/fancytech,
+/atom/movable/spawner/lootdrop/space/fancytech,
+/atom/movable/spawner/lootdrop/space/fancytech,
 /turf/open/floor/plasteel/airless/dark,
 /area/shuttle/caravan/freighter3)
 "hy" = (
@@ -694,8 +694,8 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/secure,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
+/atom/movable/spawner/lootdrop/space/cashmoney,
+/atom/movable/spawner/lootdrop/space/cashmoney,
 /turf/open/floor/plasteel/airless/dark,
 /area/shuttle/caravan/freighter2)
 "hX" = (
@@ -744,8 +744,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/secure/engineering,
-/obj/effect/spawner/lootdrop/space/fancytech,
-/obj/effect/spawner/lootdrop/space/fancytech,
+/atom/movable/spawner/lootdrop/space/fancytech,
+/atom/movable/spawner/lootdrop/space/fancytech,
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter3)
 "ic" = (

--- a/_maps/RandomRuins/SpaceRuins/crashedclownship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedclownship.dmm
@@ -48,7 +48,7 @@
 	},
 /obj/item/clothing/shoes/clown_shoes/banana_shoes,
 /obj/item/gps/spaceruin,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -31,7 +31,7 @@
 /turf/open/floor/plating,
 /area/awaymission/bmpship/aft)
 "aj" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -49,7 +49,7 @@
 /area/template_noop)
 "an" = (
 /obj/structure/window/reinforced,
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -259,7 +259,7 @@
 /turf/open/floor/plating,
 /area/awaymission/bmpship/aft)
 "bl" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -297,7 +297,7 @@
 /area/awaymission/bmpship/aft)
 "bt" = (
 /obj/structure/window/reinforced,
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -827,7 +827,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/space/rareseed,
+/atom/movable/spawner/lootdrop/space/rareseed,
 /turf/open/floor/plasteel,
 /area/awaymission/bmpship/midship)
 "dg" = (
@@ -923,7 +923,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/bmpship/aft)
 "dG" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -1060,14 +1060,14 @@
 /turf/open/floor/plating,
 /area/awaymission/bmpship/aft)
 "ed" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/awaymission/bmpship/fore)
 "ee" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/space/fancytech,
+/atom/movable/spawner/lootdrop/space/fancytech,
 /turf/open/floor/carpet,
 /area/awaymission/bmpship/fore)
 "ef" = (
@@ -1224,7 +1224,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -1265,7 +1265,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/space/fancytech,
+/atom/movable/spawner/lootdrop/space/fancytech,
 /turf/open/floor/plasteel,
 /area/awaymission/bmpship/aft)
 "eS" = (
@@ -1622,7 +1622,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/bmpship/aft)
 "gk" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
@@ -1689,7 +1689,7 @@
 /turf/open/floor/plating/airless,
 /area/awaymission/bmpship/midship)
 "gz" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /turf/open/floor/plasteel,
 /area/awaymission/bmpship/aft)
 "gA" = (
@@ -1709,7 +1709,7 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/awaymission/bmpship)
 "gF" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 4
 	},
 /obj/item/shard{
@@ -1767,7 +1767,7 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/awaymission/bmpship)
 "gR" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 6
 	},
 /turf/open/floor/plating/airless,
@@ -1842,7 +1842,7 @@
 /area/awaymission/bmpship/midship)
 "hk" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/space/cashmoney,
+/atom/movable/spawner/lootdrop/space/cashmoney,
 /turf/open/floor/plasteel,
 /area/awaymission/bmpship/aft)
 "hl" = (
@@ -1854,7 +1854,7 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/awaymission/bmpship)
 "ho" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -1882,7 +1882,7 @@
 /turf/closed/wall/mineral/titanium/interior,
 /area/awaymission/bmpship/aft)
 "hu" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end,
+/atom/movable/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/engine,
 /area/awaymission/bmpship/aft)
 "hv" = (
@@ -1913,7 +1913,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/space/rareseed,
+/atom/movable/spawner/lootdrop/space/rareseed,
 /turf/open/floor/plasteel,
 /area/awaymission/bmpship/midship)
 "EQ" = (
@@ -1928,7 +1928,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/space/rareseed,
+/atom/movable/spawner/lootdrop/space/rareseed,
 /turf/open/floor/plasteel,
 /area/awaymission/bmpship/midship)
 "Hy" = (

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -345,8 +345,8 @@
 /obj/structure/closet/cardboard,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/space/languagebook,
-/obj/effect/spawner/lootdrop/space/languagebook,
+/atom/movable/spawner/lootdrop/space/languagebook,
+/atom/movable/spawner/lootdrop/space/languagebook,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aX" = (
@@ -431,7 +431,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "bh" = (
@@ -576,7 +576,7 @@
 /area/ruin/space/has_grav/deepstorage)
 "bA" = (
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "bB" = (
@@ -795,8 +795,8 @@
 /area/ruin/space/has_grav/deepstorage)
 "cd" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/space/rareseed,
-/obj/effect/spawner/lootdrop/space/rareseed,
+/atom/movable/spawner/lootdrop/space/rareseed,
+/atom/movable/spawner/lootdrop/space/rareseed,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "cf" = (
@@ -949,7 +949,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "cw" = (
@@ -1151,7 +1151,7 @@
 /area/ruin/space/has_grav/deepstorage/storage)
 "cR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage)
@@ -1221,7 +1221,7 @@
 /area/ruin/space/has_grav/deepstorage)
 "da" = (
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/armory)
@@ -1272,7 +1272,7 @@
 /area/ruin/space/has_grav/deepstorage/storage)
 "dh" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage)
@@ -1745,7 +1745,7 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
-/obj/effect/spawner/lootdrop/space/fancytool,
+/atom/movable/spawner/lootdrop/space/fancytool,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "ey" = (
@@ -1955,7 +1955,7 @@
 	id = "bunkershutter"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/airlock)
@@ -2205,7 +2205,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "fC" = (
@@ -2270,7 +2270,7 @@
 /area/ruin/space/has_grav/deepstorage/power)
 "fK" = (
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "fL" = (
@@ -2416,7 +2416,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "gd" = (
@@ -2851,7 +2851,7 @@
 /area/ruin/space/has_grav/deepstorage/power)
 "hq" = (
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},

--- a/_maps/RandomRuins/SpaceRuins/derelict2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict2.dmm
@@ -31,7 +31,7 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/powered/dinner_for_two)
 "g" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/dinner_for_two)
 "h" = (

--- a/_maps/RandomRuins/SpaceRuins/derelict4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict4.dmm
@@ -36,7 +36,7 @@
 /turf/open/floor/mineral/titanium/blue/airless,
 /area/ruin/unpowered)
 "k" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /turf/open/floor/mineral/titanium/blue/airless,
 /area/ruin/unpowered)
 "l" = (

--- a/_maps/RandomRuins/SpaceRuins/derelict5.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict5.dmm
@@ -25,7 +25,7 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "i" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "j" = (
@@ -40,7 +40,7 @@
 /area/ruin/unpowered)
 "l" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "m" = (

--- a/_maps/RandomRuins/SpaceRuins/emptyshell.dmm
+++ b/_maps/RandomRuins/SpaceRuins/emptyshell.dmm
@@ -13,7 +13,7 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "e" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "f" = (
@@ -21,7 +21,7 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "g" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "h" = (
@@ -36,7 +36,7 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "k" = (
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
@@ -47,7 +47,7 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "m" = (
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 4;
 	name = "4maintenance loot spawner"
 	},

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -179,7 +179,7 @@
 	req_one_access_txt = "150";
 	secure = 1
 	},
-/obj/effect/spawner/lootdrop/armory_contraband/metastation,
+/atom/movable/spawner/lootdrop/armory_contraband/metastation,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "aF" = (
@@ -1201,7 +1201,7 @@
 /obj/structure/closet/crate/secure/gear{
 	req_one_access_txt = "150"
 	},
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "dl" = (
@@ -1259,8 +1259,8 @@
 /obj/structure/closet/crate/secure/gear{
 	req_one_access_txt = "150"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "dr" = (
@@ -1272,7 +1272,7 @@
 /obj/structure/closet/crate/secure/gear{
 	req_one_access_txt = "150"
 	},
-/obj/effect/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/costume,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "dt" = (

--- a/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
@@ -501,12 +501,12 @@
 "bz" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/space/cashmoney,
+/atom/movable/spawner/lootdrop/space/cashmoney,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hellfactory)
 "bA" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/space/languagebook,
+/atom/movable/spawner/lootdrop/space/languagebook,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hellfactory)
 "bB" = (
@@ -604,7 +604,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/space/languagebook,
+/atom/movable/spawner/lootdrop/space/languagebook,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bP" = (
@@ -738,7 +738,7 @@
 /area/ruin/space/has_grav/hellfactory)
 "cj" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/space/material,
+/atom/movable/spawner/lootdrop/space/material,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hellfactory)
 "ck" = (
@@ -988,7 +988,7 @@
 /obj/structure/rack,
 /obj/item/stack/wrapping_paper,
 /obj/item/stack/package_wrap,
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hellfactory)
 "oH" = (

--- a/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -77,7 +77,7 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/space/has_grav/powered/authorship)
 "p" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/authorship)
 "r" = (

--- a/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/titanium/overspace,
 /area/ruin/space/has_grav/powered/mechtransport)
 "c" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/mechtransport)
 "d" = (

--- a/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
@@ -249,7 +249,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/cat_man)
 "aP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "meow";
 	name = "kitty protection door"
@@ -337,7 +337,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "aZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "ba" = (
@@ -794,7 +794,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "ck" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},

--- a/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
@@ -121,7 +121,7 @@
 /turf/template_noop,
 /area/template_noop)
 "ay" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plasteel/airless,
 /area/tcommsat/oldaisat)
 "az" = (
@@ -439,23 +439,23 @@
 /turf/open/floor/plasteel/airless/dark,
 /area/tcommsat/oldaisat)
 "bA" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/tcommsat/oldaisat)
 "bB" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/tcommsat/oldaisat)
 "bC" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating/airless,
 /area/tcommsat/oldaisat)
 "bD" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -506,17 +506,17 @@
 /turf/open/floor/plasteel/airless/dark,
 /area/tcommsat/oldaisat)
 "bK" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/tcommsat/oldaisat)
 "bL" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
 /area/tcommsat/oldaisat)
 "bM" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -538,7 +538,7 @@
 /turf/open/floor/plasteel/airless/dark,
 /area/tcommsat/oldaisat)
 "bP" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -553,7 +553,7 @@
 /turf/open/floor/plasteel/airless/dark,
 /area/tcommsat/oldaisat)
 "bS" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
@@ -611,7 +611,7 @@
 /turf/open/floor/plasteel/airless/dark,
 /area/tcommsat/oldaisat)
 "cc" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -636,7 +636,7 @@
 /turf/open/floor/plasteel/airless/dark,
 /area/tcommsat/oldaisat)
 "ch" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -760,7 +760,7 @@
 /turf/template_noop,
 /area/template_noop)
 "cB" = (
-/obj/effect/spawner/structure/window/hollow/reinforced,
+/atom/movable/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/oldaisat)
 "cC" = (
@@ -898,12 +898,12 @@
 /area/tcommsat/oldaisat)
 "jZ" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/space/fancytech,
+/atom/movable/spawner/lootdrop/space/fancytech,
 /turf/open/floor/plasteel/airless,
 /area/tcommsat/oldaisat)
 "AX" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/spawner/lootdrop/space/fancytool,
+/atom/movable/spawner/lootdrop/space/fancytool,
 /turf/open/floor/plasteel/airless/dark,
 /area/tcommsat/oldaisat)
 

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -47,7 +47,7 @@
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/ancientstation/comm)
 "al" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 8
 	},
 /obj/machinery/door/poddoor{
@@ -56,14 +56,14 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/comm)
 "am" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /obj/machinery/door/poddoor{
 	id = "ancient"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/comm)
 "an" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /obj/machinery/door/poddoor{
@@ -366,7 +366,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
 "aZ" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -504,7 +504,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/ancientstation/medbay)
 "br" = (
-/obj/effect/spawner/structure/window/hollow/reinforced,
+/atom/movable/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006;
 	icon_state = "platingdmg1"
@@ -587,7 +587,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/ancientstation/deltaai)
 "bB" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 8
 	},
 /obj/structure/cable,
@@ -636,11 +636,11 @@
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
 "bK" = (
-/obj/effect/spawner/structure/window/hollow/reinforced,
+/atom/movable/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
 "bL" = (
-/obj/effect/spawner/structure/window/hollow/reinforced,
+/atom/movable/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
 "bM" = (
@@ -739,7 +739,7 @@
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/ancientstation)
 "bY" = (
-/obj/effect/spawner/structure/window/hollow/reinforced,
+/atom/movable/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "bZ" = (
@@ -1041,7 +1041,7 @@
 	},
 /area/ruin/space/has_grav/ancientstation/betastorage)
 "cM" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -1076,17 +1076,17 @@
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "cR" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "cS" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "cT" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -1405,7 +1405,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "dK" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -1448,7 +1448,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "dP" = (
-/obj/effect/spawner/structure/window/hollow/reinforced,
+/atom/movable/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "dQ" = (
@@ -1987,7 +1987,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation/rnd)
 "fb" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -2161,17 +2161,17 @@
 	},
 /area/ruin/space/has_grav/ancientstation/betastorage)
 "fB" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "fC" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "fD" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -2333,19 +2333,19 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/ancientstation/mining)
 "gb" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/mining)
 "gc" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 6
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/mining)
 "gd" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
@@ -2370,7 +2370,7 @@
 	},
 /area/ruin/space/has_grav/ancientstation/atmo)
 "gg" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -2432,7 +2432,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
 "gn" = (
-/obj/effect/spawner/structure/window/hollow/reinforced,
+/atom/movable/spawner/structure/window/hollow/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -2566,7 +2566,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation)
 "gA" = (
-/obj/effect/spawner/structure/window/hollow/reinforced,
+/atom/movable/spawner/structure/window/hollow/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -2592,7 +2592,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/sec)
 "gC" = (
-/obj/effect/spawner/structure/window/hollow/reinforced,
+/atom/movable/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/sec)
 "gD" = (
@@ -2650,7 +2650,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/ancientstation/atmo)
 "gL" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -2720,7 +2720,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/ancientstation/betastorage)
 "gV" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -2772,19 +2772,19 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "hf" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/rnd)
 "hg" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/rnd)
 "hh" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2808,7 +2808,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation)
 "hk" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end,
+/atom/movable/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "hl" = (
@@ -3109,7 +3109,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/engi)
 "hR" = (
-/obj/effect/spawner/structure/window/hollow/reinforced,
+/atom/movable/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "hS" = (
@@ -3745,7 +3745,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/rnd)
 "iT" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/mining)
 "iU" = (
@@ -3776,17 +3776,17 @@
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/ancientstation/engi)
 "iY" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "iZ" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "ja" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -4194,13 +4194,13 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
 "jS" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
 "jT" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -4762,13 +4762,13 @@
 /turf/closed/mineral/plasma,
 /area/ruin/unpowered)
 "li" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/proto)
 "lj" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -5255,17 +5255,17 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/ancientstation/medbay)
 "mv" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
 "mw" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
 "mx" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -5314,7 +5314,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/mining)
 "mF" = (
-/obj/effect/spawner/structure/window/hollow/reinforced,
+/atom/movable/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/mining)
 "mG" = (
@@ -6636,7 +6636,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "qJ" = (
-/obj/effect/spawner/structure/window/hollow/reinforced,
+/atom/movable/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/medbay)
 "rg" = (
@@ -6793,7 +6793,7 @@
 /area/ruin/space/has_grav/ancientstation/engi)
 "xl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
 "xP" = (
@@ -6893,7 +6893,7 @@
 /turf/closed/mineral/plasma,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
 "AF" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "AK" = (
@@ -7019,7 +7019,7 @@
 /area/ruin/space/has_grav/ancientstation/betacorridor)
 "GG" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "GP" = (
@@ -7135,7 +7135,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation)
 "Ky" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/ancientstation/betastorage)
 "KF" = (
@@ -7223,7 +7223,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/ancientstation/atmo)
 "Mt" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end,
+/atom/movable/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/atmo)
 "MG" = (
@@ -7492,7 +7492,7 @@
 /turf/template_noop,
 /area/template_noop)
 "Tk" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -7545,7 +7545,7 @@
 /area/ruin/space/has_grav/ancientstation/atmo)
 "Ve" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "Vm" = (

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -20,7 +20,7 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/onehalf/dorms_med)
 "ah" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/onehalf/dorms_med)
 "aj" = (
@@ -142,9 +142,9 @@
 	dir = 8
 	},
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/space/syndiecosmetic,
-/obj/effect/spawner/lootdrop/space/syndiecosmetic,
-/obj/effect/spawner/lootdrop/space/syndiecosmetic,
+/atom/movable/spawner/lootdrop/space/syndiecosmetic,
+/atom/movable/spawner/lootdrop/space/syndiecosmetic,
+/atom/movable/spawner/lootdrop/space/syndiecosmetic,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/dorms_med)
 "aD" = (
@@ -369,7 +369,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/drone_bay)
 "be" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/onehalf/drone_bay)
 "bf" = (
@@ -663,7 +663,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/onehalf/hallway)
 "bZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge_onehalf";
 	name = "bridge blast door"
@@ -707,7 +707,7 @@
 /area/ruin/space/has_grav/onehalf/bridge)
 "cg" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/space/cashmoney,
+/atom/movable/spawner/lootdrop/space/cashmoney,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/bridge)
 "ch" = (
@@ -741,7 +741,7 @@
 /turf/template_noop,
 /area/template_noop)
 "ck" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -778,11 +778,11 @@
 /area/ruin/space/has_grav/onehalf/bridge)
 "cp" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/space/fancytech,
+/atom/movable/spawner/lootdrop/space/fancytech,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/bridge)
 "cq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge_onehalf";
 	name = "bridge blast door"
@@ -917,7 +917,7 @@
 	},
 /area/ruin/space/has_grav/onehalf/hallway)
 "cQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/onehalf/hallway)
 "cR" = (

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -32,28 +32,28 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel/guestroom/room_3)
 "ao" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/guestroom/room_3)
 "ap" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel/guestroom/room_4)
 "aq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/guestroom/room_4)
 "ar" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel/guestroom/room_5)
 "as" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/guestroom/room_5)
 "at" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel/guestroom/room_6)
 "au" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/guestroom/room_6)
 "av" = (
@@ -742,7 +742,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "cG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
@@ -1165,7 +1165,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/hotel/workroom)
 "ec" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/workroom)
@@ -1559,7 +1559,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel/dock)
 "fv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/dock)
@@ -2973,7 +2973,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel/pool)
 "jv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3170,7 +3170,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)
 "jS" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)
 "jT" = (
@@ -3208,7 +3208,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)
 "ka" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)
@@ -3266,7 +3266,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/security)
 "km" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/security)
 "kn" = (
@@ -4471,7 +4471,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)
 "mN" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/pool)

--- a/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -89,7 +89,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/space/syndiecosmetic,
+/atom/movable/spawner/lootdrop/space/syndiecosmetic,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/turretedoutpost)
 "at" = (
@@ -236,7 +236,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/space/syndiecosmetic,
+/atom/movable/spawner/lootdrop/space/syndiecosmetic,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/turretedoutpost)
 "aM" = (
@@ -340,7 +340,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/space/syndiecosmetic,
+/atom/movable/spawner/lootdrop/space/syndiecosmetic,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/turretedoutpost)
 "aZ" = (
@@ -349,7 +349,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/space/syndiecosmetic,
+/atom/movable/spawner/lootdrop/space/syndiecosmetic,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/turretedoutpost)
 "ba" = (

--- a/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
+++ b/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
@@ -213,7 +213,7 @@
 /area/ruin/space/has_grav/powered/aesthetic)
 "Q" = (
 /obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/space/fancytech,
+/atom/movable/spawner/lootdrop/space/fancytech,
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered/no_grav)
 "R" = (

--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
@@ -35,7 +35,7 @@
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
 "gO" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/whiteship/box)
 "hT" = (

--- a/_maps/RandomZLevels/Academy.dmm
+++ b/_maps/RandomZLevels/Academy.dmm
@@ -443,7 +443,7 @@
 /turf/open/floor/plasteel/dark,
 /area/awaymission/academy/headmaster)
 "bR" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/awaymission/academy/headmaster)
@@ -1066,7 +1066,7 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/academy/classrooms)
 "es" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/academy/classrooms)
 "et" = (
@@ -2289,7 +2289,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/academy/academyaft)
 "iT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/awaymission/academy/academyaft)
@@ -2578,7 +2578,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/academy/academyaft)
 "jP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/academy/academyaft)
 "jQ" = (
@@ -2610,7 +2610,7 @@
 /turf/open/floor/carpet,
 /area/awaymission/academy/academygate)
 "jX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/academy/academygate)
 "jY" = (
@@ -2783,7 +2783,7 @@
 /turf/open/floor/engine/cult,
 /area/awaymission/academy/academycellar)
 "kV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/engine/cult,
 /area/awaymission/academy/academycellar)
 "kW" = (
@@ -3366,7 +3366,7 @@
 /turf/open/floor/carpet,
 /area/awaymission/academy/academyaft)
 "CD" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/awaymission/academy/classrooms)

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -621,7 +621,7 @@
 	},
 /area/awaymission/caves/bmp_asteroid)
 "ca" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	initial_gas_mix = "n2=23;o2=14"
 	},
@@ -693,7 +693,7 @@
 	},
 /area/awaymission/caves/bmp_asteroid/level_two)
 "cl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	initial_gas_mix = "n2=23;o2=14"
 	},
@@ -822,7 +822,7 @@
 	},
 /area/awaymission/caves/research)
 "cF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	initial_gas_mix = "n2=23;o2=14"
 	},
@@ -1047,7 +1047,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/caves/bmp_asteroid/level_two)
 "dl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/caves/bmp_asteroid/level_two)
 "dm" = (
@@ -1587,7 +1587,7 @@
 	},
 /area/awaymission/caves/bmp_asteroid)
 "fh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/caves/listeningpost)
 "fi" = (
@@ -1751,7 +1751,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/caves/bmp_asteroid)
 "fH" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/caves/bmp_asteroid)
 "fI" = (

--- a/_maps/RandomZLevels/challenge.dmm
+++ b/_maps/RandomZLevels/challenge.dmm
@@ -242,13 +242,13 @@
 /turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "aY" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "aZ" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -450,7 +450,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/challenge/main)
 "bA" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "bB" = (
@@ -861,23 +861,23 @@
 /turf/open/space,
 /area/space/nearstation)
 "cM" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/awaymission/challenge/end)
 "cN" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
 /area/awaymission/challenge/end)
 "cO" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 5
 	},
 /turf/open/floor/plating,
 /area/awaymission/challenge/end)
 "cP" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -918,7 +918,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "de" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end,
+/atom/movable/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating,
 /area/awaymission/challenge/end)
 "df" = (
@@ -967,7 +967,7 @@
 /turf/open/floor/plasteel/dark,
 /area/awaymission/challenge/end)
 "dl" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /turf/open/floor/plating,

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -732,7 +732,7 @@
 	},
 /area/awaymission/moonoutpost19/syndicate)
 "bP" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -1018,7 +1018,7 @@
 	},
 /area/awaymission/moonoutpost19/syndicate)
 "cn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -1947,7 +1947,7 @@
 	layer = 2.9;
 	name = "Acid-Proof biohazard containment door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -2108,7 +2108,7 @@
 	id = "Awaylab";
 	name = "Acid-Proof containment chamber blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -2683,7 +2683,7 @@
 	},
 /area/awaymission/moonoutpost19/research)
 "fV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -2903,7 +2903,7 @@
 	id = "Awaylab";
 	name = "Acid-Proof containment chamber blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -3431,7 +3431,7 @@
 	layer = 2.9;
 	name = "privacy shutter"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -3876,7 +3876,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "io" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -4481,7 +4481,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "jA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006;
 	icon_state = "platingdmg1";
@@ -4497,7 +4497,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "jC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251"
@@ -4574,7 +4574,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "jM" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -5421,7 +5421,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "lA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/moonoutpost19/arrivals)
 "lD" = (
@@ -5757,7 +5757,7 @@
 	desc = "A warning sign which reads 'HOSTILE ATMOSPHERE AHEAD'";
 	name = "\improper HOSTILE ATMOSPHERE AHEAD"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -5812,7 +5812,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "mB" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/moonoutpost19/arrivals)
 "mC" = (
@@ -6473,7 +6473,7 @@
 /area/awaymission/moonoutpost19/arrivals)
 "nV" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -153,7 +153,7 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/research/interior/engineering)
 "aC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/engineering)
 "aD" = (
@@ -1760,7 +1760,7 @@
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/secure)
 "dY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/research/interior)
 "dZ" = (
@@ -1793,8 +1793,8 @@
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
 "ef" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
@@ -2054,7 +2054,7 @@
 /area/awaymission/research/interior/maint)
 "eG" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
 "eH" = (
@@ -3498,7 +3498,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/research/interior/security)
 "hF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/security)
@@ -3704,14 +3704,14 @@
 /area/awaymission/research/interior/genetics)
 "hX" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
 "hY" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
 "hZ" = (
@@ -4541,7 +4541,7 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/research/interior/medbay)
 "jR" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/medbay)
 "jS" = (
@@ -4854,7 +4854,7 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/research/interior/medbay)
 "kB" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/medbay)
 "kC" = (
@@ -5399,7 +5399,7 @@
 /turf/open/floor/wood,
 /area/awaymission/research/interior/dorm)
 "lU" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 4
 	},
@@ -5486,7 +5486,7 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/research/interior/escapepods)
 "mk" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -5835,7 +5835,7 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/research/interior/escapepods)
 "mY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/escapepods)
 "mZ" = (

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -2573,7 +2573,7 @@
 /obj/structure/fireaxecabinet{
 	pixel_y = -32
 	},
-/obj/effect/spawner/lootdrop/snowdin/dungeonmisc,
+/atom/movable/spawner/lootdrop/snowdin/dungeonmisc,
 /turf/open/floor/wood,
 /area/awaymission/snowdin/outside)
 "gb" = (
@@ -2588,7 +2588,7 @@
 	},
 /area/awaymission/snowdin/cave/cavern)
 "gd" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "o2=0;n2=82;plasma=24;TEMP=120";
 	temperature = 120
@@ -2599,7 +2599,7 @@
 /area/awaymission/snowdin/cave/cavern)
 "gf" = (
 /obj/structure/closet/crate/wooden,
-/obj/effect/spawner/lootdrop/snowdin/dungeonheavy,
+/atom/movable/spawner/lootdrop/snowdin/dungeonheavy,
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "o2=0;n2=82;plasma=24;TEMP=120";
 	temperature = 120
@@ -3160,7 +3160,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/awaymission/snowdin/post/messhall)
 "hv" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/messhall)
@@ -3302,7 +3302,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/dorm)
 "hM" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post)
@@ -3471,7 +3471,7 @@
 /area/awaymission/snowdin/cave)
 "il" = (
 /obj/structure/closet/crate/wooden,
-/obj/effect/spawner/lootdrop/snowdin/dungeonmid,
+/atom/movable/spawner/lootdrop/snowdin/dungeonmid,
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "o2=0;n2=82;plasma=24;TEMP=120";
 	temperature = 120
@@ -4220,7 +4220,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/garage)
 "jH" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
 "jI" = (
@@ -4258,7 +4258,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
 "jN" = (
-/obj/effect/spawner/lootdrop/snowdin/dungeonmisc,
+/atom/movable/spawner/lootdrop/snowdin/dungeonmisc,
 /turf/open/floor/plating/asteroid/snow,
 /area/awaymission/snowdin/outside)
 "jO" = (
@@ -5312,7 +5312,7 @@
 /area/awaymission/snowdin/outside)
 "lT" = (
 /obj/structure/closet/crate/wooden,
-/obj/effect/spawner/lootdrop/snowdin/dungeonlite,
+/atom/movable/spawner/lootdrop/snowdin/dungeonlite,
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "o2=0;n2=82;plasma=24;TEMP=120";
 	temperature = 120
@@ -5580,7 +5580,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
 "mz" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
 "mA" = (
@@ -5675,7 +5675,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post)
 "mO" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/messhall)
@@ -6067,7 +6067,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/secpost)
 "nH" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/secpost)
@@ -6187,7 +6187,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/hydro)
 "nY" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/hydro)
@@ -6516,7 +6516,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/secpost)
 "oH" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/secpost)
 "oI" = (
@@ -7585,16 +7585,16 @@
 /turf/closed/wall/r_wall,
 /area/awaymission/snowdin/post/engineering)
 "rs" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/engineering)
 "rt" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/engineering)
 "ru" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/engineering)
@@ -7627,7 +7627,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/cavern2)
 "rA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -8312,7 +8312,7 @@
 /area/awaymission/snowdin/outside)
 "ts" = (
 /obj/structure/closet/crate/wooden,
-/obj/effect/spawner/lootdrop/snowdin/dungeonheavy,
+/atom/movable/spawner/lootdrop/snowdin/dungeonheavy,
 /turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
 "tt" = (
@@ -8320,7 +8320,7 @@
 /turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
 "tu" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
 "tv" = (
@@ -8329,7 +8329,7 @@
 /area/awaymission/snowdin/cave/cavern)
 "tw" = (
 /obj/structure/closet/crate/wooden,
-/obj/effect/spawner/lootdrop/snowdin/dungeonmid,
+/atom/movable/spawner/lootdrop/snowdin/dungeonmid,
 /turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
 "tx" = (
@@ -8363,7 +8363,7 @@
 /area/awaymission/snowdin/outside)
 "tD" = (
 /obj/structure/closet/crate/wooden,
-/obj/effect/spawner/lootdrop/snowdin/dungeonlite,
+/atom/movable/spawner/lootdrop/snowdin/dungeonlite,
 /turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
 "tE" = (
@@ -8399,7 +8399,7 @@
 /turf/open/floor/plating/ice/smooth,
 /area/awaymission/snowdin/outside)
 "tO" = (
-/obj/effect/spawner/lootdrop/snowdin/dungeonmid,
+/atom/movable/spawner/lootdrop/snowdin/dungeonmid,
 /turf/open/floor/plating/asteroid/snow/ice,
 /area/awaymission/snowdin/cave/cavern)
 "tP" = (
@@ -8493,7 +8493,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 1;
@@ -8812,7 +8812,7 @@
 /turf/open/floor/plating/asteroid/snow/ice,
 /area/awaymission/snowdin/cave/cavern)
 "vn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -8955,11 +8955,11 @@
 /turf/closed/wall/mineral/titanium,
 /area/awaymission/snowdin/post/broken_shuttle)
 "vM" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/broken_shuttle)
 "vN" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/effect/baseturf_helper/asteroid/snow,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/broken_shuttle)
@@ -9136,7 +9136,7 @@
 /area/awaymission/snowdin/cave)
 "wn" = (
 /obj/structure/closet/crate/wooden,
-/obj/effect/spawner/lootdrop/snowdin/dungeonlite,
+/atom/movable/spawner/lootdrop/snowdin/dungeonlite,
 /turf/open/floor/plating/asteroid/snow{
 	floor_variance = 0;
 	icon_state = "snow_dug";
@@ -9169,17 +9169,17 @@
 /area/awaymission/snowdin/cave)
 "wr" = (
 /obj/structure/closet/crate/wooden,
-/obj/effect/spawner/lootdrop/snowdin/dungeonlite,
+/atom/movable/spawner/lootdrop/snowdin/dungeonlite,
 /turf/open/floor/plating/asteroid/snow,
 /area/awaymission/snowdin/cave)
 "ws" = (
 /obj/structure/closet/crate/wooden,
-/obj/effect/spawner/lootdrop/snowdin/dungeonlite,
+/atom/movable/spawner/lootdrop/snowdin/dungeonlite,
 /turf/open/floor/plating/ice/smooth,
 /area/awaymission/snowdin/cave)
 "wt" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/snowdin/dungeonmisc,
+/atom/movable/spawner/lootdrop/snowdin/dungeonmisc,
 /turf/open/floor/plating/asteroid/snow{
 	floor_variance = 0;
 	icon_state = "snow_dug";
@@ -9501,11 +9501,11 @@
 /obj/machinery/light/broken{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_dock)
 "xr" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -9542,7 +9542,7 @@
 /turf/open/floor/engine/cult,
 /area/awaymission/snowdin/post/mining_dock)
 "xx" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -9790,7 +9790,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/mining_dock)
 "xY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_dock)
@@ -10260,7 +10260,7 @@
 /turf/open/lava/plasma,
 /area/awaymission/snowdin/cave/cavern)
 "zm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -10459,8 +10459,8 @@
 /area/awaymission/snowdin/outside)
 "zP" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/snowdin/dungeonmisc,
-/obj/effect/spawner/lootdrop/snowdin/dungeonmisc,
+/atom/movable/spawner/lootdrop/snowdin/dungeonmisc,
+/atom/movable/spawner/lootdrop/snowdin/dungeonmisc,
 /turf/open/floor/wood,
 /area/awaymission/snowdin/igloo)
 "zQ" = (
@@ -10848,13 +10848,13 @@
 /area/awaymission/snowdin/cave)
 "AU" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/snowdin/dungeonlite,
-/obj/effect/spawner/lootdrop/snowdin/dungeonlite,
+/atom/movable/spawner/lootdrop/snowdin/dungeonlite,
+/atom/movable/spawner/lootdrop/snowdin/dungeonlite,
 /turf/open/floor/wood,
 /area/awaymission/snowdin/igloo)
 "AV" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/snowdin/dungeonlite,
+/atom/movable/spawner/lootdrop/snowdin/dungeonlite,
 /turf/open/floor/wood,
 /area/awaymission/snowdin/igloo)
 "AW" = (
@@ -12049,7 +12049,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/awaymission/snowdin/cave)
 "DT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/cave)
 "DU" = (
@@ -12249,8 +12249,8 @@
 /area/awaymission/snowdin/cave)
 "Er" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/snowdin/dungeonlite,
-/obj/effect/spawner/lootdrop/snowdin/dungeonlite,
+/atom/movable/spawner/lootdrop/snowdin/dungeonlite,
+/atom/movable/spawner/lootdrop/snowdin/dungeonlite,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -12322,7 +12322,7 @@
 "Ex" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
-/obj/effect/spawner/lootdrop/snowdin/dungeonlite,
+/atom/movable/spawner/lootdrop/snowdin/dungeonlite,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -13080,7 +13080,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/mining_main/robotics)
 "GC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_main/robotics)
@@ -13288,7 +13288,7 @@
 /turf/closed/wall,
 /area/awaymission/snowdin/post/mining_main)
 "Hm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_main)
@@ -13682,7 +13682,7 @@
 	},
 /area/awaymission/snowdin/post/mining_main)
 "Iv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_main)
 "Iw" = (
@@ -13959,7 +13959,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_dock)
 "Jp" = (
@@ -14691,7 +14691,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/mining_dock)
 "La" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plating/asteroid/snow/ice,
 /area/awaymission/snowdin/cave/cavern)
 "Lw" = (

--- a/_maps/RandomZLevels/spacebattle.dmm
+++ b/_maps/RandomZLevels/spacebattle.dmm
@@ -626,7 +626,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/awaymission/spacebattle/cruiser)
 "cY" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -654,7 +654,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/awaymission/spacebattle/cruiser)
 "dd" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
@@ -789,23 +789,23 @@
 /turf/open/floor/plating/airless,
 /area/awaymission/spacebattle/cruiser)
 "dE" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 9
 	},
 /turf/open/floor/engine,
 /area/awaymission/spacebattle/cruiser)
 "dF" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/engine,
 /area/awaymission/spacebattle/cruiser)
 "dG" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 1
 	},
 /turf/open/floor/engine,
 /area/awaymission/spacebattle/cruiser)
 "dH" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 5
 	},
 /turf/open/floor/engine,
@@ -914,7 +914,7 @@
 /turf/open/floor/plating/airless,
 /area/awaymission/spacebattle/cruiser)
 "dY" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -937,7 +937,7 @@
 	},
 /area/awaymission/spacebattle/cruiser)
 "eb" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -973,7 +973,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "ek" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end,
+/atom/movable/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/engine,
 /area/awaymission/spacebattle/cruiser)
 "el" = (
@@ -1853,7 +1853,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "ha" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end,
+/atom/movable/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "hc" = (
@@ -1889,7 +1889,7 @@
 /turf/open/floor/plating/airless,
 /area/awaymission/spacebattle/cruiser)
 "hi" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -1950,7 +1950,7 @@
 /turf/closed/wall/r_wall,
 /area/awaymission/spacebattle/cruiser)
 "hu" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -2473,7 +2473,7 @@
 /area/awaymission/spacebattle/cruiser)
 "jE" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "jF" = (
@@ -2496,12 +2496,12 @@
 /area/awaymission/spacebattle/cruiser)
 "jI" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/engine,
 /area/awaymission/spacebattle/cruiser)
 "jJ" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/armory_contraband,
+/atom/movable/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "jK" = (
@@ -2609,7 +2609,7 @@
 /turf/open/floor/engine,
 /area/awaymission/spacebattle/cruiser)
 "ka" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
+/atom/movable/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "kb" = (
@@ -2644,7 +2644,7 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/spacebattle/cruiser)
 "ki" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /turf/open/floor/engine/vacuum,
@@ -2690,7 +2690,7 @@
 /turf/open/floor/engine/vacuum,
 /area/awaymission/spacebattle/cruiser)
 "kr" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/atom/movable/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
@@ -2710,17 +2710,17 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/spacebattle/cruiser)
 "kv" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/atom/movable/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/engine/vacuum,
 /area/awaymission/spacebattle/cruiser)
 "kw" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 10
 	},
 /turf/open/floor/engine/vacuum,
 /area/awaymission/spacebattle/cruiser)
 "kx" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional,
+/atom/movable/spawner/structure/window/hollow/reinforced/directional,
 /turf/open/floor/engine/vacuum,
 /area/awaymission/spacebattle/cruiser)
 "ky" = (
@@ -2728,7 +2728,7 @@
 /turf/open/floor/engine/vacuum,
 /area/awaymission/spacebattle/cruiser)
 "kz" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 6
 	},
 /turf/open/floor/engine/vacuum,

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -266,7 +266,7 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "aP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -380,7 +380,7 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "bd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/space,
 /area/awaymission/undergroundoutpost45/central)
 "be" = (
@@ -2016,7 +2016,7 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "el" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -3098,7 +3098,7 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "gr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -3290,7 +3290,7 @@
 	},
 /area/awaymission/undergroundoutpost45/gateway)
 "gU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -3651,7 +3651,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "hH" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -3805,7 +3805,7 @@
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -3824,7 +3824,7 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "hX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -4273,7 +4273,7 @@
 	},
 /area/awaymission/undergroundoutpost45/gateway)
 "iS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -4477,7 +4477,7 @@
 	},
 /area/awaymission/undergroundoutpost45/gateway)
 "jl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -4732,7 +4732,7 @@
 /area/awaymission/undergroundoutpost45/gateway)
 "jM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -4750,7 +4750,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "jO" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -6158,7 +6158,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "mi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "UO45_rdprivacy";
@@ -6169,7 +6169,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "mj" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "UO45_rdprivacy";
 	name = "privacy shutters"
@@ -8384,7 +8384,7 @@
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "qb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -8401,7 +8401,7 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "qd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/meter{
 	layer = 3.3;
 	name = "Mixed Air Tank Out"
@@ -8412,7 +8412,7 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "qe" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/meter{
 	layer = 3.3;
@@ -8453,7 +8453,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "qj" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
 	name = "SERVER ROOM";
@@ -8975,7 +8975,7 @@
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -9230,7 +9230,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "rA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
 	name = "SERVER ROOM";
@@ -9637,7 +9637,7 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -9754,7 +9754,7 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
@@ -10083,7 +10083,7 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -10185,7 +10185,7 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "td" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
@@ -11035,7 +11035,7 @@
 /turf/closed/wall/r_wall,
 /area/awaymission/undergroundoutpost45/engineering)
 "uI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 1
 	},
@@ -11047,7 +11047,7 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "uJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/meter{
 	layer = 3.3
 	},
@@ -11348,7 +11348,7 @@
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "vm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -11819,7 +11819,7 @@
 	},
 /area/awaymission/undergroundoutpost45/mining)
 "wk" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
 /turf/open/floor/plating{
@@ -11827,7 +11827,7 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "wl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -11926,7 +11926,7 @@
 	},
 /area/awaymission/undergroundoutpost45/mining)
 "ww" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -12580,7 +12580,7 @@
 	},
 /area/awaymission/undergroundoutpost45/mining)
 "xr" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -12654,7 +12654,7 @@
 	},
 /area/awaymission/undergroundoutpost45/mining)
 "xA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -12875,7 +12875,7 @@
 	},
 /area/awaymission/undergroundoutpost45/mining)
 "xY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006

--- a/_maps/RandomZLevels/wildwest.dmm
+++ b/_maps/RandomZLevels/wildwest.dmm
@@ -379,7 +379,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/tinted/frosted,
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 8
 	},
 /turf/open/floor/plating/ironsand{
@@ -469,7 +469,7 @@
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 1
 	},
 /turf/open/floor/plating/ironsand{
@@ -776,7 +776,7 @@
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 1
 	},
 /turf/open/floor/plating/ironsand{
@@ -829,7 +829,7 @@
 /turf/open/floor/plating,
 /area/awaymission/wildwest/refine)
 "dj" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/wood,
 /area/awaymission/wildwest/mines)
 "dk" = (
@@ -1563,7 +1563,7 @@
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/hollow/reinforced/directional,
+/atom/movable/spawner/structure/window/hollow/reinforced/directional,
 /turf/open/floor/plasteel,
 /area/awaymission/wildwest/refine)
 "fB" = (
@@ -1961,7 +1961,7 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/awaymission/wildwest/refine)
 "gX" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /obj/structure/window/reinforced/tinted/frosted,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -53,7 +53,7 @@
 	pixel_y = -26;
 	req_access_txt = "28"
 	},
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /obj/item/storage/box/donkpockets,
 /obj/item/clothing/head/chefhat,
 /obj/effect/turf_decal/bot,
@@ -355,7 +355,7 @@
 /turf/open/floor/carpet,
 /area/library)
 "aaO" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aaP" = (
@@ -1045,7 +1045,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
 "acf" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "acg" = (
@@ -1503,7 +1503,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "adq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
@@ -1519,7 +1519,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ads" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -1607,7 +1607,7 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "adR" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "aea" = (
@@ -2594,7 +2594,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "ail" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -2671,7 +2671,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -2824,7 +2824,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aiJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aiQ" = (
@@ -3115,7 +3115,7 @@
 "ajq" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -3408,7 +3408,7 @@
 /area/maintenance/starboard/fore)
 "ajO" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
@@ -3745,7 +3745,7 @@
 /turf/closed/wall,
 /area/security/checkpoint/customs)
 "akG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/customs)
@@ -3815,7 +3815,7 @@
 /turf/closed/wall,
 /area/security/checkpoint)
 "akQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint)
@@ -4277,7 +4277,7 @@
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/bot,
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "alQ" = (
@@ -4310,7 +4310,7 @@
 /turf/closed/wall,
 /area/crew_quarters/electronic_marketing_den)
 "alV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/electronic_marketing_den)
 "alW" = (
@@ -4596,7 +4596,7 @@
 /area/maintenance/starboard/fore)
 "amB" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -4607,7 +4607,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/item/crowbar/red,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -5056,7 +5056,7 @@
 /area/maintenance/starboard/fore)
 "anz" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/randomarcade{
+/atom/movable/spawner/randomarcade{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -5607,7 +5607,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "aox" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -5621,7 +5621,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "aoy" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -5707,7 +5707,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aoE" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aoF" = (
@@ -6146,7 +6146,7 @@
 "apB" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "apC" = (
@@ -6245,7 +6245,7 @@
 /area/engine/atmospherics_engine)
 "apP" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/arcade_boards,
+/atom/movable/spawner/lootdrop/arcade_boards,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -6860,7 +6860,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/electronic_marketing_den)
 "aqV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqW" = (
@@ -7113,7 +7113,7 @@
 "arz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arA" = (
@@ -7287,7 +7287,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arX" = (
-/obj/effect/spawner/randomarcade{
+/atom/movable/spawner/randomarcade{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -7324,7 +7324,7 @@
 /area/maintenance/starboard/fore)
 "asa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/randomarcade{
+/atom/movable/spawner/randomarcade{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -7431,7 +7431,7 @@
 /turf/open/space,
 /area/solar/port/fore)
 "asl" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "asm" = (
@@ -7793,7 +7793,7 @@
 /area/maintenance/port/fore)
 "asW" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -8208,7 +8208,7 @@
 /obj/item/weldingtool,
 /obj/item/assembly/voice,
 /obj/item/clothing/head/welding,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -9183,7 +9183,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "avk" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
@@ -9212,7 +9212,7 @@
 /area/maintenance/port/fore)
 "avo" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "avp" = (
@@ -9685,7 +9685,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "awh" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "awi" = (
@@ -9753,7 +9753,7 @@
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/suit/toggle/suspenders,
-/obj/effect/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/costume,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -10458,7 +10458,7 @@
 "axJ" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "axK" = (
@@ -10846,7 +10846,7 @@
 "ayq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cardboard,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -11020,7 +11020,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "ayE" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -11180,7 +11180,7 @@
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/jackboots,
-/obj/effect/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/costume,
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
 	},
@@ -11422,7 +11422,7 @@
 /area/quartermaster/warehouse)
 "azq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
@@ -11515,7 +11515,7 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -11525,7 +11525,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "azC" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -12063,7 +12063,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aAJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -12529,7 +12529,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "aBK" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
@@ -12567,7 +12567,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aBP" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
@@ -12652,13 +12652,13 @@
 /area/quartermaster/storage)
 "aBX" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aBY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -13677,7 +13677,7 @@
 /area/quartermaster/storage)
 "aEb" = (
 /obj/structure/closet/cardboard,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -13689,7 +13689,7 @@
 /area/quartermaster/storage)
 "aEd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -13734,7 +13734,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aEh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aEl" = (
@@ -14288,7 +14288,7 @@
 /turf/closed/wall/r_wall,
 /area/security/prison)
 "aFn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
@@ -14298,7 +14298,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "aFp" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aFq" = (
@@ -14308,7 +14308,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "aFs" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "aFt" = (
@@ -14985,7 +14985,7 @@
 "aGA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -15476,7 +15476,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmospherics_engine)
 "aHl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/hydroponics/garden/abandoned)
@@ -15713,7 +15713,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aHG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "aHH" = (
@@ -15761,7 +15761,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "aHL" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
@@ -16138,7 +16138,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "aID" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
@@ -16158,7 +16158,7 @@
 /area/engine/atmospherics_engine)
 "aIF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
@@ -16481,7 +16481,7 @@
 /obj/machinery/conveyor{
 	id = "cargodisposals"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "aJm" = (
@@ -16569,7 +16569,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aJt" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -16590,7 +16590,7 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -16929,7 +16929,7 @@
 "aKh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -17923,7 +17923,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aLX" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -18159,7 +18159,7 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/maintenance/disposal/incinerator)
 "aMB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aMC" = (
@@ -18186,7 +18186,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aME" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -18496,7 +18496,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "aNj" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/bar/atrium)
 "aNk" = (
@@ -18634,7 +18634,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aND" = (
-/obj/effect/spawner/randomarcade{
+/atom/movable/spawner/randomarcade{
 	dir = 8
 	},
 /obj/machinery/status_display/evac{
@@ -18662,7 +18662,7 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /turf/open/floor/plasteel/white,
 /area/security/prison/safe)
 "aNH" = (
@@ -19536,7 +19536,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aPl" = (
-/obj/effect/spawner/randomarcade{
+/atom/movable/spawner/randomarcade{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -19601,7 +19601,7 @@
 "aPv" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/glass/bowl,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/reagent_containers/glass/bowl,
 /obj/item/reagent_containers/glass/bowl,
 /obj/item/reagent_containers/glass/bowl,
@@ -20106,7 +20106,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/atrium)
 "aQn" = (
-/obj/effect/spawner/xmastree,
+/atom/movable/spawner/xmastree,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/carpet,
@@ -20469,14 +20469,14 @@
 /turf/closed/wall,
 /area/quartermaster/qm)
 "aQP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "aQQ" = (
 /turf/closed/wall,
 /area/quartermaster/qm)
 "aQR" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
@@ -20766,7 +20766,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aRG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den/secondary)
@@ -21080,7 +21080,7 @@
 /turf/closed/wall,
 /area/security/checkpoint/supply)
 "aSi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -21698,7 +21698,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "aTg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
@@ -22305,7 +22305,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aUh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22399,7 +22399,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aUp" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "aUr" = (
@@ -22776,7 +22776,7 @@
 /turf/open/floor/plasteel/white/corner,
 /area/engine/atmos)
 "aUY" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aUZ" = (
@@ -23041,7 +23041,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aVx" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -23799,7 +23799,7 @@
 /turf/open/space,
 /area/engine/atmos)
 "aWy" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
@@ -25110,7 +25110,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aYJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "aYK" = (
@@ -25523,7 +25523,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZL" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison)
 "aZM" = (
@@ -25557,7 +25557,7 @@
 /turf/open/space,
 /area/engine/atmos)
 "aZS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
@@ -26146,16 +26146,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "baU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "baV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "baW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -26767,7 +26767,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "bcp" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/quartermaster/office)
@@ -26930,7 +26930,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bcG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
@@ -27843,7 +27843,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bek" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -28326,7 +28326,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bfk" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "bfl" = (
@@ -28596,7 +28596,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bfG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/pods{
 	name = "MINING POD"
 	},
@@ -28918,7 +28918,7 @@
 "bgj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
@@ -29207,7 +29207,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "bgG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -29406,7 +29406,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bhb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
@@ -29435,7 +29435,7 @@
 /turf/closed/wall/r_wall,
 /area/security/main)
 "bhe" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/main)
@@ -29966,7 +29966,7 @@
 /turf/open/floor/plating,
 /area/security/range)
 "bia" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "aiuploadwindow";
 	name = "AI Upload Lockdown Door"
@@ -30242,7 +30242,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "biy" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
@@ -30484,7 +30484,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
 "biQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "hosspace";
 	name = "HoS Space Blast door"
@@ -32277,7 +32277,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "bmg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/departments/medbay/alt,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -32362,7 +32362,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bms" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "hosprivacy";
 	name = "HoS Privacy Blast door"
@@ -32723,7 +32723,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "bnc" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
@@ -32738,8 +32738,8 @@
 /area/space/nearstation)
 "bne" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/costume,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
@@ -32824,7 +32824,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bnn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "bno" = (
@@ -32843,12 +32843,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "bnp" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "bnq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "kitchenwindows";
 	name = "Kitchen Privacy Shutters"
@@ -32960,7 +32960,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "bnD" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
@@ -33220,7 +33220,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "bod" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "hosroom";
 	name = "HoS Room Blast door"
@@ -33307,7 +33307,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "bok" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
@@ -33317,7 +33317,7 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bol" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -33325,7 +33325,7 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bom" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -33349,7 +33349,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "boo" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -34408,7 +34408,7 @@
 	},
 /area/engine/atmos)
 "bpX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
@@ -35057,7 +35057,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "brd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/storage_shared)
 "bre" = (
@@ -35319,7 +35319,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bry" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
@@ -35393,7 +35393,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "brF" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
@@ -35669,7 +35669,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bsi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -35763,7 +35763,7 @@
 /turf/closed/wall,
 /area/storage/tech)
 "bst" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bsu" = (
@@ -36031,7 +36031,7 @@
 /turf/closed/wall,
 /area/hallway/primary/central)
 "btb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -36823,7 +36823,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "buq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "bur" = (
@@ -37296,7 +37296,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bvl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -37357,7 +37357,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bvr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmoslock";
 	name = "Atmospherics Lockdown Blast door"
@@ -37410,7 +37410,7 @@
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "bvw" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/storage/tech)
@@ -37468,7 +37468,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bvE" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hydroponics)
 "bvG" = (
@@ -37492,7 +37492,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bvJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/space/nearstation)
 "bvK" = (
@@ -37501,7 +37501,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bvO" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
@@ -38030,7 +38030,7 @@
 /area/hallway/primary/port)
 "bwJ" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/command,
+/atom/movable/spawner/lootdrop/techstorage/command,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -38039,13 +38039,13 @@
 /area/storage/tech)
 "bwK" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/ai,
+/atom/movable/spawner/lootdrop/techstorage/ai,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bwL" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/rnd_secure,
+/atom/movable/spawner/lootdrop/techstorage/rnd_secure,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -38108,7 +38108,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bwR" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgewindows";
 	name = "Bridge View Blast door"
@@ -38258,7 +38258,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bxr" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/main)
@@ -39317,7 +39317,7 @@
 /area/engine/break_room)
 "bzi" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -39832,7 +39832,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bzX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/nuke_storage)
@@ -40325,7 +40325,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "bAJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
@@ -40581,7 +40581,7 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bBf" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmoslock";
 	name = "Atmospherics Lockdown Blast door"
@@ -40777,7 +40777,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBw" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/bridge)
@@ -41346,7 +41346,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/abandoned_gambling_den)
 "bCt" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "aicorewindow";
 	name = "AI Core Shutters"
@@ -41415,7 +41415,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bCA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
@@ -41933,7 +41933,7 @@
 /obj/item/assembly/igniter,
 /obj/item/assembly/igniter,
 /obj/item/assembly/igniter,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -42848,13 +42848,13 @@
 /area/storage/tech)
 "bET" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/service,
+/atom/movable/spawner/lootdrop/techstorage/service,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bEU" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/medical,
+/atom/movable/spawner/lootdrop/techstorage/medical,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/tech)
@@ -42975,7 +42975,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bFe" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/primary)
 "bFf" = (
@@ -43422,7 +43422,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bFG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
@@ -43449,7 +43449,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "bFI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -43523,7 +43523,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "bFP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
@@ -43954,7 +43954,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/break_room)
@@ -44013,13 +44013,13 @@
 /area/storage/tech)
 "bGD" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/security,
+/atom/movable/spawner/lootdrop/techstorage/security,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bGE" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/rnd,
+/atom/movable/spawner/lootdrop/techstorage/rnd,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/tech)
@@ -44123,7 +44123,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bGP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -44412,7 +44412,7 @@
 /turf/closed/wall/r_wall,
 /area/security/detectives_office)
 "bHs" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "detectivewindows";
 	name = "Detective Privacy Blast door"
@@ -44454,7 +44454,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bHw" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "brigwindows";
 	name = "Brig Front Blast door"
@@ -44668,7 +44668,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bHO" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
 	},
@@ -46037,7 +46037,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "bJW" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -46177,7 +46177,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bKl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/break_room)
@@ -46211,7 +46211,7 @@
 /area/storage/tech)
 "bKq" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/engineering,
+/atom/movable/spawner/lootdrop/techstorage/engineering,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/tech)
@@ -47287,7 +47287,7 @@
 /area/storage/tech)
 "bMi" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/tcomms,
+/atom/movable/spawner/lootdrop/techstorage/tcomms,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/tech)
@@ -47340,7 +47340,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bMm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "councilblast";
 	name = "Council Chambers Blast door"
@@ -47649,7 +47649,7 @@
 "bMU" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
@@ -47661,7 +47661,7 @@
 "bMV" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -48318,7 +48318,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "bNU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
@@ -48430,7 +48430,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bOf" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
@@ -49152,7 +49152,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bPw" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
@@ -49898,7 +49898,7 @@
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/light_switch{
 	pixel_x = -26
 	},
@@ -50431,7 +50431,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "bRV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/transit_tube)
 "bRW" = (
@@ -50508,7 +50508,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bSc" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
@@ -50926,7 +50926,7 @@
 /turf/closed/wall,
 /area/storage/tools)
 "bST" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/storage/tools)
@@ -50942,7 +50942,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "bSV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/tools)
 "bSX" = (
@@ -50964,7 +50964,7 @@
 /turf/open/floor/plasteel,
 /area/security/detectives_office)
 "bSZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "detectivewindows";
 	name = "Detective Privacy Blast door"
@@ -51647,7 +51647,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bTZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ceprivacy";
 	name = "Chief's Privacy Shutters"
@@ -51685,7 +51685,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bUd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
@@ -51968,7 +51968,7 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
 "bUI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "bUK" = (
@@ -53073,7 +53073,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bWt" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -53841,7 +53841,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bXI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -55533,7 +55533,7 @@
 /turf/closed/wall,
 /area/library)
 "caH" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/library)
 "caI" = (
@@ -55585,7 +55585,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "caM" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "hopblast";
 	name = "HoP Blast door"
@@ -55775,7 +55775,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "cbn" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/security/courtroom)
 "cbo" = (
@@ -55794,7 +55794,7 @@
 /turf/closed/wall,
 /area/lawoffice)
 "cbq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "lawyerprivacy";
 	name = "Lawyer's Privacy Shutter"
@@ -55987,7 +55987,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "cbG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "cbH" = (
@@ -56579,7 +56579,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "ccZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/courtroom)
 "cda" = (
@@ -57223,7 +57223,7 @@
 "cdY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -57865,7 +57865,7 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/effect/spawner/lootdrop/aimodule_harmless{
+/atom/movable/spawner/lootdrop/aimodule_harmless{
 	fan_out_items = 1;
 	lootcount = 3;
 	lootdoubles = 0
@@ -57923,7 +57923,7 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/effect/spawner/lootdrop/aimodule_harmful{
+/atom/movable/spawner/lootdrop/aimodule_harmful{
 	fan_out_items = 1;
 	lootcount = 2;
 	lootdoubles = 0
@@ -58070,7 +58070,7 @@
 /area/engine/engineering)
 "cfR" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cfS" = (
@@ -58646,7 +58646,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "chi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "aiuploadwindow";
 	name = "AI Upload Lockdown Door"
@@ -58919,7 +58919,7 @@
 /area/engine/engineering)
 "chI" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "chK" = (
@@ -59561,7 +59561,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "cjd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cje" = (
@@ -60163,7 +60163,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ckl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -60405,7 +60405,7 @@
 /obj/item/wrench,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
@@ -60721,7 +60721,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/crowbar/red,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cly" = (
@@ -60892,7 +60892,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "clQ" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/aimodule_neutral{
+/atom/movable/spawner/lootdrop/aimodule_neutral{
 	fan_out_items = 1;
 	lootcount = 3;
 	lootdoubles = 0
@@ -61160,7 +61160,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "cmD" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/server)
@@ -61683,7 +61683,7 @@
 /turf/open/floor/plasteel,
 /area/security/range)
 "cns" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/range)
@@ -62299,7 +62299,7 @@
 /area/maintenance/starboard)
 "coC" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -62307,7 +62307,7 @@
 "coE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -63184,7 +63184,7 @@
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/command)
 "cqZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/secondary/command)
@@ -63250,7 +63250,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "crf" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/teleporter)
@@ -63458,7 +63458,7 @@
 "crw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /obj/structure/closet/wardrobe/yellow,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -63481,7 +63481,7 @@
 "cry" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "crA" = (
@@ -63491,7 +63491,7 @@
 	},
 /area/maintenance/starboard)
 "crB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -64428,7 +64428,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cti" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ctj" = (
@@ -65017,7 +65017,7 @@
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cuG" = (
@@ -65059,7 +65059,7 @@
 /turf/closed/wall,
 /area/crew_quarters/fitness/recreation)
 "cuM" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "cuN" = (
@@ -66335,7 +66335,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cxi" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/crew_quarters/locker)
 "cxj" = (
@@ -66982,7 +66982,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "cyr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
@@ -67010,7 +67010,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cyx" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/gateway)
@@ -67316,7 +67316,7 @@
 "czc" = (
 /obj/structure/rack,
 /obj/item/wrench,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -67427,7 +67427,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "czu" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/storage)
@@ -67763,7 +67763,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "czY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "corporatelounge";
 	name = "Corporate Lounge Shutters"
@@ -69818,14 +69818,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cDP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "cDQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -69839,7 +69839,7 @@
 /turf/closed/wall,
 /area/crew_quarters/fitness/recreation)
 "cDS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
 	},
@@ -70840,7 +70840,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cFE" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
@@ -71536,7 +71536,7 @@
 	pixel_y = 7;
 	specialfunctions = 4
 	},
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "cGU" = (
@@ -71929,7 +71929,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cHM" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "corporatelounge";
 	name = "Corporate Lounge Shutters"
@@ -72022,7 +72022,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cHW" = (
@@ -72481,7 +72481,7 @@
 "cIV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -73530,7 +73530,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cKX" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "cKY" = (
@@ -73843,7 +73843,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/fyellow,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -74043,7 +74043,7 @@
 /area/hallway/primary/central)
 "cMi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -74553,7 +74553,7 @@
 "cNl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cNm" = (
@@ -74575,11 +74575,11 @@
 /turf/closed/wall,
 /area/hallway/primary/central)
 "cNp" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/research)
 "cNq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/science/research)
@@ -74668,7 +74668,7 @@
 /turf/closed/wall,
 /area/medical/medbay/central)
 "cNz" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "cNA" = (
@@ -74966,7 +74966,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cOj" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cOk" = (
@@ -75001,7 +75001,7 @@
 "cOn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -75153,7 +75153,7 @@
 "cOE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -75169,7 +75169,7 @@
 "cOF" = (
 /obj/structure/rack,
 /obj/item/book/manual/wiki/engineering_guide,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -75873,7 +75873,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cQb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
@@ -75941,7 +75941,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "cQj" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "cQk" = (
@@ -76893,7 +76893,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cRY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno4";
@@ -76903,7 +76903,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cSb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno5";
@@ -76936,7 +76936,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cSe" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno6";
@@ -76946,7 +76946,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cSf" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plating,
@@ -76964,7 +76964,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cSh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
@@ -76991,7 +76991,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "cSl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/science/research)
@@ -77428,7 +77428,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "cSS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/storage)
 "cST" = (
@@ -77791,7 +77791,7 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "cTB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenosecure";
 	name = "Secure Pen Shutters"
@@ -78415,7 +78415,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cUG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
@@ -78618,7 +78618,7 @@
 /area/medical/medbay/central)
 "cUU" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -78779,14 +78779,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cVh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "cVi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -78800,7 +78800,7 @@
 /turf/closed/wall,
 /area/crew_quarters/fitness/recreation)
 "cVk" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
@@ -79262,7 +79262,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cWh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -80301,7 +80301,7 @@
 "cYl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -80520,7 +80520,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cYL" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenosecure";
 	name = "Secure Pen Shutters"
@@ -80713,7 +80713,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "cZg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
 	},
@@ -80767,7 +80767,7 @@
 /turf/closed/wall/r_wall,
 /area/science/lab)
 "cZn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rndlab1";
@@ -80776,7 +80776,7 @@
 /turf/open/floor/plating,
 /area/science/lab)
 "cZo" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rndlab1";
 	name = "Research and Development Shutter"
@@ -80825,7 +80825,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cZt" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemisttop";
 	name = "Chemistry Lobby Shutters"
@@ -80837,7 +80837,7 @@
 	id = "chemisttop";
 	name = "Chemistry Lobby Shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "cZv" = (
@@ -81164,7 +81164,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "cZT" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -81790,7 +81790,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dba" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistbot";
 	name = "Chemistry Side Shutters"
@@ -82435,7 +82435,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "dcg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno1";
@@ -82445,7 +82445,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dch" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno8";
@@ -82455,7 +82455,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dci" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno1";
 	name = "Creature Cell #1"
@@ -82464,7 +82464,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dcj" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno2";
@@ -82474,7 +82474,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dck" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno6";
@@ -82483,7 +82483,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dcl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno2";
 	name = "Creature Cell #2"
@@ -82492,7 +82492,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dcm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno3";
@@ -83173,7 +83173,7 @@
 "ddI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -83661,7 +83661,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/item/clothing/neck/stethoscope,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -83769,7 +83769,7 @@
 "deZ" = (
 /obj/structure/rack,
 /obj/item/crowbar/red,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "dfa" = (
@@ -83791,7 +83791,7 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "dfd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "rdxeno";
 	name = "Xenobiology Containment Door"
@@ -84124,7 +84124,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "dfL" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "dfN" = (
@@ -84184,7 +84184,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "dfX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dfY" = (
@@ -84662,7 +84662,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "dgQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rndlab2";
 	name = "Secondary Research and Development Shutter"
@@ -84714,7 +84714,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dgU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistbot";
 	name = "Chemistry Side Shutters"
@@ -84938,11 +84938,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "dhC" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dhD" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dhE" = (
@@ -85117,7 +85117,7 @@
 /turf/closed/wall,
 /area/science/research/abandoned)
 "dhS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/science/research/abandoned)
@@ -86063,7 +86063,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "djX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rdrnd";
 	name = "Research and Development Shutters"
@@ -86679,7 +86679,7 @@
 	},
 /area/crew_quarters/abandoned_gambling_den)
 "dkW" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /obj/structure/cable,
@@ -86702,21 +86702,21 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/abandoned_gambling_den)
 "dkY" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 9
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dkZ" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dla" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 5
 	},
 /obj/structure/cable,
@@ -86914,7 +86914,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hor)
 "dlF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "rdoffice";
 	name = "Research Director's Shutters"
@@ -86928,7 +86928,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hor)
 "dlH" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "rdoffice";
 	name = "Research Director's Shutters"
@@ -86952,7 +86952,7 @@
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
 "dlO" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "dlP" = (
@@ -87010,7 +87010,7 @@
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "dlW" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "dlX" = (
@@ -87047,7 +87047,7 @@
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "dmd" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/medical/surgery)
 "dme" = (
@@ -87101,7 +87101,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/abandoned_gambling_den)
 "dmm" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 8
 	},
 /obj/structure/cable,
@@ -87136,7 +87136,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/abandoned_gambling_den)
 "dmp" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -87214,7 +87214,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
 "dmF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/nanite)
 "dmG" = (
@@ -87834,7 +87834,7 @@
 "dnU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -88421,7 +88421,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dpg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/chemistry)
@@ -88597,7 +88597,7 @@
 	},
 /obj/item/crowbar/red,
 /obj/item/wrench,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/construction)
@@ -88657,7 +88657,7 @@
 	pixel_y = 8
 	},
 /obj/item/stack/spacecash/c100,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/abandoned_gambling_den)
 "dpP" = (
@@ -88710,7 +88710,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/abandoned_gambling_den)
 "dpU" = (
@@ -89237,7 +89237,7 @@
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "dro" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/surgery)
 "drp" = (
@@ -89300,7 +89300,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/abandoned_gambling_den)
 "drw" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 6
 	},
 /obj/structure/cable,
@@ -89511,7 +89511,7 @@
 /area/science/mixing)
 "drR" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rdtoxins";
 	name = "Toxins Lab Shutters"
@@ -90188,7 +90188,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
 "dtL" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "cmoshutter";
 	name = "CMO Office Shutters"
@@ -90409,19 +90409,19 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dug" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/atom/movable/spawner/structure/window/hollow/reinforced/directional{
 	dir = 10
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "duh" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional,
+/atom/movable/spawner/structure/window/hollow/reinforced/directional,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dui" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/atom/movable/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -90754,7 +90754,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dvr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "cmoshutter";
 	name = "CMO Office Shutters"
@@ -91130,7 +91130,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/abandoned_gambling_den)
 "dvU" = (
@@ -91897,7 +91897,7 @@
 /turf/closed/wall,
 /area/crew_quarters/heads/hor)
 "dxX" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
@@ -91945,7 +91945,7 @@
 /turf/closed/wall,
 /area/science/robotics/lab)
 "dyd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "roboticsprivacy";
 	name = "Robotics Shutters"
@@ -92250,7 +92250,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
 "dyV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "dyW" = (
@@ -92260,7 +92260,7 @@
 	},
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/abandoned_gambling_den)
 "dyX" = (
@@ -92276,7 +92276,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dyZ" = (
 /obj/structure/table/wood/poker,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
@@ -92292,7 +92292,7 @@
 "dzb" = (
 /obj/structure/table/wood/poker,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/wood,
 /area/crew_quarters/abandoned_gambling_den)
 "dzc" = (
@@ -93128,7 +93128,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dBh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "cmoshutter";
 	name = "CMO Office Shutters"
@@ -93790,7 +93790,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "dCS" = (
@@ -93805,7 +93805,7 @@
 /area/maintenance/starboard/aft)
 "dCT" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -93856,7 +93856,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -94069,7 +94069,7 @@
 /area/science/mixing)
 "dDv" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "idquarters";
 	name = "Director's Quarters Shutters"
@@ -94447,7 +94447,7 @@
 	id = "surgeryb";
 	name = "privacy shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/surgery/room_b)
 "dEc" = (
@@ -94501,7 +94501,7 @@
 /turf/closed/wall,
 /area/crew_quarters/theatre/abandoned)
 "dEj" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/abandoned)
@@ -94525,7 +94525,7 @@
 /turf/open/floor/plasteel,
 /area/security/detectives_office/private_investigators_office)
 "dEn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/misc_lab)
 "dEo" = (
@@ -94736,7 +94736,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "dEG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "dEH" = (
@@ -94978,7 +94978,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "dFh" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
@@ -95121,7 +95121,7 @@
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_y = 32
 	},
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
@@ -95740,8 +95740,8 @@
 /area/medical/medbay/central)
 "dGB" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/costume,
-/obj/effect/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/costume,
 /obj/item/clothing/neck/tie/black,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -95860,14 +95860,14 @@
 /turf/open/floor/plating,
 /area/security/detectives_office/private_investigators_office)
 "dGQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/detectives_office/private_investigators_office)
 "dGW" = (
 /turf/closed/wall/r_wall,
 /area/science/test_area)
 "dGX" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/science/test_area)
 "dGY" = (
@@ -96025,7 +96025,7 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "dHq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/server)
@@ -96051,7 +96051,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "dHs" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 9
@@ -96307,9 +96307,9 @@
 "dHW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/costume,
-/obj/effect/spawner/lootdrop/costume,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -97618,7 +97618,7 @@
 	},
 /obj/item/folder/red,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office/private_investigators_office)
 "dKu" = (
@@ -98069,7 +98069,7 @@
 	},
 /area/maintenance/starboard/aft)
 "dLo" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -98565,7 +98565,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
 /obj/item/storage/box/bodybags,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
@@ -98643,7 +98643,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dMC" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -98727,7 +98727,7 @@
 /area/maintenance/aft)
 "dMK" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -99084,7 +99084,7 @@
 /area/science/test_area)
 "dNt" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dNu" = (
@@ -99325,7 +99325,7 @@
 /turf/closed/wall,
 /area/maintenance/aft)
 "dNT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dNU" = (
@@ -99358,7 +99358,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dNX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/abandoned)
 "dNY" = (
@@ -99823,7 +99823,7 @@
 /turf/closed/wall,
 /area/library/abandoned)
 "dOO" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/library/abandoned)
@@ -100029,7 +100029,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
 "dPg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/customs/auxiliary)
@@ -100077,7 +100077,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dPl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "dPm" = (
@@ -100123,7 +100123,7 @@
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "dPr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/virology)
@@ -100519,7 +100519,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dQh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -101202,7 +101202,7 @@
 /area/library/abandoned)
 "dRx" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -101802,8 +101802,8 @@
 /area/maintenance/port/aft)
 "dSE" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/costume,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dSF" = (
@@ -101909,7 +101909,7 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "dSU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "dSY" = (
@@ -101947,7 +101947,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dTb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
 "dTc" = (
@@ -102566,7 +102566,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "dUu" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/chapel/main)
 "dUw" = (
@@ -103081,7 +103081,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "dVS" = (
-/obj/effect/spawner/xmastree,
+/atom/movable/spawner/xmastree,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 4
@@ -103326,7 +103326,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/wood,
 /area/library/abandoned)
 "dWD" = (
@@ -104097,7 +104097,7 @@
 "dYm" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/rank/civilian/curator,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/wood,
 /area/library/abandoned)
 "dYn" = (
@@ -104569,7 +104569,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "dZr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
@@ -104912,7 +104912,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "eak" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "eal" = (
@@ -105025,7 +105025,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "eaK" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -105145,7 +105145,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/port/aft)
 "eaX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -105503,7 +105503,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "ebO" = (
@@ -105636,7 +105636,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "ecc" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
@@ -106007,7 +106007,7 @@
 "ecQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
@@ -106321,7 +106321,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "edl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "edm" = (
@@ -106667,7 +106667,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "eeb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/escape)
@@ -106701,12 +106701,12 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "eej" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
 /turf/open/floor/plating,
 /area/security/checkpoint/escape)
 "eek" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/escape)
 "een" = (
@@ -107130,12 +107130,12 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
 "eff" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "efg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chapelprivacy";
 	name = "Chapel Privacy Shutters"
@@ -107744,7 +107744,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "egC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/office)
 "egD" = (
@@ -107886,7 +107886,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "emj" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -108061,7 +108061,7 @@
 "eKq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "eMd" = (
@@ -108187,7 +108187,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "fbA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/storage_shared)
@@ -108335,7 +108335,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "fDa" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "justicechamber";
 	name = "Justice Chamber Blast door"
@@ -108496,7 +108496,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/spawner/randomarcade{
+/atom/movable/spawner/randomarcade{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -108715,15 +108715,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "gRL" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "gRM" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/stack/license_plates/empty/fifty,
 /obj/item/stack/license_plates/empty/fifty,
 /obj/item/stack/license_plates/empty/fifty,
@@ -108802,7 +108802,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
 "had" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 1
 	},
@@ -109417,7 +109417,7 @@
 /area/medical/medbay/central)
 "iMR" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/canvas/nineteen_nineteen,
 /obj/item/canvas/nineteen_nineteen,
 /obj/item/canvas/nineteen_nineteen,
@@ -109560,7 +109560,7 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "jlh" = (
@@ -109810,7 +109810,7 @@
 /area/science/mixing)
 "jSe" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rdtoxins";
 	name = "Toxins Lab Shutters"
@@ -110285,7 +110285,7 @@
 /area/science/research)
 "lgw" = (
 /obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/toy/figure/syndie,
 /obj/machinery/light{
 	dir = 4;
@@ -110331,14 +110331,14 @@
 	id = "rndlab1";
 	name = "Research and Development Shutter"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/lab)
 "lpW" = (
 /obj/structure/closet/crate,
 /obj/item/toy/beach_ball/holoball/dodgeball,
 /obj/item/toy/beach_ball/holoball/dodgeball,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/instrument/harmonica,
 /obj/item/storage/pill_bottle/dice,
 /obj/item/toy/cards/deck/tarot,
@@ -110967,7 +110967,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mVC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "justicechamber";
 	name = "Justice Chamber Blast door"
@@ -111056,7 +111056,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
 "neh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno8";
@@ -111538,7 +111538,7 @@
 	id = "brigprison";
 	name = "Prison Blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison)
 "oCS" = (
@@ -111668,7 +111668,7 @@
 /turf/open/floor/plasteel,
 /area/medical/morgue)
 "oQn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -111815,7 +111815,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "pff" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "brigprison";
@@ -111913,7 +111913,7 @@
 /area/science/misc_lab/range)
 "pmV" = (
 /obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/clothing/under/rank/prisoner/skirt,
 /obj/item/clothing/under/rank/prisoner/skirt,
 /obj/structure/cable,
@@ -112155,7 +112155,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "qdq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
 "qdJ" = (
@@ -112365,7 +112365,7 @@
 /turf/open/floor/plasteel,
 /area/library)
 "qxX" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "qyG" = (
@@ -112486,7 +112486,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "qOw" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno5";
@@ -113281,7 +113281,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "sTI" = (
@@ -113291,7 +113291,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "sUa" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/departments/medbay/alt,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -113324,7 +113324,7 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "sUE" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno4";
@@ -113389,7 +113389,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/spawner/randomarcade{
+/atom/movable/spawner/randomarcade{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -113567,7 +113567,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "tDj" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno7";
@@ -113721,7 +113721,7 @@
 /obj/item/seeds/ambrosia,
 /obj/item/seeds/wheat,
 /obj/item/seeds/pumpkin,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/structure/window,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/seeds/tower,
@@ -113853,7 +113853,7 @@
 "urA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
@@ -114440,7 +114440,7 @@
 /turf/closed/wall,
 /area/medical/sleeper)
 "vUp" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno3";
@@ -114453,7 +114453,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "vVy" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/pinpointer_dispenser,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -114931,7 +114931,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/spawner/randomarcade{
+/atom/movable/spawner/randomarcade{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -115215,7 +115215,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ybK" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno7";

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -90,7 +90,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "aak" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
@@ -200,7 +200,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaA" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -398,7 +398,7 @@
 /turf/closed/wall,
 /area/security/execution/transfer)
 "abd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison)
 "abe" = (
@@ -493,7 +493,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "abo" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/main)
 "abp" = (
@@ -503,7 +503,7 @@
 /turf/closed/wall,
 /area/crew_quarters/heads/hos)
 "abr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "hosspace";
 	name = "space shutters"
@@ -601,7 +601,7 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "abD" = (
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/structure/closet/crate,
 /obj/item/stack/license_plates/empty/fifty,
 /obj/item/stack/license_plates/empty/fifty,
@@ -1074,8 +1074,8 @@
 /area/crew_quarters/heads/hos)
 "acv" = (
 /obj/structure/closet/secure_closet/contraband/armory,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/effect/spawner/lootdrop/armory_contraband/metastation,
+/atom/movable/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/armory_contraband/metastation,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acw" = (
@@ -1354,7 +1354,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "adc" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison/safe)
@@ -1463,7 +1463,7 @@
 /area/ai_monitored/security/armory)
 "adm" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
@@ -1614,7 +1614,7 @@
 "adE" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/glass/bowl,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/reagent_containers/glass/bowl,
 /obj/item/reagent_containers/glass/bowl,
 /obj/item/reagent_containers/glass/bowl,
@@ -1943,7 +1943,7 @@
 /obj/item/seeds/ambrosia,
 /obj/item/seeds/wheat,
 /obj/item/seeds/pumpkin,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aei" = (
@@ -2018,7 +2018,7 @@
 /area/security/prison/safe)
 "aeq" = (
 /obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/trash/chips,
 /obj/item/trash/candy,
 /turf/open/floor/plating,
@@ -2520,7 +2520,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afu" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "afv" = (
@@ -2549,7 +2549,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "afw" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "afx" = (
@@ -2694,7 +2694,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "afQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
@@ -3166,7 +3166,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "agW" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/warden)
 "agX" = (
@@ -3663,7 +3663,7 @@
 /area/security/warden)
 "ahY" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 4
 	},
@@ -3782,7 +3782,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/warden)
 "aij" = (
@@ -3982,7 +3982,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aiA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aiB" = (
@@ -4041,7 +4041,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
@@ -4164,7 +4164,7 @@
 /turf/closed/wall,
 /area/security/processing)
 "aiU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/processing)
 "aiV" = (
@@ -4726,7 +4726,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ajV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "ajW" = (
@@ -4746,7 +4746,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "ajZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
@@ -5029,7 +5029,7 @@
 /area/security/prison)
 "akD" = (
 /obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/trash/sosjerky,
 /obj/item/trash/boritos,
 /obj/item/trash/can,
@@ -5061,7 +5061,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/processing)
 "akH" = (
@@ -5156,7 +5156,7 @@
 /area/security/brig)
 "akS" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -5313,7 +5313,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "ali" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "alj" = (
@@ -5588,7 +5588,7 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "alO" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "alP" = (
@@ -5620,7 +5620,7 @@
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "alV" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "alW" = (
@@ -5839,7 +5839,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/courtroom)
 "ams" = (
@@ -5874,7 +5874,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "amw" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "amx" = (
@@ -6019,7 +6019,7 @@
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
@@ -6057,7 +6057,7 @@
 	id = "briggate";
 	name = "security blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
@@ -6236,7 +6236,7 @@
 /obj/item/electronics/airalarm,
 /obj/item/circuitboard/machine/seed_extractor,
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/four,
+/atom/movable/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ano" = (
@@ -6362,7 +6362,7 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "anC" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/security/courtroom)
 "anD" = (
@@ -6414,7 +6414,7 @@
 /area/maintenance/port/fore)
 "anL" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "anM" = (
@@ -6446,7 +6446,7 @@
 	dir = 8
 	},
 /obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/clothing/under/rank/prisoner,
 /obj/item/clothing/under/rank/prisoner,
 /obj/item/clothing/under/rank/prisoner/skirt,
@@ -6683,7 +6683,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/processing)
 "aor" = (
@@ -6893,7 +6893,7 @@
 /area/maintenance/solars/starboard/fore)
 "aoP" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aoQ" = (
@@ -7182,11 +7182,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "apE" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "apF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -7235,7 +7235,7 @@
 /area/security/prison)
 "apL" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stock_parts/capacitor,
 /turf/open/floor/plasteel,
@@ -7258,7 +7258,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "apP" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "apQ" = (
@@ -7558,7 +7558,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aqA" = (
@@ -7655,7 +7655,7 @@
 /area/security/prison)
 "aqO" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqP" = (
@@ -7673,7 +7673,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aqR" = (
@@ -7802,7 +7802,7 @@
 	id = "lawyer_blast";
 	name = "privacy door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/lawoffice)
 "are" = (
@@ -7890,13 +7890,13 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arq" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance/eight,
+/atom/movable/spawner/lootdrop/maintenance/eight,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arr" = (
@@ -7948,7 +7948,7 @@
 "ary" = (
 /obj/structure/closet,
 /obj/item/coin/iron,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arz" = (
@@ -7958,7 +7958,7 @@
 /area/maintenance/starboard/fore)
 "arA" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arB" = (
@@ -8071,7 +8071,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arN" = (
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arO" = (
@@ -8374,7 +8374,7 @@
 /area/crew_quarters/dorms)
 "asv" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "asw" = (
@@ -8410,7 +8410,7 @@
 /area/maintenance/starboard/fore)
 "asA" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "asB" = (
@@ -8430,7 +8430,7 @@
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "asF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "asG" = (
@@ -8530,7 +8530,7 @@
 /area/maintenance/port/fore)
 "asP" = (
 /obj/structure/chair/stool,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "asQ" = (
@@ -8582,7 +8582,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "asY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
@@ -8784,12 +8784,12 @@
 /obj/item/shard{
 	icon_state = "small"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "atw" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "atx" = (
@@ -8946,17 +8946,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "atS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/closed/wall,
 /area/quartermaster/storage)
 "atT" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "atU" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "atV" = (
@@ -9274,7 +9274,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "auB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
 "auC" = (
@@ -9294,7 +9294,7 @@
 "auE" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/bedsheet/red,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -9492,7 +9492,7 @@
 /area/security/prison)
 "avc" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/four,
+/atom/movable/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "avd" = (
@@ -9508,7 +9508,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "avf" = (
@@ -9701,7 +9701,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "avx" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
 "avy" = (
@@ -9731,7 +9731,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "avB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
@@ -9895,7 +9895,7 @@
 /area/maintenance/port/fore)
 "avW" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "avX" = (
@@ -9935,7 +9935,7 @@
 /area/crew_quarters/kitchen)
 "awc" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "awd" = (
@@ -10169,11 +10169,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "awC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/closed/wall,
 /area/quartermaster/miningdock)
 "awD" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "awE" = (
@@ -10305,7 +10305,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "awW" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "awX" = (
@@ -10531,7 +10531,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "axv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
 	name = "prison blast door"
@@ -11003,7 +11003,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison/safe)
 "ayB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -11167,7 +11167,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
@@ -11363,7 +11363,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "azp" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
@@ -11883,7 +11883,7 @@
 "aAv" = (
 /obj/structure/closet,
 /obj/effect/landmark/blobstart,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -11954,7 +11954,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aAE" = (
@@ -12111,7 +12111,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aAV" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -12307,7 +12307,7 @@
 /turf/open/floor/carpet,
 /area/vacant_room/office)
 "aBt" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
 "aBu" = (
@@ -12619,7 +12619,7 @@
 	},
 /area/crew_quarters/theatre)
 "aCi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
@@ -12761,7 +12761,7 @@
 "aCA" = (
 /obj/structure/cable,
 /obj/structure/railing,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/closet,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -12893,7 +12893,7 @@
 /turf/closed/wall,
 /area/chapel/main)
 "aCS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/maintenance/solars/port/fore)
 "aCT" = (
@@ -12922,7 +12922,7 @@
 /area/icemoon/surface/outdoors)
 "aCW" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aCX" = (
@@ -13182,7 +13182,7 @@
 /area/gateway)
 "aDz" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aDA" = (
@@ -14104,7 +14104,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aFC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "aFD" = (
@@ -14545,7 +14545,7 @@
 /area/crew_quarters/heads/hor)
 "aGt" = (
 /obj/structure/bed,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/bedsheet/red,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -14734,7 +14734,7 @@
 /area/hallway/secondary/service)
 "aGJ" = (
 /obj/structure/bed,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/bedsheet/red,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -14875,7 +14875,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGW" = (
@@ -15025,7 +15025,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aHq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/main)
 "aHr" = (
@@ -15076,11 +15076,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "aHx" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aHy" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/auxiliary)
 "aHz" = (
@@ -15596,7 +15596,7 @@
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "aIF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
@@ -15807,7 +15807,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aJd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
@@ -15911,7 +15911,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aJn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "aJo" = (
@@ -16307,7 +16307,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aKn" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hydroponics/garden)
 "aKo" = (
@@ -16320,7 +16320,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aKp" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/primary)
 "aKq" = (
@@ -16340,7 +16340,7 @@
 /area/crew_quarters/theatre)
 "aKs" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/primary)
 "aKt" = (
@@ -16546,7 +16546,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aKW" = (
@@ -16725,7 +16725,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aLw" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aLx" = (
@@ -17295,7 +17295,7 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit)
 "aNa" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "aNb" = (
@@ -17638,7 +17638,7 @@
 /turf/open/floor/wood,
 /area/library)
 "aNQ" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hydroponics)
 "aNR" = (
@@ -17986,7 +17986,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aOK" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "aOL" = (
@@ -18163,7 +18163,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "aPo" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aPq" = (
@@ -18277,7 +18277,7 @@
 /turf/closed/wall,
 /area/crew_quarters/locker)
 "aPF" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/art)
 "aPG" = (
@@ -18363,7 +18363,7 @@
 /turf/closed/wall/r_wall,
 /area/bridge)
 "aPS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "bridge blast door"
@@ -18376,13 +18376,13 @@
 	id = "bridge blast";
 	name = "bridge blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/bridge)
 "aPU" = (
 /obj/machinery/status_display/evac,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "bridge blast door"
@@ -18495,7 +18495,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aQg" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
 	id = "barShutters";
 	name = "privacy shutters"
@@ -18683,7 +18683,7 @@
 /area/hallway/secondary/entry)
 "aQL" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aQN" = (
@@ -19144,7 +19144,7 @@
 /area/storage/tools)
 "aRW" = (
 /obj/structure/sign/warning/docking,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "aRX" = (
@@ -19280,7 +19280,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aSs" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/tools)
 "aSt" = (
@@ -19830,7 +19830,7 @@
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/multitool,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -20193,7 +20193,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/spawner/randomarcade{
+/atom/movable/spawner/randomarcade{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -20335,7 +20335,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/bridge)
@@ -20736,7 +20736,7 @@
 /area/library)
 "aWa" = (
 /obj/structure/sign/warning/vacuum/external,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aWb" = (
@@ -20990,7 +20990,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "aWH" = (
@@ -21610,7 +21610,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "aXS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
@@ -22178,7 +22178,7 @@
 /area/chapel/main)
 "aZi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aZj" = (
@@ -22497,7 +22497,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/effect/spawner/randomarcade{
+/atom/movable/spawner/randomarcade{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22640,7 +22640,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "bam" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hydroponics)
 "ban" = (
@@ -23119,7 +23119,7 @@
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "bbD" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/library)
 "bbE" = (
@@ -23134,7 +23134,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "bbF" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/chapel/main)
 "bbG" = (
@@ -23257,7 +23257,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
@@ -23276,7 +23276,7 @@
 	id = "heads_meeting";
 	name = "privacy shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/bridge/meeting_room)
 "bbX" = (
@@ -23512,7 +23512,7 @@
 	id = "testlab";
 	name = "test chamber blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -23553,7 +23553,7 @@
 /area/maintenance/port)
 "bcK" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bcL" = (
@@ -23633,7 +23633,7 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "bcX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "heads_meeting";
 	name = "privacy shutters"
@@ -23716,7 +23716,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "bdi" = (
-/obj/effect/spawner/randomarcade{
+/atom/movable/spawner/randomarcade{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -24072,8 +24072,8 @@
 	req_access_txt = "20"
 	},
 /obj/structure/window/reinforced,
-/obj/effect/spawner/lootdrop/aimodule_harmless,
-/obj/effect/spawner/lootdrop/aimodule_neutral,
+/atom/movable/spawner/lootdrop/aimodule_harmless,
+/atom/movable/spawner/lootdrop/aimodule_neutral,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -24126,7 +24126,7 @@
 	},
 /obj/item/ai_module/reset/purge,
 /obj/structure/window/reinforced,
-/obj/effect/spawner/lootdrop/aimodule_harmful,
+/atom/movable/spawner/lootdrop/aimodule_harmful,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -24600,7 +24600,7 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bfm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "bfn" = (
@@ -24734,11 +24734,11 @@
 /turf/closed/wall,
 /area/medical/pharmacy)
 "bfG" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "bfH" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "bfI" = (
@@ -24964,7 +24964,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bgl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating/icemoon,
 /area/hallway/secondary/entry)
 "bgm" = (
@@ -25035,7 +25035,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bgx" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating/icemoon,
 /area/science/test_area)
 "bgy" = (
@@ -25351,7 +25351,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bhi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
@@ -25547,7 +25547,7 @@
 	id = "robotics";
 	name = "robotics lab shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "bhz" = (
@@ -25585,7 +25585,7 @@
 	id = "rnd";
 	name = "research lab shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/lab)
 "bhD" = (
@@ -26272,7 +26272,7 @@
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "bja" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bjb" = (
@@ -26449,7 +26449,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/central)
 "bjA" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bjB" = (
@@ -26923,7 +26923,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bkD" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bkE" = (
@@ -26957,7 +26957,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bkJ" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "bkK" = (
@@ -27348,7 +27348,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "blA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "blB" = (
@@ -27502,7 +27502,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "blW" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "blX" = (
@@ -27649,7 +27649,7 @@
 /area/crew_quarters/heads/hop)
 "bmp" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bmq" = (
@@ -27824,7 +27824,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
 "bmJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/departments/chemistry/pharmacy{
 	pixel_x = -32
 	},
@@ -27853,7 +27853,7 @@
 /area/security/checkpoint/medical)
 "bmO" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmP" = (
@@ -27873,7 +27873,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bmR" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "cmoprivacy";
 	name = "CMO Office"
@@ -28048,7 +28048,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bnm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
@@ -28086,7 +28086,7 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "bns" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
@@ -28258,7 +28258,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bnK" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "bnL" = (
@@ -28381,7 +28381,7 @@
 /turf/closed/wall/r_wall,
 /area/storage/mining)
 "bnW" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/mining)
 "bnX" = (
@@ -28670,7 +28670,7 @@
 /area/maintenance/starboard)
 "boI" = (
 /obj/structure/sign/warning/vacuum/external,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "boJ" = (
@@ -28974,7 +28974,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bpt" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen,
 /turf/open/floor/plating,
 /area/medical/pharmacy)
@@ -29033,7 +29033,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "bpE" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/genetics)
 "bpF" = (
@@ -29140,7 +29140,7 @@
 	id = "robotics2";
 	name = "robotics lab shutters"
 	},
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics2";
 	name = "robotics lab shutters"
@@ -29206,14 +29206,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bqg" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bqh" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -29312,7 +29312,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bqv" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "bqw" = (
@@ -29326,7 +29326,7 @@
 	id = "hop";
 	name = "Privacy Shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
@@ -29390,7 +29390,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bqF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "surgery";
 	name = "Surgery Shutter"
@@ -29933,7 +29933,7 @@
 	id = "hop";
 	name = "Privacy Shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
@@ -30331,7 +30331,7 @@
 /turf/closed/wall,
 /area/medical/storage)
 "bsN" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/storage)
 "bsO" = (
@@ -30535,7 +30535,7 @@
 /area/maintenance/starboard)
 "btq" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "btr" = (
@@ -30944,7 +30944,7 @@
 	id = "robotics2";
 	name = "robotics lab shutters"
 	},
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "bul" = (
@@ -30953,7 +30953,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/table/greyscale,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
 	},
@@ -31036,7 +31036,7 @@
 /turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors)
 "buw" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating/icemoon,
 /area/engine/atmos)
 "bux" = (
@@ -31561,7 +31561,7 @@
 	},
 /area/science/research)
 "bvJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "bvK" = (
@@ -31708,7 +31708,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bwd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
 "bwe" = (
@@ -31815,7 +31815,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bwv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "chemistry_shutters2";
 	name = "Chemistry Shutter"
@@ -32345,7 +32345,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/checkpoint/science)
 "byk" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/science)
 "byo" = (
@@ -32660,7 +32660,7 @@
 	name = "SERVER ROOM";
 	pixel_y = 32
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/server)
 "bzx" = (
@@ -33320,7 +33320,7 @@
 	req_access_txt = "26"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plasteel,
 /area/janitor)
 "bAX" = (
@@ -33668,7 +33668,7 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "bBT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -33685,7 +33685,7 @@
 	name = "SERVER ROOM";
 	pixel_y = -32
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/server)
 "bBW" = (
@@ -34225,12 +34225,12 @@
 /area/crew_quarters/heads/hor)
 "bDg" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bDh" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bDj" = (
@@ -34851,7 +34851,7 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bEU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/storage/tech)
@@ -34880,7 +34880,7 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bEY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -34982,7 +34982,7 @@
 	dir = 8;
 	sortType = 6
 	},
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bFn" = (
@@ -35002,7 +35002,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bFq" = (
@@ -35259,7 +35259,7 @@
 /turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors)
 "bGc" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/mixing)
 "bGd" = (
@@ -35305,7 +35305,7 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "bGi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "bGj" = (
@@ -35356,7 +35356,7 @@
 /area/storage/tech)
 "bGt" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/ai,
+/atom/movable/spawner/lootdrop/techstorage/ai,
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bGu" = (
@@ -35373,18 +35373,18 @@
 /area/storage/tech)
 "bGw" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/rnd,
+/atom/movable/spawner/lootdrop/techstorage/rnd,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bGx" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/tcomms,
+/atom/movable/spawner/lootdrop/techstorage/tcomms,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bGy" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/service,
+/atom/movable/spawner/lootdrop/techstorage/service,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bGz" = (
@@ -35479,7 +35479,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bGI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating/icemoon,
 /area/maintenance/solars/port/aft)
 "bGJ" = (
@@ -35626,7 +35626,7 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
@@ -35820,7 +35820,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/techstorage/command,
+/atom/movable/spawner/lootdrop/techstorage/command,
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bHI" = (
@@ -35898,11 +35898,11 @@
 /area/icemoon/surface/outdoors)
 "bHW" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bHX" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bHY" = (
@@ -36277,7 +36277,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bIT" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/structure/sign/departments/xenobio{
 	pixel_y = -32
 	},
@@ -36342,7 +36342,7 @@
 /area/quartermaster/miningdock)
 "bJe" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bJf" = (
@@ -36355,7 +36355,7 @@
 /area/storage/tech)
 "bJh" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/rnd_secure,
+/atom/movable/spawner/lootdrop/techstorage/rnd_secure,
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bJi" = (
@@ -36371,17 +36371,17 @@
 /area/storage/tech)
 "bJk" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/medical,
+/atom/movable/spawner/lootdrop/techstorage/medical,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bJl" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/engineering,
+/atom/movable/spawner/lootdrop/techstorage/engineering,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bJm" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/security,
+/atom/movable/spawner/lootdrop/techstorage/security,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bJn" = (
@@ -36661,7 +36661,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bKe" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/mixing)
 "bKf" = (
@@ -37005,11 +37005,11 @@
 /area/icemoon/surface/outdoors)
 "bLu" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bLv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bLw" = (
@@ -37250,11 +37250,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bMr" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "bMs" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/research)
 "bMt" = (
@@ -37421,7 +37421,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bMR" = (
@@ -37538,7 +37538,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bNk" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/medical/virology)
@@ -37665,7 +37665,7 @@
 /area/maintenance/starboard/aft)
 "bNB" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bNC" = (
@@ -37830,7 +37830,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOf" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
@@ -38019,7 +38019,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bON" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kanyewest";
 	name = "privacy shutters"
@@ -38175,7 +38175,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bPh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -38220,7 +38220,7 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "bPn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bPp" = (
@@ -38296,7 +38296,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bPK" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/misc_lab)
 "bPL" = (
@@ -38350,7 +38350,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bQa" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bQb" = (
@@ -38416,7 +38416,7 @@
 	id = "atmos";
 	name = "Atmospherics Blast Door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bQj" = (
@@ -38507,7 +38507,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQy" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -38654,7 +38654,7 @@
 /area/maintenance/port/aft)
 "bRe" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/maintenance/four,
+/atom/movable/spawner/lootdrop/maintenance/four,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "bRf" = (
@@ -38665,7 +38665,7 @@
 /area/maintenance/port/aft)
 "bRg" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bRi" = (
@@ -38790,7 +38790,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRx" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bRy" = (
@@ -38865,7 +38865,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -38919,7 +38919,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bRQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
 "bRR" = (
@@ -39081,7 +39081,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
 	name = "Atmospherics Blast Door"
@@ -39159,7 +39159,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
@@ -39167,21 +39167,21 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bSK" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bSM" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bSN" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -39189,7 +39189,7 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bSP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
 	},
@@ -39803,7 +39803,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bVo" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/break_room)
 "bVp" = (
@@ -39831,7 +39831,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
@@ -40059,7 +40059,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bWj" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/virology)
 "bWo" = (
@@ -40190,7 +40190,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
@@ -40711,7 +40711,7 @@
 	id = "testlab";
 	name = "test chamber blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "bYj" = (
@@ -41023,7 +41023,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/break_room)
 "bZg" = (
@@ -41033,7 +41033,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bZi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bZj" = (
@@ -41076,7 +41076,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bZv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bZx" = (
@@ -41116,7 +41116,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bZD" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "ceprivacy";
 	name = "privacy shutter"
@@ -41183,7 +41183,7 @@
 /area/maintenance/aft)
 "bZO" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bZP" = (
@@ -41226,7 +41226,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bZU" = (
@@ -41398,7 +41398,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "caA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "caC" = (
@@ -41454,7 +41454,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "caI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
@@ -41462,7 +41462,7 @@
 /area/maintenance/aft)
 "caK" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "caM" = (
@@ -41791,7 +41791,7 @@
 /area/science/misc_lab)
 "ccd" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cce" = (
@@ -42024,13 +42024,13 @@
 /area/security/checkpoint/supply)
 "ccV" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ccW" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ccY" = (
@@ -42356,7 +42356,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ceA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
 	},
@@ -42420,7 +42420,7 @@
 /area/maintenance/starboard/aft)
 "ceV" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ceW" = (
@@ -42471,7 +42471,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/chief)
 "cfc" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "ceprivacy";
 	name = "privacy shutter"
@@ -42724,7 +42724,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/aft)
 "cgF" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -42893,7 +42893,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "chz" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -42914,7 +42914,7 @@
 /area/engine/engineering)
 "chC" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -43154,12 +43154,12 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "ciu" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "civ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -43169,11 +43169,11 @@
 /area/engine/atmos)
 "ciF" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ciL" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ciN" = (
@@ -43369,7 +43369,7 @@
 "cjE" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cjF" = (
@@ -43637,7 +43637,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "ckL" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
@@ -43734,7 +43734,7 @@
 "clq" = (
 /obj/structure/rack,
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "clv" = (
@@ -43792,7 +43792,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "clJ" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "clK" = (
@@ -43868,7 +43868,7 @@
 /area/engine/atmos)
 "clX" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/spawner/xmastree,
+/atom/movable/spawner/xmastree,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -43901,7 +43901,7 @@
 /area/maintenance/starboard/aft)
 "cmo" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cmq" = (
@@ -44030,7 +44030,7 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/maintenance/aft)
 "cnj" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cnk" = (
@@ -44319,7 +44319,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqa" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
@@ -44564,7 +44564,7 @@
 /area/maintenance/port/aft)
 "cqK" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cqL" = (
@@ -44616,7 +44616,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cqY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqZ" = (
@@ -44676,7 +44676,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cro" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -44835,7 +44835,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "csD" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "csH" = (
@@ -44887,7 +44887,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "csT" = (
-/obj/effect/spawner/xmastree,
+/atom/movable/spawner/xmastree,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "csU" = (
@@ -44945,7 +44945,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cti" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
@@ -45841,7 +45841,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvu" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvv" = (
@@ -45873,7 +45873,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "cvy" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
@@ -45936,7 +45936,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvH" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
@@ -46013,7 +46013,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
 	},
@@ -46037,7 +46037,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cwb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
@@ -46145,7 +46145,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cwr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
 "cwt" = (
@@ -46195,7 +46195,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
 /obj/item/wirerod,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cwz" = (
@@ -46621,7 +46621,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "czZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -46786,7 +46786,7 @@
 /area/maintenance/disposal)
 "cAK" = (
 /obj/machinery/light/small,
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cAL" = (
@@ -46930,7 +46930,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "cBg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/hydroponics)
@@ -47302,7 +47302,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cCF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -48032,14 +48032,14 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cGE" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cGH" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -48053,7 +48053,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGK" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -48402,7 +48402,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cMm" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cMC" = (
@@ -48418,7 +48418,7 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "cMN" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "cNr" = (
@@ -48431,7 +48431,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "cNI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "cNJ" = (
@@ -48526,16 +48526,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cOw" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cOx" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cOT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cPA" = (
@@ -49514,7 +49514,7 @@
 /area/medical/medbay/aft)
 "eNr" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -49666,7 +49666,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "fxH" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/machinery/pinpointer_dispenser,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -50208,7 +50208,7 @@
 /turf/open/floor/plating,
 /area/construction)
 "gYE" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "gZK" = (
@@ -50302,7 +50302,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
 "hnW" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
 "hxq" = (
@@ -50818,7 +50818,7 @@
 /area/storage/mining)
 "jdH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance/four,
+/atom/movable/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jgM" = (
@@ -50986,7 +50986,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "jtt" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "jtQ" = (
@@ -51526,7 +51526,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
 "kyo" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "pharmacy_shutters";
 	name = "Pharmacy Shutter"
@@ -51712,12 +51712,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "kPH" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/cryo)
 "kQk" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "kQq" = (
@@ -51994,7 +51994,7 @@
 	id = "testlab";
 	name = "test chamber blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
@@ -52392,7 +52392,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mDj" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "mEX" = (
@@ -52515,7 +52515,7 @@
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "mMA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
@@ -52967,7 +52967,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "nPP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -53669,7 +53669,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
 "pCj" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
@@ -53883,7 +53883,7 @@
 /turf/closed/wall,
 /area/quartermaster/sorting)
 "pWe" = (
-/obj/effect/spawner/xmastree/rdrod,
+/atom/movable/spawner/xmastree/rdrod,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "pWN" = (
@@ -53897,7 +53897,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "pXJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay)
 "pYU" = (
@@ -53982,7 +53982,7 @@
 /turf/open/floor/plasteel,
 /area/science/nanite)
 "qgQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "qjL" = (
@@ -54083,7 +54083,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "qyX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiomain";
@@ -54132,7 +54132,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "qQH" = (
-/obj/effect/spawner/lootdrop/minor/bowler_or_that,
+/atom/movable/spawner/lootdrop/minor/bowler_or_that,
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -54172,7 +54172,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "rdP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
@@ -55022,7 +55022,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "tte" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -55237,7 +55237,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "ufp" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uga" = (
@@ -55374,7 +55374,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "uyS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
@@ -55579,7 +55579,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "vad" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
@@ -55727,7 +55727,7 @@
 /area/medical/morgue)
 "vxh" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/eight,
+/atom/movable/spawner/lootdrop/maintenance/eight,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "vyA" = (
@@ -55884,7 +55884,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "vSk" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "vXa" = (
@@ -55984,7 +55984,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "wkN" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd2";
 	name = "research lab shutters"
@@ -56169,7 +56169,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "wIi" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -56633,7 +56633,7 @@
 /area/maintenance/starboard/aft)
 "xIa" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/grille_or_trash,
+/atom/movable/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "xLr" = (

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -14,14 +14,14 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/unexplored/rivers)
 "ac" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "ad" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
 "ae" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "af" = (
@@ -76,7 +76,7 @@
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "an" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -87,7 +87,7 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "ap" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
 "aq" = (
@@ -162,7 +162,7 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "aA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "aB" = (
@@ -378,7 +378,7 @@
 /turf/closed/wall,
 /area/mine/eva)
 "bg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/eva)
 "bh" = (
@@ -422,7 +422,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/eva)
 "bn" = (
@@ -433,7 +433,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/eva)
 "bo" = (
@@ -456,7 +456,7 @@
 /turf/closed/wall,
 /area/mine/production)
 "br" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/production)
 "bs" = (
@@ -560,7 +560,7 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "bF" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/mine/eva)
 "bG" = (
@@ -860,7 +860,7 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "cp" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiomain";
@@ -980,7 +980,7 @@
 /turf/closed/wall/r_wall,
 /area/mine/maintenance)
 "cR" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "cS" = (
@@ -1056,7 +1056,7 @@
 /area/mine/production)
 "dd" = (
 /obj/structure/closet/emcloset,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "df" = (
@@ -1377,7 +1377,7 @@
 /turf/open/floor/plasteel,
 /area/mine/maintenance)
 "dQ" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "dR" = (
@@ -1408,7 +1408,7 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "dV" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/mine/production)
 "dW" = (
@@ -2242,7 +2242,7 @@
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
@@ -2410,7 +2410,7 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "ia" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/production)
@@ -2654,7 +2654,7 @@
 /area/mine/laborcamp)
 "kh" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
 	name = "Xenobio Pen 3 Blast Door"
@@ -2763,7 +2763,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "lL" = (
@@ -2781,7 +2781,7 @@
 /area/mine/production)
 "lY" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
 	name = "Xenobio Pen 5 Blast Door"
@@ -2804,7 +2804,7 @@
 /area/storage/mining)
 "mu" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "mG" = (
@@ -2837,7 +2837,7 @@
 /turf/open/floor/grass,
 /area/hydroponics)
 "na" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/mechbay)
 "nd" = (
@@ -2863,7 +2863,7 @@
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
@@ -2903,7 +2903,7 @@
 /turf/open/floor/plasteel,
 /area/mine/mechbay)
 "nI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
@@ -3109,7 +3109,7 @@
 	req_access_txt = "55"
 	},
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "pF" = (
@@ -3186,12 +3186,12 @@
 	id = "xenobio4";
 	name = "Xenobio Pen 4 Blast Door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "qn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hydroponics)
 "qt" = (
@@ -3310,7 +3310,7 @@
 	id = "xenobio7";
 	name = "Xenobio Pen 7 Blast Door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "sa" = (
@@ -3390,7 +3390,7 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "sv" = (
-/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/atom/movable/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "sw" = (
@@ -3423,7 +3423,7 @@
 	req_access_txt = "55"
 	},
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "sF" = (
@@ -3450,12 +3450,12 @@
 /area/mine/production)
 "sM" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
 "sX" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "sY" = (
@@ -3507,7 +3507,7 @@
 	req_access_txt = "55"
 	},
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "tI" = (
@@ -3541,7 +3541,7 @@
 	id = "xenobio8";
 	name = "Xenobio Pen 8 Blast Door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "ub" = (
@@ -3604,7 +3604,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
@@ -3687,7 +3687,7 @@
 "we" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "wg" = (
@@ -3726,7 +3726,7 @@
 	id = "xenobio11";
 	name = "Xenobio Pen 11 Blast Door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "wF" = (
@@ -3781,11 +3781,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "xi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/closed/wall,
 /area/mine/living_quarters)
 "xj" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
@@ -3873,7 +3873,7 @@
 /area/icemoon/underground/unexplored/rivers)
 "zb" = (
 /obj/structure/sign/warning/coldtemp,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
@@ -4309,7 +4309,7 @@
 	req_access_txt = "55"
 	},
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "DV" = (
@@ -4336,7 +4336,7 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "Ef" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
@@ -4353,7 +4353,7 @@
 	req_access_txt = "55"
 	},
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "El" = (
@@ -4504,13 +4504,13 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "FF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
 "FG" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
 	name = "Xenobio Pen 2 Blast Door"
@@ -4565,7 +4565,7 @@
 /turf/open/floor/plasteel/dark,
 /area/mine/laborcamp)
 "Gl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hydroponics)
@@ -4777,7 +4777,7 @@
 	id = "xenobio3";
 	name = "Xenobio Pen 3 Blast Door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/structure/sign/warning/electricshock,
 /turf/open/floor/plating,
@@ -4864,7 +4864,7 @@
 /area/mine/laborcamp)
 "Jv" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/item/pickaxe,
 /obj/item/mining_scanner,
 /obj/item/storage/bag/ore,
@@ -4888,7 +4888,7 @@
 	id = "misclab";
 	name = "test chamber blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -4951,7 +4951,7 @@
 /area/mine/living_quarters)
 "Kn" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
 	name = "Xenobio Pen 4 Blast Door"
@@ -4963,7 +4963,7 @@
 	id = "xenobio2";
 	name = "Xenobio Pen 2 Blast Door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5133,7 +5133,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "Mt" = (
@@ -5256,7 +5256,7 @@
 	id = "misclab";
 	name = "test chamber blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -5398,7 +5398,7 @@
 	id = "xenobio10";
 	name = "Xenobio Pen 10 Blast Door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "OD" = (
@@ -5433,7 +5433,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "OP" = (
@@ -5523,7 +5523,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/electricshock,
 /turf/open/floor/plating,
 /area/science/xenobiology)
@@ -5637,7 +5637,7 @@
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
@@ -5900,11 +5900,11 @@
 /area/mine/laborcamp)
 "TC" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "TK" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
@@ -6055,7 +6055,7 @@
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
@@ -6169,7 +6169,7 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/storage/mining)
 "Wn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hydroponics)
@@ -6217,7 +6217,7 @@
 	id = "xenobio6";
 	name = "Xenobio Pen 6 Blast Door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "WM" = (
@@ -6248,7 +6248,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
@@ -6317,7 +6317,7 @@
 	req_access_txt = "55"
 	},
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "XU" = (
@@ -6353,7 +6353,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/electricshock,
 /turf/open/floor/plating,
 /area/science/xenobiology)
@@ -6377,7 +6377,7 @@
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
@@ -6479,7 +6479,7 @@
 	id = "xenobio9";
 	name = "Xenobio Pen 9 Blast Door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "Zk" = (
@@ -6536,7 +6536,7 @@
 	name = "Xenobio Pen 6 Blast Door"
 	},
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/electricshock,
 /turf/open/floor/plating,
 /area/science/xenobiology)

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
@@ -262,7 +262,7 @@
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "Y" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/mine/eva)
 

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -15,7 +15,7 @@
 /area/space)
 "aae" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aaf" = (
@@ -238,7 +238,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aaG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
 	},
@@ -257,7 +257,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "aaH" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
 	},
@@ -1169,7 +1169,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "acK" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -1209,7 +1209,7 @@
 /turf/closed/wall,
 /area/crew_quarters/fitness/recreation)
 "acQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "acR" = (
@@ -1624,7 +1624,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
 "aea" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "hosspace";
 	name = "space shutters"
@@ -1672,7 +1672,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "aee" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aef" = (
@@ -1761,7 +1761,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "aep" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
@@ -1850,7 +1850,7 @@
 /turf/closed/wall,
 /area/security/range)
 "aez" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/range)
 "aeA" = (
@@ -1866,7 +1866,7 @@
 /turf/closed/wall,
 /area/crew_quarters/fitness/recreation)
 "aeC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -2313,7 +2313,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "afB" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -2327,7 +2327,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "afC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
@@ -2364,7 +2364,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison/safe)
 "afJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison/safe)
@@ -2595,7 +2595,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "age" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "hosprivacy";
 	name = "privacy shutters"
@@ -3127,7 +3127,7 @@
 /turf/closed/wall,
 /area/maintenance/disposal)
 "ahq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "ahr" = (
@@ -3205,7 +3205,7 @@
 	dir = 8
 	},
 /obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/clothing/under/rank/prisoner,
 /obj/item/clothing/under/rank/prisoner,
 /obj/item/clothing/under/rank/prisoner/skirt,
@@ -3429,7 +3429,7 @@
 "ahU" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ahV" = (
@@ -3567,7 +3567,7 @@
 /area/maintenance/disposal)
 "aik" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "ail" = (
@@ -3598,11 +3598,11 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
 "aip" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aiq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
@@ -3752,7 +3752,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "aiD" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/main)
@@ -3948,7 +3948,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "ajg" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -4003,7 +4003,7 @@
 /obj/item/clothing/suit/monkeysuit,
 /obj/item/clothing/head/xenos,
 /obj/item/clothing/mask/gas/monkeymask,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ajm" = (
@@ -4021,7 +4021,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ajo" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "ajp" = (
@@ -4130,21 +4130,21 @@
 	name = "contraband locker";
 	req_access_txt = "3"
 	},
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/armory_contraband/metastation,
+/atom/movable/spawner/lootdrop/armory_contraband/metastation,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ajx" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
@@ -4360,7 +4360,7 @@
 "ajO" = (
 /obj/structure/closet,
 /obj/item/clothing/gloves/color/fyellow,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ajP" = (
@@ -4583,7 +4583,7 @@
 /obj/structure/rack,
 /obj/item/mop,
 /obj/item/bikehorn/rubberducky,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/grenade/empgrenade,
 /turf/open/floor/plating,
@@ -4611,7 +4611,7 @@
 	},
 /obj/item/dice/d8,
 /obj/item/healthanalyzer,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "akt" = (
@@ -4954,7 +4954,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "akW" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/range)
@@ -5080,7 +5080,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "all" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -5120,7 +5120,7 @@
 /turf/closed/wall,
 /area/maintenance/starboard)
 "alr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "als" = (
@@ -5150,7 +5150,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "alv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "alw" = (
@@ -5287,7 +5287,7 @@
 /obj/item/storage/secure/briefcase,
 /obj/item/disk/data,
 /obj/item/grenade/flashbang,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/grenade/smokebomb,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -5401,7 +5401,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "alV" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -5911,21 +5911,21 @@
 	},
 /obj/item/book/manual/wiki/engineering_hacking,
 /obj/item/tape/random,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "amX" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/item/stock_parts/cell/crap,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "amY" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/item/electronics/firealarm,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "amZ" = (
@@ -5933,7 +5933,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "anb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -6029,7 +6029,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "anl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
@@ -6410,11 +6410,11 @@
 /obj/structure/rack,
 /obj/item/clothing/under/misc/mailman,
 /obj/item/clothing/under/misc/vice_officer,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoi" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoj" = (
@@ -6896,7 +6896,7 @@
 	name = "old sink";
 	pixel_y = 28
 	},
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "apf" = (
@@ -6913,11 +6913,11 @@
 	desc = "Takes you to a whole new level of thinking.";
 	name = "Meta-Cider"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aph" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
@@ -6966,7 +6966,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "apq" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "apr" = (
@@ -7030,7 +7030,7 @@
 /area/maintenance/port/fore)
 "apx" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/service,
+/atom/movable/spawner/lootdrop/techstorage/service,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "apy" = (
@@ -7445,7 +7445,7 @@
 "aqs" = (
 /obj/item/mmi,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aqt" = (
@@ -7611,7 +7611,7 @@
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/storage/toolbox/emergency,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqM" = (
@@ -7850,7 +7850,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "arq" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -7938,7 +7938,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "arD" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "arE" = (
@@ -7966,20 +7966,20 @@
 "arG" = (
 /obj/structure/closet,
 /obj/item/storage/box/lights/mixed,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/fore)
 "arH" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arI" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/costume,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arK" = (
@@ -7999,7 +7999,7 @@
 	pixel_x = 3;
 	pixel_y = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -8192,7 +8192,7 @@
 	},
 /area/maintenance/port/fore)
 "asi" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -8607,8 +8607,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -8837,7 +8837,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -8992,7 +8992,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "atW" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
 	name = "Xenobio Pen 6 Blast Door"
@@ -9004,7 +9004,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "atZ" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/security/main)
 "aua" = (
@@ -9196,13 +9196,13 @@
 /obj/item/stack/sheet/cardboard,
 /obj/item/flashlight,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "auz" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "auB" = (
@@ -10108,7 +10108,7 @@
 /area/hallway/primary/port)
 "awM" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "awP" = (
@@ -10155,7 +10155,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "axf" = (
@@ -10196,7 +10196,7 @@
 /area/security/warden)
 "axi" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/warden)
 "axj" = (
@@ -10615,7 +10615,7 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ayi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "ayj" = (
@@ -10793,7 +10793,7 @@
 /area/security/warden)
 "ayC" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ayE" = (
@@ -10823,7 +10823,7 @@
 /turf/closed/wall/r_wall,
 /area/security/detectives_office)
 "ayG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "detective_shutters";
 	name = "detective's office shutters"
@@ -11819,7 +11819,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "aBc" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "briglockdown";
@@ -12012,7 +12012,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -12210,7 +12210,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -12342,7 +12342,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "aCk" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
@@ -12368,7 +12368,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aCp" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "briglockdown";
@@ -12597,7 +12597,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCR" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -12628,7 +12628,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -12647,7 +12647,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aCZ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aDa" = (
@@ -12803,7 +12803,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aDz" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aDA" = (
@@ -13267,7 +13267,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aEH" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/construction/storage_wing)
@@ -13855,7 +13855,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/gambling,
+/atom/movable/spawner/lootdrop/gambling,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aGl" = (
@@ -14313,7 +14313,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aHl" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -14360,7 +14360,7 @@
 "aHv" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aHw" = (
@@ -14386,7 +14386,7 @@
 /turf/closed/wall/r_wall,
 /area/hallway/primary/fore)
 "aHy" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
@@ -14527,8 +14527,8 @@
 /area/crew_quarters/dorms)
 "aHV" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aHX" = (
@@ -14558,7 +14558,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIc" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -14583,7 +14583,7 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aIg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aIi" = (
@@ -15095,7 +15095,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "aJB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -15127,7 +15127,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aJG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
@@ -15154,7 +15154,7 @@
 /turf/closed/wall,
 /area/storage/primary)
 "aJO" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/primary)
 "aJP" = (
@@ -15361,7 +15361,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aKn" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
@@ -15897,7 +15897,7 @@
 /area/crew_quarters/locker)
 "aLJ" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -16245,7 +16245,7 @@
 "aMG" = (
 /obj/structure/table,
 /obj/item/ai_module/core/full/asimov,
-/obj/effect/spawner/lootdrop/aimodule_harmless,
+/atom/movable/spawner/lootdrop/aimodule_harmless,
 /obj/item/ai_module/core/freeformcore,
 /obj/machinery/door/window{
 	base_state = "right";
@@ -16255,7 +16255,7 @@
 	req_access_txt = "20"
 	},
 /obj/structure/window/reinforced,
-/obj/effect/spawner/lootdrop/aimodule_neutral,
+/atom/movable/spawner/lootdrop/aimodule_neutral,
 /obj/item/ai_module/core/full/custom,
 /obj/machinery/flasher{
 	id = "AI";
@@ -16278,7 +16278,7 @@
 	id = "AI";
 	pixel_y = 24
 	},
-/obj/effect/spawner/lootdrop/aimodule_harmful,
+/atom/movable/spawner/lootdrop/aimodule_harmful,
 /obj/item/ai_module/supplied/oxygen,
 /obj/item/ai_module/supplied/protect_station,
 /obj/item/ai_module/zeroth/onehuman,
@@ -16512,7 +16512,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aNg" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/hydroponics/garden)
 "aNi" = (
@@ -16704,7 +16704,7 @@
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -16826,7 +16826,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aNZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -17444,7 +17444,7 @@
 "aPq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aPt" = (
@@ -17498,7 +17498,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aPB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/courtroom)
 "aPC" = (
@@ -17542,7 +17542,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "aPG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "lawyer_shutters";
 	name = "law office shutters"
@@ -17599,7 +17599,7 @@
 "aPM" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/costume,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aPO" = (
@@ -17638,7 +17638,7 @@
 "aPS" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/fyellow,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aPT" = (
@@ -17821,7 +17821,7 @@
 "aQs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/airlock_painter/decal,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -17831,7 +17831,7 @@
 "aQt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aQu" = (
@@ -17874,7 +17874,7 @@
 "aQy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/stock_parts/cell{
 	maxcharge = 2000
 	},
@@ -18174,7 +18174,7 @@
 /area/hydroponics)
 "aRa" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/costume,
 /obj/item/clothing/mask/balaclava,
 /obj/machinery/airalarm{
 	dir = 8;
@@ -18453,7 +18453,7 @@
 "aRK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/internals,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aRL" = (
@@ -18602,7 +18602,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aSe" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/locker)
 "aSf" = (
@@ -19001,7 +19001,7 @@
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -19025,7 +19025,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aTk" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/security/courtroom)
 "aTl" = (
@@ -19520,7 +19520,7 @@
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central)
 "aUw" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
@@ -19917,7 +19917,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "aVh" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -19973,7 +19973,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "aVs" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aVt" = (
@@ -20590,7 +20590,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "aWA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
@@ -21356,7 +21356,7 @@
 /area/storage/tech)
 "aYj" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/engineering,
+/atom/movable/spawner/lootdrop/techstorage/engineering,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "aYk" = (
@@ -21364,12 +21364,12 @@
 /obj/machinery/status_display/ai{
 	pixel_y = 31
 	},
-/obj/effect/spawner/lootdrop/techstorage/medical,
+/atom/movable/spawner/lootdrop/techstorage/medical,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "aYl" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/rnd,
+/atom/movable/spawner/lootdrop/techstorage/rnd,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "aYm" = (
@@ -21528,7 +21528,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "aYz" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "AI Core shutters";
 	name = "AI core shutters"
@@ -21590,8 +21590,8 @@
 "aYJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aYL" = (
@@ -22259,7 +22259,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bak" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -22655,7 +22655,7 @@
 /area/maintenance/starboard/fore)
 "bbk" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/ai,
+/atom/movable/spawner/lootdrop/techstorage/ai,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bbl" = (
@@ -22699,7 +22699,7 @@
 /area/storage/tech)
 "bbn" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/security,
+/atom/movable/spawner/lootdrop/techstorage/security,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bbo" = (
@@ -22707,7 +22707,7 @@
 /area/maintenance/solars/port/fore)
 "bbp" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/tcomms,
+/atom/movable/spawner/lootdrop/techstorage/tcomms,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bbr" = (
@@ -22986,7 +22986,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bbQ" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
@@ -23024,7 +23024,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bcd" = (
@@ -23042,7 +23042,7 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bci" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "bcj" = (
@@ -23072,7 +23072,7 @@
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/multitool,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -23132,12 +23132,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bcu" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bcv" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/rnd_secure,
+/atom/movable/spawner/lootdrop/techstorage/rnd_secure,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bcw" = (
@@ -23910,7 +23910,7 @@
 /obj/structure/rack,
 /obj/item/electronics/apc,
 /obj/item/electronics/airlock,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -23938,7 +23938,7 @@
 /area/maintenance/starboard/fore)
 "bdX" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/command,
+/atom/movable/spawner/lootdrop/techstorage/command,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bdY" = (
@@ -24237,7 +24237,7 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "beK" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/customs)
@@ -24400,7 +24400,7 @@
 	name = "Cargo Desk";
 	req_access_txt = "50"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24497,11 +24497,11 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bfq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bfr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "bridge blast door"
@@ -24593,7 +24593,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "bfJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/tools)
 "bfK" = (
@@ -24667,7 +24667,7 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bfR" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "ceprivacy";
 	name = "privacy shutter"
@@ -24706,7 +24706,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "bfX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
@@ -25845,7 +25845,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "biq" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -25910,7 +25910,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "biE" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "biG" = (
@@ -26967,7 +26967,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/break_room)
 "blk" = (
@@ -27004,7 +27004,7 @@
 /area/engine/break_room)
 "blo" = (
 /obj/structure/table/glass,
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -27351,7 +27351,7 @@
 /turf/closed/wall,
 /area/quartermaster/sorting)
 "bmm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "bmn" = (
@@ -27579,7 +27579,7 @@
 /turf/closed/wall,
 /area/crew_quarters/bar)
 "bmM" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/art)
 "bmN" = (
@@ -27928,7 +27928,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bnM" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "bnP" = (
@@ -28215,7 +28215,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bol" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "hop";
 	name = "privacy shutters"
@@ -28514,7 +28514,7 @@
 /area/storage/tcom)
 "bph" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bpm" = (
@@ -30262,7 +30262,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bto" = (
-/obj/effect/spawner/xmastree,
+/atom/movable/spawner/xmastree,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -30802,7 +30802,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "buR" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/machinery/camera{
 	c_tag = "Bar - Starboard"
 	},
@@ -32103,7 +32103,7 @@
 /turf/open/floor/plasteel/checker,
 /area/engine/atmos)
 "bza" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bzb" = (
@@ -32983,7 +32983,7 @@
 /area/crew_quarters/toilet/auxiliary)
 "bBq" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bBr" = (
@@ -33036,7 +33036,7 @@
 /turf/closed/wall,
 /area/hallway/secondary/command)
 "bBz" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/secondary/command)
@@ -33102,7 +33102,7 @@
 	},
 /area/hallway/primary/port)
 "bBH" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "council blast";
 	name = "Council Blast Doors"
@@ -33183,7 +33183,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "bBT" = (
@@ -33367,7 +33367,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bCy" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
@@ -33402,7 +33402,7 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
 "bCE" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "bCF" = (
@@ -33415,7 +33415,7 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "bCG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -34652,7 +34652,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bFQ" = (
@@ -34709,7 +34709,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bFX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
@@ -35173,7 +35173,7 @@
 	},
 /area/engine/atmos)
 "bHx" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -35181,14 +35181,14 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bHy" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bHz" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -35196,7 +35196,7 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bHA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -35204,7 +35204,7 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bHB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
 	},
@@ -35292,7 +35292,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/auxiliary)
 "bHO" = (
@@ -35778,7 +35778,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "bJa" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
@@ -36078,7 +36078,7 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "bJM" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/teleporter)
@@ -36108,7 +36108,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "bJS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/gateway)
@@ -36512,12 +36512,12 @@
 /area/vacant_room/office)
 "bLb" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bLd" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bLe" = (
@@ -36526,15 +36526,15 @@
 /area/maintenance/port)
 "bLf" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/costume,
-/obj/effect/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bLg" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/costume,
-/obj/effect/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bLh" = (
@@ -36695,7 +36695,7 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "bLv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "corporate_privacy";
 	name = "showroom shutters"
@@ -36892,7 +36892,7 @@
 /area/maintenance/starboard)
 "bLX" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -38382,7 +38382,7 @@
 "bPJ" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/animal/horsehead,
-/obj/effect/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bPK" = (
@@ -39731,7 +39731,7 @@
 /area/maintenance/port)
 "bTv" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/paper,
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -40068,7 +40068,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bUe" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hydroponics)
 "bUf" = (
@@ -40146,7 +40146,7 @@
 	icon_state = "crateopen"
 	},
 /obj/item/storage/box/drinkingglasses,
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -40295,9 +40295,9 @@
 /area/maintenance/port)
 "bUR" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bUS" = (
@@ -41543,7 +41543,7 @@
 /area/maintenance/port)
 "bXy" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bXz" = (
@@ -41560,7 +41560,7 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bXC" = (
@@ -41726,7 +41726,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "bYc" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "bYd" = (
@@ -41933,7 +41933,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "bYC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "bYD" = (
@@ -42152,7 +42152,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/checkpoint/medical)
 "bZa" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "bZb" = (
@@ -42225,7 +42225,7 @@
 /turf/closed/wall,
 /area/science/research)
 "bZj" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/research)
 "bZk" = (
@@ -43227,7 +43227,7 @@
 /obj/structure/light_construct{
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cbA" = (
@@ -43236,7 +43236,7 @@
 	amount = 34
 	},
 /obj/item/extinguisher/mini,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cbB" = (
@@ -43926,11 +43926,11 @@
 /obj/item/stack/sheet/glass{
 	amount = 12
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cdk" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
+/atom/movable/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cdl" = (
@@ -44182,7 +44182,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cdP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/science/research)
 "cdQ" = (
@@ -44279,17 +44279,17 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "ceg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "ceh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "cei" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -44314,7 +44314,7 @@
 	pixel_y = 16
 	},
 /obj/item/hand_labeler,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ceq" = (
@@ -44325,7 +44325,7 @@
 	},
 /obj/item/wrench,
 /obj/item/flashlight/seclite,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cer" = (
@@ -44333,7 +44333,7 @@
 /obj/item/stack/rods{
 	amount = 23
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ceu" = (
@@ -44819,7 +44819,7 @@
 	},
 /area/crew_quarters/kitchen)
 "cft" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
@@ -44850,7 +44850,7 @@
 "cfC" = (
 /obj/structure/closet,
 /obj/item/extinguisher,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cfG" = (
@@ -45005,7 +45005,7 @@
 /turf/closed/wall,
 /area/medical/pharmacy)
 "cfX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "pharmacy_shutters";
 	name = "Pharmacy shutters"
@@ -45103,7 +45103,7 @@
 /turf/closed/wall/r_wall,
 /area/science/lab)
 "cge" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "research_shutters";
 	name = "research shutters"
@@ -45310,7 +45310,7 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "cgH" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -46328,7 +46328,7 @@
 	},
 /area/maintenance/starboard/secondary)
 "ciY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plating,
@@ -46945,15 +46945,15 @@
 /area/science/genetics)
 "cku" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "ckv" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
@@ -46977,7 +46977,7 @@
 	name = "old sink";
 	pixel_y = 28
 	},
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "ckz" = (
@@ -47056,7 +47056,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
 "ckN" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ckP" = (
@@ -47182,7 +47182,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cln" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -47617,7 +47617,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "cma" = (
@@ -47757,7 +47757,7 @@
 /turf/closed/wall,
 /area/crew_quarters/heads/cmo)
 "cmv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "cmoprivacy";
 	name = "privacy shutter"
@@ -48318,7 +48318,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
 "cnL" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "pharmacy_shutters_2";
 	name = "Pharmacy shutters"
@@ -48394,7 +48394,7 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cnX" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/lab)
 "cnY" = (
@@ -49630,7 +49630,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqw" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "research_shutters_2";
 	name = "research shutters"
@@ -50139,7 +50139,7 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "crJ" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -50158,7 +50158,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "crN" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "rdprivacy";
 	name = "privacy shutter"
@@ -50167,7 +50167,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "crP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "rdprivacy";
 	name = "privacy shutter"
@@ -50271,7 +50271,7 @@
 /area/maintenance/starboard/secondary)
 "cse" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -50288,7 +50288,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -50660,7 +50660,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "csT" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50744,7 +50744,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/spawner/xmastree/rdrod,
+/atom/movable/spawner/xmastree/rdrod,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -50836,7 +50836,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "ctn" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -50930,7 +50930,7 @@
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "ctK" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -51412,7 +51412,7 @@
 /obj/structure/rack,
 /obj/item/extinguisher,
 /obj/item/storage/box/lights/mixed,
-/obj/effect/spawner/lootdrop/maintenance/four,
+/atom/movable/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "cuZ" = (
@@ -51514,7 +51514,7 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "cvA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/genetics)
 "cvG" = (
@@ -52007,7 +52007,7 @@
 /area/medical/break_room)
 "cxg" = (
 /obj/structure/table/glass,
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -52610,7 +52610,7 @@
 /turf/closed/wall,
 /area/science/test_area)
 "czK" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/test_area)
 "czP" = (
@@ -53036,7 +53036,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cAP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/mixing)
 "cAQ" = (
@@ -53166,7 +53166,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cBq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "toxins_blastdoor";
 	name = "biohazard containment door"
@@ -53464,7 +53464,7 @@
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
 "cCo" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics_shutters";
 	name = "robotics shutters"
@@ -53750,7 +53750,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "cDa" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics_shutters";
 	name = "robotics shutters"
@@ -54285,7 +54285,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cEA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/space/nearstation)
 "cEB" = (
@@ -54594,7 +54594,7 @@
 "cFI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/cardboard,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/item/toy/plush/lizardplushie{
 	name = "Tends-the-Wounds"
 	},
@@ -55123,7 +55123,7 @@
 /area/medical/abandoned)
 "cHw" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/memeorgans,
+/atom/movable/spawner/lootdrop/memeorgans,
 /obj/structure/closet/crate/medical,
 /turf/open/floor/plasteel/white,
 /area/medical/abandoned)
@@ -55421,7 +55421,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "cId" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
 	name = "SERVER ROOM";
@@ -55451,7 +55451,7 @@
 /obj/structure/sign/warning/biohazard{
 	pixel_y = 32
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cIi" = (
@@ -55475,7 +55475,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cIk" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -55649,7 +55649,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cIP" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "cIQ" = (
@@ -55769,7 +55769,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cJl" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55894,7 +55894,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "cJA" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -56133,7 +56133,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "cJU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/server)
 "cJW" = (
@@ -56155,8 +56155,8 @@
 /area/maintenance/aft)
 "cJY" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/costume,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -56169,7 +56169,7 @@
 "cKa" = (
 /obj/structure/closet,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cKb" = (
@@ -56412,7 +56412,7 @@
 /turf/closed/wall/r_wall,
 /area/science/research)
 "cKJ" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -56728,7 +56728,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -56989,7 +56989,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "cMl" = (
@@ -57751,7 +57751,7 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "cNP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
@@ -57918,7 +57918,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "cOh" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cOi" = (
@@ -57936,7 +57936,7 @@
 /turf/open/floor/carpet,
 /area/chapel/main)
 "cOk" = (
-/obj/effect/spawner/xmastree,
+/atom/movable/spawner/xmastree,
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/chapel/main)
@@ -58234,7 +58234,7 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "cPe" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -58349,7 +58349,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cPv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "cPx" = (
@@ -58361,11 +58361,11 @@
 /area/maintenance/starboard/aft)
 "cPz" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/four,
+/atom/movable/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cPA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chapel_shutters_parlour";
 	name = "chapel shutters"
@@ -59000,7 +59000,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cRe" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cRh" = (
@@ -59340,7 +59340,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "cRL" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chapel_shutters_space";
 	name = "chapel shutters"
@@ -59402,7 +59402,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/structure/sign/warning/electricshock,
 /obj/machinery/door/poddoor/preopen{
@@ -59446,7 +59446,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cRZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
@@ -59611,7 +59611,7 @@
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "cSw" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/coldtemp,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -59643,7 +59643,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -59657,7 +59657,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cSD" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/structure/sign/warning/electricshock,
 /obj/structure/disposalpipe/segment{
@@ -59673,7 +59673,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/button/door{
 	id = "xenobio5";
 	layer = 3.3;
@@ -59751,7 +59751,7 @@
 /area/science/xenobiology)
 "cSN" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
 	name = "Xenobio Pen 2 Blast Door"
@@ -59760,7 +59760,7 @@
 /area/science/xenobiology)
 "cSO" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -59785,7 +59785,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
 	name = "Xenobio Pen 3 Blast Door"
@@ -59889,7 +59889,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
 	name = "Xenobio Pen 6 Blast Door"
@@ -59901,7 +59901,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/button/door{
 	id = "xenobio7";
 	layer = 3.3;
@@ -59929,7 +59929,7 @@
 /area/chapel/office)
 "cTg" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
 	name = "Xenobio Pen 7 Blast Door"
@@ -59988,11 +59988,11 @@
 /area/maintenance/department/science/xenobiology)
 "cTp" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cTq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60114,7 +60114,7 @@
 /turf/open/floor/wood,
 /area/library)
 "cUU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/library)
 "cUZ" = (
@@ -60209,7 +60209,7 @@
 /turf/open/space/basic,
 /area/space)
 "cVy" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -60266,7 +60266,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/engine/atmos)
 "cWA" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "cWB" = (
@@ -60286,7 +60286,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cWK" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "cWM" = (
@@ -60404,7 +60404,7 @@
 /area/science/robotics/lab)
 "cYj" = (
 /obj/structure/closet/firecloset,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cYE" = (
@@ -60606,7 +60606,7 @@
 	id = "Xenolab";
 	name = "test chamber blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
@@ -60616,12 +60616,12 @@
 	name = "test chamber blast door"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "daE" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/button/door{
 	id = "xenobio3";
 	layer = 3.3;
@@ -60668,7 +60668,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "daJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
 	name = "Xenobio Pen 3 Blast Door"
@@ -60875,7 +60875,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "dbv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "dbw" = (
@@ -60946,7 +60946,7 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
 "dbN" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "dbO" = (
@@ -61531,7 +61531,7 @@
 /area/science/xenobiology)
 "dcS" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
 	name = "Xenobio Pen 5 Blast Door"
@@ -61545,7 +61545,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dcU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -61567,7 +61567,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "dcW" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
@@ -61672,7 +61672,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ddi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/button/door{
 	id = "xenobio4";
 	layer = 3.3;
@@ -61760,7 +61760,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "ddr" = (
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
@@ -61939,14 +61939,14 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "ded" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dee" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -61960,7 +61960,7 @@
 /area/engine/engineering)
 "deh" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
@@ -62428,7 +62428,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dgb" = (
@@ -62468,7 +62468,7 @@
 /area/space/nearstation)
 "dgi" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -62619,7 +62619,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "dhk" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
@@ -62635,7 +62635,7 @@
 "dhn" = (
 /obj/structure/table,
 /obj/item/poster/random_contraband,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "dho" = (
@@ -62649,8 +62649,8 @@
 /obj/item/poster/random_contraband,
 /obj/item/poster/random_contraband,
 /obj/item/poster/random_contraband,
-/obj/effect/spawner/lootdrop/maintenance/four,
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/maintenance/four,
+/atom/movable/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dhp" = (
@@ -62674,7 +62674,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/item/poster/random_official,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dhr" = (
@@ -62737,7 +62737,7 @@
 /obj/item/poster/random_contraband,
 /obj/item/poster/random_contraband,
 /obj/item/poster/random_contraband,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "dhx" = (
@@ -62830,7 +62830,7 @@
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
 "dhH" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
@@ -62855,7 +62855,7 @@
 "dhK" = (
 /obj/structure/closet,
 /obj/item/poster/random_contraband,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dhM" = (
@@ -62918,7 +62918,7 @@
 /obj/structure/closet,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/poster/random_contraband,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "dhS" = (
@@ -63136,7 +63136,7 @@
 "dix" = (
 /obj/structure/rack,
 /obj/item/poster/random_contraband,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -63454,7 +63454,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "dlN" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "dlP" = (
@@ -63519,7 +63519,7 @@
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
 "dni" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "dnk" = (
@@ -63861,7 +63861,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -63959,13 +63959,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "dxk" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dxP" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/storage/belt/utility,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -64012,7 +64012,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dyw" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dyH" = (
@@ -64091,7 +64091,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dAh" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dAn" = (
@@ -64195,7 +64195,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "dBN" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/virology)
@@ -64338,7 +64338,7 @@
 /area/security/warden)
 "dCi" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "dCk" = (
@@ -64400,7 +64400,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "dCx" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "dCz" = (
@@ -64828,7 +64828,7 @@
 /obj/item/seeds/ambrosia,
 /obj/item/seeds/wheat,
 /obj/item/seeds/pumpkin,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
@@ -65014,7 +65014,7 @@
 /area/security/execution/education)
 "dXV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -65224,7 +65224,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "ekC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/button/door{
 	id = "xenobio6";
 	layer = 3.3;
@@ -65287,7 +65287,7 @@
 /area/crew_quarters/bar)
 "emz" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "emW" = (
@@ -65549,7 +65549,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -65661,7 +65661,7 @@
 /area/maintenance/port/aft)
 "eOz" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
 	},
@@ -65763,7 +65763,7 @@
 "eXS" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/storage/belt/utility,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -65888,7 +65888,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "ffu" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
 	id = "surgeryc";
 	name = "privacy shutter"
@@ -65978,7 +65978,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "flZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -65996,7 +65996,7 @@
 "fmr" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/glass/bowl,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/reagent_containers/glass/bowl,
 /obj/item/reagent_containers/glass/bowl,
 /obj/item/reagent_containers/glass/bowl,
@@ -66302,7 +66302,7 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "fGa" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66336,7 +66336,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "fIF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
 "fJl" = (
@@ -66383,7 +66383,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "fMA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -67205,7 +67205,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/cafeteria)
 "gJs" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "gJK" = (
@@ -67264,7 +67264,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "gOu" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
 	id = "surgeryb";
 	name = "privacy shutter"
@@ -67327,7 +67327,7 @@
 	name = "decommissioned sleeper"
 	},
 /obj/effect/decal/cleanable/greenglow,
-/obj/effect/spawner/lootdrop/glowstick,
+/atom/movable/spawner/lootdrop/glowstick,
 /turf/open/floor/plasteel/white,
 /area/medical/abandoned)
 "gYQ" = (
@@ -67405,7 +67405,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "hcY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "hdb" = (
@@ -67510,7 +67510,7 @@
 /area/hallway/primary/fore)
 "hkv" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
 "hkA" = (
@@ -67844,7 +67844,7 @@
 /area/maintenance/starboard)
 "hGB" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /obj/structure/closet/crate/medical,
 /turf/open/floor/plasteel/white,
 /area/medical/abandoned)
@@ -67873,7 +67873,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hKX" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68089,7 +68089,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "ifK" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/cryo)
 "ifN" = (
@@ -68291,8 +68291,8 @@
 /area/crew_quarters/theatre)
 "ixc" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ixg" = (
@@ -68646,7 +68646,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "iYR" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -68665,11 +68665,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "jah" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "jbB" = (
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/structure/closet/crate,
 /obj/item/stack/license_plates/empty/fifty,
 /obj/item/stack/license_plates/empty/fifty,
@@ -68756,7 +68756,7 @@
 /area/science/xenobiology)
 "jib" = (
 /obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/atom/movable/spawner/lootdrop/prison_contraband,
 /obj/item/trash/chips,
 /obj/item/trash/candy,
 /obj/machinery/firealarm{
@@ -69452,7 +69452,7 @@
 "jVH" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "jXH" = (
@@ -69982,7 +69982,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "kCU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "rdprivacy";
 	name = "privacy shutter"
@@ -69995,7 +69995,7 @@
 /area/crew_quarters/heads/hor)
 "kDC" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "kDM" = (
@@ -70157,7 +70157,7 @@
 	id = "Xenolab";
 	name = "test chamber blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plating,
@@ -70170,7 +70170,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "kMC" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "kNq" = (
@@ -70223,7 +70223,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "kQx" = (
@@ -70905,7 +70905,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "lUr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/nanite)
 "lUZ" = (
@@ -70917,7 +70917,7 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "lVD" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "lWo" = (
@@ -71192,7 +71192,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "mjj" = (
-/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/atom/movable/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "mjq" = (
@@ -71295,7 +71295,7 @@
 /area/maintenance/aft/secondary)
 "moO" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plasteel/white,
 /area/medical/abandoned)
 "mpe" = (
@@ -71768,7 +71768,7 @@
 /turf/open/space/basic,
 /area/solar/port/aft)
 "nde" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/break_room)
@@ -71800,7 +71800,7 @@
 /area/medical/virology)
 "nhw" = (
 /obj/structure/closet/emcloset,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "nhT" = (
@@ -72003,7 +72003,7 @@
 	},
 /area/medical/abandoned)
 "nBI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chem_lockdown";
 	name = "Chemistry shutters"
@@ -72212,7 +72212,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "nMU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/storage_wing)
 "nNB" = (
@@ -72242,7 +72242,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms)
 "nOZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "nPl" = (
@@ -72422,7 +72422,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ocT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/misc_lab/range)
 "odi" = (
@@ -73360,7 +73360,7 @@
 	pixel_x = 2;
 	pixel_y = 6
 	},
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
@@ -73721,7 +73721,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "pIt" = (
@@ -73735,7 +73735,7 @@
 /area/maintenance/starboard)
 "pJO" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -74842,7 +74842,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "raA" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -74981,7 +74981,7 @@
 	},
 /area/engine/atmos)
 "riE" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -75606,7 +75606,7 @@
 	},
 /obj/item/cultivator,
 /obj/item/clothing/head/chefhat,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/camera{
 	c_tag = "Service - Starboard";
 	dir = 4
@@ -75693,7 +75693,7 @@
 	id = "visitation";
 	name = "Visitation Shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
@@ -75719,7 +75719,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "scY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -75801,7 +75801,7 @@
 /obj/structure/closet,
 /obj/item/extinguisher,
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "sht" = (
@@ -75927,11 +75927,11 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/rack,
 /obj/item/tank/internals/anesthetic,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "sqr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "medsecprivacy";
@@ -76174,7 +76174,7 @@
 /area/crew_quarters/bar)
 "sMV" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "sNr" = (
@@ -76443,7 +76443,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "tjt" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/mixing/chamber)
 "tmp" = (
@@ -76491,7 +76491,7 @@
 /turf/open/space/basic,
 /area/space)
 "tqi" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
 	id = "surgerya";
 	name = "privacy shutter"
@@ -76534,7 +76534,7 @@
 	id = "chem_lockdown";
 	name = "Chemistry shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "tsU" = (
@@ -76722,7 +76722,7 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "tDQ" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/medical/medbay/central)
@@ -76881,7 +76881,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "tOL" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "PermaLockdown";
@@ -76949,7 +76949,7 @@
 /area/security/prison)
 "tTw" = (
 /obj/structure/chair/stool,
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "tUa" = (
@@ -77186,7 +77186,7 @@
 /area/construction/storage_wing)
 "urv" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/security/prison)
 "urx" = (
@@ -77784,7 +77784,7 @@
 	id = "medbreakroom";
 	name = "privacy shutter"
 	},
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/atom/movable/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/medical/break_room)
 "vml" = (
@@ -77806,7 +77806,7 @@
 /area/ai_monitored/turret_protected/ai)
 "vnL" = (
 /obj/structure/closet/crate/hydroponics,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "vnX" = (
@@ -77971,7 +77971,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "vxU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chem_lockdown";
@@ -77980,7 +77980,7 @@
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "vyS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/storage_shared)
 "vzK" = (
@@ -78031,7 +78031,7 @@
 /area/engine/break_room)
 "vAs" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -78058,7 +78058,7 @@
 /obj/structure/rack,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "vDb" = (
@@ -78882,7 +78882,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "wHc" = (
@@ -78917,7 +78917,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -78953,7 +78953,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/item/assembly/timer,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/storage/box/shipping,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/radio{
@@ -79628,7 +79628,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
 	name = "Xenobio Pen 7 Blast Door"
@@ -80071,7 +80071,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "yej" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "briglockdown";
 	name = "brig shutters"
@@ -80155,7 +80155,7 @@
 /turf/closed/wall,
 /area/hallway/primary/central)
 "ykb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -81,7 +81,7 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "ap" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
 "aq" = (
@@ -337,7 +337,7 @@
 /turf/closed/wall,
 /area/mine/eva)
 "bg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/eva)
 "bh" = (
@@ -394,7 +394,7 @@
 /turf/closed/wall,
 /area/mine/mechbay)
 "bo" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/mechbay)
 "bp" = (
@@ -405,7 +405,7 @@
 /turf/closed/wall,
 /area/mine/production)
 "br" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/production)
 "bs" = (
@@ -519,7 +519,7 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "bF" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/mine/eva)
 "bG" = (
@@ -584,7 +584,7 @@
 /area/mine/laborcamp/security)
 "bN" = (
 /obj/structure/sign/warning/docking,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/production)
 "bO" = (
@@ -921,7 +921,7 @@
 /turf/closed/wall/r_wall,
 /area/mine/maintenance)
 "cR" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "cS" = (
@@ -1333,7 +1333,7 @@
 /turf/open/floor/plasteel,
 /area/mine/maintenance)
 "dQ" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "dR" = (
@@ -1364,7 +1364,7 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "dV" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/mine/production)
 "dW" = (
@@ -2450,7 +2450,7 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "ia" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/production)
@@ -3559,7 +3559,7 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/laborcamp)
 "nI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
@@ -3833,7 +3833,7 @@
 /area/mine/laborcamp)
 "sM" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
 "tI" = (
@@ -3884,7 +3884,7 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "uJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -3993,7 +3993,7 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "xi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/closed/wall,
 /area/mine/living_quarters)
 "xW" = (
@@ -4309,7 +4309,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
 "FF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
@@ -4879,7 +4879,7 @@
 /area/mine/living_quarters)
 "TC" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "TJ" = (
@@ -5240,7 +5240,7 @@
 "Zn" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "Zs" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -143,7 +143,7 @@
 /turf/open/floor/engine,
 /area/science/nanite)
 "aap" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/nanite)
 "aaq" = (
@@ -205,7 +205,7 @@
 /turf/open/floor/engine,
 /area/science/nanite)
 "aaz" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/science/nanite)
@@ -263,7 +263,7 @@
 /turf/open/floor/engine,
 /area/science/nanite)
 "aaG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
@@ -898,7 +898,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "add" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
 "ade" = (
@@ -1364,7 +1364,7 @@
 /turf/closed/wall/r_wall,
 /area/security/prison)
 "aen" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
@@ -2004,7 +2004,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "afI" = (
-/obj/effect/spawner/randomarcade{
+/atom/movable/spawner/randomarcade{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -2087,7 +2087,7 @@
 /turf/closed/wall,
 /area/security/execution/transfer)
 "afX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "afZ" = (
@@ -2194,7 +2194,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "agq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "agr" = (
@@ -2447,7 +2447,7 @@
 /turf/closed/wall,
 /area/security/main)
 "agQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/main)
 "agR" = (
@@ -3039,7 +3039,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "ait" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aiu" = (
@@ -3246,11 +3246,11 @@
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/dorms)
 "aiT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "aiU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/barsign,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
@@ -4275,7 +4275,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "akT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
@@ -4312,7 +4312,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "akZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "hos_spess_shutters";
 	name = "Space shutters"
@@ -4718,7 +4718,7 @@
 /turf/closed/wall/r_wall,
 /area/security/warden)
 "amh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/warden)
 "ami" = (
@@ -5252,7 +5252,7 @@
 /area/maintenance/department/security/brig)
 "ans" = (
 /obj/item/wirecutters,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer4{
 	dir = 4
@@ -5321,7 +5321,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "anB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
@@ -5505,7 +5505,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "aod" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aoe" = (
@@ -6064,7 +6064,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "apE" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "apF" = (
@@ -6150,7 +6150,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "apR" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "apS" = (
@@ -6377,7 +6377,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aqI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
 	name = "bridge external shutters"
@@ -6470,7 +6470,7 @@
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "aqT" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -7089,7 +7089,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "ash" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "asi" = (
@@ -7100,7 +7100,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "asj" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
@@ -7622,7 +7622,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "atF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
@@ -7938,7 +7938,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "aum" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7946,7 +7946,7 @@
 /area/crew_quarters/dorms)
 "aun" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
@@ -7966,7 +7966,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "auq" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
@@ -8315,7 +8315,7 @@
 /turf/closed/wall/r_wall,
 /area/gateway)
 "avd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "Dorm3Shutters";
 	name = "Dorm Shutters"
@@ -8412,7 +8412,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "avp" = (
@@ -8833,7 +8833,7 @@
 /turf/open/floor/plating,
 /area/bridge)
 "awd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "awe" = (
@@ -9003,7 +9003,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aww" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -9097,7 +9097,7 @@
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
@@ -9318,7 +9318,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "axh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/bridge)
 "axi" = (
@@ -9408,7 +9408,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "axv" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "axw" = (
@@ -9429,7 +9429,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "axB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "axC" = (
@@ -9684,7 +9684,7 @@
 /turf/open/floor/plasteel/stairs,
 /area/hallway/primary/central)
 "ayi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "Dorm2Shutters";
 	name = "Dorm Shutters"
@@ -9804,7 +9804,7 @@
 /turf/open/space,
 /area/solar/port)
 "ayz" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
 	},
@@ -10691,7 +10691,7 @@
 /turf/closed/wall,
 /area/security/detectives_office)
 "aBe" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "datboidetective";
 	name = "privacy shutters"
@@ -10968,7 +10968,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aBL" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "Dorm1Shutters";
 	name = "Dorm Shutters"
@@ -12015,7 +12015,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aEl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aEm" = (
@@ -12181,7 +12181,7 @@
 "aED" = (
 /obj/structure/table,
 /obj/item/ai_module/core/full/asimov,
-/obj/effect/spawner/lootdrop/aimodule_harmless,
+/atom/movable/spawner/lootdrop/aimodule_harmless,
 /obj/item/ai_module/core/freeformcore,
 /obj/machinery/door/window{
 	base_state = "right";
@@ -12190,7 +12190,7 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/effect/spawner/lootdrop/aimodule_neutral,
+/atom/movable/spawner/lootdrop/aimodule_neutral,
 /obj/item/ai_module/core/full/custom,
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -12246,7 +12246,7 @@
 	req_access_txt = "20"
 	},
 /obj/item/ai_module/reset/purge,
-/obj/effect/spawner/lootdrop/aimodule_harmful,
+/atom/movable/spawner/lootdrop/aimodule_harmful,
 /obj/item/ai_module/supplied/protect_station,
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -12463,7 +12463,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "aFk" = (
-/obj/effect/spawner/lootdrop/minor/bowler_or_that,
+/atom/movable/spawner/lootdrop/minor/bowler_or_that,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -12582,7 +12582,7 @@
 	id = "hop";
 	name = "Privacy Shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
@@ -12911,7 +12911,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/spawner/randomarcade{
+/atom/movable/spawner/randomarcade{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -13092,7 +13092,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aGX" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "assistantshutters";
 	name = "storage shutters"
@@ -13123,7 +13123,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "aHb" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -13330,7 +13330,7 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "aHA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "aHC" = (
@@ -13598,7 +13598,7 @@
 /turf/closed/wall,
 /area/maintenance/solars/starboard)
 "aIq" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aIC" = (
@@ -13790,7 +13790,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aJw" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "aJD" = (
@@ -14072,7 +14072,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aKe" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
 	},
@@ -14132,7 +14132,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aKp" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
+/atom/movable/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aKq" = (
@@ -14221,7 +14221,7 @@
 /turf/closed/wall,
 /area/storage/art)
 "aKK" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/art)
 "aKL" = (
@@ -14235,7 +14235,7 @@
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aKM" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/cafeteria)
 "aKN" = (
@@ -14295,7 +14295,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aKV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
@@ -14303,7 +14303,7 @@
 /turf/closed/wall/r_wall,
 /area/storage/eva)
 "aKZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/eva)
 "aLa" = (
@@ -14328,7 +14328,7 @@
 /turf/open/floor/plasteel,
 /area/storage/eva)
 "aLc" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/teleporter)
@@ -14345,7 +14345,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aLe" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "aLf" = (
@@ -14812,7 +14812,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aMy" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
+/atom/movable/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "aMA" = (
@@ -15409,7 +15409,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aOA" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -15707,7 +15707,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aPt" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "aPv" = (
@@ -15735,7 +15735,7 @@
 	},
 /area/maintenance/department/crew_quarters/bar)
 "aPz" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -15750,8 +15750,8 @@
 /area/maintenance/department/crew_quarters/bar)
 "aPC" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/effect/spawner/lootdrop/gloves,
+/atom/movable/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/gloves,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aPD" = (
@@ -15929,7 +15929,7 @@
 /area/security/checkpoint/supply)
 "aQf" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
@@ -15946,7 +15946,7 @@
 /obj/structure/table,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/storage/box/matches,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -16099,7 +16099,7 @@
 /area/maintenance/department/crew_quarters/bar)
 "aQJ" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -16622,7 +16622,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aSe" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "aSf" = (
@@ -16997,7 +16997,7 @@
 /turf/open/floor/wood,
 /area/quartermaster/qm)
 "aTo" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "aTp" = (
@@ -17017,7 +17017,7 @@
 /area/quartermaster/storage)
 "aTr" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -17032,7 +17032,7 @@
 /obj/structure/table,
 /obj/item/assembly/igniter,
 /obj/item/assembly/igniter,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/stack/pipe_cleaner_coil/random,
 /obj/item/stack/pipe_cleaner_coil/random,
 /obj/item/stack/pipe_cleaner_coil/random,
@@ -17045,7 +17045,7 @@
 /turf/open/space/basic,
 /area/space)
 "aTy" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aTz" = (
@@ -18214,7 +18214,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aWw" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "aWz" = (
@@ -18621,7 +18621,7 @@
 /area/quartermaster/storage)
 "aXy" = (
 /obj/effect/turf_decal/bot,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -18684,7 +18684,7 @@
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/customs)
 "aXI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "papersplease";
 	name = "security shutters"
@@ -19543,7 +19543,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aZx" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aZy" = (
@@ -19903,7 +19903,7 @@
 /turf/open/floor/carpet/lone,
 /area/crew_quarters/bar)
 "baq" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
@@ -20444,7 +20444,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "bbK" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "bbO" = (
@@ -20759,7 +20759,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "bcK" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -20804,7 +20804,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bcV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "bcX" = (
@@ -20909,7 +20909,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bdm" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hydroponics)
 "bdn" = (
@@ -21013,7 +21013,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bdI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "bdJ" = (
@@ -21913,7 +21913,7 @@
 /turf/open/floor/carpet,
 /area/library/lounge)
 "bgk" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenwindowshutters";
 	name = "kitchen shutters"
@@ -23325,7 +23325,7 @@
 	id = "robotics";
 	name = "robotics lab shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "bkv" = (
@@ -24198,7 +24198,7 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bnd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "bnh" = (
@@ -24448,7 +24448,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bnT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "bnU" = (
@@ -24466,7 +24466,7 @@
 	id = "testlab";
 	name = "test chamber blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/engine,
 /area/science/explab)
@@ -24475,7 +24475,7 @@
 	id = "testlab";
 	name = "test chamber blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/explab)
 "bnX" = (
@@ -24489,7 +24489,7 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bnY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "testlab";
 	name = "test chamber blast door"
@@ -24913,7 +24913,7 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bpq" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -25028,7 +25028,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/paramedic)
 "bpR" = (
@@ -25068,7 +25068,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "bpV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters";
 	name = "chemistry shutters"
@@ -25109,7 +25109,7 @@
 /turf/closed/wall,
 /area/medical/chemistry)
 "bqb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "research_shutters_2";
 	name = "research shutters"
@@ -25434,7 +25434,7 @@
 	id = "xenobio5";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -25443,7 +25443,7 @@
 	id = "xenobio6";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -25467,7 +25467,7 @@
 	id = "xenobio6";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -26087,7 +26087,7 @@
 /area/science/xenobiology)
 "bsl" = (
 /obj/structure/sign/warning/vacuum/external,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bsm" = (
@@ -26707,7 +26707,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
 "buc" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "cmoprivacy";
@@ -26892,7 +26892,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "buz" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/explab)
 "buB" = (
@@ -28157,7 +28157,7 @@
 /area/hallway/secondary/entry)
 "byb" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/clothing/shoes/winterboots,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -28646,7 +28646,7 @@
 	id = "xenobio1";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -28671,7 +28671,7 @@
 	id = "xenobio1";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -28680,7 +28680,7 @@
 	id = "xenobio2";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -28690,7 +28690,7 @@
 	id = "xenobio2";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -28699,7 +28699,7 @@
 	id = "xenobio3";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -28724,7 +28724,7 @@
 	id = "xenobio3";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -28759,7 +28759,7 @@
 /area/hallway/secondary/entry)
 "bzC" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bzD" = (
@@ -28996,7 +28996,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bAo" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rdprivacy";
 	name = "Privacy shutters"
@@ -29023,7 +29023,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bAt" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/science)
 "bAu" = (
@@ -29903,11 +29903,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bCO" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "bCP" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/storage)
 "bCQ" = (
@@ -29943,7 +29943,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bCV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/mixing)
 "bCW" = (
@@ -30500,7 +30500,7 @@
 	id = "surgerya";
 	name = "privacy shutter"
 	},
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/surgery)
 "bEt" = (
@@ -31483,7 +31483,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "bGE" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/dock)
 "bGF" = (
@@ -31901,7 +31901,7 @@
 /turf/open/floor/plating,
 /area/chapel/dock)
 "bHL" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/chapel/dock)
@@ -31924,7 +31924,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bHR" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bHS" = (
@@ -31942,7 +31942,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bHT" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
+/atom/movable/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bHU" = (
@@ -32174,11 +32174,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bIU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/closed/wall,
 /area/chapel/dock)
 "bIV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/chapel/dock)
@@ -32220,11 +32220,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bIZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bJa" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJb" = (
@@ -32641,7 +32641,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bKn" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/virology)
 "bKo" = (
@@ -32660,7 +32660,7 @@
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "bKq" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/structure/sign/warning/deathsposal,
 /turf/open/floor/plating,
 /area/medical/virology)
@@ -32730,7 +32730,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bKM" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "bKO" = (
@@ -32862,7 +32862,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
@@ -33150,7 +33150,7 @@
 	},
 /area/hallway/primary/aft)
 "bLW" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bLX" = (
@@ -33300,7 +33300,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMi" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
 "bMj" = (
@@ -33625,7 +33625,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bNm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
@@ -33663,7 +33663,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "bNs" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/asteroid/monastery)
 "bNt" = (
@@ -33833,7 +33833,7 @@
 /obj/structure/chair/sofa/right{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/maint_drugs,
+/atom/movable/spawner/lootdrop/maint_drugs,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -33860,7 +33860,7 @@
 	},
 /area/maintenance/department/engine)
 "bNX" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bNY" = (
@@ -34034,7 +34034,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
@@ -34103,7 +34103,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bOD" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
 "bOE" = (
@@ -34637,7 +34637,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
 "bQl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -34733,7 +34733,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/spawner/lootdrop/techstorage/engineering,
+/atom/movable/spawner/lootdrop/techstorage/engineering,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -34756,7 +34756,7 @@
 	c_tag = "Tech Storage"
 	},
 /obj/item/circuitboard/computer/monastery_shuttle,
-/obj/effect/spawner/lootdrop/techstorage/service,
+/atom/movable/spawner/lootdrop/techstorage/service,
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
@@ -34774,7 +34774,7 @@
 /area/storage/tech)
 "bQx" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/rnd,
+/atom/movable/spawner/lootdrop/techstorage/rnd,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -34811,7 +34811,7 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQz" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -34930,7 +34930,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQO" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -35316,7 +35316,7 @@
 /area/storage/tech)
 "bRO" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/medical,
+/atom/movable/spawner/lootdrop/techstorage/medical,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -35331,7 +35331,7 @@
 /area/storage/tech)
 "bRP" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/tcomms,
+/atom/movable/spawner/lootdrop/techstorage/tcomms,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -35346,7 +35346,7 @@
 /area/storage/tech)
 "bRQ" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/security,
+/atom/movable/spawner/lootdrop/techstorage/security,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -35490,7 +35490,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -35530,7 +35530,7 @@
 "bSp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer4,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
 "bSq" = (
@@ -35540,7 +35540,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bSs" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/psychology)
 "bSt" = (
@@ -35552,7 +35552,7 @@
 /area/maintenance/department/engine)
 "bSu" = (
 /obj/item/broken_bottle,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bSv" = (
@@ -35672,7 +35672,7 @@
 /obj/structure/sign/departments/engineering{
 	pixel_y = -32
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/lobby)
 "bSO" = (
@@ -35777,7 +35777,7 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "bTc" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -35812,7 +35812,7 @@
 /area/maintenance/department/engine)
 "bTi" = (
 /obj/item/picket_sign,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bTj" = (
@@ -35822,7 +35822,7 @@
 "bTk" = (
 /obj/structure/closet,
 /obj/item/cigbutt/cigarbutt,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bTl" = (
@@ -36040,7 +36040,7 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "bTD" = (
@@ -36246,7 +36246,7 @@
 /area/space/nearstation)
 "bTX" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/space/basic,
 /area/maintenance/department/engine)
 "bUa" = (
@@ -36454,7 +36454,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUz" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -36817,7 +36817,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bVl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
@@ -37148,7 +37148,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bWc" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -37236,7 +37236,7 @@
 /area/crew_quarters/heads/chief)
 "bWs" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/rnd_secure,
+/atom/movable/spawner/lootdrop/techstorage/rnd_secure,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -37255,7 +37255,7 @@
 	c_tag = "Secure Tech Storage";
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/techstorage/command,
+/atom/movable/spawner/lootdrop/techstorage/command,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -37270,7 +37270,7 @@
 /area/storage/tech)
 "bWu" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/ai,
+/atom/movable/spawner/lootdrop/techstorage/ai,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -37526,7 +37526,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bWR" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
@@ -37862,7 +37862,7 @@
 /turf/open/floor/plating,
 /area/chapel/asteroid/monastery)
 "bXU" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -37880,7 +37880,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bXY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "ce_privacy";
 	name = "Privacy shutters"
@@ -37917,13 +37917,13 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bYf" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/electricshock,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "bYg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "bYh" = (
@@ -37966,12 +37966,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYp" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bYq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
 	},
@@ -38589,7 +38589,7 @@
 /area/maintenance/department/engine)
 "cab" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -38604,7 +38604,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "cae" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "caf" = (
@@ -38858,7 +38858,7 @@
 "caZ" = (
 /obj/structure/table,
 /obj/item/wirecutters,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/light/small{
 	brightness = 3;
 	dir = 8
@@ -39639,7 +39639,7 @@
 /turf/open/floor/plasteel,
 /area/engine/lobby)
 "cec" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
@@ -40138,7 +40138,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cfY" = (
@@ -40992,7 +40992,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "ckt" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
 "cku" = (
@@ -41228,7 +41228,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cls" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/closed/mineral,
 /area/asteroid/nearstation/bomb_site)
 "clv" = (
@@ -41262,11 +41262,11 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
 "clF" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/closed/mineral/random/low_chance,
 /area/asteroid/nearstation/bomb_site)
 "clG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clH" = (
@@ -41937,7 +41937,7 @@
 /area/security/main)
 "cnX" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "cod" = (
@@ -42387,7 +42387,7 @@
 	id = "barshutters";
 	name = "bar shutters"
 	},
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "cpH" = (
@@ -42663,7 +42663,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqy" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
 "cqz" = (
@@ -42753,7 +42753,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "cqW" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/closed/mineral,
 /area/chapel/asteroid/monastery)
 "cqX" = (
@@ -42762,7 +42762,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "crb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/chapel/office)
 "crd" = (
@@ -42825,7 +42825,7 @@
 /area/chapel/main/monastery)
 "crl" = (
 /obj/structure/sign/warning/vacuum/external,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/asteroid/monastery)
 "crm" = (
@@ -43098,7 +43098,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "csy" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -43204,7 +43204,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "csU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/chapel/main/monastery)
 "csY" = (
@@ -44510,7 +44510,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cyU" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/library)
 "cyY" = (
@@ -45042,7 +45042,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "cBM" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/office)
 "cBS" = (
@@ -45051,7 +45051,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cBT" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
 "cBU" = (
@@ -45299,7 +45299,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
 "cQN" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "cRC" = (
@@ -45697,7 +45697,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "dAF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/science/mixing)
@@ -45752,7 +45752,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "dJF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
@@ -45788,7 +45788,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "dMB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
 "dMI" = (
@@ -45801,7 +45801,7 @@
 /obj/structure/urinal{
 	pixel_y = 32
 	},
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "dNr" = (
@@ -45957,7 +45957,7 @@
 /area/engine/engineering)
 "eaw" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ebp" = (
@@ -45980,7 +45980,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ebD" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "lawyer_shutters";
 	name = "law office shutters"
@@ -45992,7 +45992,7 @@
 	id = "xenobio7";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -46095,7 +46095,7 @@
 	name = "Cargo Desk";
 	req_access_txt = "50"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "elk" = (
@@ -46161,7 +46161,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
@@ -46244,14 +46244,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "evB" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ewV" = (
 /turf/open/floor/carpet,
 /area/library/artgallery)
 "ezn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "ezx" = (
@@ -46448,7 +46448,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "eON" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -46461,7 +46461,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "ePB" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -46473,7 +46473,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "eQR" = (
-/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/atom/movable/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "eQZ" = (
@@ -47234,7 +47234,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "fIT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
 "fKj" = (
@@ -47432,7 +47432,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gcn" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -48027,7 +48027,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "gHZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -48063,7 +48063,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "gKG" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -48151,7 +48151,7 @@
 /area/lawoffice)
 "gSI" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "gUb" = (
@@ -48443,7 +48443,7 @@
 	id = "xenobio4";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -48659,7 +48659,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "hMa" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
 "hMc" = (
@@ -49076,7 +49076,7 @@
 /turf/open/floor/carpet,
 /area/library)
 "ijU" = (
-/obj/effect/spawner/lootdrop/organ_spawner,
+/atom/movable/spawner/lootdrop/organ_spawner,
 /obj/structure/closet/crate,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -49175,7 +49175,7 @@
 /area/maintenance/department/engine)
 "iyJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "SupermatterExternal";
 	name = "radiation shutters"
@@ -49489,7 +49489,7 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "iVJ" = (
-/obj/effect/spawner/lootdrop/organ_spawner,
+/atom/movable/spawner/lootdrop/organ_spawner,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -49504,7 +49504,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "iYO" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 4
 	},
@@ -49514,7 +49514,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library/artgallery)
 "jbo" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
@@ -49860,7 +49860,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "jzz" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -50034,7 +50034,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "jMS" = (
-/obj/effect/spawner/xmastree,
+/atom/movable/spawner/xmastree,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/library)
@@ -50071,7 +50071,7 @@
 /area/storage/emergency/starboard)
 "jPf" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/kitchen/knife,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -50088,7 +50088,7 @@
 /area/maintenance/department/science)
 "jRG" = (
 /obj/structure/cable,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "jRZ" = (
@@ -50998,7 +50998,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "lcZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/gateway)
 "ldb" = (
@@ -51167,7 +51167,7 @@
 /area/library/lounge)
 "lrI" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -51390,7 +51390,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "lMU" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -51461,7 +51461,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "lQX" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -51576,7 +51576,7 @@
 "maW" = (
 /obj/structure/table/glass,
 /obj/item/weldingtool/mini,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -51686,11 +51686,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mnG" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
 "mpd" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "mpy" = (
@@ -51701,7 +51701,7 @@
 /area/lawoffice)
 "mpU" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -51759,13 +51759,13 @@
 	id = "xenobio4";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "msX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
 	},
@@ -51912,7 +51912,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "mCe" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "engineering security door"
@@ -52080,7 +52080,7 @@
 "mSr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer4,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "mSB" = (
@@ -52282,7 +52282,7 @@
 /area/crew_quarters/fitness/recreation)
 "nih" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/costume,
+/atom/movable/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "niy" = (
@@ -52461,7 +52461,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "nvG" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "nwg" = (
@@ -52584,7 +52584,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "nEb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
 	name = "test chamber blast door"
@@ -52624,7 +52624,7 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "nGx" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -52963,7 +52963,7 @@
 /area/maintenance/department/engine)
 "nYn" = (
 /obj/structure/sign/warning/docking,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "nYu" = (
@@ -53212,7 +53212,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "orc" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating{
 	luminosity = 2
 	},
@@ -53274,7 +53274,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "otM" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
 "ous" = (
@@ -53625,7 +53625,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "oSc" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
@@ -53880,7 +53880,7 @@
 	id = "xenobio7";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -53996,7 +53996,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "pzm" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -54771,7 +54771,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/psychology)
 "qzm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/lobby)
 "qBv" = (
@@ -54819,7 +54819,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "qFu" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "SupermatterExternal";
 	name = "radiation shutters"
@@ -54914,7 +54914,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "qMi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
 	},
@@ -55151,7 +55151,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library/artgallery)
 "riF" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -55523,7 +55523,7 @@
 "rCr" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -55662,14 +55662,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "rMn" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "rMV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -55699,7 +55699,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "rNB" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "rNJ" = (
@@ -55747,7 +55747,7 @@
 /area/maintenance/department/engine)
 "rSQ" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "rTD" = (
@@ -55882,7 +55882,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "scK" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
@@ -56430,7 +56430,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "sYG" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "sYY" = (
@@ -56715,7 +56715,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "SupermatterExternal";
 	name = "radiation shutters"
@@ -56783,7 +56783,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library/artgallery)
 "tqX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
 	name = "test chamber blast door"
@@ -56852,7 +56852,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "SupermatterExternal";
 	name = "radiation shutters"
@@ -56864,7 +56864,7 @@
 	id = "xenobio8";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -57223,7 +57223,7 @@
 /area/library/artgallery)
 "tYu" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -57293,7 +57293,7 @@
 /area/quartermaster/miningdock)
 "uek" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "ueu" = (
@@ -57386,7 +57386,7 @@
 /area/medical/virology)
 "ulf" = (
 /obj/structure/table/glass,
-/obj/effect/spawner/lootdrop/donkpockets,
+/atom/movable/spawner/lootdrop/donkpockets,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -57444,7 +57444,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "umd" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/atom/movable/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ume" = (
@@ -57553,7 +57553,7 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "uqJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
@@ -57620,7 +57620,7 @@
 /turf/open/floor/carpet,
 /area/lawoffice)
 "uvo" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -58514,7 +58514,7 @@
 	amount = 5;
 	layer = 3.3
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/assembly/prox_sensor{
 	pixel_y = 2
 	},
@@ -59025,7 +59025,7 @@
 "wlc" = (
 /obj/structure/table,
 /obj/item/storage/box/mousetraps,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -59298,7 +59298,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wIX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/library/artgallery)
 "wJL" = (
@@ -59366,8 +59366,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "wMF" = (
-/obj/effect/spawner/lootdrop/three_course_meal,
-/obj/effect/spawner/lootdrop/three_course_meal,
+/atom/movable/spawner/lootdrop/three_course_meal,
+/atom/movable/spawner/lootdrop/three_course_meal,
 /obj/structure/closet/crate,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -59404,7 +59404,7 @@
 	id = "xenobio8";
 	name = "containment blast door"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -59440,7 +59440,7 @@
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "wQU" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating{
@@ -59551,12 +59551,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wVQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/space)
 "wVV" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
 "wWO" = (
@@ -59715,7 +59715,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "xee" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
@@ -60082,7 +60082,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "xyB" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -60124,7 +60124,7 @@
 /turf/closed/wall,
 /area/quartermaster/storage)
 "xCV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -60300,7 +60300,7 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "xQr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "xQO" = (
@@ -60377,7 +60377,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "yat" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
@@ -60389,7 +60389,7 @@
 /area/medical/virology)
 "ybX" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},

--- a/_maps/map_files/debug/multiz.dmm
+++ b/_maps/map_files/debug/multiz.dmm
@@ -145,7 +145,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "aJ" = (
@@ -367,7 +367,7 @@
 /turf/closed/wall/r_wall,
 /area/bridge)
 "bv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/bridge)
 "bw" = (
@@ -486,7 +486,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bT" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bU" = (
@@ -527,11 +527,11 @@
 	},
 /area/hallway/secondary/entry)
 "bY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "bZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "ce" = (
@@ -712,7 +712,7 @@
 /turf/open/floor/plasteel,
 /area/construction)
 "cR" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction)
 "cS" = (
@@ -975,7 +975,7 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "ee" = (
@@ -1036,7 +1036,7 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "eE" = (
@@ -1046,7 +1046,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "eF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "eH" = (
@@ -1093,7 +1093,7 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "eQ" = (
@@ -1190,7 +1190,7 @@
 /turf/open/floor/plasteel,
 /area/construction)
 "ip" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/space)
 "iq" = (
@@ -1222,7 +1222,7 @@
 	dir = 8;
 	icon_state = "warningline_white"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/storage)
 "jD" = (
@@ -1313,7 +1313,7 @@
 /area/storage/primary)
 "od" = (
 /obj/effect/turf_decal/stripes/white/line,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/storage)
 "oh" = (
@@ -1416,7 +1416,7 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "ty" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/construction)
@@ -1519,7 +1519,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "zC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/construction)
@@ -1611,7 +1611,7 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "DK" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/storage)
 "Eb" = (
@@ -1646,7 +1646,7 @@
 /turf/open/floor/plating,
 /area/construction)
 "FL" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
 	icon_state = "pipe11-2"
@@ -1894,7 +1894,7 @@
 	dir = 5;
 	icon_state = "warningline_white"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/storage)
 

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -98,7 +98,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "au" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/radiation/rad_area{
 	pixel_y = 32
 	},
@@ -176,7 +176,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aI" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "aJ" = (
@@ -409,11 +409,11 @@
 /turf/closed/wall/r_wall,
 /area/bridge)
 "bv" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/bridge)
 "bw" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "bx" = (
@@ -603,11 +603,11 @@
 	},
 /area/medical/medbay)
 "bY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "bZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "ca" = (
@@ -658,7 +658,7 @@
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "ck" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay)
 "cl" = (
@@ -799,7 +799,7 @@
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
 "cF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -880,7 +880,7 @@
 /turf/closed/wall/r_wall,
 /area/storage/primary)
 "cT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
@@ -1288,7 +1288,7 @@
 /turf/closed/wall/r_wall,
 /area/quartermaster/miningoffice)
 "en" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "ep" = (
@@ -1326,7 +1326,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ew" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -1591,7 +1591,7 @@
 /turf/open/space,
 /area/space)
 "fh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "fi" = (
@@ -1623,7 +1623,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "fn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -1923,7 +1923,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "gd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science)
 "ge" = (
@@ -1931,7 +1931,7 @@
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
 "gf" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "gg" = (
@@ -2232,7 +2232,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "pA" = (
@@ -2561,7 +2561,7 @@
 /turf/open/floor/plating,
 /area/medical/medbay)
 "Rb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "Re" = (
@@ -2630,7 +2630,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "Wh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "Wq" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2970,7 +2970,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "iu" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/control)
 "iv" = (
@@ -3212,7 +3212,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "iX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/supply)
 "iY" = (
@@ -3246,7 +3246,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "jb" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/centcom/supply)
@@ -4761,7 +4761,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "mk" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
@@ -5730,7 +5730,7 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "oe" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/ferry)
 "of" = (
@@ -7337,7 +7337,7 @@
 /turf/open/floor/plating/asteroid,
 /area/centcom/evac)
 "qV" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/evac)
 "qW" = (
@@ -8425,7 +8425,7 @@
 /area/centcom/supplypod)
 "ta" = (
 /obj/machinery/light/floor,
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/ferry)
 "tb" = (
@@ -8434,7 +8434,7 @@
 	},
 /area/holodeck/rec_center/photobooth)
 "tc" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/centcom/ferry)
@@ -9541,7 +9541,7 @@
 /turf/open/floor/wood,
 /area/syndicate_mothership/control)
 "vA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
@@ -9914,7 +9914,7 @@
 /turf/open/floor/wood,
 /area/centcom/holding)
 "wk" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
 "wl" = (
@@ -10251,7 +10251,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "xh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
@@ -10352,7 +10352,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "xr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
@@ -10681,7 +10681,7 @@
 /turf/open/floor/plating/airless,
 /area/syndicate_mothership/control)
 "yn" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
 /turf/open/floor/plating,
 /area/centcom/ferry)
@@ -13638,7 +13638,7 @@
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeobserve)
 "Ev" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tdome/tdomeobserve)
 "Ew" = (
@@ -15803,7 +15803,7 @@
 	},
 /area/tdome/tdomeadmin)
 "IR" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tdome/tdomeadmin)
 "IS" = (
@@ -16924,7 +16924,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
 "Lw" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/centcom/evac)
 "Lx" = (
@@ -18243,7 +18243,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/effect/spawner/xmastree,
+/atom/movable/spawner/xmastree,
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
 "RC" = (
@@ -18865,7 +18865,7 @@
 /turf/open/floor/wood,
 /area/centcom/holding)
 "UV" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "UY" = (
@@ -19273,7 +19273,7 @@
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
 "XK" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
 "XL" = (
@@ -19293,7 +19293,7 @@
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/thunderdome1218)
 "XT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/space/basic,
 /area/centcom/supplypod)
 "XZ" = (

--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -12,7 +12,7 @@
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "d" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "e" = (
@@ -24,7 +24,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "g" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/machinery/light{
 	dir = 1
 	},

--- a/_maps/shuttles/arrival_donut.dmm
+++ b/_maps/shuttles/arrival_donut.dmm
@@ -23,7 +23,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/arrival)
 "f" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "g" = (
@@ -60,7 +60,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/arrival)
 "o" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "p" = (

--- a/_maps/shuttles/arrival_pubby.dmm
+++ b/_maps/shuttles/arrival_pubby.dmm
@@ -12,7 +12,7 @@
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "d" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "e" = (

--- a/_maps/shuttles/cargo_kilo.dmm
+++ b/_maps/shuttles/cargo_kilo.dmm
@@ -265,7 +265,7 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
 "A" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/structure/shuttle/engine/heater,
 /turf/open/floor/plating,
 /area/shuttle/supply)

--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -17,7 +17,7 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "ah" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ai" = (

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "ac" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ad" = (
@@ -338,7 +338,7 @@
 /area/shuttle/escape)
 "ba" = (
 /obj/structure/table/wood/bar,
-/obj/effect/spawner/lootdrop/gambling,
+/atom/movable/spawner/lootdrop/gambling,
 /turf/open/floor/plasteel/grimy,
 /area/shuttle/escape)
 "bc" = (
@@ -397,7 +397,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "bn" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
@@ -485,7 +485,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "bF" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "bG" = (

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "c" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "d" = (

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "ac" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ad" = (

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "ac" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ad" = (
@@ -1176,7 +1176,7 @@
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "cz" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "ac" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ad" = (

--- a/_maps/shuttles/emergency_construction.dmm
+++ b/_maps/shuttles/emergency_construction.dmm
@@ -37,7 +37,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "h" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "i" = (

--- a/_maps/shuttles/emergency_cramped.dmm
+++ b/_maps/shuttles/emergency_cramped.dmm
@@ -3,7 +3,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "b" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "c" = (
@@ -81,7 +81,7 @@
 /area/shuttle/escape)
 "o" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 8;
 	name = "8maintenance loot spawner"
 	},
@@ -101,7 +101,7 @@
 /area/shuttle/escape)
 "r" = (
 /obj/structure/closet/crate/secure/weapon,
-/obj/effect/spawner/lootdrop/armory_contraband,
+/atom/movable/spawner/lootdrop/armory_contraband,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
 	dir = 4
@@ -137,7 +137,7 @@
 /area/shuttle/escape)
 "w" = (
 /obj/structure/closet/crate/secure/weapon,
-/obj/effect/spawner/lootdrop/armory_contraband,
+/atom/movable/spawner/lootdrop/armory_contraband,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -137,7 +137,7 @@
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "en" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "fB" = (

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -1374,7 +1374,7 @@
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "hB" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
 "c" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/atom/movable/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plasteel/elevatorshaft,
 /area/shuttle/escape)
 "d" = (

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "ac" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ad" = (

--- a/_maps/shuttles/emergency_goon.dmm
+++ b/_maps/shuttles/emergency_goon.dmm
@@ -46,7 +46,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "m" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "n" = (
@@ -91,7 +91,7 @@
 /area/shuttle/escape)
 "v" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "w" = (

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "ac" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ad" = (
@@ -1527,7 +1527,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "cK" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/structure/shuttle/engine/heater,
 /turf/open/floor/plating,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -61,7 +61,7 @@
 "aj" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/large,
-/obj/effect/spawner/lootdrop/maintenance/eight,
+/atom/movable/spawner/lootdrop/maintenance/eight,
 /turf/open/floor/plasteel,
 /area/shuttle/escape/luxury)
 "ak" = (
@@ -110,7 +110,7 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/luxury)
 "au" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/plating,
 /area/shuttle/escape/luxury)
 "av" = (
@@ -348,13 +348,13 @@
 "bf" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/turf_decal/loading_area,
-/obj/effect/spawner/lootdrop/maintenance/six,
+/atom/movable/spawner/lootdrop/maintenance/six,
 /turf/open/floor/plasteel,
 /area/shuttle/escape/luxury)
 "bg" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/turf_decal/loading_area,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/atom/movable/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plasteel,
 /area/shuttle/escape/luxury)
 "bi" = (
@@ -393,13 +393,13 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/engineering/electrical,
 /obj/effect/decal/cleanable/robot_debris,
-/obj/effect/spawner/lootdrop/maintenance/eight,
+/atom/movable/spawner/lootdrop/maintenance/eight,
 /turf/open/floor/plasteel,
 /area/shuttle/escape/luxury)
 "bo" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/engineering,
-/obj/effect/spawner/lootdrop/maintenance/eight,
+/atom/movable/spawner/lootdrop/maintenance/eight,
 /turf/open/floor/plasteel,
 /area/shuttle/escape/luxury)
 "bp" = (
@@ -468,7 +468,7 @@
 /obj/structure/closet/crate/large,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/robot_debris,
-/obj/effect/spawner/lootdrop/maintenance/eight,
+/atom/movable/spawner/lootdrop/maintenance/eight,
 /turf/open/floor/plasteel,
 /area/shuttle/escape/luxury)
 "bz" = (
@@ -487,7 +487,7 @@
 	icon_state = "crateopen"
 	},
 /obj/effect/decal/cleanable/oil,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plasteel,
 /area/shuttle/escape/luxury)
 "bB" = (
@@ -664,7 +664,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/large,
 /obj/effect/decal/cleanable/robot_debris,
-/obj/effect/spawner/lootdrop/maintenance/eight,
+/atom/movable/spawner/lootdrop/maintenance/eight,
 /turf/open/floor/plasteel,
 /area/shuttle/escape/luxury)
 "cd" = (
@@ -848,7 +848,7 @@
 /area/shuttle/escape/luxury)
 "cC" = (
 /obj/structure/grille/broken,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plasteel,
 /area/shuttle/escape/luxury)
 "cD" = (

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "ac" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ad" = (

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -75,7 +75,7 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "n" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "o" = (

--- a/_maps/shuttles/emergency_nature.dmm
+++ b/_maps/shuttles/emergency_nature.dmm
@@ -1251,7 +1251,7 @@
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "VI" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "VM" = (

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "ac" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ad" = (

--- a/_maps/shuttles/emergency_rollerdome.dmm
+++ b/_maps/shuttles/emergency_rollerdome.dmm
@@ -15,7 +15,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "cP" = (
-/obj/effect/spawner/randomarcade,
+/atom/movable/spawner/randomarcade,
 /turf/open/floor/eighties,
 /area/shuttle/escape)
 "dJ" = (
@@ -129,7 +129,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "wf" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/atom/movable/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plasteel/elevatorshaft,
 /area/shuttle/escape)
 "wn" = (
@@ -165,7 +165,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "zx" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "zZ" = (

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall,
 /area/shuttle/escape)
 "ac" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ad" = (
@@ -124,7 +124,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "au" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ohnorevs"
 	},

--- a/_maps/shuttles/emergency_scrapheap.dmm
+++ b/_maps/shuttles/emergency_scrapheap.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "ac" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ad" = (

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -7,7 +7,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "ad" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ae" = (

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -128,7 +128,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "as" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "at" = (

--- a/_maps/shuttles/emergency_zeta.dmm
+++ b/_maps/shuttles/emergency_zeta.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/abductor,
 /area/shuttle/escape)
 "c" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/atom/movable/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
 "d" = (

--- a/_maps/shuttles/escape_pod_default.dmm
+++ b/_maps/shuttles/escape_pod_default.dmm
@@ -24,7 +24,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "Q" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/pod_1)
 "U" = (

--- a/_maps/shuttles/ferry_base.dmm
+++ b/_maps/shuttles/ferry_base.dmm
@@ -17,7 +17,7 @@
 /turf/open/floor/plating,
 /area/shuttle/transport)
 "e" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/transport)
 "g" = (

--- a/_maps/shuttles/ferry_fancy.dmm
+++ b/_maps/shuttles/ferry_fancy.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/transport)
 "c" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/transport)
 "d" = (

--- a/_maps/shuttles/ferry_kilo.dmm
+++ b/_maps/shuttles/ferry_kilo.dmm
@@ -12,7 +12,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/transport)
 "e" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/transport)
 "f" = (

--- a/_maps/shuttles/ferry_lighthouse.dmm
+++ b/_maps/shuttles/ferry_lighthouse.dmm
@@ -87,11 +87,11 @@
 /turf/open/floor/wood,
 /area/shuttle/transport)
 "aw" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/transport)
 "az" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/transport)
 "aB" = (
@@ -170,7 +170,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "aQ" = (
-/obj/effect/spawner/structure/window,
+/atom/movable/spawner/structure/window,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "aR" = (
@@ -209,7 +209,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "aY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/transport)
 "ba" = (

--- a/_maps/shuttles/hunter_russian.dmm
+++ b/_maps/shuttles/hunter_russian.dmm
@@ -106,7 +106,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/hunter)
 "v" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/shuttle/hunter)
 "w" = (

--- a/_maps/shuttles/hunter_space_cop.dmm
+++ b/_maps/shuttles/hunter_space_cop.dmm
@@ -127,7 +127,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/hunter)
 "An" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/hunter)
 "Pq" = (

--- a/_maps/shuttles/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator_advanced.dmm
@@ -1110,7 +1110,7 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/shuttle/syndicate/hallway)
 "cl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/hallway)

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -1030,7 +1030,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/medical)
 "cl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/hallway)
 "cn" = (

--- a/_maps/shuttles/labour_box.dmm
+++ b/_maps/shuttles/labour_box.dmm
@@ -3,7 +3,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/labor)
 "b" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/labor)
 "c" = (

--- a/_maps/shuttles/labour_delta.dmm
+++ b/_maps/shuttles/labour_delta.dmm
@@ -3,7 +3,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/labor)
 "b" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/labor)
 "c" = (

--- a/_maps/shuttles/labour_kilo.dmm
+++ b/_maps/shuttles/labour_kilo.dmm
@@ -3,7 +3,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/labor)
 "b" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/labor)
 "c" = (
@@ -243,7 +243,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/labor)
 "w" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/structure/shuttle/engine/heater,
 /turf/open/floor/plating,
 /area/shuttle/labor)

--- a/_maps/shuttles/mining_box.dmm
+++ b/_maps/shuttles/mining_box.dmm
@@ -3,7 +3,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/mining)
 "b" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "c" = (

--- a/_maps/shuttles/mining_common_kilo.dmm
+++ b/_maps/shuttles/mining_common_kilo.dmm
@@ -3,7 +3,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/mining)
 "b" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "c" = (
@@ -115,7 +115,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/mining)
 "p" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/structure/shuttle/engine/heater,
 /turf/open/floor/plating,
 /area/shuttle/mining)

--- a/_maps/shuttles/mining_common_meta.dmm
+++ b/_maps/shuttles/mining_common_meta.dmm
@@ -3,7 +3,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/mining)
 "b" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "c" = (

--- a/_maps/shuttles/mining_delta.dmm
+++ b/_maps/shuttles/mining_delta.dmm
@@ -3,7 +3,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/mining)
 "b" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "c" = (

--- a/_maps/shuttles/mining_freight.dmm
+++ b/_maps/shuttles/mining_freight.dmm
@@ -3,7 +3,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/mining)
 "b" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "c" = (
@@ -113,7 +113,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/mining)
 "p" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/structure/shuttle/engine/heater,
 /turf/open/floor/plating,
 /area/template_noop)

--- a/_maps/shuttles/mining_kilo.dmm
+++ b/_maps/shuttles/mining_kilo.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "b" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/mining/large)
 "c" = (
@@ -268,7 +268,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/mining/large)
 "D" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/structure/shuttle/engine/heater,
 /turf/open/floor/plating,
 /area/shuttle/mining/large)

--- a/_maps/shuttles/mining_large.dmm
+++ b/_maps/shuttles/mining_large.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "b" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/mining/large)
 "c" = (

--- a/_maps/shuttles/ruin_caravan_victim.dmm
+++ b/_maps/shuttles/ruin_caravan_victim.dmm
@@ -788,7 +788,7 @@
 /turf/open/floor/plasteel/airless,
 /area/shuttle/caravan/freighter1)
 "LM" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "caravantrade1_bridge"
 	},

--- a/_maps/shuttles/snowdin_mining.dmm
+++ b/_maps/shuttles/snowdin_mining.dmm
@@ -14,7 +14,7 @@
 /turf/open/floor/plating,
 /area/shuttle/snowdin/elevator2)
 "b" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/snowdin/elevator2)

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -34,7 +34,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/medbay)
 "ah" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},
@@ -75,7 +75,7 @@
 /turf/open/floor/plating,
 /area/shuttle/abandoned/crew)
 "ak" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},
@@ -707,7 +707,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/bridge)
 "bf" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_bridge"
 	},

--- a/_maps/shuttles/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship_cere.dmm
@@ -81,7 +81,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "an" = (
-/obj/effect/spawner/lootdrop/whiteship_cere_ripley,
+/atom/movable/spawner/lootdrop/whiteship_cere_ripley,
 /turf/open/floor/mech_bay_recharge_floor,
 /area/shuttle/abandoned)
 "ao" = (
@@ -104,7 +104,7 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/abandoned)
 "ar" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
 "as" = (

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -36,7 +36,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/bar)
 "af" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},
@@ -868,7 +868,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/crew)
 "bI" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},
@@ -1007,7 +1007,7 @@
 /area/shuttle/abandoned/bridge)
 "bT" = (
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_bridge"
 	},
@@ -1390,7 +1390,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/cargo)
 "cz" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},
@@ -1463,7 +1463,7 @@
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/item/relic,
 /obj/item/t_scanner,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
@@ -1509,7 +1509,7 @@
 	},
 /obj/item/crowbar,
 /obj/item/wrench,
-/obj/effect/spawner/lootdrop/maintenance,
+/atom/movable/spawner/lootdrop/maintenance,
 /obj/item/extinguisher,
 /obj/item/extinguisher,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1711,7 +1711,7 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
@@ -2276,7 +2276,7 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
@@ -2362,7 +2362,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/medbay)
 "SY" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},

--- a/_maps/shuttles/whiteship_donut.dmm
+++ b/_maps/shuttles/whiteship_donut.dmm
@@ -283,7 +283,7 @@
 "aU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light,
-/obj/effect/spawner/lootdrop/whiteship_cere_ripley,
+/atom/movable/spawner/lootdrop/whiteship_cere_ripley,
 /turf/open/floor/mech_bay_recharge_floor,
 /area/shuttle/abandoned)
 "aV" = (
@@ -474,7 +474,7 @@
 /turf/open/floor/plasteel/airless,
 /area/shuttle/abandoned)
 "bq" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
 "br" = (

--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -81,7 +81,7 @@
 /turf/open/floor/plating,
 /area/shuttle/abandoned/cargo)
 "ah" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows";
 	name = "Exterior Window Blast door"
@@ -249,7 +249,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/engine)
 "au" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows";
 	name = "Exterior Window Blast door"
@@ -974,7 +974,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/spawner/lootdrop/maintenance/two,
+/atom/movable/spawner/lootdrop/maintenance/two,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
@@ -1028,7 +1028,7 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/abandoned/crew)
 "bP" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_bridge";
 	name = "Cockpit Emergency Blast door"
@@ -1341,7 +1341,7 @@
 /turf/open/floor/carpet,
 /area/shuttle/abandoned/crew)
 "cs" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows";
 	name = "Exterior Window Blast door"
@@ -1838,7 +1838,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/crew)
 "df" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows";
 	name = "Exterior Window Blast door"

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -52,7 +52,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/crew)
 "aj" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},
@@ -75,7 +75,7 @@
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "am" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},
@@ -1058,7 +1058,7 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
@@ -1180,7 +1180,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/bridge)
 "bR" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_bridge"
 	},
@@ -1223,7 +1223,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/engine)
 "bU" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
@@ -1253,14 +1253,14 @@
 /obj/effect/turf_decal/box/white/corners,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/cargo)
 "bY" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/bar)
@@ -1644,7 +1644,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
@@ -1795,7 +1795,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
@@ -2194,7 +2194,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/space/rareseed,
+/atom/movable/spawner/lootdrop/space/rareseed,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/bar)
 "do" = (
@@ -2490,7 +2490,7 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/effect/spawner/lootdrop/maintenance{
+/atom/movable/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
@@ -2642,7 +2642,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/cargo)
 "eb" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},
@@ -2727,7 +2727,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/space/rareseed,
+/atom/movable/spawner/lootdrop/space/rareseed,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/bar)
 "eh" = (

--- a/_maps/templates/hilbertshotel.dmm
+++ b/_maps/templates/hilbertshotel.dmm
@@ -72,7 +72,7 @@
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "n" = (
-/obj/effect/spawner/xmastree,
+/atom/movable/spawner/xmastree,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "o" = (
@@ -269,7 +269,7 @@
 /area/hilbertshotel)
 "V" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/three_course_meal,
+/atom/movable/spawner/lootdrop/three_course_meal,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 

--- a/_maps/templates/medium_shuttle1.dmm
+++ b/_maps/templates/medium_shuttle1.dmm
@@ -114,7 +114,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered/shuttle/medium_1)
 "s" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/powered/shuttle/medium_1)
 "t" = (
@@ -122,7 +122,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/powered/shuttle/medium_1)
 "u" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/ruin/powered/shuttle/medium_1)
 "v" = (

--- a/_maps/templates/medium_shuttle2.dmm
+++ b/_maps/templates/medium_shuttle2.dmm
@@ -122,7 +122,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered/shuttle/medium_2)
 "v" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/powered/shuttle/medium_2)
 "w" = (
@@ -130,7 +130,7 @@
 /turf/open/floor/plating,
 /area/ruin/powered/shuttle/medium_2)
 "x" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/ruin/powered/shuttle/medium_2)
 "y" = (

--- a/_maps/templates/medium_shuttle3.dmm
+++ b/_maps/templates/medium_shuttle3.dmm
@@ -63,7 +63,7 @@
 /turf/template_noop,
 /area/ruin/powered/shuttle/medium_3)
 "t" = (
-/obj/effect/spawner/structure/window/reinforced,
+/atom/movable/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/powered/shuttle/medium_3)
 "v" = (

--- a/_maps/templates/shelter_2.dmm
+++ b/_maps/templates/shelter_2.dmm
@@ -162,7 +162,7 @@
 	pixel_x = 7;
 	pixel_y = 2
 	},
-/obj/effect/spawner/lootdrop/three_course_meal,
+/atom/movable/spawner/lootdrop/three_course_meal,
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "y" = (

--- a/_maps/templates/small_shuttle_1.dmm
+++ b/_maps/templates/small_shuttle_1.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/titanium/overspace,
 /area/template_noop)
 "c" = (
-/obj/effect/spawner/structure/window/shuttle,
+/atom/movable/spawner/structure/window/shuttle,
 /turf/open/floor/plating/airless,
 /area/template_noop)
 "d" = (

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -93,7 +93,7 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/clothing/suit/toggle/labcoat = 1,
 		/obj/item/clothing/under/color/grey = 1,
 		/obj/item/clothing/gloves/color/fyellow = 1,
-		/obj/effect/spawner/lootdrop/gloves = 1,
+		/atom/movable/spawner/lootdrop/gloves = 1,
 		/obj/item/storage/wallet/random = 1,
 		/obj/item/clothing/glasses/science = 1,
 		/obj/item/clothing/glasses/meson = 1,
@@ -147,7 +147,7 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 
 		//light sources
 		/obj/item/flashlight = 1,
-		/obj/effect/spawner/lootdrop/glowstick = 1,
+		/atom/movable/spawner/lootdrop/glowstick = 1,
 		/obj/item/clothing/head/hardhat/red = 1,
 		/obj/item/flashlight/flare = 1,
 		) = 1,

--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -139,7 +139,7 @@
 
 /datum/crafting_recipe/lizardboots
 	name = "Lizard Skin Boots"
-	result = /obj/effect/spawner/lootdrop/lizardboots
+	result = /atom/movable/spawner/lootdrop/lizardboots
 	reqs = list(/obj/item/stack/sheet/animalhide/lizard = 1, /obj/item/stack/sheet/leather = 1)
 	time = 60
 	category = CAT_CLOTHING

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -539,7 +539,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			playsound(loc, 'sound/arcade/win.ogg', 50, TRUE)
 
 			if(obj_flags & EMAGGED)
-				new /obj/effect/spawner/newbomb/timer/syndicate(loc)
+				new /atom/movable/spawner/newbomb/timer/syndicate(loc)
 				new /obj/item/clothing/head/collectable/petehat(loc)
 				message_admins("[ADMIN_LOOKUPFLW(usr)] has outbombed Cuban Pete and been awarded a bomb.")
 				log_game("[key_name(usr)] has outbombed Cuban Pete and been awarded a bomb.")

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -18,7 +18,7 @@
 /obj/effect/beam/singularity_pull()
 	return
 
-/obj/effect/spawner
+/atom/movable/spawner
 	name = "object spawner"
 
 /obj/effect/list_container

--- a/code/game/objects/effects/spawners/arcade.dm
+++ b/code/game/objects/effects/spawners/arcade.dm
@@ -1,10 +1,10 @@
-/obj/effect/spawner/randomarcade
+/atom/movable/spawner/randomarcade
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "arcade"
 	name = "spawn random arcade machine"
 	desc = "Automagically transforms into a random arcade machine. If you see this while in a shift, please create a bug report."
 
-/obj/effect/spawner/randomarcade/Initialize(mapload)
+/atom/movable/spawner/randomarcade/Initialize(mapload)
 	..()
 
 	var/static/list/gameodds = list(

--- a/code/game/objects/effects/spawners/bombspawner.dm
+++ b/code/game/objects/effects/spawners/bombspawner.dm
@@ -3,7 +3,7 @@
 #define OPTIMAL_TEMP_K_PLA_BURN_SCALE(PRESSURE_P,PRESSURE_O,TEMP_O)	(((PRESSURE_P) * GLOB.meta_gas_info[/datum/gas/plasma][META_GAS_SPECIFIC_HEAT]) / (((PRESSURE_P) * GLOB.meta_gas_info[/datum/gas/plasma][META_GAS_SPECIFIC_HEAT] + (PRESSURE_O) * GLOB.meta_gas_info[/datum/gas/oxygen][META_GAS_SPECIFIC_HEAT]) / PLASMA_UPPER_TEMPERATURE - (PRESSURE_O) * GLOB.meta_gas_info[/datum/gas/oxygen][META_GAS_SPECIFIC_HEAT] / CELSIUS_TO_KELVIN(TEMP_O)))
 #define OPTIMAL_TEMP_K_PLA_BURN_RATIO(PRESSURE_P,PRESSURE_O,TEMP_O)	(CELSIUS_TO_KELVIN(TEMP_O) * PLASMA_OXYGEN_FULLBURN * (PRESSURE_P) / (PRESSURE_O))
 
-/obj/effect/spawner/newbomb
+/atom/movable/spawner/newbomb
 	name = "bomb"
 	icon = 'icons/hud/screen_gen.dmi'
 	icon_state = "x"
@@ -13,7 +13,7 @@
 	var/pressure_o = 10 * ONE_ATMOSPHERE	//tank pressures
 	var/assembly_type
 
-/obj/effect/spawner/newbomb/Initialize()
+/atom/movable/spawner/newbomb/Initialize()
 	. = ..()
 	var/obj/item/transfer_valve/V = new(src.loc)
 	var/obj/item/tank/internals/plasma/PT = new(V)
@@ -41,23 +41,23 @@
 
 	return INITIALIZE_HINT_QDEL
 
-/obj/effect/spawner/newbomb/timer/syndicate/Initialize()
+/atom/movable/spawner/newbomb/timer/syndicate/Initialize()
 	temp_p = (OPTIMAL_TEMP_K_PLA_BURN_SCALE(pressure_p, pressure_o, temp_o)/2 + OPTIMAL_TEMP_K_PLA_BURN_RATIO(pressure_p, pressure_o, temp_o)/2) - T0C
 	. = ..()
 
-/obj/effect/spawner/newbomb/timer
+/atom/movable/spawner/newbomb/timer
 	assembly_type = /obj/item/assembly/timer
 
-/obj/effect/spawner/newbomb/timer/syndicate
+/atom/movable/spawner/newbomb/timer/syndicate
 	pressure_o = TANK_LEAK_PRESSURE - 1
 	temp_o = 20
 
 	pressure_p = TANK_LEAK_PRESSURE - 1
 
-/obj/effect/spawner/newbomb/proximity
+/atom/movable/spawner/newbomb/proximity
 	assembly_type = /obj/item/assembly/prox_sensor
 
-/obj/effect/spawner/newbomb/radio
+/atom/movable/spawner/newbomb/radio
 	assembly_type = /obj/item/assembly/signaler
 
 

--- a/code/game/objects/effects/spawners/bundle.dm
+++ b/code/game/objects/effects/spawners/bundle.dm
@@ -1,4 +1,4 @@
-/obj/effect/spawner/bundle
+/atom/movable/spawner/bundle
 	name = "bundle spawner"
 	icon = 'icons/hud/screen_gen.dmi'
 	icon_state = "x2"
@@ -6,34 +6,34 @@
 
 	var/list/items
 
-/obj/effect/spawner/bundle/Initialize(mapload)
+/atom/movable/spawner/bundle/Initialize(mapload)
 	..()
 	if(items?.len)
 		for(var/path in items)
 			new path(loc)
 	return INITIALIZE_HINT_QDEL
 
-/obj/effect/spawner/bundle/costume/chicken
+/atom/movable/spawner/bundle/costume/chicken
 	name = "chicken costume spawner"
 	items = list(
 		/obj/item/clothing/suit/chickensuit,
 		/obj/item/clothing/head/chicken,
 		/obj/item/food/egg)
 
-/obj/effect/spawner/bundle/costume/gladiator
+/atom/movable/spawner/bundle/costume/gladiator
 	name = "gladiator costume spawner"
 	items = list(
 		/obj/item/clothing/under/costume/gladiator,
 		/obj/item/clothing/head/helmet/gladiator)
 
-/obj/effect/spawner/bundle/costume/madscientist
+/atom/movable/spawner/bundle/costume/madscientist
 	name = "mad scientist costume spawner"
 	items = list(
 		/obj/item/clothing/under/rank/captain/suit,
 		/obj/item/clothing/head/flatcap,
 		/obj/item/clothing/suit/toggle/labcoat/mad)
 
-/obj/effect/spawner/bundle/costume/elpresidente
+/atom/movable/spawner/bundle/costume/elpresidente
 	name = "el presidente costume spawner"
 	items = list(
 		/obj/item/clothing/under/rank/captain/suit,
@@ -41,60 +41,60 @@
 		/obj/item/clothing/mask/cigarette/cigar/havana,
 		/obj/item/clothing/shoes/jackboots)
 
-/obj/effect/spawner/bundle/costume/nyangirl
+/atom/movable/spawner/bundle/costume/nyangirl
 	name = "nyangirl costume spawner"
 	items = list(
 		/obj/item/clothing/under/costume/schoolgirl,
 		/obj/item/clothing/head/kitty,
 		/obj/item/clothing/glasses/blindfold)
 
-/obj/effect/spawner/bundle/costume/maid
+/atom/movable/spawner/bundle/costume/maid
 	name = "maid costume spawner"
 	items = list(
 		/obj/item/clothing/under/dress/skirt,
-		/obj/effect/spawner/lootdrop/minor/beret_or_rabbitears,
+		/atom/movable/spawner/lootdrop/minor/beret_or_rabbitears,
 		/obj/item/clothing/glasses/blindfold)
 
 
-/obj/effect/spawner/bundle/costume/butler
+/atom/movable/spawner/bundle/costume/butler
 	name = "butler costume spawner"
 	items = list(
 		/obj/item/clothing/accessory/waistcoat,
 		/obj/item/clothing/under/suit/black,
 		/obj/item/clothing/head/that)
 
-/obj/effect/spawner/bundle/costume/highlander
+/atom/movable/spawner/bundle/costume/highlander
 	name = "highlander costume spawner"
 	items = list(
 		/obj/item/clothing/under/costume/kilt,
 		/obj/item/clothing/head/beret)
 
-/obj/effect/spawner/bundle/costume/prig
+/atom/movable/spawner/bundle/costume/prig
 	name = "prig costume spawner"
 	items = list(
 		/obj/item/clothing/accessory/waistcoat,
 		/obj/item/clothing/glasses/monocle,
-		/obj/effect/spawner/lootdrop/minor/bowler_or_that,
+		/atom/movable/spawner/lootdrop/minor/bowler_or_that,
 		/obj/item/clothing/shoes/sneakers/black,
 		/obj/item/cane,
 		/obj/item/clothing/under/suit/sl,
 		/obj/item/clothing/mask/fakemoustache)
 
-/obj/effect/spawner/bundle/costume/plaguedoctor
+/atom/movable/spawner/bundle/costume/plaguedoctor
 	name = "plague doctor costume spawner"
 	items = list(
 		/obj/item/clothing/suit/bio_suit/plaguedoctorsuit,
 		/obj/item/clothing/head/plaguedoctorhat,
 		/obj/item/clothing/mask/gas/plaguedoctor)
 
-/obj/effect/spawner/bundle/costume/nightowl
+/atom/movable/spawner/bundle/costume/nightowl
 	name = "night owl costume spawner"
 	items = list(
 		/obj/item/clothing/suit/toggle/owlwings,
 		/obj/item/clothing/under/costume/owl,
 		/obj/item/clothing/mask/gas/owl_mask)
 
-/obj/effect/spawner/bundle/costume/griffin
+/atom/movable/spawner/bundle/costume/griffin
 	name = "griffin costume spawner"
 	items = list(
 		/obj/item/clothing/suit/toggle/owlwings/griffinwings,
@@ -102,53 +102,53 @@
 		/obj/item/clothing/under/costume/griffin,
 		/obj/item/clothing/head/griffin)
 
-/obj/effect/spawner/bundle/costume/waiter
+/atom/movable/spawner/bundle/costume/waiter
 	name = "waiter costume spawner"
 	items = list(
 		/obj/item/clothing/under/suit/waiter,
-		/obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
+		/atom/movable/spawner/lootdrop/minor/kittyears_or_rabbitears,
 		/obj/item/clothing/suit/apron)
 
-/obj/effect/spawner/bundle/costume/pirate
+/atom/movable/spawner/bundle/costume/pirate
 	name = "pirate costume spawner"
 	items = list(
 		/obj/item/clothing/under/costume/pirate,
 		/obj/item/clothing/suit/pirate,
-		/obj/effect/spawner/lootdrop/minor/pirate_or_bandana,
+		/atom/movable/spawner/lootdrop/minor/pirate_or_bandana,
 		/obj/item/clothing/glasses/eyepatch)
 
-/obj/effect/spawner/bundle/costume/commie
+/atom/movable/spawner/bundle/costume/commie
 	name = "commie costume spawner"
 	items = list(
 		/obj/item/clothing/under/costume/soviet,
 		/obj/item/clothing/head/ushanka)
 
-/obj/effect/spawner/bundle/costume/imperium_monk
+/atom/movable/spawner/bundle/costume/imperium_monk
 	name = "imperium monk costume spawner"
 	items = list(
 		/obj/item/clothing/suit/imperium_monk,
-		/obj/effect/spawner/lootdrop/minor/twentyfive_percent_cyborg_mask)
+		/atom/movable/spawner/lootdrop/minor/twentyfive_percent_cyborg_mask)
 
-/obj/effect/spawner/bundle/costume/holiday_priest
+/atom/movable/spawner/bundle/costume/holiday_priest
 	name = "holiday priest costume spawner"
 	items = list(
 		/obj/item/clothing/suit/chaplainsuit/holidaypriest)
 
-/obj/effect/spawner/bundle/costume/marisawizard
+/atom/movable/spawner/bundle/costume/marisawizard
 	name = "marisa wizard costume spawner"
 	items = list(
 		/obj/item/clothing/shoes/sandal/marisa,
 		/obj/item/clothing/head/wizard/marisa/fake,
 		/obj/item/clothing/suit/wizrobe/marisa/fake)
 
-/obj/effect/spawner/bundle/costume/cutewitch
+/atom/movable/spawner/bundle/costume/cutewitch
 	name = "cute witch costume spawner"
 	items = list(
 		/obj/item/clothing/under/dress/sundress,
 		/obj/item/clothing/head/witchwig,
 		/obj/item/staff/broom)
 
-/obj/effect/spawner/bundle/costume/wizard
+/atom/movable/spawner/bundle/costume/wizard
 	name = "wizard costume spawner"
 	items = list(
 		/obj/item/clothing/shoes/sandal,
@@ -156,53 +156,53 @@
 		/obj/item/clothing/head/wizard/fake,
 		/obj/item/staff)
 
-/obj/effect/spawner/bundle/costume/sexyclown
+/atom/movable/spawner/bundle/costume/sexyclown
 	name = "sexy clown costume spawner"
 	items = list(
 		/obj/item/clothing/mask/gas/sexyclown,
 		/obj/item/clothing/under/rank/civilian/clown/sexy)
 
-/obj/effect/spawner/bundle/costume/sexymime
+/atom/movable/spawner/bundle/costume/sexymime
 	name = "sexy mime costume spawner"
 	items = list(
 		/obj/item/clothing/mask/gas/sexymime,
 		/obj/item/clothing/under/rank/civilian/mime/sexy)
 
-/obj/effect/spawner/bundle/costume/mafia
+/atom/movable/spawner/bundle/costume/mafia
 	name = "black mafia outfit spawner"
 	items = list(
 		/obj/item/clothing/head/fedora,
 		/obj/item/clothing/under/suit/blacktwopiece,
 		/obj/item/clothing/shoes/laceup)
 
-/obj/effect/spawner/bundle/costume/mafia/white
+/atom/movable/spawner/bundle/costume/mafia/white
 	name = "white mafia outfit spawner"
 	items = list(
 		/obj/item/clothing/head/fedora/white,
 		/obj/item/clothing/under/suit/white,
 		/obj/item/clothing/shoes/laceup)
 
-/obj/effect/spawner/bundle/costume/mafia/checkered
+/atom/movable/spawner/bundle/costume/mafia/checkered
 	name = "checkered mafia outfit spawner"
 	items = list(
 		/obj/item/clothing/head/fedora,
 		/obj/item/clothing/under/suit/checkered,
 		/obj/item/clothing/shoes/laceup)
 
-/obj/effect/spawner/bundle/costume/mafia/beige
+/atom/movable/spawner/bundle/costume/mafia/beige
 	name = "beige mafia outfit spawner"
 	items = list(
 		/obj/item/clothing/head/fedora/beige,
 		/obj/item/clothing/under/suit/beige,
 		/obj/item/clothing/shoes/laceup)
 
-/obj/effect/spawner/bundle/hobo_squat
+/atom/movable/spawner/bundle/hobo_squat
 	name = "hobo squat spawner"
 	items = list(/obj/structure/bed/maint,
-				/obj/effect/spawner/scatter/grime,
-				/obj/effect/spawner/lootdrop/maint_drugs)
+				/atom/movable/spawner/scatter/grime,
+				/atom/movable/spawner/lootdrop/maint_drugs)
 
-/obj/effect/spawner/bundle/moisture_trap
+/atom/movable/spawner/bundle/moisture_trap
 	name = "moisture trap spawner"
-	items = list(/obj/effect/spawner/scatter/moisture,
+	items = list(/atom/movable/spawner/scatter/moisture,
 				/obj/structure/moisture_trap)

--- a/code/game/objects/effects/spawners/decals.dm
+++ b/code/game/objects/effects/spawners/decals.dm
@@ -1,5 +1,5 @@
 ///This spawner can spawn either a swabbable or non-swabble decal, the purpose of this is provide swabbing spots that cannot be rushed every round using map knowledge.
-/obj/effect/spawner/lootdrop/gross_decal_spawner
+/atom/movable/spawner/lootdrop/gross_decal_spawner
 	name = "gross decal spawner"
 	icon_state = "random_trash"
 	loot = list(

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -1,4 +1,4 @@
-/obj/effect/spawner/lootdrop
+/atom/movable/spawner/lootdrop
 	icon = 'icons/effects/landmarks_static.dmi'
 	icon_state = "random_loot"
 	layer = OBJ_LAYER
@@ -7,7 +7,7 @@
 	var/list/loot			//a list of possible items to spawn e.g. list(/obj/item, /obj/structure, /obj/effect)
 	var/fan_out_items = FALSE //Whether the items should be distributed to offsets 0,1,-1,2,-2,3,-3.. This overrides pixel_x/y on the spawner itself
 
-/obj/effect/spawner/lootdrop/Initialize(mapload)
+/atom/movable/spawner/lootdrop/Initialize(mapload)
 	..()
 	if(loot?.len)
 		var/loot_spawned = 0
@@ -31,7 +31,7 @@
 			loot_spawned++
 	return INITIALIZE_HINT_QDEL
 
-/obj/effect/spawner/lootdrop/donkpockets
+/atom/movable/spawner/lootdrop/donkpockets
 	name = "donk pocket box spawner"
 	lootdoubles = FALSE
 
@@ -43,17 +43,17 @@
 			/obj/item/storage/box/donkpockets/donkpockethonk = 1,
 		)
 
-/obj/effect/spawner/lootdrop/arcade_boards
+/atom/movable/spawner/lootdrop/arcade_boards
 	name = "arcade board spawner"
 	lootdoubles = FALSE
 	loot = list()
 
-/obj/effect/spawner/lootdrop/arcade_boards/Initialize(mapload)
+/atom/movable/spawner/lootdrop/arcade_boards/Initialize(mapload)
 	loot += subtypesof(/obj/item/circuitboard/computer/arcade)
 	return ..()
 
 
-/obj/effect/spawner/lootdrop/armory_contraband
+/atom/movable/spawner/lootdrop/armory_contraband
 	name = "armory contraband gun spawner"
 	lootdoubles = FALSE
 
@@ -64,14 +64,14 @@
 				/obj/item/gun/ballistic/revolver/mateba
 				)
 
-/obj/effect/spawner/lootdrop/armory_contraband/metastation
+/atom/movable/spawner/lootdrop/armory_contraband/metastation
 	loot = list(/obj/item/gun/ballistic/automatic/pistol = 5,
 				/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
 				/obj/item/gun/ballistic/automatic/pistol/deagle,
 				/obj/item/storage/box/syndie_kit/throwing_weapons = 3,
 				/obj/item/gun/ballistic/revolver/mateba)
 
-/obj/effect/spawner/lootdrop/armory_contraband/donutstation
+/atom/movable/spawner/lootdrop/armory_contraband/donutstation
 	loot = list(/obj/item/grenade/clusterbuster/teargas = 5,
 				/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
 				/obj/item/bikehorn/golden,
@@ -79,7 +79,7 @@
 				/obj/item/storage/box/syndie_kit/throwing_weapons = 3,
 				/obj/item/gun/ballistic/revolver/mateba)
 
-/obj/effect/spawner/lootdrop/prison_contraband
+/atom/movable/spawner/lootdrop/prison_contraband
 	name = "prison contraband loot spawner"
 	loot = list(/obj/item/clothing/mask/cigarette/space_cigarette = 4,
 				/obj/item/clothing/mask/cigarette/robust = 2,
@@ -121,7 +121,7 @@
 				/obj/item/pda = 1
 				)
 
-/obj/effect/spawner/lootdrop/gambling
+/atom/movable/spawner/lootdrop/gambling
 	name = "gambling valuables spawner"
 	loot = list(
 				/obj/item/gun/ballistic/revolver/russian = 5,
@@ -131,26 +131,26 @@
 				/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 				)
 
-/obj/effect/spawner/lootdrop/garbage_spawner
+/atom/movable/spawner/lootdrop/garbage_spawner
 	name = "garbage_spawner"
-	loot = list(/obj/effect/spawner/lootdrop/food_packaging = 56,
+	loot = list(/atom/movable/spawner/lootdrop/food_packaging = 56,
 				/obj/item/trash/can = 8,
 				/obj/item/shard = 8,
-				/obj/effect/spawner/lootdrop/botanical_waste = 8,
-				/obj/effect/spawner/lootdrop/cigbutt = 8,
+				/atom/movable/spawner/lootdrop/botanical_waste = 8,
+				/atom/movable/spawner/lootdrop/cigbutt = 8,
 				/obj/item/reagent_containers/syringe = 5,
 				/obj/item/reagent_containers/food/snacks/deadmouse = 2,
 				/obj/item/light/tube/broken = 3,
 				/obj/item/light/tube/broken = 1,
 				/obj/item/trash/candle = 1)
 
-/obj/effect/spawner/lootdrop/cigbutt
+/atom/movable/spawner/lootdrop/cigbutt
 	name = "cigarette butt spawner"
 	loot = list(/obj/item/cigbutt = 65,
 				/obj/item/cigbutt/roach = 20,
 				/obj/item/cigbutt/cigarbutt = 15)
 
-/obj/effect/spawner/lootdrop/food_packaging
+/atom/movable/spawner/lootdrop/food_packaging
 	name = "food packaging spawner"
 	loot = list(/obj/item/trash/raisins = 20,
 				/obj/item/trash/cheesie = 10,
@@ -165,13 +165,13 @@
 				/obj/item/trash/can/food/peaches/maint = 4,
 				/obj/item/trash/semki = 2)
 
-/obj/effect/spawner/lootdrop/botanical_waste
+/atom/movable/spawner/lootdrop/botanical_waste
 	name = "botanical waste spawner"
 	loot = list(/obj/item/grown/bananapeel = 60,
 				/obj/item/grown/corncob = 30,
 				/obj/item/reagent_containers/food/snacks/grown/bungopit = 10)
 
-/obj/effect/spawner/lootdrop/refreshing_beverage
+/atom/movable/spawner/lootdrop/refreshing_beverage
 	name = "good soda spawner"
 	loot = list(/obj/item/reagent_containers/food/drinks/drinkingglass/filled/nuka_cola = 15,
 				/obj/item/reagent_containers/food/drinks/soda_cans/grey_bull = 15,
@@ -187,7 +187,7 @@
 				/obj/item/reagent_containers/food/drinks/soda_cans/sol_dry = 5,
 				/obj/item/reagent_containers/food/drinks/soda_cans/cola = 5)
 
-/obj/effect/spawner/lootdrop/maint_drugs
+/atom/movable/spawner/lootdrop/maint_drugs
 	name = "maint drugs spawner"
 	loot = list(/obj/item/reagent_containers/food/drinks/bottle/hooch = 50,
 				/obj/item/clothing/mask/cigarette/rollie/cannabis = 15,
@@ -195,7 +195,7 @@
 				/obj/item/reagent_containers/syringe = 15,
 				/obj/item/cigbutt/roach = 15)
 
-/obj/effect/spawner/lootdrop/grille_or_trash
+/atom/movable/spawner/lootdrop/grille_or_trash
 	name = "maint grille or trash spawner"
 	loot = list(/obj/structure/grille = 5,
 			/obj/item/cigbutt = 1,
@@ -210,7 +210,7 @@
 			/obj/item/trash/sosjerky = 1,
 			/obj/item/trash/syndi_cakes = 1)
 
-/obj/effect/spawner/lootdrop/three_course_meal
+/atom/movable/spawner/lootdrop/three_course_meal
 	name = "three course meal spawner"
 	lootcount = 3
 	lootdoubles = FALSE
@@ -235,47 +235,47 @@
 			/obj/item/food/burger/superbite,
 			/obj/item/food/burger/fivealarm)
 
-/obj/effect/spawner/lootdrop/three_course_meal/Initialize(mapload)
+/atom/movable/spawner/lootdrop/three_course_meal/Initialize(mapload)
 	loot = list(pick(soups) = 1,pick(salads) = 1,pick(mains) = 1)
 	. = ..()
 
-/obj/effect/spawner/lootdrop/maintenance
+/atom/movable/spawner/lootdrop/maintenance
 	name = "maintenance loot spawner"
 	// see code/_globalvars/lists/maintenance_loot.dm for loot table
 
-/obj/effect/spawner/lootdrop/maintenance/Initialize(mapload)
+/atom/movable/spawner/lootdrop/maintenance/Initialize(mapload)
 	loot = GLOB.maintenance_loot
 	. = ..()
 
-/obj/effect/spawner/lootdrop/maintenance/two
+/atom/movable/spawner/lootdrop/maintenance/two
 	name = "2 x maintenance loot spawner"
 	lootcount = 2
 
-/obj/effect/spawner/lootdrop/maintenance/three
+/atom/movable/spawner/lootdrop/maintenance/three
 	name = "3 x maintenance loot spawner"
 	lootcount = 3
 
-/obj/effect/spawner/lootdrop/maintenance/four
+/atom/movable/spawner/lootdrop/maintenance/four
 	name = "4 x maintenance loot spawner"
 	lootcount = 4
 
-/obj/effect/spawner/lootdrop/maintenance/five
+/atom/movable/spawner/lootdrop/maintenance/five
 	name = "5 x maintenance loot spawner"
 	lootcount = 5
 
-/obj/effect/spawner/lootdrop/maintenance/six
+/atom/movable/spawner/lootdrop/maintenance/six
 	name = "6 x maintenance loot spawner"
 	lootcount = 6
 
-/obj/effect/spawner/lootdrop/maintenance/seven
+/atom/movable/spawner/lootdrop/maintenance/seven
 	name = "7 x maintenance loot spawner"
 	lootcount = 7
 
-/obj/effect/spawner/lootdrop/maintenance/eight
+/atom/movable/spawner/lootdrop/maintenance/eight
 	name = "8 x maintenance loot spawner"
 	lootcount = 8
 
-/obj/effect/spawner/lootdrop/crate_spawner
+/atom/movable/spawner/lootdrop/crate_spawner
 	name = "lootcrate spawner" //USE PROMO CODE "SELLOUT" FOR 20% OFF!
 	lootdoubles = FALSE
 
@@ -284,7 +284,7 @@
 				"" = 80
 				)
 
-/obj/effect/spawner/lootdrop/organ_spawner
+/atom/movable/spawner/lootdrop/organ_spawner
 	name = "ayylien organ spawner"
 	loot = list(
 		/obj/item/organ/heart/gland/electric = 3,
@@ -301,7 +301,7 @@
 		/obj/item/organ/regenerative_core = 2)
 	lootcount = 3
 
-/obj/effect/spawner/lootdrop/memeorgans
+/atom/movable/spawner/lootdrop/memeorgans
 	name = "meme organ spawner"
 	loot = list(
 		/obj/item/organ/ears/penguin,
@@ -323,54 +323,54 @@
 		/obj/item/organ/tail/lizard)
 	lootcount = 5
 
-/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner
+/atom/movable/spawner/lootdrop/two_percent_xeno_egg_spawner
 	name = "2% chance xeno egg spawner"
 	loot = list(
 		/obj/effect/decal/remains/xeno = 49,
-		/obj/effect/spawner/xeno_egg_delivery = 1)
+		/atom/movable/spawner/xeno_egg_delivery = 1)
 
-/obj/effect/spawner/lootdrop/costume
+/atom/movable/spawner/lootdrop/costume
 	name = "random costume spawner"
 
-/obj/effect/spawner/lootdrop/costume/Initialize()
+/atom/movable/spawner/lootdrop/costume/Initialize()
 	loot = list()
-	for(var/path in subtypesof(/obj/effect/spawner/bundle/costume))
+	for(var/path in subtypesof(/atom/movable/spawner/bundle/costume))
 		loot[path] = TRUE
 	. = ..()
 
 // Minor lootdrops follow
 
-/obj/effect/spawner/lootdrop/minor/beret_or_rabbitears
+/atom/movable/spawner/lootdrop/minor/beret_or_rabbitears
 	name = "beret or rabbit ears spawner"
 	loot = list(
 		/obj/item/clothing/head/beret = 1,
 		/obj/item/clothing/head/rabbitears = 1)
 
-/obj/effect/spawner/lootdrop/minor/bowler_or_that
+/atom/movable/spawner/lootdrop/minor/bowler_or_that
 	name = "bowler or top hat spawner"
 	loot = list(
 		/obj/item/clothing/head/bowler = 1,
 		/obj/item/clothing/head/that = 1)
 
-/obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears
+/atom/movable/spawner/lootdrop/minor/kittyears_or_rabbitears
 	name = "kitty ears or rabbit ears spawner"
 	loot = list(
 		/obj/item/clothing/head/kitty = 1,
 		/obj/item/clothing/head/rabbitears = 1)
 
-/obj/effect/spawner/lootdrop/minor/pirate_or_bandana
+/atom/movable/spawner/lootdrop/minor/pirate_or_bandana
 	name = "pirate hat or bandana spawner"
 	loot = list(
 		/obj/item/clothing/head/pirate = 1,
 		/obj/item/clothing/head/bandana = 1)
 
-/obj/effect/spawner/lootdrop/minor/twentyfive_percent_cyborg_mask
+/atom/movable/spawner/lootdrop/minor/twentyfive_percent_cyborg_mask
 	name = "25% cyborg mask spawner"
 	loot = list(
 		/obj/item/clothing/mask/gas/cyborg = 25,
 		"" = 75)
 
-/obj/effect/spawner/lootdrop/aimodule_harmless // These shouldn't allow the AI to start butchering people
+/atom/movable/spawner/lootdrop/aimodule_harmless // These shouldn't allow the AI to start butchering people
 	name = "harmless AI module spawner"
 	loot = list(
 				/obj/item/ai_module/core/full/asimov,
@@ -380,7 +380,7 @@
 				/obj/item/ai_module/core/full/paladin
 				)
 
-/obj/effect/spawner/lootdrop/aimodule_neutral // These shouldn't allow the AI to start butchering people without reason
+/atom/movable/spawner/lootdrop/aimodule_neutral // These shouldn't allow the AI to start butchering people without reason
 	name = "neutral AI module spawner"
 	loot = list(
 				/obj/item/ai_module/core/full/corp,
@@ -393,7 +393,7 @@
 				/obj/item/ai_module/core/full/hulkamania
 				)
 
-/obj/effect/spawner/lootdrop/aimodule_harmful // These will get the shuttle called
+/atom/movable/spawner/lootdrop/aimodule_harmful // These will get the shuttle called
 	name = "harmful AI module spawner"
 	loot = list(
 				/obj/item/ai_module/core/full/antimov,
@@ -406,13 +406,13 @@
 
 // Tech storage circuit board spawners
 
-/obj/effect/spawner/lootdrop/techstorage
+/atom/movable/spawner/lootdrop/techstorage
 	name = "generic circuit board spawner"
 	lootdoubles = FALSE
 	fan_out_items = TRUE
 	lootcount = INFINITY
 
-/obj/effect/spawner/lootdrop/techstorage/service
+/atom/movable/spawner/lootdrop/techstorage/service
 	name = "service circuit board spawner"
 	loot = list(
 				/obj/item/circuitboard/computer/arcade/battle,
@@ -427,7 +427,7 @@
 				/obj/item/circuitboard/computer/slot_machine
 				)
 
-/obj/effect/spawner/lootdrop/techstorage/rnd
+/atom/movable/spawner/lootdrop/techstorage/rnd
 	name = "RnD circuit board spawner"
 	loot = list(
 				/obj/item/circuitboard/computer/aifixer,
@@ -446,7 +446,7 @@
 				/obj/item/circuitboard/machine/dnascanner
 				)
 
-/obj/effect/spawner/lootdrop/techstorage/security
+/atom/movable/spawner/lootdrop/techstorage/security
 	name = "security circuit board spawner"
 	loot = list(
 				/obj/item/circuitboard/computer/secure_data,
@@ -454,7 +454,7 @@
 				/obj/item/circuitboard/computer/prisoner
 				)
 
-/obj/effect/spawner/lootdrop/techstorage/engineering
+/atom/movable/spawner/lootdrop/techstorage/engineering
 	name = "engineering circuit board spawner"
 	loot = list(
 				/obj/item/circuitboard/computer/atmos_alert,
@@ -462,7 +462,7 @@
 				/obj/item/circuitboard/computer/powermonitor
 				)
 
-/obj/effect/spawner/lootdrop/techstorage/tcomms
+/atom/movable/spawner/lootdrop/techstorage/tcomms
 	name = "tcomms circuit board spawner"
 	loot = list(
 				/obj/item/circuitboard/computer/message_monitor,
@@ -476,7 +476,7 @@
 				/obj/item/circuitboard/computer/comm_monitor
 				)
 
-/obj/effect/spawner/lootdrop/techstorage/medical
+/atom/movable/spawner/lootdrop/techstorage/medical
 	name = "medical circuit board spawner"
 	loot = list(
 				/obj/item/circuitboard/machine/chem_dispenser,
@@ -486,7 +486,7 @@
 				/obj/item/circuitboard/computer/pandemic
 				)
 
-/obj/effect/spawner/lootdrop/techstorage/ai
+/atom/movable/spawner/lootdrop/techstorage/ai
 	name = "secure AI circuit board spawner"
 	loot = list(
 				/obj/item/circuitboard/computer/aiupload,
@@ -494,7 +494,7 @@
 				/obj/item/circuitboard/aicore
 				)
 
-/obj/effect/spawner/lootdrop/techstorage/command
+/atom/movable/spawner/lootdrop/techstorage/command
 	name = "secure command circuit board spawner"
 	loot = list(
 				/obj/item/circuitboard/computer/crew,
@@ -502,7 +502,7 @@
 				/obj/item/circuitboard/computer/card
 				)
 
-/obj/effect/spawner/lootdrop/techstorage/rnd_secure
+/atom/movable/spawner/lootdrop/techstorage/rnd_secure
 	name = "secure RnD circuit board spawner"
 	loot = list(
 				/obj/item/circuitboard/computer/mecha_control,
@@ -510,20 +510,20 @@
 				/obj/item/circuitboard/computer/robotics
 				)
 
-/obj/effect/spawner/lootdrop/mafia_outfit
+/atom/movable/spawner/lootdrop/mafia_outfit
 	name = "mafia outfit spawner"
 	loot = list(
-				/obj/effect/spawner/bundle/costume/mafia = 20,
-				/obj/effect/spawner/bundle/costume/mafia/white = 5,
-				/obj/effect/spawner/bundle/costume/mafia/checkered = 2,
-				/obj/effect/spawner/bundle/costume/mafia/beige = 5
+				/atom/movable/spawner/bundle/costume/mafia = 20,
+				/atom/movable/spawner/bundle/costume/mafia/white = 5,
+				/atom/movable/spawner/bundle/costume/mafia/checkered = 2,
+				/atom/movable/spawner/bundle/costume/mafia/beige = 5
 				)
 
 //finds the probabilities of items spawning from a loot spawner's loot pool
 /obj/item/loot_table_maker
 	icon = 'icons/effects/landmarks_static.dmi'
 	icon_state = "random_loot"
-	var/spawner_to_test = /obj/effect/spawner/lootdrop/maintenance //what lootdrop spawner to use the loot pool of
+	var/spawner_to_test = /atom/movable/spawner/lootdrop/maintenance //what lootdrop spawner to use the loot pool of
 	var/loot_count = 180 //180 is about how much maint loot spawns per map as of 11/14/2019
 	//result outputs
 	var/list/spawned_table //list of all items "spawned" and how many
@@ -540,7 +540,7 @@
 /obj/item/loot_table_maker/proc/make_table()
 	spawned_table = list()
 	stat_table = list()
-	var/obj/effect/spawner/lootdrop/spawner_to_table = new spawner_to_test
+	var/atom/movable/spawner/lootdrop/spawner_to_table = new spawner_to_test
 	var/lootpool = spawner_to_table.loot
 	qdel(spawner_to_table)
 	for(var/i in 1 to loot_count)
@@ -559,12 +559,12 @@
 		lootspawn = pickweight(lootspawn)
 	return lootspawn
 
-/obj/effect/spawner/lootdrop/space
+/atom/movable/spawner/lootdrop/space
 	name = "generic space ruin loot spawner"
 	lootcount = 1
 
 /// Space loot spawner. Randomlu picks 5 wads of space cash.
-/obj/effect/spawner/lootdrop/space/cashmoney
+/atom/movable/spawner/lootdrop/space/cashmoney
 	lootcount = 5
 	fan_out_items = TRUE
 	loot = list(
@@ -580,7 +580,7 @@
 	)
 
 /// Space loot spawner. Couple of random bits of technology-adjacent stuff including anomaly cores and BEPIS techs.
-/obj/effect/spawner/lootdrop/space/fancytech
+/atom/movable/spawner/lootdrop/space/fancytech
 	lootcount = 2
 	loot = list(
 		/obj/item/raw_anomaly_core/random = 1,
@@ -589,7 +589,7 @@
 	)
 
 /// Space loot spawner. Some sort of random and rare tool. Only a single drop.
-/obj/effect/spawner/lootdrop/space/fancytool
+/atom/movable/spawner/lootdrop/space/fancytool
 	lootcount = 1
 	loot = list(
 		/obj/item/wrench/abductor = 1,
@@ -611,7 +611,7 @@
 	)
 
 /// Space loot spawner. A bunch of rarer seeds. /obj/item/seeds/random is not a random seed, but an exotic seed.
-/obj/effect/spawner/lootdrop/space/rareseed
+/atom/movable/spawner/lootdrop/space/rareseed
 	lootcount = 5
 	loot = list(
 		/obj/item/seeds/random = 30,
@@ -631,7 +631,7 @@
 	)
 
 /// Space loot spawner. A single roundstart species language book.
-/obj/effect/spawner/lootdrop/space/languagebook
+/atom/movable/spawner/lootdrop/space/languagebook
 	lootcount = 1
 	loot = list(
 		/obj/item/language_manual/roundstart_species = 100,
@@ -640,7 +640,7 @@
 	)
 
 /// Space loot spawner. Random selecton of a few rarer materials.
-/obj/effect/spawner/lootdrop/space/material
+/atom/movable/spawner/lootdrop/space/material
 	lootcount = 3
 	loot = list(
 		/obj/item/stack/sheet/plastic/fifty = 5,
@@ -653,7 +653,7 @@
 	)
 
 /// A selection of cosmetic syndicate items. Just a couple. No hardsuits or weapons.
-/obj/effect/spawner/lootdrop/space/syndiecosmetic
+/atom/movable/spawner/lootdrop/space/syndiecosmetic
 	lootcount = 2
 	loot = list(
 		/obj/item/clothing/under/syndicate = 10,
@@ -675,7 +675,7 @@
 		/obj/item/storage/fancy/cigarettes/cigpack_midori = 1
 	)
 
-/obj/effect/spawner/lootdrop/decorative_material
+/atom/movable/spawner/lootdrop/decorative_material
 	lootcount = 1
 	loot = list(
 		/obj/item/stack/sheet/sandblock{amount = 30} = 25,
@@ -688,7 +688,7 @@
 		/obj/item/stack/tile/pod/dark{amount = 20} = 3,
 	)
 
-/obj/effect/spawner/lootdrop/maintenance_carpet
+/atom/movable/spawner/lootdrop/maintenance_carpet
 	lootcount = 1
 	loot = list(
 		/obj/item/stack/tile/carpet{amount = 30} = 35,
@@ -698,11 +698,11 @@
 		/obj/item/stack/tile/carpet/executive/thirty = 15,
 	)
 
-/obj/effect/spawner/lootdrop/decorations_spawner
+/atom/movable/spawner/lootdrop/decorations_spawner
 	lootcount = 1
 	loot = list(
-	/obj/effect/spawner/lootdrop/maintenance_carpet = 25,
-	/obj/effect/spawner/lootdrop/decorative_material = 25,
+	/atom/movable/spawner/lootdrop/maintenance_carpet = 25,
+	/atom/movable/spawner/lootdrop/decorative_material = 25,
 	/obj/item/sign = 10,
 	/obj/item/flashlight/lamp/green = 10,
 	/obj/item/plaque = 5,

--- a/code/game/objects/effects/spawners/lootsite.dm
+++ b/code/game/objects/effects/spawners/lootsite.dm
@@ -5,10 +5,10 @@
 	///This is the loot table for the spawner. Try to make sure the weights add up to 1000, so it is easy to understand.
 	var/list/loot_table = list(/obj/structure/closet/crate/maint = 765,
 							/obj/structure/closet/crate/trashcart/filled = 75,
-							/obj/effect/spawner/bundle/moisture_trap = 50,
-							/obj/effect/spawner/bundle/hobo_squat = 30,
+							/atom/movable/spawner/bundle/moisture_trap = 50,
+							/atom/movable/spawner/bundle/hobo_squat = 30,
 							/obj/structure/closet/mini_fridge = 35,
-							/obj/effect/spawner/lootdrop/gross_decal_spawner = 30,
+							/atom/movable/spawner/lootdrop/gross_decal_spawner = 30,
 							/obj/structure/closet/crate/decorations = 15)
 
 

--- a/code/game/objects/effects/spawners/scatter.dm
+++ b/code/game/objects/effects/spawners/scatter.dm
@@ -1,5 +1,5 @@
 ///This spawner scatters the spawned stuff around where it is placed.
-/obj/effect/spawner/scatter
+/atom/movable/spawner/scatter
 	///determines how many things to scatter
 	var/max_spawns = 3
 	///determines how big of a range we should scatter things in.
@@ -7,7 +7,7 @@
 	///This weighted list acts as the loot table for the spawner
 	var/list/loot_table
 
-/obj/effect/spawner/scatter/Initialize()
+/atom/movable/spawner/scatter/Initialize()
 	..()
 	if(!length(loot_table))
 		return INITIALIZE_HINT_QDEL
@@ -33,17 +33,17 @@
 	return INITIALIZE_HINT_QDEL
 
 ///This spawner will scatter garbage around a dirty site.
-/obj/effect/spawner/scatter/grime
+/atom/movable/spawner/scatter/grime
 	name = "trash and grime scatterer"
 	max_spawns = 5
-	loot_table = list(/obj/effect/spawner/lootdrop/garbage_spawner = 30,
+	loot_table = list(/atom/movable/spawner/lootdrop/garbage_spawner = 30,
 					/mob/living/simple_animal/hostile/cockroach = 25,
 					/obj/effect/decal/cleanable/garbage = 20,
 					/obj/effect/decal/cleanable/vomit/old = 15,
-					/obj/effect/spawner/lootdrop/cigbutt = 10)
+					/atom/movable/spawner/lootdrop/cigbutt = 10)
 
 ///This spawner will scatter water related items around a moist site.
-/obj/effect/spawner/scatter/moisture
+/atom/movable/spawner/scatter/moisture
 	max_spawns = 2
 	radius = 1
 	loot_table = list(/obj/item/clothing/head/cone = 35,

--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -4,11 +4,11 @@ Because mapping is already tedious enough this spawner let you spawn generic
 again.
 */
 
-/obj/effect/spawner/structure
+/atom/movable/spawner/structure
 	name = "map structure spawner"
 	var/list/spawn_list
 
-/obj/effect/spawner/structure/Initialize()
+/atom/movable/spawner/structure/Initialize()
 	. = ..()
 	if(spawn_list?.len)
 		for(var/I in spawn_list)
@@ -18,22 +18,22 @@ again.
 
 //normal windows
 
-/obj/effect/spawner/structure/window
+/atom/movable/spawner/structure/window
 	icon = 'icons/obj/structures_spawners.dmi'
 	icon_state = "window_spawner"
 	name = "window spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/fulltile)
 	dir = SOUTH
 
-/obj/effect/spawner/structure/window/hollow
+/atom/movable/spawner/structure/window/hollow
 	name = "hollow window spawner"
 	icon_state = "hwindow_spawner_full"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window, /obj/structure/window/spawner/north, /obj/structure/window/spawner/east, /obj/structure/window/spawner/west)
 
-/obj/effect/spawner/structure/window/hollow/end
+/atom/movable/spawner/structure/window/hollow/end
 	icon_state = "hwindow_spawner_end"
 
-/obj/effect/spawner/structure/window/hollow/end/Initialize()
+/atom/movable/spawner/structure/window/hollow/end/Initialize()
 	switch(dir)
 		if(NORTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/spawner/north, /obj/structure/window/spawner/east, /obj/structure/window/spawner/west)
@@ -45,10 +45,10 @@ again.
 			spawn_list = list(/obj/structure/grille, /obj/structure/window, /obj/structure/window/spawner/north, /obj/structure/window/spawner/west)
 	. = ..()
 
-/obj/effect/spawner/structure/window/hollow/middle
+/atom/movable/spawner/structure/window/hollow/middle
 	icon_state = "hwindow_spawner_middle"
 
-/obj/effect/spawner/structure/window/hollow/middle/Initialize()
+/atom/movable/spawner/structure/window/hollow/middle/Initialize()
 	switch(dir)
 		if(NORTH,SOUTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window, /obj/structure/window/spawner/north)
@@ -56,10 +56,10 @@ again.
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/spawner/east, /obj/structure/window/spawner/west)
 	. = ..()
 
-/obj/effect/spawner/structure/window/hollow/directional
+/atom/movable/spawner/structure/window/hollow/directional
 	icon_state = "hwindow_spawner_directional"
 
-/obj/effect/spawner/structure/window/hollow/directional/Initialize()
+/atom/movable/spawner/structure/window/hollow/directional/Initialize()
 	switch(dir)
 		if(NORTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/spawner/north)
@@ -81,20 +81,20 @@ again.
 
 //reinforced
 
-/obj/effect/spawner/structure/window/reinforced
+/atom/movable/spawner/structure/window/reinforced
 	name = "reinforced window spawner"
 	icon_state = "rwindow_spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/fulltile)
 
-/obj/effect/spawner/structure/window/hollow/reinforced
+/atom/movable/spawner/structure/window/hollow/reinforced
 	name = "hollow reinforced window spawner"
 	icon_state = "hrwindow_spawner_full"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced, /obj/structure/window/reinforced/spawner/north, /obj/structure/window/reinforced/spawner/east, /obj/structure/window/reinforced/spawner/west)
 
-/obj/effect/spawner/structure/window/hollow/reinforced/end
+/atom/movable/spawner/structure/window/hollow/reinforced/end
 	icon_state = "hrwindow_spawner_end"
 
-/obj/effect/spawner/structure/window/hollow/reinforced/end/Initialize()
+/atom/movable/spawner/structure/window/hollow/reinforced/end/Initialize()
 	switch(dir)
 		if(NORTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/spawner/north, /obj/structure/window/reinforced/spawner/east, /obj/structure/window/reinforced/spawner/west)
@@ -106,10 +106,10 @@ again.
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced, /obj/structure/window/reinforced/spawner/north, /obj/structure/window/reinforced/spawner/west)
 	. = ..()
 
-/obj/effect/spawner/structure/window/hollow/reinforced/middle
+/atom/movable/spawner/structure/window/hollow/reinforced/middle
 	icon_state = "hrwindow_spawner_middle"
 
-/obj/effect/spawner/structure/window/hollow/reinforced/middle/Initialize()
+/atom/movable/spawner/structure/window/hollow/reinforced/middle/Initialize()
 	switch(dir)
 		if(NORTH,SOUTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced, /obj/structure/window/reinforced/spawner/north)
@@ -117,10 +117,10 @@ again.
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/spawner/east, /obj/structure/window/reinforced/spawner/west)
 	. = ..()
 
-/obj/effect/spawner/structure/window/hollow/reinforced/directional
+/atom/movable/spawner/structure/window/hollow/reinforced/directional
 	icon_state = "hrwindow_spawner_directional"
 
-/obj/effect/spawner/structure/window/hollow/reinforced/directional/Initialize()
+/atom/movable/spawner/structure/window/hollow/reinforced/directional/Initialize()
 	switch(dir)
 		if(NORTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/spawner/north)
@@ -142,7 +142,7 @@ again.
 
 //tinted
 
-/obj/effect/spawner/structure/window/reinforced/tinted
+/atom/movable/spawner/structure/window/reinforced/tinted
 	name = "tinted reinforced window spawner"
 	icon_state = "twindow_spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/tinted/fulltile)
@@ -150,7 +150,7 @@ again.
 
 //shuttle window
 
-/obj/effect/spawner/structure/window/shuttle
+/atom/movable/spawner/structure/window/shuttle
 	name = "shuttle window spawner"
 	icon_state = "swindow_spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle)
@@ -158,7 +158,7 @@ again.
 
 //plastitanium window
 
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium
+/atom/movable/spawner/structure/window/plasma/reinforced/plastitanium
 	name = "plastitanium window spawner"
 	icon_state = "plastitaniumwindow_spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma/reinforced/plastitanium)
@@ -166,7 +166,7 @@ again.
 
 //ice window
 
-/obj/effect/spawner/structure/window/ice
+/atom/movable/spawner/structure/window/ice
 	name = "ice window spawner"
 	icon_state = "icewindow_spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/fulltile/ice)
@@ -174,20 +174,20 @@ again.
 
 //survival pod window
 
-/obj/effect/spawner/structure/window/survival_pod
+/atom/movable/spawner/structure/window/survival_pod
 	name = "pod window spawner"
 	icon_state = "podwindow_spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod)
 
-/obj/effect/spawner/structure/window/hollow/survival_pod
+/atom/movable/spawner/structure/window/hollow/survival_pod
 	name = "hollow pod window spawner"
 	icon_state = "podwindow_spawner_full"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/east, /obj/structure/window/shuttle/survival_pod/spawner/west)
 
-/obj/effect/spawner/structure/window/hollow/survival_pod/end
+/atom/movable/spawner/structure/window/hollow/survival_pod/end
 	icon_state = "podwindow_spawner_end"
 
-/obj/effect/spawner/structure/window/hollow/survival_pod/end/Initialize()
+/atom/movable/spawner/structure/window/hollow/survival_pod/end/Initialize()
 	switch(dir)
 		if(NORTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/east, /obj/structure/window/shuttle/survival_pod/spawner/west)
@@ -199,10 +199,10 @@ again.
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/west)
 	. = ..()
 
-/obj/effect/spawner/structure/window/hollow/survival_pod/middle
+/atom/movable/spawner/structure/window/hollow/survival_pod/middle
 	icon_state = "podwindow_spawner_middle"
 
-/obj/effect/spawner/structure/window/hollow/survival_pod/middle/Initialize()
+/atom/movable/spawner/structure/window/hollow/survival_pod/middle/Initialize()
 	switch(dir)
 		if(NORTH,SOUTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/north)
@@ -210,10 +210,10 @@ again.
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/east, /obj/structure/window/shuttle/survival_pod/spawner/west)
 	. = ..()
 
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional
+/atom/movable/spawner/structure/window/hollow/survival_pod/directional
 	icon_state = "podwindow_spawner_directional"
 
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional/Initialize()
+/atom/movable/spawner/structure/window/hollow/survival_pod/directional/Initialize()
 	switch(dir)
 		if(NORTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/north)
@@ -236,20 +236,20 @@ again.
 
 //plasma windows
 
-/obj/effect/spawner/structure/window/plasma
+/atom/movable/spawner/structure/window/plasma
 	name = "plasma window spawner"
 	icon_state = "pwindow_spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma/fulltile)
 
-/obj/effect/spawner/structure/window/hollow/plasma
+/atom/movable/spawner/structure/window/hollow/plasma
 	name = "hollow plasma window spawner"
 	icon_state = "phwindow_spawner_full"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma, /obj/structure/window/plasma/spawner/north, /obj/structure/window/plasma/spawner/east, /obj/structure/window/plasma/spawner/west)
 
-/obj/effect/spawner/structure/window/hollow/plasma/end
+/atom/movable/spawner/structure/window/hollow/plasma/end
 	icon_state = "phwindow_spawner_end"
 
-/obj/effect/spawner/structure/window/hollow/plasma/end/Initialize()
+/atom/movable/spawner/structure/window/hollow/plasma/end/Initialize()
 	switch(dir)
 		if(NORTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma/spawner/north, /obj/structure/window/plasma/spawner/east, /obj/structure/window/plasma/spawner/west)
@@ -261,10 +261,10 @@ again.
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma, /obj/structure/window/plasma/spawner/north, /obj/structure/window/plasma/spawner/west)
 	. = ..()
 
-/obj/effect/spawner/structure/window/hollow/plasma/middle
+/atom/movable/spawner/structure/window/hollow/plasma/middle
 	icon_state = "phwindow_spawner_middle"
 
-/obj/effect/spawner/structure/window/hollow/plasma/middle/Initialize()
+/atom/movable/spawner/structure/window/hollow/plasma/middle/Initialize()
 	switch(dir)
 		if(NORTH,SOUTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma, /obj/structure/window/plasma/spawner/north)
@@ -272,10 +272,10 @@ again.
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma/spawner/east, /obj/structure/window/plasma/spawner/west)
 	. = ..()
 
-/obj/effect/spawner/structure/window/hollow/plasma/directional
+/atom/movable/spawner/structure/window/hollow/plasma/directional
 	icon_state = "phwindow_spawner_directional"
 
-/obj/effect/spawner/structure/window/hollow/plasma/directional/Initialize()
+/atom/movable/spawner/structure/window/hollow/plasma/directional/Initialize()
 	switch(dir)
 		if(NORTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma/spawner/north)
@@ -297,20 +297,20 @@ again.
 
 //plasma reinforced
 
-/obj/effect/spawner/structure/window/plasma/reinforced
+/atom/movable/spawner/structure/window/plasma/reinforced
 	name = "reinforced plasma window spawner"
 	icon_state = "prwindow_spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma/reinforced/fulltile)
 
-/obj/effect/spawner/structure/window/hollow/plasma/reinforced
+/atom/movable/spawner/structure/window/hollow/plasma/reinforced
 	name = "hollow reinforced plasma window spawner"
 	icon_state = "phrwindow_spawner_full"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma/reinforced, /obj/structure/window/plasma/reinforced/spawner/north, /obj/structure/window/plasma/reinforced/spawner/east, /obj/structure/window/plasma/reinforced/spawner/west)
 
-/obj/effect/spawner/structure/window/hollow/plasma/reinforced/end
+/atom/movable/spawner/structure/window/hollow/plasma/reinforced/end
 	icon_state = "phrwindow_spawner_end"
 
-/obj/effect/spawner/structure/window/hollow/plasma/reinforced/end/Initialize()
+/atom/movable/spawner/structure/window/hollow/plasma/reinforced/end/Initialize()
 	switch(dir)
 		if(NORTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma/reinforced/spawner/north, /obj/structure/window/plasma/reinforced/spawner/east, /obj/structure/window/plasma/reinforced/spawner/west)
@@ -322,10 +322,10 @@ again.
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma/reinforced, /obj/structure/window/plasma/reinforced/spawner/north, /obj/structure/window/plasma/reinforced/spawner/west)
 	. = ..()
 
-/obj/effect/spawner/structure/window/hollow/plasma/reinforced/middle
+/atom/movable/spawner/structure/window/hollow/plasma/reinforced/middle
 	icon_state = "phrwindow_spawner_middle"
 
-/obj/effect/spawner/structure/window/hollow/plasma/reinforced/middle/Initialize()
+/atom/movable/spawner/structure/window/hollow/plasma/reinforced/middle/Initialize()
 	switch(dir)
 		if(NORTH,SOUTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma/reinforced, /obj/structure/window/plasma/reinforced/spawner/north)
@@ -333,10 +333,10 @@ again.
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma/reinforced/spawner/east, /obj/structure/window/plasma/reinforced/spawner/west)
 	. = ..()
 
-/obj/effect/spawner/structure/window/hollow/plasma/reinforced/directional
+/atom/movable/spawner/structure/window/hollow/plasma/reinforced/directional
 	icon_state = "phrwindow_spawner_directional"
 
-/obj/effect/spawner/structure/window/hollow/plasma/reinforced/directional/Initialize()
+/atom/movable/spawner/structure/window/hollow/plasma/reinforced/directional/Initialize()
 	switch(dir)
 		if(NORTH)
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/plasma/reinforced/spawner/north)

--- a/code/game/objects/effects/spawners/traps.dm
+++ b/code/game/objects/effects/spawners/traps.dm
@@ -1,9 +1,9 @@
-/obj/effect/spawner/trap
+/atom/movable/spawner/trap
 	name = "random trap"
 	icon = 'icons/obj/hand_of_god_structures.dmi'
 	icon_state = "trap_rand"
 
-/obj/effect/spawner/trap/Initialize(mapload)
+/atom/movable/spawner/trap/Initialize(mapload)
 	..()
 	var/new_type = pick(subtypesof(/obj/structure/trap) - typesof(/obj/structure/trap/ctf))
 	new new_type(get_turf(src))

--- a/code/game/objects/effects/spawners/xeno_egg_delivery.dm
+++ b/code/game/objects/effects/spawners/xeno_egg_delivery.dm
@@ -1,10 +1,10 @@
-/obj/effect/spawner/xeno_egg_delivery
+/atom/movable/spawner/xeno_egg_delivery
 	name = "xeno egg delivery"
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "egg_growing"
 	var/announcement_time = 1200
 
-/obj/effect/spawner/xeno_egg_delivery/Initialize(mapload)
+/atom/movable/spawner/xeno_egg_delivery/Initialize(mapload)
 	..()
 	var/turf/T = get_turf(src)
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -550,12 +550,12 @@
 	name = "pink glowstick"
 	color = LIGHT_COLOR_PINK
 
-/obj/effect/spawner/lootdrop/glowstick
+/atom/movable/spawner/lootdrop/glowstick
 	name = "random colored glowstick"
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "random_glowstick"
 
-/obj/effect/spawner/lootdrop/glowstick/Initialize()
+/atom/movable/spawner/lootdrop/glowstick/Initialize()
 	loot = typesof(/obj/item/flashlight/glowstick)
 	. = ..()
 

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -83,7 +83,7 @@
 /obj/item/storage/bag/trash/filled/PopulateContents()
 	. = ..()
 	for(var/i in 1 to rand(1, 7))
-		new /obj/effect/spawner/lootdrop/garbage_spawner(src)
+		new /atom/movable/spawner/lootdrop/garbage_spawner(src)
 	update_icon_state()
 
 /obj/item/storage/bag/trash/bluespace

--- a/code/game/objects/items/wayfinding.dm
+++ b/code/game/objects/items/wayfinding.dm
@@ -104,7 +104,7 @@
 				var/mob/living/carbon/human/H = user
 				H.put_in_hands(HC)
 		else
-			var/crap = pick(subtypesof(/obj/effect/spawner/bundle/costume)) //harmless garbage some people may appreciate
+			var/crap = pick(subtypesof(/atom/movable/spawner/bundle/costume)) //harmless garbage some people may appreciate
 			new crap(user.loc)
 		qdel(WP)
 		set_expression("happy", 2 SECONDS)

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -120,10 +120,10 @@
 
 /obj/structure/closet/mini_fridge/PopulateContents()
 	. = ..()
-	new /obj/effect/spawner/lootdrop/refreshing_beverage(src)
-	new /obj/effect/spawner/lootdrop/refreshing_beverage(src)
+	new /atom/movable/spawner/lootdrop/refreshing_beverage(src)
+	new /atom/movable/spawner/lootdrop/refreshing_beverage(src)
 	if(prob(50))
-		new /obj/effect/spawner/lootdrop/refreshing_beverage(src)
+		new /atom/movable/spawner/lootdrop/refreshing_beverage(src)
 	if(prob(40))
 		new /obj/item/food/pizzaslice/moldy(src)
 	else if(prob(30))

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -88,7 +88,7 @@
 /obj/structure/closet/crate/maint/PopulateContents()
 	. = ..()
 	for(var/i in 1 to rand(2,6))
-		new /obj/effect/spawner/lootdrop/maintenance(src)
+		new /atom/movable/spawner/lootdrop/maintenance(src)
 
 /obj/structure/closet/crate/trashcart/Initialize()
 	. = ..()
@@ -99,10 +99,10 @@
 /obj/structure/closet/crate/trashcart/filled/PopulateContents()
 	. = ..()
 	for(var/i in 1 to rand(7,15))
-		new /obj/effect/spawner/lootdrop/garbage_spawner(src)
+		new /atom/movable/spawner/lootdrop/garbage_spawner(src)
 		if(prob(12))
 			new	/obj/item/storage/bag/trash/filled(src)
-	new /obj/effect/spawner/scatter/grime(loc)
+	new /atom/movable/spawner/scatter/grime(loc)
 
 /obj/structure/closet/crate/internals
 	desc = "An internals crate."
@@ -256,4 +256,4 @@
 /obj/structure/closet/crate/decorations/PopulateContents()
 	. = ..()
 	for(var/i in 1 to 4)
-		new /obj/effect/spawner/lootdrop/decorations_spawner(src)
+		new /atom/movable/spawner/lootdrop/decorations_spawner(src)

--- a/code/modules/awaymissions/mission_code/murderdome.dm
+++ b/code/modules/awaymissions/mission_code/murderdome.dm
@@ -12,7 +12,7 @@
 	flags_1 = CONDUCT_1 | NODECONSTRUCT_1
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
-/obj/effect/spawner/structure/window/reinforced/indestructable
+/atom/movable/spawner/structure/window/reinforced/indestructable
 	spawn_list = list(/obj/structure/grille/indestructable, /obj/structure/window/reinforced/fulltile/indestructable)
 
 /obj/structure/barricade/security/murderdome

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -466,13 +466,13 @@
 
 //lootspawners//--
 
-/obj/effect/spawner/lootdrop/snowdin
+/atom/movable/spawner/lootdrop/snowdin
 	name = "why are you using this dummy"
 	lootdoubles = 0
 	lootcount = 1
 	loot = list(/obj/item/bikehorn = 100)
 
-/obj/effect/spawner/lootdrop/snowdin/dungeonlite
+/atom/movable/spawner/lootdrop/snowdin/dungeonlite
 	name = "dungeon lite"
 	loot = list(/obj/item/melee/classic_baton = 11,
 				/obj/item/melee/classic_baton/telescopic = 12,
@@ -490,7 +490,7 @@
 				/obj/item/borg/upgrade/ddrill = 3,
 				/obj/item/borg/upgrade/soh = 3)
 
-/obj/effect/spawner/lootdrop/snowdin/dungeonmid
+/atom/movable/spawner/lootdrop/snowdin/dungeonmid
 	name = "dungeon mid"
 	loot = list(/obj/item/defibrillator/compact = 6,
 				/obj/item/storage/firstaid/tactical = 35,
@@ -516,7 +516,7 @@
 				/obj/item/borg/upgrade/disablercooler = 7)
 
 
-/obj/effect/spawner/lootdrop/snowdin/dungeonheavy
+/atom/movable/spawner/lootdrop/snowdin/dungeonheavy
 	name = "dungeon heavy"
 	loot = list(/obj/item/singularityhammer = 25,
 				/obj/item/mjollnir = 10,
@@ -535,7 +535,7 @@
 				/obj/item/borg/upgrade/syndicate = 13,
 				/obj/item/borg/upgrade/selfrepair = 17)
 
-/obj/effect/spawner/lootdrop/snowdin/dungeonmisc
+/atom/movable/spawner/lootdrop/snowdin/dungeonmisc
 	name = "dungeon misc"
 	lootdoubles = 2
 	lootcount = 1

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2291,7 +2291,7 @@
 
 /datum/supply_pack/costumes_toys/mafia/fill(obj/structure/closet/crate/C)
 	for(var/i in 1 to 4)
-		new /obj/effect/spawner/lootdrop/mafia_outfit(C)
+		new /atom/movable/spawner/lootdrop/mafia_outfit(C)
 		new /obj/item/virgin_mary(C)
 		if(prob(30)) //Not all mafioso have mustaches, some people also find this item annoying.
 			new /obj/item/clothing/mask/fakemoustache/italian(C)

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -235,7 +235,7 @@
 	inhand_icon_state = "wgloves"
 	custom_price = 200
 
-/obj/effect/spawner/lootdrop/gloves
+/atom/movable/spawner/lootdrop/gloves
 	name = "random gloves"
 	desc = "These gloves are supposed to be a random color..."
 	icon = 'icons/obj/clothing/gloves.dmi'

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -490,7 +490,7 @@
 	desc = "A pair of masterfully crafted lizard skin boots. Finally a good application for the station's most bothersome inhabitants."
 	icon_state = "lizardboots_blue"
 
-/obj/effect/spawner/lootdrop/lizardboots
+/atom/movable/spawner/lootdrop/lizardboots
 	name = "random lizard boot quality"
 	desc = "Which ever gets picked, the lizard race loses"
 	icon = 'icons/obj/clothing/shoes.dmi'

--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -40,7 +40,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)
 	dog_fashion = /datum/dog_fashion/head/festive
 
-/obj/effect/spawner/xmastree
+/atom/movable/spawner/xmastree
 	name = "christmas tree spawner"
 	icon = 'icons/effects/landmarks_static.dmi'
 	icon_state = "x2"
@@ -49,7 +49,7 @@
 	var/festive_tree = /obj/structure/flora/tree/pine/xmas
 	var/christmas_tree = /obj/structure/flora/tree/pine/xmas/presents
 
-/obj/effect/spawner/xmastree/Initialize()
+/atom/movable/spawner/xmastree/Initialize()
 	..()
 	if((CHRISTMAS in SSevents.holidays) && christmas_tree)
 		new christmas_tree(get_turf(src))
@@ -58,7 +58,7 @@
 
 	return INITIALIZE_HINT_QDEL
 
-/obj/effect/spawner/xmastree/rdrod
+/atom/movable/spawner/xmastree/rdrod
 	name = "festivus pole spawner"
 	festive_tree = /obj/structure/festivus
 	christmas_tree = null

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -14,7 +14,7 @@
 //lavaland_surface_seed_vault.dmm
 //Seed Vault
 
-/obj/effect/spawner/lootdrop/seed_vault
+/atom/movable/spawner/lootdrop/seed_vault
 	name = "seed vault seeds"
 	lootcount = 1
 

--- a/code/modules/ruins/lavalandruin_code/pizzaparty.dm
+++ b/code/modules/ruins/lavalandruin_code/pizzaparty.dm
@@ -1,6 +1,6 @@
 //lavaland_surface_pizzaparty.dmm
 
-/obj/effect/spawner/lootdrop/pizzaparty
+/atom/movable/spawner/lootdrop/pizzaparty
 	name = "pizza bomb spawner"
 	loot = list(/obj/item/pizzabox/margherita = 3,
 				/obj/item/pizzabox/meat = 3,

--- a/code/modules/shuttle/white_ship.dm
+++ b/code/modules/shuttle/white_ship.dm
@@ -59,7 +59,7 @@
 	GLOB.jam_on_wardec -= src
 	return ..()
 
-/obj/effect/spawner/lootdrop/whiteship_cere_ripley
+/atom/movable/spawner/lootdrop/whiteship_cere_ripley
 	name = "25% mech 75% wreckage ripley spawner"
 	loot = list(/obj/vehicle/sealed/mecha/working/ripley/mining = 1,
 				/obj/structure/mecha_wreckage/ripley = 5)


### PR DESCRIPTION
Uses VScode find-and-replace to repath most spawner objects.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Repaths /obj/effect/spawner to /atom/movable/spawner

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Might save a small amount of memory and/or init processing as objects have a bunch of init behaviors that movables don't.
- What's the point of giving armor/durability to objects that exist to delete themselves on init?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
