### PR TITLE
Fixes an oversight allowing players to list ckeys and the names of the mobs they're controlling under certain conditions

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -252,6 +252,16 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		else
 			displayed_key = C.key
 
+		// Check if both we and the player are ghosts and they're not using a fakekey
+		if(isobserver(mob) && isobserver(C.mob) && !C.holder?.fakekey)
+			// Show us if the player is a ghost or not after their displayed key
+			// Add the player's displayed key to the list
+			players["[displayed_key](ghost)"] = displayed_key
+
+		// Add the player's displayed key to the list if we or the player aren't a ghost or they're using a fakekey
+		else
+			players[displayed_key] = displayed_key
+
 	// Check if the list is empty
 	if(!players.len)
 		// Express that there are no players we can ignore in chat

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -254,9 +254,10 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 		// Check if both we and the player are ghosts and they're not using a fakekey
 		if(isobserver(mob) && isobserver(C.mob) && !C.holder?.fakekey)
-			// Show us the player's mob name in the list in front of their displayed key
-			// Add the player's displayed key to the list
-			players["[C.mob]([displayed_key])"] = displayed_key
+			// We used to look for the player's mob name and display it alongisde their ckey using the line below.
+			//players["[C.mob]([displayed_key])"] = displayed_key
+			// This gives non-admins the ability to find out who plays who. This could be used to metagrudge, players don't need this information. We're here to ignore someone's OOC messages, nothing else.
+			players[displayed_key] = displayed_key
 
 		// Add the player's displayed key to the list if we or the player aren't a ghost or they're using a fakekey
 		else

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -252,14 +252,6 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		else
 			displayed_key = C.key
 
-		// Check if both we and the player are ghosts and they're not using a fakekey
-		if(isobserver(mob) && isobserver(C.mob) && !C.holder?.fakekey)
-			players[displayed_key] = displayed_key
-
-		// Add the player's displayed key to the list if we or the player aren't a ghost or they're using a fakekey
-		else
-			players[displayed_key] = displayed_key
-
 	// Check if the list is empty
 	if(!players.len)
 		// Express that there are no players we can ignore in chat

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -254,9 +254,6 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 		// Check if both we and the player are ghosts and they're not using a fakekey
 		if(isobserver(mob) && isobserver(C.mob) && !C.holder?.fakekey)
-			// We used to look for the player's mob name and display it alongisde their ckey using the line below.
-			//players["[C.mob]([displayed_key])"] = displayed_key
-			// This gives non-admins the ability to find out who plays who. This could be used to metagrudge, players don't need this information. We're here to ignore someone's OOC messages, nothing else.
 			players[displayed_key] = displayed_key
 
 		// Add the player's displayed key to the list if we or the player aren't a ghost or they're using a fakekey


### PR DESCRIPTION
## About The Pull Request
• Resolves a probably unknown oversight allowing players to find out who plays who by using the ignore verb, which if the user is a ghost, will list the names of people's mobs alongside their ckey if they are also a ghost.

## Why It's Good For The Game
Removes a potential method of metagrudging and addresses a privacy concern for those who wish to play anonymous characters. _Yes, you can still see this stuff in the round-end report._
We don't lose anything here. If we're using this verb, we're doing it because we want to ignore someone's OOC messages. We don't need this additional information. I feel like this is just an oversight.

## Changelog
:cl:
fix: Players can no longer us the ignore verb to gather a list of people's characters and ckeys together.
/:cl: