### PR TITLE
Revenge of UNIQUE_RENAME respects labels

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -146,29 +146,50 @@
 
 /obj/item/pen/afterattack(obj/O, mob/living/user, proximity)
 	. = ..()
-	//Changing Name/Description of items. Only works if they have the 'unique_rename' flag set
+	//Changing name/description of items. Only works if they have the UNIQUE_RENAME object flag set
 	if(isobj(O) && proximity && (O.obj_flags & UNIQUE_RENAME))
-		var/penchoice = input(user, "What would you like to edit?", "Rename or change description?") as null|anything in list("Rename","Change description")
+		var/penchoice = input(user, "What would you like to edit?", "Rename, change description or reset both?") as null|anything in list("Rename","Change description","Reset")
 		if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 			return
 		if(penchoice == "Rename")
-			var/input = stripped_input(user,"What do you want to name \the [O.name]?", ,"", MAX_NAME_LEN)
+			var/input = stripped_input(user,"What do you want to name [O]?", ,"[O.name]", MAX_NAME_LEN)
 			var/oldname = O.name
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
-			if(oldname == input)
-				to_chat(user, "<span class='notice'>You changed \the [O.name] to... well... \the [O.name].</span>")
+			if(oldname == input || input == "")
+				to_chat(user, "<span class='notice'>You changed [O] to... well... [O].</span>")
 			else
 				O.name = input
-				to_chat(user, "<span class='notice'>\The [oldname] has been successfully been renamed to \the [input].</span>")
+				var/datum/component/label/label = O.GetComponent(/datum/component/label)
+				if(label)
+					label.remove_label()
+					label.apply_label()
+				to_chat(user, "<span class='notice'>You have successfully renamed \the [oldname] to [O].</span>")
 				O.renamedByPlayer = TRUE
 
 		if(penchoice == "Change description")
-			var/input = stripped_input(user,"Describe \the [O.name] here", ,"", 100)
+			var/input = stripped_input(user,"Describe [O] here:", ,"[O.desc]", 140)
+			var/olddesc = O.desc
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
-			O.desc = input
-			to_chat(user, "<span class='notice'>You have successfully changed \the [O.name]'s description.</span>")
+			if(olddesc == input || input == "")
+				to_chat(user, "<span class='notice'>You decide against changing [O]'s description.</span>")
+			else
+				O.desc = input
+				to_chat(user, "<span class='notice'>You have successfully changed [O]'s description.</span>")
+				O.renamedByPlayer = TRUE
+
+		if(penchoice == "Reset")
+			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
+				return
+			O.desc = initial(O.desc)
+			O.name = initial(O.name)
+			var/datum/component/label/label = O.GetComponent(/datum/component/label)
+			if(label)
+				label.remove_label()
+				label.apply_label()
+			to_chat(user, "<span class='notice'>You have successfully reset [O]'s name and description.</span>")
+			O.renamedByPlayer = FALSE
 
 /*
  * Sleepypens


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For UNIQUE_RENAME objects:
* You can no longer erase or duplicate a label through renaming
* You can no longer rename or change descriptions to nothing
* Current description and name are shown in text field when renaming 
* You can now reset the names and descriptions of UNIQUE_RENAME objects
* Simplified most of "\the [O.name]" to just "[O]"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
fix: Most objects renamable with a pen can no longer have their labels erased or duplicated or names and descriptions blanked
tweak: Most objects renamable with a pen can now have their names and descriptions reset to default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
