### PR TITLE
Stops hot oil from frying certain objects

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -23,13 +23,7 @@ God bless America.
 #define DEEPFRYER_COOKTIME 60
 #define DEEPFRYER_BURNTIME 120
 
-GLOBAL_LIST_INIT(deepfry_blacklisted_items, typecacheof(list(
-	/obj/item/screwdriver,
-	/obj/item/crowbar,
-	/obj/item/wrench,
-	/obj/item/wirecutters,
-	/obj/item/multitool,
-	/obj/item/weldingtool,
+GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	/obj/item/reagent_containers/glass,
 	/obj/item/reagent_containers/syringe,
 	/obj/item/reagent_containers/food/condiment,
@@ -54,6 +48,13 @@ GLOBAL_LIST_INIT(deepfry_blacklisted_items, typecacheof(list(
 	var/frying_fried //If the object has been fried; used for messages
 	var/frying_burnt //If the object has been burnt
 	var/datum/looping_sound/deep_fryer/fry_loop
+	var/static/list/deepfry_blacklisted_items = typecacheof(list(
+	/obj/item/screwdriver,
+	/obj/item/crowbar,
+	/obj/item/wrench,
+	/obj/item/wirecutters,
+	/obj/item/multitool,
+	/obj/item/weldingtool))
 
 /obj/machinery/deepfryer/Initialize()
 	. = ..()
@@ -98,7 +99,7 @@ GLOBAL_LIST_INIT(deepfry_blacklisted_items, typecacheof(list(
 	else if(default_deconstruction_screwdriver(user, "fryer_off", "fryer_off" ,I))	//where's the open maint panel icon?!
 		return
 	else
-		if(is_type_in_typecache(I, GLOB.deepfry_blacklisted_items) || HAS_TRAIT(I, TRAIT_NODROP) || (I.item_flags & (ABSTRACT | DROPDEL)))
+		if(is_type_in_typecache(I, deepfry_blacklisted_items) || is_type_in_typecache(I, GLOB.oilfry_blacklisted_items) || HAS_TRAIT(I, TRAIT_NODROP) || (I.item_flags & (ABSTRACT | DROPDEL)))
 			return ..()
 		else if(!frying && user.transferItemToLoc(I, src))
 			to_chat(user, "<span class='notice'>You put [I] into [src].</span>")

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -23,6 +23,20 @@ God bless America.
 #define DEEPFRYER_COOKTIME 60
 #define DEEPFRYER_BURNTIME 120
 
+GLOBAL_LIST_INIT(deepfry_blacklisted_items, typecacheof(list(
+	/obj/item/screwdriver,
+	/obj/item/crowbar,
+	/obj/item/wrench,
+	/obj/item/wirecutters,
+	/obj/item/multitool,
+	/obj/item/weldingtool,
+	/obj/item/reagent_containers/glass,
+	/obj/item/reagent_containers/syringe,
+	/obj/item/reagent_containers/food/condiment,
+	/obj/item/storage,
+	/obj/item/small_delivery,
+	/obj/item/his_grace)))
+
 /obj/machinery/deepfryer
 	name = "deep fryer"
 	desc = "Deep fried <i>everything</i>."
@@ -39,19 +53,6 @@ God bless America.
 	var/fry_speed = 1 //How quickly we fry food
 	var/frying_fried //If the object has been fried; used for messages
 	var/frying_burnt //If the object has been burnt
-	var/static/list/deepfry_blacklisted_items = typecacheof(list(
-		/obj/item/screwdriver,
-		/obj/item/crowbar,
-		/obj/item/wrench,
-		/obj/item/wirecutters,
-		/obj/item/multitool,
-		/obj/item/weldingtool,
-		/obj/item/reagent_containers/glass,
-		/obj/item/reagent_containers/syringe,
-		/obj/item/reagent_containers/food/condiment,
-		/obj/item/storage,
-		/obj/item/small_delivery,
-		/obj/item/his_grace))
 	var/datum/looping_sound/deep_fryer/fry_loop
 
 /obj/machinery/deepfryer/Initialize()
@@ -97,7 +98,7 @@ God bless America.
 	else if(default_deconstruction_screwdriver(user, "fryer_off", "fryer_off" ,I))	//where's the open maint panel icon?!
 		return
 	else
-		if(is_type_in_typecache(I, deepfry_blacklisted_items) || HAS_TRAIT(I, TRAIT_NODROP) || (I.item_flags & (ABSTRACT | DROPDEL)))
+		if(is_type_in_typecache(I, GLOB.deepfry_blacklisted_items) || HAS_TRAIT(I, TRAIT_NODROP) || (I.item_flags & (ABSTRACT | DROPDEL)))
 			return ..()
 		else if(!frying && user.transferItemToLoc(I, src))
 			to_chat(user, "<span class='notice'>You put [I] into [src].</span>")

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -134,7 +134,7 @@
 		return
 	if(!isitem(exposed_obj) || istype(exposed_obj, /obj/item/food/deepfryholder))
 		return
-	if(is_type_in_typecache(exposed_obj, GLOB.deepfry_blacklisted_items) || (exposed_obj.resistance_flags & INDESTRUCTIBLE))
+	if(is_type_in_typecache(exposed_obj, GLOB.oilfry_blacklisted_items) || (exposed_obj.resistance_flags & INDESTRUCTIBLE))
 		exposed_obj.loc.visible_message("<span class='notice'>The hot oil has no effect on [exposed_obj]!</span>")
 		return
 	exposed_obj.loc.visible_message("<span class='warning'>[exposed_obj] rapidly fries as it's splashed with hot oil! Somehow.</span>")

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -134,6 +134,9 @@
 		return
 	if(!isitem(exposed_obj) || istype(exposed_obj, /obj/item/food/deepfryholder))
 		return
+	if(is_type_in_typecache(exposed_obj, GLOB.deepfry_blacklisted_items) || (exposed_obj.resistance_flags & INDESTRUCTIBLE))
+		exposed_obj.loc.visible_message("<span class='notice'>The hot oil has no effect on [exposed_obj]!</span>")
+		return
 	exposed_obj.loc.visible_message("<span class='warning'>[exposed_obj] rapidly fries as it's splashed with hot oil! Somehow.</span>")
 	var/obj/item/food/deepfryholder/fry_target = new(exposed_obj.drop_location(), exposed_obj)
 	fry_target.fry(volume)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #55250.

Changes the hot oil expose_obj reaction to ignore objects on the deepfry_blacklisted_items list, as well as objects with the indestructible tag.

This means that objective items cannot be deepfried and consumed. Storage containers/beakers will also no longer be fried, finally keeping the objects within safe!

## Why It's Good For The Game

Stop round removing important objects. Prevents entire backpacks worth of items from being rendered inaccessible/useless from a single spray.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Important objects and storage containers are now resistant to hot oil.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
