### PR TITLE
Makes moths unaffected by flash directions

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -195,6 +195,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_PASSTABLE			"passtable"
 #define TRAIT_NOFLASH			"noflash" //Makes you immune to flashes
 #define TRAIT_XENO_IMMUNE		"xeno_immune"//prevents xeno huggies implanting skeletons
+#define TRAIT_LIGHT_SENSITIVE    "light_sensitive"//Makes you flashable from any direction
 #define TRAIT_NAIVE				"naive"
 #define TRAIT_PRIMITIVE			"primitive"
 #define TRAIT_GUNFLIP			"gunflip"

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -205,6 +205,10 @@
 	if(victim.loc == attacker.loc)
 		return DEVIATION_PARTIAL
 
+	// Ensures that when a moth is flashed, it will always be at no deviation. This is to make directionality irrelevant to moths.
+	if(ismoth(victim))
+		return DEVIATION_NONE
+
 	// If the victim was looking at the attacker, this is the direction they'd have to be facing.
 	var/victim_to_attacker = get_dir(victim, attacker)
 	// The victim's dir is necessarily a cardinal value.

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -205,8 +205,7 @@
 	if(victim.loc == attacker.loc)
 		return DEVIATION_PARTIAL
 
-	// Ensures that when a moth is flashed, it will always be at no deviation. This is to make directionality irrelevant to moths.
-	if(ismoth(victim))
+	if(HAS_TRAIT(victim, TRAIT_LIGHT_SENSITIVE))
 		return DEVIATION_NONE
 
 	// If the victim was looking at the attacker, this is the direction they'd have to be facing.

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -400,8 +400,8 @@
 	flash_protect = FLASH_PROTECTION_SENSITIVE
 
 /obj/item/organ/eyes/moth/Insert(mob/living/carbon/M, special = 0)
-	ADD_TRAIT(M, TRAIT_LIGHT_SENSITIVE, "light_sensitive")
 	..()
+	ADD_TRAIT(M, TRAIT_LIGHT_SENSITIVE, "light_sensitive")
 
 /obj/item/organ/eyes/moth/Remove(mob/living/carbon/M, special = 0)
 	REMOVE_TRAIT(M, TRAIT_LIGHT_SENSITIVE, "light_sensitive")
@@ -412,4 +412,3 @@
 	desc = "These eyes seem to have a large range, but might be cumbersome with glasses."
 	eye_icon_state = "snail_eyes"
 	icon_state = "snail_eyeballs"
-

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -399,6 +399,14 @@
 	desc = "These eyes seem to have increased sensitivity to bright light, with no improvement to low light vision."
 	flash_protect = FLASH_PROTECTION_SENSITIVE
 
+/obj/item/organ/eyes/moth/Insert(mob/living/carbon/M, special = 0)
+	ADD_TRAIT(M, TRAIT_LIGHT_SENSITIVE, "light_sensitive")
+	..()
+
+/obj/item/organ/eyes/moth/Remove(mob/living/carbon/M, special = 0)
+	REMOVE_TRAIT(M, TRAIT_LIGHT_SENSITIVE, "light_sensitive")
+	..()
+
 /obj/item/organ/eyes/snail
 	name = "snail eyes"
 	desc = "These eyes seem to have a large range, but might be cumbersome with glasses."

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -401,10 +401,10 @@
 
 /obj/item/organ/eyes/moth/Insert(mob/living/carbon/M, special = 0)
 	..()
-	ADD_TRAIT(M, TRAIT_LIGHT_SENSITIVE, "light_sensitive")
+	ADD_TRAIT(M, TRAIT_LIGHT_SENSITIVE, "moth eyes")
 
 /obj/item/organ/eyes/moth/Remove(mob/living/carbon/M, special = 0)
-	REMOVE_TRAIT(M, TRAIT_LIGHT_SENSITIVE, "light_sensitive")
+	REMOVE_TRAIT(M, TRAIT_LIGHT_SENSITIVE, "moth eyes")
 	..()
 
 /obj/item/organ/eyes/snail


### PR DESCRIPTION
## About The Pull Request

It makes it so directional does not matter for when moths get flashed, effectively reverting the flash nerf just for them. Moths still handle flash protection, stamina and whatnot the same. Maintainer approved by @jared-fogle

## Why It's Good For The Game

Since the nerf to flashes, the moths' downside of being weak to flashes was trivialized. Since then, the flashes being a large threat to moths stopped being a factor. This negates the main downside of moths, and makes moths much less unique or interesting as a race. By making flashes affect moths regardless of direction, this keeps flashes strong against moths as intended by their unique downside. 
Moth OP, pls ficks.

## Changelog
:cl:
balance: Moths are no longer affected by flash directions.
/:cl: