### PR TITLE
Makes Suit Storage Unit constructable

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -9,6 +9,7 @@
 	power_channel = AREA_USAGE_EQUIP
 	density = TRUE
 	max_integrity = 250
+	circuit = /obj/item/circuitboard/machine/suit_storage_unit
 
 	var/obj/item/clothing/suit/space/suit = null
 	var/obj/item/clothing/head/helmet/space/helmet = null
@@ -197,13 +198,6 @@
 	mask = null
 	storage = null
 	set_occupant(null)
-
-/obj/machinery/suit_storage_unit/deconstruct(disassembled = TRUE)
-	if(!(flags_1 & NODECONSTRUCT_1))
-		open_machine()
-		dump_inventory_contents()
-		new /obj/item/stack/sheet/metal(loc, 2)
-	qdel(src)
 
 /obj/machinery/suit_storage_unit/interact(mob/living/user)
 	var/static/list/items
@@ -512,9 +506,11 @@
 	if(!state_open)
 		if(default_deconstruction_screwdriver(user, "panel", "close", I))
 			return
+/obj/machinery/suit_storage_unit/crowbar_act(mob/living/user, obj/item/I)
 	if(default_pry_open(I))
-		dump_inventory_contents()
-		return
+		return TRUE
+	if(default_deconstruction_crowbar(I))
+		return TRUE
 
 	return ..()
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -510,6 +510,8 @@
 	if(default_pry_open(I))
 		return TRUE
 	if(default_deconstruction_crowbar(I))
+		open_machine()
+		dump_inventory_contents()
 		return TRUE
 
 	return ..()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -507,12 +507,10 @@
 		if(default_deconstruction_screwdriver(user, "panel", "close", I))
 			return
 /obj/machinery/suit_storage_unit/crowbar_act(mob/living/user, obj/item/I)
-	if(default_pry_open(I))
-		return TRUE
 	if(default_deconstruction_crowbar(I))
 		open_machine()
 		dump_inventory_contents()
-		return TRUE
+		return
 
 	return ..()
 

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -35,6 +35,16 @@
 
 //Engineering
 
+/obj/item/circuitboard/machine/suit_storage_unit
+	name = "Suit Storage Unit (Machine Board)"
+	icon_state = "engineering"
+	build_path = /obj/machinery/suit_storage_unit
+	req_components = list(
+		/obj/item/stock_parts/matter_bin = 2,
+		/obj/item/stock_parts/manipulator = 1,
+		/obj/item/stock_parts/scanning_module = 1,
+		/obj/item/stock_parts/micro_laser = 1)
+
 /obj/item/circuitboard/machine/announcement_system
 	name = "Announcement System (Machine Board)"
 	icon_state = "engineering"

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -43,7 +43,8 @@
 		/obj/item/stock_parts/matter_bin = 2,
 		/obj/item/stock_parts/manipulator = 1,
 		/obj/item/stock_parts/scanning_module = 1,
-		/obj/item/stock_parts/micro_laser = 1)
+		/obj/item/stock_parts/micro_laser = 1,
+		/obj/item/stack/sheet/mineral/silver = 2)
 
 /obj/item/circuitboard/machine/announcement_system
 	name = "Announcement System (Machine Board)"

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -20,7 +20,7 @@
 /datum/design/board/suit_storage_unit
 	name = "Machine Design (Suit Storage Unit Board)"
 	desc = "The circuit board for a Suit Storage Unit."
-	id = "smes"
+	id = "suit_storage_unit"
 	build_path = /obj/item/circuitboard/machine/suit_storage_unit
 	category = list ("Engineering Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -17,6 +17,14 @@
 	category = list ("Engineering Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
+/datum/design/board/suit_storage_unit
+	name = "Machine Design (Suit Storage Unit Board)"
+	desc = "The circuit board for a Suit Storage Unit."
+	id = "smes"
+	build_path = /obj/item/circuitboard/machine/suit_storage_unit
+	category = list ("Engineering Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+
 /datum/design/board/announcement_system
 	name = "Machine Design (Automated Announcement System Board)"
 	desc = "The circuit board for an automated announcement system."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -139,7 +139,7 @@
 	design_ids = list("solarcontrol", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "w-recycler" , "emitter", "high_cell", "adv_matter_bin", "scanner_gate",
 	"atmosalerts", "atmos_control", "recycler", "autolathe", "high_micro_laser", "nano_mani", "mesons", "welding_goggles", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod",
 	"apc_control", "cell_charger", "power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics", "cell_charger", "stack_console", "stack_machine",
-	"oxygen_tank", "plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt", "electrolyzer", "adv_electrolite", "pneumatic_seal")
+	"oxygen_tank", "plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt", "electrolyzer", "adv_electrolite", "pneumatic_seal", "suit_storage_unit")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 
 /datum/techweb_node/adv_engi


### PR DESCRIPTION
## About The Pull Request

Makes the Suit Storage Unit constructable. Requires 2 matter bins, 1 micro-manipulator, 1 micro-laser, and 1 scanning module. Available under Industrial Engineering research and printable at the Engineering lathe.

## Why It's Good For The Game

Things which can't be constructed aren't fun, so making something constructable which wasn't constructable before increases fun

## Changelog
:cl:
add: Suit Storage Unit circuit board
/:cl:
