### PR TITLE
Update precompile.sh with the one I had to use to get everything to work

### DIFF
--- a/tools/LinuxOneShot/SetupProgram/PreCompile.sh
+++ b/tools/LinuxOneShot/SetupProgram/PreCompile.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# REPO MAINTAINERS: KEEP CHANGES TO THIS IN SYNC WITH /tools/tgs4_scripts/PreCompile.sh
-
+# REPO MAINTAINERS: KEEP CHANGES TO THIS IN SYNC WITH /tools/LinuxOneShot/SetupProgram/PreCompile.sh
+# No ~mso
 set -e
 set -x
 
@@ -18,61 +18,49 @@ has_git="$(command -v git)"
 has_cargo="$(command -v ~/.cargo/bin/cargo)"
 has_sudo="$(command -v sudo)"
 has_grep="$(command -v grep)"
-DATABASE_EXISTS="$(mysqlshow --host mariadb --port 3306 --user=root --password=$MYSQL_ROOT_PASSWORD ss13_db| grep -v Wildcard | grep -o ss13_db)"
 set -e
 
 # install cargo if needful
 if ! [ -x "$has_cargo" ]; then
 	echo "Installing rust..."
-	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-host i686-unknown-linux-gnu
+	curl https://sh.rustup.rs -sSf | sh -s -- -y
 	. ~/.profile
 fi
 
 # apt packages, libssl needed by rust-g but not included in TGS barebones install
-if ! { [ -x "$has_git" ] && [ -x "$has_grep" ] && [ -f "/usr/lib/i386-linux-gnu/libssl.so" ] && [ -f "/usr/bin/mysql" ] && [ -d "/usr/include/mysql" ]; }; then
+if ! ( [ -x "$has_git" ] && [ -x "$has_grep" ] && [ -f "/usr/lib/i386-linux-gnu/libssl.so" ] ); then
 	echo "Installing apt dependencies..."
 	if ! [ -x "$has_sudo" ]; then
 		dpkg --add-architecture i386
 		apt-get update
-		apt-get install -y git libssl-dev:i386 grep mysql-client
+		apt-get install -y git libssl-dev:i386
 		rm -rf /var/lib/apt/lists/*
 	else
 		sudo dpkg --add-architecture i386
 		sudo apt-get update
-		sudo apt-get install -y git libssl-dev:i386 grep mysql-client
+		sudo apt-get install -y git libssl-dev:i386
 		sudo rm -rf /var/lib/apt/lists/*
 	fi
 fi
-
+dpkg --add-architecture i386
+apt-get update
+#apt-get upgrade -y
+apt-get install -y lib32z1 pkg-config libssl-dev:i386 libssl-dev
 #update rust-g
 if [ ! -d "rust-g" ]; then
 	echo "Cloning rust-g..."
 	git clone https://github.com/tgstation/rust-g
+	cd rust-g
+	~/.cargo/bin/rustup target add i686-unknown-linux-gnu
 else
 	echo "Fetching rust-g..."
 	cd rust-g
 	git fetch
-	cd ..
+	~/.cargo/bin/rustup target add i686-unknown-linux-gnu
 fi
 
 echo "Deploying rust-g..."
-cd rust-g
 git checkout "$RUST_G_VERSION"
-~/.cargo/bin/cargo build --release
-mv target/release/librust_g.so "$1/rust_g"
+~/.cargo/bin/cargo build --release --target=i686-unknown-linux-gnu
+mv target/i686-unknown-linux-gnu/release/librust_g.so "$1/rust_g"
 cd ..
-
-if [ ! -d "../GameStaticFiles/config" ]; then
-	echo "Creating initial config..."
-	cp -r "$1/config" "../GameStaticFiles/config"
-	echo -e "SQL_ENABLED\nFEEDBACK_TABLEPREFIX SS13_\nADDRESS mariadb\nPORT 3306\nFEEDBACK_DATABASE ss13_db\nFEEDBACK_LOGIN root\nFEEDBACK_PASSWORD $MYSQL_ROOT_PASSWORD\nASYNC_QUERY_TIMEOUT 10\nBLOCKING_QUERY_TIMEOUT 5\nBSQL_THREAD_LIMIT 50" > "../GameStaticFiles/config/dbconfig.txt"
-	echo "$TGS_ADMIN_CKEY = Host" > "../GameStaticFiles/config/admins.txt"
-fi
-
-if [ "$DATABASE_EXISTS" != "ss13_db" ]; then
-	echo "Creating initial SS13 database..."
-    mysql -u root --password=$MYSQL_ROOT_PASSWORD -h mariadb -P 3306 -e 'CREATE DATABASE IF NOT EXISTS ss13_db;'
-	cat "$1/$TGS_PREFIXED_SCHEMA_FILE"
-    mysql -u root --password=$MYSQL_ROOT_PASSWORD -h mariadb -P 3306 ss13_db < "$1/$TGS_PREFIXED_SCHEMA_FILE"
-    mysql -u root --password=$MYSQL_ROOT_PASSWORD -h mariadb -P 3306 ss13_db -e "INSERT INTO \`SS13_schema_revision\` (\`major\`, \`minor\`) VALUES ($TGS_SCHEMA_MAJOR_VERSION, $TGS_SCHEMA_MINOR_VERSION)"
-fi

--- a/tools/LinuxOneShot/SetupProgram/PreCompile.sh
+++ b/tools/LinuxOneShot/SetupProgram/PreCompile.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# REPO MAINTAINERS: KEEP CHANGES TO THIS IN SYNC WITH /tools/LinuxOneShot/SetupProgram/PreCompile.sh
-# No ~mso
+# REPO MAINTAINERS: KEEP CHANGES TO THIS IN SYNC WITH /tools/tgs4_scripts/PreCompile.sh
+
 set -e
 set -x
 
@@ -18,49 +18,61 @@ has_git="$(command -v git)"
 has_cargo="$(command -v ~/.cargo/bin/cargo)"
 has_sudo="$(command -v sudo)"
 has_grep="$(command -v grep)"
+DATABASE_EXISTS="$(mysqlshow --host mariadb --port 3306 --user=root --password=$MYSQL_ROOT_PASSWORD ss13_db| grep -v Wildcard | grep -o ss13_db)"
 set -e
 
 # install cargo if needful
 if ! [ -x "$has_cargo" ]; then
 	echo "Installing rust..."
-	curl https://sh.rustup.rs -sSf | sh -s -- -y
+	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-host i686-unknown-linux-gnu
 	. ~/.profile
 fi
 
 # apt packages, libssl needed by rust-g but not included in TGS barebones install
-if ! ( [ -x "$has_git" ] && [ -x "$has_grep" ] && [ -f "/usr/lib/i386-linux-gnu/libssl.so" ] ); then
+if ! { [ -x "$has_git" ] && [ -x "$has_grep" ] && [ -f "/usr/lib/i386-linux-gnu/libssl.so" ] && [ -f "/usr/bin/mysql" ] && [ -d "/usr/include/mysql" ]; }; then
 	echo "Installing apt dependencies..."
 	if ! [ -x "$has_sudo" ]; then
 		dpkg --add-architecture i386
 		apt-get update
-		apt-get install -y git libssl-dev:i386
+		apt-get install -y git libssl-dev:i386 grep mysql-client
 		rm -rf /var/lib/apt/lists/*
 	else
 		sudo dpkg --add-architecture i386
 		sudo apt-get update
-		sudo apt-get install -y git libssl-dev:i386
+		sudo apt-get install -y git libssl-dev:i386 grep mysql-client
 		sudo rm -rf /var/lib/apt/lists/*
 	fi
 fi
-dpkg --add-architecture i386
-apt-get update
-#apt-get upgrade -y
-apt-get install -y lib32z1 pkg-config libssl-dev:i386 libssl-dev
+
 #update rust-g
 if [ ! -d "rust-g" ]; then
 	echo "Cloning rust-g..."
 	git clone https://github.com/tgstation/rust-g
-	cd rust-g
-	~/.cargo/bin/rustup target add i686-unknown-linux-gnu
 else
 	echo "Fetching rust-g..."
 	cd rust-g
 	git fetch
-	~/.cargo/bin/rustup target add i686-unknown-linux-gnu
+	cd ..
 fi
 
 echo "Deploying rust-g..."
+cd rust-g
 git checkout "$RUST_G_VERSION"
-~/.cargo/bin/cargo build --release --target=i686-unknown-linux-gnu
-mv target/i686-unknown-linux-gnu/release/librust_g.so "$1/rust_g"
+~/.cargo/bin/cargo build --release
+mv target/release/librust_g.so "$1/rust_g"
 cd ..
+
+if [ ! -d "../GameStaticFiles/config" ]; then
+	echo "Creating initial config..."
+	cp -r "$1/config" "../GameStaticFiles/config"
+	echo -e "SQL_ENABLED\nFEEDBACK_TABLEPREFIX SS13_\nADDRESS mariadb\nPORT 3306\nFEEDBACK_DATABASE ss13_db\nFEEDBACK_LOGIN root\nFEEDBACK_PASSWORD $MYSQL_ROOT_PASSWORD\nASYNC_QUERY_TIMEOUT 10\nBLOCKING_QUERY_TIMEOUT 5\nBSQL_THREAD_LIMIT 50" > "../GameStaticFiles/config/dbconfig.txt"
+	echo "$TGS_ADMIN_CKEY = Host" > "../GameStaticFiles/config/admins.txt"
+fi
+
+if [ "$DATABASE_EXISTS" != "ss13_db" ]; then
+	echo "Creating initial SS13 database..."
+    mysql -u root --password=$MYSQL_ROOT_PASSWORD -h mariadb -P 3306 -e 'CREATE DATABASE IF NOT EXISTS ss13_db;'
+	cat "$1/$TGS_PREFIXED_SCHEMA_FILE"
+    mysql -u root --password=$MYSQL_ROOT_PASSWORD -h mariadb -P 3306 ss13_db < "$1/$TGS_PREFIXED_SCHEMA_FILE"
+    mysql -u root --password=$MYSQL_ROOT_PASSWORD -h mariadb -P 3306 ss13_db -e "INSERT INTO \`SS13_schema_revision\` (\`major\`, \`minor\`) VALUES ($TGS_SCHEMA_MAJOR_VERSION, $TGS_SCHEMA_MINOR_VERSION)"
+fi

--- a/tools/tgs4_scripts/PreCompile.sh
+++ b/tools/tgs4_scripts/PreCompile.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # REPO MAINTAINERS: KEEP CHANGES TO THIS IN SYNC WITH /tools/LinuxOneShot/SetupProgram/PreCompile.sh
-
+# No ~mso
 set -e
 set -x
 
@@ -42,21 +42,25 @@ if ! ( [ -x "$has_git" ] && [ -x "$has_grep" ] && [ -f "/usr/lib/i386-linux-gnu/
 		sudo rm -rf /var/lib/apt/lists/*
 	fi
 fi
-
+dpkg --add-architecture i386
+apt-get update
+#apt-get upgrade -y
+apt-get install -y lib32z1 pkg-config libssl-dev:i386 libssl-dev
 #update rust-g
 if [ ! -d "rust-g" ]; then
 	echo "Cloning rust-g..."
 	git clone https://github.com/tgstation/rust-g
 	cd rust-g
-	rustup target add i686-unknown-linux-gnu
+	~/.cargo/bin/rustup target add i686-unknown-linux-gnu
 else
 	echo "Fetching rust-g..."
 	cd rust-g
 	git fetch
+	~/.cargo/bin/rustup target add i686-unknown-linux-gnu
 fi
 
 echo "Deploying rust-g..."
 git checkout "$RUST_G_VERSION"
 ~/.cargo/bin/cargo build --release --target=i686-unknown-linux-gnu
-mv target/release/librust_g.so "$1/rust_g"
+mv target/i686-unknown-linux-gnu/release/librust_g.so "$1/rust_g"
 cd ..


### PR DESCRIPTION
Some notes:
* failures are hard to deal with if so many installs are behind narrowly scoped checks. This should be improved. for instance rustup failing meant it never ran again. even if you fixed the cause.
* you have to install the 64 bit version of openssl too or pkg-config can't find it.
* rustup was not in path
* setting a target changes the path the .so is dumped out to.

I don't care how ugly and bad this is, this is likely what will get used in production unless somebody hands me a better working version. 

side-note: move to debian based docker images when?
