### PR TITLE
Blast doors and shutters no longer open when bumpopen() is called

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -79,6 +79,9 @@
 	else
 		return ..()
 
+/obj/machinery/door/poddoor/shutters/bumpopen()
+	return
+
 //"BLAST" doors are obviously stronger than regular doors when it comes to BLASTS.
 /obj/machinery/door/poddoor/ex_act(severity, target)
 	if(severity == 3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Overrides the `bumpopen()` proc on pod doors to do nothing. This proc was unreachable normally, because the `Bumped()` proc is also overridden. However, my recent fix for mechs being unable to open airlocks was to have the mech call `bumpopen()` on the door with the pilot as the mob, since this proc is what handles door permissions anyway. Since pod doors cannot be `Bumped()`, they have no permissions set, and so mechs could open all shutters and blast doors. This fixes that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #54686

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Mechs no longer bump open shutters and blast doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
