### PR TITLE
Fixes infinite duration Heretic Void path potions

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -370,7 +370,7 @@
 	status_type = STATUS_EFFECT_REFRESH
 	duration = 15 SECONDS
 	examine_text = "<span class='notice'>They don't seem to be all here.</span>"
-	alert_type = /obj/screen/alert/status_effect/crucible_soul
+	alert_type = /atom/movable/screen/alert/status_effect/crucible_soul
 	var/turf/location
 
 /datum/status_effect/crucible_soul/on_apply()
@@ -392,7 +392,7 @@
 	id = "Blessing of Dusk and Dawn"
 	status_type = STATUS_EFFECT_REFRESH
 	duration = 60 SECONDS
-	alert_type =/obj/screen/alert/status_effect/duskndawn
+	alert_type = /atom/movable/screen/alert/status_effect/duskndawn
 
 /datum/status_effect/duskndawn/on_apply()
 	. = ..()
@@ -409,7 +409,7 @@
 	status_type = STATUS_EFFECT_REFRESH
 	duration = 60 SECONDS
 	tick_interval = 1 SECONDS
-	alert_type = /obj/screen/alert/status_effect/marshal
+	alert_type = /atom/movable/screen/alert/status_effect/marshal
 
 /datum/status_effect/marshal/on_apply()
 	. = ..()
@@ -445,17 +445,17 @@
 				carbie.blood_volume += carbie.blood_volume >= BLOOD_VOLUME_NORMAL ? 0 : heal_amt*3
 
 
-/obj/screen/alert/status_effect/crucible_soul
+/atom/movable/screen/alert/status_effect/crucible_soul
 	name = "Blessing of Crucible Soul"
 	desc = "You phased through the reality, you are halfway to your final destination..."
 	icon_state = "crucible"
 
-/obj/screen/alert/status_effect/duskndawn
+/atom/movable/screen/alert/status_effect/duskndawn
 	name = "Blessing of Dusk and Dawn"
 	desc = "Many things hide beyond the horizon, with Owl's help i managed to slip past sun's guard and moon's watch."
 	icon_state = "duskndawn"
 
-/obj/screen/alert/status_effect/marshal
+/atom/movable/screen/alert/status_effect/marshal
 	name = "Blessing of Wounded Soldier"
 	desc = "Some people seek power through redemption, one thing many people don't know is that battle is the ultimate redemption and wounds let you bask in eternal glory."
 	icon_state = "wounded_soldier"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

While #54252 was being coded, #54403 got merged.

#54252 was never properly tested again after resolving merge conflicts. As a result, the PR used old type-paths for screen alerts.

These runtime, causing the new potions to never start processing and thus be infinite in duration. Infinite noclip is bad.

I've correctly pathed these alerts and now the potions work as intended.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Infinite noclip is bad. Infinite x-ray from a potion is also probably bad. Combining the two is definitely bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Heretic Void path potions are no longer infinite duration and will now properly expire and properly apply their effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
