### PR TITLE
Fixes photo frames appearing empty

### DIFF
--- a/code/modules/photography/photos/frame.dm
+++ b/code/modules/photography/photos/frame.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/decals.dmi'
 	custom_materials = list(/datum/material/wood = 2000)
 	flags_1 = 0
-	icon_state = "frame-empty"
+	icon_state = "frame-overlay"
 	result_path = /obj/structure/sign/picture_frame
 	var/obj/item/photo/displayed
 
@@ -63,7 +63,7 @@
 	name = "picture frame"
 	desc = "Every time you look it makes you laugh."
 	icon = 'icons/obj/decals.dmi'
-	icon_state = "frame-empty"
+	icon_state = "frame-overlay"
 	custom_materials = list(/datum/material/wood = 2000)
 	var/obj/item/photo/framed
 	var/persistence_id


### PR DESCRIPTION
Fixes #51527

This icon state was unused and I can't find any reference to it in past versions, either way the photo overlay now shows up correctly

:cl:
fix: Picture frames no longer always appear empty
/:cl: