### PR TITLE
Revert "Removed jQuery from snowflake devices"

### DIFF
--- a/code/__DEFINES/tgs.dm
+++ b/code/__DEFINES/tgs.dm
@@ -117,22 +117,22 @@
 //REQUIRED HOOKS
 
 /**
-  * Call this somewhere in [/world/proc/New] that is always run. This function may sleep!
-  *
-  * * event_handler - Optional user defined [/datum/tgs_event_handler].
-  * * minimum_required_security_level: The minimum required security level to run the game in which the DMAPI is integrated. Can be one of [TGS_SECURITY_ULTRASAFE], [TGS_SECURITY_SAFE], or [TGS_SECURITY_TRUSTED].
-  */
+ * Call this somewhere in [/world/proc/New] that is always run. This function may sleep!
+ *
+ * * event_handler - Optional user defined [/datum/tgs_event_handler].
+ * * minimum_required_security_level: The minimum required security level to run the game in which the DMAPI is integrated. Can be one of [TGS_SECURITY_ULTRASAFE], [TGS_SECURITY_SAFE], or [TGS_SECURITY_TRUSTED].
+ */
 /world/proc/TgsNew(datum/tgs_event_handler/event_handler, minimum_required_security_level = TGS_SECURITY_ULTRASAFE)
 	return
 
 /**
-  * Call this when your initializations are complete and your game is ready to play before any player interactions happen.
-  *
-  * This may use [/world/var/sleep_offline] to make this happen so ensure no changes are made to it while this call is running.
-  * Afterwards, consider explicitly setting it to what you want to avoid this BYOND bug: http://www.byond.com/forum/post/2575184
-  * Before this point, note that any static files or directories may be in use by another server. Your code should account for this.
-  * This function should not be called before ..() in [/world/proc/New].
-  */
+ * Call this when your initializations are complete and your game is ready to play before any player interactions happen.
+ *
+ * This may use [/world/var/sleep_offline] to make this happen so ensure no changes are made to it while this call is running.
+ * Afterwards, consider explicitly setting it to what you want to avoid this BYOND bug: http://www.byond.com/forum/post/2575184
+ * Before this point, note that any static files or directories may be in use by another server. Your code should account for this.
+ * This function should not be called before ..() in [/world/proc/New].
+ */
 /world/proc/TgsInitializationComplete()
 	return
 
@@ -140,8 +140,8 @@
 #define TGS_TOPIC var/tgs_topic_return = TgsTopic(args[1]); if(tgs_topic_return) return tgs_topic_return
 
 /**
-  * Call this at the beginning of [world/proc/Reboot].
-  */
+ * Call this at the beginning of [world/proc/Reboot].
+ */
 /world/proc/TgsReboot()
 	return
 
@@ -175,16 +175,16 @@
 	var/deprefixed_parameter
 
 /**
-  * Returns [TRUE]/[FALSE] based on if the [/datum/tgs_version] contains wildcards.
-  */
+ * Returns [TRUE]/[FALSE] based on if the [/datum/tgs_version] contains wildcards.
+ */
 /datum/tgs_version/proc/Wildcard()
 	return
 
 /**
-  * Returns [TRUE]/[FALSE] based on if the [/datum/tgs_version] equals some other version.
-  *
-  * other_version - The [/datum/tgs_version] to compare against.
-  */
+ * Returns [TRUE]/[FALSE] based on if the [/datum/tgs_version] equals some other version.
+ *
+ * other_version - The [/datum/tgs_version] to compare against.
+ */
 /datum/tgs_version/proc/Equals(datum/tgs_version/other_version)
 	return
 
@@ -234,10 +234,10 @@
 	var/datum/tgs_chat_channel/channel
 
 /**
-  * User definable callback for handling TGS events.
-  *
-  * event_code - One of the TGS_EVENT_ defines. Extra parameters will be documented in each
-  */
+ * User definable callback for handling TGS events.
+ *
+ * event_code - One of the TGS_EVENT_ defines. Extra parameters will be documented in each
+ */
 /datum/tgs_event_handler/proc/HandleEvent(event_code, ...)
 	set waitfor = FALSE
 	return
@@ -252,11 +252,11 @@
 	var/admin_only = FALSE
 
 /**
-  * Process command activation. Should return a string to respond to the issuer with.
-  *
-  * sender - The [/datum/tgs_chat_user] who issued the command.
-  * params - The trimmed string following the command `/datum/tgs_chat_command/var/name].
-  */
+ * Process command activation. Should return a string to respond to the issuer with.
+ *
+ * sender - The [/datum/tgs_chat_user] who issued the command.
+ * params - The trimmed string following the command `/datum/tgs_chat_command/var/name].
+ */
 /datum/tgs_chat_command/proc/Run(datum/tgs_chat_user/sender, params)
 	CRASH("[type] has no implementation for Run()")
 
@@ -271,48 +271,48 @@
 	return
 
 /**
-  * Returns [TRUE] if DreamDaemon was launched under TGS, the API matches, and was properly initialized. [FALSE] will be returned otherwise.
-  */
+ * Returns [TRUE] if DreamDaemon was launched under TGS, the API matches, and was properly initialized. [FALSE] will be returned otherwise.
+ */
 /world/proc/TgsAvailable()
 	return
 
 // No function below this succeeds if it TgsAvailable() returns FALSE or if TgsNew() has yet to be called.
 
 /**
-  * Forces a hard reboot of DreamDaemon by ending the process.
-  *
-  * Unlike del(world) clients will try to reconnect.
-  * If TGS has not requested a [TGS_REBOOT_MODE_SHUTDOWN] DreamDaemon will be launched again
-  */
+ * Forces a hard reboot of DreamDaemon by ending the process.
+ *
+ * Unlike del(world) clients will try to reconnect.
+ * If TGS has not requested a [TGS_REBOOT_MODE_SHUTDOWN] DreamDaemon will be launched again
+ */
 /world/proc/TgsEndProcess()
 	return
 
 /**
-  * Send a message to connected chats.
-  *
-  * message - The string to send.
-  * admin_only: If [TRUE], message will be sent to admin connected chats. Vice-versa applies.
-  */
+ * Send a message to connected chats.
+ *
+ * message - The string to send.
+ * admin_only: If [TRUE], message will be sent to admin connected chats. Vice-versa applies.
+ */
 /world/proc/TgsTargetedChatBroadcast(message, admin_only = FALSE)
 	return
 
 /**
-  * Send a private message to a specific user.
-  *
-  * message - The string to send.
-  * user: The [/datum/tgs_chat_user] to PM.
-  */
+ * Send a private message to a specific user.
+ *
+ * message - The string to send.
+ * user: The [/datum/tgs_chat_user] to PM.
+ */
 /world/proc/TgsChatPrivateMessage(message, datum/tgs_chat_user/user)
 	return
 
 // The following functions will sleep if a call to TgsNew() is sleeping
 
 /**
-  * Send a message to connected chats that are flagged as game-related in TGS.
-  *
-  * message - The string to send.
-  * channels - Optional list of [/datum/tgs_chat_channel]s to restrict the message to.
-  */
+ * Send a message to connected chats that are flagged as game-related in TGS.
+ *
+ * message - The string to send.
+ * channels - Optional list of [/datum/tgs_chat_channel]s to restrict the message to.
+ */
 /world/proc/TgsChatBroadcast(message, list/channels = null)
 	return
 

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -55,6 +55,7 @@
 					dat += {"
 
 		<head>
+			<script src="[SSassets.transport.get_asset_url("jquery.min.js")]"></script>
 			<script type='text/javascript'>
 
 				function updateSearch(){
@@ -69,16 +70,10 @@
 					if(filter.value == ""){
 						return;
 					}else{
-						var body_data = document.querySelector("#maintable_data");
-						var found_data = body_data.querySelectorAll("table input");
-						if(found_data.length >0){
-							for(var i=0;  i < found_data.length; i++){
-								var elm = found_data\[i\];
-								if(elm.value.toLowerCase().indexOf(filter) == -1)
-									elm.parentElement.parentElement.parentElement.removeChild(elm.parentElement.parentElement)
-								//	elm.parentElement.parentElement.parentElement.style.visibility = "hidden";
-							}
-						}
+						$("#maintable_data").children("tbody").children("tr").children("td").children("input").filter(function(index)
+						{
+							return $(this)\[0\].value.toLowerCase().indexOf(filter) == -1
+						}).parent("td").parent("tr").hide()
 					}
 				}
 
@@ -91,8 +86,10 @@
 			</script>
 		</head>
 
+
 	"}
-					dat += {"<p style='text-align:center;'>"}
+					dat += {"
+<p style='text-align:center;'>"}
 					dat += "<A href='?src=[REF(src)];choice=New Record (General)'>New Record</A><BR>"
 					//search bar
 					dat += {"

--- a/code/modules/admin/verbs/beakerpanel.dm
+++ b/code/modules/admin/verbs/beakerpanel.dm
@@ -66,7 +66,7 @@
 	if(!check_rights())
 		return
 	var/datum/asset/asset_datum = get_asset_datum(/datum/asset/simple/namespaced/common)
-	asset_datum.send(usr.client||src)
+	asset_datum.send()
 	//Could somebody tell me why this isn't using the browser datum, given that it copypastes all of browser datum's html
 	var/dat = {"
 		<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -151,6 +151,7 @@
 
 
 /datum/asset/simple/jquery
+	legacy = TRUE
 	assets = list(
 		"jquery.min.js" = 'html/jquery.min.js',
 	)

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -42,6 +42,8 @@ Notes:
 /datum/tooltip/New(client/C)
 	if (C)
 		owner = C
+		var/datum/asset/stuff = get_asset_datum(/datum/asset/simple/jquery)
+		stuff.send(owner)
 		owner << browse(file2text('code/modules/tooltip/tooltip.html'), "window=[control]")
 
 	..()

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -87,10 +87,8 @@
 	<div id="wrap" class="wrap">
 		<div id="content" class="content"></div>
 	</div>
+	<script type="text/javascript" src="jquery.min.js"></script>
 	<script type="text/javascript">
-		function eventOnMouseover() {
-			tooltip.hide();
-		};
 		var tooltip = {
 			'tileSize': 32,
 			'control': '',
@@ -208,18 +206,18 @@
 
 				//alert(mapWidth+' | '+mapHeight+' | '+tilesShown+' | '+realIconSize+' | '+leftOffset+' | '+topOffset+' | '+left+' | '+top+' | '+posX+' | '+posY); //DEBUG
 
-				document.getElementsByTagName("body").className = tooltip.theme;
-				var content = document.getElementById("content");
-				var wrap = document.getElementById("wrap");
+				$('body').attr('class', tooltip.theme);
 
-				content.removeEventListener("onmouseover", eventOnMouseover);
-				content.innerHTML = tooltip.text;
-				wrap.style = ''
-				wrap.style.width = (parseInt(wrap.width,10) + 2) + "px";//Dumb hack to fix a bizarre sizing bug
-				// 11/15/2020 - WarlockD, Note, I have no idea what sizing bug they are talking about here
+				var $content = $('#content'),
+					$wrap 	 = $('#wrap');
+				$wrap.attr('style', '');
+				$content.off('mouseover');
+				$content.html(tooltip.text);
 
-				var docWidth	=  wrap.offsetWidth;
-					docHeight	= wrap.offsetHeight;
+				$wrap.width($wrap.width() + 2); //Dumb hack to fix a bizarre sizing bug
+
+				var docWidth	= $wrap.outerWidth(),
+					docHeight	= $wrap.outerHeight();
 
 				if (posY + docHeight > map.size.y) { //Is the bottom edge below the window? Snap it up if so
 					posY = (posY - docHeight) - realIconSizeY - tooltip.padding;
@@ -228,11 +226,13 @@
 				//Actually size, move and show the tooltip box
 				window.location = 'byond://winset?id='+tooltip.control+';size='+docWidth+'x'+docHeight+';pos='+posX+','+posY+';is-visible=true';
 
-				content.addEventListener("onmouseover", eventOnMouseover);
+				$content.on('mouseover', function() {
+					tooltip.hide();
+				});
 			},
 			update: function(params, client_vw , clien_vh , text, theme, special) {
 				//Assign our global object
-				tooltip.params = JSON.parse(params);
+				tooltip.params = $.parseJSON(params);
 				tooltip.client_view_w = parseInt(client_vw);
 				tooltip.client_view_h = parseInt(clien_vh);
 				tooltip.text = text;


### PR DESCRIPTION
Reverts tgstation/tgstation#55090

This broke tooltips pretty significantly. I can fix the missing CSS styling for themes very easily, but there are very strange artifacts with sizing of the tooltip element widths that I cannot fix in the few hours I've been playing around with this. Given that these tooltips are a very common user-facing feature, I feel whatever we gained from removing jQuery in these cases does not warrant the very broken experience for users at this moment.

This should be re-PR'd once/if the original PR creator corrects the problems outlined above.

Closes #55267 