### PR TITLE
Assign correct payment department to the NanoDrug

### DIFF
--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -71,6 +71,7 @@
 					/obj/item/plunger/reinforced = 2)
 	default_price = 50
 	extra_price = 100
+	payment_department = ACCOUNT_MED
 	refill_canister = /obj/item/vending_refill/drugs
 
 /obj/item/vending_refill/drugs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The NanoDrug was created by splitting the drugs off from the tools in the NanoMed in #55069. When this was done a payment_dept variable was not given to the new machine. The default value for this is the engineering department, so payments taken in by the machine went to the engineering budget, not medical. This also resulted in engineering getting a discount at medical's vendors, while medical staff were charged full price.

## Why It's Good For The Game
The NanoDrug belongs to the medical department, not engineering.

## Changelog
:cl:
fix: The NanoDrug vendor in Medbay is now property of the medical department and will handle payments correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
