### PR TITLE
Gulag teleporter now gives plasprisoners with nonstandard gloves a free pair

### DIFF
--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -154,15 +154,13 @@ The console is located at computer/gulag_teleporter.dm
 	var/mob/living/carbon/human/prisoner = occupant
 	if(!isplasmaman(prisoner) && jumpsuit_type)
 		var/suit_or_skirt = prisoner.jumpsuit_style == PREF_SKIRT ? jumpskirt_type : jumpsuit_type //Check player prefs for jumpsuit or jumpskirt toggle, then give appropriate prison outfit.
-		prisoner.equip_to_appropriate_slot(new suit_or_skirt)
+		prisoner.equip_to_appropriate_slot(new suit_or_skirt, qdel_on_fail = TRUE)
 	if(isplasmaman(prisoner) && !prisoner.gloves && emergency_plasglove_type)
-		var/obj/item/clothing/the_gloves = new emergency_plasglove_type
-		if(!prisoner.equip_to_appropriate_slot(the_gloves))
-			qdel(the_gloves)
+		prisoner.equip_to_appropriate_slot(new emergency_plasglove_type, qdel_on_fail = TRUE)
 	if(shoes_type)
-		prisoner.equip_to_appropriate_slot(new shoes_type)
+		prisoner.equip_to_appropriate_slot(new shoes_type, qdel_on_fail = TRUE)
 	if(id)
-		prisoner.equip_to_appropriate_slot(id)
+		prisoner.equip_to_appropriate_slot(id, qdel_on_fail = TRUE)
 	if(R)
 		R.fields["criminal"] = "Incarcerated"
 

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -156,7 +156,9 @@ The console is located at computer/gulag_teleporter.dm
 		var/suit_or_skirt = prisoner.jumpsuit_style == PREF_SKIRT ? jumpskirt_type : jumpsuit_type //Check player prefs for jumpsuit or jumpskirt toggle, then give appropriate prison outfit.
 		prisoner.equip_to_appropriate_slot(new suit_or_skirt)
 	if(isplasmaman(prisoner) && !prisoner.gloves && emergency_plasglove_type)
-		prisoner.equip_to_appropriate_slot(new emergency_plasglove_type)
+		var/obj/item/clothing/the_gloves = new emergency_plasglove_type
+		if(!prisoner.equip_to_appropriate_slot(the_gloves))
+			qdel(the_gloves)
 	if(shoes_type)
 		prisoner.equip_to_appropriate_slot(new shoes_type)
 	if(id)

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -23,6 +23,7 @@ The console is located at computer/gulag_teleporter.dm
 	var/jumpsuit_type = /obj/item/clothing/under/rank/prisoner
 	var/jumpskirt_type = /obj/item/clothing/under/rank/prisoner/skirt
 	var/shoes_type = /obj/item/clothing/shoes/sneakers/orange
+	var/emergency_plasglove_type = /obj/item/clothing/gloves/color/plasmaman
 	var/obj/machinery/gulag_item_reclaimer/linked_reclaimer
 	var/static/list/telegulag_required_items = typecacheof(list(
 		/obj/item/implant,
@@ -154,6 +155,8 @@ The console is located at computer/gulag_teleporter.dm
 	if(!isplasmaman(prisoner) && jumpsuit_type)
 		var/suit_or_skirt = prisoner.jumpsuit_style == PREF_SKIRT ? jumpskirt_type : jumpsuit_type //Check player prefs for jumpsuit or jumpskirt toggle, then give appropriate prison outfit.
 		prisoner.equip_to_appropriate_slot(new suit_or_skirt)
+	if(isplasmaman(prisoner) && !prisoner.gloves && emergency_plasglove_type)
+		prisoner.equip_to_appropriate_slot(new emergency_plasglove_type)
 	if(shoes_type)
 		prisoner.equip_to_appropriate_slot(new shoes_type)
 	if(id)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -364,7 +364,7 @@
   *
   * returns 0 if it cannot, 1 if successful
   */
-/mob/proc/equip_to_appropriate_slot(obj/item/W, swap=FALSE)
+/mob/proc/equip_to_appropriate_slot(obj/item/W, swap=FALSE, qdel_on_fail = FALSE)
 	if(!istype(W))
 		return FALSE
 	var/slot_priority = W.slot_equipment_priority
@@ -385,6 +385,8 @@
 		if(equip_to_slot_if_possible(W, slot, FALSE, TRUE, TRUE, FALSE, FALSE, swap)) //qdel_on_fail = FALSE; disable_warning = TRUE; redraw_mob = TRUE;
 			return TRUE
 
+	if(qdel_on_fail)
+		qdel(W)
 	return FALSE
 /**
   * Reset the attached clients perspective (viewpoint)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The gulag teleporter is kind enough to leave you with certain pieces of gear if you get gulag'd, such as your internals and most pieces of plasmaman gear, including plasmaman gloves. If, however, you're gulag'd while wearing any non-plasmaman gloves (mind that all gloves are equally effective at preventing you from combusting), it'll eat them and you'll die very quickly on the gulag. This PR makes it so if a plasmaman is gulag'd and doesn't have any gloves after being stripped, they'll get a free pair of basic plasmaman gloves so they don't die.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Saves plasmamen from systematic death
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Plasmamen who are gulag'd via the teleporter with non-plasmaman gloves will now be given a free pair of basic plasmaman gloves so they don't die.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
