### PR TITLE
Job gloves no longer override tongue-tied radio gloves

### DIFF
--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -257,10 +257,12 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/organ/tongue/old_tongue = locate() in H.internal_organs
 	var/obj/item/organ/tongue/tied/new_tongue = new(get_turf(H))
+	var/obj/item/clothing/gloves/old_gloves = locate() in H
 	var/obj/item/clothing/gloves/radio/gloves = new(get_turf(H))
 	old_tongue.Remove(H)
 	new_tongue.Insert(H)
 	qdel(old_tongue)
+	qdel(old_gloves)
 	H.put_in_hands(gloves)
 	H.equip_to_slot(gloves, ITEM_SLOT_GLOVES)
 	H.regenerate_icons()


### PR DESCRIPTION
## About The Pull Request

Fixes #55322 Currently, job-specific gloves like the Sec Officer's black gloves override the radio gloves of people with the tongue-tied quirk, causing quite a hassle for them. This fixes it by deleting the old gloves before the new ones are placed.

## Why It's Good For The Game

Fixes bugs, bugs bad.

## Changelog
:cl:
fix: Job gloves no longer delete radio gloves.
/:cl: