### PR TITLE
Cache values in TEST_ASSERT_EQUAL and TEST_ASSERT_NOTEQUAL

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -9,11 +9,23 @@
 
 /// Asserts that the two parameters passed are equal, fails otherwise
 /// Optionally allows an additional message in the case of a failure
-#define TEST_ASSERT_EQUAL(a, b, message) if ((a) != (b)) { return Fail("Expected [isnull(a) ? "null" : a] to be equal to [isnull(b) ? "null" : b].[message ? " [message]" : ""]") }
+#define TEST_ASSERT_EQUAL(a, b, message) do { \
+	var/lhs = ##a; \
+	var/rhs = ##b; \
+	if (lhs != rhs) { \
+		return Fail("Expected [isnull(lhs) ? "null" : lhs] to be equal to [isnull(rhs) ? "null" : rhs].[message ? " [message]" : ""]"); \
+	} \
+} while (FALSE)
 
 /// Asserts that the two parameters passed are not equal, fails otherwise
 /// Optionally allows an additional message in the case of a failure
-#define TEST_ASSERT_NOTEQUAL(a, b, message) if ((a) == (b)) { return Fail("Expected [isnull(a) ? "null" : a] to not be equal to [isnull(b) ? "null" : b].[message ? " [message]" : ""]") }
+#define TEST_ASSERT_NOTEQUAL(a, b, message) do { \
+	var/lhs = ##a; \
+	var/rhs = ##b; \
+	if (lhs == rhs) { \
+		return Fail("Expected [isnull(lhs) ? "null" : lhs] to not be equal to [isnull(rhs) ? "null" : rhs].[message ? " [message]" : ""]"); \
+	} \
+} while (FALSE)
 
 /// *Only* run the test provided within the parentheses
 /// This is useful for debugging when you want to reduce noise, but should never be pushed


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Previously if a comparison assertion failed, it would re-evaluate the `a` and `b` parameters, which could lead to confusing output if the values passed are not fixed or are impure.

i.e:

```dm
/proc/count_up()
	var/static/number = 0
	number += 1
	return number

/datum/unit_test/example/Run()
	// This would give "Expected 2 to be equal to 2"
	TEST_ASSERT_EQUAL(count_up(), 2, "count_up() was not 2")
```
    