### PR TITLE
Spraycans now consume charges in the right order when spraying graffiti. 

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -289,10 +289,6 @@
 			cost *= 0.5
 	if(check_empty(user, cost))
 		return
-	var/charges_used = use_charges(user, cost)
-	if(!charges_used)
-		return
-	. = charges_used
 
 	if(istype(target, /obj/effect/decal/cleanable))
 		target = target.loc
@@ -379,6 +375,11 @@
 	if(gang_mode || !instant)
 		if(!do_after(user, 50, target = target))
 			return
+
+	var/charges_used = use_charges(user, cost)
+	if(!charges_used)
+		return
+	. = charges_used
 
 	if(length(text_buffer))
 		drawing = text_buffer[1]

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -287,6 +287,8 @@
 	if(ishuman(user))
 		if (istagger)
 			cost *= 0.5
+	if(check_empty(user, cost))
+		return
 	var/charges_used = use_charges(user, cost)
 	if(!charges_used)
 		return


### PR DESCRIPTION
## About The Pull Request

Spraycans now check the cost of placing down a new spray before performing the do_after countdown, then uses the charge immediately after the do_after is completed.

## Why It's Good For The Game

Fixes #50799. Acts sanely compared to standard status checks performed by other objects.

## Changelog
:cl:
fix: Spraycans check and only use a charge AFTER their cooldown timer is complete.
/:cl:

Also holy fuck someone clean up this file it's a mess.