### PR TITLE
Makes drying racks apply color properly

### DIFF
--- a/code/datums/elements/dryable.dm
+++ b/code/datums/elements/dryable.dm
@@ -22,7 +22,7 @@
 
 /datum/element/dryable/proc/finish_drying(atom/source)
 	var/atom/dried_atom = source
-	if(!dry_result)//if the dried type is not set, don't bother creating a whole new item, just re-color it.
+	if(dry_result == dried_atom.type)//if the dried type the same as our currrent state, don't bother creating a whole new item, just re-color it.
 		var/atom/movable/resulting_atom = dried_atom
 		resulting_atom.add_atom_colour("#ad7257", FIXED_COLOUR_PRIORITY)
 		ADD_TRAIT(resulting_atom, TRAIT_DRIED, ELEMENT_TRAIT)

--- a/code/datums/elements/dryable.dm
+++ b/code/datums/elements/dryable.dm
@@ -22,7 +22,7 @@
 
 /datum/element/dryable/proc/finish_drying(atom/source)
 	var/atom/dried_atom = source
-	if(dry_result == dried_atom.type)//if the dried type the same as our currrent state, don't bother creating a whole new item, just re-color it.
+	if(dry_result == dried_atom.type)//if the dried type is the same as our currrent state, don't bother creating a whole new item, just re-color it.
 		var/atom/movable/resulting_atom = dried_atom
 		resulting_atom.add_atom_colour("#ad7257", FIXED_COLOUR_PRIORITY)
 		ADD_TRAIT(resulting_atom, TRAIT_DRIED, ELEMENT_TRAIT)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Drying racks aren't coloring things currently because of how that typecheck works (It should be a type == current_type instead of !type)

## Why It's Good For The Game

Muh brown coffee beans

## Changelog
:cl:
fix: Drying racks have feedback for dried things now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
