### PR TITLE
Fixes dish drives spitting out components on interact.

### DIFF
--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -26,6 +26,7 @@
 	var/time_since_dishes = 0
 	var/suction_enabled = TRUE
 	var/transmit_enabled = TRUE
+	var/list/dish_drive_contents = list()
 
 /obj/machinery/dish_drive/Initialize()
 	. = ..()
@@ -37,10 +38,11 @@
 		. += "<span class='notice'>Alt-click it to beam its contents to any nearby disposal bins.</span>"
 
 /obj/machinery/dish_drive/attack_hand(mob/living/user)
-	if(!contents.len)
+	if(!dish_drive_contents.len)
 		to_chat(user, "<span class='warning'>There's nothing in [src]!</span>")
 		return
-	var/obj/item/I = contents[contents.len] //the most recently-added item
+	var/obj/item/I = dish_drive_contents[dish_drive_contents.len] //the most recently-added item
+	dish_drive_contents -= I
 	user.put_in_hands(I)
 	to_chat(user, "<span class='notice'>You take out [I] from [src].</span>")
 	playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
@@ -50,6 +52,7 @@
 	if(is_type_in_list(I, collectable_items) && user.a_intent != INTENT_HARM)
 		if(!user.transferItemToLoc(I, src))
 			return
+		dish_drive_contents += I
 		to_chat(user, "<span class='notice'>You put [I] in [src], and it's beamed into energy!</span>")
 		playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
 		flick("synthesizer_beam", src)
@@ -88,6 +91,7 @@
 	for(var/obj/item/I in view(4, src))
 		if(is_type_in_list(I, collectable_items) && I.loc != src && (!I.reagents || !I.reagents.total_volume))
 			if(I.Adjacent(src))
+				dish_drive_contents += I
 				visible_message("<span class='notice'>[src] beams up [I]!</span>")
 				I.forceMove(src)
 				playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)

--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -41,8 +41,8 @@
 	if(!LAZYLEN(dish_drive_contents))
 		to_chat(user, "<span class='warning'>There's nothing in [src]!</span>")
 		return
-	var/obj/item/I = dish_drive_contents[dish_drive_contents.len] //the most recently-added item
-	dish_drive_contents -= I
+	var/obj/item/I = LAZYACCESS(dish_drive_contents, LAZYLEN(dish_drive_contents)) //the most recently-added item
+	LAZYREMOVE(dish_drive_contents, I)
 	user.put_in_hands(I)
 	to_chat(user, "<span class='notice'>You take out [I] from [src].</span>")
 	playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
@@ -123,7 +123,7 @@
 	var/disposed = 0
 	for(var/obj/item/I in dish_drive_contents)
 		if(is_type_in_list(I, disposable_items))
-			dish_drive_contents -= I
+			LAZYREMOVE(dish_drive_contents, I)
 			I.forceMove(bin)
 			use_power(active_power_usage)
 			disposed++

--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -26,7 +26,7 @@
 	var/time_since_dishes = 0
 	var/suction_enabled = TRUE
 	var/transmit_enabled = TRUE
-	var/list/dish_drive_contents = list()
+	var/list/dish_drive_contents
 
 /obj/machinery/dish_drive/Initialize()
 	. = ..()
@@ -38,7 +38,7 @@
 		. += "<span class='notice'>Alt-click it to beam its contents to any nearby disposal bins.</span>"
 
 /obj/machinery/dish_drive/attack_hand(mob/living/user)
-	if(!dish_drive_contents.len)
+	if(!LAZYLEN(dish_drive_contents))
 		to_chat(user, "<span class='warning'>There's nothing in [src]!</span>")
 		return
 	var/obj/item/I = dish_drive_contents[dish_drive_contents.len] //the most recently-added item
@@ -52,7 +52,7 @@
 	if(is_type_in_list(I, collectable_items) && user.a_intent != INTENT_HARM)
 		if(!user.transferItemToLoc(I, src))
 			return
-		dish_drive_contents += I
+		LAZYADD(dish_drive_contents, I)
 		to_chat(user, "<span class='notice'>You put [I] in [src], and it's beamed into energy!</span>")
 		playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
 		flick("synthesizer_beam", src)
@@ -91,7 +91,7 @@
 	for(var/obj/item/I in view(4, src))
 		if(is_type_in_list(I, collectable_items) && I.loc != src && (!I.reagents || !I.reagents.total_volume))
 			if(I.Adjacent(src))
-				dish_drive_contents += I
+				LAZYADD(dish_drive_contents, I)
 				visible_message("<span class='notice'>[src] beams up [I]!</span>")
 				I.forceMove(src)
 				playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
@@ -110,7 +110,7 @@
 		do_the_dishes(TRUE)
 
 /obj/machinery/dish_drive/proc/do_the_dishes(manual)
-	if(!dish_drive_contents.len)
+	if(!LAZYLEN(dish_drive_contents))
 		if(manual)
 			visible_message("<span class='notice'>[src] is empty!</span>")
 		return

--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -110,7 +110,9 @@
 		do_the_dishes(TRUE)
 
 /obj/machinery/dish_drive/proc/do_the_dishes(manual)
-	if(!contents.len)
+	if(!dish_drive_contents.len)
+		if(manual)
+			visible_message("<span class='notice'>[src] is empty!</span>")
 		return
 	var/obj/machinery/disposal/bin/bin = locate() in view(7, src)
 	if(!bin)
@@ -119,8 +121,9 @@
 			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
 		return
 	var/disposed = 0
-	for(var/obj/item/I in contents)
+	for(var/obj/item/I in dish_drive_contents)
 		if(is_type_in_list(I, disposable_items))
+			dish_drive_contents -= I
 			I.forceMove(bin)
 			use_power(active_power_usage)
 			disposed++
@@ -131,4 +134,6 @@
 		Beam(bin, icon_state = "rped_upgrade", time = 5)
 		bin.update_icon()
 		flick("synthesizer_beam", src)
+	else
+		visible_message("<span class='notice'>There are no disposable items in [src]!</span>")
 	time_since_dishes = world.time + 600


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #55044, fixes #54884

Dish drive should no longer spit out its components repeatedly on interact.

In addition, added some feedback for alt clicking if the dish drive contains no items or no disposable items.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Dish drive should now respect conservation of matter.

Feedback for user interactions good!

## Changelog
:cl:
fix: More robust dish drive construction no longer allows user to simply pull out components bare handed!
tweak: Updated dish drive software now lets the user know if it is empty or trying to beam non-disposable items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
