### PR TITLE
Fixes tool implant tools being storable in boxes

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -59,11 +59,13 @@
 	hand = owner.hand_bodyparts[side]
 	if(hand)
 		RegisterSignal(hand, COMSIG_ITEM_ATTACK_SELF, .proc/ui_action_click) //If the limb gets an attack-self, open the menu. Only happens when hand is empty
+		RegisterSignal(M, COMSIG_KB_MOB_DROPITEM_DOWN, .proc/dropkey) //We're nodrop, but we'll watch for the drop hotkey anyway and then stow if possible.
 
 /obj/item/organ/cyberimp/arm/Remove(mob/living/carbon/M, special = 0)
 	Retract()
 	if(hand)
 		UnregisterSignal(hand, COMSIG_ITEM_ATTACK_SELF)
+		UnregisterSignal(M, COMSIG_KB_MOB_DROPITEM_DOWN)
 	..()
 
 /obj/item/organ/cyberimp/arm/emp_act(severity)
@@ -75,6 +77,23 @@
 		// give the owner an idea about why his implant is glitching
 		Retract()
 
+/**
+  * Called when the mob uses the "drop item" hotkey
+  *
+  * Items inside toolset implants have TRAIT_NODROP, but we can still use the drop item hotkey as a
+  * quick way to store implant items. In this case, we check to make sure the user has the correct arm
+  * selected, and that the item is actually owned by us, and then we'll hand off the rest to Retract()
+**/
+/obj/item/organ/cyberimp/arm/proc/dropkey(mob/living/carbon/host)
+	to_chat(world, "DEBUG -- dropkey proc started")
+	if(!host)
+		to_chat(world, "DEBUG -- No host")
+		return //How did we even get here
+	if(hand != host.hand_bodyparts[host.active_hand_index])
+		to_chat(world, "DEBUG -- var hand ([hand]) does not equal host's active hand ([host.active_hand_index])")
+		return //wrong hand
+	Retract()
+
 /obj/item/organ/cyberimp/arm/proc/Retract()
 	if(!active_item || (active_item in src))
 		return
@@ -84,7 +103,6 @@
 		"<span class='hear'>You hear a short mechanical noise.</span>")
 
 	owner.transferItemToLoc(active_item, src, TRUE)
-	UnregisterSignal(active_item, COMSIG_ITEM_DROPPED)
 	active_item = null
 	playsound(get_turf(owner), 'sound/mecha/mechmove03.ogg', 50, TRUE)
 
@@ -93,9 +111,9 @@
 		return
 
 	active_item = item
-	RegisterSignal(active_item, COMSIG_ITEM_DROPPED, .proc/Retract) //Drop it to put away.
 
 	active_item.resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	ADD_TRAIT(active_item, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
 	active_item.slot_flags = null
 	active_item.set_custom_materials(null)
 

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -85,12 +85,9 @@
   * selected, and that the item is actually owned by us, and then we'll hand off the rest to Retract()
 **/
 /obj/item/organ/cyberimp/arm/proc/dropkey(mob/living/carbon/host)
-	to_chat(world, "DEBUG -- dropkey proc started")
 	if(!host)
-		to_chat(world, "DEBUG -- No host")
 		return //How did we even get here
 	if(hand != host.hand_bodyparts[host.active_hand_index])
-		to_chat(world, "DEBUG -- var hand ([hand]) does not equal host's active hand ([host.active_hand_index])")
 		return //wrong hand
 	Retract()
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Re-adds the TRAIT_NODROP flag to the tool implant items, and instead listens for the drop hotkey to be pressed.
Fixes #54464
As a side effect, slipping no longer drops (and thus stores) a tool implant item, which is a sad but necessary sacrifice.
Also, you now get the message about being unable to drop something when you use Q to put away the tool, but I don't know how to sanely fix that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Container code is cursed and TRAIT_NODROP is actually a holy artifact that keeps it at bay.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can no longer store tool implant tools in boxes or other container items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
