### PR TITLE
Having no addictions no longer runtime on medical kiosks.

### DIFF
--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -231,7 +231,7 @@
 	var/addict_list = list()
 	var/hallucination_status = "Patient is not hallucinating."
 
-	if(altPatient.reagents.reagent_list.len)	//Chemical Analysis details.
+	if(altPatient?.reagents?.reagent_list.len)	//Chemical Analysis details.
 		for(var/datum/reagent/R in altPatient.reagents.reagent_list)
 			chemical_list += list(list("name" = R.name, "volume" = round(R.volume, 0.01)))
 			if(R.overdosed)
@@ -246,7 +246,7 @@
 				var/bit_vol = bit.volume - belly.food_reagents[bit.type]
 				if(bit_vol > 0)
 					chemical_list += list(list("name" = bit.name, "volume" = round(bit_vol, 0.01)))
-	if(altPatient.reagents.addiction_list.len)
+	if(altPatient?.reagents?.addiction_list.len)
 		for(var/datum/reagent/R in altPatient.reagents.addiction_list)
 			addict_list += list(list("name" = R.name))
 	if (altPatient.hallucinating())


### PR DESCRIPTION

## About The Pull Request

Adds a tiny bit of sanity checks on health kiosks, so it won't go runtime on UI data when a target doesn't have any addictions.

## Why It's Good For The Game

I saw it runtiming on live and this should cleanly solve the issue.
