### PR TITLE
Scalpel can now cut pizza.

### DIFF
--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -48,6 +48,11 @@
 	tastes = list("decaying fungus" = 1)
 	foodtypes = GROSS
 
+/obj/item/food/breadslice/moldy/Initialize()
+	. = ..()
+	AddElement(/datum/element/swabable, CELL_LINE_TABLE_MOLD, CELL_VIRUS_TABLE_GENERIC, rand(2,4), 25)
+
+
 /obj/item/food/bread/meat
 	name = "meatbread loaf"
 	desc = "The culinary base of every self-respecting eloquen/tg/entleman."

--- a/code/game/objects/items/food/pizza.dm
+++ b/code/game/objects/items/food/pizza.dm
@@ -6,6 +6,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 28, /datum/reagent/consumable/nutriment/protein = 3, /datum/reagent/consumable/tomatojuice = 6, /datum/reagent/consumable/nutriment/vitamin = 5)
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1)
 	foodtypes = GRAIN | DAIRY | VEGETABLES
+	/// type is spawned 6 at a time and replaces this pizza when processed by cutting tool
 	var/obj/item/food/pizzaslice/slice_type
 
 /obj/item/food/pizza/MakeProcessable()

--- a/code/game/objects/items/food/pizza.dm
+++ b/code/game/objects/items/food/pizza.dm
@@ -1,6 +1,4 @@
-
-/////////////////////////////////////////////////PIZZA////////////////////////////////////////
-
+// Pizza (Whole)
 /obj/item/food/pizza
 	icon = 'icons/obj/food/pizzaspaghetti.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
@@ -8,7 +6,14 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 28, /datum/reagent/consumable/nutriment/protein = 3, /datum/reagent/consumable/tomatojuice = 6, /datum/reagent/consumable/nutriment/vitamin = 5)
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1)
 	foodtypes = GRAIN | DAIRY | VEGETABLES
+	var/obj/item/food/pizzaslice/slice_type
 
+/obj/item/food/pizza/MakeProcessable()
+	if (slice_type)
+		AddElement(/datum/element/processable, TOOL_KNIFE, slice_type, 6, 30)
+		AddElement(/datum/element/processable, TOOL_SCALPEL, slice_type, 6, 60)
+
+// Pizza Slice
 /obj/item/food/pizzaslice
 	icon = 'icons/obj/food/pizzaspaghetti.dmi'
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5)
@@ -18,6 +23,7 @@
 /obj/item/food/pizzaslice/MakeProcessable()
 	AddElement(/datum/element/processable, TOOL_ROLLINGPIN, /obj/item/stack/sheet/pizza, 1, 10)
 
+
 /obj/item/food/pizza/margherita
 	name = "pizza margherita"
 	desc = "The most cheezy pizza in galaxy."
@@ -26,9 +32,7 @@
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1)
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY
-
-/obj/item/food/pizza/margherita/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pizzaslice/margherita, 6, 30)
+	slice_type = /obj/item/food/pizzaslice/margherita
 
 /obj/item/food/pizza/margherita/robo
 	food_reagents = list(/datum/reagent/nanomachines = 70, /datum/reagent/consumable/nutriment = 25, /datum/reagent/consumable/nutriment/protein = 8, /datum/reagent/consumable/tomatojuice = 6, /datum/reagent/consumable/nutriment/vitamin = 5)
@@ -40,15 +44,14 @@
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY
 
+
 /obj/item/food/pizza/meat
 	name = "meatpizza"
 	desc = "Greasy pizza with delicious meat."
 	icon_state = "meatpizza"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 25, /datum/reagent/consumable/nutriment/protein = 8, /datum/reagent/consumable/tomatojuice = 6, /datum/reagent/consumable/nutriment/vitamin = 8)
 	foodtypes = GRAIN | VEGETABLES| DAIRY | MEAT
-
-/obj/item/food/pizza/meat/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pizzaslice/meat, 6, 30)
+	slice_type = /obj/item/food/pizzaslice/meat
 
 /obj/item/food/pizzaslice/meat
 	name = "meatpizza slice"
@@ -57,6 +60,7 @@
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "meat" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY | MEAT
 
+
 /obj/item/food/pizza/mushroom
 	name = "mushroom pizza"
 	desc = "Very special pizza."
@@ -64,9 +68,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 28, /datum/reagent/consumable/nutriment/protein = 3,  /datum/reagent/consumable/nutriment/vitamin = 5)
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "mushroom" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY
-
-/obj/item/food/pizza/mushroom/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pizzaslice/mushroom, 6, 30)
+	slice_type = /obj/item/food/pizzaslice/mushroom
 
 /obj/item/food/pizzaslice/mushroom
 	name = "mushroom pizza slice"
@@ -75,6 +77,7 @@
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "mushroom" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY
 
+
 /obj/item/food/pizza/vegetable
 	name = "vegetable pizza"
 	desc = "No one of Tomatos Sapiens were harmed during making this pizza."
@@ -82,9 +85,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 25, /datum/reagent/consumable/tomatojuice = 6, /datum/reagent/medicine/oculine = 12, /datum/reagent/consumable/nutriment/vitamin = 5)
 	tastes = list("crust" = 1, "tomato" = 2, "cheese" = 1, "carrot" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY
-
-/obj/item/food/pizza/vegetable/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pizzaslice/vegetable, 6, 30)
+	slice_type = /obj/item/food/pizzaslice/vegetable
 
 /obj/item/food/pizzaslice/vegetable
 	name = "vegetable pizza slice"
@@ -93,6 +94,7 @@
 	tastes = list("crust" = 1, "tomato" = 2, "cheese" = 1, "carrot" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY
 
+
 /obj/item/food/pizza/donkpocket
 	name = "donkpocket pizza"
 	desc = "Who thought this would be a good idea?"
@@ -100,9 +102,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 20, /datum/reagent/consumable/nutriment/protein = 15, /datum/reagent/consumable/tomatojuice = 6, /datum/reagent/medicine/omnizine = 10, /datum/reagent/consumable/nutriment/vitamin = 5)
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "meat" = 1, "laziness" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY | MEAT | JUNKFOOD
-
-/obj/item/food/pizza/donkpocket/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pizzaslice/donkpocket, 6, 30)
+	slice_type = /obj/item/food/pizzaslice/donkpocket
 
 /obj/item/food/pizzaslice/donkpocket
 	name = "donkpocket pizza slice"
@@ -111,6 +111,7 @@
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "meat" = 1, "laziness" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY | MEAT | JUNKFOOD
 
+
 /obj/item/food/pizza/dank
 	name = "dank pizza"
 	desc = "The hippie's pizza of choice."
@@ -118,9 +119,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 25, /datum/reagent/consumable/doctor_delight = 5, /datum/reagent/consumable/tomatojuice = 6, /datum/reagent/consumable/nutriment/vitamin = 5)
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "meat" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY
-
-/obj/item/food/pizza/dank/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pizzaslice/dank, 6, 30)
+	slice_type = /obj/item/food/pizzaslice/dank
 
 /obj/item/food/pizzaslice/dank
 	name = "dank pizza slice"
@@ -129,6 +128,7 @@
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "meat" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY
 
+
 /obj/item/food/pizza/sassysage
 	name = "sassysage pizza"
 	desc = "You can really smell the sassiness."
@@ -136,9 +136,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 20, /datum/reagent/consumable/nutriment/protein = 15, /datum/reagent/consumable/tomatojuice = 6, /datum/reagent/consumable/nutriment/vitamin = 6)
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "meat" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY
-
-/obj/item/food/pizza/sassysage/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pizzaslice/sassysage, 6, 30)
+	slice_type = /obj/item/food/pizzaslice/sassysage
 
 /obj/item/food/pizzaslice/sassysage
 	name = "sassysage pizza slice"
@@ -147,6 +145,7 @@
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "meat" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY
 
+
 /obj/item/food/pizza/pineapple
 	name = "\improper Hawaiian pizza"
 	desc = "The pizza equivalent of Einstein's riddle."
@@ -154,9 +153,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 20, /datum/reagent/consumable/nutriment/protein = 5, /datum/reagent/consumable/tomatojuice = 6, /datum/reagent/consumable/nutriment/vitamin = 6, /datum/reagent/consumable/pineapplejuice = 8)
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "pineapple" = 2, "ham" = 2)
 	foodtypes = GRAIN | VEGETABLES | DAIRY | MEAT | FRUIT | PINEAPPLE
-
-/obj/item/food/pizza/pineapple/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pizzaslice/pineapple, 6, 30)
+	slice_type = /obj/item/food/pizzaslice/pineapple
 
 /obj/item/food/pizzaslice/pineapple
 	name = "\improper Hawaiian pizza slice"
@@ -165,15 +162,30 @@
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "pineapple" = 2, "ham" = 2)
 	foodtypes = GRAIN | VEGETABLES | DAIRY | MEAT | FRUIT | PINEAPPLE
 
+
+// Moldly Pizza
+// Used in cytobiology.
+/obj/item/food/pizzaslice/moldy
+	name = "moldy pizza slice"
+	desc = "This was once a perfectly good slice of pizza pie, but now it lies here, rancid and bursting with spores. What a bummer! But we should not dwell on the past, only look towards the future."
+	icon_state = "moldy_slice"
+	food_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/peptides = 3, /datum/reagent/consumable/tomatojuice = 1, /datum/reagent/toxin/amatoxin = 2)
+	tastes = list("stale crust" = 1, "rancid cheese" = 2, "mushroom" = 1)
+	foodtypes = GRAIN | VEGETABLES | DAIRY | GROSS
+
+/obj/item/food/pizzaslice/moldy/MakeProcessable()
+	AddElement(/datum/element/swabable, CELL_LINE_TABLE_MOLD, CELL_VIRUS_TABLE_GENERIC, rand(2,4), 25)
+
+
+// Arnold Pizza
+// Has meme code.
 /obj/item/food/pizza/arnold
 	name = "\improper Arnold pizza"
 	desc = "Hello, you've reached Arnold's pizza shop. I'm not here now, I'm out killing pepperoni."
 	icon_state = "arnoldpizza"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 25, /datum/reagent/consumable/nutriment/protein = 9, /datum/reagent/consumable/nutriment/vitamin = 6, /datum/reagent/iron = 10, /datum/reagent/medicine/omnizine = 30)
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "pepperoni" = 2, "9 millimeter bullets" = 2)
-
-/obj/item/food/pizza/arnold/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/pizzaslice/arnold, 6, 30)
+	slice_type = /obj/item/food/pizzaslice/arnold
 
 //fuck it, i will leave this at the food level for now.
 /obj/item/food/proc/try_break_off(mob/living/M, mob/living/user) //maybe i give you a pizza maybe i break off your arm
@@ -219,14 +231,3 @@
 /obj/item/food/pizzaslice/arnold/attackby(obj/item/I, mob/user)
 	i_kill_you(I, user)
 	. = ..()
-
-/obj/item/food/pizzaslice/moldy
-	name = "moldy pizza slice"
-	desc = "This was once a perfectly good slice of pizza pie, but now it lies here, rancid and bursting with spores. What a bummer! But we should not dwell on the past, only look towards the future."
-	icon_state = "moldy_slice"
-	food_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/peptides = 3, /datum/reagent/consumable/tomatojuice = 1, /datum/reagent/toxin/amatoxin = 2)
-	tastes = list("stale crust" = 1, "rancid cheese" = 2, "mushroom" = 1)
-	foodtypes = GRAIN | VEGETABLES | DAIRY | GROSS
-
-/obj/item/food/pizzaslice/moldy/MakeProcessable()
-	AddElement(/datum/element/swabable, CELL_LINE_TABLE_MOLD, CELL_VIRUS_TABLE_GENERIC, rand(2,4), 25)

--- a/code/game/objects/items/food/pizza.dm
+++ b/code/game/objects/items/food/pizza.dm
@@ -174,7 +174,8 @@
 	tastes = list("stale crust" = 1, "rancid cheese" = 2, "mushroom" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY | GROSS
 
-/obj/item/food/pizzaslice/moldy/MakeProcessable()
+/obj/item/food/pizzaslice/moldy/Initialize()
+	. = ..()
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_MOLD, CELL_VIRUS_TABLE_GENERIC, rand(2,4), 25)
 
 

--- a/code/game/objects/items/food/pizza.dm
+++ b/code/game/objects/items/food/pizza.dm
@@ -11,6 +11,7 @@
 /obj/item/food/pizza/MakeProcessable()
 	if (slice_type)
 		AddElement(/datum/element/processable, TOOL_KNIFE, slice_type, 6, 30)
+		AddElement(/datum/element/processable, TOOL_SAW, slice_type, 6, 45)
 		AddElement(/datum/element/processable, TOOL_SCALPEL, slice_type, 6, 60)
 
 // Pizza Slice


### PR DESCRIPTION
## About The Pull Request
Enables scalpel tools to cut pizza. Consolidated a bunch of pizza-specific `MakeProcessable` proc defines that were just copy+pastes of each other.

## Why It's Good For The Game
You sit in medbay with your young doctor, he says he is hungry.  You agree to get him pizza. You call cargo, who brings you the box. Pizza stares at you from the table. You cannot cut it. Your palms, holding a scalpel, get sweaty, and your doctor complains. He says he is hungry. Your mind strains, searching for an answer in a world of spaghetti code. You try and ask the chef for his knife, but he has been gibbed. His knife is gone. Your doctor is hungry, he complains. The cargo delivery man stares at you, his delivery box empty, his acquisition form needing a signature. Your coworker cries tears of a pizza-less doctor. It is raining spaghetti now, you have knife embedded in your left temple and you do not understand. The doctor weeps in the corner, he is starving. Starving for the pizza.

## Changelog
:cl:
fix: Pizza can now be cut with a scalpel.
/:cl: