### PR TITLE
Lockers, Bluespace Bodybags, and all their subtypes, now properly prevent you from access internal, sub-level boxes storages.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -151,6 +151,9 @@
 	for(var/atom/movable/AM in L)
 		if(AM != src && insert(AM) == -1) // limit reached
 			break
+	for(var/i in reverseRange(L.GetAllContents()))
+		var/atom/movable/thing = i
+		SEND_SIGNAL(thing, COMSIG_TRY_STORAGE_HIDE_ALL)
 
 /obj/structure/closet/proc/open(mob/living/user, force = FALSE)
 	if(!can_open(user, force))


### PR DESCRIPTION

## About The Pull Request

Holy shit, god I wish this was just a Bluespace Bodybag issue, but no, they're all culpable of this one.
So, If you have a backpack open as your open inventory menu, and you place that backpack in a closet, then close that closet, the menu of the backpack is closed when you close the locker. That works correctly.
If you are looking at a box inside of that backpack, however, and place the backpack into the closet, then close the closet, you keep visibility of that box until you leave the range of the locker.

This erradicates that internal physics defying inventory space management by performing a reverseRange search on all of the lockers contents, and closing any open inventories of the contents inside of the closet when closed. This directly fixes #50737, and fixes #48806.

Keep in mind, if you are inside of a locker, and you close it on yourself, it will close any open inventory menus you had open before that. But then again, having the full flexibility of any non-accessible inventories open when you're crammed into a tiny metal locker seems relatively impossible anyway.


## Why It's Good For The Game

Fixes a relatively glaring exploit between both bluespace bodybags, as well as fixes it's parent issue within lockers/crates.
Being able to reach through a solid metal wall to interact with a tiny cardboard box inside is bad.

If there's a more elegant way to do this than a reverseRange I'd love to know, but as it stands it's certainly the simplest and easiest way to reach the results we want on infinite inventory space inside of bluespace bodybags.

## Changelog
:cl:
fix: Lockers/Closets/Bodybags close all open inventories of items and internal items enclosed inside of itself. For real this time.
/:cl:
