### PR TITLE
Updated and expanded boot storage.

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -59,27 +59,30 @@
 	silent = TRUE
 
 /datum/component/storage/concrete/pockets/shoes/Initialize()
-	. = ..()
-	set_holdable(list(
-		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
-		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
-		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
-		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
-		/obj/item/firing_pin
-		),
-		list(/obj/item/screwdriver/power)
-		)
+    . = ..()
+    set_holdable(list(
+        /obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
+        /obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
+        /obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
+        /obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
+        /obj/item/firing_pin, /obj/item/suppressor, /obj/item/ammo_box/magazine/m9mm, /obj/item/ammo_box/magazine/m45,
+        /obj/item/ammo_casing, /obj/item/lipstick, /obj/item/clothing/mask/cigarette, /obj/item/lighter,
+        /obj/item/match, /obj/item/holochip, /obj/item/toy/crayon),
+        list(/obj/item/screwdriver/power, /obj/item/ammo_casing/caseless/rocket, /obj/item/clothing/mask/cigarette/pipe, /obj/item/toy/crayon/spraycan)
+        )
 
 /datum/component/storage/concrete/pockets/shoes/clown/Initialize()
-	. = ..()
-	set_holdable(list(
-		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
-		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
-		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
-		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
-		/obj/item/firing_pin, /obj/item/bikehorn),
-		list(/obj/item/screwdriver/power)
-		)
+    . = ..()
+    set_holdable(list(
+        /obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
+        /obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
+        /obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
+        /obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
+        /obj/item/firing_pin, /obj/item/suppressor, /obj/item/ammo_box/magazine/m9mm, /obj/item/ammo_box/magazine/m45,
+        /obj/item/ammo_casing, /obj/item/lipstick, /obj/item/clothing/mask/cigarette, /obj/item/lighter,
+        /obj/item/match, /obj/item/holochip, /obj/item/toy/crayon, /obj/item/bikehorn),
+        list(/obj/item/screwdriver/power, /obj/item/ammo_casing/caseless/rocket, /obj/item/clothing/mask/cigarette/pipe, /obj/item/toy/crayon/spraycan)
+        )
 
 /datum/component/storage/concrete/pockets/pocketprotector
 	max_items = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes several items that really aught to be storable in boots/clown shoes now able to be stashed in them. These include suppressors, 9mm/.45 magazines, shell casings/bullets, lipstick, cigars/cigarettes, lighters, matches, holochips, and crayons.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows for sneakier traitor smuggling and all around makes what boots can store more intuitive.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Made a few more items storable by boots and clown shoes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
