### PR TITLE
Civilian bounties for machines now properly send without dropping a frame on the pad.

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -527,9 +527,8 @@ Class Procs:
 	if(A == circuit)
 		circuit = null
 	if((A in component_parts) && !QDELETED(src))
-		component_parts.Remove(A)
 		// It would be unusual for a component_part to be qdel'd ordinarily.
-		deconstruct(FALSE)
+		component_parts.Remove(A)
 	return ..()
 
 /obj/machinery/CanAllowThrough(atom/movable/mover, turf/target)
@@ -735,7 +734,7 @@ Class Procs:
  *
  * Sends all AIs a message that a hack is occurring.  Specifically used for space ninja tampering as this proc was originally in the ninja files.
  * However, the proc may also be used elsewhere.
- */	
+ */
 /obj/machinery/proc/AI_notify_hack()
 	var/alertstr = "<span class='userdanger'>Network Alert: Hacking attempt detected[get_area(src)?" in [get_area_name(src, TRUE)]":". Unable to pinpoint location"].</span>"
 	for(var/mob/living/silicon/ai/AI in GLOB.player_list)

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -87,7 +87,14 @@
 		if(curr_bounty.applies_to(AM))
 			active_stack ++
 			curr_bounty.ship(AM)
-			qdel(AM)
+			if(ismachinery(AM))
+				var/obj/machinery/machine_bounty = AM
+				for(var/obj/part in machine_bounty.component_parts)
+					qdel(part)
+				qdel(machine_bounty.circuit)
+				qdel(machine_bounty)
+			else
+				qdel(AM)
 	if(active_stack >= 1)
 		status_report += "Bounty Target Found x[active_stack]. "
 	else


### PR DESCRIPTION
## About The Pull Request

See the title, for the most part. Civilian bounties that are looking for a machine (Emitters, Rechargers, Hydroponics trays) no longer drop their circuit, and their stock parts, and their frame when sent off. It was basically a glorified way to desconstruct a machine for about 8k credits.

Major change is that this prevents machines from calling spawn_frame by going through the deconstruct proc when undergoing handle_atom_qdel, which was exclusively spawning frames upon trying to just call qdel on a machine, as far as I'm aware.

## Why It's Good For The Game

Prevents easy cheesing of machine board bounties without actually giving up the machine you're selling, and machines are slightly cleaner on qdel than before.
Waiting to heat feedback from timberpoes in case that was there for a very critical reason that I've neglected to discover yet.

Fixes #54654.

## Changelog
:cl:
fix: Nanotrasen bounty boards no longer leave behind 95% of the machine when tasked with selling one!
/:cl: