### PR TITLE
Fixes incapacitating sleep test failure, general test touch ups.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -907,9 +907,8 @@
 	if(throwing)
 		return
 	if(on && !(movement_type & FLOATING))
-		animate(src, pixel_y = pixel_y + 2, time = 10, loop = -1)
-		sleep(10)
-		animate(src, pixel_y = pixel_y - 2, time = 10, loop = -1)
+		animate(src, pixel_y = 2, time = 10, loop = -1, flags = ANIMATION_RELATIVE)
+		animate(pixel_y = -2, time = 10, loop = -1, flags = ANIMATION_RELATIVE)
 		setMovetype(movement_type | FLOATING)
 	else if (!on && (movement_type & FLOATING))
 		animate(src, pixel_y = base_pixel_y, time = 10)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -476,7 +476,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	if(drowsyness)
 		drowsyness = max(drowsyness - restingpwr, 0)
 		blur_eyes(2)
-		if(TRUE)
+		if(prob(5))
 			AdjustSleeping(100)
 
 	//Jitteriness

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -476,7 +476,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	if(drowsyness)
 		drowsyness = max(drowsyness - restingpwr, 0)
 		blur_eyes(2)
-		if(prob(5))
+		if(TRUE)
 			AdjustSleeping(100)
 
 	//Jitteriness

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -944,9 +944,8 @@
 	if(anchored || (buckled?.anchored))
 		fixed = 1
 	if(on && !(movement_type & FLOATING) && !fixed)
-		animate(src, pixel_y = pixel_y + 2, time = 10, loop = -1)
-		sleep(10)
-		animate(src, pixel_y = pixel_y - 2, time = 10, loop = -1)
+		animate(src, pixel_y = 2, time = 10, loop = -1, flags = ANIMATION_RELATIVE)
+		animate(pixel_y = -2, time = 10, loop = -1, flags = ANIMATION_RELATIVE)
 		setMovetype(movement_type | FLOATING)
 	else if(((!on || fixed) && (movement_type & FLOATING)))
 		animate(src, pixel_y = base_pixel_y + body_position_pixel_y_offset, time = 1 SECONDS)

--- a/code/modules/unit_tests/machine_disassembly.dm
+++ b/code/modules/unit_tests/machine_disassembly.dm
@@ -3,7 +3,6 @@
 	var/obj/machinery/freezer = allocate(/obj/machinery/atmospherics/components/unary/thermomachine/freezer)
 
 	var/turf/freezer_location = freezer.loc
-	freezer_location.ChangeTurf(/turf/open/floor/plasteel)
 	freezer.deconstruct()
 
 	// Check that the components are created

--- a/code/modules/unit_tests/reagent_mod_expose.dm
+++ b/code/modules/unit_tests/reagent_mod_expose.dm
@@ -11,6 +11,9 @@
 		target.health = 80
 
 /datum/unit_test/reagent_mob_expose/Run()
+	// Life() is handled just by tests
+	SSmobs.pause()
+
 	var/mob/living/carbon/human/human = allocate(/mob/living/carbon/human)
 	var/obj/item/reagent_containers/dropper/dropper = allocate(/obj/item/reagent_containers/dropper)
 	var/obj/item/reagent_containers/food/drinks/drink = allocate(/obj/item/reagent_containers/food/drinks/bottle)
@@ -23,7 +26,7 @@
 	drink.attack(human, human)
 	TEST_ASSERT_EQUAL(human.fire_stacks, 1, "Human does not have fire stacks after taking phlogiston")
 	human.Life()
-	TEST_ASSERT_EQUAL(human.fire_stacks, 2, "Human fire stacks did not increase after life tick")
+	TEST_ASSERT(human.fire_stacks > 1, "Human fire stacks did not increase after life tick")
 
 	// TOUCH
 	dropper.reagents.add_reagent(/datum/reagent/water, 1)
@@ -50,3 +53,6 @@
 	syringe.mode = SYRINGE_INJECT
 	syringe.afterattack(human, human, TRUE)
 	TEST_ASSERT_EQUAL(human.health, 80, "Human health did not update after injection from syringe")
+
+/datum/unit_test/reagent_mob_expose/Destroy()
+	SSmobs.ignite()

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -19,9 +19,14 @@ GLOBAL_VAR(test_log)
 	//Bit of metadata for the future maybe
 	var/list/procs_tested
 
-	//usable vars
+	/// The bottom left turf of the testing zone
 	var/turf/run_loc_bottom_left
+
+	/// The top right turf of the testing zone
 	var/turf/run_loc_top_right
+
+	/// The type of turf to allocate for the testing zone
+	var/test_turf_type = /turf/open/floor/plasteel
 
 	//internal shit
 	var/focus = FALSE
@@ -29,10 +34,18 @@ GLOBAL_VAR(test_log)
 	var/list/allocated
 	var/list/fail_reasons
 
+	var/static/datum/turf_reservation/turf_reservation
+
 /datum/unit_test/New()
+	if (isnull(turf_reservation))
+		turf_reservation = SSmapping.RequestBlockReservation(5, 5)
+
+	for (var/turf/reserved_turf in turf_reservation.reserved_turfs)
+		reserved_turf.ChangeTurf(test_turf_type)
+
 	allocated = new
-	run_loc_bottom_left = locate(1, 1, 1)
-	run_loc_top_right = locate(5, 5, 1)
+	run_loc_bottom_left = locate(turf_reservation.bottom_left_coords[1], turf_reservation.bottom_left_coords[2], turf_reservation.bottom_left_coords[3])
+	run_loc_top_right = locate(turf_reservation.top_right_coords[1], turf_reservation.top_right_coords[2], turf_reservation.top_right_coords[3])
 
 /datum/unit_test/Destroy()
 	//clear the test area


### PR DESCRIPTION
## About The Pull Request
- Fixes the random incapacitating sleep test failure
- Tests now provide the option to use a custom turf, by default uses plasteel tiles instead of space
- Tests now reserve turf instead of just using a corner in CentCom (which had unaccounted for tiles)

## What?

<details>

<summary>Click me for a long story about unit tests, randomness, and Life.</summary>

Randomness in unit tests is bad. It leads to inconsistent results where sometimes tests fail and sometimes they don't. Unfortunately, tests were added very late into SS13's life, and SS13 on its own is just a very complex game. It would be very difficult to track down every source of randomness and know if it would impact a test or not, so we make do, and I play whack a mole every time one comes up.

One came recently, and it was this:

```
 [08:55:54] Runtime in status_effect.dm,32: Cannot modify null.attached_effect.
  proc name: on creation (/datum/status_effect/proc/on_creation)
  src: /datum/status_effect/incapacit... (/datum/status_effect/incapacitating/sleeping)
  call stack:
  /datum/status_effect/incapacit... (/datum/status_effect/incapacitating/sleeping): on creation(Bailey Garratt (/mob/living/carbon/human), 100)
  /datum/status_effect/incapacit... (/datum/status_effect/incapacitating/sleeping): on creation(Bailey Garratt (/mob/living/carbon/human), 100)
  /datum/status_effect/incapacit... (/datum/status_effect/incapacitating/sleeping): on creation(Bailey Garratt (/mob/living/carbon/human), 100)
  /datum/status_effect/incapacit... (/datum/status_effect/incapacitating/sleeping): New(/list (/list))
  Bailey Garratt (/mob/living/carbon/human): apply status effect(/datum/status_effect/incapacit... (/datum/status_effect/incapacitating/sleeping), 100)
  Bailey Garratt (/mob/living/carbon/human): AdjustSleeping(100)
  Bailey Garratt (/mob/living/carbon/human): handle status effects()
  Bailey Garratt (/mob/living/carbon/human): Life(null)
FAIL: /datum/unit_test/spawn_humans 5s
	REASON #1: [08:55:54] Runtime in status_effect.dm,32: Cannot modify null.attached_effect.
```

Great. Let's check status_effect.dm,32.

```dm
if(alert_type)
		var/atom/movable/screen/alert/status_effect/A = owner.throw_alert(id, alert_type)
		A.attached_effect = src // <--- erroring line
		linked_alert = A
```

Ok, `throw_alert` is returning null. That's concerning. This looks like a real bug the tests have captured, just non-deterministically. No big deal. Say, how can `throw_alert` return null?

```dm
	if(!category || QDELETED(src))
		return
```

...wait, what? Okay, `category` is definitely there, so `src` must be being QDELETED...? What's going on here?

Well, it's from the spawn_humans test, so let me just isolate just that test and...*what?* It's fixed now?!?

Sigh. Where is this status effect being created from even?

```dm
	if(drowsyness)
		drowsyness = max(drowsyness - restingpwr, 0)
		blur_eyes(2)
		if(prob(5))
			AdjustSleeping(100) // <--- here
```

...Well, that would explain the randomness I guess. *Something* is making humans drowsy, and a 5% chance is being rolled to make them sleep (we set a random seed for tests to at least get things to *consistently* randomly fail on the same commit, but it wasn't working here for some reason? I never figured that one out...).

Some debugging later, we realize its reagent_mod_expose.dm, this test:

```dm
	// VAPOR
	TEST_ASSERT_EQUAL(human.drowsyness, 0, "Human is drowsy at the start of testing")
	drink.reagents.clear_reagents()
	drink.reagents.add_reagent(/datum/reagent/nitrous_oxide, 10)
	drink.reagents.trans_to(human, 10, methods = VAPOR)
	TEST_ASSERT_NOTEQUAL(human.drowsyness, 0, "Human is not drowsy after exposure to vapors")
```

It's only spawn_humans that's reporting it because...well, it's the only test that takes more than a tenth of a second (it intentionally sleeps for 5 seconds).

Changing the `prob(5)` to just `TRUE` lets us get this error consistently. Now we're getting somewhere, good.

So then, the problem is the status effect is being applied on qdeleted mobs. That shouldn't be happening, let's check Life.

```dm
		if (QDELETED(src)) // diseases can qdel the mob via transformations
			return

		if(stat != DEAD)
			//Random events (vomiting etc)
			handle_random_events()

		//Handle temperature/pressure differences between body and environment
		var/datum/gas_mixture/environment = loc.return_air()
		if(environment)
			handle_environment(environment)

		handle_gravity()

		if(stat != DEAD)
			handle_traits() // eye, ear, brain damages
			handle_status_effects() // <--- This is what adds the status effect action element
```

Wait, WHAT? It *is* checking QDELETED(src). It's not one of the functions in between deleting the mob, the reagent_mod_expose test deletes the mob once its over. That means something must be yielding between the initial condition and `handle_status_effects`. Something is yielding in ***Life***.

Setting `SHOULD_NOT_SLEEP(TRUE)` to everything helps isolate theoretical scenarios where something can sleep, and...

...for fucks sake.

```dm
/mob/living/float(on)
    if(throwing)
        return
    var/fixed = 0
    if(anchored || (buckled?.anchored))
        fixed = 1
    if(on && !(movement_type & FLOATING) && !fixed)
        animate(src, pixel_y = pixel_y + 2, time = 10, loop = -1)
        sleep(10) // <--- 🙃
        animate(src, pixel_y = pixel_y - 2, time = 10, loop = -1)
        setMovetype(movement_type | FLOATING)
    else if(((!on || fixed) && (movement_type & FLOATING)))
        animate(src, pixel_y = base_pixel_y + body_position_pixel_y_offset, time = 1 SECONDS)
        setMovetype(movement_type & ~FLOATING)
```

Because tests occur in space, every human being created was floating. Floating (called by `handle_gravity`) has a *1 second sleep* for a *fucking animation*. (AND THIS CODE IS IN TWO PLACES!!! `/atom/movable/proc/float` has the same thing!).

Okay, my God. Easy enough, just use stacking animates or whatever. Looks fine, whatever. At the same time, let's make tests just use normal tiles, it makes more sense in most scenarios anyway. Time to do one final check and...

![image](https://user-images.githubusercontent.com/35135081/100394599-926adc80-2ff2-11eb-823e-d844181a226f.png)

...give me a break, what now. (At this point I went to bed and just woke up the next morning to work on it again)

Well, there's an `adjust_fire_stacks(-0.1)` in...dear God. `handle_fire`.

![image](https://user-images.githubusercontent.com/35135081/100394672-dbbb2c00-2ff2-11eb-9f52-8325d8c938d9.png)

🙃🙃🙃🙃🙃🙃🙃🙃🙃🙃🙃🙃🙃

</details>
