### PR TITLE
Fix nearsighted glasses being able to be neutered with quick swap

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -15,7 +15,7 @@
 	var/invis_override = 0 //Override to allow glasses to set higher than normal see_invis
 	var/lighting_alpha
 	var/list/icon/current = list() //the current hud icons
-	var/vision_correction = 0 //does wearing these glasses correct some of our vision defects?
+	var/vision_correction = FALSE //does wearing these glasses correct some of our vision defects?
 	var/glass_colour_type //colors your vision when worn
 
 /obj/item/clothing/glasses/suicide_act(mob/living/carbon/user)
@@ -166,7 +166,7 @@
 	desc = "Made by Nerd. Co."
 	icon_state = "glasses"
 	inhand_icon_state = "glasses"
-	vision_correction = 1 //corrects nearsightedness
+	vision_correction = TRUE //corrects nearsightedness
 
 /obj/item/clothing/glasses/regular/jamjar
 	name = "jamjar glasses"

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -88,31 +88,31 @@
 	switch(slot)
 		if(ITEM_SLOT_BELT)
 			if (belt && swap)
-				current_equip = belt
 				if (!temporarilyRemoveItemFromInventory(belt))
 					return
+				current_equip = belt
 			belt = I
 			update_inv_belt()
 		if(ITEM_SLOT_ID)
 			if (wear_id && swap)
-				current_equip = wear_id
 				if (!temporarilyRemoveItemFromInventory(wear_id))
 					return
+				current_equip = wear_id
 			wear_id = I
 			sec_hud_set_ID()
 			update_inv_wear_id()
 		if(ITEM_SLOT_EARS)
 			if (ears && swap)
-				current_equip = ears
 				if (!temporarilyRemoveItemFromInventory(ears))
 					return
+				current_equip = ears
 			ears = I
 			update_inv_ears()
 		if(ITEM_SLOT_EYES)
 			if (glasses && swap)
-				current_equip = glasses
 				if (!temporarilyRemoveItemFromInventory(glasses))
 					return
+				current_equip = glasses
 			glasses = I
 			var/obj/item/clothing/glasses/G = I
 			if(G.glass_colour_type)
@@ -126,25 +126,25 @@
 			update_inv_glasses()
 		if(ITEM_SLOT_GLOVES)
 			if (gloves && swap)
-				current_equip = gloves
 				if (!temporarilyRemoveItemFromInventory(gloves))
 					return
+				current_equip = gloves
 			gloves = I
 			update_inv_gloves()
 		if(ITEM_SLOT_FEET)
 			if (shoes && swap)
-				current_equip = shoes
 				if (!temporarilyRemoveItemFromInventory(shoes))
 					return
+				current_equip = shoes
 			shoes = I
 			update_inv_shoes()
 		if(ITEM_SLOT_OCLOTHING)
 			var/obj/item/s_store_backup = s_store
 
 			if (swap && wear_suit)
-				current_equip = wear_suit
 				if (!temporarilyRemoveItemFromInventory(wear_suit))
 					return
+				current_equip = wear_suit
 
 			wear_suit = I
 
@@ -162,9 +162,9 @@
 			update_inv_wear_suit()
 		if(ITEM_SLOT_ICLOTHING)
 			if (w_uniform && swap)
-				current_equip = w_uniform
 				if (!temporarilyRemoveItemFromInventory(w_uniform))
 					return
+				current_equip = w_uniform
 			w_uniform = I
 			update_suit_sensors()
 			update_inv_w_uniform()
@@ -176,9 +176,9 @@
 			update_inv_pockets()
 		if(ITEM_SLOT_SUITSTORE)
 			if (s_store && swap)
-				current_equip = s_store
 				if (!temporarilyRemoveItemFromInventory(s_store))
 					return
+				current_equip = s_store
 			s_store = I
 			update_inv_s_store()
 		else

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -88,27 +88,31 @@
 	switch(slot)
 		if(ITEM_SLOT_BELT)
 			if (belt && swap)
-				belt.dropped(src, TRUE)
 				current_equip = belt
+				if (!temporarilyRemoveItemFromInventory(belt))
+					return
 			belt = I
 			update_inv_belt()
 		if(ITEM_SLOT_ID)
 			if (wear_id && swap)
-				wear_id.dropped(src, TRUE)
 				current_equip = wear_id
+				if (!temporarilyRemoveItemFromInventory(wear_id))
+					return
 			wear_id = I
 			sec_hud_set_ID()
 			update_inv_wear_id()
 		if(ITEM_SLOT_EARS)
 			if (ears && swap)
-				ears.dropped(src, TRUE)
 				current_equip = ears
+				if (!temporarilyRemoveItemFromInventory(ears))
+					return
 			ears = I
 			update_inv_ears()
 		if(ITEM_SLOT_EYES)
 			if (glasses && swap)
-				glasses.dropped(src, TRUE)
 				current_equip = glasses
+				if (!temporarilyRemoveItemFromInventory(glasses))
+					return
 			glasses = I
 			var/obj/item/clothing/glasses/G = I
 			if(G.glass_colour_type)
@@ -122,25 +126,29 @@
 			update_inv_glasses()
 		if(ITEM_SLOT_GLOVES)
 			if (gloves && swap)
-				gloves.dropped(src, TRUE)
 				current_equip = gloves
+				if (!temporarilyRemoveItemFromInventory(gloves))
+					return
 			gloves = I
 			update_inv_gloves()
 		if(ITEM_SLOT_FEET)
 			if (shoes && swap)
-				shoes.dropped(src, TRUE)
 				current_equip = shoes
+				if (!temporarilyRemoveItemFromInventory(shoes))
+					return
 			shoes = I
 			update_inv_shoes()
 		if(ITEM_SLOT_OCLOTHING)
-			if (wear_suit && swap)
-				wear_suit.dropped(src, TRUE)
+			var/obj/item/s_store_backup = s_store
+
+			if (swap && wear_suit)
 				current_equip = wear_suit
+				if (!temporarilyRemoveItemFromInventory(wear_suit))
+					return
 
 			wear_suit = I
 
-			if (s_store && swap)
-				var/obj/item/s_store_backup = s_store
+			if (swap && s_store_backup)
 				dropItemToGround(s_store_backup)
 				put_in_inactive_hand(s_store_backup)
 				equip_to_slot_if_possible(s_store_backup, ITEM_SLOT_SUITSTORE)
@@ -154,8 +162,9 @@
 			update_inv_wear_suit()
 		if(ITEM_SLOT_ICLOTHING)
 			if (w_uniform && swap)
-				w_uniform.dropped(src, TRUE)
 				current_equip = w_uniform
+				if (!temporarilyRemoveItemFromInventory(w_uniform))
+					return
 			w_uniform = I
 			update_suit_sensors()
 			update_inv_w_uniform()
@@ -167,8 +176,9 @@
 			update_inv_pockets()
 		if(ITEM_SLOT_SUITSTORE)
 			if (s_store && swap)
-				s_store.dropped(src, TRUE)
 				current_equip = s_store
+				if (!temporarilyRemoveItemFromInventory(s_store))
+					return
 			s_store = I
 			update_inv_s_store()
 		else

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -49,31 +49,37 @@
 	I.plane = ABOVE_HUD_PLANE
 	I.appearance_flags |= NO_CLIENT_COLOR
 	var/not_handled = FALSE
+
 	var/obj/item/current_equip
+
 	switch(slot)
 		if(ITEM_SLOT_BACK)
 			if (back && swap)
-				back.dropped(src, TRUE)
 				current_equip = back
+				if (!temporarilyRemoveItemFromInventory(back))
+					return
 			back = I
 			update_inv_back()
 		if(ITEM_SLOT_MASK)
 			if (wear_mask && swap)
-				wear_mask.dropped(src, TRUE)
 				current_equip = wear_mask
+				if (!temporarilyRemoveItemFromInventory(wear_mask))
+					return
 			wear_mask = I
 			wear_mask_update(I, toggle_off = 0)
 		if(ITEM_SLOT_HEAD)
 			if (head && swap)
-				head.dropped(src, TRUE)
 				current_equip = head
+				if (!temporarilyRemoveItemFromInventory(head))
+					return
 			head = I
 			SEND_SIGNAL(src, COMSIG_CARBON_EQUIP_HAT, I)
 			head_update(I)
 		if(ITEM_SLOT_NECK)
 			if (wear_neck && swap)
-				wear_neck.dropped(src, TRUE)
 				current_equip = wear_neck
+				if (!temporarilyRemoveItemFromInventory(wear_neck))
+					return
 			wear_neck = I
 			update_inv_neck(I)
 		if(ITEM_SLOT_HANDCUFFED)

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -55,31 +55,31 @@
 	switch(slot)
 		if(ITEM_SLOT_BACK)
 			if (back && swap)
-				current_equip = back
 				if (!temporarilyRemoveItemFromInventory(back))
 					return
+				current_equip = back
 			back = I
 			update_inv_back()
 		if(ITEM_SLOT_MASK)
 			if (wear_mask && swap)
-				current_equip = wear_mask
 				if (!temporarilyRemoveItemFromInventory(wear_mask))
 					return
+				current_equip = wear_mask
 			wear_mask = I
 			wear_mask_update(I, toggle_off = 0)
 		if(ITEM_SLOT_HEAD)
 			if (head && swap)
-				current_equip = head
 				if (!temporarilyRemoveItemFromInventory(head))
 					return
+				current_equip = head
 			head = I
 			SEND_SIGNAL(src, COMSIG_CARBON_EQUIP_HAT, I)
 			head_update(I)
 		if(ITEM_SLOT_NECK)
 			if (wear_neck && swap)
-				current_equip = wear_neck
 				if (!temporarilyRemoveItemFromInventory(wear_neck))
 					return
+				current_equip = wear_neck
 			wear_neck = I
 			update_inv_neck(I)
 		if(ITEM_SLOT_HANDCUFFED)

--- a/code/modules/unit_tests/quick_swap_sanity.dm
+++ b/code/modules/unit_tests/quick_swap_sanity.dm
@@ -1,5 +1,5 @@
 /// Test that quick swap correctly swaps items and invalidates suit storage
-/datum/unit_test/quick_swap_sanity/Run()
+/datum/unit_test/quick_swap_suit_storage/Run()
 	// Create a human with a medical winter coat and a health analyzer in suit storage
 	var/mob/living/carbon/human/human = allocate(/mob/living/carbon/human)
 
@@ -29,3 +29,21 @@
 	// Since the tank is a valid suit storage item, it should not be dropped
 	TEST_ASSERT(human.equip_to_appropriate_slot(coat, swap = TRUE), "Couldn't quick swap to coat")
 	TEST_ASSERT_EQUAL(human.s_store, tank, "Human dropped the oxygen tank, when it was a valid item to keep in suit storage")
+
+/// Tests that doUnEquip code is ran by checking vision correcting glasses
+/datum/unit_test/quick_swap_glasses/Run()
+	var/mob/living/carbon/human/human = allocate(/mob/living/carbon/human)
+
+	ADD_TRAIT(human, TRAIT_NEARSIGHT, TRAIT_GENERIC)
+
+	var/obj/item/clothing/glasses/regular/glasses = allocate(/obj/item/clothing/glasses/regular)
+	TEST_ASSERT(human.equip_to_slot_if_possible(glasses, ITEM_SLOT_EYES), "Couldn't equip glasses")
+	TEST_ASSERT_EQUAL(human.screens["nearsighted"], null, "Human equipped glasses, but still has overlay")
+
+	var/obj/item/clothing/glasses/monocle/monocle = allocate(/obj/item/clothing/glasses/monocle)
+
+	TEST_ASSERT(human.equip_to_slot_if_possible(monocle, ITEM_SLOT_EYES, swap = TRUE), "Couldn't quick swap to monocle")
+	TEST_ASSERT_NOTEQUAL(human.screens["nearsighted"], null, "Human quick swapped to monocle, but has no nearsighted overlay")
+
+	TEST_ASSERT(human.equip_to_slot_if_possible(glasses, ITEM_SLOT_EYES, swap = TRUE), "Couldn't quick swap to glasses")
+	TEST_ASSERT_EQUAL(human.screens["nearsighted"], null, "Human quick swapped to glasses, but still has nearsighted overlay")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently you can:
1. Choose nearsighted
2. Quick swap to another pair of glasses
3. See perfectly

This wasn't fixed by Shaps' changes since those call `dropped`, which do not run through unequip code.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I know one of you is abusing this, show yourself!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can no longer quick swap another pair of glasses with nearsighted to see perfectly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
