### PR TITLE
Gas mixes default to room temp if no temp is specified

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -296,6 +296,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	if(gas["TEMP"])
 		temperature = text2num(gas["TEMP"])
 		gas -= "TEMP"
+	else // if we do not have a temp in the new gas mix lets assume room temp.
+		temperature = T20C
 	gases.Cut()
 	for(var/id in gas)
 		var/path = id


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When generating a gas mix with no temp provided the gas mix starts out at basically 0K.
This set this gas mix to room temp if no temp is listed in the gas mix string.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Nothing should start at 0K for temp, gasses being one of the big issue points.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed gasses spawning with no temperature
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
