### PR TITLE
Mech Ammo now properly respects ammo for custom materials.

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -1171,6 +1171,9 @@
 					playsound(get_turf(user),A.load_audio,50,TRUE)
 					to_chat(user, "<span class='notice'>You add [ammo_needed] [A.round_term][ammo_needed > 1?"s":""] to the [gun.name]</span>")
 					A.rounds = A.rounds - ammo_needed
+					if(A.custom_materials)
+						for(var/i in A.custom_materials)
+							A.custom_materials[i] = A.custom_materials[i] * (A.rounds/initial(A.rounds))
 					A.update_name()
 					return TRUE
 
@@ -1182,6 +1185,7 @@
 					playsound(get_turf(user),A.load_audio,50,TRUE)
 					to_chat(user, "<span class='notice'>You add [A.rounds] [A.round_term][A.rounds > 1?"s":""] to the [gun.name]</span>")
 					A.rounds = 0
+					A.set_custom_materials(list(/datum/material/iron=2000))
 					A.update_name()
 					return TRUE
 	if(!fail_chat_override)


### PR DESCRIPTION

## About The Pull Request

Shoutout to me for actually touching mech code and surviving.
Mech code now does a basic check for the amount of remaining ammo to adjust the amount of custom materials of an ammo container based on the remaining ammo against the original amount of ammo.
When the ammo runs out, it's hard-set to 2000 iron as that's the value of the sheet of iron that it gets set to by the end.

## Why It's Good For The Game

Mech Ammo sanity gives me sanity. Also, Fixes #44864. Same solution could easily be applied in parallel to the other ammo box metal exploits if someone wanted to compile a few more times.

## Changelog
:cl:
fix: Mech ammo containers now update their material totals after refilling.
/:cl:
