### PR TITLE
Compiling changelogs via tgs3 is no longer supported

### DIFF
--- a/TGS3.json
+++ b/TGS3.json
@@ -1,19 +1,9 @@
 {
     "documentation": "/tg/station server 3 configuration file",
-    "changelog": {
-      "script": "tools/ss13_genchangelog.py",
-      "arguments": "html/changelog.html html/changelogs",
-      "pip_dependancies": [
-        "PyYaml",
-        "beautifulsoup4"
-      ]
-    },
     "synchronize_paths": [],
     "static_directories": [
       "config",
       "data"
     ],
-    "dlls": [
-      "libmariadb.dll"
-    ]
+    "dlls": []
   }

--- a/TGS3.json
+++ b/TGS3.json
@@ -8,10 +8,6 @@
         "beautifulsoup4"
       ]
     },
-    "synchronize_paths": [
-      "html/changelog.html",
-      "html/changelogs/*"
-    ],
     "static_directories": [
       "config",
       "data"

--- a/TGS3.json
+++ b/TGS3.json
@@ -8,6 +8,7 @@
         "beautifulsoup4"
       ]
     },
+    "synchronize_paths": [],
     "static_directories": [
       "config",
       "data"


### PR DESCRIPTION
If im understanding things correctly, github actions is currently handling doing this, so we can skip this error prone process here.

@Cyberboss 
