### PR TITLE
Fixes an adminPM dead end eating replies

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -282,11 +282,17 @@
 					INVOKE_ASYNC(src, .proc/popup_admin_pm, recipient, msg)
 
 			else		//neither are admins
-				to_chat(src,
-					type = MESSAGE_TYPE_ADMINPM,
-					html = "<span class='danger'>Error: Admin-PM: Non-admin to non-admin PM communication is forbidden.</span>",
-					confidential = TRUE)
-				return
+				if(!current_ticket)
+					to_chat(src,
+						type = MESSAGE_TYPE_ADMINPM,
+						html = "<span class='danger'>Error: Admin-PM: Non-admin to non-admin PM communication is forbidden.</span>",
+						confidential = TRUE)
+					to_chat(src,
+						type = MESSAGE_TYPE_ADMINPM,
+						html = "<span class='danger'><b>Message not sent:</b></span><br>[msg]",
+						confidential = TRUE)
+					return
+				current_ticket.MessageNoRecipient(msg)
 
 	if(external)
 		log_admin_private("PM: [key_name(src)]->External: [rawmsg]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If you tried to reply to an admin that had deadminned while you were typing you would get an error and your message was eaten. Now sends to MessageNoRecipient if theres an open ticket, or prints a warning and the message in chat if there isn't.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This shit is frustrating.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Admin PM replies to an admin who has deadminned while you were typing will no longer be thrown into the void. If everything fails, the message gets printed in chat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
