### PR TITLE
Fixes carbon revival bug

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -877,7 +877,7 @@
 
 /mob/living/carbon/can_be_revived()
 	. = ..()
-	if(!getorgan(/obj/item/organ/brain) && (!mind || !mind.has_antag_datum(/datum/antagonist/changeling)))
+	if(!getorgan(/obj/item/organ/brain) && (!mind || !mind.has_antag_datum(/datum/antagonist/changeling)) || HAS_TRAIT(src, TRAIT_HUSK))
 		return FALSE
 
 /mob/living/carbon/proc/can_defib()


### PR DESCRIPTION
## About The Pull Request
`can_be_revived` didn't check if a carbon was husked or not 

## Why It's Good For The Game
Prevents people from being able to avoid dealing with/abusing the husked trait, so medically living husks aren't a thing.
This didn't change anything with flesh heretic's ghouls/voiceless dead or changelings that I've been able to find.

## Changelog
:cl:
fix: Revival surgery will fail to revive patients that are husked after the surgery is started until the patient is unhusked.
/:cl: