### PR TITLE
You can('t) whisper into comms in crit.

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -47,6 +47,8 @@
 
 #define MODE_MONKEY "monkeyhive"
 
+#define MODE_MAFIA "mafia"
+
 #define MODE_SING "sing"
 
 //Spans. Robot speech, italics, etc. Applied in compose_message().
@@ -64,7 +66,6 @@
 #define ITALICS			(1<<0)
 #define REDUCE_RANGE	(1<<1)
 #define NOPASS			(1<<2)
-#define NO_RADIO		(1<<3)
 
 //Eavesdropping
 #define EAVESDROP_EXTRA_RANGE 1 //how much past the specified message_range does the message get starred, whispering only

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -64,6 +64,7 @@
 #define ITALICS			(1<<0)
 #define REDUCE_RANGE	(1<<1)
 #define NOPASS			(1<<2)
+#define NO_RADIO		(1<<3)
 
 //Eavesdropping
 #define EAVESDROP_EXTRA_RANGE 1 //how much past the specified message_range does the message get starred, whispering only

--- a/code/datums/saymode.dm
+++ b/code/datums/saymode.dm
@@ -87,6 +87,7 @@
 
 /datum/saymode/mafia
 	key = "j"
+	mode = MODE_MAFIA
 
 /datum/saymode/mafia/handle_message(mob/living/user, message, datum/language/language)
 	var/datum/mafia_controller/MF = GLOB.mafia_game

--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -54,12 +54,12 @@
 	return special_voice
 
 /mob/living/carbon/human/binarycheck()
-	if(ears)
-		var/obj/item/radio/headset/dongle = ears
-		if(!istype(dongle))
-			return FALSE
-		if(dongle.translate_binary)
-			return TRUE
+	if(stat >= SOFT_CRIT || !ears)
+		return FALSE
+	var/obj/item/radio/headset/dongle = ears
+	if(!istype(dongle))
+		return FALSE
+	return dongle.translate_binary
 
 /mob/living/carbon/human/radio(message, list/message_mods = list(), list/spans, language) //Poly has a copy of this, lazy bastard
 	. = ..()

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -26,7 +26,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	// Misc
 	RADIO_KEY_AI_PRIVATE = RADIO_CHANNEL_AI_PRIVATE, // AI Upload channel
-	MODE_KEY_VOCALCORDS = MODE_VOCALCORDS,		// vocal cords, used by Voice of God
 
 
 	//kinda localization -- rastaf0
@@ -55,8 +54,18 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	"â" = MODE_ADMIN,
 
 	// Misc
-	"ù" = RADIO_CHANNEL_AI_PRIVATE,
-	"÷" = MODE_VOCALCORDS
+	"ù" = RADIO_CHANNEL_AI_PRIVATE
+))
+
+/**
+  * Whitelist of saymodes or radio extensions that can be spoken through even if not fully conscious.
+  * Associated values are their maximum allowed mob stats.
+  */
+GLOBAL_LIST_INIT(message_modes_stat_limits, list(
+	MODE_INTERCOM = HARD_CRIT,
+	MODE_ALIEN = HARD_CRIT,
+	MODE_BINARY = HARD_CRIT, //extra stat check on human/binarycheck()
+	MODE_MAFIA = HARD_CRIT
 ))
 
 /mob/living/proc/Ellipsis(original_msg, chance = 50, keep_words)
@@ -117,14 +126,21 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(stat != DEAD && check_emote(original_message, forced))
 		return
 
+	// Checks if the saymode or channel extension can be used even if not totally conscious.
+	var/say_radio_or_mode = saymode || message_mods[RADIO_EXTENSION]
+	if(say_radio_or_mode)
+		var/mob_stat_limit = GLOB.message_modes_stat_limits[say_radio_or_mode]
+		if(stat > (isnull(mob_stat_limit) ? CONSCIOUS : mob_stat_limit))
+			saymode = null
+			message_mods -= RADIO_EXTENSION
+
 	switch(stat)
 		if(SOFT_CRIT)
 			message_mods[WHISPER_MODE] = MODE_WHISPER
 		if(UNCONSCIOUS)
-			if(!message_mods[MODE_ALIEN])
-				return
+			return
 		if(HARD_CRIT)
-			if(!(message_mods[WHISPER_MODE] || message_mods[MODE_ALIEN]))
+			if(!message_mods[WHISPER_MODE])
 				return
 		if(DEAD)
 			say_dead(original_message)
@@ -383,8 +399,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	return message
 
 /mob/living/proc/radio(message, list/message_mods = list(), list/spans, language)
-	if(stat >= SOFT_CRIT)
-		return NO_RADIO
 	var/obj/item/implant/radio/imp = locate() in src
 	if(imp?.radio.on)
 		if(message_mods[MODE_HEADSET])
@@ -409,9 +423,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			for (var/obj/item/radio/intercom/I in view(MODE_RANGE_INTERCOM, null))
 				I.talk_into(src, message, , spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
-
-		if(MODE_BINARY)
-			return ITALICS | REDUCE_RANGE //Does not return 0 since this is only reached by humans, not borgs or AIs.
 
 	return 0
 

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -65,6 +65,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	MODE_INTERCOM = HARD_CRIT,
 	MODE_ALIEN = HARD_CRIT,
 	MODE_BINARY = HARD_CRIT, //extra stat check on human/binarycheck()
+	MODE_MONKEY = HARD_CRIT,
 	MODE_MAFIA = HARD_CRIT
 ))
 

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -383,6 +383,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	return message
 
 /mob/living/proc/radio(message, list/message_mods = list(), list/spans, language)
+	if(stat >= SOFT_CRIT)
+		return NO_RADIO
 	var/obj/item/implant/radio/imp = locate() in src
 	if(imp?.radio.on)
 		if(message_mods[MODE_HEADSET])

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -122,7 +122,7 @@
 			mods[WHISPER_MODE] = MODE_WHISPER
 		else if(key == "%" && !mods[MODE_SING])
 			mods[MODE_SING] = TRUE
-		else if(key == ";" && !mods[MODE_HEADSET])
+		else if(key == ";" && !mods[MODE_HEADSET] && stat == CONSCIOUS)
 			mods[MODE_HEADSET] = TRUE
 		else if((key in GLOB.department_radio_prefixes) && length(message) > length(key) + 1 && !mods[RADIO_EXTENSION])
 			mods[RADIO_KEY] = lowertext(message[1 + length(key)])

--- a/code/modules/mob/say_readme.md
+++ b/code/modules/mob/say_readme.md
@@ -134,7 +134,6 @@ global procs
 		NOPASS = terminate say()
 		ITALICS = add italics to the message
 		REDUCE_RANGE = reduce the message range to one tile.
-		NO_RADIO = no radio will be used. Doesn't stop subtypes that don't respect parent call return values.
 
 		Return 0 if no radio was spoken into.
 		IMPORTANT: remember to call ..() and check for ..()'s return value properly!

--- a/code/modules/mob/say_readme.md
+++ b/code/modules/mob/say_readme.md
@@ -134,6 +134,7 @@ global procs
 		NOPASS = terminate say()
 		ITALICS = add italics to the message
 		REDUCE_RANGE = reduce the message range to one tile.
+		NO_RADIO = no radio will be used. Doesn't stop subtypes that don't respect parent call return values.
 
 		Return 0 if no radio was spoken into.
 		IMPORTANT: remember to call ..() and check for ..()'s return value properly!


### PR DESCRIPTION
## About The Pull Request
Fixing radios and some saymodes not properly respecting stats.

## Why It's Good For The Game
This will close #54878. 

## Changelog
:cl: 
fix: Spessmen can't whisper into comms in crit anymore (excluding handheld radios and intercomms).
fix: Humans with binary encrypted headsets shouldn't be able to speak into the binary channel when unconscious/critted anymore.
/:cl:
