### PR TITLE
Fix for infinite materials from the autolathe.

### DIFF
--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -315,7 +315,7 @@
 
 ///returns the amount of material relevant to this container; if this container does not support glass, any glass in 'I' will not be taken into account
 /datum/component/material_container/proc/get_item_material_amount(obj/item/I, breakdown_flags=src.breakdown_flags)
-	if(!istype(I) || !I.custom_materials)
+	if(!istype(I) || !length(I.custom_materials))
 		return 0
 	var/material_amount = 0
 	var/list/item_materials = I.get_material_composition(breakdown_flags)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -245,13 +245,10 @@
 		for(var/i=1, i<=multiplier, i++)
 			var/obj/item/new_item = new being_built.build_path(A)
 
-			if(!(new_item.material_flags & MATERIAL_NO_EFFECTS))
-				new_item.set_custom_materials(materials_used) // the object has effects that change the object depending on the material.
-				if(!isnull(user))
-					// Get an achievement for making a gold toolbox!
-					user.client.give_award(/datum/award/achievement/misc/getting_an_upgrade, user)
-			else
-				new_item.custom_materials = materials_used // it has no effects, so just set the amount of materials being used to make it
+			new_item.set_custom_materials(materials_used) // the object has effects that change the object depending on the material.
+			if(!isnull(user))
+				// Get an achievement for making a gold toolbox!
+				user.client.give_award(/datum/award/achievement/misc/getting_an_upgrade, user)
 
 			new_item.autolathe_crafted(src)
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -228,7 +228,6 @@
 	else
 		for(var/i=1, i<=multiplier, i++)
 			var/obj/item/new_item = new being_built.build_path(A)
-			new_item.autolathe_crafted(src)
 
 			if(length(picked_materials))
 				new_item.set_custom_materials(picked_materials, 1 / multiplier) //Ensure we get the non multiplied amount
@@ -236,6 +235,14 @@
 					var/datum/material/M = x
 					if(!istype(M, /datum/material/glass) && !istype(M, /datum/material/iron))
 						user.client.give_award(/datum/award/achievement/misc/getting_an_upgrade, user)
+			else
+				// we STILL need to set custom materials or we get unlimited autolathe works happening
+				var/old_material_flags = new_item.material_flags
+				new_item.material_flags |= MATERIAL_NO_EFFECTS
+				new_item.set_custom_materials(materials_used, 1 / multiplier)
+				new_item.material_flags = old_material_flags
+
+			new_item.autolathe_crafted(src)
 
 
 	icon_state = "autolathe"

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -35,17 +35,39 @@
 
 /obj/item/ammo_box/Initialize()
 	. = ..()
+	// We do it this way because box
 	if (!bullet_cost)
-		for (var/material in custom_materials)
-			var/material_amount = custom_materials[material]
-			LAZYSET(base_cost, material, (material_amount * 0.10))
-
-			material_amount *= 0.90 // 10% for the container
-			material_amount /= max_ammo
-			LAZYSET(bullet_cost, material, material_amount)
+		_refresh_bullet_cost()
 	if(!start_empty)
 		top_off(starting=TRUE)
 	update_icon()
+
+/obj/item/ammo_box/proc/_refresh_bullet_cost()
+	bullet_cost = list()
+	base_cost = list()
+	for (var/material in custom_materials)
+		var/material_amount = custom_materials[material]
+		base_cost[material] = (material_amount * 0.10)
+		material_amount *= 0.90 // 10% for the container
+		material_amount /= max_ammo
+		bullet_cost[material] = material_amount
+
+
+/**
+  * First time this proc has been overwritten in 5 years.  Yea?
+  *
+  * This is run by the autolathe right after the ammo is created.  Also
+  * after custom materials was set
+  *
+  * Arguments:
+  * * A - the autolathe that made this box
+  */
+/obj/item/proc/autolathe_crafted(obj/machinery/autolathe/A)
+	_refresh_bullet_cost()
+	for(var/atom/A in contents) // hard set all the bullets to this cost
+		A.custom_materials = bullet_cost
+	update_icon()
+
 
 /**
   * top_off is used to refill the magazine to max, in case you want to increase the size of a magazine with VV then refill it at once

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -51,7 +51,8 @@
 		material_amount *= 0.90 // 10% for the container
 		material_amount /= max_ammo
 		bullet_cost[material] = material_amount
-
+	for(var/atom/A in stored_ammo) // hard set all the bullets to this cost
+		A.custom_materials = bullet_cost
 
 /**
   * First time this proc has been overwritten in 5 years.  Yea?
@@ -62,10 +63,8 @@
   * Arguments:
   * * A - the autolathe that made this box
   */
-/obj/item/proc/autolathe_crafted(obj/machinery/autolathe/A)
+/obj/item/ammo_box/autolathe_crafted(obj/machinery/autolathe/A)
 	_refresh_bullet_cost()
-	for(var/atom/A in contents) // hard set all the bullets to this cost
-		A.custom_materials = bullet_cost
 	update_icon()
 
 
@@ -172,13 +171,6 @@
 		if(AMMO_BOX_FULL_EMPTY)
 			icon_state = "[initial(icon_state)]-[shells_left ? "[max_ammo]" : "0"]"
 	desc = "[initial(desc)] There [(shells_left == 1) ? "is" : "are"] [shells_left] shell\s left!"
-	if(length(bullet_cost))
-		var/temp_materials = custom_materials.Copy()
-		for (var/material in bullet_cost)
-			var/material_amount = bullet_cost[material]
-			material_amount = (material_amount*stored_ammo.len) + base_cost[material]
-			temp_materials[material] = material_amount
-		set_custom_materials(temp_materials)
 
 ///Count of number of bullets in the magazine
 /obj/item/ammo_box/magazine/proc/ammo_count(countempties = TRUE)

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -50,7 +50,7 @@
   *
   */
 /obj/item/ammo_box/proc/_refresh_bullet_cost()
-	var/ammo_count = stored_ammo?.len || max_ammo
+	var/ammo_count = length(stored_ammo) || max_ammo
 	bullet_cost = list()
 	base_cost = list()
 	for (var/material in custom_materials)

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -42,28 +42,31 @@
 		top_off(starting=TRUE)
 	update_icon()
 
+/**
+  * Called to recalculate the matinal cost of a bullet
+  *
+  * Should only be called when the custom_materials is changed
+  * so usually on create
+  *
+  */
 /obj/item/ammo_box/proc/_refresh_bullet_cost()
+	var/ammo_count = stored_ammo?.len || max_ammo
 	bullet_cost = list()
 	base_cost = list()
 	for (var/material in custom_materials)
 		var/material_amount = custom_materials[material]
 		base_cost[material] = (material_amount * 0.10)
 		material_amount *= 0.90 // 10% for the container
-		material_amount /= max_ammo
+		material_amount /= ammo_count
 		bullet_cost[material] = material_amount
-	for(var/atom/A in stored_ammo) // hard set all the bullets to this cost
-		A.custom_materials = bullet_cost
+	if(length(stored_ammo))
+		for(var/atom/A in stored_ammo) // hard set all the bullets to this cost
+			A.custom_materials = bullet_cost
+	custom_materials = base_cost
 
-/**
-  * First time this proc has been overwritten in 5 years.  Yea?
-  *
-  * This is run by the autolathe right after the ammo is created.  Also
-  * after custom materials was set
-  *
-  * Arguments:
-  * * A - the autolathe that made this box
-  */
-/obj/item/ammo_box/autolathe_crafted(obj/machinery/autolathe/A)
+
+/obj/item/ammo_box/set_custom_materials(list/materials_used, multiplier=1)
+	. = ..()
 	_refresh_bullet_cost()
 	update_icon()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Its about issue #52852.  It took a bit to find honestly.  Two issues are happening.

First, the autolathe does NOT set custom_materials to the materials being used.  The material_container uses this list to figure out how to disassemble the object so otherwise it uses the default setting for the object.  This has been fixed.

Second, ammo boxes self set itself the right material cost, but never set the bullets.   So once it's plowed through the recycler, the contents, are disassembled at full cost each as well as the box, witch is ALSO set to ALL the bullet costs.  So you would always get double your money with each box.  THIS has been fixed...I think.

Someone check my work though.  I think I got though all the use cases but I haven't checked if all obj/items have issues.

## Why It's Good For The Game

Unlimited materials is op doog.

## Changelog
:cl:
fix: No more unlimited materials from the autolathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
