### PR TITLE
Sets default food size to small.

### DIFF
--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -3,7 +3,7 @@
 	name = "food"
 	desc = "you eat this"
 	resistance_flags = FLAMMABLE
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = null
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes an oversight done during the food refactor that makes all food items normal sized instead of small.
Instead of adding weight class to a bunch of individual items [(like this PR)](https://github.com/tgstation/tgstation/pull/55174) it just makes all food default to small unless tagged to be bigger.

## Why It's Good For The Game

Being able to put 7 items on a tray instead of 4 is good, and if a food item is "too powerful", that individual item (or subtype, such as soups) can be given a larger weight class.

Fixes #54818 

## Changelog
:cl:
fix: Food is now small, unless tagged to be bigger.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
