### PR TITLE
sstimer no longer batches maintenance tasks to the bucket list to avoid edge cases and duplicated logic.

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -241,7 +241,7 @@ SUBSYSTEM_DEF(timer)
 				second_queue.Cut(1, i+1)
 			timer = null
 		if (MC_TICK_CHECK)
-				break
+			break
 
 	// Process each invoked timer
 	bucket_count -= length(invoked_timers)

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -149,42 +149,37 @@ SUBSYSTEM_DEF(timer)
 		bucket_list = src.bucket_list
 		resumed = FALSE
 
-	var/static/list/invoked_timers = list()
-	var/static/datum/timedevent/timer
-	if (!resumed)
-		timer = null
 
 	// Iterate through each bucket starting from the practical offset
 	while (practical_offset <= BUCKET_LEN && head_offset + ((practical_offset - 1) * world.tick_lag) <= world.time)
-		var/datum/timedevent/head = bucket_list[practical_offset]
-		if (!timer || !head || timer == head)
-			head = bucket_list[practical_offset]
-			timer = head
-
-		// Iterate through each timer, invoking callbacks as necessary
-		while (timer)
+		var/datum/timedevent/timer
+		while (timer = bucket_list[practical_offset])
 			var/datum/callback/callBack = timer.callBack
 			if (!callBack)
 				bucket_resolution = null // force bucket recreation
 				CRASH("Invalid timer: [get_timer_debug_string(timer)] world.time: [world.time], \
 					head_offset: [head_offset], practical_offset: [practical_offset]")
-
+			
+			timer.bucketEject() //pop the timer off of the bucket list.
+			
 			// Invoke callback if possible
 			if (!timer.spent)
 				invoked_timers += timer
 				timer.spent = world.time
 				callBack.InvokeAsync()
 				last_invoke_tick = world.time
-
-			// Break once we've invoked the entire bucket
-			timer = timer.next
-			if (timer == head)
-				break
-				
+			
+			if (timer.flags & TIMER_LOOP) // Prepare looping timers to re-enter the queue
+				timer.spent = 0
+				timer.timeToRun = world.time + timer.wait
+				timer.bucketJoin()
+			else
+				qdel(timer)
+			
 			if (MC_TICK_CHECK)
 				break
 		
-		if (!timer || !head || timer == head)
+		if (!bucket_list[practical_offset])
 			// Empty the bucket, check if anything in the secondary queue should be shifted to this bucket
 			bucket_list[practical_offset++] = null
 			var/i = 0
@@ -221,43 +216,11 @@ SUBSYSTEM_DEF(timer)
 						qdel(timer)
 					continue
 
-				// Transfer the timer into the bucket, performing necessary circular doubly-linked list operations
-				bucket_count++
-				var/bucket_pos = max(1, BUCKET_POS(timer))
-				var/datum/timedevent/bucket_head = bucket_list[bucket_pos]
-				if (!bucket_head)
-					bucket_list[bucket_pos] = timer
-					timer.next = null
-					timer.prev = null
-					continue
-
-				if (!bucket_head.prev)
-					bucket_head.prev = bucket_head
-				timer.next = bucket_head
-				timer.prev = bucket_head.prev
-				timer.next.prev = timer
-				timer.prev.next = timer
+				timer.bucketJoin()
 			if (i)
 				second_queue.Cut(1, i+1)
-			timer = null
 		if (MC_TICK_CHECK)
 			break
-
-	// Process each invoked timer
-	bucket_count -= length(invoked_timers)
-	for (var/datum/timedevent/qtimer in invoked_timers)
-		if(QDELETED(qtimer))
-			bucket_count++
-			continue
-		if(!(qtimer.flags & TIMER_LOOP))
-			qdel(qtimer)
-		else // Prepare looping timers to re-enter the queue
-			bucket_count++
-			qtimer.spent = 0
-			qtimer.bucketEject()
-			qtimer.timeToRun = (qtimer.flags & TIMER_CLIENT_TIME ? REALTIMEOFDAY : world.time) + qtimer.wait
-			qtimer.bucketJoin()
-	invoked_timers.len = 0
 
 /**
   * Generates a string with details about the timed event for debugging purposes
@@ -428,12 +391,6 @@ SUBSYSTEM_DEF(timer)
 			nextid++
 		SStimer.timer_id_dict[id] = src
 
-	// Generate debug-friendly name for timer
-	var/static/list/bitfield_flags = list("TIMER_UNIQUE", "TIMER_OVERRIDE", "TIMER_CLIENT_TIME", "TIMER_STOPPABLE", "TIMER_NO_HASH_WAIT", "TIMER_LOOP")
-	name = "Timer: [id] (\ref[src]), TTR: [timeToRun], Flags: [jointext(bitfield2list(flags, bitfield_flags), ", ")], \
-		callBack: \ref[callBack], callBack.object: [callBack.object]\ref[callBack.object]([getcallingtype()]), \
-		callBack.delegate:[callBack.delegate]([callBack.arguments ? callBack.arguments.Join(", ") : ""])"
-
 	if ((timeToRun < world.time || timeToRun < SStimer.head_offset) && !(flags & TIMER_CLIENT_TIME))
 		CRASH("Invalid timer state: Timer created that would require a backtrack to run (addtimer would never let this happen): [SStimer.get_timer_debug_string(src)]")
 
@@ -524,6 +481,12 @@ SUBSYSTEM_DEF(timer)
   * If the timed event is tracking client time, it will be added to a special bucket.
   */
 /datum/timedevent/proc/bucketJoin()
+	// Generate debug-friendly name for timer
+	var/static/list/bitfield_flags = list("TIMER_UNIQUE", "TIMER_OVERRIDE", "TIMER_CLIENT_TIME", "TIMER_STOPPABLE", "TIMER_NO_HASH_WAIT", "TIMER_LOOP")
+	name = "Timer: [id] (\ref[src]), TTR: [timeToRun], wait:[wait] Flags: [jointext(bitfield2list(flags, bitfield_flags), ", ")], \
+		callBack: \ref[callBack], callBack.object: [callBack.object]\ref[callBack.object]([getcallingtype()]), \
+		callBack.delegate:[callBack.delegate]([callBack.arguments ? callBack.arguments.Join(", ") : ""]), source: [source]"
+		
 	// Check if this timed event should be diverted to the client time bucket, or the secondary queue
 	var/list/L
 	if (flags & TIMER_CLIENT_TIME)

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -184,7 +184,7 @@ SUBSYSTEM_DEF(timer)
 			if (MC_TICK_CHECK)
 				break
 		
-		if (timer == head)
+		if (!timer || !head || timer == head)
 			// Empty the bucket, check if anything in the secondary queue should be shifted to this bucket
 			bucket_list[practical_offset++] = null
 			var/i = 0

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -153,7 +153,7 @@ SUBSYSTEM_DEF(timer)
 	// Iterate through each bucket starting from the practical offset
 	while (practical_offset <= BUCKET_LEN && head_offset + ((practical_offset - 1) * world.tick_lag) <= world.time)
 		var/datum/timedevent/timer
-		while (timer = bucket_list[practical_offset])
+		while ((timer = bucket_list[practical_offset]))
 			var/datum/callback/callBack = timer.callBack
 			if (!callBack)
 				bucket_resolution = null // force bucket recreation

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -164,7 +164,6 @@ SUBSYSTEM_DEF(timer)
 			
 			// Invoke callback if possible
 			if (!timer.spent)
-				invoked_timers += timer
 				timer.spent = world.time
 				callBack.InvokeAsync()
 				last_invoke_tick = world.time
@@ -194,27 +193,14 @@ SUBSYSTEM_DEF(timer)
 					bucket_resolution = null // force bucket recreation
 					stack_trace("[i] Invalid timer state: Timer in long run queue with a time to run less then head_offset. \
 						[get_timer_debug_string(timer)] world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset]")
-
-					if (timer.callBack && !timer.spent)
-						timer.callBack.InvokeAsync()
-						invoked_timers += timer
-						bucket_count++
-					else if(!QDELETED(timer))
-						qdel(timer)
-					continue
+					break
 
 				// Check for timers that are not capable of being scheduled to run without rebuilding buckets
 				if (timer.timeToRun < head_offset + TICKS2DS(practical_offset - 1))
 					bucket_resolution = null // force bucket recreation
 					stack_trace("[i] Invalid timer state: Timer in long run queue that would require a backtrack to transfer to \
 						short run queue. [get_timer_debug_string(timer)] world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset]")
-					if (timer.callBack && !timer.spent)
-						timer.callBack.InvokeAsync()
-						invoked_timers += timer
-						bucket_count++
-					else if(!QDELETED(timer))
-						qdel(timer)
-					continue
+					break
 
 				timer.bucketJoin()
 			if (i)


### PR DESCRIPTION
~~This was leading to bugs if certain state operations happened while a task was delayed, furthermore if the timer subsystem was overloaded, the invoked timers list would bloat as it would never get cleared out, which would make all timer invocations take longer as they had to add to an ever growing list.~~

This now removes the entire system for batching the bucket list maintenance tasks. Simpler as it just removes the head of the bucket list at the start of the loop causing the next bucket in the list to become the head of the bucket. It no longer needs to keep track of spent timers or the last timer it processed, both of those being a source of just about every bug we've ever had.