### PR TITLE
Fixes some edible material things being inedible/too edible

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -251,7 +251,7 @@ Behavior that's still missing from this component that original food items had t
 			this_food.reagents.add_reagent(r_id, amount)
 
 ///Makes sure the thing hasn't been destroyed or fully eaten to prevent eating phantom edibles
-/datum/component/edible/proc/IsFoodGone(var/atom/owner, mob/living/feeder)
+/datum/component/edible/proc/IsFoodGone(atom/owner, mob/living/feeder)
 	if(QDELETED(owner)|| !(IS_EDIBLE(owner)))
 		return TRUE
 	if(!owner.reagents.total_volume)//Shouldn't be needed but it checks to see if it has anything left in it.

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -75,7 +75,7 @@ Behavior that's still missing from this component that original food items had t
 		if (!item.grind_results)
 			item.grind_results = list() //If this doesn't already exist, add it as an empty list. This is needed for the grinder to accept it.
 
-	else if(isturf(parent))
+	else if(isturf(parent) || isstructure(parent))
 		RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, .proc/TryToEatTurf)
 
 	src.bite_consumption = bite_consumption

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -254,15 +254,9 @@ Behavior that's still missing from this component that original food items had t
 /datum/component/edible/proc/IsFoodGone(atom/owner, mob/living/feeder)
 	if(QDELETED(owner)|| !(IS_EDIBLE(owner)))
 		return TRUE
-	if(!owner.reagents.total_volume)//Shouldn't be needed but it checks to see if it has anything left in it.
-		to_chat(feeder, "<span class='warning'>None of [owner] left, oh no!</span>")
-		if(isturf(owner))
-			var/turf/T = owner
-			T.ScrapeAway(1, CHANGETURF_INHERIT_AIR)
-		else
-			qdel(owner)
-		return TRUE
-	return FALSE
+	if(owner.reagents.total_volume)
+		return FALSE
+	return TRUE
 
 ///All the checks for the act of eating itself and
 /datum/component/edible/proc/TryToEat(mob/living/eater, mob/living/feeder)
@@ -404,6 +398,7 @@ Behavior that's still missing from this component that original food items had t
 
 	on_consume?.Invoke(eater, feeder)
 
+	to_chat(feeder, "<span class='warning'>There is nothing left of [parent], oh no!</span>")
 	if(isturf(parent))
 		var/turf/T = parent
 		T.ScrapeAway(1, CHANGETURF_INHERIT_AIR)

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -76,7 +76,7 @@ Behavior that's still missing from this component that original food items had t
 			item.grind_results = list() //If this doesn't already exist, add it as an empty list. This is needed for the grinder to accept it.
 
 	else if(isturf(parent) || isstructure(parent))
-		RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, .proc/TryToEatTurf)
+		RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, .proc/TryToEatIt)
 
 	src.bite_consumption = bite_consumption
 	src.food_flags = food_flags
@@ -149,7 +149,7 @@ Behavior that's still missing from this component that original food items had t
 
 	return TryToEat(M, user)
 
-/datum/component/edible/proc/TryToEatTurf(datum/source, mob/user)
+/datum/component/edible/proc/TryToEatIt(datum/source, mob/user)
 	SIGNAL_HANDLER
 
 	return TryToEat(user, user)
@@ -250,28 +250,33 @@ Behavior that's still missing from this component that original food items had t
 		else
 			this_food.reagents.add_reagent(r_id, amount)
 
+///Makes sure the thing hasn't been destroyed or fully eaten to prevent eating phantom edibles
+/datum/component/edible/proc/IsFoodGone(var/atom/owner, mob/living/feeder)
+	if(QDELETED(owner)|| !(IS_EDIBLE(owner)))
+		return TRUE
+	if(!owner.reagents.total_volume)//Shouldn't be needed but it checks to see if it has anything left in it.
+		to_chat(feeder, "<span class='warning'>None of [owner] left, oh no!</span>")
+		if(isturf(owner))
+			var/turf/T = owner
+			T.ScrapeAway(1, CHANGETURF_INHERIT_AIR)
+		else
+			qdel(owner)
+		return TRUE
+	return FALSE
 
 ///All the checks for the act of eating itself and
 /datum/component/edible/proc/TryToEat(mob/living/eater, mob/living/feeder)
 
 	set waitfor = FALSE
 
-	if(QDELETED(parent))
-		return
-
 	var/atom/owner = parent
-
 
 	if(feeder.a_intent == INTENT_HARM)
 		return
-	if(!owner.reagents.total_volume)//Shouldn't be needed but it checks to see if it has anything left in it.
-		to_chat(feeder, "<span class='warning'>None of [owner] left, oh no!</span>")
-		if(isturf(parent))
-			var/turf/T = parent
-			T.ScrapeAway(1, CHANGETURF_INHERIT_AIR)
-		else
-			qdel(parent)
+
+	if(IsFoodGone(owner, feeder))
 		return
+
 	if(!CanConsume(eater, feeder))
 		return
 	var/fullness = eater.get_fullness() + 10 //The theoretical fullness of the person eating if they were to eat this
@@ -280,6 +285,8 @@ Behavior that's still missing from this component that original food items had t
 
 	if(eater == feeder)//If you're eating it yourself.
 		if(!do_mob(feeder, eater, eat_time)) //Gotta pass the minimal eat time
+			return
+		if(IsFoodGone(owner, feeder))
 			return
 		var/eatverb = pick(eatverbs)
 		if(junkiness && eater.satiety < -150 && eater.nutrition > NUTRITION_LEVEL_STARVING + 50 && !HAS_TRAIT(eater, TRAIT_VORACIOUS))
@@ -309,7 +316,8 @@ Behavior that's still missing from this component that original food items had t
 			return
 		if(!do_mob(feeder, eater)) //Wait 3 seconds before you can feed
 			return
-
+		if(IsFoodGone(owner, feeder))
+			return
 		log_combat(feeder, eater, "fed", owner.reagents.log_list())
 		eater.visible_message("<span class='danger'>[feeder] forces [eater] to eat [parent]!</span>", \
 									"<span class='userdanger'>[feeder] forces you to eat [parent]!</span>")


### PR DESCRIPTION
## About The Pull Request

Lets you eat other edible material things besides just walls and floor tiles.
Prevents you from eating qdel'd structures or scraped away turfs by spam clicking on it too

## Why It's Good For The Game

I have an immense desire to consume a ketchup-coated meat toilet, and otherwise I am denied this. 
No longer can you feed yourself excessively by repeatedly eating a singular pizza floor tile, either.
![image](https://user-images.githubusercontent.com/51932756/99124846-3058b300-25c0-11eb-9998-ab152cb8b122.png)

## Changelog
:cl:
fix: Things made of edible materials are more consistently edible, and can no longer be eaten multiple times over by spam clicking them. One serving per pizza floor only, please.
/:cl: