### PR TITLE
Grown objects, New food, and old food all grind equally being placed in a grinder from a bag.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -155,7 +155,7 @@
 	//Fill machine with a bag!
 	if(istype(I, /obj/item/storage/bag))
 		var/obj/item/storage/T = I
-		var/loaded = holdingitems.len
+		var/loaded = 0
 		for(var/obj/S in T.contents)
 			if(!is_type_in_typecache(S, allowed_grindables))
 				continue


### PR DESCRIPTION

## About The Pull Request

Fixes #46356. What it says on the tin, Grown objects, New food, and old food can all be moved from a tray or plant bag, and mass deposited into a reagent grinder. Anything in those 3 typepaths should all contain at least some kind of reagent content, and if not, is the sort of object to be ground down into nothing if it didn't contain any.
Also, extends newfood and /obj/item/grown parity with other food-adjacent processing tools.

## Why It's Good For The Game

Bugs bad. Improves feature parity between similar reagent-grinding mechanisms and makes processing faster with bags as expected of them.

## Changelog
:cl:
fix: "fancy" new foods and byproducts of grown foods can be mass inserted into reagent grinders as expected.
/:cl: