### PR TITLE
Nightmares no longer get deleted when shadow walking.

### DIFF
--- a/code/modules/spells/spell_types/shadow_walk.dm
+++ b/code/modules/spells/spell_types/shadow_walk.dm
@@ -76,5 +76,7 @@
 			visible_message("<span class='boldwarning'>[jaunter] is revealed by the light!</span>")
 		else
 			visible_message("<span class='boldwarning'>[jaunter] emerges from the darkness!</span>")
+		jaunter.forceMove(get_turf(src))
+		jaunter = null
 		playsound(loc, 'sound/magic/ethereal_exit.ogg', 50, TRUE, -1)
 	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #55141

#54783 broke nightmares by never forceMoving them out of the phased_mob object. Ending the jaunt would qdel the phased_mob object, the nightmare mob would be in the `contents`, `/atom/movable/Destroy()` would then qdel everything in the phased_mob object's contents - Including the nightmare.

Not sure how this bug managed to pass by the PR author as casting shadowwalk even once would have ended with you deleting yourself 100% of the time in testing.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Nightmares no longer delete themselves when shadow walking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
