### PR TITLE
Fixes donuts overriding taste reaction

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -377,15 +377,16 @@ Behavior that's still missing from this component that original food items had t
 
 	var/food_taste_reaction
 
-
 	if(check_liked) //Callback handling; use this as an override for special food like donuts
 		food_taste_reaction = check_liked.Invoke(fraction, H)
-	else if(foodtypes & H.dna.species.toxic_food)
-		food_taste_reaction = FOOD_TOXIC
-	else if(foodtypes & H.dna.species.disliked_food)
-		food_taste_reaction = FOOD_DISLIKED
-	else if(foodtypes & H.dna.species.liked_food)
-		food_taste_reaction = FOOD_LIKED
+
+	if(!food_taste_reaction)
+		if(foodtypes & H.dna.species.toxic_food)
+			food_taste_reaction = FOOD_TOXIC
+		else if(foodtypes & H.dna.species.disliked_food)
+			food_taste_reaction = FOOD_DISLIKED
+		else if(foodtypes & H.dna.species.liked_food)
+			food_taste_reaction = FOOD_LIKED
 
 	switch(food_taste_reaction)
 		if(FOOD_TOXIC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes #55302.

The donut `check_liked` callback would return null if its conditions weren't met, so the `food_taste_reaction` checks would be totally skipped over.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
No donuts for you, carnivore.

## Changelog
:cl:
fix: Lizards will now be correctly disgusted by donuts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
