### PR TITLE
Tweaks to temperature code

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -27,6 +27,9 @@
 	if (QDELETED(src))
 		return FALSE
 
+	//Body temperature stability and damage
+	dna.species.handle_body_temperature(src)
+
 	if(!IS_IN_STASIS(src))
 		if(.) //not dead
 
@@ -37,9 +40,6 @@
 			//heart attack stuff
 			handle_heart()
 			handle_liver()
-
-		//Body temperature stability and damage
-		dna.species.handle_body_temperature(src)
 
 		dna.species.spec_life(src) // for mutantraces
 	else

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1622,7 +1622,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	if(istype(humi.loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
 		return
 	//when dead the air still effects your skin temp
-	if(humi.stat == DEAD)
+	if(humi.stat == DEAD || IS_IN_STASIS(humi))
 		body_temperature_skin(humi)
 	else //when alive do all the things
 		body_temperature_core(humi)
@@ -1691,8 +1691,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	if(!humi.on_fire)
 		// Get the changes to the skin from the core temp
 		var/core_skin_diff = humi.coretemperature - humi.bodytemperature
-		// change rate of 0.08 to reflect temp back in to the core at the same rate as core to skin
-		var/core_skin_change = (1 + thermal_protection) * get_temp_change_amount(core_skin_diff, 0.08)
+		// change rate of 0.09 to reflect temp back to the skin at the slight higher rate then core to skin
+		var/core_skin_change = (1 + thermal_protection) * get_temp_change_amount(core_skin_diff, 0.09)
 
 		// We do not want to over shoot after using protection
 		if(core_skin_diff > 0)
@@ -1719,9 +1719,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		humi.remove_movespeed_modifier(/datum/movespeed_modifier/cold)
 		// display alerts based on how hot it is
 		switch(humi.bodytemperature)
-			if(0 to 461)
+			if(0 to 460)
 				humi.throw_alert("temp", /atom/movable/screen/alert/hot, 1)
-			if(460 to 700)
+			if(461 to 700)
 				humi.throw_alert("temp", /atom/movable/screen/alert/hot, 2)
 			else
 				humi.throw_alert("temp", /atom/movable/screen/alert/hot, 3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is a small tweak that makes skin temp raise up faster when cold in response to ice moon being harder.
This also makes a change to mobs in statis beds no long hold bed temp in some quantum lock but stops the natural stabilization. This means that is you put a frozen/superheated mob on the floor or a statis bed they will balance tot the room temp over time. The mob is not physically separate from the room in a statis bed and all life functions are still suspended.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better medical interaction, no long does med freak out over 20,000 degree bodies boiling in a statis bed.
Less need for coffee as a shaft miner, you will still need it but just a little less.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Body temperature stabilizes to the room temp in statis beds
fix: Body warms up a bit faster on the cold moon of ice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
