### PR TITLE
Extends the IC chat filter to be checked in two major renaming procs

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -236,6 +236,10 @@
 		if(cmptext(t_out,bad_name))
 			return	//(not case sensitive)
 
+	// Protects against names containing IC chat prohibited words.
+	if(CHAT_FILTER_CHECK(t_out))
+		return
+
 	return t_out
 
 #undef NO_CHARS_DETECTED

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1154,7 +1154,7 @@
 					transform = M.Turn(angle)
 	if(href_list[VV_HK_AUTO_RENAME] && check_rights(R_VAREDIT))
 		var/newname = input(usr, "What do you want to rename this to?", "Automatic Rename") as null|text
-		if(newname && !(CHAT_FILTER_CHECK(newname) && alert(usr, "Your selected name contains words restricted by IC chat filters. Confirm this new name?", "Confirm", "Cancel") == "Cancel"))
+		if(newname && !(CHAT_FILTER_CHECK(newname) && alert(usr, "Your selected name contains words restricted by IC chat filters. Confirm this new name?", "IC Chat Filter Conflict", "Confirm", "Cancel") == "Cancel"))
 			vv_auto_rename(newname)
 
 /atom/vv_get_header()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1154,7 +1154,8 @@
 					transform = M.Turn(angle)
 	if(href_list[VV_HK_AUTO_RENAME] && check_rights(R_VAREDIT))
 		var/newname = input(usr, "What do you want to rename this to?", "Automatic Rename") as null|text
-		if(newname && !(CHAT_FILTER_CHECK(newname) && alert(usr, "Your selected name contains words restricted by IC chat filters. Confirm this new name?", "IC Chat Filter Conflict", "Confirm", "Cancel") == "Cancel"))
+		// Check the new name against the chat filter. If it triggers the IC chat filter, give an option to confirm.
+		if(newname && !(CHAT_FILTER_CHECK(newname) && alert(usr, "Your selected name contains words restricted by IC chat filters. Confirm this new name?", "IC Chat Filter Conflict", "Confirm", "Cancel") != "Confirm"))
 			vv_auto_rename(newname)
 
 /atom/vv_get_header()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1154,7 +1154,7 @@
 					transform = M.Turn(angle)
 	if(href_list[VV_HK_AUTO_RENAME] && check_rights(R_VAREDIT))
 		var/newname = input(usr, "What do you want to rename this to?", "Automatic Rename") as null|text
-		if(newname)
+		if(newname && !(CHAT_FILTER_CHECK(newname) && alert(usr, "Your selected name contains words restricted by IC chat filters. Confirm this new name?", "Confirm", "Cancel") == "Cancel"))
 			vv_auto_rename(newname)
 
 /atom/vv_get_header()

--- a/code/modules/admin/verbs/borgpanel.dm
+++ b/code/modules/admin/verbs/borgpanel.dm
@@ -139,7 +139,7 @@
 				message_admins("[key_name_admin(user)] disabled scrambled codes on [ADMIN_LOOKUPFLW(borg)].")
 				log_admin("[key_name(user)] disabled scrambled codes on [key_name(borg)].")
 		if ("rename")
-			var/new_name = stripped_input(user,"What would you like to name this cyborg?","Input a name",borg.real_name,MAX_NAME_LEN)
+			var/new_name = sanitize_name(stripped_input(user,"What would you like to name this cyborg?","Input a name",borg.real_name,MAX_NAME_LEN), allow_numbers = TRUE)
 			if(!new_name)
 				return
 			message_admins("[key_name_admin(user)] renamed [ADMIN_LOOKUPFLW(borg)] to [new_name].")

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -29,6 +29,12 @@
 				return
 
 			var/new_name = stripped_input(usr,"What would you like to name this mob?","Input a name",M.real_name,MAX_NAME_LEN)
+
+			// If the new name is something that would be restricted by IC chat filters,
+			// give the admin a warning but allow them to do it anyway if they want.
+			if(CHAT_FILTER_CHECK(new_name) && alert(usr, "Your selected name contains words restricted by IC chat filters. Confirm this new name?", "Confirm", "Cancel") == "Cancel")
+				return
+
 			if( !new_name || !M )
 				return
 

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -32,7 +32,7 @@
 
 			// If the new name is something that would be restricted by IC chat filters,
 			// give the admin a warning but allow them to do it anyway if they want.
-			if(CHAT_FILTER_CHECK(new_name) && alert(usr, "Your selected name contains words restricted by IC chat filters. Confirm this new name?", "Confirm", "Cancel") == "Cancel")
+			if(CHAT_FILTER_CHECK(new_name) && alert(usr, "Your selected name contains words restricted by IC chat filters. Confirm this new name?", "IC Chat Filter Conflict", "Confirm", "Cancel") == "Cancel")
 				return
 
 			if( !new_name || !M )

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1269,7 +1269,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						if(new_name)
 							real_name = new_name
 						else
-							to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
+							to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and . It must not contain any words restricted by IC chat and name filters.</font>")
 
 				if("age")
 					var/new_age = input(user, "Choose your character's age:\n([AGE_MIN]-[AGE_MAX])", "Character Preference") as num|null
@@ -1981,7 +1981,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	else
 		var/sanitized_name = reject_bad_name(raw_name,namedata["allow_numbers"])
 		if(!sanitized_name)
-			to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z,[namedata["allow_numbers"] ? ",0-9," : ""] -, ' and .</font>")
+			to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z,[namedata["allow_numbers"] ? ",0-9," : ""] -, ' and . It must not contain any words restricted by IC chat and name filters.</font>")
 			return
 		else
 			custom_names[name_id] = sanitized_name

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1981,7 +1981,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	else
 		var/sanitized_name = reject_bad_name(raw_name,namedata["allow_numbers"])
 		if(!sanitized_name)
-			to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z,[namedata["allow_numbers"] ? ",0-9," : ""] -, ' and . It must not contain any words restricted by IC chat and name filters.</font>")
+			to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, [namedata["allow_numbers"] ? "0-9, " : ""]-, ' and . It must not contain any words restricted by IC chat and name filters.</font>")
 			return
 		else
 			custom_names[name_id] = sanitized_name

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -179,7 +179,7 @@
 	return ..()
 
 /obj/item/clothing/neck/petcollar/attack_self(mob/user)
-	tagname = stripped_input(user, "Would you like to change the name on the tag?", "Name your new pet", "Spot", MAX_NAME_LEN)
+	tagname = sanitize_name(stripped_input(user, "Would you like to change the name on the tag?", "Name your new pet", "Spot", MAX_NAME_LEN))
 	name = "[initial(name)] - [tagname]"
 
 //////////////

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1089,6 +1089,7 @@
 	if(CHAT_FILTER_CHECK(newname))
 		log_message("[src] failed name change from [oldname] to [newname] as new name contains a word prohibited in IC chat", LOG_OWNERSHIP)
 		to_chat(usr, "<span class='warning'>You cannot set a name that contains a word prohibited in IC chat!</span>")
+		return FALSE
 
 	log_message("[src] name changed from [oldname] to [newname]", LOG_OWNERSHIP)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1086,11 +1086,6 @@
 		log_message("[src] failed name change from [oldname] as no new name was specified", LOG_OWNERSHIP)
 		return FALSE
 
-	if(CHAT_FILTER_CHECK(newname))
-		log_message("[src] failed name change from [oldname] to [newname] as new name contains a word prohibited in IC chat", LOG_OWNERSHIP)
-		to_chat(usr, "<span class='warning'>You cannot set a name that contains a word prohibited in IC chat!</span>")
-		return FALSE
-
 	log_message("[src] name changed from [oldname] to [newname]", LOG_OWNERSHIP)
 
 	log_played_names(ckey,newname)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1082,9 +1082,15 @@
  * Calling this proc without an oldname will only update the mob and skip updating the pda, id and records ~Carn
  */
 /mob/proc/fully_replace_character_name(oldname,newname)
-	log_message("[src] name changed from [oldname] to [newname]", LOG_OWNERSHIP)
 	if(!newname)
+		log_message("[src] failed name change from [oldname] as no new name was specified", LOG_OWNERSHIP)
 		return FALSE
+
+	if(CHAT_FILTER_CHECK(newname))
+		log_message("[src] failed name change from [oldname] to [newname] as new name contains a word prohibited in IC chat", LOG_OWNERSHIP)
+		to_chat(usr, "<span class='warning'>You cannot set a name that contains a word prohibited in IC chat!</span>")
+
+	log_message("[src] name changed from [oldname] to [newname]", LOG_OWNERSHIP)
 
 	log_played_names(ckey,newname)
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -991,7 +991,7 @@
 
 	to_chat(user, "<span class='notice'>You offer [src] to [user]...</span>")
 
-	var/new_name = stripped_input(M, "What would you like your name to be?", "Input a name", M.real_name, MAX_NAME_LEN)
+	var/new_name = sanitize_name(stripped_input(M, "What would you like your name to be?", "Input a name", M.real_name, MAX_NAME_LEN))
 
 	if(!new_name || QDELETED(src) || QDELETED(M) || new_name == M.real_name || !M.Adjacent(user))
 		being_used = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Honestly, I'm not sure this is the... Correct solution? But people more familiar with this will likely show me da wae.

Prohibits creating names that can't actually be spoken in-character due to chat filters by adding CHAT_FILTER_CHECKs to the procs that handle sanitising them.

For admin-utilised renaming procs, they'll be given a simple alert box to warn them their chosen name contains words prohibited by the IC chat filter and be allowed to confirm or cancel out.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

If you can't speak the name IC, chances are the name shouldn't be allowed at all. Players may occasionally be forced to ahelp certain names because they contain words prohibited in chat filters.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Names that don't pass the IC chat filter are now more prohibited from being set in various locations including pet name tags and the character preferences menu.
admin: You will now be warned when using VV auto-renaming features if the name you've chosen is blocked by the IC chat filter for any reason and will be allowed to confirm or cancel it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
