### PR TITLE
Hardsuit Thermal regulators have proper chat feedback.

### DIFF
--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -92,6 +92,7 @@
 	if(!cell.use(THERMAL_REGULATOR_COST))
 		toggle_spacesuit()
 		update_hud_icon(user)
+		to_chat(user, "<span class='warning'>The thermal regulator cuts off as [cell] runs out of charge.</span>")
 		return
 
 	// If we got here, it means thermals are on, the cell is in and the cell has
@@ -199,11 +200,15 @@
 	// If we're turning thermal protection on, check for valid cell and for enough
 	// charge that cell. If it's too low, we shouldn't bother with setting the
 	// thermal protection value and should just return out early.
+	var/mob/living/carbon/human/user = src.loc
 	if(!thermal_on && !(cell && cell.charge >= THERMAL_REGULATOR_COST))
+		to_chat(user, "<span class='warning'>The thermal regulator on \the [src] has no charge.</span>")
 		return
 
 	thermal_on = !thermal_on
 	min_cold_protection_temperature = thermal_on ? SPACE_SUIT_MIN_TEMP_PROTECT : SPACE_SUIT_MIN_TEMP_PROTECT_OFF
+	if(user || ishuman(user) || (user.wear_suit == src))
+		to_chat(user, "<span class='notice'>You turn [thermal_on ? "on" : "off"] \the [src]'s thermal regulator.</span>")
 	SEND_SIGNAL(src, COMSIG_SUIT_SPACE_TOGGLE)
 
 // let emags override the temperature settings

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -207,7 +207,7 @@
 
 	thermal_on = !thermal_on
 	min_cold_protection_temperature = thermal_on ? SPACE_SUIT_MIN_TEMP_PROTECT : SPACE_SUIT_MIN_TEMP_PROTECT_OFF
-	if(user || ishuman(user) || (user.wear_suit == src))
+	if(user)
 		to_chat(user, "<span class='notice'>You turn [thermal_on ? "on" : "off"] \the [src]'s thermal regulator.</span>")
 	SEND_SIGNAL(src, COMSIG_SUIT_SPACE_TOGGLE)
 


### PR DESCRIPTION

## About The Pull Request

Thermal regulators now have a few to_chat messages letting you know if your hardsuit's thermal regulator is on or not, as well as letting you know when the cell has run out of charge, or when the cell is dead when attempting to toggle it on.

## Why It's Good For The Game

Improves feedback for using hardsuits, as not being able to tell when the suit is keeping you warm or not can be deadly, especially if the icon toggle stops working for any reason.

Fixes #54045.

## Changelog
:cl:
fix: Hardsuit Thermal regulators will tell you if your cell is keeping you warm, if the internal cell is dead, or when the cell turns itself off.
/:cl:
