### PR TITLE
Pen renamable objects no longer use initial() for resetting their names and desc

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -71,6 +71,10 @@
 	#define EXAMINE_POSITION_BEFORE (1<<1)
 	//End positions
 	#define COMPONENT_EXNAME_CHANGED (1<<0)
+///from base of atom/player_rename(): ()
+#define COMSIG_ATOM_PLAYER_RENAME "atom_player_rename"
+///from base of atom/reset_player_rename(): ()
+#define COMSIG_ATOM_RESET_PLAYER_RENAME "atom_reset_player_rename"
 ///from base of atom/update_icon(): ()
 #define COMSIG_ATOM_UPDATE_ICON "atom_update_icon"
 	#define COMSIG_ATOM_NO_UPDATE_ICON_STATE	(1<<0)

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -7,13 +7,14 @@
 #define BEING_SHOCKED			(1<<3) // Whether this thing is currently (already) being shocked by a tesla
 #define DANGEROUS_POSSESSION	(1<<4) //Admin possession yes/no
 #define ON_BLUEPRINTS			(1<<5)  //Are we visible on the station blueprints at roundstart?
-#define UNIQUE_RENAME			(1<<6) // can you customize the description/name of the thing?
+#define UNIQUE_RENAME			(1<<6) //Can you customize the description/name of the thing?
 #define USES_TGUI				(1<<7)	//put on things that use tgui on ui_interact instead of custom/old UI.
 #define FROZEN					(1<<8)
 #define BLOCK_Z_OUT_DOWN		(1<<9)  // Should this object block z falling from loc?
 #define BLOCK_Z_OUT_UP			(1<<10) // Should this object block z uprise from loc?
 #define BLOCK_Z_IN_DOWN			(1<<11) // Should this object block z falling from above?
 #define BLOCK_Z_IN_UP			(1<<12) // Should this object block z uprise from below?
+#define RENAMED_BY_PLAYER		(1<<13) //Have you customised the description/name of the thing?
 
 // If you add new ones, be sure to add them to /obj/Initialize as well for complete mapping support
 

--- a/code/datums/components/rename.dm
+++ b/code/datums/components/rename.dm
@@ -1,0 +1,67 @@
+/**
+	The rename component.
+
+	This component is used to manage names and descriptions changed with the pen on objects with the UNIQUE_RENAME obj_flag.
+
+	Atoms can only have one instance of this component, and therefore only one rename at a time.
+
+	When a player renames or changes the description of a UNIQUE_RENAME atom with a pen, this component gets applied to it.
+	If the player uses a pen to reset the name and description, the component will be removed from it, and the name and description will be reverted.
+ */
+/datum/component/rename
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	///The name the player is applying to the parent
+	var/player_name
+	///The desc the player is applying to the parent
+	var/player_desc
+	///The name before the player changed it
+	var/original_name
+	///The desc before the player changed it
+	var/original_desc
+
+/datum/component/rename/Initialize(_player_name, _player_desc)
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	player_name = _player_name
+	player_desc = _player_desc
+	apply_rename()
+
+/datum/component/rename/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_ATOM_PLAYER_RENAME, .proc/apply_rename)
+	RegisterSignal(parent, COMSIG_ATOM_RESET_PLAYER_RENAME, .proc/remove_rename)
+
+/datum/component/rename/UnregisterFromParent()
+	UnregisterSignal(parent, list(COMSIG_ATOM_PLAYER_RENAME, COMSIG_ATOM_RESET_PLAYER_RENAME))
+
+/**
+	This proc will fire after the parent's name or desc is changed with a pen, which is trying to apply another rename component.
+	Since the parent already has a rename component, it will remove the old one from the parent's name, and apply the new one.
+*/
+/datum/component/rename/InheritComponent(datum/component/rename/new_comp , i_am_original, _player_name, _player_desc)
+	remove_rename()
+	if(new_comp)
+		player_name = new_comp.player_name
+		player_desc = new_comp.player_desc
+	else
+		player_name = _player_name
+		player_desc = _player_desc
+	apply_rename()
+
+///Saves the current name and description before changing them to the player's inputs
+/datum/component/rename/proc/apply_rename()
+	var/atom/owner = parent
+	if(!original_name)
+		original_name = owner.name
+	if(!original_desc)
+		original_desc = owner.desc
+	owner.name = player_name
+	owner.desc = player_desc
+
+///Reverts the
+/datum/component/rename/proc/remove_rename()
+	var/atom/owner = parent
+	owner.name = original_name
+	owner.desc = original_desc
+	qdel(src)
+

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -625,6 +625,12 @@
 	if(!LAZYLEN(.)) // lol ..length
 		return list("<span class='notice'><i>You examine [src] closer, but find nothing of interest...</i></span>")
 
+/atom/proc/player_rename()
+	SEND_SIGNAL(src, COMSIG_ATOM_PLAYER_RENAME)
+
+/atom/proc/reset_player_rename()
+	SEND_SIGNAL(src, COMSIG_ATOM_RESET_PLAYER_RENAME)
+
 /// Updates the icon of the atom
 /atom/proc/update_icon()
 	SIGNAL_HANDLER

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -33,7 +33,12 @@
 	/// Custom fire overlay icon
 	var/custom_fire_overlay
 
-	var/renamedByPlayer = FALSE //set when a player uses a pen on a renamable object
+	///set when a player changes the name or desc of a renamable object
+	var/renamedByPlayer = FALSE
+	///set when a player changes the name of a renamable object
+	var/name_before_player_changed
+	///set when a player changes the desc of a renamable object
+	var/desc_before_player_changed
 
 	var/drag_slowdown // Amont of multiplicative slowdown applied if pulled. >1 makes you slower, <1 makes you faster.
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -33,8 +33,6 @@
 	/// Custom fire overlay icon
 	var/custom_fire_overlay
 
-	///set when a player changes the name or desc of a renamable object
-	var/renamedByPlayer = FALSE
 	///set when a player changes the name of a renamable object
 	var/name_before_player_changed
 	///set when a player changes the desc of a renamable object

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -19,7 +19,7 @@
 	cut_overlays()
 	if(reagents.reagent_list.len)
 		var/datum/reagent/R = reagents.get_master_reagent()
-		if(!renamedByPlayer)
+		if(!(obj_flags & RENAMED_BY_PLAYER))
 			name = R.glass_name
 			desc = R.glass_desc
 		if(R.glass_icon_state)
@@ -31,7 +31,7 @@
 			add_overlay(reagent_overlay)
 	else
 		icon_state = "glass_empty"
-		renamedByPlayer = FALSE //so new drinks can rename the glass
+		obj_flags &= ~RENAMED_BY_PLAYER //remove flag so new drinks can rename the glass
 
 //Shot glasses!//
 //  This lets us add shots in here instead of lumping them in with drinks because >logic  //

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -156,7 +156,7 @@
 			var/oldname = O.name
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
-			if(oldname == input || input == "")
+			if(input == oldname || !input)
 				to_chat(user, "<span class='notice'>You changed [O] to... well... [O].</span>")
 			else
 				O.name = input
@@ -166,30 +166,43 @@
 					label.apply_label()
 				to_chat(user, "<span class='notice'>You have successfully renamed \the [oldname] to [O].</span>")
 				O.renamedByPlayer = TRUE
+				O.name_before_player_changed = oldname
 
 		if(penchoice == "Change description")
 			var/input = stripped_input(user,"Describe [O] here:", ,"[O.desc]", 140)
 			var/olddesc = O.desc
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
-			if(olddesc == input || input == "")
+			if(input == olddesc || !input)
 				to_chat(user, "<span class='notice'>You decide against changing [O]'s description.</span>")
 			else
 				O.desc = input
 				to_chat(user, "<span class='notice'>You have successfully changed [O]'s description.</span>")
 				O.renamedByPlayer = TRUE
+				O.desc_before_player_changed = olddesc
 
 		if(penchoice == "Reset")
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
-			O.desc = initial(O.desc)
-			O.name = initial(O.name)
+			var/whatwereset
+			if(O.name_before_player_changed)
+				O.name = O.name_before_player_changed
+				whatwereset = "name"
+			if(O.desc_before_player_changed)
+				O.desc = O.desc_before_player_changed
+				if(whatwereset)
+					whatwereset += " and description"
+				else
+					whatwereset = "description"
 			var/datum/component/label/label = O.GetComponent(/datum/component/label)
 			if(label)
 				label.remove_label()
 				label.apply_label()
-			to_chat(user, "<span class='notice'>You have successfully reset [O]'s name and description.</span>")
+			to_chat(user, "<span class='notice'>You have successfully reset [O]'s [whatwereset].</span>")
 			O.renamedByPlayer = FALSE
+			O.name_before_player_changed = null
+			O.desc_before_player_changed = null
+
 
 /*
  * Sleepypens

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -165,7 +165,7 @@
 					label.remove_label()
 					label.apply_label()
 				to_chat(user, "<span class='notice'>You have successfully renamed \the [oldname] to [O].</span>")
-				O.renamedByPlayer = TRUE
+				O.obj_flags |= RENAMED_BY_PLAYER
 				O.name_before_player_changed = oldname
 
 		if(penchoice == "Change description")
@@ -178,7 +178,7 @@
 			else
 				O.desc = input
 				to_chat(user, "<span class='notice'>You have successfully changed [O]'s description.</span>")
-				O.renamedByPlayer = TRUE
+				O.obj_flags |= RENAMED_BY_PLAYER
 				O.desc_before_player_changed = olddesc
 
 		if(penchoice == "Reset")
@@ -199,10 +199,9 @@
 				label.remove_label()
 				label.apply_label()
 			to_chat(user, "<span class='notice'>You have successfully reset [O]'s [whatwereset].</span>")
-			O.renamedByPlayer = FALSE
+			O.obj_flags &= ~RENAMED_BY_PLAYER
 			O.name_before_player_changed = null
 			O.desc_before_player_changed = null
-
 
 /*
  * Sleepypens

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -159,14 +159,13 @@
 			if(input == oldname || !input)
 				to_chat(user, "<span class='notice'>You changed [O] to... well... [O].</span>")
 			else
-				O.name = input
+				O.AddComponent(/datum/component/rename, input, O.desc)
 				var/datum/component/label/label = O.GetComponent(/datum/component/label)
 				if(label)
 					label.remove_label()
 					label.apply_label()
 				to_chat(user, "<span class='notice'>You have successfully renamed \the [oldname] to [O].</span>")
 				O.obj_flags |= RENAMED_BY_PLAYER
-				O.name_before_player_changed = oldname
 
 		if(penchoice == "Change description")
 			var/input = stripped_input(user,"Describe [O] here:", ,"[O.desc]", 140)
@@ -176,32 +175,23 @@
 			if(input == olddesc || !input)
 				to_chat(user, "<span class='notice'>You decide against changing [O]'s description.</span>")
 			else
-				O.desc = input
+				O.AddComponent(/datum/component/rename, O.name, input)
 				to_chat(user, "<span class='notice'>You have successfully changed [O]'s description.</span>")
 				O.obj_flags |= RENAMED_BY_PLAYER
-				O.desc_before_player_changed = olddesc
 
 		if(penchoice == "Reset")
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
-			var/whatwereset
-			if(O.name_before_player_changed)
-				O.name = O.name_before_player_changed
-				whatwereset = "name"
-			if(O.desc_before_player_changed)
-				O.desc = O.desc_before_player_changed
-				if(whatwereset)
-					whatwereset += " and description"
-				else
-					whatwereset = "description"
+
+			SEND_SIGNAL(src, COMSIG_ATOM_RESET_PLAYER_RENAME)
+
 			var/datum/component/label/label = O.GetComponent(/datum/component/label)
 			if(label)
 				label.remove_label()
 				label.apply_label()
-			to_chat(user, "<span class='notice'>You have successfully reset [O]'s [whatwereset].</span>")
+
+			to_chat(user, "<span class='notice'>You have successfully reset [O]'s name and/or description.</span>")
 			O.obj_flags &= ~RENAMED_BY_PLAYER
-			O.name_before_player_changed = null
-			O.desc_before_player_changed = null
 
 /*
  * Sleepypens

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -402,7 +402,7 @@
 				P = new/obj/item/reagent_containers/food/condiment(drop_location())
 				if (style)
 					apply_condi_style(P, style)
-				P.renamedByPlayer = TRUE
+				P.obj_flags |= RENAMED_BY_PLAYER
 				P.name = name
 				reagents.trans_to(P, vol_each, transfered_by = usr)
 			return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -456,6 +456,7 @@
 #include "code\datums\components\radioactive.dm"
 #include "code\datums\components\religious_tool.dm"
 #include "code\datums\components\remote_materials.dm"
+#include "code\datums\components\rename.dm"
 #include "code\datums\components\riding.dm"
 #include "code\datums\components\rot.dm"
 #include "code\datums\components\rotation.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I found out on the server that initial(name) and initial(desc) aren't suitable because there's no guarantee these were meant to be seen by players. I noticed the issue on statues after resetting one's name and description. The name was "custom statue" and the description mentioned contacting Firecage if it was visible.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

When you reset an object's name and/or description each will reset to what it was before the first player change. I'm assuming this will be the coder (or admin) intended player-visible name for it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
fix: Resetting a pen renamable object's name or desc should no longer result in getting generic names or debug message descriptions
/:cl:

- [ ] Fix problem with component not resetting name and desc when Reset option selected with pen
- [ ] Fix problem with component being deleted with subsequent renames (i.e. how do I properly delete the component when name/desc are reset?)
- [ ] Figure out what the two atom procs I added based on suggestion are even supposed to be doing
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
