### PR TITLE
Hygienebots de/construct and behave like the other simplebots.

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -229,6 +229,16 @@
 	time = 40
 	category = CAT_ROBOT
 
+/datum/crafting_recipe/hygienebot
+	name = "Hygienebot"
+	result = /mob/living/simple_animal/bot/hygienebot
+	reqs = list(/obj/item/bot_assembly/hygienebot = 1,
+				/obj/item/stack/ducts = 1,
+				/obj/item/assembly/prox_sensor = 1)
+	tools = list(TOOL_WELDER)
+	time = 40
+	category = CAT_ROBOT
+
 /datum/crafting_recipe/improvised_pneumatic_cannon //Pretty easy to obtain but
 	name = "Pneumatic Cannon"
 	result = /obj/item/pneumatic_cannon/ghetto

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -470,26 +470,37 @@
 
 /obj/item/bot_assembly/hygienebot/attackby(obj/item/I, mob/user, params)
 	. = ..()
+	var/atom/Tsec = drop_location()
 	switch(build_step)
 		if(ASSEMBLY_FIRST_STEP)
-			if(I.tool_behaviour == TOOL_WELDER)
+			if(I.tool_behaviour == TOOL_WELDER) //Construct
 				if(I.use_tool(src, user, 0, volume=40))
 					to_chat(user, "<span class='notice'>You weld a water hole in [src]!</span>")
 					build_step++
 					return
+			if(I.tool_behaviour == TOOL_WRENCH) //Deconstruct
+				if(I.use_tool(src, user, 0, volume=40))
+					new /obj/item/stack/sheet/metal(Tsec, 2)
+					to_chat(user, "<span class='notice'>You disconnect the hygienebot assembly.</span>")
+					qdel(src)
 
 		if(ASSEMBLY_SECOND_STEP)
-			if(isprox(I))
+			if(isprox(I)) //Construct
 				if(!user.temporarilyRemoveItemFromInventory(I))
 					return
 				build_step++
 				to_chat(user, "<span class='notice'>You add [I] to [src].</span>")
 				qdel(I)
+			if(I.tool_behaviour == TOOL_WELDER) //Deconstruct
+				if(I.use_tool(src, user, 0, volume=30))
+					to_chat(user, "<span class='notice'>You weld close the water hole in [src]!</span>")
+					build_step--
+					return
 
 		if(ASSEMBLY_THIRD_STEP)
 			if(!can_finish_build(I, user, 0))
 				return
-			if(istype(I, /obj/item/stack/ducts))
+			if(istype(I, /obj/item/stack/ducts)) //Construct
 				var/obj/item/stack/ducts/D = I
 				if(D.get_amount() < 1)
 					to_chat(user, "<span class='warning'>You need one fluid duct to finish [src]</span>")
@@ -500,3 +511,7 @@
 					var/mob/living/simple_animal/bot/hygienebot/H = new(drop_location())
 					H.name = created_name
 					qdel(src)
+			if(I.tool_behaviour == TOOL_SCREWDRIVER) //deconstruct
+				new /obj/item/assembly/prox_sensor(Tsec)
+				to_chat(user, "<span class='notice'>You detach the proximity sensor from [src].</span>")
+				build_step--

--- a/code/modules/mob/living/simple_animal/bot/hygienebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/hygienebot.dm
@@ -20,14 +20,21 @@
 	allow_pai = FALSE
 	layer = ABOVE_MOB_LAYER
 
+	///The human target the bot is trying to wash.
 	var/mob/living/carbon/human/target
+	///The mob's current speed, which varies based on how long the bot chases it's target.
 	var/currentspeed = 5
+	///Is the bot currently washing it's target/everything else that crosses it?
 	var/washing = FALSE
+	///Have the target evaded the bot for long enough that it will swear at it like kirk did to kahn?
 	var/mad = FALSE
+	///The last time that the previous/current target was found.
 	var/last_found
+	///Name of the previous target the bot was pursuing.
 	var/oldtarget_name
-
+	///Visual overlay of the bot spraying water.
 	var/mutable_appearance/water_overlay
+	///Visual overlay of the bot commiting warcrimes.
 	var/mutable_appearance/fire_overlay
 
 /mob/living/simple_animal/bot/hygienebot/Initialize()

--- a/code/modules/mob/living/simple_animal/bot/hygienebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/hygienebot.dm
@@ -220,7 +220,7 @@ Maintenance panel is [open ? "opened" : "closed"]"}
 	return	dat.Join("")
 
 /mob/living/simple_animal/bot/hygienebot/proc/check_purity(mob/living/L)
-	if(emagged && L.stat != DEAD)
+	if((emagged == 2) && L.stat != DEAD)
 		return FALSE
 
 	for(var/X in list(ITEM_SLOT_HEAD, ITEM_SLOT_MASK, ITEM_SLOT_ICLOTHING, ITEM_SLOT_OCLOTHING, ITEM_SLOT_FEET))


### PR DESCRIPTION

## About The Pull Request

Adds simple deconstruct steps to the hygiene bot assembly, as well as adds a simple crafting menu option to craft one.
Also, corrects an issue with hygienebots not needing to be opened in order to be emagged. They now need to be emagged to be opened with a screwdriver, then emag the open panel in order to emag the robot, just like every other robot.

## Why It's Good For The Game

Fixes #49514. Bring hygiene bots up to the same standard as all other simple robots.

## Changelog
:cl:
fix: Hygiene Robots are now craftable and deconstructable in the same way as other simple robots.
fix: Hygiene Robots must be opened in order to be emagged just like the rest.
/:cl:
