### PR TITLE
Old Medibot should now heal things besides brute

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -432,16 +432,16 @@
 
 	//They're injured enough for it!
 	var/list/treat_me_for = list()
-	if(C.getBruteLoss() >= heal_threshold)
+	if((C.getBruteLoss() >= heal_threshold) && C.getBruteLoss() != 0)
 		treat_me_for += BRUTE
 
-	if(C.getOxyLoss() >= (5 + heal_threshold))
+	if((C.getOxyLoss() >= heal_threshold) && C.getOxyLoss() != 0)
 		treat_me_for += OXY
 
-	if(C.getFireLoss() >= heal_threshold)
+	if((C.getFireLoss() >= heal_threshold) && C.getFireLoss() != 0)
 		treat_me_for += BURN
 
-	if(C.getToxLoss() >= heal_threshold)
+	if((C.getToxLoss() >= heal_threshold) && C.getToxLoss() != 0)
 		treat_me_for += TOX
 
 	if(damagetype_healer in treat_me_for)
@@ -513,16 +513,16 @@
 		var/treatment_method
 		var/list/potential_methods = list()
 
-		if(C.getBruteLoss() >= heal_threshold)
+		if((C.getBruteLoss() >= heal_threshold) && C.getBruteLoss() != 0)
 			potential_methods += BRUTE
 
-		else if(C.getFireLoss() >= heal_threshold)
+		else if((C.getFireLoss() >= heal_threshold) && C.getFireLoss() != 0)
 			potential_methods += BURN
 
-		else if(C.getOxyLoss() >= (5 + heal_threshold))
+		else if((C.getOxyLoss() >= 5 + heal_threshold) && C.getOxyLoss() != 0)
 			potential_methods += OXY
 
-		else if(C.getToxLoss() >= heal_threshold)
+		else if((C.getToxLoss() >= heal_threshold) && C.getToxLoss() != 0)
 			potential_methods += TOX
 
 		for(var/i in potential_methods)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -435,7 +435,7 @@
 	if((C.getBruteLoss() >= heal_threshold) && C.getBruteLoss() != 0)
 		treat_me_for += BRUTE
 
-	if((C.getOxyLoss() >= 5 + heal_threshold) && C.getOxyLoss() != 0)
+	if((C.getOxyLoss() >= (5 + heal_threshold)) && C.getOxyLoss() != 0)
 		treat_me_for += OXY
 
 	if((C.getFireLoss() >= heal_threshold) && C.getFireLoss() != 0)
@@ -519,7 +519,7 @@
 		else if((C.getFireLoss() >= heal_threshold) && C.getFireLoss() != 0)
 			potential_methods += BURN
 
-		else if((C.getOxyLoss() >= 5 + heal_threshold) && C.getOxyLoss() != 0)
+		else if((C.getOxyLoss() >= (5 + heal_threshold)) && C.getOxyLoss() != 0)
 			potential_methods += OXY
 
 		else if((C.getToxLoss() >= heal_threshold) && C.getToxLoss() != 0)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -441,7 +441,7 @@
 	if((C.getFireLoss() >= heal_threshold) && C.getFireLoss() != 0)
 		treat_me_for += BURN
 
-	if((C.getToxLoss() >= heal_threshold) && C.getToxLoss() != 0)
+	if((C.getToxLoss() >= 5 + heal_threshold) && C.getToxLoss() != 0)
 		treat_me_for += TOX
 
 	if(damagetype_healer in treat_me_for)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -516,13 +516,13 @@
 		if((C.getBruteLoss() >= heal_threshold) && C.getBruteLoss() != 0)
 			potential_methods += BRUTE
 
-		else if((C.getFireLoss() >= heal_threshold) && C.getFireLoss() != 0)
+		if((C.getFireLoss() >= heal_threshold) && C.getFireLoss() != 0)
 			potential_methods += BURN
 
-		else if((C.getOxyLoss() >= (5 + heal_threshold)) && C.getOxyLoss() != 0)
+		if((C.getOxyLoss() >= (5 + heal_threshold)) && C.getOxyLoss() != 0)
 			potential_methods += OXY
 
-		else if((C.getToxLoss() >= heal_threshold) && C.getToxLoss() != 0)
+		if((C.getToxLoss() >= heal_threshold) && C.getToxLoss() != 0)
 			potential_methods += TOX
 
 		for(var/i in potential_methods)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -435,13 +435,13 @@
 	if((C.getBruteLoss() >= heal_threshold) && C.getBruteLoss() != 0)
 		treat_me_for += BRUTE
 
-	if((C.getOxyLoss() >= heal_threshold) && C.getOxyLoss() != 0)
+	if((C.getOxyLoss() >= 5 + heal_threshold) && C.getOxyLoss() != 0)
 		treat_me_for += OXY
 
 	if((C.getFireLoss() >= heal_threshold) && C.getFireLoss() != 0)
 		treat_me_for += BURN
 
-	if((C.getToxLoss() >= 5 + heal_threshold) && C.getToxLoss() != 0)
+	if((C.getToxLoss() >= heal_threshold) && C.getToxLoss() != 0)
 		treat_me_for += TOX
 
 	if(damagetype_healer in treat_me_for)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -432,16 +432,16 @@
 
 	//They're injured enough for it!
 	var/list/treat_me_for = list()
-	if((C.getBruteLoss() >= heal_threshold) && C.getBruteLoss() != 0)
+	if(C.getBruteLoss() > heal_threshold)
 		treat_me_for += BRUTE
 
-	if((C.getOxyLoss() >= (5 + heal_threshold)) && C.getOxyLoss() != 0)
+	if(C.getOxyLoss() > (5 + heal_threshold))
 		treat_me_for += OXY
 
-	if((C.getFireLoss() >= heal_threshold) && C.getFireLoss() != 0)
+	if(C.getFireLoss() > heal_threshold)
 		treat_me_for += BURN
 
-	if((C.getToxLoss() >= heal_threshold) && C.getToxLoss() != 0)
+	if(C.getToxLoss() > heal_threshold)
 		treat_me_for += TOX
 
 	if(damagetype_healer in treat_me_for)
@@ -513,16 +513,16 @@
 		var/treatment_method
 		var/list/potential_methods = list()
 
-		if((C.getBruteLoss() >= heal_threshold) && C.getBruteLoss() != 0)
+		if(C.getBruteLoss() > heal_threshold)
 			potential_methods += BRUTE
 
-		if((C.getFireLoss() >= heal_threshold) && C.getFireLoss() != 0)
+		if(C.getFireLoss() > heal_threshold)
 			potential_methods += BURN
 
-		if((C.getOxyLoss() >= (5 + heal_threshold)) && C.getOxyLoss() != 0)
+		if(C.getOxyLoss() > (5 + heal_threshold))
 			potential_methods += OXY
 
-		if((C.getToxLoss() >= heal_threshold) && C.getToxLoss() != 0)
+		if(C.getToxLoss() > heal_threshold)
 			potential_methods += TOX
 
 		for(var/i in potential_methods)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #54904 

Old medibot had a `heal_threshold` of 0, so all the `heal_threshold` checks will always evaluate to `TRUE`, so the medbots always get stuck in brute healing.

This adds another check so that if the damage is 0, skip it!

## Why It's Good For The Game

Fewer bugs! Should also allow future 0 heal threshold medbots (if any) that are added in the future to work properly.

## Changelog
:cl:
fix: Old Medibot on the Authorship space ruin should now heal all damage types properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
