### PR TITLE
Z-levels visible below you now have a slight blur to imply depth of field.

### DIFF
--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -39,6 +39,18 @@
 /atom/movable/screen/plane_master/proc/clear_filters()
 	filters = list()
 
+///Blur rendered on z-levels below.
+/atom/movable/screen/plane_master/openspace_blur
+    name = "open space blur plane master"
+    plane = OPENSPACE_PLANE
+    appearance_flags = PLANE_MASTER
+    blend_mode = BLEND_OVERLAY
+    alpha = 255
+
+/atom/movable/screen/plane_master/openspace_blur/Initialize()
+    . = ..()
+    filters += filter(type = "blur", size = 0.75)
+
 ///Contains just the floor
 /atom/movable/screen/plane_master/floor
 	name = "floor plane master"

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -16,15 +16,15 @@
 //Trust me, you need one. Period. If you don't think you do, you're doing something extremely wrong.
 /atom/movable/screen/plane_master/proc/backdrop(mob/mymob)
 
-///Things rendered on "openspace"; holes in multi-z
-/atom/movable/screen/plane_master/openspace
-	name = "open space plane master"
+///Drop shadows rendered on backdrop for openspace.
+/atom/movable/screen/plane_master/openspace_backdrop
+	name = "open space backdrop plane master"
 	plane = OPENSPACE_BACKDROP_PLANE
 	appearance_flags = PLANE_MASTER
 	blend_mode = BLEND_MULTIPLY
 	alpha = 255
 
-/atom/movable/screen/plane_master/openspace/Initialize()
+/atom/movable/screen/plane_master/openspace_backdrop/Initialize()
 	. = ..()
 	filters += filter(type = "drop_shadow", color = "#04080FAA", size = -10)
 	filters += filter(type = "drop_shadow", color = "#04080FAA", size = -15)
@@ -39,15 +39,15 @@
 /atom/movable/screen/plane_master/proc/clear_filters()
 	filters = list()
 
-///Blur rendered on z-levels below.
-/atom/movable/screen/plane_master/openspace_blur
-	name = "open space blur plane master"
+///Things rendered on "openspace"; holes in multi-z
+/atom/movable/screen/plane_master/openspace
+	name = "open space plane master"
 	plane = OPENSPACE_PLANE
 	appearance_flags = PLANE_MASTER
 	blend_mode = BLEND_OVERLAY
 	alpha = 255
 
-/atom/movable/screen/plane_master/openspace_blur/Initialize()
+/atom/movable/screen/plane_master/openspace/Initialize()
 	. = ..()
 	add_filter("z_level_blur", 1, list(type = "blur", size = 0.75))
 

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -48,8 +48,8 @@
 	alpha = 255
 
 /atom/movable/screen/plane_master/openspace_blur/Initialize()
-    . = ..()
-    filters += filter(type = "blur", size = 0.75)
+	. = ..()
+	filters += filter(type = "blur", size = 0.75)
 
 ///Contains just the floor
 /atom/movable/screen/plane_master/floor

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -49,7 +49,7 @@
 
 /atom/movable/screen/plane_master/openspace_blur/Initialize()
 	. = ..()
-	filters += filter(type = "blur", size = 0.75)
+	add_filter("z_level_blur", 1, list(type = "blur", size = 0.75))
 
 ///Contains just the floor
 /atom/movable/screen/plane_master/floor

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -41,11 +41,11 @@
 
 ///Blur rendered on z-levels below.
 /atom/movable/screen/plane_master/openspace_blur
-    name = "open space blur plane master"
-    plane = OPENSPACE_PLANE
-    appearance_flags = PLANE_MASTER
-    blend_mode = BLEND_OVERLAY
-    alpha = 255
+	name = "open space blur plane master"
+	plane = OPENSPACE_PLANE
+	appearance_flags = PLANE_MASTER
+	blend_mode = BLEND_OVERLAY
+	alpha = 255
 
 /atom/movable/screen/plane_master/openspace_blur/Initialize()
     . = ..()


### PR DESCRIPTION
## About The Pull Request

![blur](https://user-images.githubusercontent.com/51800976/101396009-56583700-3890-11eb-9f1b-8312134d5c85.png)
https://i.gyazo.com/d9f21c044a44ebaada10ad99f037a060.mp4
https://i.gyazo.com/b6f25ff1a95343a7a62c1ea0777d9874.mp4
https://i.gyazo.com/714b960ce0f85f5c9012398da362b95f.mp4

Thanks to @SireTurret for the original idea and @Azarak for help getting this working.
If this can be implemented in a better or more performant way please let me know.

### **Issues noticed so far:**

- [ ] Floor lights (as in the third video) and some other things are not blurred when they should be.

- [ ] Turfs with transparency element are having their own icon also blurred, not just the openspace plane, as visible in the screenshot.

## Why It's Good For The Game

Looks cool, gives multi-z a more tangible feeling of height.

## Changelog
:cl:
add: Z-levels visible below the current z-level you're on now have a slight blur and look like they have depth of field.
/:cl: