### PR TITLE
Admins can now see chronological order of events in logging tabs.

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -214,3 +214,6 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define EWDIRFLIP(d)     (d^(EAST|WEST))
 ///Turns the dir by 180 degrees
 #define DIRFLIP(d)       turn(d, 180)
+
+/// 33554431 (2^24 - 1) is the maximum value our bitflags can reach.
+#define MAX_BITFLAG_DIGITS 8

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1376,6 +1376,8 @@
 /// Helper for logging chat messages or other logs with arbitrary inputs (e.g. announcements)
 /atom/proc/log_talk(message, message_type, tag=null, log_globally=TRUE, forced_by=null)
 	var/prefix = tag ? "([tag]) " : ""
+	if(message_type == LOG_WHISPER)
+		prefix += "whispers "
 	var/suffix = forced_by ? " FORCED by [forced_by]" : ""
 	log_message("[prefix]\"[message]\"[suffix]", message_type, log_globally=log_globally)
 

--- a/code/modules/admin/verbs/individual_logging.dm
+++ b/code/modules/admin/verbs/individual_logging.dm
@@ -63,5 +63,5 @@
 	var/slabel = label
 	if(selected_type == log_type && selected_src == log_src)
 		slabel = "<b>\[[label]\]</b>"
-
+	log_type = num2text(log_type, 10)
 	return "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[log_type];log_src=[log_src]'>[slabel]</a>"

--- a/code/modules/admin/verbs/individual_logging.dm
+++ b/code/modules/admin/verbs/individual_logging.dm
@@ -50,11 +50,9 @@
 	for(var/log_type in log_source)
 		var/nlog_type = text2num(log_type)
 		if(nlog_type & ntype)
-			var/list/reversed = log_source[log_type]
-			if(islist(reversed))
-				reversed = reverseRange(reversed.Copy())
-				for(var/entry in reversed)
-					concatenated_logs += "<font size=2px><b>[entry]</b><br>[reversed[entry]]</font><br>"
+			var/list/all_the_entrys = log_source[log_type]
+			for(var/entry in all_the_entrys)
+				concatenated_logs += "<font size=2px><b>[entry]</b><br>[all_the_entrys[entry]]</font><br>"
 	for(var/string in sortList(concatenated_logs,cmp=/proc/cmp_text_dsc))
 		dat += string
 

--- a/code/modules/admin/verbs/individual_logging.dm
+++ b/code/modules/admin/verbs/individual_logging.dm
@@ -52,11 +52,11 @@
 		if(nlog_type & ntype)
 			var/list/all_the_entrys = log_source[log_type]
 			for(var/entry in all_the_entrys)
-				concatenated_logs += "[entry]</b><br>[all_the_entrys[entry]]"
+				concatenated_logs += "<b>[entry]</b><br>[all_the_entrys[entry]]"
 	if(length(concatenated_logs))
 		sortTim(concatenated_logs, cmp = /proc/cmp_text_dsc) //Sort by timestamp.
-		dat += "<font size=2px><b>"
-		dat += concatenated_logs.Join("<br><b>")
+		dat += "<font size=2px>"
+		dat += concatenated_logs.Join("<br>")
 		dat += "</font>"
 
 	var/datum/browser/popup = new(usr, "invidual_logging_[key_name(M)]", "Individual Logs", 600, 600)

--- a/code/modules/admin/verbs/individual_logging.dm
+++ b/code/modules/admin/verbs/individual_logging.dm
@@ -55,7 +55,6 @@
 				reversed = reverseRange(reversed.Copy())
 				for(var/entry in reversed)
 					dat += "<font size=2px><b>[entry]</b><br>[reversed[entry]]</font><br>"
-			dat += "<hr>"
 
 	usr << browse(dat, "window=invidual_logging_[key_name(M)];size=600x480")
 

--- a/code/modules/admin/verbs/individual_logging.dm
+++ b/code/modules/admin/verbs/individual_logging.dm
@@ -68,5 +68,5 @@
 	if(selected_type == log_type && selected_src == log_src)
 		slabel = "<b>\[[label]\]</b>"
 	//This is necessary because num2text drops digits and rounds on big numbers. If more defines get added in the future it could break again.
-	log_type = num2text(log_type, 10)
+	log_type = num2text(log_type, MAX_BITFLAG_DIGITS)
 	return "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[log_type];log_src=[log_src]'>[slabel]</a>"

--- a/code/modules/admin/verbs/individual_logging.dm
+++ b/code/modules/admin/verbs/individual_logging.dm
@@ -63,5 +63,6 @@
 	var/slabel = label
 	if(selected_type == log_type && selected_src == log_src)
 		slabel = "<b>\[[label]\]</b>"
+	//This is necessary because num2text drops digits and rounds on big numbers. If more defines get added in the future it could break again.
 	log_type = num2text(log_type, 10)
 	return "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[log_type];log_src=[log_src]'>[slabel]</a>"

--- a/code/modules/admin/verbs/individual_logging.dm
+++ b/code/modules/admin/verbs/individual_logging.dm
@@ -46,7 +46,7 @@
 	var/log_source = M.logging;
 	if(source == LOGSRC_CLIENT && M.client) //if client doesn't exist just fall back to the mob log
 		log_source = M.client.player_details.logging //should exist, if it doesn't that's a bug, don't check for it not existing
-
+	var/list/concatenated_logs = list()
 	for(var/log_type in log_source)
 		var/nlog_type = text2num(log_type)
 		if(nlog_type & ntype)
@@ -54,7 +54,9 @@
 			if(islist(reversed))
 				reversed = reverseRange(reversed.Copy())
 				for(var/entry in reversed)
-					dat += "<font size=2px><b>[entry]</b><br>[reversed[entry]]</font><br>"
+					concatenated_logs += "<font size=2px><b>[entry]</b><br>[reversed[entry]]</font><br>"
+	for(var/string in sortList(concatenated_logs,cmp=/proc/cmp_text_dsc))
+		dat += string
 
 	usr << browse(dat, "window=invidual_logging_[key_name(M)];size=600x480")
 

--- a/code/modules/admin/verbs/individual_logging.dm
+++ b/code/modules/admin/verbs/individual_logging.dm
@@ -5,7 +5,7 @@
 	var/ntype = text2num(type)
 
 	//Add client links
-	var/dat = ""
+	var/list/dat = list()
 	if(M.client)
 		dat += "<center><p>Client</p></center>"
 		dat += "<center>"
@@ -52,11 +52,16 @@
 		if(nlog_type & ntype)
 			var/list/all_the_entrys = log_source[log_type]
 			for(var/entry in all_the_entrys)
-				concatenated_logs += "<font size=2px><b>[entry]</b><br>[all_the_entrys[entry]]</font><br>"
-	for(var/string in sortList(concatenated_logs,cmp=/proc/cmp_text_dsc))
-		dat += string
+				concatenated_logs += "[entry]</b><br>[all_the_entrys[entry]]"
+	if(length(concatenated_logs))
+		sortTim(concatenated_logs, cmp = /proc/cmp_text_dsc) //Sort by timestamp.
+		dat += "<font size=2px><b>"
+		dat += concatenated_logs.Join("<br><b>")
+		dat += "</font>"
 
-	usr << browse(dat, "window=invidual_logging_[key_name(M)];size=600x480")
+	var/datum/browser/popup = new(usr, "invidual_logging_[key_name(M)]", "Individual Logs", 600, 600)
+	popup.set_content(dat.Join())
+	popup.open()
 
 /proc/individual_logging_panel_link(mob/M, log_type, log_src, label, selected_src, selected_type)
 	var/slabel = label

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -152,7 +152,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	if(message_mods[WHISPER_MODE] == MODE_WHISPER)
 		message_range = 1
-		log_talk(message, LOG_WHISPER)
+		log_talk(message, LOG_WHISPER, "whispers")
 		if(stat == HARD_CRIT)
 			var/health_diff = round(-HEALTH_THRESHOLD_DEAD + health)
 			// If we cut our message short, abruptly end it with a-..
@@ -163,7 +163,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			message_mods[WHISPER_MODE] = MODE_WHISPER_CRIT
 			succumbed = TRUE
 	else
-		log_talk(message, LOG_SAY, forced_by=forced)
+		log_talk(message, LOG_SAY, "whispers", forced_by=forced)
 
 	message = treat_message(message) // unfortunately we still need this
 	var/sigreturn = SEND_SIGNAL(src, COMSIG_MOB_SAY, args)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -152,7 +152,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	if(message_mods[WHISPER_MODE] == MODE_WHISPER)
 		message_range = 1
-		log_talk(message, LOG_WHISPER, "whispers")
+		log_talk(message, LOG_WHISPER)
 		if(stat == HARD_CRIT)
 			var/health_diff = round(-HEALTH_THRESHOLD_DEAD + health)
 			// If we cut our message short, abruptly end it with a-..
@@ -163,7 +163,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			message_mods[WHISPER_MODE] = MODE_WHISPER_CRIT
 			succumbed = TRUE
 	else
-		log_talk(message, LOG_SAY, "whispers", forced_by=forced)
+		log_talk(message, LOG_SAY, forced_by=forced)
 
 	message = treat_message(message) // unfortunately we still need this
 	var/sigreturn = SEND_SIGNAL(src, COMSIG_MOB_SAY, args)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -482,7 +482,7 @@
 		else
 			colored_message = "<font color='[color]'>[message]</font>"
 
-	var/list/timestamped_message = list("[LAZYLEN(logging[smessage_type]) + 1]\[[time_stamp()]\] [key_name(src)] [loc_name(src)]" = colored_message)
+	var/list/timestamped_message = list("\[[time_stamp()]\] [key_name(src)] [loc_name(src)]" = colored_message)
 
 	logging[smessage_type] += timestamped_message
 


### PR DESCRIPTION
## About The Pull Request

Individual logging (the logging one sees when they view a player's playerpanel and click on LOGS) was broken and poorly coded, this fixes and improves it. The Show All tab was notably completely broken (it only showed attack logs), due to a rounding error from text2num trying to parse a bitflag value. (Thanks @LemonInTheDark for unraveling that mystery) Also in this PR, I made whispers visually distinguishable from regular say's.

Most importantly: **logs will now be sorted chronologically** regardless of category, and tabs that list multiple categories (like the say tab, comms tab, and show all tab) will concatenate them all instead of displaying them all separately.

Previous behavior, using the say tab as an example was:
[show all regular say logs here, in order]
[then below all of them, show all whispers, in order]
[then below all of both of the above, show all deadchat in order]

The above was stupid, this is way better.

![log](https://user-images.githubusercontent.com/51800976/99021744-f4254400-2526-11eb-8edb-cffc1e9a308f.png)

![logcombat](https://user-images.githubusercontent.com/51800976/99021816-1d45d480-2527-11eb-9781-66cd245fcc79.png)

A current limitation is that due to this relying on sortTim(), things are sorted by time stamp.
There is a non-zero chance that if somebody has more than one log within the same second, that they could display in the wrong order.
I don't see this as much of an issue, because between ping and people's reaction time, how often do things even take place in the same second? And how often would their exact order be the key to dealing with a ticket?

Also, self-admitted room for improvement: colors and formatting.

In summary, a lot of the admin tools are laggy and clunky and held together with duct tape, and there is much room for refactor and improvement. A TGUI redo of most of them would be great, for instance. But, this PR addresses one isolated matter that alone will greatly improve quality of life for admins, and thus for players also.


## Why It's Good For The Game

This will make investigating issues incredibly much less hassle for the admin team.
No more endlessly switching back and forth between attack and say tabs in the logs for multiple different people, no more feverishly memorizing timestamps or copy and pasting them into notepad windows.

## Changelog
:cl:
fix: Fixed "Show All" tab in player panel logs being broken.
fix: Whispers display differently in logs, distinguishing them from say logs in display.
refactor: Player panel logs will now show all logs chronologically, so you'll see commingled say and attack logs if you're on the "Show All" tab, etc...
/:cl:
