### PR TITLE
Fixes lightbulb injections

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -888,6 +888,8 @@
 /obj/item/light/on_reagent_change(changetype)
 	rigged = (reagents.has_reagent(/datum/reagent/toxin/plasma, LIGHT_REAGENT_CAPACITY)) //has_reagent returns the reagent datum
 	return ..()
+	
+	#undef LIGHT_REAGENT_CAPACITY
 
 /obj/item/light/attack(mob/living/M, mob/living/user, def_zone)
 	..()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -889,7 +889,7 @@
 	rigged = (reagents.has_reagent(/datum/reagent/toxin/plasma, LIGHT_REAGENT_CAPACITY)) //has_reagent returns the reagent datum
 	return ..()
 	
-	#undef LIGHT_REAGENT_CAPACITY
+#undef LIGHT_REAGENT_CAPACITY
 
 /obj/item/light/attack(mob/living/M, mob/living/user, def_zone)
 	..()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -863,6 +863,7 @@
 
 /obj/item/light/Initialize()
 	. = ..()
+	create_reagents(5, INJECTABLE | DRAINABLE)
 	update()
 
 /obj/item/light/ComponentInitialize()
@@ -881,21 +882,9 @@
 
 // attack bulb/tube with object
 // if a syringe, can inject plasma to make it explode
-/obj/item/light/attackby(obj/item/I, mob/user, params)
-	..()
-	if(istype(I, /obj/item/reagent_containers/syringe))
-		var/obj/item/reagent_containers/syringe/S = I
-
-		to_chat(user, "<span class='notice'>You inject the solution into \the [src].</span>")
-
-		if(S.reagents.has_reagent(/datum/reagent/toxin/plasma, 5))
-
-			rigged = TRUE
-
-		S.reagents.clear_reagents()
-	else
-		..()
-	return
+/obj/item/light/on_reagent_change(changetype)
+	rigged = (reagents.has_reagent(/datum/reagent/toxin/plasma, 5)) //has_reagent returns the reagent datum
+	return ..()
 
 /obj/item/light/attack(mob/living/M, mob/living/user, def_zone)
 	..()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -15,6 +15,9 @@
 #define LIGHT_DRAIN_TIME 25
 #define LIGHT_POWER_GAIN 35
 
+//How many reagents the lights can hold
+#define LIGHT_REAGENT_CAPACITY 5
+
 /obj/item/wallframe/light_fixture
 	name = "light fixture frame"
 	desc = "Used for building lights."
@@ -863,7 +866,7 @@
 
 /obj/item/light/Initialize()
 	. = ..()
-	create_reagents(5, INJECTABLE | DRAINABLE)
+	create_reagents(LIGHT_REAGENT_CAPACITY, INJECTABLE | DRAINABLE)
 	update()
 
 /obj/item/light/ComponentInitialize()
@@ -883,7 +886,7 @@
 // attack bulb/tube with object
 // if a syringe, can inject plasma to make it explode
 /obj/item/light/on_reagent_change(changetype)
-	rigged = (reagents.has_reagent(/datum/reagent/toxin/plasma, 5)) //has_reagent returns the reagent datum
+	rigged = (reagents.has_reagent(/datum/reagent/toxin/plasma, LIGHT_REAGENT_CAPACITY)) //has_reagent returns the reagent datum
 	return ..()
 
 /obj/item/light/attack(mob/living/M, mob/living/user, def_zone)


### PR DESCRIPTION
## About The Pull Request

Fixes #55071. Light bulb injections worked odd, and I simply made it work the same as it does for energy cells. This makes it so you can only inject the plasma once, as intended.

## Why It's Good For The Game

Fixes are good, and bugs are bad.

## Changelog
:cl:
fix: You can no longer inject infinite plasma into a light bulb with no addition effect
/:cl: