### PR TITLE
Cell chargers now pull from the grid's surplus rather than their room's APC cell

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -124,10 +124,18 @@
 
 /obj/machinery/cell_charger/process(delta_time)
 	if(!charging || !anchored || (machine_stat & (BROKEN|NOPOWER)))
+		//to_chat(world, "DEBUG -- CELL CHARGER EARLY RETURN(generic error)")
 		return
 
 	if(charging.percent() >= 100)
 		return
-	if(directly_use_power(charge_rate * delta_time))
-		charging.give(charge_rate * delta_time)
-		update_icon()
+
+	var/main_draw = use_power_from_net(charge_rate * delta_time, take_any = TRUE) //Pulls directly from the power net for the cell itself
+	if(!main_draw)
+		return
+	charging.give(main_draw)
+	use_power(charge_rate / 100) //use a small bit for the charger itself, but power usage scales up with the part tier
+
+	//if(directly_use_power(charge_rate * delta_time))
+	//	charging.give(charge_rate * delta_time)
+	update_icon()

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -136,6 +136,4 @@
 	charging.give(main_draw)
 	use_power(charge_rate / 100) //use a small bit for the charger itself, but power usage scales up with the part tier
 
-	//if(directly_use_power(charge_rate * delta_time))
-	//	charging.give(charge_rate * delta_time)
 	update_icon()

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -124,13 +124,12 @@
 
 /obj/machinery/cell_charger/process(delta_time)
 	if(!charging || !anchored || (machine_stat & (BROKEN|NOPOWER)))
-		//to_chat(world, "DEBUG -- CELL CHARGER EARLY RETURN(generic error)")
 		return
 
 	if(charging.percent() >= 100)
 		return
 
-	var/main_draw = use_power_from_net(charge_rate * delta_time, take_any = TRUE) //Pulls directly from the power net for the cell itself
+	var/main_draw = use_power_from_net(charge_rate * delta_time, take_any = TRUE) //Pulls directly from the Powernet to dump into the cell
 	if(!main_draw)
 		return
 	charging.give(main_draw)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -119,14 +119,14 @@
 	return TRUE
 
 /**
-  * Attemps to draw power directly from the APC's powernet rather than the APC's battery. For high-draw machines, like the cell charger
+  * Attempts to draw power directly from the APC's Powernet rather than the APC's battery. For high-draw machines, like the cell charger
   *
   * Checks the surplus power on the APC's powernet, and compares to the requested amount. If the requested amount is available, this proc
   * will add the amount to the APC's usage and return that amount. Otherwise, this proc will return FALSE.
   * If the take_any var arg is set to true, this proc will use and return any surplus that is under the requested amount, assuming that
   * the surplus is above zero.
   * Args:
-  * - amount, the amount of power requested from the powernet. In standard loosely-defined SS13 power units.
+  * - amount, the amount of power requested from the Powernet. In standard loosely-defined SS13 power units.
   * - take_any, a bool of whether any amount of power is acceptable, instead of all or nothing. Defaults to FALSE
  */
 /obj/machinery/proc/use_power_from_net(amount, take_any = FALSE)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -133,6 +133,12 @@
 	if(amount <= 0) //just in case
 		return FALSE
 	var/area/home = get_area(src)
+
+	if(!home)
+		return FALSE //apparently space isn't an area
+	if(!home.requires_power)
+		return amount //Shuttles get free power, don't ask why
+
 	var/obj/machinery/power/apc/local_apc = home?.get_apc()
 	if(!local_apc)
 		return FALSE

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -118,6 +118,34 @@
 	local_apc.cell.use(amount)
 	return TRUE
 
+/**
+  * Attemps to draw power directly from the APC's powernet rather than the APC's battery. For high-draw machines, like the cell charger
+  *
+  * Checks the surplus power on the APC's powernet, and compares to the requested amount. If the requested amount is available, this proc
+  * will add the amount to the APC's usage and return that amount. Otherwise, this proc will return FALSE.
+  * If the take_any var arg is set to true, this proc will use and return any surplus that is under the requested amount, assuming that
+  * the surplus is above zero.
+  * Args:
+  * - amount, the amount of power requested from the powernet. In standard loosely-defined SS13 power units.
+  * - take_any, a bool of whether any amount of power is acceptable, instead of all or nothing. Defaults to FALSE
+ */
+/obj/machinery/proc/use_power_from_net(amount, take_any = FALSE)
+	if(amount <= 0) //just in case
+		return FALSE
+	var/area/home = get_area(src)
+	var/obj/machinery/power/apc/local_apc = home?.get_apc()
+	if(!local_apc)
+		return FALSE
+	var/surplus = local_apc.surplus()
+	if(surplus <= 0) //I don't know if powernet surplus can ever end up negative, but I'm just gonna failsafe it
+		return FALSE
+	if(surplus < amount)
+		if(!take_any)
+			return FALSE
+		amount = surplus
+	local_apc.add_load(amount)
+	return amount
+
 /obj/machinery/proc/addStaticPower(value, powerchannel)
 	var/area/A = get_area(src)
 	if(!A)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As the title says.

- Creates a new proc, `use_power_from_net()` that attempts to pull power from the grid (by adding the amount needed to the APC's powernet load), and returns the amount gathered if there was enough surplus to do so. This bypasses the APC's internal cell for power drawn this way.

- Changes cell chargers to use this new proc for charging a cell. The charger machine still uses some power from the APC, set to 1% of it's max cell charging rate, for machine-related power costs. I'm not deadset on that number, I just needed to start with something. To be clear, this 1% is to simulate running the cell charger's circuitry; all of the power for the cell it's charging is 1-to-1 coming from the powernet.

- This does not subvert the original PR's purpose; cells are still drawing as much power from the grid as they charge with. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes cell chargers breaking rooms after the prior cell charger fix. The load is now on the grid, and it being surplus means that it (probably) won't actually powersink anything. 

Fixes #54919 by taking a different approach that entirely avoids the issue.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cell chargers will no longer powersink the room they're in, as they now draw all the power for the cell from the powernet directly through the APC. They still require a trickle of power on the equipment breaker, though.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Power code is a fuck, but I tested this and it seems to be working as intended.