### PR TITLE
Fixes Issues Regarding Finding Spider and Swarmer Spawns

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -91,11 +91,16 @@
 	pixel_y = base_pixel_y + rand(3,-3)
 	START_PROCESSING(SSobj, src)
 	. = ..()
+	GLOB.poi_list |= src
+
+/obj/structure/spider/eggcluster/Destroy()
+	. = ..()
+	GLOB.poi_list.Remove(src)
 
 /obj/structure/spider/eggcluster/process(delta_time)
 	amount_grown += rand(0,1) * delta_time
 	if(amount_grown >= 100 && !ghost_ready)
-		notify_ghosts("[src] is ready to hatch!", null, enter_link="<a href=?src=[REF(src)];activate=1>(Click to play)</a>", source=src, action=NOTIFY_ATTACK, ignore_key = POLL_IGNORE_SPIDER)
+		notify_ghosts("[src] is ready to hatch!", null, enter_link="<a href=?src=[REF(src)];activate=1>(Click to play)</a>", source=src, action=NOTIFY_ORBIT, ignore_key = POLL_IGNORE_SPIDER)
 		ghost_ready = TRUE
 
 /obj/structure/spider/eggcluster/attack_ghost(mob/user)
@@ -163,7 +168,7 @@
 	var/list/faction = list("spiders")
 
 /obj/structure/spider/spiderling/Destroy()
-	new/obj/item/food/spiderling(get_turf(src))
+	new/obj/item/reagent_containers/food/snacks/spiderling(get_turf(src))
 	. = ..()
 
 /obj/structure/spider/spiderling/Initialize()

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -168,7 +168,7 @@
 	var/list/faction = list("spiders")
 
 /obj/structure/spider/spiderling/Destroy()
-	new/obj/item/reagent_containers/food/snacks/spiderling(get_turf(src))
+	new/obj/item/food/spiderling(get_turf(src))
 	. = ..()
 
 /obj/structure/spider/spiderling/Initialize()

--- a/code/modules/swarmers/swarmer_objs.dm
+++ b/code/modules/swarmers/swarmer_objs.dm
@@ -54,6 +54,14 @@
 	///Whether or not a swarmer is currently being created by this beacon
 	var/processing_swarmer = FALSE
 
+/obj/structure/swarmer_beacon/Initialize()
+	. = ..()
+	GLOB.poi_list |= src
+
+/obj/structure/swarmer_beacon/Destroy()
+	. = ..()
+	GLOB.poi_list.Remove(src)
+
 /obj/structure/swarmer_beacon/attack_ghost(mob/user)
 	. = ..()
 	if(processing_swarmer)


### PR DESCRIPTION
## About The Pull Request

This PR fixes the issue where people couldn't teleport to spider egg clusters using the notification.

It also adds both the swarmer beacon and spider egg clusters to the ghost orbit menu.  While this is technically a feature, its extremely minor and I've been given permission by Potato/Lemon to PR it.  This should make it easier to find instances of both in cases where a player might miss the initial notification.

## Why It's Good For The Game

Being able to find spawners for swarmers/spiders shouldn't be an arduous process like it is currently.  This PR seeks to resolves the current issues.

## Changelog
:cl:
add: You can now find swarmer beacons and spider egg clusters using the ghost orbit menu.
fix: Fixed being unable to teleport to spider egg clusters using the pop-up notification.
/:cl: