### PR TITLE
Fix 'your mind won't reach that far' message when clicking moodlet with TK

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -672,6 +672,9 @@
 	icon_state = "mood5"
 	screen_loc = ui_mood
 
+/atom/movable/screen/mood/attack_tk()
+	return
+
 /atom/movable/screen/splash
 	icon = 'icons/blank_title.png'
 	icon_state = ""


### PR DESCRIPTION
## About The Pull Request
The mood `/atom/movable/screen`, instead of having a `Click()` override, instead has its `COMSIG_ATOM_CLICK` registered in the mood component. This has the side effect of normal attack chain protocol being ran on it, meaning that if you click it with TK you will get a message saying "Your mind won't reach that far". This fixes that by overriding attack_tk into a noop.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: You will no longer get a warning when checking your mood with telekinesis.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
