### PR TITLE
Fixes forced speech nanite oversight

### DIFF
--- a/code/modules/research/nanites/nanite_programs/suppression.dm
+++ b/code/modules/research/nanites/nanite_programs/suppression.dm
@@ -136,7 +136,7 @@
 	rogue_types = list(/datum/nanite_program/brain_misfire, /datum/nanite_program/brain_decay)
 	var/static/list/blacklist = list(
 		"*surrender",
-		"*collapse"
+		"*collapse",
 		"*faint"
 	)
 

--- a/code/modules/research/nanites/nanite_programs/suppression.dm
+++ b/code/modules/research/nanites/nanite_programs/suppression.dm
@@ -137,6 +137,7 @@
 	var/static/list/blacklist = list(
 		"*surrender",
 		"*collapse"
+		"*faint"
 	)
 
 /datum/nanite_program/comm/speech/register_extra_settings()

--- a/code/modules/research/nanites/nanite_programs/suppression.dm
+++ b/code/modules/research/nanites/nanite_programs/suppression.dm
@@ -137,7 +137,7 @@
 	var/static/list/blacklist = list(
 		"*surrender",
 		"*collapse",
-		"*faint"
+		"*faint",
 	)
 
 /datum/nanite_program/comm/speech/register_extra_settings()


### PR DESCRIPTION
## About The Pull Request

All of the stunning emotes were blacklisted from the forced speech program. However, *faint was not added this to the list, and this is an oversight. This is a simple one line fix to add it to the blacklist.

## Why It's Good For The Game

It is no longer possible to make a good portion of the station locked into sleep.

## Changelog
:cl:
fix: Forced speech nanites can no longer make people faint.
/:cl:
