### PR TITLE
Makse baseturfs work as expected

### DIFF
--- a/code/__HELPERS/string_lists.dm
+++ b/code/__HELPERS/string_lists.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_EMPTY(string_lists)
 ///A wrapper for baseturf string lists, to offer support of non list values, and a stack_trace if we have major issues
 /proc/baseturfs_string_list(list/values, turf/baseturf_holder)
 	if(!islist(values))
-		values = list(values)
+		return values //baseturf things
 	//	return values
 	if(length(values) > 10)
 		stack_trace("The baseturfs list of [baseturf_holder] at [baseturf_holder.x], [baseturf_holder.y], [baseturf_holder.x] is [length(values)], it should never be this long, investigate. I've set baseturfs to a flashing wall as a visual queue")

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -341,7 +341,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	if(created_baseturf_lists[current_target])
 		var/list/premade_baseturfs = created_baseturf_lists[current_target]
 		if(length(premade_baseturfs))
-			baseturfs = baseturfs_string_list(premade_baseturfs, src)
+			baseturfs = baseturfs_string_list(premade_baseturfs.Copy(), src)
 		else
 			baseturfs = baseturfs_string_list(premade_baseturfs, src)
 		return baseturfs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When there's only one baseturf, we expect it to be stored not as a list, but as a single item.
I failed to support this in my string lists pr, which caused a few related issues.

Fixes #54880 , alt of #54883

## Why It's Good For The Game

Makes baseturfs act as expected.

Oh and copies a list rather then just sending it, makes things a bit more clean, and prevents ref issues.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
