### PR TITLE
Makes the abductor baton's sleep less cancerous

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -462,7 +462,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 
 	var/mode = BATON_STUN
 
-	var/sleep_time = 2 MINUTES
+	var/sleep_time = 1 MINUTE
 	var/time_to_cuff = 3 SECONDS
 
 /obj/item/melee/baton/abductor/ComponentInitialize()
@@ -559,6 +559,9 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 
 /obj/item/melee/baton/abductor/proc/SleepAttack(mob/living/L,mob/living/user)
 	playsound(src, stun_sound, 50, TRUE, -1)
+	if(L.IsSleeping())
+		L.visible_message("<span class='danger'>[user] tries to induce sleep in [L] with [src], but [L.p_they()] is already asleep!</span>")
+		return
 	if(L.incapacitated(TRUE, TRUE))
 		if(L.anti_magic_check(FALSE, FALSE, TRUE))
 			to_chat(user, "<span class='warning'>The specimen's tinfoil protection is interfering with the sleep inducement!</span>")

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -560,7 +560,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 /obj/item/melee/baton/abductor/proc/SleepAttack(mob/living/L,mob/living/user)
 	playsound(src, stun_sound, 50, TRUE, -1)
 	if(L.IsSleeping())
-		L.visible_message("<span class='danger'>[user] tries to induce sleep in [L] with [src], but [L.p_they()] is already asleep!</span>")
+		L.visible_message("<span class='danger'>[user] tries to induce sleep in [L] with [src], but [L.p_they()] [L.p_are()] already asleep!</span>")
 		return
 	if(L.incapacitated(TRUE, TRUE))
 		if(L.anti_magic_check(FALSE, FALSE, TRUE))

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -462,7 +462,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 
 	var/mode = BATON_STUN
 
-	var/sleep_time = 1 MINUTE
+	var/sleep_time = 1 MINUTES
 	var/time_to_cuff = 3 SECONDS
 
 /obj/item/melee/baton/abductor/ComponentInitialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Makes the sleep last one minute instead of two
2. Makes abductors unable to put people to sleep who are already asleep
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Being unconscious indefinitely is not an enjoyable experience as a player, nor is it kind to allow players to do this to each other. This will hopefully open up the opportunity for the abducted to roleplay their abduction instead of having to stare at a black screen with a pinhole in it for ten minutes with no IC chat or messages. If it encourages you to alt+tab or stop playing entirely it's a poor mechanic.

In case I need to explain why the baton is overpowered: It can stun for 14 seconds, sleep for two minutes, its sleeps can be restarted indefinitely and it requires no charging. Even if abductors can't kill people they can still make them miserable by keeping them asleep for too long. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
balance: Abductor baton's sleep lasts one minute instead of two now
balance: Abductor baton's sleep can't be done to mobs that are already asleep
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
