### PR TITLE
Fixes a xenobio megafauna duplication bug

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -232,10 +232,13 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/black
 	colour = "black"
-	effect_desc = "Fully heals the target and creates a duplicate of them, that drops dead soon after."
+	effect_desc = "Fully heals the target and creates an imperfect duplicate of them made of slime, that fakes their death."
 
 /obj/item/slimecross/regenerative/black/core_effect_before(mob/living/target, mob/user)
 	var/dummytype = target.type
+	if(ismegafauna(target)) //Prevents megafauna duping in a lame way
+		dummytype = /mob/living/simple_animal/slime
+		to_chat(user, "<span class='warning'>The milky goo flows over [target], falling into a weak puddle.</span>")
 	var/mob/living/dummy = new dummytype(target.loc)
 	to_chat(target, "<span class='notice'>The milky goo flows from your skin, forming an imperfect copy of you.</span>")
 	if(iscarbon(target))
@@ -247,7 +250,7 @@ Regenerative extracts:
 	dummy.adjustBruteLoss(target.getBruteLoss())
 	dummy.adjustFireLoss(target.getFireLoss())
 	dummy.adjustToxLoss(target.getToxLoss())
-	dummy.adjustOxyLoss(200)
+	dummy.death()
 
 /obj/item/slimecross/regenerative/lightpink
 	colour = "light pink"


### PR DESCRIPTION
## About The Pull Request

Makes regenerative black extracts create a slime instead of a duplicate mega, and actually kills things instead of just dealing 200 oxy damage to them.

## Why It's Good For The Game

Prevents this
![image](https://user-images.githubusercontent.com/51932756/99349345-02da6680-2859-11eb-8af9-fdc24f7cfdd4.png)


## Changelog
:cl:
fix: Regenerative black slime extracts won't duplicate megafauna any more.
/:cl: