### PR TITLE
Machines no longer dump out their component_parts when qdel'd.

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -170,7 +170,7 @@ Class Procs:
 /obj/machinery/Destroy()
 	GLOB.machines.Remove(src)
 	end_processing()
-	dump_contents()
+	dump_inventory_contents()
 	QDEL_LIST(component_parts)
 	QDEL_NULL(circuit)
 	return ..()
@@ -735,7 +735,7 @@ Class Procs:
  *
  * Sends all AIs a message that a hack is occurring.  Specifically used for space ninja tampering as this proc was originally in the ninja files.
  * However, the proc may also be used elsewhere.
- */	
+ */
 /obj/machinery/proc/AI_notify_hack()
 	var/alertstr = "<span class='userdanger'>Network Alert: Hacking attempt detected[get_area(src)?" in [get_area_name(src, TRUE)]":". Unable to pinpoint location"].</span>"
 	for(var/mob/living/silicon/ai/AI in GLOB.player_list)

--- a/code/modules/vending/cola.dm
+++ b/code/modules/vending/cola.dm
@@ -34,6 +34,7 @@
 	name = "\improper Random Drinkies"
 	icon_state = "random_cola"
 	desc = "Uh oh!"
+	circuit = null
 
 /obj/machinery/vending/cola/random/Initialize()
 	// No need to call parent, we're not doing anything with this machine. Just picking a new type of machine to use, spawning it and deleting ourselves.

--- a/code/modules/vending/snack.dm
+++ b/code/modules/vending/snack.dm
@@ -30,6 +30,7 @@
 	name = "\improper Random Snackies"
 	icon_state = "random_snack"
 	desc = "Uh oh!"
+	circuit = null
 
 /obj/machinery/vending/snack/random/Initialize()
 	// No need to call parent, we're not doing anything with this machine. Just picking a new type of machine to use, spawning it and deleting ourselves.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #54928
Fixes #54654

Machines no longer vomit out their component parts when qdel'd and instead only vomit out their actual inventory contents.

Doing this uncovered another issue - Random vending machines will return INITIALIZE_HINT_QDEL and then attempt to qdel their circuits, which are still type paths and not initialised atoms yet (circuit was previously nulled by dump_contents, but this no longer happens in dump_inventory_contents). These circuits have been set to null appropriately.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Machines no longer vomit out component parts when they shouldn't. This includes constructed BSAs not vomiting out their component parts when built, allowing you to build more.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Nanotrasen bounty boards no longer leave behind 95% of the machine when tasked with selling one! (Special thanks to ArcaneMusic)
fix: The BSA will no longer refund all of its component parts and circuitboard when constructed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
