### PR TITLE
Allows dynamic game modes to be disabled

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -37,7 +37,7 @@
 	var/required_enemies = list(1,1,0,0,0,0,0,0,0,0)
 	/// The rule needs this many candidates (post-trimming) to be executed (example: Cult needs 4 players at round start)
 	var/required_candidates = 0
-	/// 1 -> 9, probability for this rule to be picked against other rules
+	/// 0 -> 9, probability for this rule to be picked against other rules. If zero this will effectively disable the rule.
 	var/weight = 5
 	/// Threat cost for this rule, this is decreased from the mode's threat when the rule is executed.
 	var/cost = 0


### PR DESCRIPTION
Currently for headmins to disable game modes they need to set the list of valid threats to 101, counting on the fact that the threat level doesn't go higher than 100.
This is brittle, bypasses checks for having enough valid game modes, and a hacky solution at best.

Made it so that setting the weight of a ruleset set to zero, be it via configs or by var-editing, will no longer draft it for picking, effectively disabling it.