### PR TITLE
Poker table dismantling now respects carpet subtypes

### DIFF
--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -64,8 +64,8 @@
 	return ..()
 
 
-/obj/structure/table_frame/proc/make_new_table(table_type, custom_materials) //makes sure the new table made retains what we had as a frame
-	var/obj/structure/table/T = new table_type(loc)
+/obj/structure/table_frame/proc/make_new_table(table_type, custom_materials, _buildstack) //makes sure the new table made retains what we had as a frame
+	var/obj/structure/table/T = new table_type(loc, _buildstack)
 	T.frame = type
 	T.framestack = framestack
 	T.framestackamount = framestackamount
@@ -108,6 +108,6 @@
 				return
 			to_chat(user, "<span class='notice'>You start adding [material] to [src]...</span>")
 			if(do_after(user, 20, target = src) && material.use(1))
-				make_new_table(toConstruct)
+				make_new_table(toConstruct, null, type)
 	else
 		return ..()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -37,6 +37,11 @@
 	smoothing_groups = list(SMOOTH_GROUP_TABLES)
 	canSmoothWith = list(SMOOTH_GROUP_TABLES)
 
+/obj/structure/table/Initialize(mapload, _buildstack)
+	. = ..()
+	if(_buildstack)
+		buildstack = _buildstack
+
 /obj/structure/table/examine(mob/user)
 	. = ..()
 	. += deconstruction_hints(user)


### PR DESCRIPTION
## About The Pull Request
Nothing fancy like differently colored poker tables, that'd be a feature.

## Why It's Good For The Game
This will close #53535, checked. 

## Changelog
:cl:
fix: Poker table dismantling now respects carpet subtypes.
/:cl: