### PR TITLE
fixes the flags of some shocks

### DIFF
--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -32,7 +32,7 @@
 		return
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
-		if(C.electrocute_act(15, user, 1, SHOCK_NOSTUN))//doesnt stun. never let this stun
+		if(C.electrocute_act(15, user, 1, SHOCK_NOGLOVES | SHOCK_NOSTUN))//doesnt stun. never let this stun
 			C.dropItemToGround(C.get_active_held_item())
 			C.dropItemToGround(C.get_inactive_held_item())
 			C.add_confusion(15)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -183,7 +183,7 @@
 	if(!shockcd)
 		if(ismob(user))
 			var/mob/living/M = user
-			M.electrocute_act(15,"Energy Barrier", flags = SHOCK_NOGLOVES)
+			M.electrocute_act(15,"Energy Barrier")
 			shockcd = TRUE
 			addtimer(CALLBACK(src, .proc/cooldown), 5)
 
@@ -195,6 +195,6 @@
 		return
 
 	var/mob/living/M = AM
-	M.electrocute_act(15,"Energy Barrier", flags = SHOCK_NOGLOVES)
+	M.electrocute_act(15,"Energy Barrier")
 	shockcd = TRUE
 	addtimer(CALLBACK(src, .proc/cooldown), 5)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -757,7 +757,7 @@
 /datum/reagent/consumable/liquidelectricity/on_mob_life(mob/living/carbon/M)
 	if(prob(25) && !isethereal(M))
 		M.electrocute_act(rand(10,15), "Liquid Electricity in their body", 1) //lmao at the newbs who eat energy bars
-		playsound(M, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+		playsound(M, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, SHOCK_NOGLOVES) //the shock is coming from inside the house
 	return ..()
 
 /datum/reagent/consumable/astrotame

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -755,9 +755,9 @@
 		stomach.adjust_charge(reac_volume * REM * 20)
 
 /datum/reagent/consumable/liquidelectricity/on_mob_life(mob/living/carbon/M)
-	if(prob(25) && !isethereal(M))
-		M.electrocute_act(rand(10,15), "Liquid Electricity in their body", 1) //lmao at the newbs who eat energy bars
-		playsound(M, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, SHOCK_NOGLOVES) //the shock is coming from inside the house
+	if(prob(25) && !isethereal(M)) //lmao at the newbs who eat energy bars
+		M.electrocute_act(rand(10,15), "Liquid Electricity in their body", 1, SHOCK_NOGLOVES) //the shock is coming from inside the house
+		playsound(M, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	return ..()
 
 /datum/reagent/consumable/astrotame


### PR DESCRIPTION
## About The Pull Request

The shocks from the shock touch mutation now ignore insulated gloves, because you're touching your victim's body, not giving them a handshake.

The shocks from punching charged energy fields (special holosigns from emagged cyborgs) now DON'T ignore insulated gloves, because you're literally punching them with your hand.

The shocks from running into charged energy fields now DON'T ignore insulated gloves, to be consistent with things like electrified doors.

The shocks from the on_mob_life() effect of liquid electricity now ignore insulated gloves, like the shocks from the on_mob_life() effect of teslium do (thanks for pointing this out, Angustmeta!).

## Why It's Good For The Game

Logical sense and consistency in what forms of protection shocks check for are good things, I think.

## Changelog
:cl: ATHATH
fix: The shocks from the shock touch mutation now ignore insulated gloves.
fix: The shocks from punching or running into charged energy fields now DON'T ignore insulated gloves.
fix: The shocks from liquid electricity now ignore insulated gloves.
/:cl: