### PR TITLE
Mice, Rats, and Regal Rats all trigger mousetrap effects properly.

### DIFF
--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -118,7 +118,7 @@
 						triggered(H)
 						H.visible_message("<span class='warning'>[H] accidentally steps on [src].</span>", \
 										  "<span class='warning'>You accidentally step on [src]</span>")
-				else if(ismouse(MM))
+				else if(ismouse(MM) || israt(MM) || isregalrat(MM))
 					triggered(MM)
 		else if(AM.density) // For mousetrap grenades, set off by anything heavy
 			triggered(AM)


### PR DESCRIPTION

## About The Pull Request

I forgot to check more than `ismouse()` on the mousetrap side, because I am blind.
This adds the extra checks for `israt()` and `isregalrat()` to the trap triggering.

## Why It's Good For The Game

Fixes #54962. Bugs are bad.

## Changelog
:cl:
fix: Rats and Regal Rats now properly trigger mouse traps when crossed.
/:cl: