### PR TITLE
Two condiment fixes

### DIFF
--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -82,7 +82,7 @@
 		to_chat(user, "<span class='notice'>You fill [src] with [trans] units of the contents of [target].</span>")
 
 	//Something like a glass or a food item. Player probably wants to transfer TO it.
-	else if(target.is_drainable() || istype(target, /obj/item/reagent_containers/food/snacks))
+	else if(target.is_drainable() || IS_EDIBLE(target))
 		if(!reagents.total_volume)
 			to_chat(user, "<span class='warning'>[src] is empty!</span>")
 			return
@@ -244,12 +244,11 @@
 	return
 
 /obj/item/reagent_containers/food/condiment/pack/afterattack(obj/target, mob/user , proximity)
-	. = ..()
 	if(!proximity)
 		return
 
 	//You can tear the bag open above food to put the condiments on it, obviously.
-	if(istype(target, /obj/item/reagent_containers/food/snacks))
+	if(IS_EDIBLE(target))
 		if(!reagents.total_volume)
 			to_chat(user, "<span class='warning'>You tear open [src], but there's nothing in it.</span>")
 			qdel(src)
@@ -262,6 +261,8 @@
 			to_chat(user, "<span class='notice'>You tear open [src] above [target] and the condiments drip onto it.</span>")
 			src.reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
 			qdel(src)
+			return
+	. = ..()
 
 /obj/item/reagent_containers/food/condiment/pack/on_reagent_change(changetype)
 	if(reagents.reagent_list.len > 0)


### PR DESCRIPTION
## About The Pull Request

Lets you use condiments on edible things, which includes the new food and food-based material things, also improves sauce packet feedback

## Why It's Good For The Game

1. Allows you to season your monkey steak
2. Allows you to put ketchup on a meat toilet 
3. Doesn't tell you that you tore the packet open after emptying it only to find said torn packet to be empty (Object permanence is a myth, don't let physicists tell you otherwise.)
![image](https://user-images.githubusercontent.com/51932756/99017720-c257b180-2515-11eb-8ce8-a473327e48c6.png)

## Changelog
:cl:
fix: Condiments work with food items more consistently, and packets don't give useless feedback.
/:cl: