### PR TITLE
Food processors and microwaves now respect food trays

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -91,6 +91,7 @@
 	RegisterSignal(parent, COMSIG_ITEM_PRE_ATTACK, .proc/preattack_intercept)
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK_SELF, .proc/attack_self)
 	RegisterSignal(parent, COMSIG_ITEM_PICKUP, .proc/signal_on_pickup)
+	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/update_actions)
 
 	RegisterSignal(parent, COMSIG_MOVABLE_POST_THROW, .proc/close_all)
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/on_move)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -146,13 +146,7 @@
 				to_chat(user,  "<span class='notice'>You [open ? "close":"open"] [src].</span>")
 				toggle_lock(user)
 	else if(open && !showpiece)
-		if(showpiece_type && !istype(W, showpiece_type))
-			to_chat(user, "<span class='notice'>This doesn't belong in this kind of display.</span>")
-			return TRUE
-		if(user.transferItemToLoc(W, src))
-			showpiece = W
-			to_chat(user, "<span class='notice'>You put [W] on display.</span>")
-			update_icon()
+		insert_showpiece(W, user)
 	else if(glass_fix && broken && istype(W, /obj/item/stack/sheet/glass))
 		var/obj/item/stack/sheet/glass/G = W
 		if(G.get_amount() < 2)
@@ -166,6 +160,15 @@
 			update_icon()
 	else
 		return ..()
+
+/obj/structure/displaycase/proc/insert_showpiece(obj/item/wack, mob/user)
+	if(showpiece_type && !istype(wack, showpiece_type))
+		to_chat(user, "<span class='notice'>This doesn't belong in this kind of display.</span>")
+		return TRUE
+	if(user.transferItemToLoc(wack, src))
+		showpiece = wack
+		to_chat(user, "<span class='notice'>You put [wack] on display.</span>")
+		update_icon()
 
 /obj/structure/displaycase/proc/toggle_lock(mob/user)
 	open = !open
@@ -384,7 +387,6 @@
 	density = FALSE
 	max_integrity = 100
 	req_access = null
-	showpiece_type = /obj/item/reagent_containers/food
 	alert = FALSE //No, we're not calling the fire department because someone stole your cookie.
 	glass_fix = FALSE //Fixable with tools instead.
 	///The price of the item being sold. Altered by grab intent ID use.
@@ -577,3 +579,9 @@
 /obj/structure/displaycase/forsale/kitchen
 	desc = "A display case with an ID-card swiper. Use your ID to purchase the contents. Meant for the bartender and chef."
 	req_one_access = list(ACCESS_KITCHEN, ACCESS_BAR)
+
+/obj/structure/displaycase/forsale/insert_showpiece(obj/item/wack, mob/user)
+	if(!IS_EDIBLE(wack))
+		to_chat(user, "<span class='notice'>\The [src] smartly rejects [wack], as it only accepts food and drink.</span>")
+		return TRUE
+	. = ..()

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -582,6 +582,6 @@
 
 /obj/structure/displaycase/forsale/insert_showpiece(obj/item/wack, mob/user)
 	if(!IS_EDIBLE(wack))
-		to_chat(user, "<span class='notice'>\The [src] smartly rejects [wack], as it only accepts food and drink.</span>")
+		to_chat(user, "<span class='notice'>\The [src] smartly rejects [wack], as it only accepts food and drinks.</span>")
 		return TRUE
 	. = ..()

--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -69,11 +69,11 @@
 			qdel(DG)
 			glasses++
 			to_chat(user, "<span class='notice'>[src] accepts the drinking glass, sterilizing it.</span>")
-	else if(istype(O, /obj/item/reagent_containers/food/snacks))
+	else if(IS_EDIBLE(O))
 		if(isFull())
 			to_chat(user, "<span class='warning'>[src] is at full capacity.</span>")
 		else
-			var/obj/item/reagent_containers/food/snacks/S = O
+			var/obj/item/S = O
 			if(!user.transferItemToLoc(S, src))
 				return
 			if(stored_food[sanitize(S.name)])
@@ -88,11 +88,13 @@
 			to_chat(user, "<span class='notice'>[src] accepts a sheet of glass.</span>")
 	else if(istype(O, /obj/item/storage/bag/tray))
 		var/obj/item/storage/bag/tray/T = O
-		for(var/obj/item/reagent_containers/food/snacks/S in T.contents)
+		for(var/obj/item/S in T.contents)
 			if(isFull())
 				to_chat(user, "<span class='warning'>[src] is at full capacity.</span>")
 				break
 			else
+				if(!IS_EDIBLE(S))
+					continue
 				if(SEND_SIGNAL(T, COMSIG_TRY_STORAGE_TAKE, S, src))
 					if(stored_food[sanitize(S.name)])
 						stored_food[sanitize(S.name)]++

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -24,6 +24,11 @@
 	var/datum/looping_sound/microwave/soundloop
 	var/list/ingredients = list() // may only contain /atom/movables
 
+	///Static list of cookable items that can be mass-deposited into the microwave.
+	var/static/list/allowed_cookables = typecacheof(list(
+		/obj/item/food,
+		/obj/item/reagent_containers/food))
+
 	var/static/radial_examine = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_examine")
 	var/static/radial_eject = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_eject")
 	var/static/radial_use = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_use")
@@ -165,7 +170,9 @@
 	if(istype(O, /obj/item/storage/bag/tray))
 		var/obj/item/storage/T = O
 		var/loaded = 0
-		for(var/obj/item/reagent_containers/food/snacks/S in T.contents)
+		for(var/obj/S in T.contents)
+			if(!is_type_in_typecache(S, allowed_cookables))
+				continue
 			if(ingredients.len >= max_n_of_items)
 				to_chat(user, "<span class='warning'>\The [src] is full, you can't put anything in!</span>")
 				return TRUE

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -24,11 +24,6 @@
 	var/datum/looping_sound/microwave/soundloop
 	var/list/ingredients = list() // may only contain /atom/movables
 
-	///Static list of cookable items that can be mass-deposited into the microwave.
-	var/static/list/allowed_cookables = typecacheof(list(
-		/obj/item/food,
-		/obj/item/reagent_containers/food))
-
 	var/static/radial_examine = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_examine")
 	var/static/radial_eject = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_eject")
 	var/static/radial_use = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_use")
@@ -171,7 +166,7 @@
 		var/obj/item/storage/T = O
 		var/loaded = 0
 		for(var/obj/S in T.contents)
-			if(!is_type_in_typecache(S, allowed_cookables))
+			if(!IS_EDIBLE(S))
 				continue
 			if(ingredients.len >= max_n_of_items)
 				to_chat(user, "<span class='warning'>\The [src] is full, you can't put anything in!</span>")

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -14,9 +14,6 @@
 	var/processing = FALSE
 	var/rating_speed = 1
 	var/rating_amount = 1
-	var/static/list/allowed_cookables = typecacheof(list(
-		/obj/item/food,
-		/obj/item/reagent_containers/food))
 
 /obj/machinery/processor/RefreshParts()
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -66,7 +66,7 @@
 		var/obj/item/storage/T = O
 		var/loaded = 0
 		for(var/obj/S in T.contents)
-			if(!is_type_in_typecache(S, allowed_cookables))
+			if(!IS_EDIBLE(S))
 				continue
 			var/datum/food_processor_process/P = select_recipe(S)
 			if(P)

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -14,6 +14,9 @@
 	var/processing = FALSE
 	var/rating_speed = 1
 	var/rating_amount = 1
+	var/static/list/allowed_cookables = typecacheof(list(
+		/obj/item/food,
+		/obj/item/reagent_containers/food))
 
 /obj/machinery/processor/RefreshParts()
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
@@ -62,7 +65,9 @@
 	if(istype(O, /obj/item/storage/bag/tray))
 		var/obj/item/storage/T = O
 		var/loaded = 0
-		for(var/obj/item/reagent_containers/food/snacks/S in T.contents)
+		for(var/obj/S in T.contents)
+			if(!is_type_in_typecache(S, allowed_cookables))
+				continue
 			var/datum/food_processor_process/P = select_recipe(S)
 			if(P)
 				if(SEND_SIGNAL(T, COMSIG_TRY_STORAGE_TAKE, S, src))


### PR DESCRIPTION
## About The Pull Request

Really it's a bandaid as it would be better to wait until the refactor is done, but it turned out to be a rather easy fix.
Food trays may now once again mass insert both new and old food into the microwaves and food processors.
Adds a static typecache between the two machines to compare against when handling mass-insertion, and handles the basic sorting/denying.

## Why It's Good For The Game

Fixes #53646 and Fixes #54812.
Prevents any manual handing when cooking large quantities of food at once. 
Also, you get the switch gathering mode button when being given the serving tray again.

## Changelog
:cl:
fix: Food trays may deposit old and new foods into the microwave and food processor again.
fix: Food trays give you the switch gathering mode button when bought from a vending machine again.
/:cl:
