### PR TITLE
Fixes some food item sizes

### DIFF
--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -29,6 +29,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 10)
 	tastes = list("bread" = 10)
 	foodtypes = GRAIN
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/bread/plain/MakeProcessable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/plain, 5, 30)
@@ -293,6 +294,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("butter" = 1, "biscuit" = 1)
 	foodtypes = GRAIN | BREAKFAST
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/butterdog
 	name = "butterdog"
@@ -303,6 +305,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("butter" = 1, "exotic butter" = 1)
 	foodtypes = GRAIN | DAIRY
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/butterdog/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -6,6 +6,7 @@
 	tastes = list("bun" = 2, "beef patty" = 4)
 	foodtypes = GRAIN | MEAT //lettuce doesn't make burger a vegetable.
 	eat_time = 15 //Quick snack
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/burger/plain
 	name = "burger"

--- a/code/game/objects/items/food/egg.dm
+++ b/code/game/objects/items/food/egg.dm
@@ -92,6 +92,7 @@
 	bite_consumption = 1
 	tastes = list("egg" = 4, "salt" = 1, "pepper" = 1)
 	foodtypes = MEAT | FRIED | BREAKFAST
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/boiledegg
 	name = "boiled egg"
@@ -100,6 +101,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 3, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("egg" = 1)
 	foodtypes = MEAT | BREAKFAST
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/omelette	//FUCK THIS
 	name = "omelette du fromage"
@@ -108,7 +110,7 @@
 	trash_type = /obj/item/trash/plate
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 10, /datum/reagent/consumable/nutriment/vitamin = 3)
 	bite_consumption = 1
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	tastes = list("egg" = 1, "cheese" = 1)
 	foodtypes = MEAT | BREAKFAST | DAIRY
 
@@ -136,6 +138,6 @@
 	icon_state = "benedict"
 	food_reagents = list(/datum/reagent/consumable/nutriment/vitamin = 6, /datum/reagent/consumable/nutriment/protein = 6, /datum/reagent/consumable/nutriment = 3)
 	trash_type = /obj/item/trash/plate
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	tastes = list("egg" = 1, "bacon" = 1, "bun" = 1)
 	foodtypes = MEAT | BREAKFAST | GRAIN

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -12,6 +12,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/protein = 6,  /datum/reagent/consumable/capsaicin = 1, /datum/reagent/consumable/nutriment/vitamin = 4)
 	tastes = list("fish" = 4, "batter" = 1, "hot peppers" = 1)
 	foodtypes = MEAT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/carpmeat
 	name = "carp fillet"
@@ -22,6 +23,7 @@
 	tastes = list("fish" = 1)
 	foodtypes = MEAT
 	eatverbs = list("bite","chew","gnaw","swallow","chomp")
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/carpmeat/Initialize()
 	. = ..()
@@ -40,6 +42,7 @@
 	bite_consumption = 1
 	tastes = list("fish" = 1, "breadcrumbs" = 1)
 	foodtypes = MEAT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/fishandchips
 	name = "fish and chips"
@@ -56,6 +59,7 @@
 	food_reagents = list (/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 3)
 	tastes = list("fish" = 1, "pan seared vegtables" = 1)
 	foodtypes = MEAT | VEGETABLES | FRIED
+	w_class = WEIGHT_CLASS_SMALL
 
 ////////////////////////////////////////////MEATS AND ALIKE////////////////////////////////////////////
 
@@ -66,6 +70,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 2)
 	tastes = list("tofu" = 1)
 	foodtypes = VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/tofu/prison
 	name = "soggy tofu"
@@ -81,6 +86,7 @@
 	microwaved_type = /obj/item/food/boiledspiderleg
 	tastes = list("cobwebs" = 1)
 	foodtypes = MEAT | TOXIC
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/cornedbeef
 	name = "corned beef and cabbage"
@@ -90,6 +96,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/protein = 6, /datum/reagent/consumable/nutriment/vitamin = 4)
 	tastes = list("meat" = 1, "cabbage" = 1)
 	foodtypes = MEAT | VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/bearsteak
 	name = "Filet migrawr"
@@ -99,6 +106,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/vitamin = 9, /datum/reagent/consumable/ethanol/manly_dorf = 5)
 	tastes = list("meat" = 1, "salmon" = 1)
 	foodtypes = MEAT | ALCOHOL
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/meatball
 	name = "meatball"
@@ -107,6 +115,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("meat" = 1)
 	foodtypes = MEAT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/sausage
 	name = "sausage"
@@ -117,6 +126,7 @@
 	foodtypes = MEAT | BREAKFAST
 	eatverbs = list("bite","chew","nibble","deep throat","gobble","chomp")
 	var/roasted = FALSE
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/sausage/MakeProcessable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/salami, 6, 30)
@@ -128,6 +138,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 1)
 	tastes = list("meat" = 1, "smoke" = 1)
 	foodtypes = MEAT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/rawkhinkali
 	name = "raw khinkali"
@@ -137,6 +148,7 @@
 	microwaved_type = /obj/item/food/khinkali
 	tastes = list("meat" = 1, "onions" = 1, "garlic" = 1)
 	foodtypes = MEAT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/khinkali
 	name = "khinkali"
@@ -146,6 +158,7 @@
 	bite_consumption = 3
 	tastes = list("meat" = 1, "onions" = 1, "garlic" = 1)
 	foodtypes = MEAT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/monkeycube
 	name = "monkey cube"
@@ -217,6 +230,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/protein = 7, /datum/reagent/consumable/capsaicin = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("hot peppers" = 1, "meat" = 3, "cheese" = 1, "sour cream" = 1)
 	foodtypes = MEAT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/stewedsoymeat
 	name = "stewed soy meat"
@@ -227,6 +241,7 @@
 	tastes = list("soy" = 1, "vegetables" = 1)
 	eatverbs = list("slurp","sip","inhale","drink")
 	foodtypes = VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/stewedsoymeat/Initialize()
 	. = ..()
@@ -240,6 +255,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/consumable/capsaicin = 4, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("hot peppers" = 1, "cobwebs" = 1)
 	foodtypes = MEAT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/spidereggsham
 	name = "green eggs and ham"
@@ -250,6 +266,7 @@
 	bite_consumption = 4
 	tastes = list("meat" = 1, "the colour green" = 1)
 	foodtypes = MEAT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/sashimi
 	name = "carp sashimi"
@@ -258,6 +275,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 10, /datum/reagent/consumable/capsaicin = 9, /datum/reagent/consumable/nutriment/vitamin = 4)
 	tastes = list("fish" = 1, "hot peppers" = 1)
 	foodtypes = MEAT | TOXIC
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/sashimi/Initialize()
 	. = ..()
@@ -268,6 +286,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/protein = 2, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("\"chicken\"" = 1)
 	foodtypes = MEAT
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/nugget/Initialize()
 	. = ..()
@@ -282,6 +301,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/protein = 5, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("meat" = 1, "butter" = 1)
 	foodtypes = MEAT | DAIRY
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/bbqribs
 	name = "bbq ribs"
@@ -298,6 +318,7 @@
 	icon_state = "meatclown"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/consumable/banana = 2)
 	tastes = list("meat" = 5, "clowns" = 3, "sixteen teslas" = 1)
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/meatclown/ComponentInitialize()
 	. = ..()
@@ -319,6 +340,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 14)
 	tastes = list("meat" = 3, "metal" = 1)
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/kebab/human
 	name = "human-kebab"
@@ -374,6 +396,7 @@
 	material_flags = MATERIAL_NO_EFFECTS
 	var/subjectname = ""
 	var/subjectjob = null
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/meat/slab
 	name = "meat"
@@ -945,6 +968,7 @@
 	tastes = list("chicken" = 3, "fried batter" = 1)
 	foodtypes = MEAT | FRIED
 	junkiness = 25
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/fried_chicken/Initialize()
 	. = ..()

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -33,6 +33,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/protein = 1, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("cheese" = 1)
 	foodtypes = DAIRY
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/watermelonslice
 	name = "watermelon slice"
@@ -41,6 +42,7 @@
 	tastes = list("watermelon" = 1)
 	foodtypes = FRUIT
 	juice_results = list(/datum/reagent/consumable/watermelonjuice = 5)
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/candy_corn
 	name = "candy corn"
@@ -49,6 +51,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/sugar = 2)
 	tastes = list("candy corn" = 1)
 	foodtypes = JUNKFOOD | SUGAR
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/candy_corn/prison
 	name = "desiccated candy corn"
@@ -65,6 +68,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/sugar = 2, /datum/reagent/consumable/coco = 2)
 	tastes = list("chocolate" = 1)
 	foodtypes = JUNKFOOD | SUGAR
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/hugemushroomslice
 	name = "huge mushroom slice"
@@ -73,6 +77,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("mushroom" = 1)
 	foodtypes = VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/popcorn
 	name = "popcorn"
@@ -84,6 +89,7 @@
 	tastes = list("popcorn" = 3, "butter" = 1)
 	foodtypes = JUNKFOOD
 	eatverbs = list("bite","nibble","gnaw","gobble","chomp")
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/loadedbakedpotato
 	name = "loaded baked potato"
@@ -92,6 +98,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("potato" = 1)
 	foodtypes = VEGETABLES | DAIRY
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/fries
 	name = "space fries"
@@ -101,6 +108,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 4)
 	tastes = list("fries" = 3, "salt" = 1)
 	foodtypes = VEGETABLES | GRAIN | FRIED
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/fries/Initialize()
 	. = ..()
@@ -113,6 +121,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 4)
 	tastes = list("potato" = 3, "valids" = 1)
 	foodtypes = FRIED | VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/tatortot/Initialize()
 	. = ..()
@@ -126,6 +135,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/protein = 1)
 	tastes = list("soy" = 1)
 	foodtypes = VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/cheesyfries
 	name = "cheesy fries"
@@ -135,6 +145,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("fries" = 3, "cheese" = 1)
 	foodtypes = VEGETABLES | GRAIN | DAIRY
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/cheesyfries/Initialize()
 	. = ..()
@@ -146,6 +157,7 @@
 	icon_state = "badrecipe"
 	food_reagents = list(/datum/reagent/toxin/bad_food = 30)
 	foodtypes = GROSS
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/carrotfries
 	name = "carrot fries"
@@ -155,6 +167,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/medicine/oculine = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("carrots" = 3, "salt" = 1)
 	foodtypes = VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/carrotfries/Initialize()
 	. = ..()
@@ -168,6 +181,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/sugar = 3, /datum/reagent/consumable/caramel = 5)
 	tastes = list("apple" = 2, "caramel" = 3)
 	foodtypes = JUNKFOOD | FRUIT | SUGAR
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/mint
 	name = "mint"
@@ -177,6 +191,7 @@
 	trash_type = /obj/item/trash/plate
 	food_reagents = list(/datum/reagent/toxin/minttoxin = 2)
 	foodtypes = TOXIC | SUGAR
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/eggwrap
 	name = "egg wrap"
@@ -185,6 +200,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/protein = 2, /datum/reagent/consumable/nutriment/vitamin = 3)
 	tastes = list("egg" = 1)
 	foodtypes = MEAT | GRAIN
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/spidereggs
 	name = "spider eggs"
@@ -193,6 +209,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/toxin = 2)
 	tastes = list("cobwebs" = 1)
 	foodtypes = MEAT | TOXIC
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/spiderling
 	name = "spiderling"
@@ -201,6 +218,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 2, /datum/reagent/toxin = 4)
 	tastes = list("cobwebs" = 1, "guts" = 2)
 	foodtypes = MEAT | TOXIC
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/chewable/spiderlollipop
 	name = "spider lollipop"
@@ -218,6 +236,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/coco = 1, /datum/reagent/consumable/sugar = 1)
 	tastes = list("chocolate" = 1)
 	foodtypes = JUNKFOOD | SUGAR
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/fudgedice
 	name = "fudge dice"
@@ -227,6 +246,7 @@
 	trash_type = /obj/item/dice/fudge
 	tastes = list("fudge" = 1)
 	foodtypes = JUNKFOOD | SUGAR
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/chocoorange
 	name = "chocolate orange"
@@ -235,6 +255,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/sugar = 1)
 	tastes = list("chocolate" = 3, "oranges" = 1)
 	foodtypes = JUNKFOOD | SUGAR
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/eggplantparm
 	name = "eggplant parmigiana"
@@ -244,6 +265,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/protein = 2, /datum/reagent/consumable/nutriment/vitamin = 4)
 	tastes = list("eggplant" = 3, "cheese" = 1)
 	foodtypes = VEGETABLES | DAIRY
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/tortilla
 	name = "tortilla"
@@ -253,6 +275,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("tortilla" = 1)
 	foodtypes = GRAIN
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/burrito
 	name = "burrito"
@@ -261,6 +284,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2,/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("torilla" = 2, "meat" = 3)
 	foodtypes = GRAIN | MEAT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/cheesyburrito
 	name = "cheesy burrito"
@@ -269,6 +293,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/protein = 5, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("torilla" = 2, "meat" = 3, "cheese" = 1)
 	foodtypes = GRAIN | MEAT | DAIRY
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/carneburrito
 	name = "carne asada burrito"
@@ -277,6 +302,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/protein = 6, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("torilla" = 2, "meat" = 4)
 	foodtypes = GRAIN | MEAT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/fuegoburrito
 	name = "fuego plasma burrito"
@@ -285,6 +311,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/protein = 2, /datum/reagent/consumable/capsaicin = 5, /datum/reagent/consumable/nutriment/vitamin = 3)
 	tastes = list("torilla" = 2, "meat" = 3, "hot peppers" = 1)
 	foodtypes = GRAIN | MEAT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/yakiimo
 	name = "yaki imo"
@@ -294,6 +321,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/vitamin = 4)
 	tastes = list("sweet potato" = 1)
 	foodtypes = GRAIN | VEGETABLES | SUGAR
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/roastparsnip
 	name = "roast parsnip"
@@ -303,6 +331,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 4)
 	tastes = list("parsnip" = 1)
 	foodtypes = VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/melonfruitbowl
 	name = "melon fruit bowl"
@@ -312,6 +341,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	tastes = list("melon" = 1)
 	foodtypes = FRUIT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/nachos
 	name = "nachos"
@@ -320,6 +350,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("nachos" = 1)
 	foodtypes = VEGETABLES | FRIED
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/cheesynachos
 	name = "cheesy nachos"
@@ -328,6 +359,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/protein = 1, /datum/reagent/consumable/nutriment/vitamin = 3)
 	tastes = list("nachos" = 2, "cheese" = 1)
 	foodtypes = VEGETABLES | FRIED | DAIRY
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/cubannachos
 	name = "Cuban nachos"
@@ -336,6 +368,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 7, /datum/reagent/consumable/capsaicin = 8, /datum/reagent/consumable/nutriment/vitamin = 4)
 	tastes = list("nachos" = 2, "hot pepper" = 1)
 	foodtypes = VEGETABLES | FRIED | DAIRY
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/melonkeg
 	name = "melon keg"
@@ -354,6 +387,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/honey = 5)
 	tastes = list("oats" = 3, "nuts" = 2, "honey" = 1)
 	foodtypes = GRAIN | SUGAR
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/stuffedlegion
 	name = "stuffed legion"
@@ -362,6 +396,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/protein = 5, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/consumable/capsaicin = 2)
 	tastes = list("death" = 2, "rock" = 1, "meat" = 1, "hot peppers" = 1)
 	foodtypes = MEAT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/powercrepe
 	name = "Powercrepe"
@@ -432,6 +467,7 @@
 	var/headcolor = rgb(0, 0, 0)
 	tastes = list("candy" = 1)
 	foodtypes = JUNKFOOD | SUGAR
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/chewable/lollipop/Initialize()
 	. = ..()
@@ -473,6 +509,7 @@
 	food_reagents = list(/datum/reagent/consumable/sugar = 5)
 	tastes = list("candy" = 1)
 	succ_dur = 15 * 60
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/chewable/bubblegum/nicotine
 	name = "nicotine gum"
@@ -537,6 +574,7 @@
 	food_reagents = list(/datum/reagent/consumable/sugar = 5, /datum/reagent/medicine/sal_acid = 2, /datum/reagent/medicine/oxandrolone = 2)	//Kek
 	tastes = list("candy")
 	foodtypes = JUNKFOOD
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/chewable/gumball/Initialize()
 	. = ..()
@@ -564,6 +602,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/protein = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("taco" = 4, "meat" = 2, "cheese" = 2, "lettuce" = 1)
 	foodtypes = MEAT | DAIRY | GRAIN | VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/taco/plain
 	desc = "A traditional taco with meat and cheese, minus the rabbit food."
@@ -579,6 +618,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/consumable/salt = 8)
 	tastes = list("bran" = 4, "raisins" = 3, "salt" = 1)
 	foodtypes = GRAIN | FRUIT | BREAKFAST
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/butter
 	name = "stick of butter"
@@ -587,6 +627,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5)
 	tastes = list("butter" = 1)
 	foodtypes = DAIRY
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/butter/examine(mob/user)
 	. = ..()
@@ -621,6 +662,7 @@
 	gender = PLURAL
 	tastes = list("batter" = 3, "onion" = 1)
 	foodtypes = VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/pineappleslice
 	name = "pineapple slice"
@@ -629,6 +671,7 @@
 	juice_results = list(/datum/reagent/consumable/pineapplejuice = 3)
 	tastes = list("pineapple" = 1)
 	foodtypes = FRUIT | PINEAPPLE
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/tinychocolate
 	name = "chocolate"
@@ -637,6 +680,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/sugar = 1, /datum/reagent/consumable/coco = 1)
 	tastes = list("chocolate" = 1)
 	foodtypes = JUNKFOOD | SUGAR
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/canned
 	name = "Canned Air"
@@ -646,6 +690,7 @@
 	food_flags = FOOD_IN_CONTAINER
 	w_class = WEIGHT_CLASS_NORMAL
 	max_volume = 30
+	w_class = WEIGHT_CLASS_SMALL
 
 
 /obj/item/food/canned/proc/open_can(mob/user)
@@ -709,6 +754,7 @@
 	junkiness = 20
 	tastes = list("fried corn" = 1)
 	foodtypes = JUNKFOOD | FRIED
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/cornchips/MakeLeaveTrash()
 	if(trash_type)

--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -411,6 +411,7 @@
 	microwaved_type = /obj/item/food/donkpocket/warm
 	tastes = list("meat" = 2, "dough" = 2, "laziness" = 1)
 	foodtypes = GRAIN
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/donkpocket/warm
 	name = "warm Donk-pocket"

--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -339,6 +339,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("muffin" = 1)
 	foodtypes = GRAIN | SUGAR | BREAKFAST
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/muffin/berry
 	name = "berry muffin"
@@ -373,6 +374,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 8, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("waffles" = 1)
 	foodtypes = GRAIN | SUGAR | BREAKFAST
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/soylentgreen
 	name = "\improper Soylent Green"
@@ -382,6 +384,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 10, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/consumable/nutriment/protein = 4)
 	tastes = list("waffles" = 7, "people" = 1)
 	foodtypes = GRAIN | MEAT
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/soylenviridians
 	name = "\improper Soylent Virdians"
@@ -391,6 +394,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 10, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/consumable/nutriment/protein = 2)
 	tastes = list("waffles" = 7, "the colour green" = 1)
 	foodtypes = GRAIN
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/rofflewaffles
 	name = "roffle waffles"
@@ -401,6 +405,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 8, /datum/reagent/drug/mushroomhallucinogen = 2, /datum/reagent/consumable/nutriment/vitamin = 4)
 	tastes = list("waffle" = 1, "mushrooms" = 1)
 	foodtypes = GRAIN | VEGETABLES | SUGAR | BREAKFAST
+	w_class = WEIGHT_CLASS_SMALL
 
 ////////////////////////////////////////////DONK POCKETS////////////////////////////////////////////
 
@@ -542,6 +547,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2)
 	tastes = list("cookie" = 1)
 	foodtypes = GRAIN | SUGAR
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/cookie/Initialize()
 	. = ..()
@@ -557,6 +563,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5)
 	tastes = list("cookie" = 1)
 	foodtypes = GRAIN | SUGAR
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/poppypretzel
 	name = "poppy pretzel"
@@ -565,6 +572,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("pretzel" = 1)
 	foodtypes = GRAIN | SUGAR
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/plumphelmetbiscuit
 	name = "plump helmet biscuit"
@@ -573,6 +581,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("mushroom" = 1, "biscuit" = 1)
 	foodtypes = GRAIN | VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/plumphelmetbiscuit/Initialize()
 	var/fey = prob(10)
@@ -592,6 +601,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2)
 	tastes = list("cracker" = 1)
 	foodtypes = GRAIN
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/hotdog
 	name = "hotdog"
@@ -601,6 +611,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/protein = 1, /datum/reagent/consumable/ketchup = 3, /datum/reagent/consumable/nutriment/vitamin = 6)
 	tastes = list("bun" = 3, "meat" = 2)
 	foodtypes = GRAIN | MEAT | VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/hotdog/debug
 	eat_time = 0
@@ -612,6 +623,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 7, /datum/reagent/consumable/nutriment/vitamin = 4)
 	tastes = list("bun" = 3, "meat" = 2)
 	foodtypes = GRAIN | MEAT | VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/khachapuri
 	name = "khachapuri"
@@ -620,6 +632,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 11, /datum/reagent/consumable/nutriment/protein = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("bread" = 1, "egg" = 1, "cheese" = 1)
 	foodtypes = GRAIN | MEAT | DAIRY
+	w_class = WEIGHT_CLASS_SMALL
 
 
 /obj/item/food/cookie/sugar
@@ -637,6 +650,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("biscuit" = 3, "chocolate" = 1)
 	foodtypes = GRAIN | JUNKFOOD
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/cookie/oatmeal
 	name = "oatmeal cookie"
@@ -661,6 +675,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("cake" = 3, "cherry" = 1)
 	foodtypes = GRAIN | FRUIT | SUGAR
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/cherrycupcake/blue
 	name = "blue cherry cupcake"
@@ -676,6 +691,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/honey = 6)
 	tastes = list("pastry" = 1, "sweetness" = 1)
 	foodtypes = GRAIN | SUGAR
+	w_class = WEIGHT_CLASS_SMALL
 
 #define PANCAKE_MAX_STACK 10
 
@@ -687,6 +703,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("pancakes" = 1)
 	foodtypes = GRAIN | SUGAR | BREAKFAST
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/pancakes/blueberry
 	name = "blueberry pancake"
@@ -785,6 +802,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("pastry" = 1)
 	foodtypes = GRAIN | DAIRY | SUGAR
+	w_class = WEIGHT_CLASS_TINY
 
 
 #undef DONUT_SPRINKLE_CHANCE

--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -14,6 +14,7 @@
 	tastes = list("donut" = 1)
 	foodtypes = JUNKFOOD | GRAIN | FRIED | SUGAR | BREAKFAST
 	food_flags = FOOD_FINGER_FOOD
+	w_class = WEIGHT_CLASS_SMALL
 	var/decorated_icon = "donut_homer"
 	var/is_decorated = FALSE
 	var/extra_reagent = null

--- a/code/game/objects/items/food/sandwichtoast.dm
+++ b/code/game/objects/items/food/sandwichtoast.dm
@@ -8,6 +8,7 @@
 	microwaved_type = /obj/item/food/toastedsandwich
 	tastes = list("meat" = 2, "cheese" = 1, "bread" = 2, "lettuce" = 1)
 	foodtypes = GRAIN | VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/toastedsandwich
 	name = "toasted sandwich"
@@ -18,6 +19,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/protein = 5, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/carbon = 4)
 	tastes = list("toast" = 1)
 	foodtypes = GRAIN
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/grilledcheese
 	name = "cheese sandwich"
@@ -28,6 +30,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 7, /datum/reagent/consumable/nutriment/protein = 3, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("toast" = 1, "cheese" = 1)
 	foodtypes = GRAIN | DAIRY
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/jellysandwich
 	name = "jelly sandwich"
@@ -38,6 +41,7 @@
 	bite_consumption = 3
 	tastes = list("bread" = 1, "jelly" = 1)
 	foodtypes = GRAIN
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/jellysandwich/slime
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/toxin/slimejelly = 10, /datum/reagent/consumable/nutriment/vitamin = 4)
@@ -56,6 +60,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 10)
 	tastes = list("nothing suspicious" = 1)
 	foodtypes = GRAIN | GROSS
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/jelliedtoast
 	name = "jellied toast"
@@ -66,6 +71,7 @@
 	bite_consumption = 3
 	tastes = list("toast" = 1, "jelly" = 1)
 	foodtypes = GRAIN | BREAKFAST
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/jelliedtoast/cherry
 	food_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/cherryjelly = 8, /datum/reagent/consumable/nutriment/vitamin = 4)
@@ -84,6 +90,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("butter" = 1, "toast" = 1)
 	foodtypes = GRAIN | BREAKFAST
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/twobread
 	name = "two bread"
@@ -93,3 +100,4 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 4)
 	tastes = list("bread" = 2)
 	foodtypes = GRAIN
+	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Donk pockets were to large, now they are small size and fit in their box properly.
Also donut's.

Fixes #55170 
Fixes #55167 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Proper sizing of objects good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Donk pockets now fit in donk pocket boxes
fix: Donuts are no longer bigger than the box they came in
fix: Many food items have been resized
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
