### PR TITLE
Fixes Donut Whiteship

### DIFF
--- a/_maps/shuttles/whiteship_donut.dmm
+++ b/_maps/shuttles/whiteship_donut.dmm
@@ -28,7 +28,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/stack/sheet/metal,
 /turf/open/floor/plasteel/airless,
 /area/shuttle/abandoned)
 "af" = (
@@ -129,6 +128,7 @@
 /area/shuttle/abandoned)
 "ax" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/metal,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plasteel/airless,
 /area/shuttle/abandoned)
@@ -233,6 +233,8 @@
 "aN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/cable_coil,
 /turf/open/floor/plasteel/airless,
 /area/shuttle/abandoned)
 "aO" = (
@@ -284,6 +286,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light,
 /obj/effect/spawner/lootdrop/whiteship_cere_ripley,
+/obj/item/stack/sheet/mineral/titanium/fifty,
 /turf/open/floor/mech_bay_recharge_floor,
 /area/shuttle/abandoned)
 "aV" = (
@@ -319,6 +322,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plasteel/airless,
 /area/shuttle/abandoned)
 "aZ" = (
@@ -517,6 +521,29 @@
 /obj/item/crowbar/red,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
+"HU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/metal,
+/obj/item/stack/rods,
+/turf/open/floor/plasteel/airless,
+/area/shuttle/abandoned)
+"Iu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 10
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"LL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plasteel/airless,
+/area/shuttle/abandoned)
+"Pd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
 
 (1,1,1) = {"
 aa
@@ -605,7 +632,7 @@ aa
 aa
 ac
 ac
-ag
+Iu
 al
 al
 al
@@ -631,7 +658,7 @@ aq
 al
 ai
 ap
-ao
+LL
 ab
 bg
 bl
@@ -721,7 +748,7 @@ bq
 (11,1,1) = {"
 ab
 ah
-ag
+Pd
 ak
 al
 aq
@@ -751,7 +778,7 @@ al
 aq
 ag
 ag
-ax
+HU
 ab
 bh
 bo
@@ -763,7 +790,7 @@ aa
 aa
 aa
 aa
-aq
+al
 aq
 aq
 al
@@ -783,7 +810,7 @@ aa
 aa
 aa
 aa
-aq
+al
 aq
 al
 ag
@@ -824,8 +851,8 @@ aa
 aa
 aa
 aq
-aq
-aq
+al
+al
 aw
 aB
 aE

--- a/_maps/shuttles/whiteship_donut.dmm
+++ b/_maps/shuttles/whiteship_donut.dmm
@@ -315,7 +315,6 @@
 /area/shuttle/abandoned)
 "aY" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stack/sheet/metal,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -521,28 +520,28 @@
 /obj/item/crowbar/red,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
-"HU" = (
+"wg" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stack/sheet/metal,
-/obj/item/stack/rods,
-/turf/open/floor/plasteel/airless,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
-"Iu" = (
+"Cf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/mineral/uranium{
 	amount = 10
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
-"LL" = (
+"Fz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/metal,
+/obj/item/stack/rods,
+/turf/open/floor/plasteel/airless,
+/area/shuttle/abandoned)
+"HO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plasteel/airless,
-/area/shuttle/abandoned)
-"Pd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
 
 (1,1,1) = {"
@@ -632,7 +631,7 @@ aa
 aa
 ac
 ac
-Iu
+Cf
 al
 al
 al
@@ -658,7 +657,7 @@ aq
 al
 ai
 ap
-LL
+HO
 ab
 bg
 bl
@@ -748,7 +747,7 @@ bq
 (11,1,1) = {"
 ab
 ah
-Pd
+wg
 ak
 al
 aq
@@ -778,7 +777,7 @@ al
 aq
 ag
 ag
-HU
+Fz
 ab
 bh
 bo


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR is made to do bare bones fixing to the donutstation whiteship so that it is actually functional. It adds a pacman and 10 uranium so that you can actually generate power, a set of titanium so you can actually repair the shuttle walls, a few lattices to denote the edges of the ship area (which was previously unclear), some cabling to wire up power, and an air canister to fill the space with oxygen once you fix the ship.

**If anyone thinks this goes too far as a fix let me know and I'll tone it back.**

## Why It's Good For The Game

Since a whiteship for the map is spawned based on the pool of whiteships, I think it's good to make sure each of those whiteships are at least functional (albiet with a little bit of work to make them so). As it stands with the odds and complicated materials required, only people who are deliberately powergaming space exploration and very competent may gather the necessary materials beforehand, and I think the purpose of the whiteships are to find them, fix them, and take them back to the station where you can do better repairs. Newer players out exploring space won't understand what materials they'd need and will likely be frustrated and think it's their fault since every other ship is able to be flown. Also, not understanding the boundaries of the shuttle will create unintended frustration for any level of player, as work could be ruined when the shuttle changes location.

## Changelog
:cl:

fix: Makes the Donutstation Whiteship functional.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
