### PR TITLE
shuttle catastrophe now cant trigger if it already happened

### DIFF
--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -5,6 +5,8 @@
 	max_occurrences = 1
 
 /datum/round_event_control/shuttle_catastrophe/canSpawnEvent(players, gamemode)
+	if(SSshuttle.shuttle_purchased == SHUTTLEPURCHASE_FORCED)
+		return FALSE //don't do it if its already been done
 	if(istype(SSshuttle.emergency, /obj/docking_port/mobile/emergency/shuttle_build))
 		return FALSE //don't undo manual player engineering, it also would unload people and ghost them, there's just a lot of problems
 	if(EMERGENCY_AT_LEAST_DOCKED)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

what the title says

## Why It's Good For The Game

this makes my life miserable

## Changelog
:cl:
fix: shuttle catastrophe now cant trigger if it already happened
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
