### PR TITLE
Fixes borg upgrades with action buttons being broken

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -907,8 +907,11 @@
 /mob/living/silicon/robot/proc/add_to_upgrades(obj/item/borg/upgrade/new_upgrade, mob/user)
 	if(new_upgrade in upgrades)
 		return
+	if(!user.temporarilyRemoveItemFromInventory(new_upgrade)) //calling the upgrade's dropped() proc /before/ we add action buttons
+		return
 	if(!new_upgrade.action(src, user))
 		to_chat(user, "<span class='danger'>Upgrade error.</span>")
+		new_upgrade.forceMove(loc) //gets lost otherwise
 		return FALSE
 	to_chat(user, "<span class='notice'>You apply the upgrade to [src].</span>")
 	to_chat(src, "----------------\nNew hardware detected...Identified as \"<b>[new_upgrade]</b>\"...Setup complete.\n----------------")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -906,9 +906,9 @@
 ///Use this to add upgrades to robots. It'll register signals for when the upgrade is moved or deleted, if not single use.
 /mob/living/silicon/robot/proc/add_to_upgrades(obj/item/borg/upgrade/new_upgrade, mob/user)
 	if(new_upgrade in upgrades)
-		return
+		return FALSE
 	if(!user.temporarilyRemoveItemFromInventory(new_upgrade)) //calling the upgrade's dropped() proc /before/ we add action buttons
-		return
+		return FALSE
 	if(!new_upgrade.action(src, user))
 		to_chat(user, "<span class='danger'>Upgrade error.</span>")
 		new_upgrade.forceMove(loc) //gets lost otherwise


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
To take a brief stroll through the process of installing an upgrade with an action button to a borg;

- Pinpointer upgrade attempts install
- Borg gets action button. As per normal action button setup, the owner variable now references the borg.
- Upgrade is then moved into the borg via forcemove
- The `dropped()` proc is called on the upgrade at the /obj/item level because it left the human's hand
- Dropped calls the `Remove()` proc on all actions for that item
- Action's owner var is set to null in the `Remove()` proc even though the referenced mob (the human) isn't the same as the owner
- Action button doesn't go away, but now the action fails because of the empty owner var. If the icon is ever reloaded, the proc to do that will mark the button as disabled due to no owner being set.
- This breaks the action button for the borg.

Thus, we add in a call for `temporarilyRemoveItemFromInventory()` to trigger the inevitable `dropped()` proc beforehand. An extra force move for install failures is also included to keep the upgrade from being lost in the void. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #55257 
You can probably also currently install upgrades somehow stuck to your hand, and if so this would also fix that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Borg upgrades with action buttons will no longer have broken action buttons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
