### PR TITLE
unfucks hitting simplemobs with melee attacks (sorry!)

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -146,7 +146,7 @@
 		return TRUE //successful attack
 
 /mob/living/simple_animal/attacked_by(obj/item/I, mob/living/user)
-	if(attack_threshold_check(I.force, I.damtype, MELEE, FALSE))
+	if(!attack_threshold_check(I.force, I.damtype, MELEE, FALSE))
 		playsound(loc, 'sound/weapons/tap.ogg', I.get_clamped_volume(), TRUE, -1)
 	else
 		return ..()


### PR DESCRIPTION
## About The Pull Request

Adds a single "!" to the code I added (in https://github.com/tgstation/tgstation/pull/55023) to make it not make most simplemobs immune to being hit with most melee weapons.

Proof of testing:
![image](https://user-images.githubusercontent.com/42606352/100703448-2c22e880-3369-11eb-8950-e15674c13398.png)

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/55260.

## Changelog
:cl: ATHATH
fix: Simplemobs should be able to be properly melee attacked again. Sorry for borking it in the first place!
/:cl: