### PR TITLE
Deadchat plays everything - A simple way for admins to let deadchat control things.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -42,6 +42,9 @@
 #define COMSIG_PARENT_QDELETING "parent_qdeleting"
 /// generic topic handler (usr, href_list)
 #define COMSIG_TOPIC "handle_topic"
+/// handler for vv_do_topic (usr, href_list)
+#define COMSIG_VV_TOPIC "vv_topic"
+	#define COMPONENT_VV_HANDLED (1<<0)
 
 /// fires on the target datum when an element is attached to it (/datum/element)
 #define COMSIG_ELEMENT_ATTACH "element_attach"

--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -87,6 +87,9 @@
 #define VV_HK_EDIT_FILTERS "edit_filters"
 #define VV_HK_ADD_AI "add_ai"
 
+// /atom/movable
+#define VV_HK_DEADCHAT_PLAYS "deadchat_plays"
+
 // /obj
 #define VV_HK_OSAY "osay"
 #define VV_HK_MASS_DEL_TYPE "mass_delete_type"

--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -23,7 +23,6 @@
 		timerid = addtimer(CALLBACK(src, .proc/democracy_loop), input_cooldown, TIMER_STOPPABLE | TIMER_LOOP)
 	notify_ghosts("[parent] is now deadchat controllable!", source = parent, action = NOTIFY_ORBIT, header="Something Interesting!")
 
-
 /datum/component/deadchat_control/Destroy(force, silent)
 	inputs = null
 	orbiters = null
@@ -35,7 +34,7 @@
 
 	message = lowertext(message)
 	if(!inputs[message])
-		return 
+		return
 	if(deadchat_mode == ANARCHY_MODE)
 		var/cooldown = ckey_to_cooldown[source.ckey]
 		if(cooldown)
@@ -49,7 +48,7 @@
 
 /datum/component/deadchat_control/proc/remove_cooldown(ckey)
 	ckey_to_cooldown.Remove(ckey)
-	
+
 /datum/component/deadchat_control/proc/democracy_loop()
 	if(QDELETED(parent) || deadchat_mode != DEMOCRACY_MODE)
 		deltimer(timerid)
@@ -64,7 +63,7 @@
 		var/message = "<span class='deadsay italics bold'>No votes were cast this cycle.</span>"
 		for(var/M in orbiters)
 			to_chat(M, message)
-			
+
 /datum/component/deadchat_control/proc/count_democracy_votes()
 	if(!length(ckey_to_cooldown))
 		return
@@ -74,7 +73,7 @@
 	for(var/vote in ckey_to_cooldown)
 		votes[ckey_to_cooldown[vote]]++
 		ckey_to_cooldown.Remove(vote)
-	
+
 	// Solve which had most votes.
 	var/prev_value = 0
 	var/result
@@ -82,7 +81,7 @@
 		if(votes[vote] > prev_value)
 			prev_value = votes[vote]
 			result = vote
-	
+
 	if(result in inputs)
 		return result
 
@@ -110,3 +109,17 @@
 	if(orbiter in orbiters)
 		UnregisterSignal(orbiter, COMSIG_MOB_DEADSAY)
 		orbiters -= orbiter
+
+/**
+ * Simple helper proc to add additional inputs to the deadchat_control component.
+ *
+ * Useful for snowflake mobs - For example, could add a new input to allow players to make Birdboat vomit.
+ * Arguments:
+ * * input_text - User input string to assign the callback to in the input list.
+ * * callback - Proc callback for the input.
+ */
+/datum/component/deadchat_control/proc/add_input(input_text, callback)
+	if(!input_text || !callback)
+		return
+
+	inputs[input_text] = callback

--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -1,29 +1,48 @@
 #define DEMOCRACY_MODE "democracy"
 #define ANARCHY_MODE "anarchy"
 
+/**
+ * Deadchat Plays Things - The Componenting
+ *
+ * Allows deadchat to control stuff and things by typing commands into chat.
+ * These commands will then trigger callbacks to execute procs!
+ */
 /datum/component/deadchat_control
 	dupe_mode = COMPONENT_DUPE_UNIQUE
-	var/timerid
 
+	/// The id for the DEMOCRACY_MODE looping vote timer.
+	var/timerid
+	/// Assoc list of key-chat command string, value-callback pairs. list("right" = CALLBACK(GLOBAL_PROC, .proc/_step, src, EAST))
 	var/list/datum/callback/inputs = list()
+	/// Assoc list of ckey:value pairings. In DEMOCRACY_MODE, value is the player's vote. In ANARCHY_MODE, value is world.time when their cooldown expires.
 	var/list/ckey_to_cooldown = list()
+	/// List of everything orbitting this component's parent.
 	var/orbiters = list()
+	/// Either DEMOCRACY_MODE which will execute a single command after the cooldown based on player votes, or ANARCHY_MODE which allows each player to do a single command every cooldown.
 	var/deadchat_mode
+	/// In DEMOCRACY_MODE, this is how long players have to vote on an input. In ANARCHY_MODE, this is how long between inputs for each unique player.
 	var/input_cooldown
 
-/datum/component/deadchat_control/Initialize(_deadchat_mode, _inputs, _input_cooldown = 12 SECONDS)
+	/// Callback invoked when this component is Destroy()ed to allow the parent to return to a non-deadchat controlled state.
+	var/datum/callback/on_removal
+
+/datum/component/deadchat_control/Initialize(_deadchat_mode, _inputs, _input_cooldown = 12 SECONDS, _on_removal)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 	RegisterSignal(parent, COMSIG_ATOM_ORBIT_BEGIN, .proc/orbit_begin)
 	RegisterSignal(parent, COMSIG_ATOM_ORBIT_STOP, .proc/orbit_stop)
+	RegisterSignal(parent, COMSIG_VV_TOPIC, .proc/handle_vv_topic)
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/on_examine)
 	deadchat_mode = _deadchat_mode
 	inputs = _inputs
 	input_cooldown = _input_cooldown
+	on_removal = _on_removal
 	if(deadchat_mode == DEMOCRACY_MODE)
 		timerid = addtimer(CALLBACK(src, .proc/democracy_loop), input_cooldown, TIMER_STOPPABLE | TIMER_LOOP)
 	notify_ghosts("[parent] is now deadchat controllable!", source = parent, action = NOTIFY_ORBIT, header="Something Interesting!")
 
 /datum/component/deadchat_control/Destroy(force, silent)
+	on_removal?.Invoke()
 	inputs = null
 	orbiters = null
 	ckey_to_cooldown = null
@@ -33,21 +52,24 @@
 	SIGNAL_HANDLER
 
 	message = lowertext(message)
+
 	if(!inputs[message])
 		return
+
 	if(deadchat_mode == ANARCHY_MODE)
-		var/cooldown = ckey_to_cooldown[source.ckey]
-		if(cooldown)
+		var/cooldown = ckey_to_cooldown[source.ckey] - world.time
+		if(cooldown > 0)
+			to_chat(source, "<span class='warning'>Your deadchat control inputs are still on cooldown for another [cooldown * 0.1] seconds.</span>")
 			return MOB_DEADSAY_SIGNAL_INTERCEPT
 		inputs[message].Invoke()
-		ckey_to_cooldown[source.ckey] = TRUE
-		addtimer(CALLBACK(src, .proc/remove_cooldown, source.ckey), input_cooldown)
-	else if(deadchat_mode == DEMOCRACY_MODE)
-		ckey_to_cooldown[source.ckey] = message
-	return MOB_DEADSAY_SIGNAL_INTERCEPT
+		ckey_to_cooldown[source.ckey] = world.time + input_cooldown
+		to_chat(source, "<span class='notice'>\"[message]\" input accepted. You are now on cooldown for [input_cooldown * 0.1] seconds.</span>")
+		return MOB_DEADSAY_SIGNAL_INTERCEPT
 
-/datum/component/deadchat_control/proc/remove_cooldown(ckey)
-	ckey_to_cooldown.Remove(ckey)
+	if(deadchat_mode == DEMOCRACY_MODE)
+		ckey_to_cooldown[source.ckey] = message
+		to_chat(source, "<span class='notice'>You have voted for \"[message]\".</span>")
+		return MOB_DEADSAY_SIGNAL_INTERCEPT
 
 /datum/component/deadchat_control/proc/democracy_loop()
 	if(QDELETED(parent) || deadchat_mode != DEMOCRACY_MODE)
@@ -56,7 +78,7 @@
 	var/result = count_democracy_votes()
 	if(!isnull(result))
 		inputs[result].Invoke()
-		var/message = "<span class='deadsay italics bold'>[parent] has done action [result]!<br>New vote started. It will end in [input_cooldown/10] seconds.</span>"
+		var/message = "<span class='deadsay italics bold'>[parent] has done action [result]!<br>New vote started. It will end in [input_cooldown * 0.1] seconds.</span>"
 		for(var/M in orbiters)
 			to_chat(M, message)
 	else
@@ -110,16 +132,60 @@
 		UnregisterSignal(orbiter, COMSIG_MOB_DEADSAY)
 		orbiters -= orbiter
 
-/**
- * Simple helper proc to add additional inputs to the deadchat_control component.
- *
- * Useful for snowflake mobs - For example, could add a new input to allow players to make Birdboat vomit.
- * Arguments:
- * * input_text - User input string to assign the callback to in the input list.
- * * callback - Proc callback for the input.
- */
-/datum/component/deadchat_control/proc/add_input(input_text, callback)
-	if(!input_text || !callback)
+/// Allows for this component to be removed via a dedicated VV dropdown entry.
+/datum/component/deadchat_control/proc/handle_vv_topic(datum/source, mob/user, list/href_list)
+	SIGNAL_HANDLER
+	if(!href_list[VV_HK_DEADCHAT_PLAYS] || !check_rights(R_FUN))
 		return
+	. = COMPONENT_VV_HANDLED
+	INVOKE_ASYNC(src, .proc/async_handle_vv_topic, user, href_list)
 
-	inputs[input_text] = callback
+/// Async proc handling the alert input and associated logic for an admin removing this component via the VV dropdown.
+/datum/component/deadchat_control/proc/async_handle_vv_topic(mob/user, list/href_list)
+	if(alert(user, "Remove deadchat control from [parent]?", "Deadchat Plays [parent]", "Remove", "Cancel") == "Remove")
+		// Quick sanity check as this is an async call.
+		if(QDELETED(src))
+			return
+
+		to_chat(user, "<span class='notice'>Deadchat can no longer control [parent].</span>")
+		log_admin("[key_name(user)] has removed deadchat control from [parent]")
+		message_admins("<span class='notice'>[key_name(user)] has removed deadchat control from [parent]</span>")
+
+		qdel(src)
+
+/// Informs any examiners to the inputs available as part of deadchat control, as well as the current operating mode and cooldowns.
+/datum/component/deadchat_control/proc/on_examine(atom/A, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
+	examine_list += "<span class='notice'>[A.p_theyre(TRUE)] currently under deadchat control using the [deadchat_mode] ruleset!</span>"
+
+	if(deadchat_mode == DEMOCRACY_MODE)
+		examine_list += "<span class='notice'>Type a command into chat to vote on an action. This happens once every [input_cooldown * 0.1] seconds.</span>"
+	else if(deadchat_mode == ANARCHY_MODE)
+		examine_list += "<span class='notice'>Type a command into chat to perform. You may do this once every [input_cooldown * 0.1] seconds.</span>"
+
+	var/extended_examine = "<span class='notice'>Command list:"
+
+	for(var/possible_input in inputs)
+		extended_examine += " [possible_input]"
+
+	extended_examine += ".</span>"
+
+	examine_list += extended_examine
+
+/**
+ * Deadchat Moves Things
+ *
+ * A special variant of the deadchat_control component that comes pre-baked with all the hottest inputs for a spicy
+ * singularity or vomit goose.
+ */
+/datum/component/deadchat_control/cardinal_movement/Initialize(_deadchat_mode, _inputs, _input_cooldown, _on_removal)
+	if(!ismovable(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	. = ..()
+
+	inputs["up"] = CALLBACK(GLOBAL_PROC, .proc/_step, parent, NORTH)
+	inputs["down"] = CALLBACK(GLOBAL_PROC, .proc/_step, parent, SOUTH)
+	inputs["left"] = CALLBACK(GLOBAL_PROC, .proc/_step, parent, WEST)
+	inputs["right"] = CALLBACK(GLOBAL_PROC, .proc/_step, parent, EAST)

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -39,6 +39,8 @@
 /datum/proc/vv_do_topic(list/href_list)
 	if(!usr || !usr.client || !usr.client.holder || !check_rights(NONE))
 		return FALSE			//This is VV, not to be called by anything else.
+	if(SEND_SIGNAL(src, COMSIG_VV_TOPIC, usr, href_list) & COMPONENT_VV_HANDLED)
+		return FALSE
 	if(href_list[VV_HK_MODIFY_TRAITS])
 		usr.client.holder.modify_traits(src)
 	return TRUE

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1072,7 +1072,7 @@
  * Arguments:
  * * deadchat_plays_comp - The deadchat_control component that is being removed.
  */
-/atom/movable/proc/stop_deadchat_plays(var/deadchat_plays_comp)
+/atom/movable/proc/stop_deadchat_plays(deadchat_plays_comp)
 	SIGNAL_HANDLER
 
 /atom/movable/vv_get_dropdown()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1075,6 +1075,26 @@
 /atom/movable/proc/stop_deadchat_plays(var/deadchat_plays_comp)
 	SIGNAL_HANDLER
 
+/atom/movable/vv_get_dropdown()
+	. = ..()
+	VV_DROPDOWN_OPTION(VV_HK_DEADCHAT_PLAYS, "Start/Stop Deadchat Plays")
+
+/atom/movable/vv_do_topic(list/href_list)
+	. = ..()
+	if(href_list[VV_HK_DEADCHAT_PLAYS] && check_rights(R_FUN))
+		var/component = GetComponent(/datum/component/deadchat_control)
+		if(component)
+			if(alert(usr, "Remove deadchat control from [src]?", "Deadchat Plays [src]", "Remove", "Cancel") == "Remove")
+				qdel(component)
+				to_chat(usr, "<span class='notice'>Deadchat can no longer control [src].</span>")
+		else
+			if(alert(usr, "Allow deadchat to move [src]?", "Deadchat Plays [src]", "Allow", "Cancel") == "Allow")
+				var/deadchat_plays_comp = deadchat_plays()
+				if(deadchat_plays_comp)
+					to_chat(usr, "<span class='notice'>Deadchat now control [src].</span>")
+				else
+					to_chat(usr, "<span class='notice'>Error adding component. Deadchat can not control [src].</span>")
+
 /obj/item/proc/do_pickup_animation(atom/target)
 	set waitfor = FALSE
 	if(!istype(loc, /turf))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1042,7 +1042,38 @@
 			if(. <= GRAB_AGGRESSIVE)
 				ADD_TRAIT(pulling, TRAIT_FLOORED, CHOKEHOLD_TRAIT)
 
+/**
+ * Adds the deadchat_plays component to this atom with simple movement commands.
+ *
+ * Subtypes can override this to add additional functionality beyond basic movement controls.
+ * Registers the COMSIG_COMPONENT_REMOVING signal to call the stop_deadchat_plays proc when the component is removed.
+ *
+ * Returns the component added.
+ * Arguments:
+ * * mode - Either ANARCHY_MODE or DEMOCRACY_MODE passed to the deadchat_control component. See [/datum/component/deadchat_control] for more info.
+ * * per_player_cooldown - The cooldown between command inputs passed to the deadchat_control component. See [/datum/component/deadchat_control] for more info.
+ */
+/atom/movable/proc/deadchat_plays(mode = ANARCHY_MODE, cooldown = 12 SECONDS)
+	var/component = AddComponent(/datum/component/deadchat_control, ANARCHY_MODE, list(
+		"up" = CALLBACK(GLOBAL_PROC, .proc/_step, src, NORTH),
+		"down" = CALLBACK(GLOBAL_PROC, .proc/_step, src, SOUTH),
+		"left" = CALLBACK(GLOBAL_PROC, .proc/_step, src, WEST),
+		"right" = CALLBACK(GLOBAL_PROC, .proc/_step, src, EAST)), cooldown)
 
+	if(!component)
+		CRASH("Failed to create deadchat_control component.")
+
+	RegisterSignal(component, COMSIG_COMPONENT_REMOVING, .proc/stop_deadchat_plays)
+	return component
+
+/**
+ * Allows for simple cleanup when the deadchat_control component is removed to restore default mob control states.
+ *
+ * Arguments:
+ * * deadchat_plays_comp - The deadchat_control component that is being removed.
+ */
+/atom/movable/proc/stop_deadchat_plays(var/deadchat_plays_comp)
+	SIGNAL_HANDLER
 
 /obj/item/proc/do_pickup_animation(atom/target)
 	set waitfor = FALSE

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1087,13 +1087,17 @@
 			if(alert(usr, "Remove deadchat control from [src]?", "Deadchat Plays [src]", "Remove", "Cancel") == "Remove")
 				qdel(component)
 				to_chat(usr, "<span class='notice'>Deadchat can no longer control [src].</span>")
+				log_admin("[key_name(usr)] has removed deadchat control from [src]")
+				message_admins("<span class='notice'>[key_name(usr)] has removed deadchat control from [src]</span>")
 		else
 			if(alert(usr, "Allow deadchat to move [src]?", "Deadchat Plays [src]", "Allow", "Cancel") == "Allow")
 				var/deadchat_plays_comp = deadchat_plays()
 				if(deadchat_plays_comp)
 					to_chat(usr, "<span class='notice'>Deadchat now control [src].</span>")
+					log_admin("[key_name(usr)] has added deadchat control to [src]")
+					message_admins("<span class='notice'>[key_name(usr)] has added deadchat control to [src]</span>")
 				else
-					to_chat(usr, "<span class='notice'>Error adding component. Deadchat can not control [src].</span>")
+					to_chat(usr, "<span class='notice'>Error adding deadchat control component to [src]. Deadchat are currently not controlling it.</span>")
 
 /obj/item/proc/do_pickup_animation(atom/target)
 	set waitfor = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/goose.dm
@@ -103,7 +103,7 @@
 	// 5% chance every round to have anarchy mode deadchat control on birdboat.
 	if(prob(5))
 		desc = "[initial(desc)] It's waddling more than usual. It seems to be possessed."
-		deadchat_plays_goose()
+		deadchat_plays()
 
 /mob/living/simple_animal/hostile/retaliate/goose/vomit/Destroy()
 	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
@@ -233,14 +233,15 @@
 		vomitTimeBonus = 0
 
 /// A proc to make it easier for admins to make the goose playable by deadchat.
-/mob/living/simple_animal/hostile/retaliate/goose/vomit/proc/deadchat_plays_goose()
-	stop_automated_movement = TRUE
-	AddComponent(/datum/component/deadchat_control, ANARCHY_MODE, list(
-		"up" = CALLBACK(GLOBAL_PROC, .proc/_step, src, NORTH),
-		"down" = CALLBACK(GLOBAL_PROC, .proc/_step, src, SOUTH),
-		"left" = CALLBACK(GLOBAL_PROC, .proc/_step, src, WEST),
-		"right" = CALLBACK(GLOBAL_PROC, .proc/_step, src, EAST),
-		"vomit" = CALLBACK(src, .proc/vomit_prestart, 25)), 12 SECONDS, 4 SECONDS)
+/mob/living/simple_animal/hostile/retaliate/goose/vomit/deadchat_plays(mode = ANARCHY_MODE, cooldown = 12 SECONDS)
+	. = ..()
+
+	var/datum/component/deadchat_control/deadchat_plays_comp = .
+
+	if(!istype(deadchat_plays_comp))
+		CRASH("deadchat_plays proc called but parent parent returned invalid component: [deadchat_plays_comp.type]")
+
+	deadchat_plays_comp.add_input("vomit", CALLBACK(src, .proc/vomit_prestart, 25))
 
 /datum/action/cooldown/vomit
 	name = "Vomit"

--- a/code/modules/mob/living/simple_animal/hostile/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/goose.dm
@@ -234,14 +234,15 @@
 
 /// A proc to make it easier for admins to make the goose playable by deadchat.
 /mob/living/simple_animal/hostile/retaliate/goose/vomit/deadchat_plays(mode = ANARCHY_MODE, cooldown = 12 SECONDS)
-	. = ..()
+	. = AddComponent(/datum/component/deadchat_control/cardinal_movement, mode, list(
+		"vomit" = CALLBACK(src, .proc/vomit_prestart, 25),
+		"honk" = CALLBACK(src, /atom/movable.proc/say, "HONK!!!"),
+		"spin" = CALLBACK(src, /mob.proc/emote, "spin")), cooldown, CALLBACK(src, .proc/stop_deadchat_plays))
 
-	var/datum/component/deadchat_control/deadchat_plays_comp = .
+	if(. == COMPONENT_INCOMPATIBLE)
+		return
 
-	if(!istype(deadchat_plays_comp))
-		CRASH("deadchat_plays proc called but parent parent returned invalid component: [deadchat_plays_comp.type]")
-
-	deadchat_plays_comp.add_input("vomit", CALLBACK(src, .proc/vomit_prestart, 25))
+	stop_automated_movement = TRUE
 
 /datum/action/cooldown/vomit
 	name = "Vomit"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -702,3 +702,13 @@
 	if(user.incapacitated())
 		return
 	return relaydrive(user, direction)
+
+/mob/living/simple_animal/deadchat_plays(mode = ANARCHY_MODE, cooldown = 12 SECONDS)
+	. = ..()
+	stop_automated_movement = TRUE
+
+/mob/living/simple_animal/stop_deadchat_plays(var/deadchat_plays_comp)
+	SIGNAL_HANDLER
+
+	. = ..()
+	stop_automated_movement = FALSE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -704,9 +704,12 @@
 	return relaydrive(user, direction)
 
 /mob/living/simple_animal/deadchat_plays(mode = ANARCHY_MODE, cooldown = 12 SECONDS)
-	. = ..()
+	. = AddComponent(/datum/component/deadchat_control/cardinal_movement, mode, list(), cooldown, CALLBACK(src, .proc/stop_deadchat_plays))
+
+	if(. == COMPONENT_INCOMPATIBLE)
+		return
+
 	stop_automated_movement = TRUE
 
-/mob/living/simple_animal/stop_deadchat_plays(deadchat_plays_comp)
-	. = ..()
+/mob/living/simple_animal/proc/stop_deadchat_plays()
 	stop_automated_movement = FALSE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -707,6 +707,6 @@
 	. = ..()
 	stop_automated_movement = TRUE
 
-/mob/living/simple_animal/stop_deadchat_plays(var/deadchat_plays_comp)
+/mob/living/simple_animal/stop_deadchat_plays(deadchat_plays_comp)
 	. = ..()
 	stop_automated_movement = FALSE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -708,7 +708,5 @@
 	stop_automated_movement = TRUE
 
 /mob/living/simple_animal/stop_deadchat_plays(var/deadchat_plays_comp)
-	SIGNAL_HANDLER
-
 	. = ..()
 	stop_automated_movement = FALSE

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -413,13 +413,17 @@
 	qdel(src)
 	return gain
 
-/obj/singularity/deadchat_controlled
+/obj/singularity/deadchat_plays(mode = DEMOCRACY_MODE, cooldown = 12 SECONDS)
+	. = ..()
 	move_self = FALSE
+
+/obj/singularity/stop_deadchat_plays(var/deadchat_plays_comp)
+	SIGNAL_HANDLER
+
+	. = ..()
+	move_self = TRUE
 
 /obj/singularity/deadchat_controlled/Initialize(mapload, starting_energy)
 	. = ..()
-	AddComponent(/datum/component/deadchat_control, DEMOCRACY_MODE, list(
-		"up" = CALLBACK(GLOBAL_PROC, .proc/_step, src, NORTH),
-		"down" = CALLBACK(GLOBAL_PROC, .proc/_step, src, SOUTH),
-		"left" = CALLBACK(GLOBAL_PROC, .proc/_step, src, WEST),
-		"right" = CALLBACK(GLOBAL_PROC, .proc/_step, src, EAST)))
+	deadchat_plays(mode = DEMOCRACY_MODE)
+

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -414,11 +414,14 @@
 	return gain
 
 /obj/singularity/deadchat_plays(mode = DEMOCRACY_MODE, cooldown = 12 SECONDS)
-	. = ..()
+	. = AddComponent(/datum/component/deadchat_control/cardinal_movement, mode, list(), cooldown, CALLBACK(src, .proc/stop_deadchat_plays))
+
+	if(. == COMPONENT_INCOMPATIBLE)
+		return
+
 	move_self = FALSE
 
-/obj/singularity/stop_deadchat_plays(deadchat_plays_comp)
-	. = ..()
+/obj/singularity/proc/stop_deadchat_plays()
 	move_self = TRUE
 
 /obj/singularity/deadchat_controlled/Initialize(mapload, starting_energy)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -417,7 +417,7 @@
 	. = ..()
 	move_self = FALSE
 
-/obj/singularity/stop_deadchat_plays(var/deadchat_plays_comp)
+/obj/singularity/stop_deadchat_plays(deadchat_plays_comp)
 	. = ..()
 	move_self = TRUE
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -418,8 +418,6 @@
 	move_self = FALSE
 
 /obj/singularity/stop_deadchat_plays(var/deadchat_plays_comp)
-	SIGNAL_HANDLER
-
 	. = ..()
 	move_self = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right now we have a deadchat_control component, however basic setup for this component is a nightmare for admins in-game. As a result, we only realistically have deadchat controlled singulos and deadchat_plays_goose.

Adds a bunch of code improvements to the deadchat control component including a subtype that comes pre-baked with cardinal movements and is restricted to /atom/movable and improved code documentation.

When the `deadchat_control` component is removed, there's now proper cleanup which should restore the atom's state to a sane default.

The component hooks into examining and will display available commands and the remaining cooldown. There's also a host of other code improvements in the user-feedback aisle.

This is also added to VV in a toggle-style manner, allowing the deadchat component to be added and/or removed with an associated alert box to allow the admin to confirm what they're about to do.

Huge thanks to @Qustinnus for spending time trying to explain how to appropriately leverage components and implement this properly, as well as implementing a new signal to allow my component to hook into VV topic calls as necessary.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Deadchat plays everything.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Admins may now call the deadchat_plays proc on any movable atom in the game, allowing deadchat to move it around with zero effort. They should now call the generic deadchat_plays instead of deadchat_plays_goose to turn Birdboat into a deadchat controlled vomit goose.
admin: The VV dropdown now contains an option to enable or disable deadchat control. This comes with an alert confirmation box to allow you to back out and chat messages to tell you the result.
refactor: There's now a lot more feedback when deadchat is controlling something, including telling you when command inputs are successful, telling you the remaining cooldown until you can input new commands when it fails and additional examine text detailling the control mode, commands and overall cooldown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
