### PR TITLE
Makes the usage of force_threshold in the attackby() proc for simplemobs consistent with the way it's used everywhere else

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -146,7 +146,7 @@
 		return TRUE //successful attack
 
 /mob/living/simple_animal/attacked_by(obj/item/I, mob/living/user)
-	if(I.force <= force_threshold || I.damtype == STAMINA)
+	if(attack_threshold_check(I.force, I.damtype, MELEE, FALSE))
 		playsound(loc, 'sound/weapons/tap.ogg', I.get_clamped_volume(), TRUE, -1)
 	else
 		return ..()

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -146,7 +146,7 @@
 		return TRUE //successful attack
 
 /mob/living/simple_animal/attacked_by(obj/item/I, mob/living/user)
-	if(I.force < force_threshold || I.damtype == STAMINA)
+	if(I.force <= force_threshold || I.damtype == STAMINA)
 		playsound(loc, 'sound/weapons/tap.ogg', I.get_clamped_volume(), TRUE, -1)
 	else
 		return ..()

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -134,8 +134,9 @@
 	if(temp_damage >= 0 && temp_damage <= force_threshold)
 		visible_message("<span class='warning'>[src] looks unharmed!</span>")
 		return FALSE
-	else if(actuallydamage)
-		apply_damage(damage, damagetype, null, getarmor(null, armorcheck))
+	else
+		if(actuallydamage)
+			apply_damage(damage, damagetype, null, getarmor(null, armorcheck))
 		return TRUE
 
 /mob/living/simple_animal/bullet_act(obj/projectile/Proj)

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -124,7 +124,7 @@
 		return
 	return ..()
 
-/mob/living/simple_animal/proc/attack_threshold_check(damage, damagetype = BRUTE, armorcheck = MELEE)
+/mob/living/simple_animal/proc/attack_threshold_check(damage, damagetype = BRUTE, armorcheck = MELEE, actuallydamage = TRUE)
 	var/temp_damage = damage
 	if(!damage_coeff[damagetype])
 		temp_damage = 0
@@ -134,7 +134,7 @@
 	if(temp_damage >= 0 && temp_damage <= force_threshold)
 		visible_message("<span class='warning'>[src] looks unharmed!</span>")
 		return FALSE
-	else
+	else if(actuallydamage)
 		apply_damage(damage, damagetype, null, getarmor(null, armorcheck))
 		return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Namely, this means that a simplemob's immunity to melee attacks of force X or lower now accounts for that simplemobs damage multipliers to various damage types. It also means that simplemobs with a force_threshold of X are now immune to melee attacks of force X or lower, not melee attacks with a force less than X (<= vs. <).

## Why It's Good For The Game

**tldr;
This make the code for simplemob "your stick must be this strong to deal damage" thresholds more consistent.**

Xenomorphs, xenomorph larvae, barehanded monkeys, slimes, and simplemobs in general all multiply the damage of their attacks by the relevant damage resistance multiplier BEFORE checking it against the force_threshold of the simplemob they're attacking, and also check to see if their damage is <= the force_threshold of the simplemob they're attacking (instead of requiring it to be strictly < the force_threshold of the simplemob they're attacking).

As for balance concerns, while this will affect juggernauts *slightly* (as they'll now be immune to force <= 10 melee weapons instead of just force < 10 melee weapons), I'm not too worried about that. What I _am_ worried about is blobbernauts, who, after this change, will be immune to brute melee weapons of force 20 or lower (due to their 0.5 brute damage multiplier). You will, of course, still be able to welder them just as effectively as you could before, but I'm worried that this could make blob-aligned blobbernauts even stronger than they already are.

## Changelog
:cl: ATHATH
fix: The code for determining whether or not a simplemob no sells a melee attack because it uses a weapon that doesn't have a high enough force to damage it now uses a <= in its equation instead of a <, and factors in the simplemob's damage multipliers and resistances as well.
/:cl:
