### PR TITLE
Fix misleading examine messages on the head without body

### DIFF
--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -74,7 +74,7 @@
 		else if(brainmob?.health <= HEALTH_THRESHOLD_DEAD)
 			. += "<span class='info'>It's leaking some kind of... clear fluid? The brain inside must be in pretty bad shape.</span>"
 		else if(brainmob)
-			if(brainmob.get_ghost(FALSE, TRUE))
+			if(brainmob.key || brainmob.get_ghost(FALSE, TRUE))
 				. += "<span class='info'>Its muscles are twitching slightly... It seems to have some life still in it.</span>"
 			else
 				. += "<span class='info'>It's completely lifeless. Perhaps there'll be a chance for them later.</span>"


### PR DESCRIPTION
## About The Pull Request
Fix #54973 

Tested in on local server with 2 clients.
For both cases described in issue message says `Its muscles are twitching slightly... It seems to have some life still in it.`
If client logs out, it shows `It's completely lifeless. Perhaps there'll be a chance for them later.`

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Examinining head without body shows proper message if client has reentered corpse.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
