### PR TITLE
The DNA vault now modifies your physiology, not your species

### DIFF
--- a/code/modules/actionspeed/modifiers/status_effects.dm
+++ b/code/modules/actionspeed/modifiers/status_effects.dm
@@ -3,3 +3,6 @@
 
 /datum/actionspeed_modifier/blunt_wound
 	variable = TRUE
+
+/datum/actionspeed_modifier/dnavault //this isn't really a status effect, but this is the closest file that fits
+	multiplicative_slowdown = -0.20 //I am speed

--- a/code/modules/actionspeed/modifiers/status_effects.dm
+++ b/code/modules/actionspeed/modifiers/status_effects.dm
@@ -5,4 +5,4 @@
 	variable = TRUE
 
 /datum/actionspeed_modifier/dnavault //this isn't really a status effect, but this is the closest file that fits
-	multiplicative_slowdown = -0.20 //I am speed
+	multiplicative_slowdown = -0.30 //I am speed

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -288,6 +288,6 @@
 			H.add_movespeed_modifier(/datum/movespeed_modifier/dna_vault_speedup) //short and sweet- movement speed buffs are stronk
 		if(VAULT_QUICK)
 			to_chat(H, "<span class='notice'>Your arms move as fast as lightning.</span>")
-			H.next_move_modifier *= 0.5
-			H.add_actionspeed_modifier(/datum/actionspeed_modifier/dnavault) //multiplies the lengths of your do_after()s by 0.8
+			H.next_move_modifier *= 0.7 //a next_move_modifier of 0.5 is quite frankly TOO insane, even for a DNA vault ability, so you'll have to settle for a next_move_modifier of "merely" 0.7 (which'll still let you ORA ORA with a faster attack speed than that of a standard holoparasite, mind you)
+			H.add_actionspeed_modifier(/datum/actionspeed_modifier/dnavault) //multiplies the lengths of your do_after()s by 0.7
 	power_lottery[H] = list()

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -288,6 +288,6 @@
 			H.add_movespeed_modifier(/datum/movespeed_modifier/dna_vault_speedup) //short and sweet- movement speed buffs are stronk
 		if(VAULT_QUICK)
 			to_chat(H, "<span class='notice'>Your arms move as fast as lightning.</span>")
-			H.next_move_modifier *= 0.7 //a next_move_modifier of 0.5 is quite frankly TOO insane, even for a DNA vault ability, so you'll have to settle for a next_move_modifier of "merely" 0.7 (which'll still let you ORA ORA with a faster attack speed than that of a standard holoparasite, mind you)
+			H.next_move_modifier *= 0.5
 			H.add_actionspeed_modifier(/datum/actionspeed_modifier/dnavault) //multiplies the lengths of your do_after()s by 0.7
 	power_lottery[H] = list()


### PR DESCRIPTION
## About The Pull Request

See the title. In layman's terms, you'll keep your vault abilities even after changing species- before, some of them would go away when you changed species, but you'd still be locked out of using the DNA vault again (with that body) to get replacements for them.

In addition, the DNA vault now uses multiplication in more places instead of just directly setting values. Previously, if you were, say, a glass golem and chose the fireproofing option, you'd actually become MORE vulnerable to burn damage (because the dna vault would set your species's burnmod to 0.5).

Also, you could extract someone's lungs after they chose the toxin adaptation option and stick them in a new body, and those lungs would still have their ability to ignore plasma in the air.

... And, uh, I _kind of sort of_ realized that some of the vault options are just really, really sad and underwhelming (especially considering the amount of effort required to construct and collect the required samples for a DNA vault), so I _may_ have gotten a bit carried away and FIXED this ISSUE by adding a few more abilities to most of the options. This most certainly is NOT a balance change PR in No Nerf November, no sir.

## Why It's Good For The Game

Feex good.

Also, a DNA vault option should not be able to be replicated with a single virus symptom (seriously, what the fuck?), nor should it actively hinder you by making you immune to the good virus that the virologist made or by making you unable to be directly healed by sutures, ointment, etc.

## Changelog
:cl: ATHATH
fix: DNA vault options should play more nicely with resistances that you already have from your species now.
fix: Some of the DNA vault options should no longer be incredibly underwhelming, or even be (much of) an active hinderance to you.
/:cl:
