### PR TITLE
Web edit fixing "Admins can't give spiders, and xenos common"

### DIFF
--- a/code/modules/language/language_menu.dm
+++ b/code/modules/language/language_menu.dm
@@ -96,6 +96,10 @@
 					if("Both")
 						spoken = TRUE
 						understood = TRUE
+				if(language_holder.blocked_languages && language_holder.blocked_languages[language_datum])
+					choice = alert(user, "Do you want to lift the blockage that's also preventing the language to be spoken or understood?", "[language_datum]", "Yes", "No")
+					if(choice == "Yes")
+						language_holder.remove_blocked_language(language_datum, LANGUAGE_ALL)
 				language_holder.grant_language(language_datum, understood, spoken)
 				if(is_admin)
 					message_admins("[key_name_admin(user)] granted the [language_name] language to [key_name_admin(AM)].")


### PR DESCRIPTION
## About The Pull Request
See changelog.

## Why It's Good For The Game
This will close #54987, close #50204.

## Changelog
:cl:
admin: Admins now have the option to remove a language from the blocked_languages list when granting it to a mob through the language menu.
/:cl:

