### PR TITLE
Change cure and fix cure text for Gluttony's Blessing

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -299,8 +299,8 @@
 
 /datum/disease/transformation/morph
 	name = "Gluttony's Blessing"
-	cure_text = /datum/reagent/consumable/nothing
-	cures = list(/datum/reagent/medicine/adminordrazine)
+	cure_text = "Nothing"
+	cures = list(/datum/reagent/consumable/nothing)
 	agent = "Gluttony's Blessing"
 	desc = "A 'gift' from somewhere terrible."
 	stage_prob = 20


### PR DESCRIPTION
## About The Pull Request
Changes the Gluttony's Blessing cure to Nothing, and fixes the cure text.

When you use a med scanner on someone with Gluttony's Blessing, the possible cure is a little funky.

![image](https://user-images.githubusercontent.com/60521518/98274690-b8581080-1f61-11eb-9a9d-a7e1f28a1cc4.png)

It turns out the reason for this is that the cure_text for Gluttony's Blessing is just /datum/reagent/consumable/nothing, not even in quotes. The actual cure for Gluttony's Blessing is Adminordazine, so essentially, there is no cure.
## Why It's Good For The Game
At first i was just going to change the cure_text to say "Death" or something, but i actually really enjoyed the idea of Nothing, as in the mime drink, being the cure. The only way to get rid of Gluttony's Blessing is to consume "Nothing." Kind of poetic if you ask me.
## Changelog
:cl:
tweak: Made Nothing the cure for Gluttony's Blessing instead of Adminordazine.
fix: Fixed the cure text so it both no longer displays a DM path, and also displays the correct cure.
/:cl:

Special thanks to HugoOdaX for actually finding this bug.
