### PR TITLE
Fixes Space Ninja Comms Console Hack Not Working on Occasion

### DIFF
--- a/code/modules/ninja/suit/ninjaDrainAct.dm
+++ b/code/modules/ninja/suit/ninjaDrainAct.dm
@@ -163,7 +163,7 @@
 		return
 	AI_notify_hack()
 	if(do_after(ninja, 300))
-		var/announcement_pick = rand(0, 2)
+		var/announcement_pick = rand(0, 1)
 		switch(announcement_pick)
 			if(0)
 				priority_announce("Attention crew, it appears that someone on your station has made unexpected communication with an alien device in nearby space.", "[command_name()] High-Priority Update")


### PR DESCRIPTION
## About The Pull Request

Because of a dangerous assumption on how rand() works in BYOND, space ninja's interaction with the comms console isn't guaranteed to do anything because rand can pick 2.  This PR fixes that issue.

## Why It's Good For The Game

Bugs and false expectations are things we strive to avoid.

## Changelog
:cl:
fix: Fixed Space Ninja's console hack occasionally doing nothing.
/:cl: