### PR TITLE
Fixes picked up bees, again

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -122,6 +122,7 @@
 	if(beegent?.color)
 		col = beegent.color
 
+	icon_state = "[icon_base]_base"
 	add_overlay("[icon_base]_base")
 
 	var/static/mutable_appearance/greyscale_overlay


### PR DESCRIPTION
## About The Pull Request

Bees don't actually have a set icon state, their entire existence is their mutable appearance. This creates problems when something checks for the bee's icon state, like `mob_holder`s. So, this PR sets their `icon_state` to the corresponding base bee icon on initialization. Visually identical to before, because the overlays / mutable appearance covers it, but their `icon_state` is no longer null.

## Why It's Good For The Game

Bee bombs are back, again, again?

## Changelog
:cl: Melbert
fix: Fixed bees being unable to enter bags when scooped up
/:cl:
