### PR TITLE
Fixes flat dough element bug

### DIFF
--- a/code/game/objects/items/food/dough.dm
+++ b/code/game/objects/items/food/dough.dm
@@ -85,7 +85,7 @@
 	tastes = list("dough" = 1)
 	foodtypes = GRAIN | DAIRY
 
-/obj/item/food/flatdough/MakeProcessable()
+/obj/item/food/piedough/MakeProcessable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/rawpastrybase, 3, 30)
 
 /obj/item/food/rawpastrybase


### PR DESCRIPTION
## About The Pull Request

Stops giving flat dough the element intended for pie dough
fixes:https://github.com/tgstation/tgstation/issues/55117
fixes:https://github.com/tgstation/tgstation/issues/55118

## Why It's Good For The Game

Chefs can make dough slices and pastry bases again

## Changelog
:cl:
fix: Flat dough and pie doughs cut into the proper results again
/:cl: