### PR TITLE
Fixes NanoDrug Plus unused sprite

### DIFF
--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -44,8 +44,8 @@
 /obj/machinery/vending/drugs
 	name = "\improper NanoDrug Plus"
 	desc = "Medical drugs dispenser."
-	icon_state = "med"
-	icon_deny = "med-deny"
+	icon_state = "drug"
+	icon_deny = "drug-deny"
 	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"
 	req_access = list(ACCESS_MEDICAL)
 	products = list(/obj/item/reagent_containers/pill/patch/libital = 5,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

NanoDrug Plus has a distinct sprite to NanoMed Plus. It isn't used. This uses it.

"New" sprite here:
![NanoDrug Plus](https://user-images.githubusercontent.com/8881105/100822968-47febb00-344b-11eb-9ac8-9d3451966926.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No more running to the wrong machine

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Uses unused NanoDrug Plus sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
