### PR TITLE
Limit custom burger ingredients

### DIFF
--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -28,7 +28,7 @@
 		atom/replacement,
 		fill_type,
 		ingredient_type = CUSTOM_INGREDIENT_TYPE_EDIBLE,
-		max_ingredients = INFINITY,
+		max_ingredients = 98,
 		list/obj/item/initial_ingredients = null)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE


### PR DESCRIPTION

## Changelog
:cl: That REALLY Good Soda Flavor
fix: Custom burgers are limited to 98 ingredients.
/:cl:

If you put on too many ingredients, they will disappear because of the overlay limit.