### PR TITLE
Stomach food reagents on vomit

### DIFF
--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -85,14 +85,24 @@
 	if(!nutri)
 		return
 
+	// remove the food reagent amount
+	var/nutri_vol = nutri.volume
+	var/amount_food = food_reagents[nutri.type]
+	if(amount_food)
+		nutri_vol = max(nutri_vol - amount_food, 0)
+
+	// found nutriment was stomach food reagent
+	if(!(nutri_vol > 0))
+		return
+
 	//The stomach is damage has nutriment but low on theshhold, lo prob of vomit
-	if(prob(damage * 0.025 * nutri.volume * nutri.volume))
+	if(prob(damage * 0.025 * nutri_vol * nutri_vol))
 		body.vomit(damage)
 		to_chat(body, "<span class='warning'>Your stomach reels in pain as you're incapable of holding down all that food!</span>")
 		return
 
 	// the change of vomit is now high
-	if(damage > high_threshold && prob(damage * 0.1 * nutri.volume * nutri.volume))
+	if(damage > high_threshold && prob(damage * 0.1 * nutri_vol * nutri_vol))
 		body.vomit(damage)
 		to_chat(body, "<span class='warning'>Your stomach reels in pain as you're incapable of holding down all that food!</span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Missed check for stomach food reagents in stomach vomit code causing pain.
Now vomit code checks that the reagents it has are not in the food reagents when applying damage.

fixes #55000 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Random damage was less then good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed stomach vomit damage on food reagents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
