### PR TITLE
Prevents mecha drills from stacking do_afters on the same target.

### DIFF
--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -108,7 +108,6 @@
 /obj/item/mecha_parts/mecha_equipment/proc/do_after_mecha(atom/target, mob/user, delay)
 	if(!chassis)
 		return
-
 	var/C = chassis.loc
 	. = do_after(user, delay, target=target)
 	if(!chassis || 	chassis.loc != C || src != chassis.selected || !(get_dir(chassis, target)&chassis.dir))

--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -108,6 +108,11 @@
 /obj/item/mecha_parts/mecha_equipment/proc/do_after_mecha(atom/target, mob/user, delay)
 	if(!chassis)
 		return
+
+	// You can't drill harder by clicking more.
+	if(target in user.do_afters)
+		return
+
 	var/C = chassis.loc
 	. = do_after(user, delay, target=target)
 	if(!chassis || 	chassis.loc != C || src != chassis.selected || !(get_dir(chassis, target)&chassis.dir))

--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -109,10 +109,6 @@
 	if(!chassis)
 		return
 
-	// You can't drill harder by clicking more.
-	if(target in user.do_afters)
-		return
-
 	var/C = chassis.loc
 	. = do_after(user, delay, target=target)
 	if(!chassis || 	chassis.loc != C || src != chassis.selected || !(get_dir(chassis, target)&chassis.dir))

--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -44,7 +44,8 @@
 					"<span class='userdanger'>[chassis] starts to drill [target]...</span>", \
 					 "<span class='hear'>You hear drilling.</span>")
 
-	if(do_after_cooldown(target, source))
+	// You can't drill harder by clicking more.
+	if(!(target in source.do_afters) && do_after_cooldown(target, source))
 		log_message("Started drilling [target]", LOG_MECHA)
 		// Drilling a turf is a one-and-done procedure.
 		if(isturf(target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mecha drill do_after stacking is a pain in the ass. Under certain edge cases they can be infinitely looped. It causes the drill itself to do damage as fast as you can click. It's bad. It's going.

Mecha drills can now only have a single do_after active on a target at once. They can still do multiple do_afters in general simultaneously, but only on different targets.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Assholes no longer rake up time dilation to triple and quadrouple figures by using mech drills.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Mecha drills can no longer infinitely stack up actions as fast as the player can click their mouse.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
