### PR TITLE
Fixes a possible oversight in photocopier code.

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -292,7 +292,7 @@
 		var/mob/living/carbon/human/H = ass
 		var/datum/species/spec = H.dna.species
 		if(spec.ass_image)
-			temp_img = spec.ass_image
+			temp_img = icon(spec.ass_image)
 		else
 			temp_img = icon(ass.gender == FEMALE ? 'icons/ass/assfemale.png' : 'icons/ass/assmale.png')
 	else if(isalienadult(ass) || istype(ass, /mob/living/simple_animal/hostile/alien)) //Xenos have their own asses, thanks to Pybro.


### PR DESCRIPTION
## About The Pull Request

I think https://github.com/tgstation/tgstation/pull/54336 neglected to use the icon() proc when it should have. This is a Byond proc apparently, and the rest of the code in the photocopier (and other picture related things I checked elsewhere) seems to use it when setting an image, I guess it's sort of like typecasting? So this will probably maintain consistency and prevent some weird bugs in the future.

## Why It's Good For The Game

Further increases the accuracy of the photocopier.