### PR TITLE
[READY] Lavaland Elite Changes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -95,7 +95,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		button.maptext = ""
 		UpdateButtonIcon()
 	else
-		button.maptext = "<b>[round(timeleft/10, 0.1)]</b>"
+		button.maptext = "<b class='maptext'>[round(timeleft/10, 0.1)]</b>"
 
 /datum/action/innate/elite_attack/Grant(mob/living/L)
 	if(istype(L, /mob/living/simple_animal/hostile/asteroid/elite))

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -71,19 +71,42 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	icon_icon = 'icons/mob/actions/actions_elites.dmi'
 	button_icon_state = ""
 	background_icon_state = "bg_default"
-	var/mob/living/simple_animal/hostile/asteroid/elite/M
+	///The lavaland elite who owns this action
+	var/mob/living/simple_animal/hostile/asteroid/elite/elite_owner
+	///The displayed message into chat when this attack is selected
 	var/chosen_message
+	///The internal attack ID for the elite's OpenFire() proc to use
 	var/chosen_attack_num = 0
+
+/datum/action/innate/elite_attack/New()
+	..()
+	button.maptext = ""
+	button.maptext_x = 8
+	button.maptext_y = 0
+	button.maptext_width = 24
+	button.maptext_height = 12
+
+/datum/action/innate/elite_attack/process()
+	if(elite_owner == null)
+		STOP_PROCESSING(SSfastprocess, src)
+		qdel(src)
+	var/timeleft = max(elite_owner.ranged_cooldown - world.time, 0)
+	if(timeleft == 0)
+		button.maptext = ""
+		UpdateButtonIcon()
+	else
+		button.maptext = "<b>[round(timeleft/10, 0.1)]</b>"
 
 /datum/action/innate/elite_attack/Grant(mob/living/L)
 	if(istype(L, /mob/living/simple_animal/hostile/asteroid/elite))
-		M = L
+		elite_owner = L
+		START_PROCESSING(SSfastprocess, src)
 		return ..()
 	return FALSE
 
 /datum/action/innate/elite_attack/Activate()
-	M.chosen_attack = chosen_attack_num
-	to_chat(M, chosen_message)
+	elite_owner.chosen_attack = chosen_attack_num
+	to_chat(elite_owner, chosen_message)
 
 //The Pulsing Tumor, the actual "spawn-point" of elites, handles the spawning, arena, and procs for dealing with basic scenarios.
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -133,7 +133,7 @@
 		children_list += newchild
 
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother/proc/rage()
-	ranged_cooldown = world.time + 70
+	ranged_cooldown = world.time + 100
 	playsound(src,'sound/spookoween/insane_low_laugh.ogg', 200, 1)
 	visible_message("<span class='warning'>[src] starts picking up speed!</span>")
 	color = "#FF0000"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -147,7 +147,7 @@
 	shoot_projectile(target_turf, angle_to_target, FALSE, TRUE)
 	addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 2)
 	addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 4)
-	if(health < maxHealth * 0.5 && !is_mirror)
+	if(health < maxHealth * 0.5)
 		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 10)
 		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 12)
@@ -169,7 +169,7 @@
 		icon_state = "herald_enraged"
 	playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 	addtimer(CALLBACK(src, .proc/herald_circleshot, 0), 5)
-	if(health < maxHealth * 0.5 && !is_mirror)
+	if(health < maxHealth * 0.5)
 		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 		addtimer(CALLBACK(src, .proc/herald_circleshot, 22.5), 15)
 	addtimer(CALLBACK(src, .proc/unenrage), 20)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -147,7 +147,7 @@
 	shoot_projectile(target_turf, angle_to_target, FALSE, TRUE)
 	addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 2)
 	addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 4)
-	if(health < maxHealth * 0.5)
+	if(health < maxHealth * 0.5 && !is_mirror)
 		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 10)
 		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 12)
@@ -169,7 +169,7 @@
 		icon_state = "herald_enraged"
 	playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 	addtimer(CALLBACK(src, .proc/herald_circleshot, 0), 5)
-	if(health < maxHealth * 0.5)
+	if(health < maxHealth * 0.5 && !is_mirror)
 		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 		addtimer(CALLBACK(src, .proc/herald_circleshot, 22.5), 15)
 	addtimer(CALLBACK(src, .proc/unenrage), 20)
@@ -182,7 +182,7 @@
 	shoot_projectile(target_turf, angle_to_target, TRUE, FALSE)
 
 /mob/living/simple_animal/hostile/asteroid/elite/herald/proc/herald_mirror()
-	ranged_cooldown = world.time + 2 SECONDS
+	ranged_cooldown = world.time + 4 SECONDS
 	playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 	if(my_mirror != null)
 		qdel(my_mirror)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -33,7 +33,7 @@
 	attack_verb_simple = "preach to"
 	attack_sound = 'sound/magic/clockwork/ratvar_attack.ogg'
 	throw_message = "doesn't affect the purity of"
-	speed = 4
+	speed = 2
 	move_to_delay = 10
 	mouse_opacity = MOUSE_OPACITY_ICON
 	deathsound = 'sound/magic/demon_dies.ogg'
@@ -147,7 +147,7 @@
 	shoot_projectile(target_turf, angle_to_target, FALSE, TRUE)
 	addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 2)
 	addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 4)
-	if(health < maxHealth * 0.5)
+	if(health < maxHealth * 0.5 && !is_mirror)
 		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 10)
 		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 12)
@@ -164,12 +164,12 @@
 	icon_state = "herald"
 
 /mob/living/simple_animal/hostile/asteroid/elite/herald/proc/herald_directionalshot()
-	ranged_cooldown = world.time + 50
+	ranged_cooldown = world.time + 3 SECONDS
 	if(!is_mirror)
 		icon_state = "herald_enraged"
 	playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 	addtimer(CALLBACK(src, .proc/herald_circleshot, 0), 5)
-	if(health < maxHealth * 0.5)
+	if(health < maxHealth * 0.5 && !is_mirror)
 		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 		addtimer(CALLBACK(src, .proc/herald_circleshot, 22.5), 15)
 	addtimer(CALLBACK(src, .proc/unenrage), 20)
@@ -182,7 +182,7 @@
 	shoot_projectile(target_turf, angle_to_target, TRUE, FALSE)
 
 /mob/living/simple_animal/hostile/asteroid/elite/herald/proc/herald_mirror()
-	ranged_cooldown = world.time + 40
+	ranged_cooldown = world.time + 2 SECONDS
 	playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 	if(my_mirror != null)
 		qdel(my_mirror)
@@ -198,6 +198,7 @@
 	health = 60
 	maxHealth = 60
 	icon_state = "herald_mirror"
+	icon_aggro = "herald_mirror"
 	deathmessage = "shatters violently!"
 	deathsound = 'sound/effects/glassbr1.ogg'
 	movement_type = FLYING
@@ -217,7 +218,7 @@
 /obj/projectile/herald
 	name ="death bolt"
 	icon_state= "chronobolt"
-	damage = 15
+	damage = 20
 	armour_penetration = 60
 	speed = 2
 	eyeblur = 0

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -12,7 +12,7 @@
  * - Charges at the target after a telegraph, throwing them across the arena should it connect.
  * - Legionnaire's head detaches, attacking as it's own entity.  Has abilities of it's own later into the fight.  Once dead, regenerates after a brief period.  If the skill is used while the head is off, it will be killed.
  * - Leaves a pile of bones at your location.  Upon using this skill again, you'll swap locations with the bone pile.
- * - Spews a cloud of smoke from it's maw, wherever said maw is.  This attack will also spawn legion turrets.
+ * - Spews a cloud of smoke from it's maw, wherever said maw is.
  * A unique fight incorporating the head mechanic of legion into a whole new beast.  Combatants will need to make sure the tag-team of head and body don't lure them into a deadly trap.
  */
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -27,8 +27,8 @@
 	health_doll_icon = "legionnaire"
 	maxHealth = 1000
 	health = 1000
-	melee_damage_lower = 40
-	melee_damage_upper = 40
+	melee_damage_lower = 35
+	melee_damage_upper = 35
 	attack_verb_continuous = "slashes its arms at"
 	attack_verb_simple = "slash your arms at"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
@@ -113,7 +113,7 @@
 		myhead.Goto(T, myhead.move_to_delay)
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/legionnaire_charge(target)
-	ranged_cooldown = world.time + 2.0 SECONDS
+	ranged_cooldown = world.time + 4.0 SECONDS
 	charging = TRUE
 	var/dir_to_target = get_dir(get_turf(src), get_turf(target))
 	var/turf/T = get_step(get_turf(src), dir_to_target)
@@ -154,7 +154,7 @@
 		to_chat(L, "<span class='userdanger'>[src] tramples you and kicks you away!</span>")
 		L.safe_throw_at(throwtarget, 10, 1, src)
 		L.Paralyze(20)
-		L.adjustBruteLoss(50)
+		L.adjustBruteLoss(melee_damage_upper)
 	addtimer(CALLBACK(src, .proc/legionnaire_charge_2, move_dir, (times_ran + 1)), 0.7)
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/head_detach(target)
@@ -278,12 +278,15 @@
 	var/mob/living/simple_animal/hostile/asteroid/elite/legionnaire/myowner = null
 
 
-/obj/structure/legionnaire_bonfire/Entered(atom/movable/mover, atom/target)
-	if(isliving(mover))
-		var/mob/living/L = mover
-		L.adjust_fire_stacks(3)
-		L.IgniteMob()
+/obj/structure/legionnaire_bonfire/Crossed(atom/movable/mover)
 	. = ..()
+	if(isobj(mover))
+		var/obj/object = mover
+		object.fire_act(1000, 500)
+	if(isliving(mover))
+		var/mob/living/fire_walker = mover
+		fire_walker.adjust_fire_stacks(5)
+		fire_walker.IgniteMob()
 
 /obj/structure/legionnaire_bonfire/Destroy()
 	if(myowner != null)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -12,7 +12,7 @@
  * - Charges at the target after a telegraph, throwing them across the arena should it connect.
  * - Legionnaire's head detaches, attacking as it's own entity.  Has abilities of it's own later into the fight.  Once dead, regenerates after a brief period.  If the skill is used while the head is off, it will be killed.
  * - Leaves a pile of bones at your location.  Upon using this skill again, you'll swap locations with the bone pile.
- * - Spews a cloud of smoke from it's maw, wherever said maw is.
+ * - Spews a cloud of smoke from it's maw, wherever said maw is.  This attack will also spawn legion turrets.
  * A unique fight incorporating the head mechanic of legion into a whole new beast.  Combatants will need to make sure the tag-team of head and body don't lure them into a deadly trap.
  */
 
@@ -27,8 +27,8 @@
 	health_doll_icon = "legionnaire"
 	maxHealth = 1000
 	health = 1000
-	melee_damage_lower = 30
-	melee_damage_upper = 30
+	melee_damage_lower = 40
+	melee_damage_upper = 40
 	attack_verb_continuous = "slashes its arms at"
 	attack_verb_simple = "slash your arms at"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
@@ -113,7 +113,7 @@
 		myhead.Goto(T, myhead.move_to_delay)
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/legionnaire_charge(target)
-	ranged_cooldown = world.time + 3.5 SECONDS
+	ranged_cooldown = world.time + 2.0 SECONDS
 	charging = TRUE
 	var/dir_to_target = get_dir(get_turf(src), get_turf(target))
 	var/turf/T = get_step(get_turf(src), dir_to_target)
@@ -155,10 +155,10 @@
 		L.safe_throw_at(throwtarget, 10, 1, src)
 		L.Paralyze(20)
 		L.adjustBruteLoss(50)
-	addtimer(CALLBACK(src, .proc/legionnaire_charge_2, move_dir, (times_ran + 1)), 1.5)
+	addtimer(CALLBACK(src, .proc/legionnaire_charge_2, move_dir, (times_ran + 1)), 0.7)
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/head_detach(target)
-	ranged_cooldown = world.time + 10
+	ranged_cooldown = world.time + 1 SECONDS
 	if(myhead != null)
 		myhead.adjustBruteLoss(600)
 		return
@@ -217,12 +217,12 @@
 		mypile.forceMove(legionturf)
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/spew_smoke()
-	ranged_cooldown = world.time + 60
-	var/turf/T = null
+	ranged_cooldown = world.time + 4 SECONDS
+	var/turf/smoke_location = null
 	if(myhead != null)
-		T = get_turf(myhead)
+		smoke_location = get_turf(myhead)
 	else
-		T = get_turf(src)
+		smoke_location = get_turf(src)
 	if(myhead != null)
 		myhead.visible_message("<span class='boldwarning'>[myhead] spews smoke from its maw!</span>")
 	else if(!has_head)
@@ -230,7 +230,7 @@
 	else
 		visible_message("<span class='boldwarning'>[src] spews smoke from its maw!</span>")
 	var/datum/effect_system/smoke_spread/smoke = new
-	smoke.set_up(2, T)
+	smoke.set_up(2, smoke_location)
 	smoke.start()
 
 //The legionnaire's head.  Basically the same as any legion head, but we have to tell our creator when we die so they can generate another head.

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
@@ -171,7 +171,7 @@
 
 //The specific version of hiero's squares pandora uses
 /obj/effect/temp_visual/hierophant/blast/damaging/pandora
-	damage = 20
+	damage = 30
 	monster_damage_boost = FALSE
 
 //Pandora's loot: Hope

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
@@ -12,7 +12,7 @@
  * - Fires hierophant blasts in a straight line.  Can only fire in a straight line in 8 directions, being the diagonals and cardinals.
  * - Creates a box of hierophant blasts around the target.  If they try to run away to avoid it, they'll very likely get hit.
  * - Teleports the pandora from one location to another, almost identical to Hierophant.
- * - Spawns a 5x5 AOE at the location of choice, spreading out from the center.
+ * - Spawns a 7x7 AOE at the location of choice, spreading out from the center.
  * Pandora's fight mirrors Hierophant's closely, but has stark differences in attack effects.  Instead of long-winded dodge times and long cooldowns, Pandora constantly attacks the opponent, but leaves itself open for attack.
  */
 
@@ -33,7 +33,7 @@
 	attack_verb_simple = "smash into the side of"
 	attack_sound = 'sound/weapons/sonic_jackhammer.ogg'
 	throw_message = "merely dinks off of the"
-	speed = 4
+	speed = 3
 	move_to_delay = 10
 	mouse_opacity = MOUSE_OPACITY_ICON
 	deathsound = 'sound/magic/repulse.ogg'
@@ -98,13 +98,13 @@
 /mob/living/simple_animal/hostile/asteroid/elite/pandora/Life()
 	. = ..()
 	if(health >= maxHealth * 0.5)
-		cooldown_time = 20
+		cooldown_time = 2 SECONDS
 		return
 	if(health < maxHealth * 0.5 && health > maxHealth * 0.25)
-		cooldown_time = 15
+		cooldown_time = 1.5 SECONDS
 		return
 	else
-		cooldown_time = 10
+		cooldown_time = 1 SECONDS
 
 /mob/living/simple_animal/hostile/asteroid/elite/pandora/proc/singular_shot(target)
 	ranged_cooldown = world.time + (cooldown_time * 0.5)
@@ -118,7 +118,7 @@
 	new /obj/effect/temp_visual/hierophant/blast/damaging/pandora(T, src)
 	T = get_step(T, angleused)
 	procsleft = procsleft - 1
-	addtimer(CALLBACK(src, .proc/singular_shot_line, procsleft, angleused, T), 2)
+	addtimer(CALLBACK(src, .proc/singular_shot_line, procsleft, angleused, T), cooldown_time * 0.1)
 
 /mob/living/simple_animal/hostile/asteroid/elite/pandora/proc/magic_box(target)
 	ranged_cooldown = world.time + cooldown_time
@@ -128,13 +128,15 @@
 			new /obj/effect/temp_visual/hierophant/blast/damaging/pandora(t, src)
 
 /mob/living/simple_animal/hostile/asteroid/elite/pandora/proc/pandora_teleport(target)
+	var/turf/turf_target = get_turf(target)
+	if(!(turf_target in view(12, src)))
+		return
 	ranged_cooldown = world.time + (cooldown_time * 2)
-	var/turf/T = get_turf(target)
 	var/turf/source = get_turf(src)
-	new /obj/effect/temp_visual/hierophant/telegraph(T, src)
+	new /obj/effect/temp_visual/hierophant/telegraph(turf_target, src)
 	new /obj/effect/temp_visual/hierophant/telegraph(source, src)
 	playsound(source,'sound/machines/airlockopen.ogg', 200, 1)
-	addtimer(CALLBACK(src, .proc/pandora_teleport_2, T, source), 2)
+	addtimer(CALLBACK(src, .proc/pandora_teleport_2, turf_target, source), 2)
 
 /mob/living/simple_animal/hostile/asteroid/elite/pandora/proc/pandora_teleport_2(turf/T, turf/source)
 	new /obj/effect/temp_visual/hierophant/telegraph/teleport(T, src)
@@ -158,7 +160,7 @@
 	ranged_cooldown = world.time + cooldown_time
 	var/turf/T = get_turf(target)
 	new /obj/effect/temp_visual/hierophant/blast/damaging/pandora(T, src)
-	var/max_size = 2
+	var/max_size = 3
 	addtimer(CALLBACK(src, .proc/aoe_squares_2, T, 0, max_size), 2)
 
 /mob/living/simple_animal/hostile/asteroid/elite/pandora/proc/aoe_squares_2(turf/T, ring, max_size)
@@ -167,7 +169,7 @@
 	for(var/t in spiral_range_turfs(ring, T))
 		if(get_dist(t, T) == ring)
 			new /obj/effect/temp_visual/hierophant/blast/damaging/pandora(t, src)
-	addtimer(CALLBACK(src, .proc/aoe_squares_2, T, (ring + 1), max_size), 2)
+	addtimer(CALLBACK(src, .proc/aoe_squares_2, T, (ring + 1), max_size), cooldown_time * 0.1)
 
 //The specific version of hiero's squares pandora uses
 /obj/effect/temp_visual/hierophant/blast/damaging/pandora


### PR DESCRIPTION
## About The Pull Request

This PR just does some balancing to the Lavaland Elites, along with some QOL.  The changes:

- Ability buttons now show the current cooldown on them for when you can attack again.

**BROODMOTHER**
- Nerfed Rage attack cooldown from 7 seconds to 10 seconds

**HERALD**
- Speed increased from 4 to 2
- Directional Shot cooldown nerfed from 5 to 3 seconds
- Projectiles now deal 20 damage instead of 15

**LEGIONNAIRE**
- Melee attacks now deal 35 damage instead of 30
- Charge is now much faster to perform once it starts moving (moves faster) and combos into itself
- Charge does melee damage per step now
- Smoke cooldown decreased from 6 to 4 seconds
- Fixed the bonfire not lighting things on fire who cross over it

**PANDORA**
- Damage tiles now deal 30 damage instead of 20
- Can no longer teleport to tiles it cannot see
- AOE Blast is now 7x7 instead of 5x5
- AOE Blast and Lineshot now move based on Pandora's current damage, speeding up as it gets lower

## Why It's Good For The Game

These are just some changes in order to better balance out the elites, giving strength to everyone but the broodmother and nerfing a tad BS attack the Broodmother possessed

## Changelog
:cl:
tweak: Lavaland elite abilities now show a cooldown timer on their icons
balance: Lavaland elites have have some of their stats and cooldowns changed for better balance
/:cl:
