### PR TITLE
Labels some things in player logging better.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1376,8 +1376,6 @@
 /// Helper for logging chat messages or other logs with arbitrary inputs (e.g. announcements)
 /atom/proc/log_talk(message, message_type, tag=null, log_globally=TRUE, forced_by=null)
 	var/prefix = tag ? "([tag]) " : ""
-	if(message_type == LOG_WHISPER)
-		prefix += "whispers "
 	var/suffix = forced_by ? " FORCED by [forced_by]" : ""
 	log_message("[prefix]\"[message]\"[suffix]", message_type, log_globally=log_globally)
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -482,6 +482,17 @@
 		else
 			colored_message = "<font color='[color]'>[message]</font>"
 
+	//This makes readability a bit better for admins.
+	switch(message_type)
+		if(LOG_WHISPER)
+			colored_message = "(WHISPER) [colored_message]"
+		if(LOG_OOC)
+			colored_message = "(OOC) [colored_message]"
+		if(LOG_ASAY)
+			colored_message = "(ASAY) [colored_message]"
+		if(LOG_EMOTE)
+			colored_message = "(EMOTE) [colored_message]"
+	
 	var/list/timestamped_message = list("\[[time_stamp()]\] [key_name(src)] [loc_name(src)]" = colored_message)
 
 	logging[smessage_type] += timestamped_message


### PR DESCRIPTION
## About The Pull Request

After https://github.com/tgstation/tgstation/pull/54939 I noticed some things weren't indicated as to what log type they are, and appeared visually identical to regular chat logs. This PR attempts to address that.
Not exactly the prettiest solution but this type of code is already spaghettied around a few different files and I don't feel up to a from-scratch refactor at this time.

## Why It's Good For The Game

Increases readability of logs for admins.

![logupdate](https://user-images.githubusercontent.com/51800976/99249187-4daf9c00-27cf-11eb-8e52-360013a9b0ba.png)

## Changelog
:cl:
tweak: Some things are better labeled for admin readability in player logs now.
/:cl:
