### PR TITLE
Fixes PDA bombing have equal chances to work on PDAs without manifest access vs PDAs with it

### DIFF
--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -68,7 +68,7 @@
 		if(target.cartridge)
 			difficulty += BitCount(target.cartridge.access&(CART_MEDICAL | CART_SECURITY | CART_ENGINE | CART_CLOWN | CART_JANITOR | CART_MANIFEST))
 			if(target.cartridge.access & CART_MANIFEST)
-				difficulty ++ //if cartridge has manifest access it has extra snowflake difficulty
+				difficulty++ //if cartridge has manifest access it has extra snowflake difficulty
 		if(SEND_SIGNAL(target, COMSIG_PDA_CHECK_DETONATE) & COMPONENT_PDA_NO_DETONATE || prob(difficulty * 15))
 			U.show_message("<span class='danger'>An error flashes on your [src].</span>", MSG_VISUAL)
 		else

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -68,7 +68,7 @@
 		if(target.cartridge)
 			difficulty += BitCount(target.cartridge.access&(CART_MEDICAL | CART_SECURITY | CART_ENGINE | CART_CLOWN | CART_JANITOR | CART_MANIFEST))
 			if(target.cartridge.access & CART_MANIFEST)
-				difficulty++ //if cartridge has manifest access it has extra snowflake difficulty
+				difficulty += 4 //if cartridge has manifest access it has extra snowflake difficulty
 			else
 				difficulty += 2
 		if(SEND_SIGNAL(target, COMSIG_PDA_CHECK_DETONATE) & COMPONENT_PDA_NO_DETONATE || prob(difficulty * 15))

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -68,9 +68,7 @@
 		if(target.cartridge)
 			difficulty += BitCount(target.cartridge.access&(CART_MEDICAL | CART_SECURITY | CART_ENGINE | CART_CLOWN | CART_JANITOR | CART_MANIFEST))
 			if(target.cartridge.access & CART_MANIFEST)
-				difficulty += 4 //if cartridge has manifest access it has extra snowflake difficulty
-			else
-				difficulty += 2
+				difficulty ++ //if cartridge has manifest access it has extra snowflake difficulty
 		if(SEND_SIGNAL(target, COMSIG_PDA_CHECK_DETONATE) & COMPONENT_PDA_NO_DETONATE || prob(difficulty * 15))
 			U.show_message("<span class='danger'>An error flashes on your [src].</span>", MSG_VISUAL)
 		else


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so PDAs with manifest access get a +4 to it's bombing difficulty (which it was supposed to before) instead of the +2 to PDAs without it
Fixes https://github.com/tgstation/tgstation/issues/54990
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bad code bad, fix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: PDAs with manifest access now properly have more protection against PDA bombs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
