### PR TITLE
game_options config for departmental airlock wiring.

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -52,6 +52,8 @@
 
 /datum/config_entry/flag/sec_start_brig	//makes sec start in brig instead of dept sec posts
 
+/datum/config_entry/flag/wires_can_use_dictionary_keys // gives airlocks different wire patterns for each part of the station
+
 /datum/config_entry/flag/force_random_names
 
 /datum/config_entry/flag/humans_need_surnames

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -48,8 +48,13 @@
 
 	src.holder = holder
 
-	// If there is a dictionary key set, we'll want to use that. Otherwise, use the holder type.
-	var/key = dictionary_key ? dictionary_key : holder_type
+	var/key = null
+	// If this config is set, wires may be set by their dictionary key. (Doors use this for department based wiring.)
+	if(CONFIG_GET(flag/wires_can_use_dictionary_keys))
+		// If there is a dictionary key set, we'll want to use that. Otherwise, use the holder type.
+		key = dictionary_key ? dictionary_key : holder_type
+	else
+		key = holder_type
 
 	RegisterSignal(holder, COMSIG_PARENT_QDELETING, .proc/on_holder_qdel)
 	if(randomize)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -315,6 +315,8 @@ MINIMAL_ACCESS_THRESHOLD 20
 ## Comment this out this to make security officers spawn in departmental security posts
 SEC_START_BRIG
 
+## Comment this out to make airlocks use a common wire dictionary instead of a different dictionary for each part of the station.
+WIRES_CAN_USE_DICTIONARY_KEYS
 
 ## GHOST INTERACTION ###
 ## Uncomment to let ghosts spin chairs. You may be wondering why this is a config option. Don't ask.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Creates a config for disabling department specific airlock wiring.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gameplay feature is controversial and it is beneficial for the downstream ecosystem to have this be an upstream config option.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
config: Added WIRES_CAN_USE_DICTIONARY_KEYS in game_options.txt to disable department based airlock wiring.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
