### PR TITLE
Fixes detdrobe construction bug

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -548,6 +548,7 @@
 		/obj/machinery/vending/games = "\improper Good Clean Fun",
 		/obj/machinery/vending/autodrobe = "AutoDrobe",
 		/obj/machinery/vending/wardrobe/sec_wardrobe = "SecDrobe",
+		/obj/machinery/vending/wardrobe/det_wardrobe = "DetDrobe",
 		/obj/machinery/vending/wardrobe/medi_wardrobe = "MediDrobe",
 		/obj/machinery/vending/wardrobe/engi_wardrobe = "EngiDrobe",
 		/obj/machinery/vending/wardrobe/atmos_wardrobe = "AtmosDrobe",


### PR DESCRIPTION
## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/51797

## Why It's Good For The Game
Lets detectives disassemble their vendor to restock it I guess.
They could rebuild it if someone else broke in and took it apart too?

## Changelog
:cl:
fix: DetDrobes can be restocked again, and no longer produce a custom vendor card when disassembled.
/:cl:
