### PR TITLE
Fixes multiple cybernetic stomach runtimes by making them an important part of eating.

### DIFF
--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -221,6 +221,13 @@
 	var/emp_vulnerability = 80	//Chance of permanent effects if emp-ed.
 	metabolism_efficiency = 0.7 // not as good at digestion
 
+/obj/item/organ/stomach/cybernetic/Initialize()
+	. = ..()
+	// If we didn't get any reagents as part of parent proc calls, we'll create our own.
+	// This is because stomachs are now an important part of eating and even cybernetic ones need to be able to store nutriment.
+	if(!reagents)
+		create_reagents(reagent_vol)
+
 /obj/item/organ/stomach/cybernetic/tier2
 	name = "cybernetic stomach"
 	icon_state = "stomach-c-u"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/99529781-48ea1400-2998-11eb-9073-004a3b2f7fb9.png)

Stomachs are an important part of eating. (#53228, #54632)

Stomachs get their reagent containers from being an organ.

Organs get reagent containers from their edible component (WHYYYYYY).

Cybernetic organs are not edible and never get reagent containers as a result.

Cybernetic stomachs need reagent containers to digest food else they turn into massive runtime factories while their owners slowly starve to death.

Cybernetic stomachs now create their own reagent containers on `Init` if the parent proc calls didn't create one already.

Cybernetic stomachs can now hold reagents. This probably makes sense considering they have special metabolism var values set in general, including handling eating ordinarily disgusting foods better.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People don't starve to death with supposedly superior stomachs. Runtime factory fixed.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes being unable to eat when you have a cybernetic stomach by allowing them to hold reagents. Players can once again utilise the full power of cybernetic stomachs in order to not starve to death!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
