### PR TITLE
removes duplicate flyperson organ assignments

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -4,9 +4,6 @@
 	say_mod = "buzzes"
 	species_traits = list(NOEYESPRITES,HAS_FLESH,HAS_BONE)
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_BUG
-	mutanttongue = /obj/item/organ/tongue/fly
-	mutantliver = /obj/item/organ/liver/fly
-	mutantstomach = /obj/item/organ/stomach/fly
 	meat = /obj/item/food/meat/slab/human/mutant/fly
 	disliked_food = null
 	liked_food = GROSS
@@ -14,6 +11,7 @@
 	species_language_holder = /datum/language_holder/fly
 	payday_modifier = 0.75
 
+	mutanttongue = /obj/item/organ/tongue/fly
 	mutantheart = /obj/item/organ/heart/fly
 	mutantlungs = /obj/item/organ/lungs/fly
 	mutantliver = /obj/item/organ/liver/fly


### PR DESCRIPTION
## About The Pull Request

mutantliver and mutantstomach were set twice for the flyperson race; this is no longer the case.

Also, I moved the place where mutanttongue is set for the flyperson race down to where the other mutant organ variables are set for them.

## Why It's Good For The Game

https://en.wikipedia.org/wiki/Marty_McFly

## Changelog
:cl: ATHATH
fix: The code for the mutant organs of flypeople has been slightly cleaned up. This shouldn't have any effects on actual gameplay.
/:cl: