### PR TITLE
Fixing armsy del ref issue and invincibility

### DIFF
--- a/code/modules/mob/living/simple_animal/eldritch_demons.dm
+++ b/code/modules/mob/living/simple_animal/eldritch_demons.dm
@@ -154,29 +154,19 @@
 	maxHealth = len * maxHealth
 	health = maxHealth
 	///previous link
-	var/mob/living/simple_animal/hostile/eldritch/armsy/prev
+	var/mob/living/simple_animal/hostile/eldritch/armsy/prev = src
 	///current link
 	var/mob/living/simple_animal/hostile/eldritch/armsy/current
-	for(var/i in 0 to len)
+	for(var/i in 1 to len)
+		current = new type(drop_location(),FALSE)
+		current.icon_state = "armsy_mid"
+		current.icon_living = "armsy_mid"
+		current.AIStatus = AI_OFF
+		current.front = prev
+		prev.back = current
 		prev = current
-		//i tried using switch, but byond is really fucky and it didnt work as intended. Im sorry
-		if(i == 0)
-			current = new type(drop_location(),FALSE)
-			current.icon_state = "armsy_mid"
-			current.icon_living = "armsy_mid"
-			current.front = src
-			back = current
-			current.AIStatus = AI_OFF
-		else if(i < len)
-			current = new type(drop_location(),FALSE)
-			prev.icon_state = "armsy_mid"
-			prev.icon_living = "armsy_mid"
-			current.front = prev
-			prev.back = current
-			prev.AIStatus = AI_OFF
-		else
-			prev.icon_state = "armsy_end"
-			prev.icon_living = "armsy_end"
+	prev.icon_state = "armsy_end"
+	prev.icon_living = "armsy_end"
 
 /mob/living/simple_animal/hostile/eldritch/armsy/adjustBruteLoss(amount, updating_health, forced)
 	if(back)

--- a/code/modules/mob/living/simple_animal/eldritch_demons.dm
+++ b/code/modules/mob/living/simple_animal/eldritch_demons.dm
@@ -153,8 +153,6 @@
 	///sets the hp of the head to be exactly the length times hp, so the head is de facto the hardest to destroy.
 	maxHealth = len * maxHealth
 	health = maxHealth
-	///next link
-	var/mob/living/simple_animal/hostile/eldritch/armsy/next
 	///previous link
 	var/mob/living/simple_animal/hostile/eldritch/armsy/prev
 	///current link
@@ -167,21 +165,18 @@
 			current.icon_state = "armsy_mid"
 			current.icon_living = "armsy_mid"
 			current.front = src
-			current.AIStatus = AI_OFF
 			back = current
+			current.AIStatus = AI_OFF
 		else if(i < len)
 			current = new type(drop_location(),FALSE)
-			prev.back = current
 			prev.icon_state = "armsy_mid"
 			prev.icon_living = "armsy_mid"
-			prev.front = next
+			current.front = prev
+			prev.back = current
 			prev.AIStatus = AI_OFF
 		else
 			prev.icon_state = "armsy_end"
 			prev.icon_living = "armsy_end"
-			prev.front = next
-			prev.AIStatus = AI_OFF
-		next = prev
 
 /mob/living/simple_animal/hostile/eldritch/armsy/adjustBruteLoss(amount, updating_health, forced)
 	if(back)


### PR DESCRIPTION
## About The Pull Request
On the second iteration of the for/var loop found on `Initialize()` the `front` variable of the second link of the armsy worm (the one just before the head) is set to `null` because `next` is also `null`. That said, the second link will fail to soft delete because it's still referenced in the `back` variable of the first link since the `front.back = null` line on `Destroy()` couldn't be reached.

Also the code was formulated in a byzantine way.


## Why It's Good For The Game
This will close #54876.

## Changelog
:cl:
fix: The head of Armsies and Armsy Primes is no longer invincible.
/:cl:
