### PR TITLE
Snail Shells are now properly deleted on gib.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -55,6 +55,11 @@
 	max_integrity = 200
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
+/obj/item/storage/backpack/snail/dropped(mob/user, silent)
+	. = ..()
+	emptyStorage()
+	qdel(src)
+
 /obj/item/storage/backpack/snail/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, "snailshell")


### PR DESCRIPTION

## About The Pull Request

Snail shells, when gibbed, were previously dropping along with the rest of the snail's organs/equipment/etc.
This was causing issues, as the snailshell has the nodrop trait, and was getting permanently getting stuck to non-snails hands, unable to be removed forever.
This adds behavior to empty and then delete the snail shell's when dropped, and keeping people from getting 2 "snailhands" for all eternity.

## Why It's Good For The Game

Fixes #54933.

## Changelog
:cl:
fix: Snail's shells, if removed from their body, are now destroyed as appropriate.
/:cl:
