### PR TITLE
Makes the old reftracking option compile!

### DIFF
--- a/code/modules/admin/view_variables/reference_tracking.dm
+++ b/code/modules/admin/view_variables/reference_tracking.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_EMPTY(deletion_failures)
 	set name = "Find References"
 	set src in world
 
-	find_references(FALSE)
+	find_references_legacy(FALSE)
 
 
 /datum/proc/find_references_legacy(skip_alert)
@@ -165,7 +165,7 @@ GLOBAL_LIST_EMPTY(deletion_failures)
 
 	qdel(src, TRUE) //force a qdel
 	if(!running_find_references)
-		find_references(TRUE)
+		find_references_legacy(TRUE)
 
 
 /datum/verb/qdel_then_if_fail_find_references()


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It got updated when extools ref tracking was added, but it was never tested, and a proc was renamed. This makes it properly compile.

## Why It's Good For The Game

My computer is allergic to extools, and I got mad at the garbage SS taking up so much overtime. This change facilitates more harddel removals, like fucking dog beds.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
