### PR TITLE
Events stop at point of no return

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -611,7 +611,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		midround_injection_cooldown = (round(clamp(EXP_DISTRIBUTION(midround_injection_cooldown_middle), GLOB.dynamic_midround_delay_min, GLOB.dynamic_midround_delay_max)) + world.time)
 
 		// Time to inject some threat into the round
-		if(EMERGENCY_ESCAPED_OR_ENDGAMED) // Unless the shuttle is gone
+		if(EMERGENCY_PAST_POINT_OF_NO_RETURN) // Unless the game is ending
 			return
 
 		message_admins("DYNAMIC: Checking for midround injection.")
@@ -684,7 +684,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 /datum/game_mode/dynamic/make_antag_chance(mob/living/carbon/human/newPlayer)
 	if (GLOB.dynamic_forced_extended)
 		return
-	if(EMERGENCY_ESCAPED_OR_ENDGAMED) // No more rules after the shuttle has left
+	if(EMERGENCY_PAST_POINT_OF_NO_RETURN) // No more rules after the point of no return
 		return
 
 	if (forced_latejoin_rule)

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -51,7 +51,7 @@
 		return FALSE
 	if(holidayID && (!SSevents.holidays || !SSevents.holidays[holidayID]))
 		return FALSE
-	if(EMERGENCY_ESCAPED_OR_ENDGAMED)
+	if(EMERGENCY_PAST_POINT_OF_NO_RETURN)
 		return FALSE
 	if(ispath(typepath, /datum/round_event/ghost_role) && !(GLOB.ghost_role_flags & GHOSTROLE_MIDROUND_EVENT))
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This change will stop random events from firing and dynamic threats from being created once the shuttle has reached the point of no return. This is 10 minutes left on green, 5 on blue, and 2 1/2 minutes on red, until the completion of the game. This is inclusive of the 3 minute ETD, which is a timeframe the current code will allow events to spawn in.

## Why It's Good For The Game
Examples of why EMERGENCY_PAST_POINT_OF_NO_RETURN is preferable to EMERGENCY_ESCAPED_OR_ENDGAMED:
1. Players who get offered Space Pirate roles 30 seconds before the shuttle departs are more disappointed and frustrated than if they had not having been offered antag roles at all.
2. When the shuttle has almost arrived, people's brains are shutting off and they're looking forward to the next round. No one wants to deal with new threats. Even for antagonists, dealing with a docile crew that lets you kill them is not fun.
3. The blob can spawn as the shuttle is docked, delay the shuttle, and continually proc new random events despite players desperately wanting the round to end by that point.
4. Even less serious threats, like gravitational anomalies, only serve to annoy a population which is already just tired of the round.

The main purpose of these events is to generate a threat to self-preservation. When the crew is mentally fatigued and have thrown in the towel for the shuttle, they expect the events of the game to start winding down, not continue on aimlessly. Any new danger during this period can disrupt the 'story' that the round has developed, and this type of disruption leads to a round ending which is unsatisfying to the players's internal narrative. (i.e. people stop giving a shit about what's happening when their hard work is thrown back in their face 30 seconds from launch.)

## Changelog
:cl:
tweak: Events and dynamic threats stop once the shuttle is past the point of no return, rather than after it's already left for CentCom.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
