### PR TITLE
Fixing the point emote being both usable and unusable

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -253,7 +253,7 @@
 			else
 				message_param = "<span class='userdanger'>bumps [user.p_their()] head on the ground</span> trying to motion towards %t."
 				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
-	..()
+	return ..()
 
 /datum/emote/living/pout
 	key = "pout"


### PR DESCRIPTION
## About The Pull Request
This is not quantum physics.

## Why It's Good For The Game
This will fix #55056

## Changelog
:cl:
fix: Fixing the point emote outputting the "unusable emote" message even if actually usable.
/:cl:
