### PR TITLE
Make sure slowdown effects get removed when items are unequipped from a mob

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -273,6 +273,7 @@
 		s_store = null
 		if(!QDELETED(src))
 			update_inv_s_store()
+	update_equipment_speed_mods()
 
 	// Send a signal for when we unequip an item that used to cover our feet/shoes. Used for bloody feet
 	if((I.body_parts_covered & FEET) || (I.flags_inv | I.transparent_protection) & HIDESHOES)

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -134,6 +134,7 @@
 		legcuffed = null
 		if(!QDELETED(src))
 			update_inv_legcuffed()
+	update_equipment_speed_mods()
 
 //handle stuff to update when a mob equips/unequips a mask.
 /mob/living/proc/wear_mask_update(obj/item/I, toggle_off = 1)


### PR DESCRIPTION
Basically, speed mods were being updated in mob/doUnEquip, but the way update_equipment_speed_mods works is by checking the mob's item slots, which only get unset in carbon/doUnEquip and human/doUnEquip, so we have to update the mob's speed after the child proc is done unsetting stuff too.

fixes #54936
