### PR TITLE
Removed jQuery from snowflake devices

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -55,7 +55,6 @@
 					dat += {"
 
 		<head>
-			<script src="[SSassets.transport.get_asset_url("jquery.min.js")]"></script>
 			<script type='text/javascript'>
 
 				function updateSearch(){
@@ -70,10 +69,16 @@
 					if(filter.value == ""){
 						return;
 					}else{
-						$("#maintable_data").children("tbody").children("tr").children("td").children("input").filter(function(index)
-						{
-							return $(this)\[0\].value.toLowerCase().indexOf(filter) == -1
-						}).parent("td").parent("tr").hide()
+						var body_data = document.querySelector("#maintable_data");
+						var found_data = body_data.querySelectorAll("table input");
+						if(found_data.length >0){
+							for(var i=0;  i < found_data.length; i++){
+								var elm = found_data\[i\];
+								if(elm.value.toLowerCase().indexOf(filter) == -1)
+									elm.parentElement.parentElement.parentElement.removeChild(elm.parentElement.parentElement)
+								//	elm.parentElement.parentElement.parentElement.style.visibility = "hidden";
+							}
+						}
 					}
 				}
 
@@ -86,10 +91,8 @@
 			</script>
 		</head>
 
-
 	"}
-					dat += {"
-<p style='text-align:center;'>"}
+					dat += {"<p style='text-align:center;'>"}
 					dat += "<A href='?src=[REF(src)];choice=New Record (General)'>New Record</A><BR>"
 					//search bar
 					dat += {"

--- a/code/modules/admin/verbs/beakerpanel.dm
+++ b/code/modules/admin/verbs/beakerpanel.dm
@@ -65,8 +65,11 @@
 	set name = "Spawn reagent container"
 	if(!check_rights())
 		return
+/*
+	// Maybe some day, but this doesn't work without a client
 	var/datum/asset/asset_datum = get_asset_datum(/datum/asset/simple/namespaced/common)
 	asset_datum.send()
+*/
 	//Could somebody tell me why this isn't using the browser datum, given that it copypastes all of browser datum's html
 	var/dat = {"
 		<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">

--- a/code/modules/admin/verbs/beakerpanel.dm
+++ b/code/modules/admin/verbs/beakerpanel.dm
@@ -65,11 +65,8 @@
 	set name = "Spawn reagent container"
 	if(!check_rights())
 		return
-/*
-	// Maybe some day, but this doesn't work without a client
 	var/datum/asset/asset_datum = get_asset_datum(/datum/asset/simple/namespaced/common)
-	asset_datum.send()
-*/
+	asset_datum.send(usr.client||src)
 	//Could somebody tell me why this isn't using the browser datum, given that it copypastes all of browser datum's html
 	var/dat = {"
 		<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -151,7 +151,6 @@
 
 
 /datum/asset/simple/jquery
-	legacy = TRUE
 	assets = list(
 		"jquery.min.js" = 'html/jquery.min.js',
 	)

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -42,8 +42,6 @@ Notes:
 /datum/tooltip/New(client/C)
 	if (C)
 		owner = C
-		var/datum/asset/stuff = get_asset_datum(/datum/asset/simple/jquery)
-		stuff.send(owner)
 		owner << browse(file2text('code/modules/tooltip/tooltip.html'), "window=[control]")
 
 	..()

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -87,8 +87,10 @@
 	<div id="wrap" class="wrap">
 		<div id="content" class="content"></div>
 	</div>
-	<script type="text/javascript" src="jquery.min.js"></script>
 	<script type="text/javascript">
+		function eventOnMouseover() {
+			tooltip.hide();
+		};
 		var tooltip = {
 			'tileSize': 32,
 			'control': '',
@@ -206,18 +208,18 @@
 
 				//alert(mapWidth+' | '+mapHeight+' | '+tilesShown+' | '+realIconSize+' | '+leftOffset+' | '+topOffset+' | '+left+' | '+top+' | '+posX+' | '+posY); //DEBUG
 
-				$('body').attr('class', tooltip.theme);
+				document.getElementsByTagName("body").className = tooltip.theme;
+				var content = document.getElementById("content");
+				var wrap = document.getElementById("wrap");
 
-				var $content = $('#content'),
-					$wrap 	 = $('#wrap');
-				$wrap.attr('style', '');
-				$content.off('mouseover');
-				$content.html(tooltip.text);
+				content.removeEventListener("onmouseover", eventOnMouseover);
+				content.innerHTML = tooltip.text;
+				wrap.style = ''
+				wrap.style.width = (parseInt(wrap.width,10) + 2) + "px";//Dumb hack to fix a bizarre sizing bug
+				// 11/15/2020 - WarlockD, Note, I have no idea what sizing bug they are talking about here
 
-				$wrap.width($wrap.width() + 2); //Dumb hack to fix a bizarre sizing bug
-
-				var docWidth	= $wrap.outerWidth(),
-					docHeight	= $wrap.outerHeight();
+				var docWidth	=  wrap.offsetWidth;
+					docHeight	= wrap.offsetHeight;
 
 				if (posY + docHeight > map.size.y) { //Is the bottom edge below the window? Snap it up if so
 					posY = (posY - docHeight) - realIconSizeY - tooltip.padding;
@@ -226,13 +228,11 @@
 				//Actually size, move and show the tooltip box
 				window.location = 'byond://winset?id='+tooltip.control+';size='+docWidth+'x'+docHeight+';pos='+posX+','+posY+';is-visible=true';
 
-				$content.on('mouseover', function() {
-					tooltip.hide();
-				});
+				content.addEventListener("onmouseover", eventOnMouseover);
 			},
 			update: function(params, client_vw , clien_vh , text, theme, special) {
 				//Assign our global object
-				tooltip.params = $.parseJSON(params);
+				tooltip.params = JSON.parse(params);
 				tooltip.client_view_w = parseInt(client_vw);
 				tooltip.client_view_h = parseInt(clien_vh);
 				tooltip.text = text;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removed jQuery from the use of the Security Terminal and Tooltips.  Was going to go for the admin beaker regent creator and voting panel but they use the widgets so it be a bit better to use tgui for those interfaces.

## Why It's Good For The Game

Just reducing the amount of libraries that are hardly used in the game is a good thing.

## Changelog
:cl:
tweak: Security Terminal and Tooltips don't use jQuery anymore
/:cl:

