### PR TITLE
Fix client time timers duplicating if any client time timer caused a stack overflow.

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -100,7 +100,10 @@ SUBSYSTEM_DEF(timer)
 		log_world(to_log.Join("\n"))
 
 	// Process client-time timers
-	var/next_clienttime_timer_index = 0
+	var/static/next_clienttime_timer_index = 0
+	if (next_clienttime_timer_index)
+		clienttime_timers.Cut(1, next_clienttime_timer_index+1)
+		next_clienttime_timer_index = 0
 	for (next_clienttime_timer_index in 1 to length(clienttime_timers))
 		if (MC_TICK_CHECK)
 			next_clienttime_timer_index--
@@ -129,6 +132,7 @@ SUBSYSTEM_DEF(timer)
 	// Remove invoked client-time timers
 	if (next_clienttime_timer_index)
 		clienttime_timers.Cut(1, next_clienttime_timer_index+1)
+		next_clienttime_timer_index = 0
 
 	if (MC_TICK_CHECK)
 		return

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -115,7 +115,6 @@ SUBSYSTEM_DEF(timer)
 
 		var/datum/callback/callBack = ctime_timer.callBack
 		if (!callBack)
-			clienttime_timers.Cut(next_clienttime_timer_index,next_clienttime_timer_index + 1)
 			CRASH("Invalid timer: [get_timer_debug_string(ctime_timer)] world.time: [world.time], \
 				head_offset: [head_offset], practical_offset: [practical_offset], REALTIMEOFDAY: [REALTIMEOFDAY]")
 


### PR DESCRIPTION
No idea if this fixes any issues we've been having, but a code audit of timers found this edge case.

note, stack overflows sometimes don't get logged because byond is lame.