### PR TITLE
Lowers Stasis Bed Overlay below objects to prevent overlay issues.

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -84,7 +84,7 @@
 
 	if(mattress_state)
 		if(!mattress_on || !managed_vis_overlays)
-			mattress_on = SSvis_overlays.add_vis_overlay(src, icon, mattress_state, layer, plane, dir, alpha = 0, unique = TRUE)
+			mattress_on = SSvis_overlays.add_vis_overlay(src, icon, mattress_state, BELOW_OBJ_LAYER, plane, dir, alpha = 0, unique = TRUE)
 
 		if(mattress_on.alpha ? !_running : _running) //check the inverse of _running compared to truthy alpha, to see if they differ
 			var/new_alpha = _running ? 255 : 0


### PR DESCRIPTION

## About The Pull Request

Stasis Beds overlay layer was using the default for vis_contents overlays, the issue there was that it was still high enough that things like crates or lockers could find themselves between the stasis bed itself and the overlay. This moves the overlay's layer down a bit, so now objects/items/solid structures find themselves distinct above stasis beds, while open/very low layer structures (open lockers) find themselves fully below the stasis bed.

## Why It's Good For The Game

Visual clarity go up, number of bug go down. Fixes #50218.

## Changelog
:cl:
fix: Stasis beds will now properly glow right above the bed, not inbetween structures.
/:cl:
