### PR TITLE
Removed semicolon output in critical state

### DIFF
--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -124,6 +124,8 @@
 			mods[MODE_SING] = TRUE
 		else if(key == ";" && !mods[MODE_HEADSET] && stat == CONSCIOUS)
 			mods[MODE_HEADSET] = TRUE
+		else if(key == ";" && !mods[MODE_HEADSET] && stat != CONSCIOUS)
+			chop_to = length(key) + 1
 		else if((key in GLOB.department_radio_prefixes) && length(message) > length(key) + 1 && !mods[RADIO_EXTENSION])
 			mods[RADIO_KEY] = lowertext(message[1 + length(key)])
 			mods[RADIO_EXTENSION] = GLOB.department_radio_keys[mods[RADIO_KEY]]

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -122,10 +122,9 @@
 			mods[WHISPER_MODE] = MODE_WHISPER
 		else if(key == "%" && !mods[MODE_SING])
 			mods[MODE_SING] = TRUE
-		else if(key == ";" && !mods[MODE_HEADSET] && stat == CONSCIOUS)
-			mods[MODE_HEADSET] = TRUE
-		else if(key == ";" && !mods[MODE_HEADSET] && stat != CONSCIOUS)
-			chop_to = length(key) + 1
+		else if(key == ";" && !mods[MODE_HEADSET])
+			if(stat == CONSCIOUS) //necessary indentation so it gets stripped of the semicolon anyway.
+				mods[MODE_HEADSET] = TRUE
 		else if((key in GLOB.department_radio_prefixes) && length(message) > length(key) + 1 && !mods[RADIO_EXTENSION])
 			mods[RADIO_KEY] = lowertext(message[1 + length(key)])
 			mods[RADIO_EXTENSION] = GLOB.department_radio_keys[mods[RADIO_KEY]]


### PR DESCRIPTION
## About The Pull Request
removed semicolon display in critical health

Fixes #55386 

## Why It's Good For The Game

Bug fixes always make the game better

## Changelog
:cl:
fix: Semicolon will no longer display in critical condition
/:cl:
