### PR TITLE
Removes source of Ian harddel (I hope)

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -201,7 +201,9 @@
 	name = "Runtime's bed"
 	anchored = TRUE
 
-/obj/structure/bed/dogbed/proc/update_owner(mob/living/M)
+/obj/structure/bed/dogbed/proc/update_owner(mob/living/M)\
+	if(type != /obj/structure/bed/dogbed) //Only marked beds
+		continue
 	owned = TRUE
 	name = "[M]'s bed"
 	desc = "[M]'s bed! Looks comfy."

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -170,7 +170,7 @@
 	anchored = FALSE
 	buildstacktype = /obj/item/stack/sheet/mineral/wood
 	buildstackamount = 10
-	var/mob/living/owner = null
+	var/owned = FALSE
 
 /obj/structure/bed/dogbed/ian
 	desc = "Ian's bed! Looks comfy."
@@ -202,7 +202,7 @@
 	anchored = TRUE
 
 /obj/structure/bed/dogbed/proc/update_owner(mob/living/M)
-	owner = M
+	owned = TRUE
 	name = "[M]'s bed"
 	desc = "[M]'s bed! Looks comfy."
 

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -169,11 +169,9 @@
 	. = ..()
 	var/dog_area = get_area(src)
 	for(var/obj/structure/bed/dogbed/D in dog_area)
-		if(D.type != /obj/structure/bed/dogbed) //Only marked beds
-			continue
-		if(!D.owned) //No muscling in on my turf you fucking parrot
-			D.update_owner(src)
-			break
+			if(!D.owned) //No muscling in on my turf you fucking parrot
+				D.update_owner(src)
+				break
 
 /mob/living/simple_animal/pet/dog/corgi/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -169,7 +169,7 @@
 	. = ..()
 	var/dog_area = get_area(src)
 	for(var/obj/structure/bed/dogbed/D in dog_area)
-		if(!D.owner)
+		if(!D.owned) //No muscling in on my turf you fucking parrot
 			D.update_owner(src)
 			break
 

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -169,6 +169,8 @@
 	. = ..()
 	var/dog_area = get_area(src)
 	for(var/obj/structure/bed/dogbed/D in dog_area)
+		if(D.type != /obj/structure/bed/dogbed) //Only marked beds
+			continue
 		if(!D.owned) //No muscling in on my turf you fucking parrot
 			D.update_owner(src)
 			break


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Dog beds have an obscure mechanic where if a dog spawns in the same area as one, that bed becomes "theirs".
The issue is this causes that dog to harddel, as nothing cleans up the bed ref.

I'm modifying this in two ways. First of all, the bed ownership only works for /obj/structure/bed/dogbed, no subtypes.
This prevents say, Mc Gruffs bed from getting the wrong description.

Secondly, instead of tracking the dog themselves, I track if the bed is owned at all.
This means when a dog dels, the bed is still theirs. I think this adds soul.
## Why It's Good For The Game

Soul/Harddel shit
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Dog beds are now properly tagged, and if your pet bites the dust, the bed will be kept in their memory.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
