### PR TITLE
Cell chargers now respect the law of conservation of energy.

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -128,7 +128,6 @@
 
 	if(charging.percent() >= 100)
 		return
-	use_power(charge_rate * delta_time)
-	charging.give(charge_rate * delta_time)	//this is 2558, efficient batteries exist
-
-	update_icon()
+	if(direct_cost_power(charge_rate * delta_time))
+		charging.give(charge_rate * delta_time)
+		update_icon()

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -128,6 +128,6 @@
 
 	if(charging.percent() >= 100)
 		return
-	if(direct_cost_power(charge_rate * delta_time))
+	if(directly_use_power(charge_rate * delta_time))
 		charging.give(charge_rate * delta_time)
 		update_icon()

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -105,18 +105,15 @@
   * An alternative to 'use_power', this proc directly costs the APC in direct charge, as opposed to being calculated periodically.
   * - Amount: How much power the APC's cell is to be costed.
   */
-/obj/machinery/proc/direct_cost_power(amount)
+/obj/machinery/proc/directly_use_power(amount)
 	var/area/A = get_area(src)
 	var/obj/machinery/power/apc/local_apc
 	if(!A)
-		say("No area found.")
 		return FALSE
 	local_apc = A.get_apc()
 	if(!local_apc)
-		say("No local APC")
 		return FALSE
 	if(!local_apc.cell)
-		say("No cell in APC")
 		return FALSE
 	local_apc.cell.use(amount)
 	return TRUE

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -101,6 +101,26 @@
 		chan = power_channel
 	A.use_power(amount, chan)
 
+/**
+  * An alternative to 'use_power', this proc directly costs the APC in direct charge, as opposed to being calculated periodically.
+  * - Amount: How much power the APC's cell is to be costed.
+  */
+/obj/machinery/proc/direct_cost_power(amount)
+	var/area/A = get_area(src)
+	var/obj/machinery/power/apc/local_apc
+	if(!A)
+		say("No area found.")
+		return FALSE
+	local_apc = A.get_apc()
+	if(!local_apc)
+		say("No local APC")
+		return FALSE
+	if(!local_apc.cell)
+		say("No cell in APC")
+		return FALSE
+	local_apc.cell.use(amount)
+	return TRUE
+
 /obj/machinery/proc/addStaticPower(value, powerchannel)
 	var/area/A = get_area(src)
 	if(!A)


### PR DESCRIPTION
## About The Pull Request

Hopefully I can make this PR as knowledge filled as possible, so sit down and buckle up, because we're about to talk about POWER USE.

So, machines use power. The station uses power. Without power, key, critical aspects of the game don't function, and keeping the station's lifeblood pumped with electricity is the primary goal of the engineering department. Cool. So there's currently 2 methods of "power use" that machines can use, that is, through the passive use of power (Assigned by the `idle_power_usage` and `active_power_usage` variables), or through the `use_power()` proc. What's interesting, is that neither proc actually draws directly from the cell of the APC, which is sort of assumed by a proc called `use_power()`, after all. Where the passive power draw aspect of an APC is done automatically as machines are processed, and then applied to the APC seperately, taking power per cycle, use_power just applies a temporary blip of power usage to one of the APC's power tracks (Equipment, Lighting, or Enviroment). One would assume then that this temporary power drain would apply for long enough that it would apply the intended cost to the cell, and then turn off.

But I'm making this PR, right?

So the most egregious issue this brings is in terms of the cell recharger. If you place a power cell into a cell recharger, the recharger calls use_power every processing tick in order to reduce the APC cell by an equivalent amount to what the cell is intending to gain in charge. After all, you're just moving the charge from the APC to the power cell, plus the processing charge required by the cell_charger. However, lets look a bit closer at how use_power actually works. For this example we'll use a default, unupgraded cell recharger attempting to put it's default 250 watts into an empty bluespace cell.
Because power is heavily linked to the area that the machinery is placed in, we snag the area, determine the power channel, and call a use power proc on the area. The area use power proc simply adds that 250 watts, or rather joules into the equipment power channel of the APC, a part of power usage. All of this is parroted over to the APC's processing side, where the actual cost to the power cell is calcualted as follows:
`var/cellused = min(cell.charge, GLOB.CELLRATE * lastused_total)	// clamp deduction to a max, amount left in cell
		cell.use(cellused)`
So that number, the 250 joules of power we're calling to the cell, is actually being multiplied by a global cellrate, which is applied to every power drain on the station, actually charging the APC cell a total of 0.5 kj.
Based on some rumentary math and some experimentation, I filled a full bluespace power cell with 40Mj of power using 351 Kj of power from a standard, stock APC cell with no other drain except the 5 joules of power draw from the cell recharger.

So: What does this mean?

- Power draw is completely fucking busted (We knew this).
- Using two power cells, an APC, and an inducer, you can create infinite energy, anywhere, at zero cost to the station.
- We really need to make cell recharging a direct power draw.

Thankfully, that last one actually fits the portfolio of being a fix!
This adds a new proc to machines called `directly_use_power`. It does what it says on the tin, directly charges the APC for instances where power is going 1-1 from a power cell to another cell, in order to prevent infinite energy exploits.

## Why It's Good For The Game

Power is all kinds of unbalanced. Attempting to enforce the concept that a single unit of power is equal to itself is probably a good step in the right direction and in all likelyhood appears to have been the original intent with cell chargers in the first place.

I'm self-aware enough to see that this has ramifications beyond just fixing an issue within the cell charger alone, so if maintainers want to close this until december that's perfectly fine, but this is one of those things that could really easily snap basic station balance in twain.

## Changelog
:cl:
fix: Cell rechargers now actually attempt to fill the power cell with the amount of power necessary to fill the cell, based on the APC's charge, preventing infinite energy.
/:cl:
