### PR TITLE
Hauberoach's now properly give correct feedback if you're immune to their headspike.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/cockroach.dm
+++ b/code/modules/mob/living/simple_animal/hostile/cockroach.dm
@@ -117,6 +117,8 @@
 			A.visible_message("<span class='danger'>[A] steps onto [src]'s spike!</span>", "<span class='userdanger'>You step onto [src]'s spike!</span>")
 		else if(HAS_TRAIT(A, TRAIT_PACIFISM))
 			A.visible_message("<span class='notice'>[A] carefully steps over [src].</span>", "<span class='notice'>You carefully step over [src] to avoid hurting it.</span>")
+		else if(HAS_TRAIT(A, TRAIT_PIERCEIMMUNE))
+			A.visible_message("<span class='danger'>[A] steps onto [src]'s spike, but is unfazed!</span>", "<span class='userdanger'>You step onto [src]'s spike, and are unaffected!</span>")
 		else
 			A.visible_message("<span class='notice'>[A] squashes [src], not even noticing its spike.</span>", "<span class='notice'>You squashed [src], not even noticing its spike.</span>")
 			adjustBruteLoss(1) //kills a normal cockroach

--- a/code/modules/mob/living/simple_animal/hostile/cockroach.dm
+++ b/code/modules/mob/living/simple_animal/hostile/cockroach.dm
@@ -118,7 +118,7 @@
 		else if(HAS_TRAIT(A, TRAIT_PACIFISM))
 			A.visible_message("<span class='notice'>[A] carefully steps over [src].</span>", "<span class='notice'>You carefully step over [src] to avoid hurting it.</span>")
 		else if(HAS_TRAIT(A, TRAIT_PIERCEIMMUNE))
-			A.visible_message("<span class='danger'>[A] steps onto [src]'s spike, but is unfazed!</span>", "<span class='userdanger'>You step onto [src]'s spike, and are unaffected!</span>")
+			A.visible_message("<span class='danger'>[A] steps onto [src]'s spike, but is unfazed!</span>", "<span class='userdanger'>You step onto [src]'s spike, but you're unaffected!</span>")
 		else
 			A.visible_message("<span class='notice'>[A] squashes [src], not even noticing its spike.</span>", "<span class='notice'>You squashed [src], not even noticing its spike.</span>")
 			adjustBruteLoss(1) //kills a normal cockroach


### PR DESCRIPTION

## About The Pull Request

Fixes #52925. Hauberoaches now give a different, clearer line of dialog when stepped on by a pierce immune carbon mob.

## Why It's Good For The Game

The alternative made it appear that they were being injured when they were in fact unaffected by their tiny little headpike attack.
Also, bugs begone, unless the bugs are the one's creating the bugs, because that would be a removal, you get the point.
Pun.

## Changelog
:cl:
fix: Mobs immune to cockroaches with spikey hats now properly display that they're immune to impalement of the foot.
/:cl:
