### PR TITLE
Fixes oversight where pAIs are not able to select headset radio channels from encryption keys

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -251,6 +251,7 @@
 			if("encryptionkeys")
 				if(href_list["toggle"])
 					encryptmod = TRUE
+					radio.subspace_transmission = TRUE
 
 			if("translator")
 				if(href_list["toggle"])	//This is permanent.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

pAI integrated headsets are the only headsets that don't have `subspace_transmission = TRUE` - Ordinarily they're not able to install encryption keys, so this isn't necessary or useful to them.

However, selecting departmental channels based on the installed encryption key is a function locked behind `subspace_transmission = TRUE` and I think the fact this flag isn't set when the pAI installs its encryption keys upgrade is most likely an oversight.

This should fix all issues where pAIs get fancy encryption keys like Captain ones, but are unable to utilise any frequencies except the default ones that come pre-enabled (such as the Cap key coming with only Sec/Command enabled and having all others disabled).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: pAIs are now able to fully utilise installed encryption keys through their integrated transciever's menu when they have the encryption key software upgrade. The issue where pAIs are only able to change integrated radio settings when in holochassis form still persists and will be fixed in a later PR.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
