### PR TITLE
Fixing the arena shuttle not being unlockable if medals are disabled.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -418,7 +418,7 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/grant_achievement(medaltype,scoretype)
 	. = ..()
-	if(.)
+	if(!(flags_1 & ADMIN_SPAWNED_1))
 		SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_BUBBLEGUM] = TRUE
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/do_attack_animation(atom/A, visual_effect_icon, obj/item/used_item, no_effect)


### PR DESCRIPTION
## About The Pull Request
This will close #41218.

## Why It's Good For The Game
This will close #41218.

## Changelog
:cl:
fix: Fixed the arena shuttle not being unlockable if medals are disabled.
/:cl:
