### PR TITLE
Fixes new players harddeling when the player logs out

### DIFF
--- a/code/modules/mob/dead/new_player/logout.dm
+++ b/code/modules/mob/dead/new_player/logout.dm
@@ -3,5 +3,6 @@
 	..()
 	if(!spawning)//Here so that if they are spawning and log out, the other procs can play out and they will have a mob to come back to.
 		key = null//We null their key before deleting the mob, so they are properly kicked out.
+		QDEL_NULL(mind) //Clean out mind, yes this fucking sucks
 		qdel(src)
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

New players qdel when the associated client logs out, but this doesn't clean up mind and its refs, so we get in trouble.
Fixes #55277 
Maybe fixes #11365 

## Why It's Good For The Game

REEEEEE I want my overrun time back

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
