### PR TITLE
Lazy storage element

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -34,6 +34,7 @@
 #define EYE_STAB				(1<<13) /// Item can be used to eyestab
 #define HAND_ITEM				(1<<14) /// If an item is just your hand (circled hand, slapper) and shouldn't block things like riding
 #define EXAMINE_SKIP			(1<<15) /// Makes the Examine proc not read out this item.
+#define ITEM_LAZY_STORAGE		(1<<16) /// Contents are populated on first access
 
 // Flags for the clothing_flags var on /obj/item/clothing
 

--- a/code/datums/elements/lazystorage.dm
+++ b/code/datums/elements/lazystorage.dm
@@ -1,0 +1,76 @@
+/datum/element/lazystorage
+
+/datum/element/lazystorage/Attach(datum/target)
+	. = ..()
+	if(!istype(target, /obj/item/storage))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_CONTAINS_STORAGE, .proc/on_check)
+	RegisterSignal(target, COMSIG_IS_STORAGE_LOCKED, .proc/check_locked)
+	RegisterSignal(target, COMSIG_TRY_STORAGE_SHOW, .proc/signal_show_attempt)
+	RegisterSignal(target, COMSIG_TRY_STORAGE_INSERT, .proc/signal_insertion_attempt)
+	RegisterSignal(target, COMSIG_TRY_STORAGE_CAN_INSERT, .proc/signal_can_insert)
+	RegisterSignal(target, COMSIG_TRY_STORAGE_TAKE_TYPE, .proc/signal_take_type)
+	RegisterSignal(target, COMSIG_TRY_STORAGE_FILL_TYPE, .proc/signal_fill_type)
+	RegisterSignal(target, COMSIG_TRY_STORAGE_SET_LOCKSTATE, .proc/set_locked)
+	RegisterSignal(target, COMSIG_TRY_STORAGE_TAKE, .proc/signal_take_obj)
+	RegisterSignal(target, COMSIG_TRY_STORAGE_QUICK_EMPTY, .proc/signal_quick_empty)
+	RegisterSignal(target, COMSIG_TRY_STORAGE_HIDE_FROM, .proc/signal_hide_attempt)
+	RegisterSignal(target, COMSIG_TRY_STORAGE_HIDE_ALL, .proc/close_all)
+	RegisterSignal(target, COMSIG_TRY_STORAGE_RETURN_INVENTORY, .proc/signal_return_inv)
+	RegisterSignal(target, COMSIG_CLICK_ALT, .proc/on_alt_click)
+	RegisterSignal(target, COMSIG_MOUSEDROP_ONTO, .proc/mousedrop_onto)
+	RegisterSignal(target, COMSIG_MOUSEDROPPED_ONTO, .proc/mousedrop_receive)
+
+/datum/element/lazystorage/Detach(obj/item/storage/source, force)
+	. = ..()
+	UnregisterSignal(source, COMSIG_CONTAINS_STORAGE)
+	UnregisterSignal(source, COMSIG_IS_STORAGE_LOCKED)
+	UnregisterSignal(source, COMSIG_TRY_STORAGE_SHOW)
+	UnregisterSignal(source, COMSIG_TRY_STORAGE_INSERT)
+	UnregisterSignal(source, COMSIG_TRY_STORAGE_CAN_INSERT)
+	UnregisterSignal(source, COMSIG_TRY_STORAGE_TAKE_TYPE)
+	UnregisterSignal(source, COMSIG_TRY_STORAGE_FILL_TYPE)
+	UnregisterSignal(source, COMSIG_TRY_STORAGE_SET_LOCKSTATE)
+	UnregisterSignal(source, COMSIG_TRY_STORAGE_TAKE)
+	UnregisterSignal(source, COMSIG_TRY_STORAGE_QUICK_EMPTY)
+	UnregisterSignal(source, COMSIG_TRY_STORAGE_HIDE_FROM)
+	UnregisterSignal(source, COMSIG_TRY_STORAGE_HIDE_ALL)
+	UnregisterSignal(source, COMSIG_TRY_STORAGE_RETURN_INVENTORY)
+	UnregisterSignal(source, COMSIG_CLICK_ALT)
+	UnregisterSignal(source, COMSIG_MOUSEDROP_ONTO)
+	UnregisterSignal(source, COMSIG_MOUSEDROPPED_ONTO)
+
+
+/datum/element/lazystorage/proc/monkeymagic(obj/item/storage/target)
+	SIGNAL_HANDLER
+
+	target.item_flags &= ~ITEM_LAZY_STORAGE
+
+#define LAZYSTORAGE_PASSTHROUGH_PROC(name, signal) \
+/datum/element/lazystorage/proc/##name(obj/item/storage/source, ...) {\
+	var/datum/component/storage/real_storage = source.AddComponent(source.component_type);\
+	Detach(source);\
+	source.item_flags &= ~ITEM_LAZY_STORAGE;\
+	source.PopulateContents();\
+	source.StorageInitialize(real_storage);\
+	if (real_storage.signal_procs[source] && real_storage.signal_procs[source][signal]) {\
+		return call(real_storage, real_storage.signal_procs[source][signal])(arglist(args));\
+	};\
+}
+
+LAZYSTORAGE_PASSTHROUGH_PROC(on_check, COMSIG_CONTAINS_STORAGE)
+LAZYSTORAGE_PASSTHROUGH_PROC(check_locked, COMSIG_IS_STORAGE_LOCKED)
+LAZYSTORAGE_PASSTHROUGH_PROC(signal_show_attempt, COMSIG_TRY_STORAGE_SHOW)
+LAZYSTORAGE_PASSTHROUGH_PROC(signal_insertion_attempt, COMSIG_TRY_STORAGE_INSERT)
+LAZYSTORAGE_PASSTHROUGH_PROC(signal_can_insert, COMSIG_TRY_STORAGE_CAN_INSERT)
+LAZYSTORAGE_PASSTHROUGH_PROC(signal_take_type, COMSIG_TRY_STORAGE_TAKE_TYPE)
+LAZYSTORAGE_PASSTHROUGH_PROC(signal_fill_type, COMSIG_TRY_STORAGE_FILL_TYPE)
+LAZYSTORAGE_PASSTHROUGH_PROC(set_locked, COMSIG_TRY_STORAGE_SET_LOCKSTATE)
+LAZYSTORAGE_PASSTHROUGH_PROC(signal_take_obj, COMSIG_TRY_STORAGE_TAKE)
+LAZYSTORAGE_PASSTHROUGH_PROC(signal_quick_empty, COMSIG_TRY_STORAGE_QUICK_EMPTY)
+LAZYSTORAGE_PASSTHROUGH_PROC(signal_hide_attempt, COMSIG_TRY_STORAGE_HIDE_FROM)
+LAZYSTORAGE_PASSTHROUGH_PROC(close_all, COMSIG_TRY_STORAGE_HIDE_ALL)
+LAZYSTORAGE_PASSTHROUGH_PROC(signal_return_inv, COMSIG_TRY_STORAGE_RETURN_INVENTORY)
+LAZYSTORAGE_PASSTHROUGH_PROC(on_alt_click, COMSIG_CLICK_ALT)
+LAZYSTORAGE_PASSTHROUGH_PROC(mousedrop_onto, COMSIG_MOUSEDROP_ONTO)
+LAZYSTORAGE_PASSTHROUGH_PROC(mousedrop_receive, COMSIG_MOUSEDROPPED_ONTO)

--- a/code/datums/elements/lazystorage.dm
+++ b/code/datums/elements/lazystorage.dm
@@ -14,33 +14,34 @@
 	RegisterSignal(target, COMSIG_TRY_STORAGE_SET_LOCKSTATE, .proc/set_locked)
 	RegisterSignal(target, COMSIG_TRY_STORAGE_TAKE, .proc/signal_take_obj)
 	RegisterSignal(target, COMSIG_TRY_STORAGE_QUICK_EMPTY, .proc/signal_quick_empty)
-	RegisterSignal(target, COMSIG_TRY_STORAGE_HIDE_FROM, .proc/signal_hide_attempt)
-	RegisterSignal(target, COMSIG_TRY_STORAGE_HIDE_ALL, .proc/close_all)
 	RegisterSignal(target, COMSIG_TRY_STORAGE_RETURN_INVENTORY, .proc/signal_return_inv)
 	RegisterSignal(target, COMSIG_CLICK_ALT, .proc/on_alt_click)
 	RegisterSignal(target, COMSIG_MOUSEDROP_ONTO, .proc/mousedrop_onto)
 	RegisterSignal(target, COMSIG_MOUSEDROPPED_ONTO, .proc/mousedrop_receive)
+	RegisterSignal(target, COMSIG_ITEM_ATTACK_SELF, .proc/attack_self)
 
 /datum/element/lazystorage/Detach(obj/item/storage/source, force)
 	. = ..()
-	UnregisterSignal(source, COMSIG_CONTAINS_STORAGE)
-	UnregisterSignal(source, COMSIG_IS_STORAGE_LOCKED)
-	UnregisterSignal(source, COMSIG_TRY_STORAGE_SHOW)
-	UnregisterSignal(source, COMSIG_TRY_STORAGE_INSERT)
-	UnregisterSignal(source, COMSIG_TRY_STORAGE_CAN_INSERT)
-	UnregisterSignal(source, COMSIG_TRY_STORAGE_TAKE_TYPE)
-	UnregisterSignal(source, COMSIG_TRY_STORAGE_FILL_TYPE)
-	UnregisterSignal(source, COMSIG_TRY_STORAGE_SET_LOCKSTATE)
-	UnregisterSignal(source, COMSIG_TRY_STORAGE_TAKE)
-	UnregisterSignal(source, COMSIG_TRY_STORAGE_QUICK_EMPTY)
-	UnregisterSignal(source, COMSIG_TRY_STORAGE_HIDE_FROM)
-	UnregisterSignal(source, COMSIG_TRY_STORAGE_HIDE_ALL)
-	UnregisterSignal(source, COMSIG_TRY_STORAGE_RETURN_INVENTORY)
-	UnregisterSignal(source, COMSIG_CLICK_ALT)
-	UnregisterSignal(source, COMSIG_MOUSEDROP_ONTO)
-	UnregisterSignal(source, COMSIG_MOUSEDROPPED_ONTO)
+	UnregisterSignal(source, list(
+		COMSIG_CONTAINS_STORAGE,
+		COMSIG_IS_STORAGE_LOCKED,
+		COMSIG_TRY_STORAGE_SHOW,
+		COMSIG_TRY_STORAGE_INSERT,
+		COMSIG_TRY_STORAGE_CAN_INSERT,
+		COMSIG_TRY_STORAGE_TAKE_TYPE,
+		COMSIG_TRY_STORAGE_FILL_TYPE,
+		COMSIG_TRY_STORAGE_SET_LOCKSTATE,
+		COMSIG_TRY_STORAGE_TAKE,
+		COMSIG_TRY_STORAGE_QUICK_EMPTY,
+		COMSIG_TRY_STORAGE_RETURN_INVENTORY,
+		COMSIG_CLICK_ALT,
+		COMSIG_MOUSEDROP_ONTO,
+		COMSIG_MOUSEDROPPED_ONTO,
+		COMSIG_ITEM_ATTACK_SELF,
+	))
 
 
+/// ( ͡° ͜ʖ ͡°)
 #define LAZYSTORAGE_PASSTHROUGH_PROC(name, signal) \
 /datum/element/lazystorage/proc/##name(obj/item/storage/source, ...) {\
 	var/datum/component/storage/real_storage = source.AddComponent(source.component_type);\
@@ -63,9 +64,8 @@ LAZYSTORAGE_PASSTHROUGH_PROC(signal_fill_type, COMSIG_TRY_STORAGE_FILL_TYPE)
 LAZYSTORAGE_PASSTHROUGH_PROC(set_locked, COMSIG_TRY_STORAGE_SET_LOCKSTATE)
 LAZYSTORAGE_PASSTHROUGH_PROC(signal_take_obj, COMSIG_TRY_STORAGE_TAKE)
 LAZYSTORAGE_PASSTHROUGH_PROC(signal_quick_empty, COMSIG_TRY_STORAGE_QUICK_EMPTY)
-LAZYSTORAGE_PASSTHROUGH_PROC(signal_hide_attempt, COMSIG_TRY_STORAGE_HIDE_FROM)
-LAZYSTORAGE_PASSTHROUGH_PROC(close_all, COMSIG_TRY_STORAGE_HIDE_ALL)
 LAZYSTORAGE_PASSTHROUGH_PROC(signal_return_inv, COMSIG_TRY_STORAGE_RETURN_INVENTORY)
 LAZYSTORAGE_PASSTHROUGH_PROC(on_alt_click, COMSIG_CLICK_ALT)
 LAZYSTORAGE_PASSTHROUGH_PROC(mousedrop_onto, COMSIG_MOUSEDROP_ONTO)
 LAZYSTORAGE_PASSTHROUGH_PROC(mousedrop_receive, COMSIG_MOUSEDROPPED_ONTO)
+LAZYSTORAGE_PASSTHROUGH_PROC(attack_self, COMSIG_ITEM_ATTACK_SELF)

--- a/code/datums/elements/lazystorage.dm
+++ b/code/datums/elements/lazystorage.dm
@@ -41,11 +41,6 @@
 	UnregisterSignal(source, COMSIG_MOUSEDROPPED_ONTO)
 
 
-/datum/element/lazystorage/proc/monkeymagic(obj/item/storage/target)
-	SIGNAL_HANDLER
-
-	target.item_flags &= ~ITEM_LAZY_STORAGE
-
 #define LAZYSTORAGE_PASSTHROUGH_PROC(name, signal) \
 /datum/element/lazystorage/proc/##name(obj/item/storage/source, ...) {\
 	var/datum/component/storage/real_storage = source.AddComponent(source.component_type);\

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -46,7 +46,7 @@
 	fancy_open = !fancy_open
 	update_icon()
 	. = ..()
-	if(!contents.len)
+	if(!(item_flags & ITEM_LAZY_STORAGE) && !contents.len)
 		new fold_result(user.drop_location())
 		to_chat(user, "<span class='notice'>You fold the [src] into [initial(fold_result.name)].</span>")
 		user.put_in_active_hand(fold_result)
@@ -79,9 +79,7 @@
 	appearance_flags = KEEP_TOGETHER
 	custom_premium_price = PAYCHECK_HARD * 1.75
 
-/obj/item/storage/fancy/donut_box/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+/obj/item/storage/fancy/donut_box/StorageInitialize(datum/component/storage/STR)
 	STR.max_items = 6
 	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/donut))
 
@@ -130,9 +128,7 @@
 	desc = "A carton for containing eggs."
 	spawn_type = /obj/item/food/egg
 
-/obj/item/storage/fancy/egg_box/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+/obj/item/storage/fancy/egg_box/StorageInitialize(datum/component/storage/STR)
 	STR.max_items = 12
 	STR.set_holdable(list(/obj/item/food/egg))
 
@@ -182,6 +178,7 @@
 	spawn_type = /obj/item/clothing/mask/cigarette/space_cigarette
 	custom_price = PAYCHECK_MEDIUM
 	age_restricted = TRUE
+	item_flags = ITEM_LAZY_STORAGE
 	///for cigarette overlay
 	var/candy = FALSE
 	/// Does this cigarette packet come with a coupon attached?
@@ -190,7 +187,7 @@
 	var/rigged_omen = FALSE
 
 /obj/item/storage/fancy/cigarettes/attack_self(mob/user)
-	if(contents.len == 0 && spawn_coupon)
+	if(!(item_flags & ITEM_LAZY_STORAGE) && contents.len == 0 && spawn_coupon)
 		to_chat(user, "<span class='notice'>You rip the back off \the [src] and get a coupon!</span>")
 		var/obj/item/coupon/attached_coupon = new
 		user.put_in_hands(attached_coupon)
@@ -204,9 +201,7 @@
 		return
 	return ..()
 
-/obj/item/storage/fancy/cigarettes/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+/obj/item/storage/fancy/cigarettes/StorageInitialize(datum/component/storage/STR)
 	STR.max_items = 6
 	STR.set_holdable(list(/obj/item/clothing/mask/cigarette, /obj/item/lighter))
 
@@ -220,6 +215,8 @@
 /obj/item/storage/fancy/cigarettes/AltClick(mob/living/carbon/user)
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
+	if (item_flags & ITEM_LAZY_STORAGE)
+		SEND_SIGNAL(src, COMSIG_CONTAINS_STORAGE)
 	var/obj/item/clothing/mask/cigarette/W = locate(/obj/item/clothing/mask/cigarette) in contents
 	if(W && contents.len > 0)
 		SEND_SIGNAL(src, COMSIG_TRY_STORAGE_TAKE, W, user)
@@ -364,9 +361,7 @@
 	spawn_type = /obj/item/rollingpaper
 	custom_price = PAYCHECK_PRISONER
 
-/obj/item/storage/fancy/rollingpapers/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+/obj/item/storage/fancy/rollingpapers/StorageInitialize(datum/component/storage/STR)
 	STR.max_items = 10
 	STR.set_holdable(list(/obj/item/rollingpaper))
 
@@ -393,9 +388,7 @@
 	spawn_type = /obj/item/clothing/mask/cigarette/cigar
 	spawn_coupon = FALSE
 
-/obj/item/storage/fancy/cigarettes/cigars/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+/obj/item/storage/fancy/cigarettes/cigars/StorageInitialize(datum/component/storage/STR)
 	STR.max_items = 5
 	STR.set_holdable(list(/obj/item/clothing/mask/cigarette/cigar))
 
@@ -441,12 +434,9 @@
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
 	spawn_type = /obj/item/food/tinychocolate
 
-/obj/item/storage/fancy/heart_box/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+/obj/item/storage/fancy/heart_box/StorageInitialize(datum/component/storage/STR)
 	STR.max_items = 8
 	STR.set_holdable(list(/obj/item/food/tinychocolate))
-
 
 /obj/item/storage/fancy/nugget_box
 	name = "nugget box"
@@ -456,8 +446,6 @@
 	icon_type = "nugget"
 	spawn_type = /obj/item/food/nugget
 
-/obj/item/storage/fancy/nugget_box/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+/obj/item/storage/fancy/heart_box/StorageInitialize(datum/component/storage/STR)
 	STR.max_items = 6
 	STR.set_holdable(list(/obj/item/food/nugget))

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -228,7 +228,7 @@
 
 /obj/item/storage/fancy/cigarettes/update_icon_state()
 	if(fancy_open || !contents.len)
-		if(!contents.len)
+		if(!(item_flags & ITEM_LAZY_STORAGE) && !contents.len)
 			icon_state = "[initial(icon_state)]_empty"
 		else
 			icon_state = initial(icon_state)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -10,10 +10,19 @@
 
 /obj/item/storage/Initialize()
 	. = ..()
-	PopulateContents()
+	if (!(item_flags & ITEM_LAZY_STORAGE))
+		PopulateContents()
 
 /obj/item/storage/ComponentInitialize()
-	AddComponent(component_type)
+	. = ..()
+	if (!(item_flags & ITEM_LAZY_STORAGE))
+		var/STR = AddComponent(component_type)
+		StorageInitialize(STR)
+	else
+		AddElement(/datum/element/lazystorage)
+
+/// Set up vars for the storage component
+/obj/item/storage/proc/StorageInitialize(datum/component/storage/STR)
 
 /obj/item/storage/AllowDrop()
 	return FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -579,6 +579,7 @@
 #include "code\datums\elements\empprotection.dm"
 #include "code\datums\elements\firestacker.dm"
 #include "code\datums\elements\forced_gravity.dm"
+#include "code\datums\elements\lazystorage.dm"
 #include "code\datums\elements\light_blocking.dm"
 #include "code\datums\elements\obj_regen.dm"
 #include "code\datums\elements\rad_insulation.dm"


### PR DESCRIPTION
## About The Pull Request

Adds a lazy storage element that sneakily implements a subset of storage component signals and when receiving one of them, populates the contents on the item and sets up the storage component and passes on the signal to the component.

This element is initially used for cigarette packs. It also kills the @ninjanomnom.

## Why It's Good For The Game

This saves a bit of memory and recursive loop iterations for things like cigarette packs that contain 10+ items with multiple reagents each and mostly don't get interacted with during a round.

## Changelog
:cl: Naksu
code: Added a lazy storage component to facilitate spawning storage items as empty and plonking in the contents when interacted with.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
