### PR TITLE
The DNA vault now modifies your physiology, not your species (this time without the buffs)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -207,6 +207,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_PERMANENTLY_ONFIRE	"permanently_onfire" //overrides the update_fire proc to always add fire (for lava)
 #define TRAIT_SIGN_LANG				"sign_language" //Galactic Common Sign Language
 #define TRAIT_NANITE_MONITORING	"nanite_monitoring" //The mob's nanites are sending a monitoring signal visible on diag HUD
+#define TRAIT_AUGMENTED_DNA "augmented_dna" //this mob has received a power from a DNA vault, so it's been marked as being unable to gain another power
 
 //SKILLS
 #define TRAIT_UNDERWATER_BASKETWEAVING_KNOWLEDGE "underwater_basketweaving"

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -252,7 +252,7 @@
 		return
 	switch(upgrade_type)
 		if(VAULT_TOXIN)
-			to_chat(H, "<span class='notice'>You feel resistant to airborne toxins.</span>")
+			to_chat(H, "<span class='notice'>You feel resistant to airborne toxins.</span>") //I WILL be back for this after No Nerf November ends, mark my words
 			if(locate(/obj/item/organ/lungs) in H.internal_organs)
 				var/obj/item/organ/lungs/L = H.internal_organs_slot[ORGAN_SLOT_LUNGS]
 				L.tox_breath_dam_min = 0

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -250,6 +250,11 @@
 		return
 	if(!istype(H))
 		return
+	power_lottery[H] = list()
+	if(HAS_TRAIT(H, TRAIT_AUGMENTED_DNA)) //no double dipping (with the same body, anyway)
+		to_chat(H, "<span class='alert'>Your body has already been improved by a DNA vault!</span>")
+		return
+	ADD_TRAIT(H, TRAIT_AUGMENTED_DNA, "dna_vault")
 	switch(upgrade_type)
 		if(VAULT_TOXIN)
 			to_chat(H, "<span class='notice'>You feel resistant to airborne toxins.</span>") //I WILL be back for this after No Nerf November ends, mark my words.
@@ -282,4 +287,3 @@
 		if(VAULT_QUICK)
 			to_chat(H, "<span class='notice'>Your arms move as fast as lightning.</span>")
 			H.next_move_modifier *= 0.5
-	power_lottery[H] = list()

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -257,7 +257,7 @@
 	ADD_TRAIT(H, TRAIT_AUGMENTED_DNA, "dna_vault")
 	switch(upgrade_type)
 		if(VAULT_TOXIN)
-			to_chat(H, "<span class='notice'>You feel resistant to airborne toxins.</span>") //I WILL be back for this after No Nerf November ends, mark my words.
+			to_chat(H, "<span class='notice'>You feel resistant to airborne toxins.</span>")
 			if(locate(/obj/item/organ/lungs) in H.internal_organs)
 				var/obj/item/organ/lungs/L = H.internal_organs_slot[ORGAN_SLOT_LUNGS]
 				L.tox_breath_dam_min = 0

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -248,7 +248,8 @@
 /obj/machinery/dna_vault/proc/upgrade(mob/living/carbon/human/H,upgrade_type)
 	if(!(upgrade_type in power_lottery[H]))
 		return
-	var/datum/species/S = H.dna.species
+	if(!istype(H))
+		return
 	switch(upgrade_type)
 		if(VAULT_TOXIN)
 			to_chat(H, "<span class='notice'>You feel resistant to airborne toxins.</span>")
@@ -262,20 +263,23 @@
 			ADD_TRAIT(H, TRAIT_NOBREATH, "dna_vault")
 		if(VAULT_FIREPROOF)
 			to_chat(H, "<span class='notice'>You feel fireproof.</span>")
-			S.burnmod = 0.5
+			H.physiology.burn_mod *= 0.5
 			ADD_TRAIT(H, TRAIT_RESISTHEAT, "dna_vault")
 			ADD_TRAIT(H, TRAIT_NOFIRE, "dna_vault")
 		if(VAULT_STUNTIME)
 			to_chat(H, "<span class='notice'>Nothing can keep you down for long.</span>")
-			S.stunmod = 0.5
+			H.physiology.stun_mod *= 0.5
 		if(VAULT_ARMOUR)
 			to_chat(H, "<span class='notice'>You feel tough.</span>")
-			S.armor = 30
+			H.physiology.armor.melee += 30
+			H.physiology.armor.bullet += 30
+			H.physiology.armor.laser += 30
+			H.physiology.armor.energy += 30
 			ADD_TRAIT(H, TRAIT_PIERCEIMMUNE, "dna_vault")
 		if(VAULT_SPEED)
 			to_chat(H, "<span class='notice'>Your legs feel faster.</span>")
 			H.add_movespeed_modifier(/datum/movespeed_modifier/dna_vault_speedup)
 		if(VAULT_QUICK)
 			to_chat(H, "<span class='notice'>Your arms move as fast as lightning.</span>")
-			H.next_move_modifier = 0.5
+			H.next_move_modifier *= 0.5
 	power_lottery[H] = list()

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -252,7 +252,7 @@
 		return
 	switch(upgrade_type)
 		if(VAULT_TOXIN)
-			to_chat(H, "<span class='notice'>You feel resistant to airborne toxins.</span>") //I WILL be back for this after No Nerf November ends, mark my words
+			to_chat(H, "<span class='notice'>You feel resistant to airborne toxins.</span>") //I WILL be back for this after No Nerf November ends, mark my words.
 			if(locate(/obj/item/organ/lungs) in H.internal_organs)
 				var/obj/item/organ/lungs/L = H.internal_organs_slot[ORGAN_SLOT_LUNGS]
 				L.tox_breath_dam_min = 0


### PR DESCRIPTION
## About The Pull Request

See the title. In layman's terms, you'll keep your vault abilities even after changing species- before, some of them would go away when you changed species, but you'd still be locked out of using the DNA vault again (with that body) to get replacements for them.

In addition, the DNA vault now uses multiplication in more places instead of just directly setting values. Previously, if you were, say, a glass golem and chose the fireproofing option, you'd actually become MORE vulnerable to burn damage (because the dna vault would set your species's burnmod to 0.5).

## Why It's Good For The Game

Feex good.

## Changelog
:cl:
fix: DNA vault options should play more nicely with resistances that you already have from your species now.
/:cl: