### PR TITLE
Removes roundstart miasma, from everything.

### DIFF
--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -10,6 +10,10 @@
 
 	START_PROCESSING(SSprocessing, src)
 
+/datum/component/rot/Destroy(force, silent)
+	STOP_PROCESSING(SSprocessing, src)
+	. = ..()
+
 /datum/component/rot/process(delta_time)
 	var/atom/A = parent
 

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -60,6 +60,8 @@
 	. = ..()
 	reagents.add_reagent(/datum/reagent/liquidgibs, 5)
 	RegisterSignal(src, COMSIG_MOVABLE_PIPE_EJECTING, .proc/on_pipe_eject)
+	if(mapload) //Don't rot at roundstart for the love of god
+		return
 	if(already_rotting)
 		start_rotting(rename=FALSE)
 	else

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1,9 +1,11 @@
-/mob/living/carbon/Initialize()
+/mob/living/carbon/Initialize(mapload)
 	. = ..()
 	create_reagents(1000)
 	assign_bodypart_ownership()
 	update_body_parts() //to update the carbon's new bodyparts appearance
 	GLOB.carbon_list += src
+	if(!mapload)  //I don't want no gas leaks on my space ruin you hear?
+		RegisterSignal(src, COMSIG_LIVING_DEATH, .proc/attach_rot)
 
 /mob/living/carbon/Destroy()
 	//This must be done first, so the mob ghosts correctly before DNA etc is nulled
@@ -1311,3 +1313,6 @@
 		return
 
 	return ..()
+
+/mob/living/carbon/proc/attach_rot(mapload)
+	AddComponent(/datum/component/rot/corpse)

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -14,6 +14,9 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 /mob/living/carbon/human/dummy/Life()
 	return
 
+/mob/living/carbon/human/dummy/attach_rot(mapload)
+	return
+
 /mob/living/carbon/human/dummy/proc/wipe_state()
 	delete_equipment()
 	cut_overlays(TRUE)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -28,7 +28,6 @@
 
 	if(stat == DEAD)
 		stop_sound_channel(CHANNEL_HEARTBEAT)
-		LoadComponent(/datum/component/rot/corpse)
 	else
 		var/bprv = handle_bodyparts()
 		if(bprv & BODYPART_LIFE_UPDATE_HEALTH)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Removes roundstart miasma. Yes, even the gibs that are marked as miasma producers. Fuck you. Carbons now start listening for death at init, then get the component when they die. Gibs behave just as they used to. I've added an exception for dummies, cause that's just dumb.

## Why It's Good For The Game

Roundstart miasma.
Fuck it.

We should not simulate things that a player does not cause/is related to. If you want your space ruin to have fartgas, map it in. It should be treated the same way as roundstart atmos diffs.

## Changelog
:cl:
tweak: Mapped in dead bodies/gibs no longer produce miasma
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
