### PR TITLE
Fix the implosion compressor runtiming when the bomb is too weak

### DIFF
--- a/code/modules/research/anomaly/explosive_compressor.dm
+++ b/code/modules/research/anomaly/explosive_compressor.dm
@@ -132,11 +132,11 @@
 	mix.react()		// build more pressure
 	var/pressure = mix.return_pressure()
 	var/range = (pressure - TANK_FRAGMENT_PRESSURE) / TANK_FRAGMENT_SCALE
-	QDEL_NULL(inserted_bomb)	// bomb goes poof
 	if(range < required_radius)
 		inserted_bomb.forceMove(src)
 		say("Resultant detonation failed to produce enough implosive power to compress [inserted_core]. Core ejected.")
 		return
+	QDEL_NULL(inserted_bomb)	// bomb goes poof
 	inserted_core.create_core(drop_location(), TRUE, TRUE)
 	inserted_core = null
 	say("Success. Resultant detonation has theoretical range of [range]. Required radius was [required_radius]. Core production complete.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Previously, the implosion compressor would runtime when the bomb was too weak due to a badly ordered QDEL_NULL. Now, it properly returns the message.

~~Untested, will test later.~~ It works.

## Changelog
:cl:
fix: The implosion compressor now properly gives a message when the bomb is too weak, and will give it back.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
