### PR TITLE
Butchering mobs will now drop their embedded objects.

### DIFF
--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -106,6 +106,9 @@
 		butcher.visible_message("<span class='notice'>[butcher] butchers [meat].</span>", \
 								"<span class='notice'>You butcher [meat].</span>")
 	ButcherEffects(meat)
+	if(iscarbon(meat))
+		var/mob/living/carbon/carbonized_meat = meat
+		carbonized_meat.remove_all_embedded_objects()
 	meat.harvest(butcher)
 	meat.gib(FALSE, FALSE, TRUE)
 

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -106,9 +106,6 @@
 		butcher.visible_message("<span class='notice'>[butcher] butchers [meat].</span>", \
 								"<span class='notice'>You butcher [meat].</span>")
 	ButcherEffects(meat)
-	if(iscarbon(meat))
-		var/mob/living/carbon/carbonized_meat = meat
-		carbonized_meat.remove_all_embedded_objects()
 	meat.harvest(butcher)
 	meat.gib(FALSE, FALSE, TRUE)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -928,6 +928,7 @@
 			O.forceMove(drop_location())
 	if(organs_amt)
 		to_chat(user, "<span class='notice'>You retrieve some of [src]\'s internal organs!</span>")
+	remove_all_embedded_objects()
 
 /mob/living/carbon/extinguish_mob()
 	for(var/X in get_equipped_items())


### PR DESCRIPTION


## About The Pull Request

The butchering component now checks for embedded objects when butchering the target, and if any exist it will drop the embedded objects along with the butchering results.
Carbon mobs are the only mobs that can have embedded objects from the looks of it, so this should cleanly cover the usecases of the linked issue.

## Why It's Good For The Game

Fixes #54835. Prevents monkeys from taking your embedded throwing spears and ninja stars to the grave.

## Changelog
:cl:
fix: Butchering mobs with embedded objects inside of them will now drop the embedded objects as well.
/:cl:
