### PR TITLE
Makes swarmers and morphs ghost-visible in the orbit menu

### DIFF
--- a/code/modules/antagonists/morph/morph_antag.dm
+++ b/code/modules/antagonists/morph/morph_antag.dm
@@ -1,6 +1,7 @@
 /datum/antagonist/morph
 	name = "Morph"
 	show_name_in_check_antagonists = TRUE
+	show_to_ghosts = TRUE
 	show_in_antagpanel = FALSE
 	var/playstyle_string = "<span class='big bold'>You are a morph,</span> a shapeshifting abomination that can eat almost anything. \
 							You may take the form of anything you can see by shift-clicking it. This process will alert any nearby \

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -11,6 +11,7 @@
 /datum/antagonist/swarmer
 	name = "Swarmer"
 	job_rank = ROLE_ALIEN
+	show_to_ghosts = TRUE
 	show_in_antagpanel = FALSE
 	prevent_roundtype_conversion = FALSE
 	var/datum/team/swarmer/swarmer_team


### PR DESCRIPTION
## About The Pull Request

Makes Morphs and Swarmers have their own part of the orbit menu, like other visible antagonists. Given pretty much every other ghost-obvious antagonist is, it's more of an oversight that you couldn't.

## Why It's Good For The Game

More consistent, and makes it just a bit easier to orbit them.

## Changelog
:cl:
fix: Morphs and Swarmers now have their own categories in the orbit menu.
/:cl: