### PR TITLE
Makes it so living crate creatures can pass plastic flaps as god intended.

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -108,6 +108,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define LETPASSTHROW	(1<<6)
 #define	PASSMACHINE		(1<<7)
 #define PASSSTRUCTURE	(1<<8)
+#define PASSFLAPS		(1<<9)
 
 //Movement Types
 #define GROUND			(1<<0)

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -90,8 +90,6 @@
 
 	else if(isliving(A)) // You Shall Not Pass!
 		var/mob/living/M = A
-		if(isbot(A)) //Bots understand the secrets
-			return TRUE
 		if(M.buckled && istype(M.buckled, /mob/living/simple_animal/bot/mulebot)) // mulebot passenger gets a free pass.
 			return TRUE
 		if(M.body_position == STANDING_UP && !M.ventcrawler && M.mob_size != MOB_SIZE_TINY)	//If your not laying down, or a ventcrawler or a small creature, no pass.

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -71,7 +71,8 @@
 
 /obj/structure/plasticflaps/CanAllowThrough(atom/movable/A, turf/T)
 	. = ..()
-
+	if(A.pass_flags & PASSFLAPS) //For anything specifically engineered to cross plastic flaps.
+		return TRUE
 	if(istype(A) && (A.pass_flags & PASSGLASS))
 		return prob(60)
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -14,6 +14,7 @@
 	has_unlimited_silicon_privilege = 1
 	sentience_type = SENTIENCE_ARTIFICIAL
 	status_flags = NONE //no default canpush
+	pass_flags = PASSFLAPS
 	verb_say = "states"
 	verb_ask = "queries"
 	verb_exclaim = "declares"

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -14,6 +14,7 @@
 	health = 250
 	gender = NEUTER
 	mob_biotypes = NONE
+	pass_flags = PASSFLAPS
 
 	harm_intent_damage = 5
 	melee_damage_lower = 8


### PR DESCRIPTION

## About The Pull Request

This PR makes it so that mimics, AKA sentient crates have a flag called PASSFLAPS, so that they can cross plastic flaps, while still being large crate-like creatures. Plastic flaps allow any kind of object or structure through, however they have more or less a complicated whitelist of creatures that they let pass as well. This whitelist however forbids mimics from crossing however, despite in all ways except physical being a crate with teeth.

This also adds a can_pass flag for this to bypass flaps going forward.

## Why It's Good For The Game

Fixes #48102.

## Changelog
:cl:
fix: Living crates now properly behave like crates when faced against plastic flaps.
/:cl:
