### PR TITLE
[READY] Swarmer Balance Buffs

### DIFF
--- a/code/modules/swarmers/swarmer.dm
+++ b/code/modules/swarmers/swarmer.dm
@@ -457,7 +457,7 @@
 	. = ..()
 	if(!.)
 		return
-	if((!istype(target, /mob/living/simple_animal) && !ishuman(target)) || istype(target, /mob/living/simple_animal/hostile/swarmer))
+	if((!isanimal(target) && !ishuman(target)) || isswarmer(target))
 		return
 	if(ishuman(target))
 		var/mob/living/carbon/human/possibleHulk = target

--- a/code/modules/swarmers/swarmer.dm
+++ b/code/modules/swarmers/swarmer.dm
@@ -1,18 +1,18 @@
 /**
-  * # Swarmer
-  *
-  * Tiny machines made by an ancient civilization, they seek only to consume materials and replicate.
-  *
-  * Tiny robots which, while not lethal, seek to destroy station components in order to recycle them into more swarmers.
-  * Sentient player swarmers spawn from a beacon spawned in maintenance and they can spawn melee swarmers to protect them.
-  * Swarmers have the following abilities:
-  * - Can melee targets to deal stamina damage.  Stuns cyborgs.
-  * - Can teleport friend and foe alike away using ctrl + click.  Applies binds to carbons, preventing them from immediate retaliation
-  * - Can shoot lasers which deal stamina damage to carbons and direct damage to simple mobs
-  * - Can self repair for free, completely healing themselves
-  * - Can construct traps which stun targets, and walls which block non-swarmer entites and projectiles
-  * - Can create swarmer drones, which lack the above abilities sans melee stunning targets.  A swarmer can order its drones around by middle-clicking a tile.
-  */
+ * # Swarmer
+ *
+ * Tiny machines made by an ancient civilization, they seek only to consume materials and replicate.
+ *
+ * Tiny robots which, while not lethal, seek to destroy station components in order to recycle them into more swarmers.
+ * Sentient player swarmers spawn from a beacon spawned in maintenance and they can spawn melee swarmers to protect them.
+ * Swarmers have the following abilities:
+ * - Can melee targets to deal stamina damage.  Stuns cyborgs.
+ * - Can teleport friend and foe alike away using ctrl + click.  Applies binds to carbons, preventing them from immediate retaliation
+ * - Can shoot lasers which deal stamina damage to carbons and direct damage to simple mobs
+ * - Can self repair for free, completely healing themselves
+ * - Can construct traps which stun targets, and walls which block non-swarmer entites and projectiles
+ * - Can create swarmer drones, which lack the above abilities sans melee stunning targets.  A swarmer can order its drones around by middle-clicking a tile.
+ */
 
 /mob/living/simple_animal/hostile/swarmer
 	name = "swarmer"
@@ -69,7 +69,7 @@
 	///Maximum amount of resources a swarmer can store
 	var/max_resources = 100
 	///List used for player swarmers to keep track of their drones
-	var/list/mob/living/simple_animal/hostile/swarmer/melee/dronelist
+	var/list/mob/living/simple_animal/hostile/swarmer/drone/dronelist
 	///Bitflags to store boolean conditions, such as whether the light is on or off.
 	var/swarmer_flags = NONE
 
@@ -145,13 +145,13 @@
 ////END CTRL CLICK FOR SWARMERS////
 
 /**
-  * Called when a swarmer creates a structure or drone
-  *
-  * Proc called whenever a swarmer creates a structure or drone
-  * Arguments:
-  * * fabrication_object - The atom to create
-  * * fabrication_cost - How many resources it costs for a swarmer to create the object
-  */
+ * Called when a swarmer creates a structure or drone
+ *
+ * Proc called whenever a swarmer creates a structure or drone
+ * Arguments:
+ * * fabrication_object - The atom to create
+ * * fabrication_cost - How many resources it costs for a swarmer to create the object
+ */
 /mob/living/simple_animal/hostile/swarmer/proc/Fabricate(atom/fabrication_object,fabrication_cost = 0)
 	if(!isturf(loc))
 		to_chat(src, "<span class='warning'>This is not a suitable location for fabrication. We need more space.</span>")
@@ -163,12 +163,12 @@
 	return new fabrication_object(drop_location())
 
 /**
-  * Called when a swarmer attempts to consume an object
-  *
-  * Proc which determines interaction between a swarmer and whatever it is attempting to consume
-  * Arguments:
-  * * target - The material or object the swarmer is attempting to consume
-  */
+ * Called when a swarmer attempts to consume an object
+ *
+ * Proc which determines interaction between a swarmer and whatever it is attempting to consume
+ * Arguments:
+ * * target - The material or object the swarmer is attempting to consume
+ */
 /mob/living/simple_animal/hostile/swarmer/proc/Integrate(obj/target)
 	var/resource_gain = target.integrate_amount()
 	if(resources + resource_gain > max_resources)
@@ -193,12 +193,12 @@
 	return TRUE
 
 /**
-  * Called when a swarmer attempts to destroy a structure
-  *
-  * Proc which determines interaction between a swarmer and a structure it is destroying
-  * Arguments:
-  * * target - The material or object the swarmer is attempting to destroy
-  */
+ * Called when a swarmer attempts to destroy a structure
+ *
+ * Proc which determines interaction between a swarmer and a structure it is destroying
+ * Arguments:
+ * * target - The material or object the swarmer is attempting to destroy
+ */
 /mob/living/simple_animal/hostile/swarmer/proc/dis_integrate(atom/movable/target)
 	new /obj/effect/temp_visual/swarmer/disintegration(get_turf(target))
 	do_attack_animation(target)
@@ -206,12 +206,12 @@
 	SSexplosions.low_mov_atom += target
 
 /**
-  * Called when a swarmer attempts to teleport a living entity away
-  *
-  * Proc which finds a safe location to teleport a living entity to when a swarmer teleports it away.  Also energy handcuffs carbons.
-  * Arguments:
-  * * target - The entity the swarmer is trying to teleport away
-  */
+ * Called when a swarmer attempts to teleport a living entity away
+ *
+ * Proc which finds a safe location to teleport a living entity to when a swarmer teleports it away.  Also energy handcuffs carbons.
+ * Arguments:
+ * * target - The entity the swarmer is trying to teleport away
+ */
 /mob/living/simple_animal/hostile/swarmer/proc/prepare_target(mob/living/target)
 	if(target == src)
 		return
@@ -254,12 +254,12 @@
 	return ..()
 
 /**
-  * Called when a swarmer attempts to disassemble a machine
-  *
-  * Proc called when a swarmer attempts to disassemble a machine.  Destroys the machine, and gives the swarmer metal.
-  * Arguments:
-  * * target - The machine the swarmer is attempting to disassemble
-  */
+ * Called when a swarmer attempts to disassemble a machine
+ *
+ * Proc called when a swarmer attempts to disassemble a machine.  Destroys the machine, and gives the swarmer metal.
+ * Arguments:
+ * * target - The machine the swarmer is attempting to disassemble
+ */
 /mob/living/simple_animal/hostile/swarmer/proc/dismantle_machine(obj/machinery/target)
 	do_attack_animation(target)
 	to_chat(src, "<span class='info'>We begin to dismantle this machine. We will need to be uninterrupted.</span>")
@@ -286,10 +286,10 @@
 		qdel(target)
 
 /**
-  * Called when a swarmer attempts to create a trap
-  *
-  * Proc used to allow a swarmer to create a trap.  Checks if a trap is on the tile, then if the swarmer can afford, and then places the trap.
-  */
+ * Called when a swarmer attempts to create a trap
+ *
+ * Proc used to allow a swarmer to create a trap.  Checks if a trap is on the tile, then if the swarmer can afford, and then places the trap.
+ */
 /mob/living/simple_animal/hostile/swarmer/proc/create_trap()
 	set name = "Create trap"
 	set category = "Swarmer"
@@ -303,10 +303,10 @@
 	Fabricate(/obj/structure/swarmer/trap, 4)
 
 /**
-  * Called when a swarmer attempts to create a barricade
-  *
-  * Proc used to allow a swarmer to create a barricade.  Checks if a barricade is on the tile, then if the swarmer can afford it, and then will attempt to create a barricade after a second delay.
-  */
+ * Called when a swarmer attempts to create a barricade
+ *
+ * Proc used to allow a swarmer to create a barricade.  Checks if a barricade is on the tile, then if the swarmer can afford it, and then will attempt to create a barricade after a second delay.
+ */
 /mob/living/simple_animal/hostile/swarmer/proc/create_barricade()
 	set name = "Create barricade"
 	set category = "Swarmer"
@@ -322,10 +322,10 @@
 	Fabricate(/obj/structure/swarmer/blockade, 4)
 
 /**
-  * Called when a swarmer attempts to create a drone
-  *
-  * Proc used to allow a swarmer to create a drone.  Checks if the swarmer can afford the drone, then creates it after 5 seconds, and also registers it to the creating swarmer so it can command it
-  */
+ * Called when a swarmer attempts to create a drone
+ *
+ * Proc used to allow a swarmer to create a drone.  Checks if the swarmer can afford the drone, then creates it after 5 seconds, and also registers it to the creating swarmer so it can command it
+ */
 /mob/living/simple_animal/hostile/swarmer/proc/create_swarmer()
 	set name = "Replicate"
 	set category = "Swarmer"
@@ -347,18 +347,18 @@
 	playsound(loc,'sound/items/poster_being_created.ogg', 20, TRUE, -1)
 
 /**
-  * Used to determine what type of swarmer a swarmer should create
-  *
-  * Returns the type of the swarmer to be created
-  */
+ * Used to determine what type of swarmer a swarmer should create
+ *
+ * Returns the type of the swarmer to be created
+ */
 /mob/living/simple_animal/hostile/swarmer/proc/swarmer_type_to_create()
-	return /mob/living/simple_animal/hostile/swarmer/melee
+	return /mob/living/simple_animal/hostile/swarmer/drone
 
 /**
-  * Called when a swarmer attempts to repair itself
-  *
-  * Proc used to allow a swarmer self-repair.  If the swarmer does not move after a period of time, then it will heal fully
-  */
+ * Called when a swarmer attempts to repair itself
+ *
+ * Proc used to allow a swarmer self-repair.  If the swarmer does not move after a period of time, then it will heal fully
+ */
 /mob/living/simple_animal/hostile/swarmer/proc/repair_self()
 	if(!isturf(loc))
 		return
@@ -369,10 +369,10 @@
 	to_chat(src, "<span class='info'>We successfully repaired ourselves.</span>")
 
 /**
-  * Called when a swarmer toggles its light
-  *
-  * Proc used to allow a swarmer to toggle its  light on and off.  If a swarmer has any drones, change their light settings to match their master's.
-  */
+ * Called when a swarmer toggles its light
+ *
+ * Proc used to allow a swarmer to toggle its  light on and off.  If a swarmer has any drones, change their light settings to match their master's.
+ */
 /mob/living/simple_animal/hostile/swarmer/proc/toggle_light()
 	if(swarmer_flags & SWARMER_LIGHT_ON)
 		swarmer_flags = ~SWARMER_LIGHT_ON
@@ -380,7 +380,7 @@
 		if(!mind)
 			return
 		for(var/d in dronelist)
-			var/mob/living/simple_animal/hostile/swarmer/melee/drone = d
+			var/mob/living/simple_animal/hostile/swarmer/drone/drone = d
 			drone.swarmer_flags = ~SWARMER_LIGHT_ON
 			drone.set_light_on(FALSE)
 		return
@@ -389,18 +389,18 @@
 	if(!mind)
 		return
 	for(var/d in dronelist)
-		var/mob/living/simple_animal/hostile/swarmer/melee/drone = d
+		var/mob/living/simple_animal/hostile/swarmer/drone/drone = d
 		drone.swarmer_flags |= SWARMER_LIGHT_ON
 		drone.set_light_on(TRUE)
 
 
 /**
-  * Proc which is used for swarmer comms
-  *
-  * Proc called which sends a message to all other swarmers.
-  * Arugments:
-  * * msg - The message the swarmer is sending, gotten from ContactSwarmers()
-  */
+ * Proc which is used for swarmer comms
+ *
+ * Proc called which sends a message to all other swarmers.
+ * Arugments:
+ * * msg - The message the swarmer is sending, gotten from ContactSwarmers()
+ */
 /mob/living/simple_animal/hostile/swarmer/proc/swarmer_chat(msg)
 	var/rendered = "<B>Swarm communication - [src]</b> [say_quote(msg)]"
 	for(var/i in GLOB.mob_list)
@@ -412,10 +412,10 @@
 			to_chat(listener, "[link] [rendered]")
 
 /**
-  * Proc which is used for inputting a swarmer message
-  *
-  * Proc which is used for a swarmer to input a message on a pop-up box, then attempt to send that message to the other swarmers
-  */
+ * Proc which is used for inputting a swarmer message
+ *
+ * Proc which is used for a swarmer to input a message on a pop-up box, then attempt to send that message to the other swarmers
+ */
 /mob/living/simple_animal/hostile/swarmer/proc/contact_swarmers()
 	var/message = stripped_input(src, "Announce to other swarmers", "Swarmer contact")
 	// TODO get swarmers their own colour rather than just boldtext
@@ -430,13 +430,13 @@
 
 
 /**
-  * Removes a drone from the swarmer's list.
-  *
-  * Removes the drone from our list.
-  * Called specifically when a drone is about to be destroyed, so we don't have any null references.
-  * Arguments:
-  * * mob/drone - The drone to be removed from the list.
-  */
+ * Removes a drone from the swarmer's list.
+ *
+ * Removes the drone from our list.
+ * Called specifically when a drone is about to be destroyed, so we don't have any null references.
+ * Arguments:
+ * * mob/drone - The drone to be removed from the list.
+ */
 /mob/living/simple_animal/hostile/swarmer/proc/remove_drone(mob/drone, force)
 	SIGNAL_HANDLER
 
@@ -444,11 +444,11 @@
 	dronelist -= drone
 
 /**
-  * # Swarmer Drone
-  *
-  * Melee subtype of swarmers, always AI-controlled under normal circumstances.
-  */
-/mob/living/simple_animal/hostile/swarmer/melee
+ * # Swarmer Drone
+ *
+ * AI subtype of swarmers, always AI-controlled under normal circumstances.  Automatically attacks nearby threats.
+ */
+/mob/living/simple_animal/hostile/swarmer/drone
 	icon_state = "swarmer_melee"
 	icon_living = "swarmer_melee"
 	AIStatus = AI_ON
@@ -457,7 +457,7 @@
 	. = ..()
 	if(!.)
 		return
-	if((!istype(target, /mob/living/simple_animal) && !ishuman(target)) || !istype(firer, /mob/living/simple_animal/hostile/swarmer))
+	if((!istype(target, /mob/living/simple_animal) && !ishuman(target)) || istype(target, /mob/living/simple_animal/hostile/swarmer))
 		return
 	if(ishuman(target))
 		var/mob/living/carbon/human/possibleHulk = target

--- a/code/modules/swarmers/swarmer.dm
+++ b/code/modules/swarmers/swarmer.dm
@@ -1,18 +1,18 @@
 /**
- * # Swarmer
- *
- * Tiny machines made by an ancient civilization, they seek only to consume materials and replicate.
- *
- * Tiny robots which, while not lethal, seek to destroy station components in order to recycle them into more swarmers.
- * Sentient player swarmers spawn from a beacon spawned in maintenance and they can spawn melee swarmers to protect them.
- * Swarmers have the following abilities:
- * - Can melee targets to deal stamina damage.  Stuns cyborgs.
- * - Can teleport friend and foe alike away using ctrl + click.  Applies binds to carbons, preventing them from immediate retaliation
- * - Can shoot lasers which deal stamina damage to carbons and direct damage to simple mobs
- * - Can self repair for free, completely healing themselves
- * - Can construct traps which stun targets, and walls which block non-swarmer entites and projectiles
- * - Can create swarmer drones, which lack the above abilities sans melee stunning targets.  A swarmer can order its drones around by middle-clicking a tile.
- */
+  * # Swarmer
+  *
+  * Tiny machines made by an ancient civilization, they seek only to consume materials and replicate.
+  *
+  * Tiny robots which, while not lethal, seek to destroy station components in order to recycle them into more swarmers.
+  * Sentient player swarmers spawn from a beacon spawned in maintenance and they can spawn melee swarmers to protect them.
+  * Swarmers have the following abilities:
+  * - Can melee targets to deal stamina damage.  Stuns cyborgs.
+  * - Can teleport friend and foe alike away using ctrl + click.  Applies binds to carbons, preventing them from immediate retaliation
+  * - Can shoot lasers which deal stamina damage to carbons and direct damage to simple mobs
+  * - Can self repair for free, completely healing themselves
+  * - Can construct traps which stun targets, and walls which block non-swarmer entites and projectiles
+  * - Can create swarmer drones, which lack the above abilities sans melee stunning targets.  A swarmer can order its drones around by middle-clicking a tile.
+  */
 
 /mob/living/simple_animal/hostile/swarmer
 	name = "swarmer"
@@ -35,8 +35,8 @@
 	maxbodytemp = 500
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 0
-	melee_damage_lower = 15
-	melee_damage_upper = 15
+	melee_damage_lower = 30
+	melee_damage_upper = 30
 	melee_damage_type = STAMINA
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	hud_possible = list(ANTAG_HUD, DIAG_STAT_HUD, DIAG_HUD)
@@ -145,13 +145,13 @@
 ////END CTRL CLICK FOR SWARMERS////
 
 /**
- * Called when a swarmer creates a structure or drone
- *
- * Proc called whenever a swarmer creates a structure or drone
- * Arguments:
- * * fabrication_object - The atom to create
- * * fabrication_cost - How many resources it costs for a swarmer to create the object
- */
+  * Called when a swarmer creates a structure or drone
+  *
+  * Proc called whenever a swarmer creates a structure or drone
+  * Arguments:
+  * * fabrication_object - The atom to create
+  * * fabrication_cost - How many resources it costs for a swarmer to create the object
+  */
 /mob/living/simple_animal/hostile/swarmer/proc/Fabricate(atom/fabrication_object,fabrication_cost = 0)
 	if(!isturf(loc))
 		to_chat(src, "<span class='warning'>This is not a suitable location for fabrication. We need more space.</span>")
@@ -163,12 +163,12 @@
 	return new fabrication_object(drop_location())
 
 /**
- * Called when a swarmer attempts to consume an object
- *
- * Proc which determines interaction between a swarmer and whatever it is attempting to consume
- * Arguments:
- * * target - The material or object the swarmer is attempting to consume
- */
+  * Called when a swarmer attempts to consume an object
+  *
+  * Proc which determines interaction between a swarmer and whatever it is attempting to consume
+  * Arguments:
+  * * target - The material or object the swarmer is attempting to consume
+  */
 /mob/living/simple_animal/hostile/swarmer/proc/Integrate(obj/target)
 	var/resource_gain = target.integrate_amount()
 	if(resources + resource_gain > max_resources)
@@ -193,12 +193,12 @@
 	return TRUE
 
 /**
- * Called when a swarmer attempts to destroy a structure
- *
- * Proc which determines interaction between a swarmer and a structure it is destroying
- * Arguments:
- * * target - The material or object the swarmer is attempting to destroy
- */
+  * Called when a swarmer attempts to destroy a structure
+  *
+  * Proc which determines interaction between a swarmer and a structure it is destroying
+  * Arguments:
+  * * target - The material or object the swarmer is attempting to destroy
+  */
 /mob/living/simple_animal/hostile/swarmer/proc/dis_integrate(atom/movable/target)
 	new /obj/effect/temp_visual/swarmer/disintegration(get_turf(target))
 	do_attack_animation(target)
@@ -206,12 +206,12 @@
 	SSexplosions.low_mov_atom += target
 
 /**
- * Called when a swarmer attempts to teleport a living entity away
- *
- * Proc which finds a safe location to teleport a living entity to when a swarmer teleports it away.  Also energy handcuffs carbons.
- * Arguments:
- * * target - The entity the swarmer is trying to teleport away
- */
+  * Called when a swarmer attempts to teleport a living entity away
+  *
+  * Proc which finds a safe location to teleport a living entity to when a swarmer teleports it away.  Also energy handcuffs carbons.
+  * Arguments:
+  * * target - The entity the swarmer is trying to teleport away
+  */
 /mob/living/simple_animal/hostile/swarmer/proc/prepare_target(mob/living/target)
 	if(target == src)
 		return
@@ -254,12 +254,12 @@
 	return ..()
 
 /**
- * Called when a swarmer attempts to disassemble a machine
- *
- * Proc called when a swarmer attempts to disassemble a machine.  Destroys the machine, and gives the swarmer metal.
- * Arguments:
- * * target - The machine the swarmer is attempting to disassemble
- */
+  * Called when a swarmer attempts to disassemble a machine
+  *
+  * Proc called when a swarmer attempts to disassemble a machine.  Destroys the machine, and gives the swarmer metal.
+  * Arguments:
+  * * target - The machine the swarmer is attempting to disassemble
+  */
 /mob/living/simple_animal/hostile/swarmer/proc/dismantle_machine(obj/machinery/target)
 	do_attack_animation(target)
 	to_chat(src, "<span class='info'>We begin to dismantle this machine. We will need to be uninterrupted.</span>")
@@ -286,10 +286,10 @@
 		qdel(target)
 
 /**
- * Called when a swarmer attempts to create a trap
- *
- * Proc used to allow a swarmer to create a trap.  Checks if a trap is on the tile, then if the swarmer can afford, and then places the trap.
- */
+  * Called when a swarmer attempts to create a trap
+  *
+  * Proc used to allow a swarmer to create a trap.  Checks if a trap is on the tile, then if the swarmer can afford, and then places the trap.
+  */
 /mob/living/simple_animal/hostile/swarmer/proc/create_trap()
 	set name = "Create trap"
 	set category = "Swarmer"
@@ -303,10 +303,10 @@
 	Fabricate(/obj/structure/swarmer/trap, 4)
 
 /**
- * Called when a swarmer attempts to create a barricade
- *
- * Proc used to allow a swarmer to create a barricade.  Checks if a barricade is on the tile, then if the swarmer can afford it, and then will attempt to create a barricade after a second delay.
- */
+  * Called when a swarmer attempts to create a barricade
+  *
+  * Proc used to allow a swarmer to create a barricade.  Checks if a barricade is on the tile, then if the swarmer can afford it, and then will attempt to create a barricade after a second delay.
+  */
 /mob/living/simple_animal/hostile/swarmer/proc/create_barricade()
 	set name = "Create barricade"
 	set category = "Swarmer"
@@ -322,10 +322,10 @@
 	Fabricate(/obj/structure/swarmer/blockade, 4)
 
 /**
- * Called when a swarmer attempts to create a drone
- *
- * Proc used to allow a swarmer to create a drone.  Checks if the swarmer can afford the drone, then creates it after 5 seconds, and also registers it to the creating swarmer so it can command it
- */
+  * Called when a swarmer attempts to create a drone
+  *
+  * Proc used to allow a swarmer to create a drone.  Checks if the swarmer can afford the drone, then creates it after 5 seconds, and also registers it to the creating swarmer so it can command it
+  */
 /mob/living/simple_animal/hostile/swarmer/proc/create_swarmer()
 	set name = "Replicate"
 	set category = "Swarmer"
@@ -347,18 +347,18 @@
 	playsound(loc,'sound/items/poster_being_created.ogg', 20, TRUE, -1)
 
 /**
- * Used to determine what type of swarmer a swarmer should create
- *
- * Returns the type of the swarmer to be created
- */
+  * Used to determine what type of swarmer a swarmer should create
+  *
+  * Returns the type of the swarmer to be created
+  */
 /mob/living/simple_animal/hostile/swarmer/proc/swarmer_type_to_create()
 	return /mob/living/simple_animal/hostile/swarmer/melee
 
 /**
- * Called when a swarmer attempts to repair itself
- *
- * Proc used to allow a swarmer self-repair.  If the swarmer does not move after a period of time, then it will heal fully
- */
+  * Called when a swarmer attempts to repair itself
+  *
+  * Proc used to allow a swarmer self-repair.  If the swarmer does not move after a period of time, then it will heal fully
+  */
 /mob/living/simple_animal/hostile/swarmer/proc/repair_self()
 	if(!isturf(loc))
 		return
@@ -369,10 +369,10 @@
 	to_chat(src, "<span class='info'>We successfully repaired ourselves.</span>")
 
 /**
- * Called when a swarmer toggles its light
- *
- * Proc used to allow a swarmer to toggle its  light on and off.  If a swarmer has any drones, change their light settings to match their master's.
- */
+  * Called when a swarmer toggles its light
+  *
+  * Proc used to allow a swarmer to toggle its  light on and off.  If a swarmer has any drones, change their light settings to match their master's.
+  */
 /mob/living/simple_animal/hostile/swarmer/proc/toggle_light()
 	if(swarmer_flags & SWARMER_LIGHT_ON)
 		swarmer_flags = ~SWARMER_LIGHT_ON
@@ -395,12 +395,12 @@
 
 
 /**
- * Proc which is used for swarmer comms
- *
- * Proc called which sends a message to all other swarmers.
- * Arugments:
- * * msg - The message the swarmer is sending, gotten from ContactSwarmers()
- */
+  * Proc which is used for swarmer comms
+  *
+  * Proc called which sends a message to all other swarmers.
+  * Arugments:
+  * * msg - The message the swarmer is sending, gotten from ContactSwarmers()
+  */
 /mob/living/simple_animal/hostile/swarmer/proc/swarmer_chat(msg)
 	var/rendered = "<B>Swarm communication - [src]</b> [say_quote(msg)]"
 	for(var/i in GLOB.mob_list)
@@ -412,10 +412,10 @@
 			to_chat(listener, "[link] [rendered]")
 
 /**
- * Proc which is used for inputting a swarmer message
- *
- * Proc which is used for a swarmer to input a message on a pop-up box, then attempt to send that message to the other swarmers
- */
+  * Proc which is used for inputting a swarmer message
+  *
+  * Proc which is used for a swarmer to input a message on a pop-up box, then attempt to send that message to the other swarmers
+  */
 /mob/living/simple_animal/hostile/swarmer/proc/contact_swarmers()
 	var/message = stripped_input(src, "Announce to other swarmers", "Swarmer contact")
 	// TODO get swarmers their own colour rather than just boldtext
@@ -430,13 +430,13 @@
 
 
 /**
- * Removes a drone from the swarmer's list.
- *
- * Removes the drone from our list.
- * Called specifically when a drone is about to be destroyed, so we don't have any null references.
- * Arguments:
- * * mob/drone - The drone to be removed from the list.
- */
+  * Removes a drone from the swarmer's list.
+  *
+  * Removes the drone from our list.
+  * Called specifically when a drone is about to be destroyed, so we don't have any null references.
+  * Arguments:
+  * * mob/drone - The drone to be removed from the list.
+  */
 /mob/living/simple_animal/hostile/swarmer/proc/remove_drone(mob/drone, force)
 	SIGNAL_HANDLER
 
@@ -444,17 +444,14 @@
 	dronelist -= drone
 
 /**
- * # Swarmer Drone
- *
- * Melee subtype of swarmers, always AI-controlled under normal circumstances.  Cannot fire projectiles, but does double stamina damage on melee
- */
+  * # Swarmer Drone
+  *
+  * Melee subtype of swarmers, always AI-controlled under normal circumstances.
+  */
 /mob/living/simple_animal/hostile/swarmer/melee
 	icon_state = "swarmer_melee"
 	icon_living = "swarmer_melee"
-	ranged = FALSE
 	AIStatus = AI_ON
-	melee_damage_lower = 30
-	melee_damage_upper = 30
 
 /obj/projectile/beam/disabler/swarmer/on_hit(atom/target, blocked = FALSE)
 	. = ..()

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -1,10 +1,10 @@
 /**
-  * Determines what happens to an atom when a swarmer interacts with it
-  *
-  * Determines behavior upon being interacted on by a swarmer.
-  * Arguments:
-  * * S - A reference to the swarmer doing the interaction
-  */
+ * Determines what happens to an atom when a swarmer interacts with it
+ *
+ * Determines behavior upon being interacted on by a swarmer.
+ * Arguments:
+ * * S - A reference to the swarmer doing the interaction
+ */
 #define DANGEROUS_DELTA_P 250	//Value in kPa where swarmers arent allowed to break a wall or window with this difference in pressure.
 
 ///Finds the greatest difference in pressure across a turf, only considers open turfs.
@@ -48,8 +48,8 @@
 	return actor.Integrate(src)
 
 /**
-  * Return used to determine how many resources a swarmer gains when consuming an object
-  */
+ * Return used to determine how many resources a swarmer gains when consuming an object
+ */
 /obj/proc/integrate_amount()
 	return 0
 

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -1,10 +1,10 @@
 /**
- * Determines what happens to an atom when a swarmer interacts with it
- *
- * Determines behavior upon being interacted on by a swarmer.
- * Arguments:
- * * S - A reference to the swarmer doing the interaction
- */
+  * Determines what happens to an atom when a swarmer interacts with it
+  *
+  * Determines behavior upon being interacted on by a swarmer.
+  * Arguments:
+  * * S - A reference to the swarmer doing the interaction
+  */
 #define DANGEROUS_DELTA_P 250	//Value in kPa where swarmers arent allowed to break a wall or window with this difference in pressure.
 
 ///Finds the greatest difference in pressure across a turf, only considers open turfs.
@@ -48,8 +48,8 @@
 	return actor.Integrate(src)
 
 /**
- * Return used to determine how many resources a swarmer gains when consuming an object
- */
+  * Return used to determine how many resources a swarmer gains when consuming an object
+  */
 /obj/proc/integrate_amount()
 	return 0
 

--- a/code/modules/swarmers/swarmer_objs.dm
+++ b/code/modules/swarmers/swarmer_objs.dm
@@ -30,14 +30,14 @@
 	qdel(src)
 
 /**
-  * # Swarmer Beacon
-  *
-  * Beacon which creates sentient player swarmers.
-  *
-  * The beacon which creates sentient player swarmers during the swarmer event.  Spawns in maint on xeno locations, and can create a player swarmer once every 30 seconds.
-  * The beacon cannot be damaged by swarmers, and must be destroyed to prevent the spawning of further player-controlled swarmers.
-  * Holds a swarmer within itself during the 30 seconds before releasing it and allowing for another swarmer to be spawned in.
-  */
+ * # Swarmer Beacon
+ *
+ * Beacon which creates sentient player swarmers.
+ *
+ * The beacon which creates sentient player swarmers during the swarmer event.  Spawns in maint on xeno locations, and can create a player swarmer once every 30 seconds.
+ * The beacon cannot be damaged by swarmers, and must be destroyed to prevent the spawning of further player-controlled swarmers.
+ * Holds a swarmer within itself during the 30 seconds before releasing it and allowing for another swarmer to be spawned in.
+ */
 
 /obj/structure/swarmer_beacon
 	name = "swarmer beacon"
@@ -54,6 +54,14 @@
 	///Whether or not a swarmer is currently being created by this beacon
 	var/processing_swarmer = FALSE
 
+/obj/structure/swarmer_beacon/Initialize()
+	. = ..()
+	GLOB.poi_list |= src
+
+/obj/structure/swarmer_beacon/Destroy()
+	. = ..()
+	GLOB.poi_list.Remove(src)
+
 /obj/structure/swarmer_beacon/attack_ghost(mob/user)
 	. = ..()
 	if(processing_swarmer)
@@ -62,12 +70,12 @@
 	que_swarmer(user)
 
 /**
-  * Interaction when a ghost interacts with a swarmer beacon
-  *
-  * Called when a ghost interacts with a swarmer beacon, allowing them to become a swarmer
-  * Arguments:
-  * * user - A reference to the ghost interacting with the beacon
-  */
+ * Interaction when a ghost interacts with a swarmer beacon
+ *
+ * Called when a ghost interacts with a swarmer beacon, allowing them to become a swarmer
+ * Arguments:
+ * * user - A reference to the ghost interacting with the beacon
+ */
 /obj/structure/swarmer_beacon/proc/que_swarmer(mob/user)
 	var/swarm_ask = alert("Become a swarmer?", "Do you wish to consume the station?", "Yes", "No")
 	if(swarm_ask == "No" || QDELETED(src) || QDELETED(user) || processing_swarmer)
@@ -80,23 +88,23 @@
 	return TRUE
 
 /**
-  * Releases a swarmer from the beacon and tells it what to do
-  *
-  * Occcurs 30 seconds after a ghost becomes a swarmer.  The beacon releases it, tells it what to do, and opens itself up to spawn in a new swarmer.
-  * Arguments:
-  * * swarmer - The swarmer being released and told what to do
-  */
+ * Releases a swarmer from the beacon and tells it what to do
+ *
+ * Occcurs 10 seconds after a ghost becomes a swarmer.  The beacon releases it, tells it what to do, and opens itself up to spawn in a new swarmer.
+ * Arguments:
+ * * swarmer - The swarmer being released and told what to do
+ */
 /obj/structure/swarmer_beacon/proc/release_swarmer(mob/swarmer)
 	to_chat(swarmer, "<span class='bold'>SWARMER CONSTRUCTION COMPLETED.  OBJECTIVES:\n\
-	                     1. CONSUME RESOURCES AND REPLICATE UNTIL THERE ARE NO MORE RESOURCES LEFT\n\
-						 2. ENSURE PROTECTION OF THE BEACON SO THIS LOCATION CAN BE INVADED AT A LATER DATE; DO NOT PERFORM ACTIONS THAT WOULD RENDER THIS LOCATION DANGEROUS OR INHOSPITABLE\n\
-						 3. BIOLOGICAL RESOURCES WILL BE HARVESTED AT A LATER DATE: DO NOT HARM THEM\n\
-						 OPERATOR NOTES:\n\
-						 - CONSUME RESOURCES TO CONSTRUCT TRAPS, BARRIERS, AND FOLLOWER DRONES\n\
-						 - FOLLOWER DRONES WILL FOLLOW YOU AUTOMATCIALLY UNLESS THEY POSSESS A TARGET.  WHILE DRONES CANNOT ASSIST IN RESOURCE HARVESTING, THEY CAN PROTECT YOU FROM THREATS\n\
-						 - LCTRL + ATTACKING AN ORGANIC WILL ALOW YOU TO REMOVE SAID ORGANIC FROM THE AREA\n\
-						 - YOU AND YOUR DRONES HAVE A STUN EFFECT ON MELEE.  YOU ARE ALSO ARMED WITH A DISABLER PROJECTILE, USE THESE TO PREVENT ORGANICS FROM HALTING YOUR PROGRESS\n\
-						 GLORY TO !*# $*#^</span>")
+		1. CONSUME RESOURCES AND REPLICATE UNTIL THERE ARE NO MORE RESOURCES LEFT\n\
+		2. ENSURE PROTECTION OF THE BEACON SO THIS LOCATION CAN BE INVADED AT A LATER DATE; DO NOT PERFORM ACTIONS THAT WOULD RENDER THIS LOCATION DANGEROUS OR INHOSPITABLE\n\
+		3. BIOLOGICAL RESOURCES WILL BE HARVESTED AT A LATER DATE: DO NOT HARM THEM\n\
+		OPERATOR NOTES:\n\
+		- CONSUME RESOURCES TO CONSTRUCT TRAPS, BARRIERS, AND FOLLOWER DRONES\n\
+		- FOLLOWER DRONES WILL FOLLOW YOU AUTOMATCIALLY UNLESS THEY POSSESS A TARGET.  WHILE DRONES CANNOT ASSIST IN RESOURCE HARVESTING, THEY CAN PROTECT YOU FROM THREATS\n\
+		- LCTRL + ATTACKING AN ORGANIC WILL ALOW YOU TO REMOVE SAID ORGANIC FROM THE AREA\n\
+		- YOU AND YOUR DRONES HAVE A STUN EFFECT ON MELEE.  YOU ARE ALSO ARMED WITH A DISABLER PROJECTILE, USE THESE TO PREVENT ORGANICS FROM HALTING YOUR PROGRESS\n\
+		GLORY TO !*# $*#^</span>")
 	swarmer.forceMove(get_turf(src))
 	processing_swarmer = FALSE
 

--- a/code/modules/swarmers/swarmer_objs.dm
+++ b/code/modules/swarmers/swarmer_objs.dm
@@ -119,6 +119,7 @@
  * Called specifically when a swarmer is about to be destroyed, so we don't have any null references.
  * Arguments:
  * * mob/swarmer - The swarmer to be removed from the list.
+ * * force - Parameter sent by the COSMIG_PARENT_QDELETING signal.  Does nothing in this proc.
  */
 /obj/structure/swarmer_beacon/proc/remove_swarmer(mob/swarmer, force)
 	SIGNAL_HANDLER

--- a/code/modules/swarmers/swarmer_objs.dm
+++ b/code/modules/swarmers/swarmer_objs.dm
@@ -30,14 +30,14 @@
 	qdel(src)
 
 /**
- * # Swarmer Beacon
- *
- * Beacon which creates sentient player swarmers.
- *
- * The beacon which creates sentient player swarmers during the swarmer event.  Spawns in maint on xeno locations, and can create a player swarmer once every 30 seconds.
- * The beacon cannot be damaged by swarmers, and must be destroyed to prevent the spawning of further player-controlled swarmers.
- * Holds a swarmer within itself during the 30 seconds before releasing it and allowing for another swarmer to be spawned in.
- */
+  * # Swarmer Beacon
+  *
+  * Beacon which creates sentient player swarmers.
+  *
+  * The beacon which creates sentient player swarmers during the swarmer event.  Spawns in maint on xeno locations, and can create a player swarmer once every 30 seconds.
+  * The beacon cannot be damaged by swarmers, and must be destroyed to prevent the spawning of further player-controlled swarmers.
+  * Holds a swarmer within itself during the 30 seconds before releasing it and allowing for another swarmer to be spawned in.
+  */
 
 /obj/structure/swarmer_beacon
 	name = "swarmer beacon"
@@ -45,7 +45,7 @@
 	icon = 'icons/mob/swarmer.dmi'
 	icon_state = "swarmer_console"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 100, BOMB = 50, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
-	max_integrity = 400
+	max_integrity = 500
 	layer = MASSIVE_OBJ_LAYER
 	light_color = LIGHT_COLOR_CYAN
 	light_range = 10
@@ -53,14 +53,6 @@
 	density = FALSE
 	///Whether or not a swarmer is currently being created by this beacon
 	var/processing_swarmer = FALSE
-
-/obj/structure/swarmer_beacon/Initialize()
-	. = ..()
-	GLOB.poi_list |= src
-
-/obj/structure/swarmer_beacon/Destroy()
-	. = ..()
-	GLOB.poi_list.Remove(src)
 
 /obj/structure/swarmer_beacon/attack_ghost(mob/user)
 	. = ..()
@@ -70,41 +62,41 @@
 	que_swarmer(user)
 
 /**
- * Interaction when a ghost interacts with a swarmer beacon
- *
- * Called when a ghost interacts with a swarmer beacon, allowing them to become a swarmer
- * Arguments:
- * * user - A reference to the ghost interacting with the beacon
- */
+  * Interaction when a ghost interacts with a swarmer beacon
+  *
+  * Called when a ghost interacts with a swarmer beacon, allowing them to become a swarmer
+  * Arguments:
+  * * user - A reference to the ghost interacting with the beacon
+  */
 /obj/structure/swarmer_beacon/proc/que_swarmer(mob/user)
 	var/swarm_ask = alert("Become a swarmer?", "Do you wish to consume the station?", "Yes", "No")
 	if(swarm_ask == "No" || QDELETED(src) || QDELETED(user) || processing_swarmer)
 		return FALSE
 	var/mob/living/simple_animal/hostile/swarmer/newswarmer = new /mob/living/simple_animal/hostile/swarmer(src)
 	newswarmer.key = user.key
-	addtimer(CALLBACK(src, .proc/release_swarmer, newswarmer), 30 SECONDS)
-	to_chat(newswarmer, "<span class='boldannounce'>SWARMER CONSTRUCTION INITIALIZED.  TIME TO COMPLETION: 30 SECONDS</span>")
+	addtimer(CALLBACK(src, .proc/release_swarmer, newswarmer), 10 SECONDS)
+	to_chat(newswarmer, "<span class='boldannounce'>SWARMER CONSTRUCTION INITIALIZED.  TIME TO COMPLETION: 10 SECONDS</span>")
 	processing_swarmer = TRUE
 	return TRUE
 
 /**
- * Releases a swarmer from the beacon and tells it what to do
- *
- * Occcurs 30 seconds after a ghost becomes a swarmer.  The beacon releases it, tells it what to do, and opens itself up to spawn in a new swarmer.
- * Arguments:
- * * swarmer - The swarmer being released and told what to do
- */
+  * Releases a swarmer from the beacon and tells it what to do
+  *
+  * Occcurs 30 seconds after a ghost becomes a swarmer.  The beacon releases it, tells it what to do, and opens itself up to spawn in a new swarmer.
+  * Arguments:
+  * * swarmer - The swarmer being released and told what to do
+  */
 /obj/structure/swarmer_beacon/proc/release_swarmer(mob/swarmer)
 	to_chat(swarmer, "<span class='bold'>SWARMER CONSTRUCTION COMPLETED.  OBJECTIVES:\n\
-		1. CONSUME RESOURCES AND REPLICATE UNTIL THERE ARE NO MORE RESOURCES LEFT\n\
-		2. ENSURE PROTECTION OF THE BEACON SO THIS LOCATION CAN BE INVADED AT A LATER DATE; DO NOT PERFORM ACTIONS THAT WOULD RENDER THIS LOCATION DANGEROUS OR INHOSPITABLE\n\
-		3. BIOLOGICAL RESOURCES WILL BE HARVESTED AT A LATER DATE: DO NOT HARM THEM\n\
-		OPERATOR NOTES:\n\
-		- CONSUME RESOURCES TO CONSTRUCT TRAPS, BARRIERS, AND FOLLOWER DRONES\n\
-		- FOLLOWER DRONES WILL FOLLOW YOU AUTOMATCIALLY UNLESS THEY POSSESS A TARGET.  WHILE DRONES CANNOT ASSIST IN RESOURCE HARVESTING, THEY CAN PROTECT YOU FROM THREATS\n\
-		- LCTRL + ATTACKING AN ORGANIC WILL ALOW YOU TO REMOVE SAID ORGANIC FROM THE AREA\n\
-		- YOU AND YOUR DRONES HAVE A STUN EFFECT ON MELEE.  YOU ARE ALSO ARMED WITH A DISABLER PROJECTILE, USE THESE TO PREVENT ORGANICS FROM HALTING YOUR PROGRESS\n\
-		GLORY TO !*# $*#^</span>")
+	                     1. CONSUME RESOURCES AND REPLICATE UNTIL THERE ARE NO MORE RESOURCES LEFT\n\
+						 2. ENSURE PROTECTION OF THE BEACON SO THIS LOCATION CAN BE INVADED AT A LATER DATE; DO NOT PERFORM ACTIONS THAT WOULD RENDER THIS LOCATION DANGEROUS OR INHOSPITABLE\n\
+						 3. BIOLOGICAL RESOURCES WILL BE HARVESTED AT A LATER DATE: DO NOT HARM THEM\n\
+						 OPERATOR NOTES:\n\
+						 - CONSUME RESOURCES TO CONSTRUCT TRAPS, BARRIERS, AND FOLLOWER DRONES\n\
+						 - FOLLOWER DRONES WILL FOLLOW YOU AUTOMATCIALLY UNLESS THEY POSSESS A TARGET.  WHILE DRONES CANNOT ASSIST IN RESOURCE HARVESTING, THEY CAN PROTECT YOU FROM THREATS\n\
+						 - LCTRL + ATTACKING AN ORGANIC WILL ALOW YOU TO REMOVE SAID ORGANIC FROM THE AREA\n\
+						 - YOU AND YOUR DRONES HAVE A STUN EFFECT ON MELEE.  YOU ARE ALSO ARMED WITH A DISABLER PROJECTILE, USE THESE TO PREVENT ORGANICS FROM HALTING YOUR PROGRESS\n\
+						 GLORY TO !*# $*#^</span>")
 	swarmer.forceMove(get_turf(src))
 	processing_swarmer = FALSE
 


### PR DESCRIPTION
## About The Pull Request

This PR makes the following changes to Swarmers:
- Player swarmers melee attacked buffed from 15 to 30 stamina, identical to the drones
- Drones can now fire swarmer disabler beams, and will do so while closing the space between itself and the target
- Swarmer beacon integrity increased from 400 to 500
- Swarmer beacon spawn time decreased from 30 seconds to 5 seconds plus an additional 2 seconds for every active swarmer
- Swarmers can no longer teleport other swarmers by shooting them
- Swarmer traps now electrocute carbons again, as before this they didn't do anything

## Why It's Good For The Game

After the last patch of changes, swarmers have been in a rough spot.  The main issues which stood out were the uselessness of drones and the overly excessive spawn time on the beacon.  These buffs should serve to give swarmers a better fighting chance when starting out instead of getting snuffed out immediately.  If this doesn't suffice, further changes will be pending.

## Changelog
:cl:
balance: Swarmer beacon spawn time decreased from 30 seconds to a shorter timer based on the number of active swarmers
balance: Swarmer drones now fire disabler beams at their target when not in melee range
balance: Swarmer beacon integrity has been increased
balance: Player swarmers now deal more stamina damage on melee attacks.
fix: Swarmer shock traps now actually work again
/:cl: