### PR TITLE
Fixes mob_holders not going into storage

### DIFF
--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -3,13 +3,13 @@
 /obj/item/clothing/head/mob_holder
 	name = "bugged mob"
 	desc = "Yell at coderbrush."
-	icon_state = "ian"
+	icon = null
+	icon_state = ""
 	slot_flags = NONE
 	var/mob/living/held_mob
 	var/destroying = FALSE
 
 /obj/item/clothing/head/mob_holder/Initialize(mapload, mob/living/M, worn_state, head_icon, lh_icon, rh_icon, worn_slot_flags = NONE)
-	. = ..()
 	if(head_icon)
 		worn_icon = head_icon
 	if(worn_state)
@@ -21,6 +21,7 @@
 	if(worn_slot_flags)
 		slot_flags = worn_slot_flags
 	deposit(M)
+	. = ..()
 
 /obj/item/clothing/head/mob_holder/Destroy()
 	destroying = TRUE

--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -3,8 +3,7 @@
 /obj/item/clothing/head/mob_holder
 	name = "bugged mob"
 	desc = "Yell at coderbrush."
-	icon = null
-	icon_state = ""
+	icon_state = "ian"
 	slot_flags = NONE
 	var/mob/living/held_mob
 	var/destroying = FALSE


### PR DESCRIPTION
## About The Pull Request

#53305 made it so clothing objects without an `icon_state` on initialize were given `ABSTRACT` flags. 

unfortunately for `mob_holder` objs, they gained their icon *after* that step of initialization.

this PR just moves the parent call to after the `icon_state` is updated, preventing them from incorrectly gaining the abstract flag.

Fixes #53872

## Why It's Good For The Game

bee bombs are back, baby

## Changelog
:cl: Melbert
fix: Fixed being unable to put scooped up mobs (ian, bees, etc) in storage containers
/:cl:
