### PR TITLE
Fixes being unable to install cyborg modules.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -184,11 +184,15 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		var/obj/item/borg/upgrade/U = W
 		if(!opened)
 			to_chat(user, "<span class='warning'>You must access the cyborg's internals!</span>")
-		else if(!src.module && U.require_module)
+			return
+		if(!src.module && U.require_module)
 			to_chat(user, "<span class='warning'>The cyborg must choose a module before it can be upgraded!</span>")
-		else if(U.locked)
+			return
+		if(U.locked)
 			to_chat(user, "<span class='warning'>The upgrade is locked and cannot be used yet!</span>")
-		else if(user.canUnEquip(U))
+			return
+		if(!user.canUnEquip(U))
+			to_chat(user, "<span class='warning'>The upgrade is stuck to you and you can't seem to let go of it!</span>")
 			return
 		add_to_upgrades(U, user)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Functionality broken by https://github.com/tgstation/tgstation/pull/54842

Fixes #55227

Missing ! meant that if an upgrade was unequippable, it would be installable. If it wasn't unequippable, it wouldn't be installable. This is fixed.

No reason I can see for cyborg upgrades to pass through the attack chain if they fail to get installed in general. Most other things stop immediately if they fail. Removed ugly if-then-else chain as a result. **I'm sure someone will correct me if I'm wrong on this, it's 2:15am and I want to sleep.**

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

If I fix this, I can nerf cyborgs even more.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cyborgs upgrades can be installed properly again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
