### PR TITLE
Fixes being able to commit suicide with an UNREAL SORD

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -420,6 +420,11 @@
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 
+/obj/item/nullrod/sord/suicide_act(mob/user) //a near-exact copy+paste of the actual sord suicide_act()
+	user.visible_message("<span class='suicide'>[user] is trying to impale [user.p_them()]self with [src]! It might be a suicide attempt if it weren't so HOLY.</span>", \
+	"<span class='suicide'>You try to impale yourself with [src], but it's TOO HOLY...</span>")
+	return SHAME
+
 /obj/item/nullrod/scythe
 	icon_state = "scythe1"
 	inhand_icon_state = "scythe1"


### PR DESCRIPTION
## About The Pull Request

The UNREAL SORD null rod form's suicide_act() now closely matches the suicide_act of an actual SORD.

For reference, an actual SORD's suicide_act() is:
```
/obj/item/sord/suicide_act(mob/user)
	user.visible_message("<span class='suicide'>[user] is trying to impale [user.p_them()]self with [src]! It might be a suicide attempt if it weren't so shitty.</span>", \
	"<span class='suicide'>You try to impale yourself with [src], but it's USELESS...</span>")
	return SHAME
```

And the UNREAL SORD null rod form's new suicide_act() is:
```
/obj/item/nullrod/sord/suicide_act(mob/user) //a near-exact copy+paste of the actual sord suicide_act()
	user.visible_message("<span class='suicide'>[user] is trying to impale [user.p_them()]self with [src]! It might be a suicide attempt if it weren't so HOLY.</span>", \
	"<span class='suicide'>You try to impale yourself with [src], but it's TOO HOLY...</span>")
	return SHAME
```

## Why It's Good For The Game

UNREAL SORDs are very clearly meant to be replicas of actual SORDs, so they should share their inability to be used as a means to (directly) commit suicide.

## Changelog
:cl:
fix: An issue with the UNREAL SORD's suicide text and effect has been fixed.
/:cl:
