### PR TITLE
Luxury shuttle scanner gate bugfixes and improvements

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -174,6 +174,8 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 
 #define ismachinery(A) (istype(A, /obj/machinery))
 
+#define isvehicle(A) (istype(A, /obj/vehicle))
+
 #define ismecha(A) (istype(A, /obj/vehicle/sealed/mecha))
 
 #define ismedicalmecha(A) (istype(A, /obj/vehicle/sealed/mecha/medical))

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -231,13 +231,19 @@
 
 	if(mover in approved_passengers)
 		set_scanline("scanning", 10)
+		if(isvehicle(mover))
+			var/obj/vehicle/vehicle = mover
+			for(var/mob/living/rat in vehicle.occupants)
+				if(!(rat in approved_passengers))
+					say("<span class='robot'>Stowaway detected. Please exit the structure first.</span>")
+					return FALSE
 		return TRUE
 	if(isitem(mover))
 		return TRUE
 	if(isstructure(mover))
 		var/obj/structure/struct = mover
 		for(var/mob/living/rat in struct.contents)
-			say("<span class='robot'>Stowaway detected. Please exist the structure first.</span>")
+			say("<span class='robot'>Stowaway detected. Please exit the structure first.</span>")
 			return FALSE
 		return TRUE
 
@@ -254,6 +260,10 @@
 
 #define LUXURY_MESSAGE_COOLDOWN 100
 /obj/machinery/scanner_gate/luxury_shuttle/Bumped(atom/movable/AM)
+	///If the atom entering the gate is a vehicle, we store it here to add to the approved list to enter/leave the scanner gate.
+	var/obj/vehicle/vehicle
+	///We store the driver of vehicles seperately so that we can add them to the approved list once payment is fully processed.
+	var/mob/living/driver_holdout
 	if(!isliving(AM) && !isvehicle(AM))
 		alarm_beep()
 		return ..()
@@ -271,14 +281,15 @@
 		account = L.get_bank_account()
 
 	else if(isvehicle(AM))
-		var/obj/vehicle/vehicle = AM
+		vehicle = AM
 		for(var/passenger in vehicle.occupants)
-			if(!isliving(vehicle.occupants[passenger]))
+			if(!isliving(passenger))
 				continue
-			var/mob/living/rider = vehicle.occupants[passenger]
+			var/mob/living/rider = passenger
 			if(vehicle.is_driver(rider))
+				driver_holdout = rider
 				var/obj/item/card/id/id = rider.get_idcard(TRUE)
-				account = id.registered_account
+				account = id?.registered_account
 				break
 
 	if(account)
@@ -290,40 +301,40 @@
 			account.adjust_money(-money_owed)
 			payees[AM] += money_owed
 
+	//Here is all the possible paygate payment methods.
 	var/list/counted_money = list()
-
-	for(var/obj/item/coin/C in AM.GetAllContents())
+	for(var/obj/item/coin/C in AM.GetAllContents()) //Coins.
 		if(payees[AM] >= threshold)
 			break
 		payees[AM] += C.value
 		counted_money += C
-	for(var/obj/item/stack/spacecash/S in AM.GetAllContents())
+	for(var/obj/item/stack/spacecash/S in AM.GetAllContents()) //Paper Cash
 		if(payees[AM] >= threshold)
 			break
 		payees[AM] += S.value * S.amount
 		counted_money += S
-	for(var/obj/item/holochip/H in AM.GetAllContents())
+	for(var/obj/item/holochip/H in AM.GetAllContents()) //Holocredits
 		if(payees[AM] >= threshold)
 			break
 		payees[AM] += H.credits
 		counted_money += H
 
-	if(payees[AM] < threshold && istype(AM.pulling, /obj/item/coin))
+	if(payees[AM] < threshold && istype(AM.pulling, /obj/item/coin)) //Coins(Pulled).
 		var/obj/item/coin/C = AM.pulling
 		payees[AM] += C.value
 		counted_money += C
 
-	else if(payees[AM] < threshold && istype(AM.pulling, /obj/item/stack/spacecash))
+	else if(payees[AM] < threshold && istype(AM.pulling, /obj/item/stack/spacecash)) //Cash(Pulled).
 		var/obj/item/stack/spacecash/S = AM.pulling
 		payees[AM] += S.value * S.amount
 		counted_money += S
 
-	else if(payees[AM] < threshold && istype(AM.pulling, /obj/item/holochip))
+	else if(payees[AM] < threshold && istype(AM.pulling, /obj/item/holochip)) //Holocredits(pulled).
 		var/obj/item/holochip/H = AM.pulling
 		payees[AM] += H.credits
 		counted_money += H
 
-	if(payees[AM] < threshold)
+	if(payees[AM] < threshold) //Suggestions for those with no arms/simple animals.
 		var/armless
 		if(!ishuman(AM) && !istype(AM, /mob/living/simple_animal/slime))
 			armless = TRUE
@@ -346,7 +357,7 @@
 		var/change = FALSE
 		if(payees[AM] > 0)
 			change = TRUE
-			var/obj/item/holochip/HC = new /obj/item/holochip(AM.loc)
+			var/obj/item/holochip/HC = new /obj/item/holochip(AM.loc) //Change is made in holocredits exclusively.
 			HC.credits = payees[AM]
 			HC.name = "[HC.credits] credit holochip"
 			if(istype(AM, /mob/living/carbon/human))
@@ -357,8 +368,12 @@
 				AM.pulling = HC
 			payees[AM] -= payees[AM]
 
-		say("<span class='robot'>Welcome to first class, [AM]![change ? " Here is your change." : ""]</span>")
-		approved_passengers += AM
+		say("<span class='robot'>Welcome to first class, [driver_holdout ? "[driver_holdout]" : "[AM]" ]![change ? " Here is your change." : ""]</span>")
+		approved_passengers |= AM
+		if(vehicle)
+			approved_passengers |= vehicle
+		if(driver_holdout)
+			approved_passengers |= driver_holdout
 
 		check_times -= AM
 		return

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -235,7 +235,7 @@
 			var/obj/vehicle/vehicle = mover
 			for(var/mob/living/rat in vehicle.occupants)
 				if(!(rat in approved_passengers))
-					say("<span class='robot'>Stowaway detected. Please exit the structure first.</span>")
+					say("<span class='robot'>Stowaway detected. Please exit the vehicle first.</span>")
 					return FALSE
 		return TRUE
 	if(isitem(mover))


### PR DESCRIPTION

## About The Pull Request

Oh man this one took me a hot second.
Luxury Shuttle gates now do the following:

Respect simplemobs dragging through credits so they can be considered legitimate passengers.

Respect vehicles and by proxy mechs so that you don't block the narrow causway into the shuttle. Entering the gate with cash will add both yourself and the vehicle to the whitelist. Entering the gate in a whitelisted vehicle, but without paying yet will throw angry buzzing at you as expected.

The shuttle will only take the correct credit count now, or at least provide the correct change.

The scanner is now invincible as it LITERALLY only exists on a roundend shuttle.

## Why It's Good For The Game

Fixes #54961. Fixes #50155. Fixes #40772. Fixes #42017.
Improves consistency, and makes the scanner gate cover far more edge cases as a result.

## Changelog
:cl:
fix: Luxury shuttle's scanner gates now accept vehicles and simple animals.
fix: Luxury shuttle's scanner gates are now unbreakable, and consistency charge the correct amount.
/:cl:
