### PR TITLE
Specifies if DNR was pushed in body examine text

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -22,6 +22,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	light_power = 2
 	light_on = FALSE
 	var/can_reenter_corpse
+	var/pushed_do_not_resuscitate = FALSE
 	var/datum/hud/living/carbon/hud = null // hud
 	var/bootime = 0
 	var/started_as_observer //This variable is set to 1 when you enter the game as an observer.
@@ -377,6 +378,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 
 	can_reenter_corpse = FALSE
+	pushed_do_not_resuscitate = TRUE
 	// Update med huds
 	var/mob/living/carbon/current = mind.current
 	current.med_hud_set_status()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -123,8 +123,9 @@
 			if(suiciding)
 				. += "<span class='warning'>[t_He] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>"
 			. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life</span>"
-			if(getorgan(/obj/item/organ/brain) && !key && !get_ghost(FALSE, TRUE))
-				if(pushed_do_not_resuscitate)
+			var/mob/dead/observer/ghost = get_ghost(TRUE, TRUE)
+			if(getorgan(/obj/item/organ/brain) && !key && !(ghost?.can_reenter_corpse))
+				if(ghost.pushed_do_not_resuscitate)
 					. += "<span class='deadsay'> and [t_his] soul has lost the will to live...</span>"
 				else
 					. += "<span class='deadsay'> and [t_his] soul has departed...</span>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -124,11 +124,11 @@
 				. += "<span class='warning'>[t_He] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>"
 			. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life</span>"
 			var/mob/dead/observer/ghost = get_ghost(TRUE, TRUE)
-			if(getorgan(/obj/item/organ/brain) && !key && !(ghost?.can_reenter_corpse))
-				if(ghost.pushed_do_not_resuscitate)
-					. += "<span class='deadsay'> and [t_his] soul has lost the will to live...</span>"
-				else
+			if(getorgan(/obj/item/organ/brain) && !key)
+				if(!ghost) //There's no ghost with a mind matching the body's
 					. += "<span class='deadsay'> and [t_his] soul has departed...</span>"
+				else if (!ghost.can_reenter_corpse || ghost.pushed_do_not_resuscitate) //There is a ghost with a matching mind but they pushed DNR or otherwise can't enter
+					. += "<span class='deadsay'> and [t_his] soul has lost the will to live...</span>"
 			else
 				. += "<span class='deadsay'>...</span>"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -122,11 +122,14 @@
 		if(!just_sleeping)
 			if(suiciding)
 				. += "<span class='warning'>[t_He] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>"
-			. += ""
+			. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life</span>"
 			if(getorgan(/obj/item/organ/brain) && !key && !get_ghost(FALSE, TRUE))
-				. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has departed...</span>"
+				if(pushed_do_not_resuscitate)
+					. += "<span class='deadsay'> and [t_his] soul has lost the will to live...</span>"
+				else
+					. += "<span class='deadsay'> and [t_his] soul has departed...</span>"
 			else
-				. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life...</span>"
+				. += "<span class='deadsay'>...</span>"
 
 	if(get_bodypart(BODY_ZONE_HEAD) && !getorgan(/obj/item/organ/brain))
 		. += "<span class='deadsay'>It appears that [t_his] brain is missing...</span>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -122,15 +122,15 @@
 		if(!just_sleeping)
 			if(suiciding)
 				. += "<span class='warning'>[t_He] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>"
-			. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life</span>"
+
 			var/mob/dead/observer/ghost = get_ghost(TRUE, TRUE)
 			if(getorgan(/obj/item/organ/brain) && !key)
-				if(!ghost) //There's no ghost with a mind matching the body's
-					. += "<span class='deadsay'> and [t_his] soul has departed...</span>"
-				else if (!ghost.can_reenter_corpse || ghost.pushed_do_not_resuscitate) //There is a ghost with a matching mind but they pushed DNR or otherwise can't enter
-					. += "<span class='deadsay'> and [t_his] soul has lost the will to live...</span>"
+				if(!ghost) //There's no ghost with a mind matching the body's, the ghost has likely disconnected
+					. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has departed...</span>"
+				else if (!ghost.can_reenter_corpse || ghost.pushed_do_not_resuscitate) //There is a ghost with a matching mind but they pushed DNR or otherwise can't reenter
+					. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has lost the will to live...</span>"
 			else
-				. += "<span class='deadsay'>...</span>"
+				. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life...</span>"
 
 	if(get_bodypart(BODY_ZONE_HEAD) && !getorgan(/obj/item/organ/brain))
 		. += "<span class='deadsay'>It appears that [t_his] brain is missing...</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the examine text " and [t_his] soul has lost the will to live..." instead of the usual "soul departed" message if the person hits DNR.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There have been a couple of times where I've looked at a dead body and saw that their soul departed, and wondered if they died so hard they quit the game or if they just felt like observing. 
This information was already available via ooc who so I figured why not
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Bodies will now tell you if someone hit DNR or not
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
