### PR TITLE
Fixes paystands sending signals when attached with a signaler.

### DIFF
--- a/code/modules/economy/pay_stand.dm
+++ b/code/modules/economy/pay_stand.dm
@@ -122,7 +122,7 @@
 	my_card.registered_account.bank_card_talk("Purchase made at your vendor by [buyer] for [price] credits.")
 	amount_deposited = amount_deposited + price
 	if(signaler && amount_deposited >= signaler_threshold)
-		signaler.activate()
+		signaler.signal()
 		amount_deposited = 0
 
 /obj/machinery/paystand/default_unfasten_wrench(mob/user, obj/item/I, time = 20)


### PR DESCRIPTION
## About The Pull Request

Corrects how paystand's interact with their signalers by actually using the correct proc, and signaling out of the machine.
Not much else to say here.

## Why It's Good For The Game

Fixes #45655. Bug bad.

## Changelog
:cl:
fix: Paystands now properly signal out when attached to a paystand and their pay threshold is met.
/:cl:

