### PR TITLE
Adaptive Paint now uses a radial menu for choosing its color variants

### DIFF
--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -7,48 +7,49 @@
 	desc = "Used to recolor floors and walls. Can be removed by the janitor."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "paint_neutral"
-	var/paint_color = "FFFFFF"
 	inhand_icon_state = "paintcan"
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
+	/// With what color will we paint with
+	var/paint_color = COLOR_WHITE
+	/// How many uses are left
 	var/paintleft = 10
 
 /obj/item/paint/red
 	name = "red paint"
-	paint_color = "C73232" //"FF0000"
+	paint_color = COLOR_RED
 	icon_state = "paint_red"
 
 /obj/item/paint/green
 	name = "green paint"
-	paint_color = "2A9C3B" //"00FF00"
+	paint_color = COLOR_VIBRANT_LIME
 	icon_state = "paint_green"
 
 /obj/item/paint/blue
 	name = "blue paint"
-	paint_color = "5998FF" //"0000FF"
+	paint_color = COLOR_BLUE
 	icon_state = "paint_blue"
 
 /obj/item/paint/yellow
 	name = "yellow paint"
-	paint_color = "CFB52B" //"FFFF00"
+	paint_color = COLOR_YELLOW
 	icon_state = "paint_yellow"
 
 /obj/item/paint/violet
 	name = "violet paint"
-	paint_color = "AE4CCD" //"FF00FF"
+	paint_color = COLOR_MAGENTA
 	icon_state = "paint_violet"
 
 /obj/item/paint/black
 	name = "black paint"
-	paint_color = "333333"
+	paint_color = COLOR_ALMOST_BLACK
 	icon_state = "paint_black"
 
 /obj/item/paint/white
 	name = "white paint"
-	paint_color = "FFFFFF"
+	paint_color = COLOR_WHITE
 	icon_state = "paint_white"
-
 
 /obj/item/paint/anycolor
 	gender = PLURAL
@@ -56,27 +57,50 @@
 	icon_state = "paint_neutral"
 
 /obj/item/paint/anycolor/attack_self(mob/user)
-	var/t1 = input(user, "Please select a color:", "[src]", null) in sortList(list( "red", "blue", "green", "yellow", "violet", "black", "white"))
-	if ((user.get_active_held_item() != src || user.stat != CONSCIOUS || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED)))
-		return
-	switch(t1)
-		if("red")
-			paint_color = "C73232"
-		if("blue")
-			paint_color = "5998FF"
-		if("green")
-			paint_color = "2A9C3B"
-		if("yellow")
-			paint_color = "CFB52B"
-		if("violet")
-			paint_color = "AE4CCD"
-		if("white")
-			paint_color = "FFFFFF"
+	var/list/possible_colors = list(
+		"black" = image(icon = src.icon, icon_state = "paint_black"),
+		"blue" = image(icon = src.icon, icon_state = "paint_blue"),
+		"green" = image(icon = src.icon, icon_state = "paint_green"),
+		"red" = image(icon = src.icon, icon_state = "paint_red"),
+		"violet" = image(icon = src.icon, icon_state = "paint_violet"),
+		"white" = image(icon = src.icon, icon_state = "paint_white"),
+		"yellow" = image(icon = src.icon, icon_state = "paint_yellow")
+		)
+	var/picked_color = show_radial_menu(user, src, possible_colors, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 38, require_near = TRUE)
+	switch(picked_color)
 		if("black")
-			paint_color = "333333"
-	icon_state = "paint_[t1]"
+			paint_color = COLOR_ALMOST_BLACK
+		if("blue")
+			paint_color = COLOR_BLUE
+		if("green")
+			paint_color = COLOR_VIBRANT_LIME
+		if("red")
+			paint_color = COLOR_RED
+		if("violet")
+			paint_color = COLOR_MAGENTA
+		if("white")
+			paint_color = COLOR_WHITE
+		if("yellow")
+			paint_color = COLOR_YELLOW
+		else
+			return
+	icon_state = "paint_[picked_color]"
 	add_fingerprint(user)
 
+/**
+  * Checks if we are allowed to interact with a radial menu
+  *
+  * Arguments:
+  * * user The mob interacting with the menu
+  */
+/obj/item/paint/anycolor/proc/check_menu(mob/user)
+	if(!istype(user))
+		return FALSE
+	if(!user.is_holding(src))
+		return FALSE
+	if(user.incapacitated())
+		return FALSE
+	return TRUE
 
 /obj/item/paint/afterattack(atom/target, mob/user, proximity)
 	. = ..()
@@ -87,8 +111,7 @@
 		return
 	if(!isturf(target) || isspaceturf(target))
 		return
-	var/newcolor = "#" + paint_color
-	target.add_atom_colour(newcolor, WASHABLE_COLOUR_PRIORITY)
+	target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 
 /obj/item/paint/paint_remover
 	gender =  PLURAL

--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -88,11 +88,11 @@
 	add_fingerprint(user)
 
 /**
-  * Checks if we are allowed to interact with a radial menu
-  *
-  * Arguments:
-  * * user The mob interacting with the menu
-  */
+ * Checks if we are allowed to interact with a radial menu
+ *
+ * Arguments:
+ * * user The mob interacting with the menu
+ */
 /obj/item/paint/anycolor/proc/check_menu(mob/user)
 	if(!istype(user))
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adaptive Paint now uses a radial menu for choosing its color variants instead of clumsy input menu. I have also replaced pseudo-color codes with proper color defines for paint colors and documented paint variables for better code readability,

Example image:

![AdaptivePaintRadial](https://user-images.githubusercontent.com/43862960/100868793-693bc780-349c-11eb-860e-9f35814b0be5.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Better color selection method and code improvement.

## Changelog
:cl: Arkatos
tweak: Adaptive Paint now uses a radial menu for choosing its color variants.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
