### PR TITLE
Graveyard graves now sound like they're being dug open/closed.

### DIFF
--- a/code/modules/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -119,6 +119,8 @@
 	anchored = TRUE
 	locked = TRUE
 	breakout_time = 900
+	open_sound = 'sound/effects/shovel_dig.ogg'
+	close_sound = 'sound/effects/shovel_dig.ogg'
 	cutting_tool = /obj/item/shovel
 	var/lead_tomb = FALSE
 	var/first_open = FALSE


### PR DESCRIPTION

## About The Pull Request

Woah, crates have a var for their open/close sound. What do you know. They now properly sound like a shovel when being dug open/closed.

## Why It's Good For The Game

Fixes #51346. Improves sound clarity when digging up graves and when closing them back up.

## Changelog
:cl:
fix: Dirt graves now sound like dirt being shoveled in/out when being closed up by hand.
/:cl: