### PR TITLE
Fixes improvised jetpacks working as infinite one tick boosters

### DIFF
--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -131,8 +131,7 @@
 		to_chat(user, "<span class='notice'>You feel your jetpack's engines cut out.</span>")
 		turn_off(user)
 		return
-	else ..()
-	return TRUE
+	return ..()
 
 /obj/item/tank/jetpack/void
 	name = "void jetpack (oxygen)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes improvised jetpacks working as infinite one tick boosters
`allow_thrust` is used as a check when the jetpack is toggled on to see if it should be allowed to turn on. This line needs to return the parent call instead of presuming it passes.

## Why It's Good For The Game

Sweeps up a missed change in a recent pr, makes improvised jetpacks not work as infinite flight tools

## Changelog
:cl:
fix: Improvised jetpacks can no longer be used when empty for short bursts of airtime.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
