### PR TITLE
Airlocks take small amounts of damage from Jaws of Life

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -96,7 +96,6 @@
 	var/delayed_close_requested = FALSE // TRUE means the door will automatically close the next time it's opened.
 	var/air_tight = FALSE	//TRUE means density will be set as soon as the door begins to close
 	var/prying_so_hard = FALSE
-	var/pried_so_hard = FALSE
 
 	flags_1 = RAD_PROTECT_CONTENTS_1 | RAD_NO_CONTAMINATE_1
 	rad_insulation = RAD_MEDIUM_INSULATION
@@ -661,9 +660,6 @@
 		else
 			. += "It looks very robust."
 
-	if(pried_so_hard)
-		. += "<span class='warning'>There are dents and scratches where the halves of the airlock meet, signs of forced entry.</span>"
-
 	if(issilicon(user) && !(machine_stat & BROKEN))
 		. += "<span class='notice'>Shift-click [src] to [ density ? "open" : "close"] it.</span>"
 		. += "<span class='notice'>Ctrl-click [src] to [ locked ? "raise" : "drop"] its bolts.</span>"
@@ -1012,7 +1008,6 @@
 								"<span class='hear'>You hear welding.</span>")
 				if(W.use_tool(src, user, 40, volume=50, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
 					obj_integrity = max_integrity
-					pried_so_hard = FALSE // Remove the signs of Jaws of Life entry
 					set_machine_stat(machine_stat & ~BROKEN)
 					user.visible_message("<span class='notice'>[user] finishes welding [src].</span>", \
 										"<span class='notice'>You finish repairing the airlock.</span>")
@@ -1090,7 +1085,6 @@
 						return
 					open(2)
 					take_damage(25, BRUTE, 0, 0) // Enough to sometimes spark
-					pried_so_hard = TRUE // Just for the description
 					if(density && !open(2))
 						to_chat(user, "<span class='warning'>Despite your attempts, [src] refuses to open.</span>")
 				prying_so_hard = FALSE

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -96,6 +96,7 @@
 	var/delayed_close_requested = FALSE // TRUE means the door will automatically close the next time it's opened.
 	var/air_tight = FALSE	//TRUE means density will be set as soon as the door begins to close
 	var/prying_so_hard = FALSE
+	var/pried_so_hard = FALSE
 
 	flags_1 = RAD_PROTECT_CONTENTS_1 | RAD_NO_CONTAMINATE_1
 	rad_insulation = RAD_MEDIUM_INSULATION
@@ -660,6 +661,9 @@
 		else
 			. += "It looks very robust."
 
+	if(pried_so_hard)
+		. += "<span class='warning'>There are dents and scratches where the halves of the airlock meet, signs of forced entry.</span>"
+
 	if(issilicon(user) && !(machine_stat & BROKEN))
 		. += "<span class='notice'>Shift-click [src] to [ density ? "open" : "close"] it.</span>"
 		. += "<span class='notice'>Ctrl-click [src] to [ locked ? "raise" : "drop"] its bolts.</span>"
@@ -1008,6 +1012,7 @@
 								"<span class='hear'>You hear welding.</span>")
 				if(W.use_tool(src, user, 40, volume=50, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
 					obj_integrity = max_integrity
+					pried_so_hard = FALSE // Remove the signs of Jaws of Life entry
 					set_machine_stat(machine_stat & ~BROKEN)
 					user.visible_message("<span class='notice'>[user] finishes welding [src].</span>", \
 										"<span class='notice'>You finish repairing the airlock.</span>")
@@ -1084,6 +1089,8 @@
 						prying_so_hard = FALSE
 						return
 					open(2)
+					take_damage(25, BRUTE, 0, 0) // Enough to sometimes spark
+					pried_so_hard = TRUE // Just for the description
 					if(density && !open(2))
 						to_chat(user, "<span class='warning'>Despite your attempts, [src] refuses to open.</span>")
 				prying_so_hard = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Forcing open an airlock with the Jaws of Life tool now makes it take some damage. This leaves a small examine text, and has a chance to cause sparks. The examine text can be removed by repairing the airlock with a welder.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It gives departments a reason to go mildly >:( when people are jaws'ing their way inside - the damage makes sense considering you're forcing a struggling/resisting airlock open with a power tool. The examine cue it leaves also lets people know when someone with a power tool made their way inside.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Airlocks take a small amount of damage and leave an examine hint when you Jaws of Life your way inside.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
