### PR TITLE
Remove PHP_VERSION from dependencies.sh

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -16,9 +16,6 @@ export RUST_G_VERSION=0.4.5
 #node version
 export NODE_VERSION=12
 
-# PHP version
-export PHP_VERSION=7.2
-
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.6
 


### PR DESCRIPTION
Used to be used by CI, not anymore