### PR TITLE
Changes grenade proc names to be more clear

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -613,7 +613,7 @@
 // /obj/item/grenade signals
 
 ///called in /obj/item/gun/process_fire (user, target, params, zone_override)
-#define COMSIG_GRENADE_PRIME "grenade_prime"
+#define COMSIG_GRENADE_DETONATE "grenade_prime"
 ///called in /obj/item/gun/process_fire (user, target, params, zone_override)
 #define COMSIG_GRENADE_ARMED "grenade_armed"
 

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -12,7 +12,7 @@
 	*	-Directed: This means you're shooting multiple pellets, like buckshot. If an ammo casing is defined as having multiple pellets, it will automatically create a pellet cloud
 	*		and call COMSIG_PELLET_CLOUD_INIT (see [/obj/item/ammo_casing/proc/fire_casing]). Thus, the only projectiles fired will be the ones fired here.
 	*		The magnitude var controls how many pellets are created.
-	*	-Circular: This results in a big spray of shrapnel flying all around the detonation point when the grenade fires COMSIG_GRENADE_PRIME or landmine triggers COMSIG_MINE_TRIGGERED.
+	*	-Circular: This results in a big spray of shrapnel flying all around the detonation point when the grenade fires COMSIG_GRENADE_DETONATE or landmine triggers COMSIG_MINE_TRIGGERED.
 	*		The magnitude var controls how big the detonation radius is (the bigger the magnitude, the more shrapnel is created). Grenades can be covered with bodies to reduce shrapnel output.
 	*
 	* Once all of the fired projectiles either hit a target or disappear due to ranging out/whatever else, we resolve the list of all the things we hit and print aggregate messages so we get
@@ -82,14 +82,14 @@
 		RegisterSignal(parent, COMSIG_PELLET_CLOUD_INIT, .proc/create_casing_pellets)
 	else if(isgrenade(parent))
 		RegisterSignal(parent, COMSIG_GRENADE_ARMED, .proc/grenade_armed)
-		RegisterSignal(parent, COMSIG_GRENADE_PRIME, .proc/create_blast_pellets)
+		RegisterSignal(parent, COMSIG_GRENADE_DETONATE, .proc/create_blast_pellets)
 	else if(islandmine(parent))
 		RegisterSignal(parent, COMSIG_MINE_TRIGGERED, .proc/create_blast_pellets)
 	else if(issupplypod(parent))
 		RegisterSignal(parent, COMSIG_SUPPLYPOD_LANDED, .proc/create_blast_pellets)
 
 /datum/component/pellet_cloud/UnregisterFromParent()
-	UnregisterSignal(parent, list(COMSIG_PARENT_PREQDELETED, COMSIG_PELLET_CLOUD_INIT, COMSIG_GRENADE_PRIME, COMSIG_GRENADE_ARMED, COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_UNCROSSED, COMSIG_MINE_TRIGGERED, COMSIG_ITEM_DROPPED))
+	UnregisterSignal(parent, list(COMSIG_PARENT_PREQDELETED, COMSIG_PELLET_CLOUD_INIT, COMSIG_GRENADE_DETONATE, COMSIG_GRENADE_ARMED, COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_UNCROSSED, COMSIG_MINE_TRIGGERED, COMSIG_ITEM_DROPPED))
 
 /**
   * create_casing_pellets() is for directed pellet clouds for ammo casings that have multiple pellets (buckshot and scatter lasers for instance)

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -66,7 +66,7 @@
 
 /datum/wires/explosive/c4/explode()
 	var/obj/item/grenade/c4/P = holder
-	P.prime()
+	P.detonate()
 
 /datum/wires/explosive/pizza
 	holder_type = /obj/item/pizzabox

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -45,8 +45,8 @@
 	log_game("\An [assembly] has pulsed a grenade, which was installed by [fingerprint].")
 	var/mob/M = get_mob_by_ckey(fingerprint)
 	var/turf/T = get_turf(M)
-	G.log_grenade(M, T) //Used in preprime() too but this one convays where the mob who triggered the bomb is
-	G.preprime() //The one here convays where the bomb was when it went boom
+	G.log_grenade(M, T) //Used in arm_grenade() too but this one convays where the mob who triggered the bomb is
+	G.arm_grenade() //The one here convays where the bomb was when it went boom
 
 /datum/wires/explosive/chem_grenade/detach_assembly(color)
 	var/obj/item/assembly/S = get_attached(color)

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -46,7 +46,7 @@
 	var/mob/M = get_mob_by_ckey(fingerprint)
 	var/turf/T = get_turf(M)
 	G.log_grenade(M, T) //Used in arm_grenade() too but this one convays where the mob who triggered the bomb is
-	G.arm_grenade() //The one here convays where the bomb was when it went boom
+	G.arm_grenade() //The one here conveys where the bomb was when it went boom
 
 /datum/wires/explosive/chem_grenade/detach_assembly(color)
 	var/obj/item/assembly/S = get_attached(color)

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -209,7 +209,7 @@
 	icon_state = "moustacheg"
 	clumsy_check = GRENADE_NONCLUMSY_FUMBLE
 
-/obj/item/grenade/chem_grenade/teargas/moustache/prime(mob/living/lanced_by)
+/obj/item/grenade/chem_grenade/teargas/moustache/detonate(mob/living/lanced_by)
 	var/myloc = get_turf(src)
 	. = ..()
 	for(var/mob/living/carbon/M in view(6, myloc))

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -185,7 +185,7 @@
 		to_chat(loc, "<span class='danger'>[src] begins to beep.</span>")
 		var/mob/living/carbon/C = loc
 		C.throw_mode_on()
-	bomb.preprime(loc, null, FALSE)
+	bomb.arm_grenade(loc, null, FALSE)
 
 /obj/item/grown/bananapeel/bombanana/ComponentInitialize()
 	. = ..()
@@ -198,7 +198,7 @@
 /obj/item/grown/bananapeel/bombanana/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is deliberately slipping on the [src.name]! It looks like \he's trying to commit suicide.</span>")
 	playsound(loc, 'sound/misc/slip.ogg', 50, TRUE, -1)
-	bomb.preprime(user, 0, FALSE)
+	bomb.arm_grenade(user, 0, FALSE)
 	return (BRUTELOSS)
 
 //TEARSTACHE GRENADE

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -169,7 +169,7 @@
 
 	to_chat(user, "<span class='notice'>[src] is now in [mode] mode.</span>")
 
-/obj/item/grenade/barrier/prime(mob/living/lanced_by)
+/obj/item/grenade/barrier/detonate(mob/living/lanced_by)
 	. = ..()
 	new /obj/structure/barricade/security(get_turf(src.loc))
 	switch(mode)

--- a/code/game/objects/items/grenades/antigravity.dm
+++ b/code/game/objects/items/grenades/antigravity.dm
@@ -7,7 +7,7 @@
 	var/forced_value = 0
 	var/duration = 300
 
-/obj/item/grenade/antigravity/prime(mob/living/lanced_by)
+/obj/item/grenade/antigravity/detonate(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 

--- a/code/game/objects/items/grenades/atmos_grenades.dm
+++ b/code/game/objects/items/grenades/atmos_grenades.dm
@@ -52,9 +52,9 @@
 	icon_state = initial(icon_state) + "_active"
 	playsound(src, 'sound/effects/hit_on_shattered_glass.ogg', volume, TRUE)
 	SEND_SIGNAL(src, COMSIG_GRENADE_ARMED, det_time, delayoverride)
-	addtimer(CALLBACK(src, .proc/prime), isnull(delayoverride)? det_time : delayoverride)
+	addtimer(CALLBACK(src, .proc/detonate), isnull(delayoverride)? det_time : delayoverride)
 
-/obj/item/grenade/gas_crystal/healium_crystal/prime(mob/living/lanced_by)
+/obj/item/grenade/gas_crystal/healium_crystal/detonate(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	playsound(src, 'sound/effects/spray2.ogg', 100, TRUE)
@@ -76,7 +76,7 @@
 			live_mob.adjust_bodytemperature(-150 / distance_from_center)
 	qdel(src)
 
-/obj/item/grenade/gas_crystal/proto_nitrate_crystal/prime(mob/living/lanced_by)
+/obj/item/grenade/gas_crystal/proto_nitrate_crystal/detonate(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	playsound(src, 'sound/effects/spray2.ogg', 100, TRUE)
@@ -89,7 +89,7 @@
 		floor_loc.air_update_turf()
 	qdel(src)
 
-/obj/item/grenade/gas_crystal/zauker_crystal/prime(mob/living/lanced_by)
+/obj/item/grenade/gas_crystal/zauker_crystal/detonate(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	qdel(src)

--- a/code/game/objects/items/grenades/atmos_grenades.dm
+++ b/code/game/objects/items/grenades/atmos_grenades.dm
@@ -38,7 +38,7 @@
 	ex_light = 4
 	ex_flame = 2
 
-/obj/item/grenade/gas_crystal/preprime(mob/user, delayoverride, msg = TRUE, volume = 60)
+/obj/item/grenade/gas_crystal/arm_grenade(mob/user, delayoverride, msg = TRUE, volume = 60)
 	var/turf/turf_loc = get_turf(src)
 	log_grenade(user, turf_loc) //Inbuilt admin procs already handle null users
 	if(user)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -172,9 +172,9 @@
 		landminemode.activate()
 		return
 	active = TRUE
-	addtimer(CALLBACK(src, .proc/prime), isnull(delayoverride)? det_time : delayoverride)
+	addtimer(CALLBACK(src, .proc/detonate), isnull(delayoverride)? det_time : delayoverride)
 
-/obj/item/grenade/chem_grenade/prime(mob/living/lanced_by)
+/obj/item/grenade/chem_grenade/detonate(mob/living/lanced_by)
 	if(stage != GRENADE_READY)
 		return
 
@@ -213,7 +213,7 @@
 	ignition_temp = 25 // Large grenades are slightly more effective at setting off heat-sensitive mixtures than smaller grenades.
 	threatscale = 1.1	// 10% more effective.
 
-/obj/item/grenade/chem_grenade/large/prime(mob/living/lanced_by)
+/obj/item/grenade/chem_grenade/large/detonate(mob/living/lanced_by)
 	if(stage != GRENADE_READY)
 		return
 
@@ -280,7 +280,7 @@
 			to_chat(user, "<span class='notice'>The new value is out of bounds. Minimum spread is 5 units, maximum is 100 units.</span>")
 	..()
 
-/obj/item/grenade/chem_grenade/adv_release/prime(mob/living/lanced_by)
+/obj/item/grenade/chem_grenade/adv_release/detonate(mob/living/lanced_by)
 	if(stage != GRENADE_READY)
 		return
 
@@ -298,7 +298,7 @@
 	chem_splash(get_turf(src), affected_area, list(reactants), ignition_temp, threatscale)
 
 	var/turf/DT = get_turf(src)
-	addtimer(CALLBACK(src, .proc/prime), det_time)
+	addtimer(CALLBACK(src, .proc/detonate), det_time)
 	log_game("A grenade detonated at [AREACOORD(DT)]")
 
 

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -156,7 +156,7 @@
 	else
 		log_bomber(user, "primed a", src, "containing:[reagent_string]")
 
-/obj/item/grenade/chem_grenade/preprime(mob/user, delayoverride, msg = TRUE, volume = 60)
+/obj/item/grenade/chem_grenade/arm_grenade(mob/user, delayoverride, msg = TRUE, volume = 60)
 	var/turf/T = get_turf(src)
 	log_grenade(user, T) //Inbuilt admin procs already handle null users
 	if(user)

--- a/code/game/objects/items/grenades/clusterbuster.dm
+++ b/code/game/objects/items/grenades/clusterbuster.dm
@@ -14,7 +14,7 @@
 	var/max_spawned = 8
 	var/segment_chance = 35
 
-/obj/item/grenade/clusterbuster/prime(mob/living/lanced_by)
+/obj/item/grenade/clusterbuster/detonate(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	var/numspawned = rand(min_spawned,max_spawned)
@@ -58,9 +58,9 @@
 	var/steps = rand(1,4)
 	for(var/i in 1 to steps)
 		step_away(src,loc)
-	addtimer(CALLBACK(src, .proc/prime), rand(15,60))
+	addtimer(CALLBACK(src, .proc/detonate), rand(15,60))
 
-/obj/item/grenade/clusterbuster/segment/prime(mob/living/lanced_by)
+/obj/item/grenade/clusterbuster/segment/detonate(mob/living/lanced_by)
 	new payload_spawner(drop_location(), payload, rand(min_spawned,max_spawned))
 	playsound(src, prime_sound, 75, TRUE, -3)
 	qdel(src)
@@ -78,7 +78,7 @@
 		var/obj/item/grenade/P = new type(loc)
 		if(istype(P))
 			P.active = TRUE
-			addtimer(CALLBACK(P, /obj/item/grenade/proc/prime), rand(15,60))
+			addtimer(CALLBACK(P, /obj/item/grenade/proc/detonate), rand(15,60))
 		var/steps = rand(1,4)
 		for(var/i in 1 to steps)
 			step_away(src,loc)

--- a/code/game/objects/items/grenades/emgrenade.dm
+++ b/code/game/objects/items/grenades/emgrenade.dm
@@ -4,7 +4,7 @@
 	icon_state = "emp"
 	inhand_icon_state = "emp"
 
-/obj/item/grenade/empgrenade/prime(mob/living/lanced_by)
+/obj/item/grenade/empgrenade/detonate(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	empulse(src, 4, 10)

--- a/code/game/objects/items/grenades/festive.dm
+++ b/code/game/objects/items/grenades/festive.dm
@@ -79,7 +79,7 @@
 	var/ignition_msg = W.ignition_effect(src, user)
 	if(ignition_msg && !active)
 		visible_message(ignition_msg)
-		preprime(user)
+		arm_grenade(user)
 	else
 		return ..()
 
@@ -98,7 +98,7 @@
 	else
 		to_chat(user, "<span class='danger'>You've already removed all of the fuse!</span>")
 
-/obj/item/grenade/firecracker/preprime(mob/user, delayoverride, msg = TRUE, volume = 80)
+/obj/item/grenade/firecracker/arm_grenade(mob/user, delayoverride, msg = TRUE, volume = 80)
 	var/turf/T = get_turf(src)
 	log_grenade(user, T)
 	if(user)

--- a/code/game/objects/items/grenades/festive.dm
+++ b/code/game/objects/items/grenades/festive.dm
@@ -84,7 +84,7 @@
 		return ..()
 
 /obj/item/grenade/firecracker/fire_act(exposed_temperature, exposed_volume)
-	prime()
+	detonate()
 
 /obj/item/grenade/firecracker/wirecutter_act(mob/living/user, obj/item/I)
 	if(active)
@@ -108,9 +108,9 @@
 	playsound(src, 'sound/effects/fuse.ogg', volume, TRUE)
 	active = TRUE
 	icon_state = initial(icon_state) + "_active"
-	addtimer(CALLBACK(src, .proc/prime), isnull(delayoverride)? det_time : delayoverride)
+	addtimer(CALLBACK(src, .proc/detonate), isnull(delayoverride)? det_time : delayoverride)
 
-/obj/item/grenade/firecracker/prime(mob/living/lanced_by)
+/obj/item/grenade/firecracker/detonate(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	var/explosion_loc = get_turf(src)

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -6,7 +6,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	var/flashbang_range = 7 //how many tiles away the mob will be stunned.
 
-/obj/item/grenade/flashbang/prime(mob/living/lanced_by)
+/obj/item/grenade/flashbang/detonate(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	var/flashbang_turf = get_turf(src)
@@ -57,7 +57,7 @@
 	shrapnel_type = /obj/projectile/bullet/pellet/stingball/mega
 	shrapnel_radius = 12
 
-/obj/item/grenade/stingbang/prime(mob/living/lanced_by)
+/obj/item/grenade/stingbang/detonate(mob/living/lanced_by)
 	if(iscarbon(loc))
 		var/mob/living/carbon/C = loc
 		var/obj/item/bodypart/B = C.get_holding_bodypart_of_item(src)
@@ -118,7 +118,7 @@
 		rots++
 		user.changeNext_move(CLICK_CD_RAPID)
 
-/obj/item/grenade/primer/prime(mob/living/lanced_by)
+/obj/item/grenade/primer/detonate(mob/living/lanced_by)
 	shrapnel_radius = round(rots / rots_per_mag)
 	. = ..()
 	qdel(src)

--- a/code/game/objects/items/grenades/ghettobomb.dm
+++ b/code/game/objects/items/grenades/ghettobomb.dm
@@ -63,7 +63,7 @@
 			cut_overlay("improvised_grenade_filled")
 			arm_grenade(user, null, FALSE)
 
-/obj/item/grenade/iedcasing/prime(mob/living/lanced_by) //Blowing that can up
+/obj/item/grenade/iedcasing/detonate(mob/living/lanced_by) //Blowing that can up
 	. = ..()
 	update_mob()
 	explosion(src.loc,-1,-1,2, flame_range = 4)	// small explosion, plus a very large fireball.

--- a/code/game/objects/items/grenades/ghettobomb.dm
+++ b/code/game/objects/items/grenades/ghettobomb.dm
@@ -61,7 +61,7 @@
 		if(!botch_check(user))
 			to_chat(user, "<span class='warning'>You light the [name]!</span>")
 			cut_overlay("improvised_grenade_filled")
-			preprime(user, null, FALSE)
+			arm_grenade(user, null, FALSE)
 
 /obj/item/grenade/iedcasing/prime(mob/living/lanced_by) //Blowing that can up
 	. = ..()

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -46,7 +46,7 @@
 
 /obj/item/grenade/deconstruct(disassembled = TRUE)
 	if(!disassembled)
-		prime()
+		detonate()
 	if(!QDELETED(src))
 		qdel(src)
 
@@ -104,9 +104,9 @@
 	active = TRUE
 	icon_state = initial(icon_state) + "_active"
 	SEND_SIGNAL(src, COMSIG_GRENADE_ARMED, det_time, delayoverride)
-	addtimer(CALLBACK(src, .proc/prime), isnull(delayoverride)? det_time : delayoverride)
+	addtimer(CALLBACK(src, .proc/detonate), isnull(delayoverride)? det_time : delayoverride)
 
-/obj/item/grenade/proc/prime(mob/living/lanced_by)
+/obj/item/grenade/proc/detonate(mob/living/lanced_by)
 	if(shrapnel_type && shrapnel_radius && !shrapnel_initialized) // add a second check for adding the component in case whatever triggered the grenade went straight to prime (badminnery for example)
 		shrapnel_initialized = TRUE
 		AddComponent(/datum/component/pellet_cloud, projectile_type=shrapnel_type, magnitude=shrapnel_radius)
@@ -164,7 +164,7 @@
 		var/turf/T = get_turf(src)
 		log_game("A projectile ([hitby]) detonated a grenade held by [key_name(owner)] at [COORD(T)]")
 		message_admins("A projectile ([hitby]) detonated a grenade held by [key_name_admin(owner)] at [ADMIN_COORDJMP(T)]")
-		prime()
+		detonate()
 		return TRUE //It hit the grenade, not them
 
 /obj/item/grenade/afterattack(atom/target, mob/user)

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -19,7 +19,7 @@
 	var/display_timer = 1
 	var/clumsy_check = GRENADE_CLUMSY_FUMBLE
 	var/sticky = FALSE
-	// I moved the explosion vars and behavior to base grenades because we want all grenades to call [/obj/item/grenade/proc/prime] so we can send COMSIG_GRENADE_PRIME
+	// I moved the explosion vars and behavior to base grenades because we want all grenades to call [/obj/item/grenade/proc/prime] so we can send COMSIG_GRENADE_DETONATE
 	///how big of a devastation explosion radius on prime
 	var/ex_dev = 0
 	///how big of a heavy explosion radius on prime
@@ -77,10 +77,9 @@
 /obj/item/grenade/attack_self(mob/user)
 	if(HAS_TRAIT(src, TRAIT_NODROP))
 		to_chat(user, "<span class='notice'>You try prying [src] off your hand...</span>")
-		if(do_after(user, 70, target=src))
+		if(do_after(user, 7 SECONDS, target=src))
 			to_chat(user, "<span class='notice'>You manage to remove [src] from your hand.</span>")
 			REMOVE_TRAIT(src, TRAIT_NODROP, STICKY_NODROP)
-
 		return
 
 	if(!active)
@@ -90,6 +89,7 @@
 /obj/item/grenade/proc/log_grenade(mob/user, turf/T)
 	log_bomber(user, "has primed a", src, "for detonation")
 
+///
 /obj/item/grenade/proc/preprime(mob/user, delayoverride, msg = TRUE, volume = 60)
 	var/turf/T = get_turf(src)
 	log_grenade(user, T) //Inbuilt admin procs already handle null users
@@ -111,7 +111,7 @@
 		shrapnel_initialized = TRUE
 		AddComponent(/datum/component/pellet_cloud, projectile_type=shrapnel_type, magnitude=shrapnel_radius)
 
-	SEND_SIGNAL(src, COMSIG_GRENADE_PRIME, lanced_by)
+	SEND_SIGNAL(src, COMSIG_GRENADE_DETONATE, lanced_by)
 	if(ex_dev || ex_heavy || ex_light || ex_flame)
 		explosion(loc, ex_dev, ex_heavy, ex_light, flame_range = ex_flame)
 

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -39,7 +39,7 @@
 /obj/item/grenade/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] primes [src], then eats it! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(src, 'sound/items/eatfood.ogg', 50, TRUE)
-	preprime(user, det_time)
+	arm_grenade(user, det_time)
 	user.transferItemToLoc(src, user, TRUE)//>eat a grenade set to 5 seconds >rush captain
 	sleep(det_time)//so you dont die instantly
 	return BRUTELOSS
@@ -55,11 +55,11 @@
 	if(clumsy && (clumsy_check == GRENADE_CLUMSY_FUMBLE))
 		if(prob(50))
 			to_chat(user, "<span class='warning'>Huh? How does this thing work?</span>")
-			preprime(user, 5, FALSE)
+			arm_grenade(user, 5, FALSE)
 			return TRUE
 	else if(!clumsy && (clumsy_check == GRENADE_NONCLUMSY_FUMBLE))
 		to_chat(user, "<span class='warning'>You pull the pin on [src]. Attached to it is a pink ribbon that says, \"<span class='clown'>HONK</span>\"</span>")
-		preprime(user, 5, FALSE)
+		arm_grenade(user, 5, FALSE)
 		return TRUE
 	else if(sticky && prob(50)) // to add risk to sticky tape grenade cheese, no return cause we still prime as normal after
 		to_chat(user, "<span class='warning'>What the... [src] is stuck to your hand!</span>")
@@ -84,13 +84,13 @@
 
 	if(!active)
 		if(!botch_check(user)) // if they botch the prime, it'll be handled in botch_check
-			preprime(user)
+			arm_grenade(user)
 
 /obj/item/grenade/proc/log_grenade(mob/user, turf/T)
 	log_bomber(user, "has primed a", src, "for detonation")
 
 ///
-/obj/item/grenade/proc/preprime(mob/user, delayoverride, msg = TRUE, volume = 60)
+/obj/item/grenade/proc/arm_grenade(mob/user, delayoverride, msg = TRUE, volume = 60)
 	var/turf/T = get_turf(src)
 	log_grenade(user, T) //Inbuilt admin procs already handle null users
 	if(user)

--- a/code/game/objects/items/grenades/hypno.dm
+++ b/code/game/objects/items/grenades/hypno.dm
@@ -7,7 +7,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	var/flashbang_range = 7
 
-/obj/item/grenade/hypnotic/prime(mob/living/lanced_by)
+/obj/item/grenade/hypnotic/detonate(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	var/flashbang_turf = get_turf(src)

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -42,7 +42,7 @@
 	else
 		return ..()
 
-/obj/item/grenade/c4/prime(mob/living/lanced_by)
+/obj/item/grenade/c4/detonate(mob/living/lanced_by)
 	if(QDELETED(src))
 		return
 
@@ -66,7 +66,7 @@
 
 //assembly stuff
 /obj/item/grenade/c4/receive_signal()
-	prime()
+	detonate()
 
 /obj/item/grenade/c4/attack_self(mob/user)
 	var/newtime = input(usr, "Please set the timer.", "Timer", 10) as num|null
@@ -111,7 +111,7 @@
 
 		target.add_overlay(plastic_overlay)
 		to_chat(user, "<span class='notice'>You plant the bomb. Timer counting down from [det_time].</span>")
-		addtimer(CALLBACK(src, .proc/prime), det_time*10)
+		addtimer(CALLBACK(src, .proc/detonate), det_time*10)
 
 /obj/item/grenade/c4/proc/shout_syndicate_crap(mob/M)
 	if(!M)
@@ -148,7 +148,7 @@
 	log_game("[key_name(user)] suicided with [src] at [AREACOORD(user)]")
 	user.visible_message("<span class='suicide'>[user] activates [src] and holds it above [user.p_their()] head! It looks like [user.p_theyre()] going out with a bang!</span>")
 	shout_syndicate_crap(user)
-	explosion(user,0,2,0) //Cheap explosion imitation because putting prime() here causes runtimes
+	explosion(user,0,2,0) //Cheap explosion imitation because putting detonate() here causes runtimes
 	user.gib(1, 1)
 	qdel(src)
 

--- a/code/game/objects/items/grenades/smokebomb.dm
+++ b/code/game/objects/items/grenades/smokebomb.dm
@@ -19,7 +19,7 @@
 	desc = "The word '[pick(bruh_moment)]' is scribbled on it in crayon."
 
 ///Here we generate some smoke and also damage blobs??? for some reason. Honestly not sure why we do that.
-/obj/item/grenade/smokebomb/prime(mob/living/lanced_by)
+/obj/item/grenade/smokebomb/detonate(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	playsound(src, 'sound/effects/smoke.ogg', 50, TRUE, -3)

--- a/code/game/objects/items/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/grenades/spawnergrenade.dm
@@ -7,7 +7,7 @@
 	var/spawner_type = null // must be an object path
 	var/deliveryamt = 1 // amount of type to deliver
 
-/obj/item/grenade/spawnergrenade/prime(mob/living/lanced_by)			// Prime now just handles the two loops that query for people in lockers and people who can see it.
+/obj/item/grenade/spawnergrenade/detonate(mob/living/lanced_by)			// Prime now just handles the two loops that query for people in lockers and people who can see it.
 	. = ..()
 	update_mob()
 	if(spawner_type && deliveryamt)

--- a/code/game/objects/items/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/grenades/syndieminibomb.dm
@@ -10,7 +10,7 @@
 	ex_light = 4
 	ex_flame = 2
 
-/obj/item/grenade/syndieminibomb/prime(mob/living/lanced_by)
+/obj/item/grenade/syndieminibomb/detonate(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	qdel(src)
@@ -39,7 +39,7 @@
 	shrapnel_type = /obj/projectile/bullet/shrapnel/mega
 	shrapnel_radius = 12
 
-/obj/item/grenade/frag/prime(mob/living/lanced_by)
+/obj/item/grenade/frag/detonate(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	qdel(src)
@@ -54,7 +54,7 @@
 	var/rad_damage = 350
 	var/stamina_damage = 30
 
-/obj/item/grenade/gluon/prime(mob/living/lanced_by)
+/obj/item/grenade/gluon/detonate(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	playsound(loc, 'sound/effects/empulse.ogg', 50, TRUE)

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -111,7 +111,7 @@
 		to_chat(user, "<span class='notice'>You pet [src]. D'awww.</span>")
 		if(grenade && !grenade.active)
 			log_game("[key_name(user)] activated a hidden grenade in [src].")
-			grenade.preprime(user, msg = FALSE, volume = 10)
+			grenade.arm_grenade(user, msg = FALSE, volume = 10)
 	else
 		to_chat(user, "<span class='notice'>You try to pet [src], but it has no stuffing. Aww...</span>")
 

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -107,7 +107,7 @@
 	user.visible_message("<span class='suicide'>[user] begins to sword-swallow \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	user.say("[war_cry]", forced="spear warcry")
 	explosive.forceMove(user)
-	explosive.prime()
+	explosive.detonate()
 	user.gib()
 	qdel(src)
 	return BRUTELOSS
@@ -131,7 +131,7 @@
 	if(wielded)
 		user.say("[war_cry]", forced="spear warcry")
 		explosive.forceMove(AM)
-		explosive.prime(lanced_by=user)
+		explosive.detonate(lanced_by=user)
 		qdel(src)
 
 //GREY TIDE

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -118,10 +118,10 @@
 		C.throw_mode_on()
 	icon_state = "firelemon_active"
 	playsound(loc, 'sound/weapons/armbomb.ogg', 75, TRUE, -3)
-	addtimer(CALLBACK(src, .proc/prime), rand(10, 60))
+	addtimer(CALLBACK(src, .proc/detonate), rand(10, 60))
 
 /obj/item/food/grown/firelemon/burn()
-	prime()
+	detonate()
 	..()
 
 /obj/item/food/grown/firelemon/proc/update_mob()
@@ -132,7 +132,7 @@
 /obj/item/food/grown/firelemon/ex_act(severity)
 	qdel(src) //Ensuring that it's deleted by its own explosion
 
-/obj/item/food/grown/firelemon/proc/prime(mob/living/lanced_by)
+/obj/item/food/grown/firelemon/proc/detonate(mob/living/lanced_by)
 	switch(seed.potency) //Combustible lemons are alot like IEDs, lots of flame, very little bang.
 		if(0 to 30)
 			update_mob()

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -214,18 +214,18 @@
 /obj/item/food/grown/cherry_bomb/attack_self(mob/living/user)
 	user.visible_message("<span class='warning'>[user] plucks the stem from [src]!</span>", "<span class='userdanger'>You pluck the stem from [src], which begins to hiss loudly!</span>")
 	log_bomber(user, "primed a", src, "for detonation")
-	prime()
+	detonate()
 
 /obj/item/food/grown/cherry_bomb/deconstruct(disassembled = TRUE)
 	if(!disassembled)
-		prime()
+		detonate()
 	if(!QDELETED(src))
 		qdel(src)
 
 /obj/item/food/grown/cherry_bomb/ex_act(severity)
 	qdel(src) //Ensuring that it's deleted by its own explosion. Also prevents mass chain reaction with piles of cherry bombs
 
-/obj/item/food/grown/cherry_bomb/proc/prime(mob/living/lanced_by)
+/obj/item/food/grown/cherry_bomb/proc/detonate(mob/living/lanced_by)
 	icon_state = "cherry_bomb_lit"
 	playsound(src, 'sound/effects/fuse.ogg', seed.potency, FALSE)
 	reagents.chem_temp = 1000 //Sets off the gunpowder

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -772,7 +772,7 @@
 		if(istype(held_item, /obj/item/grenade))
 			var/obj/item/grenade/G = held_item
 			G.forceMove(drop_location())
-			G.prime()
+			G.detonate()
 			to_chat(src, "<span class='danger'>You let go of [held_item]!</span>")
 			held_item = null
 			return 1

--- a/code/modules/ninja/ninja_explosive.dm
+++ b/code/modules/ninja/ninja_explosive.dm
@@ -11,7 +11,7 @@
 	desc = "A modified C-4 charge supplied to you by the Spider Clan.  Its explosive power has been juiced up, but only works in one specific area."
 	boom_sizes = list(4, 8, 12)
 	var/mob/detonator = null
-	
+
 /obj/item/grenade/c4/ninja/afterattack(atom/movable/AM, mob/user, flag)
 	var/datum/antagonist/ninja/ninja_antag = user.mind.has_antag_datum(/datum/antagonist/ninja)
 	if(!ninja_antag)
@@ -26,8 +26,8 @@
 		return
 	detonator = user
 	return ..()
-		
-/obj/item/grenade/c4/ninja/prime(mob/living/lanced_by)
+
+/obj/item/grenade/c4/ninja/detonate(mob/living/lanced_by)
 	. = ..()
 	//Since we already did the checks in afterattack, the denonator must be a ninja with the bomb objective.
 	if(!detonator)

--- a/code/modules/projectiles/guns/misc/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/misc/grenade_launcher.dm
@@ -43,4 +43,4 @@
 	F.active = 1
 	F.icon_state = initial(F.icon_state) + "_active"
 	playsound(user.loc, 'sound/weapons/armbomb.ogg', 75, TRUE, -3)
-	addtimer(CALLBACK(F, /obj/item/grenade.proc/prime), 15)
+	addtimer(CALLBACK(F, /obj/item/grenade.proc/detonate), 15)

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -547,7 +547,7 @@
 		S.visible_message("<span class='danger'>Infused with plasma, the core begins to expand uncontrollably!</span>")
 		S.icon_state = "[S.base_state]_active"
 		S.active = TRUE
-		addtimer(CALLBACK(S, /obj/item/grenade.proc/prime), rand(15,60))
+		addtimer(CALLBACK(S, /obj/item/grenade.proc/detonate), rand(15,60))
 	else
 		var/mob/living/simple_animal/slime/random/S = new (get_turf(holder.my_atom))
 		S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and a new baby slime emerges from it!</span>")
@@ -564,7 +564,7 @@
 	S.visible_message("<span class='danger'>Infused with slime jelly, the core begins to expand uncontrollably!</span>")
 	S.icon_state = "[S.base_state]_active"
 	S.active = TRUE
-	addtimer(CALLBACK(S, /obj/item/grenade.proc/prime), rand(15,60))
+	addtimer(CALLBACK(S, /obj/item/grenade.proc/detonate), rand(15,60))
 	var/lastkey = holder.my_atom.fingerprintslast
 	var/touch_msg = "N/A"
 	if(lastkey)

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -291,7 +291,7 @@
 			investigate_log("Experimentor has transformed [savedName] into [loaded_item]", INVESTIGATE_EXPERIMENTOR)
 			if(istype(loaded_item, /obj/item/grenade/chem_grenade))
 				var/obj/item/grenade/chem_grenade/CG = loaded_item
-				CG.prime()
+				CG.detonate()
 			ejectItem()
 	////////////////////////////////////////////////////////////////////////////////////////////////
 	if(exp == SCANTYPE_GAS)
@@ -613,13 +613,13 @@
 /obj/item/relic/proc/clean(mob/user)
 	playsound(src, "sparks", rand(25,50), TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	var/obj/item/grenade/chem_grenade/cleaner/CL = new/obj/item/grenade/chem_grenade/cleaner(get_turf(user))
-	CL.prime()
+	CL.detonate()
 	warn_admins(user, "Smoke", 0)
 
 /obj/item/relic/proc/flash(mob/user)
 	playsound(src, "sparks", rand(25,50), TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	var/obj/item/grenade/flashbang/CB = new/obj/item/grenade/flashbang(user.loc)
-	CB.prime()
+	CB.detonate()
 	warn_admins(user, "Flash")
 
 /obj/item/relic/proc/petSpray(mob/user)

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -377,7 +377,7 @@
 	var/turf/T = get_turf(src)
 	message_admins("[ADMIN_LOOKUPFLW(user)] fired a [F] in [ADMIN_VERBOSEJMP(T)]")
 	log_game("[key_name(user)] fired a [F] in [AREACOORD(T)]")
-	addtimer(CALLBACK(F, /obj/item/grenade/flashbang.proc/prime), det_time)
+	addtimer(CALLBACK(F, /obj/item/grenade/flashbang.proc/detonate), det_time)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang/clusterbang //Because I am a heartless bastard -Sieve //Heartless? for making the poor man's honkblast? - Kaze
 	name = "\improper SOB-3 grenade launcher"

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -30,7 +30,7 @@
 /obj/machinery/vending/security/pre_throw(obj/item/I)
 	if(istype(I, /obj/item/grenade))
 		var/obj/item/grenade/G = I
-		G.preprime()
+		G.arm_grenade()
 	else if(istype(I, /obj/item/flashlight))
 		var/obj/item/flashlight/F = I
 		F.on = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Grenades have, for the longest time, used the proc name preprime() to refer to arming a timed grenade so that it will boom in a few seconds, and prime() to refer to the grenade actually going boom (or releasing foam or anything else grenades do when they go off). This was very confusing, so now these two procs are called arm_grenade() and detonate().
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
MSO said it was good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->