### PR TITLE
Fixes Ghost Dynamic Abductors

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -575,12 +575,12 @@
 /datum/dynamic_ruleset/midround/from_ghosts/abductors/ready(forced = FALSE)
 	if (required_candidates > (dead_players.len + list_observers.len))
 		return FALSE
-	new_team = new
-	if(new_team.team_number > ABDUCTOR_MAX_TEAMS)
-		return MAP_ERROR
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/abductors/finish_setup(mob/new_character, index)
+	new_team = new
+	if(new_team.team_number > ABDUCTOR_MAX_TEAMS)
+		return MAP_ERROR
 	if (index == 1) // Our first guy is the scientist.
 		var/datum/antagonist/abductor/scientist/new_role = new
 		new_character.mind.add_antag_datum(new_role, new_team)


### PR DESCRIPTION
## About The Pull Request

Fixes an issue where an abductor team was created every time a midround antagonist was created by Dynamic, even if it wasn't Abductors.  This was simply due to some misplaced code.

## Why It's Good For The Game

We shouldn't list an antagonist on round end that never existed in the first place.

## Changelog
:cl:
fix: Fixed abductors being listed at round end on Dynamic despite none existing
/:cl: