### PR TITLE
improves away missions and load times

### DIFF
--- a/_maps/RandomZLevels/Academy.dmm
+++ b/_maps/RandomZLevels/Academy.dmm
@@ -1111,7 +1111,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/academy)
 "eA" = (
 /obj/machinery/door/airlock/public/glass,
@@ -1188,7 +1188,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/academy)
 "eK" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -1331,7 +1331,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/academy)
 "fc" = (
 /obj/structure/window/reinforced,
@@ -2660,12 +2660,6 @@
 /obj/machinery/light,
 /turf/open/floor/carpet,
 /area/awaymission/academy/academygate)
-"kw" = (
-/turf/closed/indestructible/fakeglass{
-	dir = 8;
-	icon_state = "fakewindows"
-	},
-/area/awaymission/academy/headmaster)
 "kx" = (
 /turf/open/floor/carpet/lone,
 /area/awaymission/academy/academygate)
@@ -2713,12 +2707,6 @@
 /mob/living/simple_animal/hostile/wizard,
 /turf/open/floor/plasteel,
 /area/awaymission/academy/academyaft)
-"kF" = (
-/turf/closed/indestructible/fakeglass{
-	dir = 8;
-	icon_state = "fakewindows2"
-	},
-/area/awaymission/academy/headmaster)
 "kG" = (
 /mob/living/simple_animal/hostile/wizard,
 /turf/open/floor/plasteel/cafeteria,
@@ -3242,12 +3230,6 @@
 /obj/item/clothing/gloves/combat,
 /turf/open/floor/plating/asteroid/snow,
 /area/awaymission/academy/academycellar)
-"mW" = (
-/turf/closed/indestructible/fakeglass{
-	dir = 4;
-	icon_state = "fakewindows"
-	},
-/area/awaymission/academy/headmaster)
 "mX" = (
 /obj/item/clothing/under/syndicate,
 /obj/effect/decal/cleanable/blood/old,
@@ -3256,18 +3238,6 @@
 "mY" = (
 /turf/closed/mineral/random,
 /area/space/nearstation)
-"mZ" = (
-/turf/closed/indestructible/fakeglass{
-	dir = 1;
-	icon_state = "fakewindows"
-	},
-/area/awaymission/academy/headmaster)
-"na" = (
-/turf/closed/indestructible/fakeglass{
-	dir = 1;
-	icon_state = "fakewindows2"
-	},
-/area/awaymission/academy/headmaster)
 "nb" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -3282,42 +3252,6 @@
 "nc" = (
 /turf/closed/indestructible/fakeglass,
 /area/awaymission/academy/headmaster)
-"nd" = (
-/turf/closed/indestructible/fakeglass{
-	dir = 1;
-	icon_state = "fakewindows"
-	},
-/area/awaymission/academy/academyengine)
-"ne" = (
-/turf/closed/indestructible/fakeglass{
-	dir = 1;
-	icon_state = "fakewindows2"
-	},
-/area/awaymission/academy/academyengine)
-"nf" = (
-/turf/closed/indestructible/fakeglass{
-	dir = 6;
-	icon_state = "fakewindows2"
-	},
-/area/awaymission/academy/headmaster)
-"ng" = (
-/turf/closed/indestructible/fakeglass{
-	dir = 8;
-	icon_state = "fakewindows"
-	},
-/area/awaymission/academy/academyengine)
-"nh" = (
-/turf/closed/indestructible/fakeglass{
-	dir = 8;
-	icon_state = "fakewindows2"
-	},
-/area/awaymission/academy/academyengine)
-"ni" = (
-/turf/closed/indestructible/fakeglass{
-	dir = 4;
-	icon_state = "fakewindows"
-	},
-/area/awaymission/academy/academyengine)
 "nj" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/drinks/bottle/wine,
@@ -11355,12 +11289,12 @@ aa
 aa
 aa
 ab
-mZ
-na
-na
-na
-na
-na
+nc
+nc
+nc
+nc
+nc
+nc
 nc
 ab
 aP
@@ -11496,10 +11430,10 @@ ab
 ab
 ab
 ab
-nf
+nc
 ab
 ab
-nf
+nc
 ab
 ab
 ab
@@ -11742,7 +11676,7 @@ aa
 aa
 aa
 aa
-kw
+nc
 ad
 ah
 ah
@@ -11872,7 +11806,7 @@ aa
 aa
 aa
 aa
-kF
+nc
 ae
 ai
 ah
@@ -12002,7 +11936,7 @@ aa
 aa
 aa
 aa
-kF
+nc
 af
 ah
 ah
@@ -12132,7 +12066,7 @@ aa
 aa
 aa
 aa
-kF
+nc
 ae
 ah
 al
@@ -12262,7 +12196,7 @@ aa
 aa
 aa
 aa
-kF
+nc
 ae
 ah
 am
@@ -12392,7 +12326,7 @@ aa
 aa
 aa
 aa
-kF
+nc
 ag
 ai
 al
@@ -12522,7 +12456,7 @@ aa
 aa
 aa
 aa
-kF
+nc
 ae
 ah
 al
@@ -12652,7 +12586,7 @@ aa
 aa
 aa
 aa
-mW
+nc
 ah
 ah
 al
@@ -12926,10 +12860,10 @@ ab
 ab
 ab
 ab
-nf
+nc
 ab
 ab
-nf
+nc
 ab
 ab
 ab
@@ -13045,12 +12979,12 @@ aa
 aa
 aa
 ab
-mZ
-na
-na
-na
-na
-na
+nc
+nc
+nc
+nc
+nc
+nc
 nc
 ab
 aP
@@ -17294,7 +17228,7 @@ mu
 mu
 mu
 mu
-ng
+lF
 aa
 aa
 aa
@@ -17424,7 +17358,7 @@ mu
 mu
 mA
 mu
-nh
+lF
 aa
 aa
 aa
@@ -17554,7 +17488,7 @@ mu
 my
 mz
 mM
-nh
+lF
 aa
 aa
 aa
@@ -17684,7 +17618,7 @@ mu
 mu
 mC
 mu
-nh
+lF
 aa
 aa
 aa
@@ -17814,7 +17748,7 @@ mu
 mu
 mB
 mu
-nh
+lF
 aa
 aa
 aa
@@ -17944,7 +17878,7 @@ mu
 mu
 mu
 mu
-ni
+lF
 aa
 aa
 aa
@@ -19032,8 +18966,8 @@ ll
 ll
 ll
 ll
-nd
-ne
+lF
+lF
 lF
 ll
 aG

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -324,8 +324,13 @@
 /area/awaymission/caves/bmp_asteroid/level_three)
 "aX" = (
 /obj/effect/bump_teleporter{
-	id = "minedeepdown";
-	id_target = "minedeepup"
+	icon = 'icons/obj/doors/airlocks/station/overlays.dmi';
+	icon_state = "unres_w";
+	id = "minedeepup";
+	id_target = "minedeepdown";
+	invisibility = 0;
+	mouse_opacity = 0;
+	name = "light of the tunnel"
 	},
 /turf/open/floor/plating{
 	initial_gas_mix = "n2=23;o2=14"
@@ -583,8 +588,13 @@
 /area/awaymission/caves/bmp_asteroid/level_two)
 "bU" = (
 /obj/effect/bump_teleporter{
+	icon = 'icons/obj/doors/airlocks/station/overlays.dmi';
+	icon_state = "unres_w";
 	id = "minedeepdown";
-	id_target = "minedeepup"
+	id_target = "minedeepup";
+	invisibility = 0;
+	mouse_opacity = 0;
+	name = "light of the tunnel"
 	},
 /turf/open/floor/plating{
 	initial_gas_mix = "n2=23;o2=14"
@@ -1016,8 +1026,13 @@
 /area/awaymission/caves/research)
 "dg" = (
 /obj/effect/bump_teleporter{
+	icon = 'icons/obj/doors/airlocks/station/overlays.dmi';
+	icon_state = "unres_e";
 	id = "mineintrodown";
-	id_target = "mineintroup"
+	id_target = "mineintroup";
+	invisibility = 0;
+	mouse_opacity = 0;
+	name = "light of the tunnel"
 	},
 /turf/open/floor/plating{
 	initial_gas_mix = "n2=23;o2=14"
@@ -1693,8 +1708,13 @@
 /area/awaymission/caves/bmp_asteroid/level_two)
 "fx" = (
 /obj/effect/bump_teleporter{
+	icon = 'icons/obj/doors/airlocks/station/overlays.dmi';
+	icon_state = "unres_e";
 	id = "mineintroup";
-	id_target = "mineintrodown"
+	id_target = "mineintrodown";
+	invisibility = 0;
+	mouse_opacity = 0;
+	name = "light of the tunnel"
 	},
 /turf/open/floor/plating{
 	initial_gas_mix = "n2=23;o2=14"
@@ -2164,6 +2184,17 @@
 /obj/effect/baseturf_helper/asteroid/basalt,
 /turf/closed/wall,
 /area/awaymission/caves/northblock)
+"lO" = (
+/turf/open/floor/plating/asteroid/basalt/airless,
+/area/awaymission/caves/bmp_asteroid/level_two)
+"OX" = (
+/turf/closed/indestructible/oldshuttle{
+	desc = "Go through.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "black";
+	name = "the other side"
+	},
+/area/space/nearstation)
 
 (1,1,1) = {"
 aa
@@ -3912,10 +3943,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+OX
+OX
+OX
+OX
 aa
 aa
 aa
@@ -5594,11 +5625,11 @@ aa
 aa
 aa
 ab
-bJ
+lO
 ab
-bJ
+lO
 ab
-bJ
+lO
 ab
 ab
 ab
@@ -5851,11 +5882,11 @@ aa
 aa
 aa
 ab
-bJ
+lO
 ab
-bJ
+lO
 ab
-bJ
+lO
 ab
 ab
 ab
@@ -5916,10 +5947,10 @@ ab
 ab
 ab
 ab
-bJ
+lO
 ab
 ab
-bJ
+lO
 ab
 ab
 aa
@@ -6109,11 +6140,9 @@ aa
 aa
 ab
 ab
-bJ
+lO
 ab
-bJ
-ab
-ab
+lO
 ab
 ab
 ab
@@ -6172,11 +6201,13 @@ ab
 ab
 ab
 ab
-bJ
-bJ
-bJ
-bJ
-bJ
+ab
+ab
+lO
+lO
+lO
+lO
+lO
 ab
 ab
 aa
@@ -6433,7 +6464,7 @@ ab
 ab
 ab
 ab
-bJ
+lO
 ab
 ab
 aa
@@ -6622,11 +6653,11 @@ aa
 aa
 aa
 ab
-bJ
-bJ
-bJ
-bJ
-bJ
+lO
+lO
+lO
+lO
+lO
 ab
 ab
 ab
@@ -6687,7 +6718,7 @@ ab
 ab
 ab
 ab
-bJ
+lO
 ab
 ab
 ab
@@ -6879,9 +6910,9 @@ aa
 aa
 aa
 ab
-bJ
+lO
 ab
-bJ
+lO
 ab
 ab
 ab
@@ -6943,11 +6974,11 @@ ab
 ab
 ab
 ab
-bJ
+lO
 ab
-bJ
+lO
 ab
-bJ
+lO
 ab
 ab
 aa
@@ -7137,12 +7168,10 @@ aa
 aa
 ab
 ab
-bJ
+lO
 ab
-bJ
-bJ
-ab
-ab
+lO
+lO
 ab
 ab
 ab
@@ -7200,11 +7229,13 @@ ab
 ab
 ab
 ab
-bJ
 ab
-bJ
 ab
-bJ
+lO
+ab
+lO
+ab
+lO
 ab
 ab
 aa
@@ -7460,7 +7491,7 @@ ab
 ab
 ab
 ab
-bJ
+lO
 ab
 ab
 ab
@@ -7650,11 +7681,11 @@ aa
 aa
 aa
 ab
-bJ
-bJ
-bJ
-bJ
-bJ
+lO
+lO
+lO
+lO
+lO
 ab
 ab
 ab
@@ -7907,15 +7938,11 @@ aa
 aa
 aa
 ab
-bJ
+lO
 ab
 ab
 ab
-bJ
-ab
-ab
-ab
-ab
+lO
 ab
 ab
 ab
@@ -7971,7 +7998,11 @@ ab
 ab
 ab
 ab
-bJ
+ab
+ab
+ab
+ab
+lO
 ab
 ab
 ab
@@ -8165,9 +8196,9 @@ aa
 aa
 ab
 ab
-bJ
-bJ
-bJ
+lO
+lO
+lO
 ab
 ab
 ab
@@ -8228,11 +8259,11 @@ ab
 ab
 ab
 ab
-bJ
-bJ
-bJ
-bJ
-bJ
+lO
+lO
+lO
+lO
+lO
 ab
 ab
 aa
@@ -8485,7 +8516,7 @@ ab
 ab
 ab
 ab
-bJ
+lO
 ab
 ab
 ab
@@ -20718,10 +20749,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+OX
+OX
+OX
+OX
 aa
 aa
 aa
@@ -51688,10 +51719,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+OX
+OX
+OX
+OX
 aa
 aa
 aa
@@ -54450,8 +54481,8 @@ aa
 aa
 aa
 ab
-bJ
-bJ
+lO
+lO
 ab
 ab
 ab
@@ -54709,7 +54740,7 @@ aa
 ab
 ab
 ab
-bJ
+lO
 ab
 ab
 ab
@@ -54964,11 +54995,11 @@ aa
 aa
 aa
 ab
-bJ
-bJ
-bJ
-bJ
-bJ
+lO
+lO
+lO
+lO
+lO
 ab
 ab
 ab
@@ -55478,7 +55509,7 @@ aa
 aa
 aa
 ab
-bJ
+lO
 ab
 ab
 ab
@@ -55735,11 +55766,11 @@ aa
 aa
 aa
 ab
-bJ
-bJ
-bJ
-bJ
-bJ
+lO
+lO
+lO
+lO
+lO
 ab
 ab
 ab
@@ -55773,11 +55804,11 @@ ab
 ab
 ab
 ab
-bJ
+lO
 ab
 ab
-bJ
-bJ
+lO
+lO
 ab
 aa
 aa
@@ -55992,7 +56023,7 @@ aa
 aa
 aa
 ab
-bJ
+lO
 ab
 ab
 ab
@@ -56030,11 +56061,11 @@ ab
 ab
 ab
 ab
-bJ
+lO
 ab
-bJ
+lO
 ab
-bJ
+lO
 ab
 aa
 aa
@@ -56288,10 +56319,10 @@ ab
 ab
 ab
 ab
-bJ
+lO
 ab
 ab
-bJ
+lO
 ab
 aa
 aa
@@ -56506,11 +56537,11 @@ aa
 aa
 aa
 ab
-bJ
-bJ
-bJ
-bJ
-bJ
+lO
+lO
+lO
+lO
+lO
 ab
 ab
 ab
@@ -56765,7 +56796,7 @@ aa
 ab
 ab
 ab
-bJ
+lO
 ab
 ab
 ab
@@ -56801,11 +56832,11 @@ ab
 ab
 ab
 ab
-bJ
-bJ
-bJ
-bJ
-bJ
+lO
+lO
+lO
+lO
+lO
 ab
 aa
 aa
@@ -57020,11 +57051,11 @@ aa
 aa
 aa
 ab
-bJ
-bJ
-bJ
-bJ
-bJ
+lO
+lO
+lO
+lO
+lO
 ab
 ab
 ab
@@ -57059,7 +57090,7 @@ ab
 ab
 ab
 ab
-bJ
+lO
 ab
 ab
 ab
@@ -57317,9 +57348,9 @@ ab
 ab
 ab
 ab
-bJ
-bJ
-bJ
+lO
+lO
+lO
 ab
 aa
 aa
@@ -57829,11 +57860,11 @@ ab
 ab
 ab
 ab
-bJ
-bJ
-bJ
-bJ
-bJ
+lO
+lO
+lO
+lO
+lO
 ab
 aa
 aa
@@ -58086,11 +58117,11 @@ ab
 ab
 ab
 ab
-bJ
+lO
 ab
 ab
 ab
-bJ
+lO
 ab
 aa
 aa
@@ -58344,9 +58375,9 @@ ab
 ab
 ab
 ab
-bJ
-bJ
-bJ
+lO
+lO
+lO
 ab
 ab
 aa
@@ -66068,10 +66099,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+OX
+OX
+OX
+OX
 aa
 aa
 aa

--- a/_maps/RandomZLevels/challenge.dmm
+++ b/_maps/RandomZLevels/challenge.dmm
@@ -12,7 +12,7 @@
 /turf/open/floor/plating/airless,
 /area/awaymission/challenge/start)
 "ad" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/start)
 "ae" = (
 /turf/open/floor/plasteel/airless{
@@ -79,7 +79,7 @@
 /area/awaymission/challenge/start)
 "aq" = (
 /obj/item/stack/rods,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/airless,
 /area/awaymission/challenge/start)
 "ar" = (
 /obj/effect/decal/cleanable/oil,
@@ -90,10 +90,6 @@
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged2"
 	},
-/area/awaymission/challenge/start)
-"at" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
 /area/awaymission/challenge/start)
 "au" = (
 /turf/closed/wall,
@@ -113,7 +109,7 @@
 "ax" = (
 /obj/effect/decal/cleanable/oil,
 /mob/living/simple_animal/hostile/syndicate,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/start)
 "ay" = (
 /obj/effect/decal/cleanable/blood,
@@ -133,10 +129,7 @@
 /area/awaymission/challenge/main)
 "aB" = (
 /obj/structure/girder,
-/turf/open/floor/plating,
-/area/awaymission/challenge/main)
-"aC" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "aD" = (
 /turf/open/floor/plasteel/airless{
@@ -201,7 +194,7 @@
 /area/awaymission/challenge/main)
 "aR" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/airless,
 /area/awaymission/challenge/main)
 "aS" = (
 /obj/machinery/power/emitter/ctf{
@@ -257,7 +250,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/airless,
 /area/awaymission/challenge/main)
 "bb" = (
 /obj/item/multitool,
@@ -277,7 +270,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "be" = (
 /obj/structure/window/reinforced{
@@ -286,7 +279,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "bf" = (
 /obj/machinery/power/emitter/ctf{
@@ -298,7 +291,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "bg" = (
 /obj/structure/window/reinforced{
@@ -310,10 +303,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plating,
-/area/awaymission/challenge/main)
-"bh" = (
-/turf/open/floor/plasteel,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "bi" = (
 /obj/machinery/power/emitter/ctf{
@@ -325,18 +315,18 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "bj" = (
 /obj/machinery/light,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "bk" = (
 /obj/machinery/power/emitter/ctf{
 	dir = 1
 	},
 /obj/machinery/light,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "bl" = (
 /obj/structure/window/reinforced{
@@ -348,7 +338,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "bm" = (
 /obj/machinery/door/window,
@@ -365,21 +355,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "bp" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/awaymission/challenge/main)
-"bq" = (
-/obj/machinery/porta_turret{
-	dir = 8;
-	installation = /obj/item/gun/energy/lasercannon;
-	set_obj_flags = "EMAGGED"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "br" = (
 /obj/structure/window/reinforced{
@@ -388,7 +370,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "bs" = (
 /obj/structure/window/reinforced{
@@ -409,12 +391,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "bv" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "bw" = (
 /obj/structure/window/reinforced{
@@ -424,7 +406,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/awaymission/challenge/main)
 "bx" = (
 /obj/machinery/power/emitter/ctf{
@@ -440,14 +422,14 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/airless,
 /area/awaymission/challenge/main)
 "bz" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/airless,
 /area/awaymission/challenge/main)
 "bA" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
@@ -458,7 +440,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/airless,
 /area/awaymission/challenge/main)
 "bC" = (
 /obj/structure/window/reinforced{
@@ -483,14 +465,19 @@
 /turf/open/floor/plasteel/airless,
 /area/awaymission/challenge/main)
 "bF" = (
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/white/corner{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/awaymission/challenge/main)
 "bG" = (
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel/white/side{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/awaymission/challenge/main)
 "bH" = (
 /turf/open/floor/plasteel/white/corner{
-	dir = 8
+	dir = 8;
+	initial_gas_mix = "TEMP=2.7"
 	},
 /area/awaymission/challenge/main)
 "bI" = (
@@ -557,7 +544,9 @@
 /area/awaymission/challenge/end)
 "bQ" = (
 /obj/item/gun/ballistic/revolver/russian,
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel/white/side{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/awaymission/challenge/main)
 "bR" = (
 /obj/structure/table/reinforced,
@@ -588,7 +577,9 @@
 /area/awaymission/challenge/main)
 "bU" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/awaymission/challenge/main)
 "bV" = (
 /obj/structure/window/reinforced{
@@ -655,7 +646,17 @@
 	name = "Airlock";
 	req_access_txt = "109"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
 /area/awaymission/challenge/end)
 "cg" = (
 /obj/item/radio/intercom{
@@ -27346,7 +27347,7 @@ aH
 aH
 aH
 aH
-bh
+aH
 aJ
 aH
 aH
@@ -28117,7 +28118,7 @@ ba
 aH
 aH
 aH
-bh
+aH
 bm
 aH
 aH
@@ -28619,7 +28620,7 @@ ad
 aw
 av
 aB
-aC
+aF
 aJ
 aR
 aH
@@ -28872,10 +28873,10 @@ af
 al
 ah
 af
-at
+ac
 af
 an
-aC
+aF
 aG
 aK
 aR
@@ -28888,9 +28889,9 @@ aH
 aH
 aH
 bf
-aC
+aF
 bn
-bq
+aX
 bv
 aH
 aH
@@ -29133,7 +29134,7 @@ au
 af
 ay
 aD
-aC
+aF
 aL
 aR
 aH
@@ -29145,9 +29146,9 @@ aH
 aH
 aH
 be
-aC
+aF
 bn
-bq
+aX
 bv
 aH
 aH
@@ -29386,7 +29387,7 @@ ah
 al
 ah
 aq
-at
+ac
 an
 az
 aE
@@ -29916,7 +29917,7 @@ ba
 aH
 aH
 aH
-bh
+aH
 bm
 aH
 aH
@@ -30687,7 +30688,7 @@ aH
 aH
 aH
 aH
-bh
+aH
 aM
 aH
 aH

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -1630,12 +1630,8 @@
 /obj/structure/closet/secure_closet/personal/cabinet{
 	req_access_txt = "150"
 	},
-/obj/item/ammo_box/magazine/m9mm{
-	icon_state = "9x19p-8"
-	},
-/obj/item/ammo_box/magazine/m9mm{
-	icon_state = "9x19p-8"
-	},
+/obj/item/ammo_box/magazine/m9mm,
+/obj/item/ammo_box/magazine/m9mm,
 /obj/item/suppressor,
 /turf/open/floor/wood{
 	heat_capacity = 1e+006;
@@ -1830,7 +1826,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/syndicate)
 "dJ" = (
 /obj/item/storage/bag/ore,
@@ -1851,11 +1851,19 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/syndicate)
 "dM" = (
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/main)
 "dN" = (
 /obj/item/stack/ore/iron{
@@ -4693,9 +4701,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "kb" = (
-/obj/machinery/door/firedoor/closed{
-	opacity = 0
-	},
+/obj/machinery/door/firedoor/closed,
 /obj/structure/cable,
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -4774,9 +4780,7 @@
 /area/awaymission/moonoutpost19/arrivals)
 "kj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/closed{
-	opacity = 0
-	},
+/obj/machinery/door/firedoor/closed,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plasteel{
@@ -4930,9 +4934,7 @@
 /area/awaymission/moonoutpost19/arrivals)
 "kA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/closed{
-	opacity = 0
-	},
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
@@ -4992,9 +4994,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "kH" = (
-/obj/machinery/door/firedoor/closed{
-	opacity = 0
-	},
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
@@ -5090,18 +5090,14 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "kR" = (
-/obj/machinery/door/firedoor/closed{
-	opacity = 0
-	},
+/obj/machinery/door/firedoor/closed,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "kS" = (
-/obj/machinery/door/firedoor/closed{
-	opacity = 0
-	},
+/obj/machinery/door/firedoor/closed,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -6191,7 +6187,11 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 6
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/arrivals)
 "nw" = (
 /obj/machinery/washing_machine,
@@ -6486,7 +6486,11 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 10
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/arrivals)
 "nX" = (
 /obj/structure/chair/comfy/black{
@@ -6519,7 +6523,11 @@
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/main)
 "oa" = (
 /obj/structure/chair/comfy/black,
@@ -6549,7 +6557,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/main)
 "od" = (
 /obj/item/shard{
@@ -6597,7 +6609,11 @@
 "qK" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/main)
 "rk" = (
 /obj/structure/disposalpipe/segment,
@@ -6608,14 +6624,22 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/main)
 "vJ" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 9
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/main)
 "vV" = (
 /obj/machinery/door/airlock/external,
@@ -6638,21 +6662,33 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 6
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/main)
 "Hw" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/main)
 "IW" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/main)
 "Mm" = (
 /obj/machinery/door/airlock/medical{
@@ -6675,7 +6711,11 @@
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/main)
 "VE" = (
 /obj/machinery/light/small{
@@ -6685,7 +6725,11 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 6
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/arrivals)
 "Wf" = (
 /obj/machinery/door/airlock/external,
@@ -6701,14 +6745,22 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 5
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/main)
 "Zf" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 10
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
+	temperature = 251
+	},
 /area/awaymission/moonoutpost19/main)
 
 (1,1,1) = {"

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -52720,7 +52720,7 @@ aa
 aa
 aa
 aa
-ac
+ae
 ae
 ae
 ae

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -10739,7 +10739,9 @@
 /turf/open/floor/plating/snowed,
 /area/awaymission/snowdin/outside)
 "AD" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
 /area/awaymission/snowdin/outside)
 "AE" = (
 /obj/item/pen,

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -2099,11 +2099,11 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "ev" = (
-/obj/item/clothing/under/misc/pj,
 /obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
 	req_access_txt = "201"
 	},
+/obj/item/clothing/under/misc/pj/red,
 /turf/open/floor/carpet{
 	heat_capacity = 1e+006
 	},
@@ -8176,14 +8176,10 @@
 /area/awaymission/undergroundoutpost45/engineering)
 "pE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos{
-	icon_state = "in";
 	id_tag = "UO45_air_out";
 	name = "air out"
 	},
-/turf/open/floor/engine{
-	initial_gas_mix = "n2=10580;o2=2644";
-	name = "air floor"
-	},
+/turf/open/floor/engine/air,
 /area/awaymission/undergroundoutpost45/engineering)
 "pF" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
@@ -8447,10 +8443,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=500,TEMP=80";
-	name = "Server Walkway"
-	},
+/turf/open/floor/plasteel/dark/telecomms,
 /area/awaymission/undergroundoutpost45/research)
 "qj" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -8817,10 +8810,7 @@
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=500,TEMP=80";
-	name = "Server Walkway"
-	},
+/turf/open/floor/plasteel/dark/telecomms,
 /area/awaymission/undergroundoutpost45/research)
 "qR" = (
 /obj/machinery/atmospherics/pipe/simple{
@@ -9162,7 +9152,7 @@
 	locked = 0;
 	req_access_txt = "201"
 	},
-/obj/item/clothing/under/misc/pj,
+/obj/item/clothing/under/misc/pj/blue,
 /turf/open/floor/carpet{
 	heat_capacity = 1e+006
 	},
@@ -9224,10 +9214,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "n2=500,TEMP=80";
-	name = "Server Walkway"
-	},
+/turf/open/floor/plasteel/dark/telecomms,
 /area/awaymission/undergroundoutpost45/research)
 "rA" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -13159,7 +13146,11 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 6
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	temperature = 363.9
+	},
 /area/awaymission/undergroundoutpost45/caves)
 "KE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -13170,14 +13161,22 @@
 "OF" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	temperature = 363.9
+	},
 /area/awaymission/undergroundoutpost45/caves)
 "UM" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 10
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	temperature = 363.9
+	},
 /area/awaymission/undergroundoutpost45/caves)
 
 (1,1,1) = {"

--- a/_maps/RandomZLevels/wildwest.dmm
+++ b/_maps/RandomZLevels/wildwest.dmm
@@ -51,7 +51,9 @@
 /turf/open/floor/circuit/off,
 /area/awaymission/wildwest/vault)
 "an" = (
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/awaymission/wildwest/vault)
 "ao" = (
 /turf/open/floor/circuit/green/off,
@@ -128,7 +130,9 @@
 /area/awaymission/wildwest/vault)
 "aL" = (
 /obj/item/paper/fluff/awaymissions/wildwest/grinder,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/awaymission/wildwest/vault)
 "aM" = (
 /turf/closed/mineral/silver,
@@ -138,7 +142,9 @@
 /area/awaymission/wildwest/mines)
 "aO" = (
 /obj/effect/mob_spawn/human/corpse/syndicatecommando,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/awaymission/wildwest/vault)
 "aP" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -150,14 +156,10 @@
 /area/awaymission/wildwest/mines)
 "aR" = (
 /obj/structure/ore_box,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "aT" = (
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "aV" = (
 /turf/closed/mineral,
@@ -167,22 +169,16 @@
 /area/awaymission/wildwest/refine)
 "aY" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "aZ" = (
 /obj/effect/mine/sound/bwoink,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "ba" = (
 /obj/effect/mine/sound/bwoink,
 /obj/item/ammo_box/c10mm,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "bb" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -194,15 +190,11 @@
 /area/awaymission/wildwest/refine)
 "be" = (
 /obj/item/ammo_box/c10mm,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "bf" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/smg,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "bg" = (
 /turf/closed/wall/mineral/sandstone,
@@ -214,9 +206,7 @@
 "bi" = (
 /obj/effect/mob_spawn/human/miner/rig,
 /obj/effect/mine/sound/bwoink,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "bj" = (
 /turf/open/floor/wood,
@@ -382,9 +372,7 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 8
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "bR" = (
 /obj/structure/window/reinforced/tinted/frosted{
@@ -392,9 +380,7 @@
 	},
 /obj/structure/window/reinforced/tinted/frosted,
 /obj/structure/grille,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "bS" = (
 /obj/structure/window/reinforced/tinted/frosted{
@@ -405,9 +391,7 @@
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "bT" = (
 /obj/structure/window/reinforced/tinted/frosted{
@@ -448,14 +432,10 @@
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "bY" = (
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "bZ" = (
 /turf/open/floor/plating/ironsand{
@@ -472,9 +452,7 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 1
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "cb" = (
 /obj/machinery/door/window,
@@ -496,9 +474,7 @@
 	dir = 4
 	},
 /obj/structure/grille,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "cf" = (
 /obj/structure/window/reinforced/tinted/frosted{
@@ -508,9 +484,7 @@
 	dir = 8
 	},
 /obj/structure/grille,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "cg" = (
 /obj/structure/table/wood,
@@ -607,9 +581,7 @@
 "cB" = (
 /obj/effect/mine/gas/plasma,
 /obj/item/ammo_box/c10mm,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "cC" = (
 /obj/structure/table/wood,
@@ -692,9 +664,7 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted/frosted,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "cR" = (
 /obj/structure/chair/wood/wings{
@@ -711,9 +681,7 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted/frosted,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "cT" = (
 /obj/effect/decal/remains/human,
@@ -779,9 +747,7 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 1
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "dd" = (
 /obj/structure/table/wood,
@@ -815,9 +781,7 @@
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "dh" = (
 /obj/effect/mob_spawn/human/corpse/syndicatecommando{
@@ -840,16 +804,12 @@
 /area/awaymission/wildwest/mines)
 "dm" = (
 /obj/structure/mineral_door/wood,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "dn" = (
 /obj/structure/mineral_door/wood,
 /obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "do" = (
 /obj/structure/window/reinforced{
@@ -888,9 +848,7 @@
 /area/awaymission/wildwest/gov)
 "dt" = (
 /obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "du" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -903,9 +861,7 @@
 /area/awaymission/wildwest/mines)
 "dw" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "dx" = (
 /turf/open/floor/plating/ironsand{
@@ -938,9 +894,7 @@
 /area/awaymission/wildwest/gov)
 "dD" = (
 /obj/structure/mineral_door/wood,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "dE" = (
 /obj/structure/closet/crate/large,
@@ -1012,9 +966,7 @@
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "dS" = (
 /obj/structure/window/reinforced/tinted/frosted,
@@ -1022,9 +974,7 @@
 	dir = 1
 	},
 /obj/structure/grille,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "dT" = (
 /obj/structure/window/reinforced/tinted/frosted,
@@ -1035,16 +985,12 @@
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "dU" = (
 /obj/machinery/door/airlock/sandstone,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "dV" = (
 /obj/machinery/shower{
@@ -1120,17 +1066,13 @@
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "eh" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 "ei" = (
 /obj/structure/window/reinforced/tinted/frosted{
@@ -1143,9 +1085,7 @@
 /area/space/nearstation)
 "ej" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "ek" = (
 /obj/effect/mine/gas/plasma,
@@ -1263,9 +1203,7 @@
 /obj/structure/mecha_wreckage/gygax{
 	anchored = 1
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "eL" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -1458,9 +1396,7 @@
 /obj/structure/mecha_wreckage/seraph{
 	anchored = 1
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "fl" = (
 /obj/structure/mecha_wreckage/ripley/deathripley{
@@ -1498,9 +1434,7 @@
 /obj/structure/mecha_wreckage/ripley/deathripley{
 	anchored = 1
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "fu" = (
 /obj/structure/chair/comfy/beige{
@@ -1568,23 +1502,17 @@
 /area/awaymission/wildwest/refine)
 "fB" = (
 /obj/effect/mine/gas/plasma,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "fC" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "fD" = (
 /obj/structure/mecha_wreckage/mauler{
 	anchored = 1
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "fE" = (
 /obj/structure/chair/office{
@@ -1663,15 +1591,11 @@
 	anchored = 1
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "fQ" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "fR" = (
 /obj/effect/mine/sound/bwoink,
@@ -1840,9 +1764,7 @@
 /area/awaymission/wildwest/mines)
 "gx" = (
 /obj/item/gun/ballistic/shotgun,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "gy" = (
 /obj/effect/mob_spawn/human/corpse/syndicatecommando{
@@ -1948,9 +1870,7 @@
 /area/awaymission/wildwest/refine)
 "gV" = (
 /obj/effect/landmark/awaystart,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "gW" = (
 /obj/structure/table/reinforced,
@@ -1969,9 +1889,7 @@
 /area/awaymission/wildwest/refine)
 "gY" = (
 /obj/item/paper/fluff/awaymissions/wildwest/journal/page8,
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "pD" = (
 /obj/machinery/door/airlock/external,
@@ -2004,9 +1922,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/plating/ironsand{
-	icon_state = "ironsand1"
-	},
+/turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/gov)
 
 (1,1,1) = {"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

removes roundstart atmos differences from away missions i could find on a glance
fixes some items with unexisting sprites on moon outpost
makes it way more obvious that you can pass through the tunnels in bmp asteroid away mission
something else probaably i dont remember
thankies to hugbug

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
game loading faster because no atmos differences = good!!!

## Changelog
:cl:
fix: fixes active turfs on away missions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
