### PR TITLE
Makes /obj/machinery/door/airlock/do_animate non blocking, fixing clown car access woes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -39,7 +39,10 @@
 #define AIRLOCK_DAMAGE_DEFLECTION_N  21  // Normal airlock damage deflection
 #define AIRLOCK_DAMAGE_DEFLECTION_R  30  // Reinforced airlock damage deflection
 
+#define AIRLOCK_DENY_ANIMATION_TIME (0.6 SECONDS) /// The amount of time for the airlock deny animation to show
+
 #define DOOR_CLOSE_WAIT 60 /// Time before a door closes, if not overridden
+
 /obj/machinery/door/airlock
 	name = "airlock"
 	icon = 'icons/obj/doors/airlocks/station/public.dmi'
@@ -621,8 +624,7 @@
 			if(!machine_stat)
 				update_icon(AIRLOCK_DENY)
 				playsound(src,doorDeni,50,FALSE,3)
-				sleep(6)
-				update_icon(AIRLOCK_CLOSED)
+				addtimer(CALLBACK(src, /atom/proc/update_icon, AIRLOCK_CLOSED), AIRLOCK_DENY_ANIMATION_TIME)
 
 /obj/machinery/door/airlock/examine(mob/user)
 	. = ..()
@@ -1587,5 +1589,7 @@
 #undef AIRLOCK_SEAL_MULTIPLIER
 #undef AIRLOCK_DAMAGE_DEFLECTION_N
 #undef AIRLOCK_DAMAGE_DEFLECTION_R
+
+#undef AIRLOCK_DENY_ANIMATION_TIME
 
 #undef DOOR_CLOSE_WAIT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Vehicles driving into a door runs the following code:

```
/obj/vehicle/Bump(atom/A)
	. = ..()
	if(emulate_door_bumps)
		if(istype(A, /obj/machinery/door))
			var/obj/machinery/door/conditionalwall = A
			for(var/m in occupants)
				conditionalwall.bumpopen(m)
```

This seems fine, but `do_animate` (called by `bumpopen`) sleeps for 0.6 seconds if the access was denied. This means that this code looped over every occupant, and waited 0.6 seconds if the user didn't have access. This is notably problematic for clown cars, which have God knows how many occupants in them at a time.

This PR makes `do_animate` non blocking so that this problem does not occur.

Another possible solution is to make the `bumpopen` call invoked asynchronously, but I prefer this solution unless there is some performance loss with it since we don't seem to like sleep anyway. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Vehicles bumping into doors will now check access on all occupants at the same time. This means that clown cars now correctly open doors immediately.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
