### PR TITLE
Fixes template use for 'Report Issue' button in-game + show [s] testmerged prs

### DIFF
--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -47,8 +47,6 @@
 		var/datum/tgs_revision_information/test_merge/tm = line
 		var/cm = tm.pull_request_commit
 		var/details = ": '" + html_encode(tm.title) + "' by " + html_encode(tm.author) + " at commit " + html_encode(copytext_char(cm, 1, 11))
-		if(details && findtext(details, "\[s\]") && (!usr || !usr.client.holder))
-			continue
 		. += "<a href=\"[CONFIG_GET(string/githuburl)]/pull/[tm.number]\">#[tm.number][details]</a><br>"
 
 /client/verb/showrevinfo()

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -86,7 +86,7 @@
 			var/list/all_tms = list()
 			for(var/entry in GLOB.revdata.testmerge)
 				var/datum/tgs_revision_information/test_merge/tm = entry
-				all_tms += "- #[tm.number]"
+				all_tms += "- \[[tm.title]\]([githuburl]/pull/[tm.number])"
 			var/all_tms_joined = all_tms.Join("\n") // for some reason this can't go in the []
 			local_template = replacetext(local_template, "## Testmerges:\n", "## Testmerges:\n[all_tms_joined]")
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -65,16 +65,21 @@
 			message += GLOB.revdata.GetTestMergeInfo(FALSE)
 		if(tgalert(src, message, "Report Issue","Yes","No")!="Yes")
 			return
+
+		// Keep a static version of the template to avoid reading file
 		var/static/issue_template = file2text(".github/ISSUE_TEMPLATE/bug_report.md")
 
+		// Get a local copy of the template for modification
+		var/local_template = issue_template
+
 		// Remove comment header
-		var/content_start = findtext(issue_template, "<")
+		var/content_start = findtext(local_template, "<")
 		if(content_start)
-			issue_template = copytext(issue_template, content_start)
+			local_template = copytext(local_template, content_start)
 
 		// Insert round
 		if(GLOB.round_id)
-			issue_template = replacetext(issue_template, "## Round ID:\n", "## Round ID:\n[GLOB.round_id]")
+			local_template = replacetext(local_template, "## Round ID:\n", "## Round ID:\n[GLOB.round_id]")
 
 		// Insert testmerges
 		if(GLOB.revdata.testmerge.len)
@@ -83,10 +88,9 @@
 				var/datum/tgs_revision_information/test_merge/tm = entry
 				all_tms += "- #[tm.number]"
 			var/all_tms_joined = all_tms.Join("\n") // for some reason this can't go in the []
-			issue_template = replacetext(issue_template, "## Testmerges:\n", "## Testmerges:\n[all_tms_joined]")
+			local_template = replacetext(local_template, "## Testmerges:\n", "## Testmerges:\n[all_tms_joined]")
 
-		var/servername = CONFIG_GET(string/servername)
-		var/url_params = "Reporting client version: [byond_version].[byond_build]\n\n[issue_template]"
+		var/url_params = "Reporting client version: [byond_version].[byond_build]\n\n[local_template]"
 		DIRECT_OUTPUT(src, link("[githuburl]/issues/new?body=[url_encode(url_params)]"))
 	else
 		to_chat(src, "<span class='danger'>The Github URL is not set in the server configuration.</span>")

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -65,11 +65,28 @@
 			message += GLOB.revdata.GetTestMergeInfo(FALSE)
 		if(tgalert(src, message, "Report Issue","Yes","No")!="Yes")
 			return
-		var/static/issue_template = file2text(".github/ISSUE_TEMPLATE.md")
+		var/static/issue_template = file2text(".github/ISSUE_TEMPLATE/bug_report.md")
+
+		// Remove comment header
+		var/content_start = findtext(issue_template, "<")
+		if(content_start)
+			issue_template = copytext(issue_template, content_start)
+
+		// Insert round
+		if(GLOB.round_id)
+			issue_template = replacetext(issue_template, "## Round ID:\n", "## Round ID:\n[GLOB.round_id]")
+
+		// Insert testmerges
+		if(GLOB.revdata.testmerge.len)
+			var/list/all_tms = list()
+			for(var/entry in GLOB.revdata.testmerge)
+				var/datum/tgs_revision_information/test_merge/tm = entry
+				all_tms += "- #[tm.number]"
+			var/all_tms_joined = all_tms.Join("\n") // for some reason this can't go in the []
+			issue_template = replacetext(issue_template, "## Testmerges:\n", "## Testmerges:\n[all_tms_joined]")
+
 		var/servername = CONFIG_GET(string/servername)
 		var/url_params = "Reporting client version: [byond_version].[byond_build]\n\n[issue_template]"
-		if(GLOB.round_id || servername)
-			url_params = "Issue reported from [GLOB.round_id ? " Round ID: [GLOB.round_id][servername ? " ([servername])" : ""]" : servername]\n\n[url_params]"
 		DIRECT_OUTPUT(src, link("[githuburl]/issues/new?body=[url_encode(url_params)]"))
 	else
 		to_chat(src, "<span class='danger'>The Github URL is not set in the server configuration.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed and improved the bug report template use when the 'Report Issue' button is used in-game. It now uses the correct template location, as well as automatically filling in the round ID and testmerges.

We also now show [s] PRs that are testmerged, as ok-d by oranges, as this is an unofficial label that anyone can apply and doesn't necessitate hiding. It also makes debugging rounds where this was present but not reported more difficult.

Example of generated bug report from button use in-game below:
![image](https://user-images.githubusercontent.com/10467687/100033203-1d1fc180-2dd0-11eb-9b98-3b499141ee6a.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We love easier bug reporting for users

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
fix: Fixed the in-game 'Report Issue' button to use the template properly. Now more easier than ever to report a bug, try it today!
tweak: The show-server-revision verb, as well as the bug reporting, will now show [s]-flagged testmerged PRs to non-admins and admins alike.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
