### PR TITLE
Crates and bountes are now defined by crate's value and paygrades. Civilian bounty payout is higher and uncheesable.

### DIFF
--- a/code/__DEFINES/cargo.dm
+++ b/code/__DEFINES/cargo.dm
@@ -37,6 +37,7 @@
 
 #define SUPPLYPOD_X_OFFSET -16
 
+/// The baseline unit for cargo crates. Adjusting this will change the cost of all in-game shuttles, crate export values, bounty rewards, and all supply pack import values, as they use this as their unit of measurement.
 #define CARGO_CRATE_VALUE 200
 
 GLOBAL_LIST_EMPTY(supplypod_loading_bays)

--- a/code/__DEFINES/cargo.dm
+++ b/code/__DEFINES/cargo.dm
@@ -37,6 +37,8 @@
 
 #define SUPPLYPOD_X_OFFSET -16
 
+#define CARGO_CRATE_VALUE 200
+
 GLOBAL_LIST_EMPTY(supplypod_loading_bays)
 
 GLOBAL_LIST_INIT(podstyles, list(\

--- a/code/datums/components/payment.dm
+++ b/code/datums/components/payment.dm
@@ -10,6 +10,7 @@
  * Improving standardizing every form of payment handing, as some custom handling is specific to that object.
  **/
 /datum/component/payment
+	dupe_mode = COMPONENT_DUPE_UNIQUE ///NO OVERRIDING TO CHEESE BOUNTIES
 	///Standardized of operation.
 	var/cost = 10
 	///Flavor style for handling cash (Friendly? Hostile? etc.)

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -8,11 +8,12 @@
 	var/description
 	var/prerequisites
 	var/admin_notes
-
+	/// How much does this shuttle cost the cargo budget to purchase? Put in terms of CARGO_CRATE_VALUE to properly scale the cost with the current balance of cargo's income.
 	var/credit_cost = INFINITY
+	/// Can the  be legitimately purchased by the station? Used by hardcoded or pre-mapped shuttles like the lavaland or cargo shuttle.
 	var/can_be_bought = TRUE
-
-	var/list/movement_force // If set, overrides default movement_force on shuttle
+	/// If set, overrides default movement_force on shuttle
+	var/list/movement_force
 
 	var/port_x_offset
 	var/port_y_offset
@@ -181,7 +182,7 @@
 	name = "Build your own shuttle kit"
 	description = "For the enterprising shuttle engineer! The chassis will dock upon purchase, but launch will have to be authorized as usual via shuttle call. Comes stocked with construction materials. Unlocks the ability to buy shuttle engine crates from cargo."
 	admin_notes = "No brig, no medical facilities, no shuttle console."
-	credit_cost = 2500
+	credit_cost = CARGO_CRATE_VALUE * 5
 
 /datum/map_template/shuttle/emergency/airless/post_load()
 	. = ..()
@@ -194,7 +195,7 @@
 	suffix = "asteroid"
 	name = "Asteroid Station Emergency Shuttle"
 	description = "A respectable mid-sized shuttle that first saw service shuttling Nanotrasen crew to and from their asteroid belt embedded facilities."
-	credit_cost = 3000
+	credit_cost = CARGO_CRATE_VALUE * 6
 
 /datum/map_template/shuttle/emergency/bar
 	suffix = "bar"
@@ -202,7 +203,7 @@
 	description = "Features include sentient bar staff (a Bardrone and a Barmaid), bathroom, a quality lounge for the heads, and a large gathering table."
 	admin_notes = "Bardrone and Barmaid are GODMODE, will be automatically sentienced by the fun balloon at 60 seconds before arrival. \
 	Has medical facilities."
-	credit_cost = 5000
+	credit_cost = CARGO_CRATE_VALUE * 10
 
 /datum/map_template/shuttle/emergency/pod
 	suffix = "pod"
@@ -216,14 +217,14 @@
 	name = "Mother Russia Bleeds"
 	description = "Dis is a high-quality shuttle, da. Many seats, lots of space, all equipment! Even includes entertainment! Such as lots to drink, and a fighting arena for drunk crew to have fun! If arena not fun enough, simply press button of releasing bears. Do not worry, bears trained not to break out of fighting pit, so totally safe so long as nobody stupid or drunk enough to leave door open. Try not to let asimov babycons ruin fun!"
 	admin_notes = "Includes a small variety of weapons. And bears. Only captain-access can release the bears. Bears won't smash the windows themselves, but they can escape if someone lets them."
-	credit_cost = 5000 // While the shuttle is rusted and poorly maintained, trained bears are costly.
+	credit_cost = CARGO_CRATE_VALUE * 10 // While the shuttle is rusted and poorly maintained, trained bears are costly.
 
 /datum/map_template/shuttle/emergency/meteor
 	suffix = "meteor"
 	name = "Asteroid With Engines Strapped To It"
 	description = "A hollowed out asteroid with engines strapped to it, the hollowing procedure makes it very difficult to hijack but is very expensive. Due to its size and difficulty in steering it, this shuttle may damage the docking area."
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
-	credit_cost = 15000
+	credit_cost = CARGO_CRATE_VALUE * 30
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/luxury
@@ -232,14 +233,14 @@
 	description = "A luxurious golden shuttle complete with an indoor swimming pool. Each crewmember wishing to board must bring 500 credits, payable in cash and mineral coin."
 	extra_desc = "This shuttle costs 500 credits to board."
 	admin_notes = "Due to the limited space for non paying crew, this shuttle may cause a riot."
-	credit_cost = 10000
+	credit_cost = CARGO_CRATE_VALUE * 20
 
 /datum/map_template/shuttle/emergency/discoinferno
 	suffix = "discoinferno"
 	name = "Disco Inferno"
 	description = "The glorious results of centuries of plasma research done by Nanotrasen employees. This is the reason why you are here. Get on and dance like you're on fire, burn baby burn!"
 	admin_notes = "Flaming hot. The main area has a dance machine as well as plasma floor tiles that will be ignited by players every single time."
-	credit_cost = 10000
+	credit_cost = CARGO_CRATE_VALUE * 20
 	can_be_bought = FALSE
 
 /datum/map_template/shuttle/emergency/arena
@@ -247,7 +248,7 @@
 	name = "The Arena"
 	description = "The crew must pass through an otherworldy arena to board this shuttle. Expect massive casualties. The source of the Bloody Signal must be tracked down and eliminated to unlock this shuttle."
 	admin_notes = "RIP AND TEAR."
-	credit_cost = 10000
+	credit_cost = CARGO_CRATE_VALUE * 20
 	/// Whether the arena z-level has been created
 	var/arena_loaded = FALSE
 
@@ -269,12 +270,12 @@
 	suffix = "birdboat"
 	name = "Birdboat Station Emergency Shuttle"
 	description = "Though a little on the small side, this shuttle is feature complete, which is more than can be said for the pattern of station it was commissioned for."
-	credit_cost = 1000
+	credit_cost = CARGO_CRATE_VALUE * 2
 
 /datum/map_template/shuttle/emergency/box
 	suffix = "box"
 	name = "Box Station Emergency Shuttle"
-	credit_cost = 2000
+	credit_cost = CARGO_CRATE_VALUE * 4
 	description = "The gold standard in emergency exfiltration, this tried and true design is equipped with everything the crew needs for a safe flight home."
 
 /datum/map_template/shuttle/emergency/donut
@@ -282,7 +283,7 @@
 	name = "Donutstation Emergency Shuttle"
 	description = "The perfect spearhead for any crude joke involving the station's shape, this shuttle supports a separate containment cell for prisoners and a compact medical wing."
 	admin_notes = "Has airlocks on both sides of the shuttle and will probably intersect near the front on some stations that build past departures."
-	credit_cost = 2500
+	credit_cost = CARGO_CRATE_VALUE * 5
 
 /datum/map_template/shuttle/emergency/clown
 	suffix = "clown"
@@ -293,7 +294,7 @@
 	Collect all the bedsheets before your neighbour does! Check if the AI is watching you with our patent pending \"Peeping Tom AI Multitool Detector\" or PEEEEEETUR for short. \
 	Have a fun ride!"
 	admin_notes = "Brig is replaced by anchored greentext book surrounded by lavaland chasms, stationside door has been removed to prevent accidental dropping. No brig."
-	credit_cost = 8000
+	credit_cost = CARGO_CRATE_VALUE * 16
 
 /datum/map_template/shuttle/emergency/cramped
 	suffix = "cramped"
@@ -307,25 +308,25 @@
 /datum/map_template/shuttle/emergency/meta
 	suffix = "meta"
 	name = "Meta Station Emergency Shuttle"
-	credit_cost = 4000
+	credit_cost = CARGO_CRATE_VALUE * 8
 	description = "A fairly standard shuttle, though larger and slightly better equipped than the Box Station variant."
 
 /datum/map_template/shuttle/emergency/kilo
 	suffix = "kilo"
 	name = "Kilo Station Emergency Shuttle"
-	credit_cost = 5000
+	credit_cost = CARGO_CRATE_VALUE * 10
 	description = "A fully functional shuttle including a complete infirmary, storage facilties and regular amenities."
 
 /datum/map_template/shuttle/emergency/mini
 	suffix = "mini"
 	name = "Ministation emergency shuttle"
-	credit_cost = 1000
+	credit_cost = CARGO_CRATE_VALUE * 2
 	description = "Despite its namesake, this shuttle is actually only slightly smaller than standard, and still complete with a brig and medbay."
 
 /datum/map_template/shuttle/emergency/scrapheap
 	suffix = "scrapheap"
 	name = "Standby Evacuation Vessel \"Scrapheap Challenge\""
-	credit_cost = -1000
+	credit_cost = CARGO_CRATE_VALUE * -2
 	description = "Due to a lack of functional emergency shuttles, we bought this second hand from a scrapyard and pressed it into service. Please do not lean too heavily on the exterior windows, they are fragile."
 	admin_notes = "An abomination with no functional medbay, sections missing, and some very fragile windows. Surprisingly airtight."
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
@@ -336,7 +337,7 @@
 	description = "Looks like this shuttle may have wandered into the darkness between the stars on route to the station. Let's not think too hard about where all the bodies came from."
 	admin_notes = "Contains real cult ruins, mob eyeballs, and inactive constructs. Cult mobs will automatically be sentienced by fun balloon. \
 	Cloning pods in 'medbay' area are showcases and nonfunctional."
-	credit_cost = 6667
+	credit_cost = 6667 ///The joke is the number so no defines
 
 /datum/map_template/shuttle/emergency/narnar/prerequisites_met()
 	return SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_NARNAR]
@@ -346,7 +347,7 @@
 	name = "Pubby Station Emergency Shuttle"
 	description = "A train but in space! Complete with a first, second class, brig and storage area."
 	admin_notes = "Choo choo motherfucker!"
-	credit_cost = 1000
+	credit_cost = CARGO_CRATE_VALUE * 2
 
 /datum/map_template/shuttle/emergency/cere
 	suffix = "cere"
@@ -354,7 +355,7 @@
 	description = "The large, beefed-up version of the box-standard shuttle. Includes an expanded brig, fully stocked medbay, enhanced cargo storage with mech chargers, \
 	an engine room stocked with various supplies, and a crew capacity of 80+ to top it all off. Live large, live Cere."
 	admin_notes = "Seriously big, even larger than the Delta shuttle."
-	credit_cost = 10000
+	credit_cost = CARGO_CRATE_VALUE * 20
 
 /datum/map_template/shuttle/emergency/supermatter
 	suffix = "supermatter"
@@ -367,7 +368,7 @@
 	Outside of admin intervention, it cannot explode. \
 	It does, however, still dust anything on contact, emits high levels of radiation, and induce hallucinations in anyone looking at it without protective goggles. \
 	Emitters spawn powered on, expect admin notices, they are harmless."
-	credit_cost = 100000
+	credit_cost = CARGO_CRATE_VALUE * 200
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/imfedupwiththisworld
@@ -383,7 +384,7 @@
 	suffix = "goon"
 	name = "NES Port"
 	description = "The Nanotrasen Emergency Shuttle Port(NES Port for short) is a shuttle used at other less known Nanotrasen facilities and has a more open inside for larger crowds, but fewer onboard shuttle facilities."
-	credit_cost = 500
+	credit_cost = CARGO_CRATE_VALUE
 
 /datum/map_template/shuttle/emergency/rollerdome
 	suffix = "rollerdome"
@@ -391,7 +392,7 @@
 	description = "Developed by a member of Nanotrasen's R&D crew that claims to have travelled from the year 2028. \
 	He says this shuttle is based off an old entertainment complex from the 1990s, though our database has no records on anything pertaining to that decade."
 	admin_notes = "ONLY NINETIES KIDS REMEMBER. Uses the fun balloon and drone from the Emergency Bar."
-	credit_cost = 2500
+	credit_cost = CARGO_CRATE_VALUE * 5
 
 /datum/map_template/shuttle/emergency/wabbajack
 	suffix = "wabbajack"
@@ -400,27 +401,27 @@
 	The only occupants were a number of dead rodents, who appeared to have clawed each other to death. \
 	Needless to say, no engineering team wanted to go near the thing, and it's only being used as an Emergency Escape Shuttle because there is literally nothing else available."
 	admin_notes = "If the crew can solve the puzzle, they will wake the wabbajack statue. It will likely not end well. There's a reason it's boarded up. Maybe they should have just left it alone."
-	credit_cost = 15000
+	credit_cost = CARGO_CRATE_VALUE * 30
 
 /datum/map_template/shuttle/emergency/omega
 	suffix = "omega"
 	name = "Omegastation Emergency Shuttle"
 	description = "On the smaller size with a modern design, this shuttle is for the crew who like the cosier things, while still being able to stretch their legs."
-	credit_cost = 1000
+	credit_cost = CARGO_CRATE_VALUE * 2
 
 /datum/map_template/shuttle/emergency/cruise
 	suffix = "cruise"
 	name = "The NTSS Independence"
 	description = "Ordinarily reserved for special functions and events, the Cruise Shuttle Independence can bring a summery cheer to your next station evacuation for a 'modest' fee!"
 	admin_notes = "This motherfucker is BIG. You might need to force dock it."
-	credit_cost = 50000
+	credit_cost = CARGO_CRATE_VALUE * 100
 
 /datum/map_template/shuttle/emergency/monkey
 	suffix = "nature"
 	name = "Dynamic Environmental Interaction Shuttle"
 	description = "A large shuttle with a center biodome that is flourishing with life. Frolick with the monkeys! (Extra monkeys are stored on the bridge.)"
 	admin_notes = "Pretty freakin' large, almost as big as Raven or Cere. Excercise caution with it."
-	credit_cost = 8000
+	credit_cost = CARGO_CRATE_VALUE * 16
 
 /datum/map_template/shuttle/ferry/base
 	suffix = "base"
@@ -507,7 +508,7 @@
 	name = "Delta Station Emergency Shuttle"
 	description = "A large shuttle for a large station, this shuttle can comfortably fit all your overpopulation and crowding needs. Complete with all facilities plus additional equipment."
 	admin_notes = "Go big or go home."
-	credit_cost = 7500
+	credit_cost = CARGO_CRATE_VALUE * 15
 
 /datum/map_template/shuttle/emergency/raven
 	suffix = "raven"
@@ -516,7 +517,7 @@
 	Once first to the scene to pick through warzones for valuable remains, it now serves as an excellent escape option for stations under heavy fire from outside forces. \
 	This escape shuttle boasts shields and numerous anti-personnel turrets guarding its perimeter to fend off meteors and enemy boarding attempts."
 	admin_notes = "Comes with turrets that will target anything without the neutral faction (nuke ops, xenos etc, but not pets)."
-	credit_cost = 30000
+	credit_cost = CARGO_CRATE_VALUE * 60
 
 /datum/map_template/shuttle/emergency/zeta
 	suffix = "zeta"
@@ -524,7 +525,7 @@
 	description = "A glitch appears on your monitor, flickering in and out of the options laid before you. \
 	It seems strange and alien, you may need a special technology to access the signal.."
 	admin_notes = "Has alien surgery tools, and a void core that provides unlimited power."
-	credit_cost = 8000
+	credit_cost = CARGO_CRATE_VALUE * 16
 
 /datum/map_template/shuttle/emergency/zeta/prerequisites_met()
 	return SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_ALIENTECH]

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -100,7 +100,7 @@
 		SSeconomy.civ_bounty_tracker++
 		var/obj/item/bounty_cube/reward = new /obj/item/bounty_cube(drop_location())
 		reward.bounty_value = curr_bounty.reward
-		reward.AddComponent(/datum/component/pricetag, inserted_scan_id.registered_account, 10)
+		reward.AddComponent(/datum/component/pricetag, inserted_scan_id.registered_account, 30)
 	pad.visible_message("<span class='notice'>[pad] activates!</span>")
 	flick(pad.sending_state,pad)
 	pad.icon_state = pad.idle_state

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -1,126 +1,126 @@
 /datum/bounty/item/assistant/strange_object
 	name = "Strange Object"
 	description = "Nanotrasen has taken an interest in strange objects. Find one in maint, and ship it off to CentCom right away."
-	reward = 1200
+	reward = CARGO_CRATE_VALUE * 2.4
 	wanted_types = list(/obj/item/relic)
 
 /datum/bounty/item/assistant/scooter
 	name = "Scooter"
 	description = "Nanotrasen has determined walking to be wasteful. Ship a scooter to CentCom to speed operations up."
-	reward = 1080 // the mat hoffman
+	reward = CARGO_CRATE_VALUE * 2.16 // the mat hoffman
 	wanted_types = list(/obj/vehicle/ridden/scooter)
 	include_subtypes = FALSE
 
 /datum/bounty/item/assistant/skateboard
 	name = "Skateboard"
 	description = "Nanotrasen has determined walking to be wasteful. Ship a skateboard to CentCom to speed operations up."
-	reward = 900 // the tony hawk
+	reward = CARGO_CRATE_VALUE * 1.8 // the tony hawk
 	wanted_types = list(/obj/vehicle/ridden/scooter/skateboard, /obj/item/melee/skateboard)
 
 /datum/bounty/item/assistant/stunprod
 	name = "Stunprod"
 	description = "CentCom demands a stunprod to use against dissidents. Craft one, then ship it."
-	reward = 1300
+	reward = CARGO_CRATE_VALUE * 2.6
 	wanted_types = list(/obj/item/melee/baton/cattleprod)
 
 /datum/bounty/item/assistant/soap
 	name = "Soap"
 	description = "Soap has gone missing from CentCom's bathrooms and nobody knows who took it. Replace it and be the hero CentCom needs."
-	reward = 2000
+	reward = CARGO_CRATE_VALUE * 4
 	required_count = 3
 	wanted_types = list(/obj/item/soap)
 
 /datum/bounty/item/assistant/spear
 	name = "Spears"
 	description = "CentCom's security forces are going through budget cuts. You will be paid if you ship a set of spears."
-	reward = 2000
+	reward = CARGO_CRATE_VALUE * 4
 	required_count = 5
 	wanted_types = list(/obj/item/spear)
 
 /datum/bounty/item/assistant/toolbox
 	name = "Toolboxes"
 	description = "There's an absence of robustness at Central Command. Hurry up and ship some toolboxes as a solution."
-	reward = 2000
+	reward = CARGO_CRATE_VALUE * 4
 	required_count = 6
 	wanted_types = list(/obj/item/storage/toolbox)
 
 /datum/bounty/item/assistant/statue
 	name = "Statue"
 	description = "Central Command would like to commision an artsy statue for the lobby. Ship one out, when possible."
-	reward = 2000
+	reward = CARGO_CRATE_VALUE * 4
 	wanted_types = list(/obj/structure/statue)
 
 /datum/bounty/item/assistant/clown_box
 	name = "Clown Box"
 	description = "The universe needs laughter. Stamp cardboard with a clown stamp and ship it out."
-	reward = 1500
+	reward = CARGO_CRATE_VALUE * 3
 	wanted_types = list(/obj/item/storage/box/clown)
 
 /datum/bounty/item/assistant/cheesiehonkers
 	name = "Cheesie Honkers"
 	description = "Apparently the company that makes Cheesie Honkers is going out of business soon. CentCom wants to stock up before it happens!"
-	reward = 1200
+	reward = CARGO_CRATE_VALUE * 2.4
 	required_count = 3
 	wanted_types = list(/obj/item/food/cheesiehonkers)
 
 /datum/bounty/item/assistant/baseball_bat
 	name = "Baseball Bat"
 	description = "Baseball fever is going on at CentCom! Be a dear and ship them some baseball bats, so that management can live out their childhood dream."
-	reward = 2000
+	reward = CARGO_CRATE_VALUE * 4
 	required_count = 5
 	wanted_types = list(/obj/item/melee/baseball_bat)
 
 /datum/bounty/item/assistant/extendohand
 	name = "Extendo-Hand"
 	description = "Commander Betsy is getting old, and can't bend over to get the telescreen remote anymore. Management has requested an extendo-hand to help her out."
-	reward = 2500
+	reward = CARGO_CRATE_VALUE * 5
 	wanted_types = list(/obj/item/extendohand)
 
 /datum/bounty/item/assistant/donut
 	name = "Donuts"
 	description = "CentCom's security forces are facing heavy losses against the Syndicate. Ship donuts to raise morale."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	required_count = 10
 	wanted_types = list(/obj/item/food/donut)
 
 /datum/bounty/item/assistant/donkpocket
 	name = "Donk-Pockets"
 	description = "Consumer safety recall: Warning. Donk-Pockets manufactured in the past year contain hazardous lizard biomatter. Return units to CentCom immediately."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	required_count = 10
 	wanted_types = list(/obj/item/food/donkpocket)
 
 /datum/bounty/item/assistant/briefcase
 	name = "Briefcase"
 	description = "Central Command will be holding a business convention this year. Ship a few briefcases in support."
-	reward = 2500
+	reward = CARGO_CRATE_VALUE * 5
 	required_count = 5
 	wanted_types = list(/obj/item/storage/briefcase, /obj/item/storage/secure/briefcase)
 
 /datum/bounty/item/assistant/sunglasses
 	name = "Sunglasses"
 	description = "A famous blues duo is passing through the sector, but they've lost their shades and they can't perform. Ship new sunglasses to CentCom to rectify this."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	required_count = 2
 	wanted_types = list(/obj/item/clothing/glasses/sunglasses)
 
 /datum/bounty/item/assistant/monkey_hide
 	name = "Monkey Hide"
 	description = "One of the scientists at CentCom is interested in testing products on monkey skin. Your mission is to acquire monkey's hide and ship it."
-	reward = 1500
+	reward = CARGO_CRATE_VALUE * 3
 	wanted_types = list(/obj/item/stack/sheet/animalhide/monkey)
 
 /datum/bounty/item/assistant/comfy_chair
 	name = "Comfy Chairs"
 	description = "Commander Pat is unhappy with his chair. He claims it hurts his back. Ship some alternatives out to humor him."
-	reward = 1500
+	reward = CARGO_CRATE_VALUE * 3
 	required_count = 5
 	wanted_types = list(/obj/structure/chair/comfy)
 
 /datum/bounty/item/assistant/geranium
 	name = "Geraniums"
 	description = "Commander Zot has the hots for Commander Zena. Send a shipment of geraniums - her favorite flower - and he'll happily reward you."
-	reward = 4000
+	reward = CARGO_CRATE_VALUE * 8
 	required_count = 3
 	wanted_types = list(/obj/item/food/grown/poppy/geranium)
 	include_subtypes = FALSE
@@ -128,7 +128,7 @@
 /datum/bounty/item/assistant/poppy
 	name = "Poppies"
 	description = "Commander Zot really wants to sweep Security Officer Olivia off her feet. Send a shipment of Poppies - her favorite flower - and he'll happily reward you."
-	reward = 1000
+	reward = CARGO_CRATE_VALUE * 2
 	required_count = 3
 	wanted_types = list(/obj/item/food/grown/poppy)
 	include_subtypes = FALSE
@@ -136,54 +136,54 @@
 /datum/bounty/item/assistant/shadyjims
 	name = "Shady Jim's"
 	description = "There's an irate officer at CentCom demanding that he receive a box of Shady Jim's cigarettes. Please ship one. He's starting to make threats."
-	reward = 500
+	reward = CARGO_CRATE_VALUE
 	wanted_types = list(/obj/item/storage/fancy/cigarettes/cigpack_shadyjims)
 
 /datum/bounty/item/assistant/potted_plants
 	name = "Potted Plants"
 	description = "Central Command is looking to commission a new BirdBoat-class station. You've been ordered to supply the potted plants."
-	reward = 2000
+	reward = CARGO_CRATE_VALUE * 4
 	required_count = 8
 	wanted_types = list(/obj/item/kirbyplants)
 
 /datum/bounty/item/assistant/monkey_cubes
 	name = "Monkey Cubes"
 	description = "Due to a recent genetics accident, Central Command is in serious need of monkeys. Your mission is to ship monkey cubes."
-	reward = 2000
+	reward = CARGO_CRATE_VALUE * 4
 	required_count = 3
 	wanted_types = list(/obj/item/food/monkeycube)
 
 /datum/bounty/item/assistant/ied
 	name = "IED"
 	description = "Nanotrasen's maximum security prison at CentCom is undergoing personnel training. Ship a handful of IEDs to serve as a training tools."
-	reward = 2000
+	reward = CARGO_CRATE_VALUE * 4
 	required_count = 3
 	wanted_types = list(/obj/item/grenade/iedcasing)
 
 /datum/bounty/item/assistant/corgimeat
 	name = "Raw Corgi Meat"
 	description = "The Syndicate recently stole all of CentCom's Corgi meat. Ship out a replacement immediately."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	wanted_types = list(/obj/item/food/meat/slab/corgi)
 
 /datum/bounty/item/assistant/action_figures
 	name = "Action Figures"
 	description = "The vice president's son saw an ad for action figures on the telescreen and now he won't shut up about them. Ship some to ease his complaints."
-	reward = 4000
+	reward = CARGO_CRATE_VALUE * 8
 	required_count = 5
 	wanted_types = list(/obj/item/toy/figure)
 
 /datum/bounty/item/assistant/dead_mice
 	name = "Dead Mice"
 	description = "Station 14 ran out of freeze-dried mice. Ship some fresh ones so their janitor doesn't go on strike."
-	reward = 5000
+	reward = CARGO_CRATE_VALUE * 10
 	required_count = 5
 	wanted_types = list(/obj/item/food/deadmouse)
 
 /datum/bounty/item/assistant/paper_bin
 	name = "Paper Bins"
 	description = "Our accounting division is all out of paper. We need a new shipment immediately."
-	reward = 2500
+	reward = CARGO_CRATE_VALUE * 5
 	required_count = 5
 	wanted_types = list(/obj/item/paper_bin)
 
@@ -191,14 +191,14 @@
 /datum/bounty/item/assistant/crayons
 	name = "Crayons"
 	description = "Dr Jones' kid ate all our crayons again. Please send us yours."
-	reward = 2000
+	reward = CARGO_CRATE_VALUE * 4
 	required_count = 24
 	wanted_types = list(/obj/item/toy/crayon)
 
 /datum/bounty/item/assistant/pens
 	name = "Pens"
 	description = "We are hosting the intergalactic pen balancing competition. We need you to send us some standardized ball point pens."
-	reward = 2000
+	reward = CARGO_CRATE_VALUE * 4
 	required_count = 10
 	include_subtypes = FALSE
 	wanted_types = list(/obj/item/pen)

--- a/code/modules/cargo/bounties/botany.dm
+++ b/code/modules/cargo/bounties/botany.dm
@@ -1,5 +1,5 @@
 /datum/bounty/item/botany
-	reward = 5000
+	reward = CARGO_CRATE_VALUE * 10
 	var/datum/bounty/item/botany/multiplier = 0 //adds bonus reward money; increased for higher tier or rare mutations
 	var/datum/bounty/item/botany/bonus_desc //for adding extra flavor text to bounty descriptions
 	var/datum/bounty/item/botany/foodtype = "meal" //same here
@@ -7,7 +7,7 @@
 /datum/bounty/item/botany/New()
 	..()
 	description = "Central Command's head chef is looking to prepare a fine [foodtype] with [name]. [bonus_desc]"
-	reward += multiplier * 1000
+	reward += multiplier * (CARGO_CRATE_VALUE * 2)
 	required_count = rand(5, 10)
 
 /datum/bounty/item/botany/ambrosia_vulgaris

--- a/code/modules/cargo/bounties/chef.dm
+++ b/code/modules/cargo/bounties/chef.dm
@@ -1,144 +1,144 @@
 /datum/bounty/item/chef/birthday_cake
 	name = "Birthday Cake"
 	description = "Nanotrasen's birthday is coming up! Ship them a birthday cake to celebrate!"
-	reward = 4000
+	reward = CARGO_CRATE_VALUE * 8
 	wanted_types = list(/obj/item/food/cake/birthday, /obj/item/food/cakeslice/birthday)
 
 /datum/bounty/item/chef/soup
 	name = "Soup"
 	description = "To quell the homeless uprising, Nanotrasen will be serving soup to all underpaid workers. Ship any type of soup."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	required_count = 3
 	wanted_types = list(/obj/item/food/soup)
 
 /datum/bounty/item/chef/popcorn
 	name = "Popcorn Bags"
 	description = "Upper management wants to host a movie night. Ship bags of popcorn for the occasion."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	required_count = 3
 	wanted_types = list(/obj/item/food/popcorn)
 
 /datum/bounty/item/chef/onionrings
 	name = "Onion Rings"
 	description = "Nanotrasen is remembering Saturn day. Ship onion rings to show the station's support."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	required_count = 3
 	wanted_types = list(/obj/item/food/onionrings)
 
 /datum/bounty/item/chef/icecreamsandwich
 	name = "Ice Cream Sandwiches"
 	description = "Upper management has been screaming non-stop for ice cream. Please send some."
-	reward = 4000
+	reward = CARGO_CRATE_VALUE * 8
 	required_count = 3
 	wanted_types = list(/obj/item/food/icecreamsandwich)
 
 /datum/bounty/item/chef/strawberryicecreamsandwich
 	name = " Strawberry Ice Cream Sandwiches"
 	description = "Upper management has been screaming non-stop for more flavourful ice cream. Please send some."
-	reward = 5000
+	reward = CARGO_CRATE_VALUE * 10
 	required_count = 3
 	wanted_types = list(/obj/item/food/strawberryicecreamsandwich)
 
 /datum/bounty/item/chef/bread
 	name = "Bread"
 	description = "Problems with central planning have led to bread prices skyrocketing. Ship some bread to ease tensions."
-	reward = 1000
+	reward = CARGO_CRATE_VALUE * 2
 	wanted_types = list(/obj/item/food/bread, /obj/item/food/breadslice, /obj/item/food/bun, /obj/item/food/pizzabread, /obj/item/food/rawpastrybase)
 
 /datum/bounty/item/chef/pie
 	name = "Pie"
 	description = "3.14159? No! CentCom management wants edible pie! Ship a whole one."
-	reward = 3142
+	reward = 3142 //Screw it I'll do this one by hand
 	wanted_types = list(/obj/item/food/pie)
 
 /datum/bounty/item/chef/salad
 	name = "Salad or Rice Bowls"
 	description = "CentCom management is going on a health binge. Your order is to ship salad or rice bowls."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	required_count = 3
 	wanted_types = list(/obj/item/food/salad)
 
 /datum/bounty/item/chef/carrotfries
 	name = "Carrot Fries"
 	description = "Night sight can mean life or death! A shipment of carrot fries is the order."
-	reward = 3500
+	reward = CARGO_CRATE_VALUE * 7
 	required_count = 3
 	wanted_types = list(/obj/item/food/carrotfries)
 
 /datum/bounty/item/chef/superbite
 	name = "Super Bite Burger"
 	description = "Commander Tubbs thinks he can set a competitive eating world record. All he needs is a super bite burger shipped to him."
-	reward = 12000
+	reward = CARGO_CRATE_VALUE * 24
 	wanted_types = list(/obj/item/food/burger/superbite)
 
 /datum/bounty/item/chef/poppypretzel
 	name = "Poppy Pretzel"
 	description = "Central Command needs a reason to fire their HR head. Send over a poppy pretzel to force a failed drug test."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	wanted_types = list(/obj/item/food/poppypretzel)
 
 /datum/bounty/item/chef/cubancarp
 	name = "Cuban Carp"
 	description = "To celebrate the birth of Castro XXVII, ship one cuban carp to CentCom."
-	reward = 8000
+	reward = CARGO_CRATE_VALUE * 16
 	wanted_types = list(/obj/item/food/cubancarp)
 
 /datum/bounty/item/chef/hotdog
 	name = "Hot Dog"
 	description = "Nanotrasen is conducting taste tests to determine the best hot dog recipe. Ship your station's version to participate."
-	reward = 8000
+	reward = CARGO_CRATE_VALUE * 16
 	wanted_types = list(/obj/item/food/hotdog)
 
 /datum/bounty/item/chef/eggplantparm
 	name = "Eggplant Parmigianas"
 	description = "A famous singer will be arriving at CentCom, and their contract demands that they only be served Eggplant Parmigiana. Ship some, please!"
-	reward = 3500
+	reward = CARGO_CRATE_VALUE * 7
 	required_count = 3
 	wanted_types = list(/obj/item/food/eggplantparm)
 
 /datum/bounty/item/chef/muffin
 	name = "Muffins"
 	description = "The Muffin Man is visiting CentCom, but he's forgotten his muffins! Your order is to rectify this."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	required_count = 3
 	wanted_types = list(/obj/item/food/muffin)
 
 /datum/bounty/item/chef/chawanmushi
 	name = "Chawanmushi"
 	description = "Nanotrasen wants to improve relations with its sister company, Japanotrasen. Ship Chawanmushi immediately."
-	reward = 8000
+	reward = CARGO_CRATE_VALUE * 16
 	wanted_types = list(/obj/item/food/chawanmushi)
 
 /datum/bounty/item/chef/kebab
 	name = "Kebabs"
 	description = "Remove all kebab from station you are best food. Ship to CentCom to remove from the premises."
-	reward = 3500
+	reward = CARGO_CRATE_VALUE * 7
 	required_count = 3
 	wanted_types = list(/obj/item/food/kebab)
 
 /datum/bounty/item/chef/soylentgreen
 	name = "Soylent Green"
 	description = "CentCom has heard wonderful things about the product 'Soylent Green', and would love to try some. If you endulge them, expect a pleasant bonus."
-	reward = 5000
+	reward = CARGO_CRATE_VALUE * 10
 	wanted_types = list(/obj/item/food/soylentgreen)
 
 /datum/bounty/item/chef/pancakes
 	name = "Pancakes"
 	description = "Here at Nanotrasen we consider employees to be family. And you know what families love? Pancakes. Ship a baker's dozen."
-	reward = 5000
+	reward = CARGO_CRATE_VALUE * 10
 	required_count = 13
 	wanted_types = list(/obj/item/food/pancakes)
 
 /datum/bounty/item/chef/nuggies
 	name = "Chicken Nuggets"
 	description = "The vice president's son won't shut up about chicken nuggies. Would you mind shipping some?"
-	reward = 4000
+	reward = CARGO_CRATE_VALUE * 8
 	required_count = 6
 	wanted_types = list(/obj/item/food/nugget)
 
 /datum/bounty/item/chef/corgifarming //Butchering is a chef's job.
 	name = "Corgi Hides"
 	description = "Admiral Weinstein's space yacht needs new upholstery. A dozen Corgi furs should do just fine."
-	reward = 30000 //that's a lot of dead dogs
+	reward = CARGO_CRATE_VALUE * 60 //that's a lot of dead dogs
 	required_count = 12
 	wanted_types = list(/obj/item/stack/sheet/animalhide/corgi)

--- a/code/modules/cargo/bounties/engineering.dm
+++ b/code/modules/cargo/bounties/engineering.dm
@@ -1,7 +1,7 @@
 /datum/bounty/item/engineering/gas
 	name = "Full Tank of Pluoxium"
 	description = "CentCom RnD is researching extra compact internals. Ship us a tank full of Pluoxium and you'll be compensated."
-	reward = 7500
+	reward = CARGO_CRATE_VALUE * 15
 	wanted_types = list(/obj/item/tank)
 	var/moles_required = 20 // A full tank is 28 moles, but CentCom ignores that fact.
 	var/gas_type = /datum/gas/pluoxium
@@ -37,17 +37,17 @@
 /datum/bounty/item/engineering/gas/zauker_tank
 	name = "Full Tank of Zauker"
 	description = "The main planet of \[REDACTED] has been chosen as testing grounds for the new weapon that uses Zauker gas. Ship us a tank full of it. (20 Moles)"
-	reward = 10000
+	reward = CARGO_CRATE_VALUE * 20
 	gas_type = /datum/gas/zauker
 
 /datum/bounty/item/engineering/emitter
 	name = "Emitter"
 	description = "We think there may be a defect in your station's emitter designs, based on the sheer number of delaminations your sector seems to see. Ship us one of yours."
-	reward = 2500
+	reward = CARGO_CRATE_VALUE * 5
 	wanted_types = list(/obj/machinery/power/emitter)
 
 /datum/bounty/item/engineering/hydro_tray
 	name = "Hydroponics Tray"
 	description = "The lab technicians are trying to figure out how to lower the power drain of hydroponics trays, but we fried our last one. Mind building one for us?"
-	reward = 2000
+	reward = CARGO_CRATE_VALUE * 4
 	wanted_types = list(/obj/machinery/hydroponics/constructable)

--- a/code/modules/cargo/bounties/mech.dm
+++ b/code/modules/cargo/bounties/mech.dm
@@ -15,25 +15,25 @@
 
 /datum/bounty/item/mech/ripleymk2
 	name = "APLU MK-II \"Ripley\""
-	reward = 13000
+	reward = CARGO_CRATE_VALUE * 26
 	wanted_types = list(/obj/vehicle/sealed/mecha/working/ripley/mk2)
 
 /datum/bounty/item/mech/clarke
 	name = "Clarke"
-	reward = 16000
+	reward = CARGO_CRATE_VALUE * 32
 	wanted_types = list(/obj/vehicle/sealed/mecha/working/clarke)
 
 /datum/bounty/item/mech/odysseus
 	name = "Odysseus"
-	reward = 11000
+	reward = CARGO_CRATE_VALUE * 22
 	wanted_types = list(/obj/vehicle/sealed/mecha/medical/odysseus)
 
 /datum/bounty/item/mech/gygax
 	name = "Gygax"
-	reward = 28000
+	reward = CARGO_CRATE_VALUE * 56
 	wanted_types = list(/obj/vehicle/sealed/mecha/combat/gygax)
 
 /datum/bounty/item/mech/durand
 	name = "Durand"
-	reward = 20000
+	reward = CARGO_CRATE_VALUE * 40
 	wanted_types = list(/obj/vehicle/sealed/mecha/combat/durand)

--- a/code/modules/cargo/bounties/medical.dm
+++ b/code/modules/cargo/bounties/medical.dm
@@ -1,7 +1,7 @@
 /datum/bounty/item/medical/heart
 	name = "Heart"
 	description = "Commander Johnson is in critical condition after suffering yet another heart attack. Doctors say he needs a new heart fast. Ship one, pronto! We'll take a better cybernetic one, if need be."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	wanted_types = list(/obj/item/organ/heart)
 	exclude_types = list(/obj/item/organ/heart/cybernetic)//Excluding tier 1s, no cheesing.
 	special_include_types = list(/obj/item/organ/heart/cybernetic/tier2, /obj/item/organ/heart/cybernetic/tier3)
@@ -9,7 +9,7 @@
 /datum/bounty/item/medical/lung
 	name = "Lungs"
 	description = "A recent explosion at Central Command has left multiple staff with punctured lungs. Ship spare lungs to be rewarded.  We'll take a better cybernetic one, if need be."
-	reward = 10000
+	reward = CARGO_CRATE_VALUE * 20
 	required_count = 3
 	wanted_types = list(/obj/item/organ/lungs)
 	exclude_types = list(/obj/item/organ/lungs/cybernetic)//As above, for all printable organs.
@@ -18,13 +18,13 @@
 /datum/bounty/item/medical/appendix
 	name = "Appendix"
 	description = "Chef Gibb of Central Command wants to prepare a meal using a very special delicacy: an appendix. If you ship one, he'll pay.  We'll take a better cybernetic one, if need be."
-	reward = 5000 //there are no synthetic appendixes
+	reward = CARGO_CRATE_VALUE * 10 //there are no synthetic appendixes
 	wanted_types = list(/obj/item/organ/appendix)
 
 /datum/bounty/item/medical/ears
 	name = "Ears"
 	description = "Multiple staff at Station 12 have been left deaf due to unauthorized clowning. Ship them new ears. "
-	reward = 10000
+	reward = CARGO_CRATE_VALUE * 10
 	required_count = 3
 	wanted_types = list(/obj/item/organ/ears)
 	exclude_types = list(/obj/item/organ/ears/cybernetic)
@@ -33,7 +33,7 @@
 /datum/bounty/item/medical/liver
 	name = "Livers"
 	description = "Multiple high-ranking CentCom diplomats have been hospitalized with liver failure after a recent meeting with Third Soviet Union ambassadors. Help us out, will you? We'll take better cybernetic ones, if need be."
-	reward = 10000
+	reward = CARGO_CRATE_VALUE * 10
 	required_count = 3
 	wanted_types = list(/obj/item/organ/liver)
 	exclude_types = list(/obj/item/organ/liver/cybernetic)
@@ -42,7 +42,7 @@
 /datum/bounty/item/medical/eye
 	name = "Organic Eyes"
 	description = "Station 5's Research Director Willem is requesting a few pairs of non-robotic eyes. Don't ask questions, just ship them."
-	reward = 10000
+	reward = CARGO_CRATE_VALUE * 20
 	required_count = 3
 	wanted_types = list(/obj/item/organ/eyes)
 	exclude_types = list(/obj/item/organ/eyes/robotic)
@@ -50,42 +50,42 @@
 /datum/bounty/item/medical/tongue
 	name = "Tongues"
 	description = "A recent attack by Mime extremists has left staff at Station 23 speechless. Ship some spare tongues."
-	reward = 10000
+	reward = CARGO_CRATE_VALUE * 20
 	required_count = 3
 	wanted_types = list(/obj/item/organ/tongue)
 
 /datum/bounty/item/medical/lizard_tail
 	name = "Lizard Tail"
 	description = "The Wizard Federation has made off with Nanotrasen's supply of lizard tails. While CentCom is dealing with the wizards, can the station spare a tail of their own?"
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	wanted_types = list(/obj/item/organ/tail/lizard)
 
 /datum/bounty/item/medical/cat_tail
 	name = "Cat Tail"
 	description = "Central Command has run out of heavy duty pipe cleaners. Can you ship over a cat tail to help us out?"
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	wanted_types = list(/obj/item/organ/tail/cat)
 
 /datum/bounty/item/medical/chainsaw
 	name = "Chainsaw"
 	description = "A CMO at CentCom is having trouble operating on golems. She requests one chainsaw, please."
-	reward = 2500
+	reward = CARGO_CRATE_VALUE * 5
 	wanted_types = list(/obj/item/chainsaw)
 
 /datum/bounty/item/medical/tail_whip //Like the cat tail bounties, with more processing.
 	name = "Nine Tails whip"
 	description = "Commander Jackson is looking for a fine addition to her exotic weapons collection. She will reward you handsomely for either a Cat or Liz o' Nine Tails."
-	reward = 4000
+	reward = CARGO_CRATE_VALUE * 8
 	wanted_types = list(/obj/item/melee/chainofcommand/tailwhip)
 
 /datum/bounty/item/medical/surgerycomp
 	name = "Surgery Computer"
 	description = "After another freak bombing incident at our annual cheesefest at centcom, we have a massive stack of injured crew on our end. Please send us a fresh surgery computer, if at all possible."
-	reward = 6000
+	reward = CARGO_CRATE_VALUE * 12
 	wanted_types = list(/obj/machinery/computer/operating)
 
 /datum/bounty/item/medical/surgerytable
 	name = "Operating Table"
 	description = "After a recent influx of infected crew members recently, we've seen that masks just aren't cutting it alone. Silver Operating tables might just do the trick though, send us one to use."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	wanted_types = list(/obj/structure/table/optable)

--- a/code/modules/cargo/bounties/mining.dm
+++ b/code/modules/cargo/bounties/mining.dm
@@ -1,71 +1,71 @@
 /datum/bounty/item/mining/goliath_steaks
 	name = "Lava-Cooked Goliath Steaks"
 	description = "Admiral Pavlov has gone on hunger strike ever since the canteen started serving only monkey and monkey byproducts. She is demanding lava-cooked Goliath steaks."
-	reward = 5000
+	reward = CARGO_CRATE_VALUE * 10
 	required_count = 3
 	wanted_types = list(/obj/item/food/meat/steak/goliath)
 
 /datum/bounty/item/mining/goliath_boat
 	name = "Goliath Hide Boat"
 	description = "Commander Menkov wants to participate in the annual Lavaland Regatta. He is asking your shipwrights to build the swiftest boat known to man."
-	reward = 10000
+	reward = CARGO_CRATE_VALUE * 20
 	wanted_types = list(/obj/vehicle/ridden/lavaboat)
 
 /datum/bounty/item/mining/bone_oar
 	name = "Bone Oars"
 	description = "Commander Menkov requires oars to participate in the annual Lavaland Regatta. Ship a pair over."
-	reward = 4000
+	reward = CARGO_CRATE_VALUE * 8
 	required_count = 2
 	wanted_types = list(/obj/item/oar)
 
 /datum/bounty/item/mining/bone_axe
 	name = "Bone Axe"
 	description = "Station 12 has had their fire axes stolen by marauding clowns. Ship them a bone axe as a replacement."
-	reward = 7500
+	reward = CARGO_CRATE_VALUE * 15
 	wanted_types = list(/obj/item/fireaxe/boneaxe)
 
 /datum/bounty/item/mining/bone_armor
 	name = "Bone Armor"
 	description = "Station 14 has volunteered their lizard crew for ballistic armor testing. Ship over some bone armor."
-	reward = 5000
+	reward = CARGO_CRATE_VALUE * 10
 	wanted_types = list(/obj/item/clothing/suit/armor/bone)
 
 /datum/bounty/item/mining/skull_helmet
 	name = "Skull Helmet"
 	description = "Station 42's Head of Security has her birthday tomorrow! We want to suprise her with a fashionable skull helmet."
-	reward = 4000
+	reward = CARGO_CRATE_VALUE * 8
 	wanted_types = list(/obj/item/clothing/head/helmet/skull)
 
 /datum/bounty/item/mining/bone_talisman
 	name = "Bone Talismans"
 	description = "Station 14's Research Director claims that pagan bone talismans protect their wearer. Ship them a few so they can start testing."
-	reward = 7500
+	reward = CARGO_CRATE_VALUE * 15
 	required_count = 3
 	wanted_types = list(/obj/item/clothing/accessory/talisman)
 
 /datum/bounty/item/mining/bone_dagger
 	name = "Bone Daggers"
 	description = "Central Command's canteen is undergoing budget cuts. Ship over some bone daggers so our Chef can keep working."
-	reward = 5000
+	reward = CARGO_CRATE_VALUE * 10
 	required_count = 3
 	wanted_types = list(/obj/item/kitchen/knife/combat/bone)
 
 /datum/bounty/item/mining/polypore_mushroom
 	name = "Mushroom Bowl"
 	description = "Lieutenant Jeb dropped his favorite mushroom bowl. Cheer him up by shipping a new one, will you?"
-	reward = 7500 //5x mushroom shavings
+	reward = CARGO_CRATE_VALUE * 15 //5x mushroom shavings
 	wanted_types = list(/obj/item/reagent_containers/glass/bowl/mushroom_bowl)
 
 /datum/bounty/item/mining/inocybe_mushroom
 	name = "Mushroom Caps"
 	description = "Our botanist claims that he can distill tasty liquor from absolutely any plant. Let's see what he'll do with Inocybe mushroom caps."
-	reward = 4500
+	reward = CARGO_CRATE_VALUE * 9
 	required_count = 3
 	wanted_types = list(/obj/item/food/grown/ash_flora/mushroom_cap)
 
 /datum/bounty/item/mining/porcini_mushroom
 	name = "Mushroom Leaves"
 	description = "Porcini mushroom leaves are rumored to have healing properties. Our researchers want to put that claim to the test."
-	reward = 4500
+	reward = CARGO_CRATE_VALUE * 9
 	required_count = 3
 	wanted_types = list(/obj/item/food/grown/ash_flora/mushroom_leaf)

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -33,7 +33,7 @@
 
 /datum/bounty/reagent/simple_drink
 	name = "Simple Drink"
-	reward = 1500
+	reward = CARGO_CRATE_VALUE * 3
 
 /datum/bounty/reagent/simple_drink/New()
 	// Don't worry about making this comprehensive. It doesn't matter if some drinks are skipped.
@@ -89,7 +89,7 @@
 
 /datum/bounty/reagent/complex_drink
 	name = "Complex Drink"
-	reward = 4000
+	reward = CARGO_CRATE_VALUE * 8
 
 /datum/bounty/reagent/complex_drink/New()
 	// Don't worry about making this comprehensive. It doesn't matter if some drinks are skipped.
@@ -122,7 +122,7 @@
 
 /datum/bounty/reagent/chemical_simple
 	name = "Simple Chemical"
-	reward = 4000
+	reward = CARGO_CRATE_VALUE * 8
 	required_volume = 30
 
 /datum/bounty/reagent/chemical_simple/New()
@@ -160,7 +160,7 @@
 
 /datum/bounty/reagent/chemical_complex
 	name = "Rare Chemical"
-	reward = 6000
+	reward = CARGO_CRATE_VALUE * 12
 	required_volume = 20
 
 /datum/bounty/reagent/chemical_complex/New()
@@ -227,7 +227,7 @@
 
 /datum/bounty/pill/simple_pill
 	name = "Simple Pill"
-	reward = 10000
+	reward = CARGO_CRATE_VALUE * 20
 
 /datum/bounty/pill/simple_pill/New()
 	//reagent that are possible to be chem factory'd
@@ -255,4 +255,4 @@
 	required_ammount += rand(1,60)
 	wanted_vol += rand(1,20)
 	description = "CentCom requires [required_ammount] of [name] containing at least [wanted_vol] each. Ship a container of it to be rewarded."
-	reward += rand(1, 5) * 3000
+	reward += rand(1, 5) * (CARGO_CRATE_VALUE * 6)

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -2,7 +2,7 @@
 /datum/bounty/item/science/relic
 	name = "E.X.P.E.R.I-MENTORially Discovered Devices"
 	description = "Psst, hey. Don't tell the assistants, but we're undercutting them on the value of those 'strange objects' they've been finding. Fish one up and send us a discovered one by using the E.X.P.E.R.I-MENTOR."
-	reward = 4000
+	reward = CARGO_CRATE_VALUE * 8
 	wanted_types = list(/obj/item/relic)
 
 /datum/bounty/item/science/relic/applies_to(obj/O)
@@ -16,13 +16,13 @@
 /datum/bounty/item/science/bepis_disc
 	name = "Reformatted Tech Disk"
 	description = "It turns out the diskettes the BEPIS prints experimental nodes on are extremely space-efficient. Send us one of your spares when you're done with it."
-	reward = 4000
+	reward = CARGO_CRATE_VALUE * 8
 	wanted_types = list(/obj/item/disk/tech_disk/major, /obj/item/disk/tech_disk/spaceloot)
 
 /datum/bounty/item/science/genetics
 	name = "Genetics Disability Mutator"
 	description = "Understanding the humanoid genome is the first step to curing many spaceborn genetic defects, and exceeding our basest limits."
-	reward = 1000
+	reward = CARGO_CRATE_VALUE * 2
 	wanted_types = list(/obj/item/dnainjector)
 	///What's the instability
 	var/desired_instability = 0
@@ -30,7 +30,7 @@
 /datum/bounty/item/science/genetics/New()
 	. = ..()
 	desired_instability = rand(10,40)
-	reward += desired_instability * 100
+	reward += desired_instability * (CARGO_CRATE_VALUE * 0.2)
 	description += " We want a DNA injector whose total instability is higher than [desired_instability] points."
 
 /datum/bounty/item/science/genetics/applies_to(obj/O)
@@ -53,21 +53,21 @@
 /datum/bounty/item/science/NTNet
 	name = "Modular Tablets"
 	description = "Turns out that NTNet wasn't actually a fad afterall, who knew. Ship us some fully constructed tablets and send it turned on."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	required_count = 4
 	wanted_types = list(/obj/item/modular_computer/tablet)
 
 /datum/bounty/item/science/NTNet/laptops
 	name = "Modular Laptops"
 	description = "Central command brass need something more powerful than a tablet, but more portable than a console. Help these old fogeys out by shipping us some working laptops. Send it turned on."
-	reward = 1500
+	reward = CARGO_CRATE_VALUE * 3
 	required_count = 2
 	wanted_types = list(/obj/item/modular_computer/laptop)
 
 /datum/bounty/item/science/NTNet/console
 	name = "Modular Computer Console"
 	description = "Our big data devision needs more powerful hardware to play 'Outbomb Cuban Pe-', err, to closely monitor threats in your sector. Send us a working modular computer console."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	required_count = 1
 	wanted_types = list(/obj/machinery/modular_computer/console)
 

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -1,47 +1,47 @@
 /datum/bounty/item/security/riotshotgun
 	name = "Riot Shotguns"
 	description = "Hooligans have boarded CentCom! Ship riot shotguns quick, or things are going to get dirty."
-	reward = 5000
+	reward = CARGO_CRATE_VALUE * 10
 	required_count = 2
 	wanted_types = list(/obj/item/gun/ballistic/shotgun/riot)
 
 /datum/bounty/item/security/recharger
 	name = "Rechargers"
 	description = "Nanotrasen military academy is conducting marksmanship exercises. They request that rechargers be shipped."
-	reward = 2000
+	reward = CARGO_CRATE_VALUE * 4
 	required_count = 3
 	wanted_types = list(/obj/machinery/recharger)
 
 /datum/bounty/item/security/pepperspray
 	name = "Pepperspray"
 	description = "We've been having a bad run of riots on Space Station 76. We could use some new pepperspray cans."
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 	required_count = 4
 	wanted_types = list(/obj/item/reagent_containers/spray/pepper)
 
 /datum/bounty/item/security/prison_clothes
 	name = "Prison Uniforms"
 	description = "Terragov has been unable to source any new prisoner uniforms, so if you have any spares, we'll take them off your hands."
-	reward = 2000
+	reward = CARGO_CRATE_VALUE * 4
 	required_count = 4
 	wanted_types = list(/obj/item/clothing/under/rank/prisoner)
 
 /datum/bounty/item/security/plates
 	name = "License Plates"
 	description = "As a result of a bad clown car crash, we could use an advance on some of your prisoner's license plates."
-	reward = 1000
+	reward = CARGO_CRATE_VALUE * 2
 	required_count = 10
 	wanted_types = list(/obj/item/stack/license_plates/filled)
 
 /datum/bounty/item/security/earmuffs
 	name = "Earmuffs"
 	description = "Central Command is getting tired of your station's messages. They've ordered that you ship some earmuffs to lessen the annoyance."
-	reward = 1000
+	reward = CARGO_CRATE_VALUE * 2
 	wanted_types = list(/obj/item/clothing/ears/earmuffs)
 
 /datum/bounty/item/security/handcuffs
 	name = "Handcuffs"
 	description = "A large influx of escaped convicts have arrived at Central Command. Now is the perfect time to ship out spare handcuffs (or restraints)."
-	reward = 1000
+	reward = CARGO_CRATE_VALUE * 2
 	required_count = 5
 	wanted_types = list(/obj/item/restraints/handcuffs)

--- a/code/modules/cargo/bounties/slime.dm
+++ b/code/modules/cargo/bounties/slime.dm
@@ -1,5 +1,5 @@
 /datum/bounty/item/slime
-	reward = 3000
+	reward = CARGO_CRATE_VALUE * 6
 
 /datum/bounty/item/slime/New()
 	..()

--- a/code/modules/cargo/bounties/special.dm
+++ b/code/modules/cargo/bounties/special.dm
@@ -1,14 +1,14 @@
 /datum/bounty/item/alien_organs
 	name = "Alien Organs"
 	description = "Nanotrasen is interested in studying Xenomorph biology. Ship a set of organs to be thoroughly compensated."
-	reward = 25000
+	reward = CARGO_CRATE_VALUE * 50
 	required_count = 3
 	wanted_types = list(/obj/item/organ/brain/alien, /obj/item/organ/alien, /obj/item/organ/body_egg/alien_embryo, /obj/item/organ/liver/alien, /obj/item/organ/tongue/alien, /obj/item/organ/eyes/night_vision/alien)
 
 /datum/bounty/item/syndicate_documents
 	name = "Syndicate Documents"
 	description = "Intel regarding the syndicate is highly prized at CentCom. If you find syndicate documents, ship them. You could save lives."
-	reward = 15000
+	reward = CARGO_CRATE_VALUE * 30
 	wanted_types = list(/obj/item/documents/syndicate, /obj/item/documents/photocopy)
 
 /datum/bounty/item/syndicate_documents/applies_to(obj/O)
@@ -22,14 +22,14 @@
 /datum/bounty/item/adamantine
 	name = "Adamantine"
 	description = "Nanotrasen's anomalous materials division is in desparate need for Adamantine. Send them a large shipment and we'll make it worth your while."
-	reward = 35000
+	reward = CARGO_CRATE_VALUE * 70
 	required_count = 10
 	wanted_types = list(/obj/item/stack/sheet/mineral/adamantine)
 
 /datum/bounty/item/trash
 	name = "Trash"
 	description = "Recently a group of janitors have run out of trash to clean up, without any trash CentCom wants to fire them to cut costs. Send a shipment of trash to keep them employed, and they'll give you a small compensation."
-	reward = 1000
+	reward = CARGO_CRATE_VALUE * 2
 	required_count = 10
 	wanted_types = list(/obj/item/trash)
 

--- a/code/modules/cargo/bounties/virus.dm
+++ b/code/modules/cargo/bounties/virus.dm
@@ -1,5 +1,5 @@
 /datum/bounty/virus
-	reward = 5000
+	reward = CARGO_CRATE_VALUE * 10
 	var/shipped = FALSE
 	var/stat_value = 0
 	var/stat_name = ""
@@ -11,7 +11,7 @@
 		stat_value *= -1
 	name = "Virus ([stat_name] of [stat_value])"
 	description = "Nanotrasen is interested in a virus with a [stat_name] stat of exactly [stat_value]. Central Command will pay handsomely for such a virus."
-	reward += rand(0, 4) * 500
+	reward += rand(0, 4) * CARGO_CRATE_VALUE
 
 /datum/bounty/virus/completion_string()
 	return shipped ? "Shipped" : "Not Shipped"

--- a/code/modules/cargo/exports/gear.dm
+++ b/code/modules/cargo/exports/gear.dm
@@ -1,105 +1,105 @@
 /datum/export/gear
 
 /datum/export/gear/sec_helmet
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "helmet"
 	export_types = list(/obj/item/clothing/head/helmet/sec)
 
 /datum/export/gear/sec_armor
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "armor vest"
 	export_types = list(/obj/item/clothing/suit/armor/vest)
 
 /datum/export/gear/riot_shield
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "riot shield"
 	export_types = list(/obj/item/shield/riot)
 
 
 /datum/export/gear/mask/breath
-	cost = 2
+	cost = CARGO_CRATE_VALUE * 0.01
 	unit_name = "breath mask"
 	export_types = list(/obj/item/clothing/mask/breath)
 
 /datum/export/gear/mask/gas
-	cost = 10
+	cost = CARGO_CRATE_VALUE * 0.05
 	unit_name = "gas mask"
 	export_types = list(/obj/item/clothing/mask/gas)
 	include_subtypes = FALSE
 
 
 /datum/export/gear/space/helmet
-	cost = 75
+	cost = CARGO_CRATE_VALUE * 0.15
 	unit_name = "space helmet"
 	export_types = list(/obj/item/clothing/head/helmet/space, /obj/item/clothing/head/helmet/space/eva, /obj/item/clothing/head/helmet/space/nasavoid)
 	include_subtypes = FALSE
 
 /datum/export/gear/space/suit
-	cost = 150
+	cost = CARGO_CRATE_VALUE * 0.3
 	unit_name = "space suit"
 	export_types = list(/obj/item/clothing/suit/space, /obj/item/clothing/suit/space/eva, /obj/item/clothing/suit/space/nasavoid)
 	include_subtypes = FALSE
 
 
 /datum/export/gear/space/syndiehelmet
-	cost = 150
+	cost = CARGO_CRATE_VALUE * 0.3
 	unit_name = "Syndicate space helmet"
 	export_types = list(/obj/item/clothing/head/helmet/space/syndicate)
 
 /datum/export/gear/space/syndiesuit
-	cost = 300
+	cost = CARGO_CRATE_VALUE * 0.6
 	unit_name = "Syndicate space suit"
 	export_types = list(/obj/item/clothing/suit/space/syndicate)
 
 
 /datum/export/gear/radhelmet
-	cost = 50
+	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "radsuit hood"
 	export_types = list(/obj/item/clothing/head/radiation)
 
 /datum/export/gear/radsuit
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.2
 	unit_name = "radsuit"
 	export_types = list(/obj/item/clothing/suit/radiation)
 
 /datum/export/gear/biohood
-	cost = 50
+	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "biosuit hood"
 	export_types = list(/obj/item/clothing/head/bio_hood)
 
 /datum/export/gear/biosuit
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.2
 	unit_name = "biosuit"
 	export_types = list(/obj/item/clothing/suit/bio_suit)
 
 /datum/export/gear/bombhelmet
-	cost = 50
+	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "bomb suit hood"
 	export_types = list(/obj/item/clothing/head/bomb_hood)
 
 /datum/export/gear/bombsuit
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.2
 	unit_name = "bomb suit"
 	export_types = list(/obj/item/clothing/suit/bomb_suit)
 
 /datum/export/gear/lizardboots
-	cost = 350
+	cost = CARGO_CRATE_VALUE * 0.7
 	unit_name = "lizard skin boots"
 	export_types = list(/obj/item/clothing/shoes/cowboy/lizard)
 	include_subtypes = FALSE
 
 /datum/export/gear/lizardmasterwork
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	unit_name = "Hugs-the-Feet lizard boots"
 	export_types = list(/obj/item/clothing/shoes/cowboy/lizard/masterwork)
 
 /datum/export/gear/bilton
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 5
 	unit_name = "bilton wrangler boots"
 	export_types = list(/obj/item/clothing/shoes/cowboy/fancy)
 
 /datum/export/gear/ebonydie
-	cost = 500
+	cost = CARGO_CRATE_VALUE
 	unit_name = "ebony die"
 	export_types = list(/obj/item/dice/d6/ebony)
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -32,7 +32,7 @@
 	export_types = list(/obj/structure/closet/crate/coffin)
 
 /datum/export/large/reagent_dispenser
-	cost = 100 // +0-400 depending on amount of reagents left
+	cost = CARGO_CRATE_VALUE * 0.5 // +0-400 depending on amount of reagents left
 	var/contents_cost = 400
 
 /datum/export/large/reagent_dispenser/get_cost(obj/O)
@@ -52,57 +52,57 @@
 
 /datum/export/large/reagent_dispenser/beer
 	unit_name = "beer keg"
-	contents_cost = 700
+	contents_cost = CARGO_CRATE_VALUE * 3.5
 	export_types = list(/obj/structure/reagent_dispensers/beerkeg)
 
 
 /datum/export/large/pipedispenser
-	cost = 500
+	cost = CARGO_CRATE_VALUE * 2.5
 	unit_name = "pipe dispenser"
 	export_types = list(/obj/machinery/pipedispenser)
 
 /datum/export/large/emitter
-	cost = 550
+	cost = CARGO_CRATE_VALUE * 2.75
 	unit_name = "emitter"
 	export_types = list(/obj/machinery/power/emitter)
 
 /datum/export/large/field_generator
-	cost = 550
+	cost = CARGO_CRATE_VALUE * 2.75
 	unit_name = "field generator"
 	export_types = list(/obj/machinery/field/generator)
 
 /datum/export/large/collector
-	cost = 400
+	cost = CARGO_CRATE_VALUE * 2
 	unit_name = "radiation collector"
 	export_types = list(/obj/machinery/power/rad_collector)
 
 /datum/export/large/tesla_coil
-	cost = 450
+	cost = CARGO_CRATE_VALUE * 2.25
 	unit_name = "tesla coil"
 	export_types = list(/obj/machinery/power/tesla_coil)
 
 /datum/export/large/supermatter
-	cost = 8000
+	cost = CARGO_CRATE_VALUE * 16
 	unit_name = "supermatter shard"
 	export_types = list(/obj/machinery/power/supermatter_crystal/shard)
 
 /datum/export/large/grounding_rod
-	cost = 350
+	cost = CARGO_CRATE_VALUE * 1.75
 	unit_name = "grounding rod"
 	export_types = list(/obj/machinery/power/grounding_rod)
 
 /datum/export/large/iv
-	cost = 50
+	cost = CARGO_CRATE_VALUE * 0.25
 	unit_name = "iv drip"
 	export_types = list(/obj/machinery/iv_drip)
 
 /datum/export/large/barrier
-	cost = 25
+	cost = CARGO_CRATE_VALUE * 0.25
 	unit_name = "security barrier"
 	export_types = list(/obj/item/grenade/barrier, /obj/structure/barricade/security)
 
 /datum/export/large/gas_canister
-	cost = 10 //Base cost of canister. You get more for nice gases inside.
+	cost = CARGO_CRATE_VALUE * 0.05 //Base cost of canister. You get more for nice gases inside.
 	unit_name = "Gas Canister"
 	export_types = list(/obj/machinery/portable_atmospherics/canister)
 	k_elasticity = 0.00033

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -87,7 +87,7 @@
 	export_types = list(/obj/machinery/power/supermatter_crystal/shard)
 
 /datum/export/large/grounding_rod
-	cost = CARGO_CRATE_VALUE * 1.75
+	cost = CARGO_CRATE_VALUE * 1.2
 	unit_name = "grounding rod"
 	export_types = list(/obj/machinery/power/grounding_rod)
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -1,5 +1,5 @@
 /datum/export/large/crate
-	cost = 500
+	cost = CARGO_CRATE_VALUE
 	k_elasticity = 0
 	unit_name = "crate"
 	export_types = list(/obj/structure/closet/crate)
@@ -11,7 +11,7 @@
 		. += " Thanks for participating in Nanotrasen Crates Recycling Program."
 
 /datum/export/large/crate/wooden
-	cost = 100
+	cost = CARGO_CRATE_VALUE/5
 	unit_name = "large wooden crate"
 	export_types = list(/obj/structure/closet/crate/large)
 	exclude_types = list()
@@ -21,13 +21,13 @@
 	export_types = list(/obj/structure/ore_box)
 
 /datum/export/large/crate/wood
-	cost = 240
+	cost = CARGO_CRATE_VALUE * 0.48
 	unit_name = "wooden crate"
 	export_types = list(/obj/structure/closet/crate/wooden)
 	exclude_types = list()
 
 /datum/export/large/crate/coffin
-	cost = 250//50 wooden crates cost 2000 points, and you can make 10 coffins in seconds with those planks. Each coffin selling for 250 means you can make a net gain of 500 points for wasting your time making coffins.
+	cost = CARGO_CRATE_VALUE/2 //50 wooden crates cost 2000 points, and you can make 10 coffins in seconds with those planks. Each coffin selling for 250 means you can make a net gain of 500 points for wasting your time making coffins.
 	unit_name = "coffin"
 	export_types = list(/obj/structure/closet/crate/coffin)
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -127,7 +127,7 @@
 								/datum/gas/halon
 								)
 
-	var/list/gas_prices = list(/datum/gas/bz = 4,
+	var/list/gas_prices = list(/datum/gas/bz = 2,
 								/datum/gas/stimulum = 100,
 								/datum/gas/hypernoblium = 5,
 								/datum/gas/miasma = 2,

--- a/code/modules/cargo/exports/lavaland.dm
+++ b/code/modules/cargo/exports/lavaland.dm
@@ -2,7 +2,7 @@
 //Consumable or one-use items like the magic D20 and gluttony's blessing are omitted
 
 /datum/export/lavaland/minor
-	cost = 10000
+	cost = CARGO_CRATE_VALUE * 20
 	unit_name = "minor lava planet artifact"
 	export_types = list(/obj/item/immortality_talisman,
 						/obj/item/book_of_babel,
@@ -28,7 +28,7 @@
 						/obj/item/veilrender/vealrender)
 
 /datum/export/lavaland/major //valuable chest/ruin loot and staff of storms
-	cost = 20000
+	cost = CARGO_CRATE_VALUE * 40
 	unit_name = "lava planet artifact"
 	export_types = list(/obj/item/guardiancreator,
 						/obj/item/rod_of_asclepius,
@@ -39,7 +39,7 @@
 //Megafauna loot, except for ash drakes and legion
 
 /datum/export/lavaland/megafauna
-	cost = 40000
+	cost = CARGO_CRATE_VALUE * 80
 	unit_name = "major lava planet artifact"
 	export_types = list(/obj/item/hierophant_club,
 						/obj/item/melee/transforming/cleaving_saw,
@@ -54,11 +54,11 @@
 		. += " On behalf of the Nanotrasen RnD division: Thank you for your hard work."
 
 /datum/export/lavaland/megafauna/hev/suit
-	cost = 30000
+	cost = CARGO_CRATE_VALUE * 60
 	unit_name = "H.E.C.K. suit"
 	export_types = list(/obj/item/clothing/suit/space/hostile_environment)
 
 /datum/export/lavaland/megafauna/hev/helmet
-	cost = 10000
+	cost = CARGO_CRATE_VALUE * 20
 	unit_name = "H.E.C.K. helmet"
 	export_types = list(/obj/item/clothing/head/helmet/space/hostile_environment)

--- a/code/modules/cargo/exports/manifest.dm
+++ b/code/modules/cargo/exports/manifest.dm
@@ -1,7 +1,7 @@
 // Approved manifest.
-// +200 credits flat.
+// +80 credits flat.
 /datum/export/manifest_correct
-	cost = 200
+	cost =  CARGO_CRATE_VALUE 0.4
 	k_elasticity = 0
 	unit_name = "approved manifest"
 	export_types = list(/obj/item/paper/fluff/jobs/cargo/manifest)
@@ -18,7 +18,7 @@
 // Correctly denied manifest.
 // Refunds the package cost minus the cost of crate.
 /datum/export/manifest_error_denied
-	cost = -500
+	cost = -CARGO_CRATE_VALUE
 	k_elasticity = 0
 	unit_name = "correctly denied manifest"
 	export_types = list(/obj/item/paper/fluff/jobs/cargo/manifest)

--- a/code/modules/cargo/exports/manifest.dm
+++ b/code/modules/cargo/exports/manifest.dm
@@ -60,7 +60,7 @@
 // Erroneously denied manifest.
 // Substracts the package cost minus the cost of crate.
 /datum/export/manifest_correct_denied
-	cost = 500
+	cost = CARGO_CRATE_VALUE
 	unit_name = "erroneously denied manifest"
 	export_types = list(/obj/item/paper/fluff/jobs/cargo/manifest)
 

--- a/code/modules/cargo/exports/manifest.dm
+++ b/code/modules/cargo/exports/manifest.dm
@@ -1,7 +1,7 @@
 // Approved manifest.
 // +80 credits flat.
 /datum/export/manifest_correct
-	cost =  CARGO_CRATE_VALUE 0.4
+	cost =  CARGO_CRATE_VALUE * 0.4
 	k_elasticity = 0
 	unit_name = "approved manifest"
 	export_types = list(/obj/item/paper/fluff/jobs/cargo/manifest)

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -27,68 +27,68 @@
 // Materials. Nothing but plasma is really worth selling. Better leave it all to RnD and sell some plasma instead.
 
 /datum/export/material/bananium
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	material_id = /datum/material/bananium
 	message = "cm3 of bananium"
 
 /datum/export/material/diamond
-	cost = 500
+	cost = CARGO_CRATE_VALUE
 	material_id = /datum/material/diamond
 	message = "cm3 of diamonds"
 
 /datum/export/material/plasma
-	cost = 200
+	cost = CARGO_CRATE_VALUE * 0.4
 	k_elasticity = 0
 	material_id = /datum/material/plasma
 	message = "cm3 of plasma"
 
 /datum/export/material/uranium
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.2
 	material_id = /datum/material/uranium
 	message = "cm3 of uranium"
 
 /datum/export/material/gold
-	cost = 125
+	cost = CARGO_CRATE_VALUE * 0.25
 	material_id = /datum/material/gold
 	message = "cm3 of gold"
 
 /datum/export/material/silver
-	cost = 50
+	cost = CARGO_CRATE_VALUE * 0.1
 	material_id = /datum/material/silver
 	message = "cm3 of silver"
 
 /datum/export/material/titanium
-	cost = 125
+	cost = CARGO_CRATE_VALUE * 0.25
 	material_id = /datum/material/titanium
 	message = "cm3 of titanium"
 
 /datum/export/material/adamantine
-	cost = 500
+	cost = CARGO_CRATE_VALUE
 	material_id = /datum/material/adamantine
 	message = "cm3 of adamantine"
 
 /datum/export/material/mythril
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	material_id = /datum/material/mythril
 	message = "cm3 of mythril"
 
 /datum/export/material/bscrystal
-	cost = 300
+	cost = CARGO_CRATE_VALUE * 0.6
 	message = "of bluespace crystals"
 	material_id = /datum/material/bluespace
 
 /datum/export/material/plastic
-	cost = 25
+	cost = CARGO_CRATE_VALUE * 0.05
 	message = "cm3 of plastic"
 	material_id = /datum/material/plastic
 
 /datum/export/material/runite
-	cost = 600
+	cost = CARGO_CRATE_VALUE * 1.2
 	message = "cm3 of runite"
 	material_id = /datum/material/runite
 
 /datum/export/material/metal
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.01
 	message = "cm3 of metal"
 	material_id = /datum/material/iron
 	export_types = list(
@@ -96,20 +96,20 @@
 		/obj/item/stack/rods, /obj/item/stack/ore, /obj/item/coin)
 
 /datum/export/material/glass
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.01
 	message = "cm3 of glass"
 	material_id = /datum/material/glass
 	export_types = list(/obj/item/stack/sheet/glass, /obj/item/stack/ore,
 		/obj/item/shard)
 
 /datum/export/material/hot_ice
-	cost = 400
+	cost = CARGO_CRATE_VALUE * 0.8
 	message = "cm3 of Hot Ice"
 	material_id = /datum/material/hot_ice
 	export_types = /obj/item/stack/sheet/hot_ice
 
 /datum/export/material/metal_hydrogen
-	cost = 550
+	cost = CARGO_CRATE_VALUE * 1.05
 	unit_name = "of metallic hydrogen"
 	material_id = /datum/material/metalhydrogen
 	export_types = /obj/item/stack/sheet/mineral/metal_hydrogen

--- a/code/modules/cargo/exports/organs.dm
+++ b/code/modules/cargo/exports/organs.dm
@@ -3,53 +3,53 @@
 	export_category = EXPORT_CONTRABAND
 
 /datum/export/organ/heart
-	cost = 10 //For the man who has everything and nothing.
+	cost = CARGO_CRATE_VALUE * 0.2 //For the man who has everything and nothing.
 	unit_name = "humanoid heart"
 	export_types = list(/obj/item/organ/heart)
 
 /datum/export/organ/eyes
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "humanoid eyes"
 	export_types = list(/obj/item/organ/eyes)
 
 /datum/export/organ/ears
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "humanoid ears"
 	export_types = list(/obj/item/organ/ears)
 
 /datum/export/organ/liver
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "humanoid liver"
 	export_types = list(/obj/item/organ/liver)
 
 /datum/export/organ/lungs
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "humanoid lungs"
 	export_types = list(/obj/item/organ/lungs)
 
 /datum/export/organ/stomach
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "humanoid stomach"
 	export_types = list(/obj/item/organ/stomach)
 
 /datum/export/organ/tongue
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "humanoid tounge"
 	export_types = list(/obj/item/organ/tongue)
 
 /datum/export/organ/tail/lizard
-	cost = 250
+	cost = CARGO_CRATE_VALUE * 1.25
 	unit_name = "lizard tail"
 	export_types = list(/obj/item/organ/tail/lizard)
 
 
 /datum/export/organ/tail/cat
-	cost = 300
+	cost = CARGO_CRATE_VALUE * 1.5
 	unit_name = "cat tail"
 	export_types = list(/obj/item/organ/tail/cat)
 
 /datum/export/organ/ears/cat
-	cost = 200
+	cost = CARGO_CRATE_VALUE
 	unit_name = "cat ears"
 	export_types = list(/obj/item/organ/ears/cat)
 

--- a/code/modules/cargo/exports/parts.dm
+++ b/code/modules/cargo/exports/parts.dm
@@ -1,23 +1,23 @@
 // Circuit boards, spare parts, etc.
 
 /datum/export/solar/assembly
-	cost = 50
+	cost = CARGO_CRATE_VALUE * 0.25
 	unit_name = "solar panel assembly"
 	export_types = list(/obj/item/solar_assembly)
 
 /datum/export/solar/tracker_board
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "solar tracker board"
 	export_types = list(/obj/item/electronics/tracker)
 
 /datum/export/solar/control_board
-	cost = 150
+	cost = CARGO_CRATE_VALUE * 0.75
 	unit_name = "solar panel control board"
 	export_types = list(/obj/item/circuitboard/computer/solar_control)
 
 //Computer Tablets and Parts
 /datum/export/modular_part
-	cost = 15
+	cost = CARGO_CRATE_VALUE * 0.075
 	unit_name = "miscellaneous computer part"
 	export_types = list(/obj/item/computer_hardware)
 	include_subtypes = TRUE
@@ -25,13 +25,13 @@
 //Processors.
 
 /datum/export/modular_part/processor
-	cost = 40
+	cost = CARGO_CRATE_VALUE * 0.2
 	unit_name = "computer processor"
 	export_types = list(/obj/item/computer_hardware/processor_unit)
 	include_subtypes = FALSE
 
 /datum/export/modular_part/processor/photoic
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "advanced computer processor"
 	export_types = list(/obj/item/computer_hardware/processor_unit)
 	include_subtypes = FALSE
@@ -39,21 +39,21 @@
 //Batteries.
 
 /datum/export/modular_part/battery
-	cost = 40
+	cost = CARGO_CRATE_VALUE * 0.2
 	unit_name = "computer power cell"
 	export_types = list(/obj/item/stock_parts/cell/computer/nano)
 	include_subtypes = FALSE
 
 
 /datum/export/modular_part/battery/upgraded
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "upgraded computer power cell"
 	export_types = list(/obj/item/stock_parts/cell/computer/micro)
 	include_subtypes = FALSE
 
 
 /datum/export/modular_part/battery/advanced
-	cost = 150
+	cost = CARGO_CRATE_VALUE * 0.75
 	unit_name = "advanced computer power cell"
 	export_types = list(/obj/item/stock_parts/cell/computer)
 	include_subtypes = FALSE
@@ -61,38 +61,38 @@
 //Hard Drives.
 
 /datum/export/modular_part/harddrive
-	cost = 10
+	cost = CARGO_CRATE_VALUE * 0.05
 	unit_name = "tiny computer harddrive"
 	export_types = list(/obj/item/computer_hardware/hard_drive/micro)
 	include_subtypes = TRUE
 
 /datum/export/modular_part/harddrive/small
-	cost = 50
+	cost = CARGO_CRATE_VALUE * 0.25
 	unit_name = "small computer harddrive"
 	export_types = list(/obj/item/computer_hardware/hard_drive/small)
 	include_subtypes = FALSE
 
 /datum/export/modular_part/harddrive/normal
-	cost = 80
+	cost = CARGO_CRATE_VALUE * 0.4
 	unit_name = "computer harddrive"
 	export_types = list(/obj/item/computer_hardware/hard_drive)
 	include_subtypes = FALSE
 
 //Networking/Card Parts
 /datum/export/modular_part/networkcard
-	cost = 50
+	cost = CARGO_CRATE_VALUE * 0.25
 	unit_name = "computer network card"
 	export_types = list(/obj/item/computer_hardware/network_card)
 	include_subtypes = TRUE
 
 /datum/export/modular_part/idcard
-	cost = 20
+	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "computer ID card slot"
 	export_types = list(/obj/item/computer_hardware/card_slot)
 	include_subtypes = TRUE
 
 /datum/export/modular_part/intellicard
-	cost = 40
+	cost = CARGO_CRATE_VALUE * 0.2
 	unit_name = "computer intellicard slot"
 	export_types = list(/obj/item/computer_hardware/ai_slot)
 	include_subtypes = TRUE

--- a/code/modules/cargo/exports/seeds.dm
+++ b/code/modules/cargo/exports/seeds.dm
@@ -1,5 +1,5 @@
 /datum/export/seed
-	cost = 50 // Gets multiplied by potency
+	cost = CARGO_CRATE_VALUE * 0.25 // Gets multiplied by potency
 	k_elasticity = 1	//price inelastic/quantity elastic, only need to export a few samples
 	unit_name = "new plant species sample"
 	export_types = list(/obj/item/seeds)
@@ -22,7 +22,7 @@
 
 
 /datum/export/seed/potency
-	cost = 2.5 // Gets multiplied by potency and rarity.
+	cost = CARGO_CRATE_VALUE * 0.0125 // Gets multiplied by potency and rarity.
 	unit_name = "improved plant sample"
 	export_types = list(/obj/item/seeds)
 	needs_discovery = TRUE // Only for already discovered species

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -79,7 +79,7 @@
 	export_types = list(/obj/item/stack/sheet/mineral/plastitanium)
 
 /datum/export/stack/wood
-	cost = CARGO_CRATE_VALUE * 0.15
+	cost = CARGO_CRATE_VALUE * 0.05
 	unit_name = "wood plank"
 	export_types = list(/obj/item/stack/sheet/mineral/wood)
 

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -10,51 +10,51 @@
 // Hides
 
 /datum/export/stack/skin/monkey
-	cost = 50
+	cost = CARGO_CRATE_VALUE * 0.25
 	unit_name = "monkey hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/monkey)
 
 /datum/export/stack/skin/human
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	export_category = EXPORT_CONTRABAND
 	unit_name = "piece"
 	message = "of human skin"
 	export_types = list(/obj/item/stack/sheet/animalhide/human)
 
 /datum/export/stack/skin/goliath_hide
-	cost = 200
+	cost = CARGO_CRATE_VALUE
 	unit_name = "goliath hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/goliath_hide)
 
 /datum/export/stack/skin/cat
-	cost = 150
+	cost = CARGO_CRATE_VALUE * 0.75
 	export_category = EXPORT_CONTRABAND
 	unit_name = "cat hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/cat)
 
 /datum/export/stack/skin/corgi
-	cost = 200
+	cost = CARGO_CRATE_VALUE
 	export_category = EXPORT_CONTRABAND
 	unit_name = "corgi hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/corgi)
 
 /datum/export/stack/skin/lizard
-	cost = 150
+	cost = CARGO_CRATE_VALUE * 0.75
 	unit_name = "lizard hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/lizard)
 
 /datum/export/stack/skin/gondola
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 10
 	unit_name = "gondola hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/gondola)
 
 /datum/export/stack/skin/xeno
-	cost = 500
+	cost = CARGO_CRATE_VALUE * 2.5
 	unit_name = "alien hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/xeno)
 
 /datum/export/stack/licenseplate
-	cost = 25
+	cost = CARGO_CRATE_VALUE * 0.125
 	unit_name = "license plate"
 	export_types = list(/obj/item/stack/license_plates/filled)
 
@@ -63,65 +63,65 @@
 // For base materials, see materials.dm
 
 /datum/export/stack/plasteel
-	cost = 155 // 2000u of plasma + 2000u of metal.
+	cost = CARGO_CRATE_VALUE * 0.41 // 2000u of plasma + 2000u of metal.
 	message = "of plasteel"
 	export_types = list(/obj/item/stack/sheet/plasteel)
 
 // 1 glass + 0.5 metal, cost is rounded up.
 /datum/export/stack/rglass
-	cost = 8
+	cost = CARGO_CRATE_VALUE * 0.02
 	message = "of reinforced glass"
 	export_types = list(/obj/item/stack/sheet/rglass)
 
 /datum/export/stack/plastitanium
-	cost = 325 // plasma + titanium costs
+	cost = CARGO_CRATE_VALUE * 0.65 // plasma + titanium costs
 	message = "of plastitanium"
 	export_types = list(/obj/item/stack/sheet/mineral/plastitanium)
 
 /datum/export/stack/wood
-	cost = 30
+	cost = CARGO_CRATE_VALUE * 0.15
 	unit_name = "wood plank"
 	export_types = list(/obj/item/stack/sheet/mineral/wood)
 
 /datum/export/stack/cloth
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.025
 	message = "rolls of cloth"
 	export_types = list(/obj/item/stack/sheet/cloth)
 
 /datum/export/stack/durathread
-	cost = 70
+	cost = CARGO_CRATE_VALUE * 0.35
 	message = "rolls of durathread"
 	export_types = list(/obj/item/stack/sheet/durathread)
 
 
 /datum/export/stack/cardboard
-	cost = 2
+	cost = CARGO_CRATE_VALUE * 0.01
 	message = "of cardboard"
 	export_types = list(/obj/item/stack/sheet/cardboard)
 
 /datum/export/stack/sandstone
-	cost = 1
+	cost = CARGO_CRATE_VALUE * 0.005
 	unit_name = "block"
 	message = "of sandstone"
 	export_types = list(/obj/item/stack/sheet/mineral/sandstone)
 
 /datum/export/stack/cable
-	cost = 0.2
+	cost = CARGO_CRATE_VALUE * 0.001
 	unit_name = "cable piece"
 	export_types = list(/obj/item/stack/cable_coil)
 
 /datum/export/stack/ammonia_crystals
-	cost = 25
+	cost = CARGO_CRATE_VALUE * 0.125
 	unit_name = "of ammonia crystal"
 	export_types = list(/obj/item/stack/ammonia_crystals)
 
 /datum/export/stack/pizza
-	cost = 12
+	cost = CARGO_CRATE_VALUE * 0.06
 	unit_name = "of sheetza"
 	export_types = list(/obj/item/stack/sheet/pizza)
 
 /datum/export/stack/meat
-	cost = 8
+	cost = CARGO_CRATE_VALUE * 0.04
 	unit_name = "of meat"
 	export_types = list(/obj/item/stack/sheet/meat)
 
@@ -129,6 +129,6 @@
 // Weird Stuff
 
 /datum/export/stack/abductor
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	message = "of alien alloy"
 	export_types = list(/obj/item/stack/sheet/mineral/abductor)

--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -1,5 +1,5 @@
 /datum/export/toolbox
-	cost = 4
+	cost = CARGO_CRATE_VALUE * 0.02
 	unit_name = "toolbox"
 	export_types = list(/obj/item/storage/toolbox)
 
@@ -10,149 +10,149 @@
 
 // Basic tools
 /datum/export/screwdriver
-	cost = 2
+	cost = CARGO_CRATE_VALUE * 0.01
 	unit_name = "screwdriver"
 	export_types = list(/obj/item/screwdriver)
 	include_subtypes = FALSE
 
 /datum/export/wrench
-	cost = 2
+	cost = CARGO_CRATE_VALUE * 0.01
 	unit_name = "wrench"
 	export_types = list(/obj/item/wrench)
 
 /datum/export/crowbar
-	cost = 2
+	cost = CARGO_CRATE_VALUE * 0.01
 	unit_name = "crowbar"
 	export_types = list(/obj/item/crowbar)
 
 /datum/export/wirecutters
-	cost = 2
+	cost = CARGO_CRATE_VALUE * 0.01
 	unit_name = "pair"
 	message = "of wirecutters"
 	export_types = list(/obj/item/wirecutters)
 
 
 /datum/export/weldingtool
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.025
 	unit_name = "welding tool"
 	export_types = list(/obj/item/weldingtool)
 	include_subtypes = FALSE
 
 /datum/export/weldingtool/emergency
-	cost = 2
+	cost = CARGO_CRATE_VALUE * 0.01
 	unit_name = "emergency welding tool"
 	export_types = list(/obj/item/weldingtool/mini)
 
 /datum/export/weldingtool/industrial
-	cost = 10
+	cost = CARGO_CRATE_VALUE * 0.05
 	unit_name = "industrial welding tool"
 	export_types = list(/obj/item/weldingtool/largetank, /obj/item/weldingtool/hugetank)
 
 
 /datum/export/extinguisher
-	cost = 15
+	cost = CARGO_CRATE_VALUE * 0.075
 	unit_name = "fire extinguisher"
 	export_types = list(/obj/item/extinguisher)
 	include_subtypes = FALSE
 
 /datum/export/extinguisher/mini
-	cost = 2
+	cost = CARGO_CRATE_VALUE * 0.01
 	unit_name = "pocket fire extinguisher"
 	export_types = list(/obj/item/extinguisher/mini)
 
 
 /datum/export/flashlight
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.025
 	unit_name = "flashlight"
 	export_types = list(/obj/item/flashlight)
 	include_subtypes = FALSE
 
 /datum/export/flashlight/flare
-	cost = 2
+	cost = CARGO_CRATE_VALUE * 0.01
 	unit_name = "flare"
 	export_types = list(/obj/item/flashlight/flare)
 
 /datum/export/flashlight/seclite
-	cost = 10
+	cost = CARGO_CRATE_VALUE * 0.05
 	unit_name = "seclite"
 	export_types = list(/obj/item/flashlight/seclite)
 
 
 /datum/export/analyzer
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.025
 	unit_name = "analyzer"
 	export_types = list(/obj/item/analyzer)
 
 /datum/export/analyzer/t_scanner
-	cost = 10
+	cost = CARGO_CRATE_VALUE * 0.025
 	unit_name = "t-ray scanner"
 	export_types = list(/obj/item/t_scanner)
 
 
 /datum/export/radio
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.025
 	unit_name = "radio"
 	export_types = list(/obj/item/radio)
 	exclude_types = list(/obj/item/radio/mech)
 
 //Advanced/Power Tools.
 /datum/export/weldingtool/experimental
-	cost = 90
+	cost = CARGO_CRATE_VALUE * 0.45
 	unit_name = "experimental welding tool"
 	export_types = list(/obj/item/weldingtool/experimental)
 
 /datum/export/jawsoflife
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "jaws of life"
 	export_types = list(/obj/item/crowbar/power)
 
 /datum/export/handdrill
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "hand drill"
 	export_types = list(/obj/item/screwdriver/power)
 
 /datum/export/rld_mini
-	cost = 150
+	cost = CARGO_CRATE_VALUE * 0.75
 	unit_name = "mini rapid lighting device"
 	export_types = list(/obj/item/construction/rld/mini)
 
 /datum/export/rsf
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "rapid service fabricator"
 	export_types = list(/obj/item/rsf)
 
 /datum/export/rcd
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "rapid construction device"
 	export_types = list(/obj/item/construction/rcd)
 
 /datum/export/rcd_ammo
-	cost = 60
+	cost = CARGO_CRATE_VALUE * 0.3
 	unit_name = "compressed matter cardridge"
 	export_types = list(/obj/item/rcd_ammo)
 
 /datum/export/rpd
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "rapid pipe dispenser"
 	export_types = list(/obj/item/pipe_dispenser)
 
 //artisanal exports for the mom and pops
 /datum/export/soap
-	cost = 75
+	cost = CARGO_CRATE_VALUE * 0.375
 	unit_name = "soap"
 	export_types = list(/obj/item/soap)
 
 /datum/export/soap/homemade
-	cost = 30
+	cost = CARGO_CRATE_VALUE * 0.15
 	unit_name = "artisanal soap"
 	export_types = list(/obj/item/soap/homemade)
 
 /datum/export/soap/omega
-	cost = 7000
+	cost = CARGO_CRATE_VALUE * 14
 	unit_name = "omega soap"
 	export_types = list(/obj/item/soap/omega)
 
 /datum/export/candle
-	cost = 25
+	cost = CARGO_CRATE_VALUE * 0.125
 	unit_name = "candle"
 	export_types = list(/obj/item/candle)

--- a/code/modules/cargo/exports/weapons.dm
+++ b/code/modules/cargo/exports/weapons.dm
@@ -4,68 +4,68 @@
 	include_subtypes = FALSE
 
 /datum/export/weapon/baton
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "stun baton"
 	export_types = list(/obj/item/melee/baton)
 	exclude_types = list(/obj/item/melee/baton/cattleprod)
 	include_subtypes = TRUE
 
 /datum/export/weapon/knife
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "combat knife"
 	export_types = list(/obj/item/kitchen/knife/combat)
 
 
 /datum/export/weapon/taser
-	cost = 200
+	cost = CARGO_CRATE_VALUE
 	unit_name = "advanced taser"
 	export_types = list(/obj/item/gun/energy/e_gun/advtaser)
 
 /datum/export/weapon/laser
-	cost = 200
+	cost = CARGO_CRATE_VALUE
 	unit_name = "laser gun"
 	export_types = list(/obj/item/gun/energy/laser)
 
 /datum/export/weapon/disabler
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "disabler"
 	export_types = list(/obj/item/gun/energy/disabler)
 
 /datum/export/weapon/energy_gun
-	cost = 300
+	cost = CARGO_CRATE_VALUE * 1.5
 	unit_name = "energy gun"
 	export_types = list(/obj/item/gun/energy/e_gun)
 
 /datum/export/weapon/wt550
-	cost = 300
+	cost = CARGO_CRATE_VALUE * 1.5
 	unit_name = "WT-550 automatic rifle"
 	export_types = list(/obj/item/gun/ballistic/automatic/wt550)
 
 /datum/export/weapon/shotgun
-	cost = 300
+	cost = CARGO_CRATE_VALUE * 1.5
 	unit_name = "combat shotgun"
 	export_types = list(/obj/item/gun/ballistic/shotgun/automatic/combat)
 
 
 /datum/export/weapon/flashbang
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.025
 	unit_name = "flashbang grenade"
 	export_types = list(/obj/item/grenade/flashbang)
 
 /datum/export/weapon/teargas
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.025
 	unit_name = "tear gas grenade"
 	export_types = list(/obj/item/grenade/chem_grenade/teargas)
 
 
 /datum/export/weapon/flash
-	cost = 5
+	cost = CARGO_CRATE_VALUE * 0.025
 	unit_name = "handheld flash"
 	export_types = list(/obj/item/assembly/flash)
 	include_subtypes = TRUE
 
 /datum/export/weapon/handcuffs
-	cost = 3
+	cost = CARGO_CRATE_VALUE * 0.015
 	unit_name = "pair"
 	message = "of handcuffs"
 	export_types = list(/obj/item/restraints/handcuffs)

--- a/code/modules/cargo/exports/xenobio.dm
+++ b/code/modules/cargo/exports/xenobio.dm
@@ -1,37 +1,37 @@
 /datum/export/slime
 
 /datum/export/slime/grey
-	cost = 25
+	cost = CARGO_CRATE_VALUE * 0.05
 	unit_name = "grey slime core"
 	export_types = list(/obj/item/slime_extract/grey)
 
 /datum/export/slime/common
-	cost = 60
+	cost = CARGO_CRATE_VALUE * 0.12
 	unit_name = "common slime core"
 	export_types = list(/obj/item/slime_extract/metal,/obj/item/slime_extract/orange,/obj/item/slime_extract/purple,/obj/item/slime_extract/blue)
 
 /datum/export/slime/uncommon
-	cost = 100
+	cost = CARGO_CRATE_VALUE * 0.2
 	unit_name = "uncommon slime core"
 	export_types = list(/obj/item/slime_extract/gold,/obj/item/slime_extract/green,/obj/item/slime_extract/red,/obj/item/slime_extract/pink)
 
 /datum/export/slime/rare
-	cost = 140
+	cost = CARGO_CRATE_VALUE * 0.28
 	unit_name = "rare slime core"
 	export_types = list(/obj/item/slime_extract/silver,/obj/item/slime_extract/darkblue,/obj/item/slime_extract/darkpurple,/obj/item/slime_extract/yellow)
 
 /datum/export/slime/hypercharged
-	cost = 600
+	cost = CARGO_CRATE_VALUE * 1.2
 	unit_name = "hypercharged slime core"
 	export_types = list(/obj/item/stock_parts/cell/high/slime_hypercharged)
 
 /datum/export/slime/epic //EPIIIIIIC
-	cost = 220
+	cost = CARGO_CRATE_VALUE * 0.44
 	unit_name = "epic slime core"
 	export_types = list(/obj/item/slime_extract/black,/obj/item/slime_extract/cerulean,/obj/item/slime_extract/oil,/obj/item/slime_extract/sepia,/obj/item/slime_extract/pyrite,/obj/item/slime_extract/adamantine,/obj/item/slime_extract/lightpink,/obj/item/slime_extract/bluespace)
 
 /datum/export/slime/rainbow
-	cost = 500
+	cost = CARGO_CRATE_VALUE
 	unit_name = "rainbow slime core"
 	export_types = list(/obj/item/slime_extract/rainbow)
 

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -7,140 +7,140 @@
 /datum/supply_pack/goody/dumdum38
 	name = ".38 DumDum Speedloader"
 	desc = "Contains one speedloader of .38 DumDum ammunition, good for embedding in soft targets."
-	cost = 350
+	cost = PAYCHECK_MEDIUM * 2
 	access_view = ACCESS_BRIG
 	contains = list(/obj/item/ammo_box/c38/dumdum)
 
 /datum/supply_pack/goody/match38
 	name = ".38 Match Grade Speedloader"
 	desc = "Contains one speedloader of match grade .38 ammunition, perfect for showing off trickshots."
-	cost = 350
+	cost = PAYCHECK_MEDIUM * 2
 	access_view = ACCESS_BRIG
 	contains = list(/obj/item/ammo_box/c38/match)
 
 /datum/supply_pack/goody/rubber
 	name = ".38 Rubber Speedloader"
 	desc = "Contains one speedloader of bouncy rubber .38 ammunition, for when you want to bounce your shots off anything and everything."
-	cost = 350
+	cost = PAYCHECK_MEDIUM * 1.5
 	access_view = ACCESS_BRIG
 	contains = list(/obj/item/ammo_box/c38/match/bouncy)
 
 /datum/supply_pack/goody/stingbang
 	name = "Stingbang Single-Pack"
 	desc = "Contains one \"stingbang\" grenade, perfect for playing meanhearted pranks."
-	cost = 700
+	cost = PAYCHECK_HARD * 2.5
 	access_view = ACCESS_BRIG
 	contains = list(/obj/item/grenade/stingbang)
 
 /datum/supply_pack/goody/combatknives_single
 	name = "Combat Knife Single-Pack"
 	desc = "Contains one sharpened combat knive. Guaranteed to fit snugly inside any Nanotrasen-standard boot."
-	cost = 1250
+	cost = PAYCHECK_HARD * 1.75
 	contains = list(/obj/item/kitchen/knife/combat)
 
 /datum/supply_pack/goody/ballistic_single
 	name = "Combat Shotgun Single-Pack"
 	desc = "For when the enemy absolutely needs to be replaced with lead. Contains one Aussec-designed Combat Shotgun, and one Shotgun Bandolier."
-	cost = 4000
+	cost = PAYCHECK_HARD * 15
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/gun/ballistic/shotgun/automatic/combat, /obj/item/storage/belt/bandolier)
 
 /datum/supply_pack/goody/energy_single
 	name = "Energy Gun Single-Pack"
 	desc = "Contains one energy gun, capable of firing both nonlethal and lethal blasts of light."
-	cost = 1500
+	cost = PAYCHECK_HARD * 12
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/gun/energy/e_gun)
 
 /datum/supply_pack/goody/hell_single
 	name = "Hellgun Single-Pack"
 	desc = "Contains one hellgun, an old pattern of laser gun infamous for its ability to horribly disfigure targets with burns. Technically violates the Space Geneva Convention when used on humanoids."
-	cost = 2250
+	cost = PAYCHECK_HARD * 18
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/gun/energy/laser/hellgun)
 
 /datum/supply_pack/goody/wt550_single
 	name = "WT-550 Auto Rifle Single-Pack"
 	desc = "Contains one high-powered, semiautomatic rifles chambered in 4.6x30mm." // "high-powered" lol yea right
-	cost = 2000
+	cost = PAYCHECK_HARD * 20
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/gun/ballistic/automatic/wt550)
 
 /datum/supply_pack/goody/wt550ammo_single
 	name = "WT-550 Auto Rifle Ammo Single-Pack"
 	desc = "Contains a 20-round magazine for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads."
-	cost = 900
+	cost = PAYCHECK_HARD * 6
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/ammo_box/magazine/wt550m9)
 
 /datum/supply_pack/goody/sologamermitts
 	name = "Insulated Gloves Single-Pack"
 	desc = "The backbone of modern society. Barely ever ordered for actual engineering."
-	cost = 800
+	cost = PAYCHECK_MEDIUM * 8
 	contains = list(/obj/item/clothing/gloves/color/yellow)
 
 /datum/supply_pack/goody/gripper_single
 	name = "Gripper Gloves Single-Pack"
 	desc = "A spare pair of gripper gloves. Perfect for when the security vendor is empty (or when you're not actually a security officer)."
-	cost = 600
+	cost = PAYCHECK_HARD * 6
 	contains = list(/obj/item/clothing/gloves/tackler)
 
 /datum/supply_pack/goody/firstaidbruises_single
 	name = "Bruise Treatment Kit Single-Pack"
 	desc = "A single brute first-aid kit, perfect for recovering from being crushed in an airlock. Did you know people get crushed in airlocks all the time? Interesting..."
-	cost = 330
+	cost = PAYCHECK_MEDIUM * 4
 	contains = list(/obj/item/storage/firstaid/brute)
 
 /datum/supply_pack/goody/firstaidburns_single
 	name = "Burn Treatment Kit Single-Pack"
 	desc = "A single burn first-aid kit. The advertisement displays a winking atmospheric technician giving a thumbs up, saying \"Mistakes happen!\""
-	cost = 330
+	cost = PAYCHECK_MEDIUM * 4
 	contains = list(/obj/item/storage/firstaid/fire)
 
 /datum/supply_pack/goody/firstaid_single
 	name = "First Aid Kit Single-Pack"
 	desc = "A single first-aid kit, fit for healing most types of bodily harm."
-	cost = 250
+	cost = PAYCHECK_MEDIUM * 3
 	contains = list(/obj/item/storage/firstaid/regular)
 
 /datum/supply_pack/goody/firstaidoxygen_single
 	name = "Oxygen Deprivation Kit Single-Pack"
 	desc = "A single oxygen deprivation first-aid kit, marketed heavily to those with crippling fears of asphyxiation."
-	cost = 330
+	cost = PAYCHECK_MEDIUM * 4
 	contains = list(/obj/item/storage/firstaid/o2)
 
 /datum/supply_pack/goody/firstaidtoxins_single
 	name = "Toxin Treatment Kit Single-Pack"
 	desc = "A single first aid kit focused on healing damage dealt by heavy toxins."
-	cost = 330
+	cost = PAYCHECK_MEDIUM * 4
 	contains = list(/obj/item/storage/firstaid/toxin)
 
 /datum/supply_pack/goody/toolbox // mostly just to water down coupon probability
 	name = "Mechanical Toolbox"
 	desc = "A fully stocked mechanical toolbox, for when you're too lazy to just print them out."
-	cost = 300
+	cost = PAYCHECK_MEDIUM * 3
 	contains = list(/obj/item/storage/toolbox/mechanical)
 
 /datum/supply_pack/goody/valentine
 	name = "Valentine Card"
 	desc = "Make an impression on that special someone! Comes with one valentine card and a free candy heart!"
-	cost = 150
+	cost = PAYCHECK_ASSISTANT * 2
 	contains = list(/obj/item/valentine, /obj/item/food/candyheart)
 
 /datum/supply_pack/goody/beeplush
 	name = "Bee Plushie"
 	desc = "The most important thing you could possibly spend your hard-earned money on."
-	cost = 1500
+	cost = PAYCHECK_EASY * 4
 	contains = list(/obj/item/toy/plush/beeplushie)
 
 /datum/supply_pack/goody/beach_ball
 	name = "Beach Ball"
 	desc = "The simple beach ball is one of Nanotrasen's most popular products. 'Why do we make beach balls? Because we can! (TM)' - Nanotrasen"
-	cost = 200
+	cost = PAYCHECK_MEDIUM
 	contains = list(/obj/item/toy/beach_ball)
 
 /datum/supply_pack/goody/medipen_twopak
 	name = "Medipen Two-Pak"
 	desc = "Contains one standard epinephrine medipen and one standard emergency first-aid kit medipen. For when you want to prepare for the worst."
-	cost = 500
+	cost = PAYCHECK_MEDIUM * 2
 	contains = list(/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/hypospray/medipen/ekit)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -3,7 +3,8 @@
 	var/group = ""
 	var/hidden = FALSE
 	var/contraband = FALSE
-	var/cost = 700 // Minimum cost, or infinite points are possible.
+	/// Cost of the crate. DO NOT GO ANY LOWER THAN X1.4 the "CARGO_CRATE_VALUE" value if using regular crates, or infinite profit will be possible!
+	var/cost = CARGO_CRATE_VALUE * 1.4
 	var/access = FALSE
 	var/access_view = FALSE
 	var/access_any = FALSE
@@ -56,7 +57,7 @@
 /datum/supply_pack/emergency/vehicle
 	name = "Biker Gang Kit" //TUNNEL SNAKES OWN THIS TOWN
 	desc = "TUNNEL SNAKES OWN THIS TOWN. Contains an unbranded All Terrain Vehicle, and a complete gang outfit -- consists of black gloves, a menacing skull bandanna, and a SWEET leather overcoat!"
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contraband = TRUE
 	contains = list(/obj/vehicle/ridden/atv,
 					/obj/item/key,
@@ -70,7 +71,7 @@
 /datum/supply_pack/emergency/bio
 	name = "Biological Emergency Crate"
 	desc = "This crate holds 2 full bio suits which will protect you from viruses."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/clothing/head/bio_hood,
 					/obj/item/clothing/head/bio_hood,
 					/obj/item/clothing/suit/bio_suit,
@@ -85,7 +86,7 @@
 /datum/supply_pack/emergency/equipment
 	name = "Emergency Bot/Internals Crate"
 	desc = "Explosions got you down? These supplies are guaranteed to patch up holes, in stations and people alike! Comes with two floorbots, two medbots, five oxygen masks and five small oxygen tanks."
-	cost = 3500
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/mob/living/simple_animal/bot/floorbot,
 					/mob/living/simple_animal/bot/floorbot,
 					/mob/living/simple_animal/bot/medbot,
@@ -106,7 +107,7 @@
 /datum/supply_pack/emergency/bomb
 	name = "Explosive Emergency Crate"
 	desc = "Science gone bonkers? Beeping behind the airlock? Buy now and be the hero the station des... I mean needs! (time not included)"
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/clothing/head/bomb_hood,
 					/obj/item/clothing/suit/bomb_suit,
 					/obj/item/clothing/mask/gas,
@@ -118,7 +119,7 @@
 /datum/supply_pack/emergency/firefighting
 	name = "Firefighting Crate"
 	desc = "Only you can prevent station fires. Partner up with two firefighter suits, gas masks, flashlights, large oxygen tanks, extinguishers, and hardhats!"
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/clothing/suit/fire/firefighter,
 					/obj/item/clothing/suit/fire/firefighter,
 					/obj/item/clothing/mask/gas,
@@ -136,7 +137,7 @@
 /datum/supply_pack/emergency/atmostank
 	name = "Firefighting Tank Backpack"
 	desc = "Mow down fires with this high-capacity fire fighting tank backpack. Requires Atmospherics access to open."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 1.5
 	access = ACCESS_ATMOSPHERICS
 	contains = list(/obj/item/watertank/atmos)
 	crate_name = "firefighting backpack crate"
@@ -145,7 +146,7 @@
 /datum/supply_pack/emergency/internals
 	name = "Internals Crate"
 	desc = "Master your life energy and control your breathing with three breath masks, three emergency oxygen tanks and three large air tanks."//IS THAT A
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 1.25
 	contains = list(/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
@@ -164,14 +165,14 @@
 /datum/supply_pack/emergency/metalfoam
 	name = "Metal Foam Grenade Crate"
 	desc = "Seal up those pesky hull breaches with 7 Metal Foam Grenades."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 1.25
 	contains = list(/obj/item/storage/box/metalfoam)
 	crate_name = "metal foam grenade crate"
 
 /datum/supply_pack/emergency/plasma_spacesuit
 	name = "Plasmaman Space Envirosuits"
 	desc = "Contains two space-worthy envirosuits for Plasmamen. Order now and we'll throw in two free helmets! Requires EVA access to open."
-	cost = 4000
+	cost = CARGO_CRATE_VALUE * 2
 	access = ACCESS_EVA
 	contains = list(/obj/item/clothing/suit/space/eva/plasmaman,
 					/obj/item/clothing/suit/space/eva/plasmaman,
@@ -183,7 +184,7 @@
 /datum/supply_pack/emergency/plasmaman
 	name = "Plasmaman Supply Kit"
 	desc = "Keep those Plasmamen alive with two sets of Plasmaman outfits. Each set contains a plasmaman jumpsuit, gloves, internals tank, and helmet."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/clothing/under/plasmaman,
 					/obj/item/clothing/under/plasmaman,
 					/obj/item/tank/internals/plasmaman/belt/full,
@@ -197,7 +198,7 @@
 /datum/supply_pack/emergency/radiation
 	name = "Radiation Protection Crate"
 	desc = "Survive the Nuclear Apocalypse and Supermatter Engine alike with two sets of Radiation suits. Each set contains a helmet, suit, and Geiger counter. We'll even throw in a bottle of vodka and some glasses too, considering the life-expectancy of people who order this."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/clothing/head/radiation,
 					/obj/item/clothing/head/radiation,
 					/obj/item/clothing/suit/radiation,
@@ -213,7 +214,7 @@
 /datum/supply_pack/emergency/spacesuit
 	name = "Space Suit Crate"
 	desc = "Contains one aging suit from Space-Goodwill and a jetpack. Requires EVA access to open."
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 3
 	access = ACCESS_EVA
 	contains = list(/obj/item/clothing/suit/space,
 					/obj/item/clothing/head/helmet/space,
@@ -226,7 +227,7 @@
 	name = "Special Ops Supplies"
 	desc = "(*!&@#SAD ABOUT THAT NULL_ENTRY, HUH OPERATIVE? WELL, THIS LITTLE ORDER CAN STILL HELP YOU OUT IN A PINCH. CONTAINS A BOX OF FIVE EMP GRENADES, THREE SMOKEBOMBS, AN INCENDIARY GRENADE, AND A \"SLEEPY PEN\" FULL OF NICE TOXINS!#@*$"
 	hidden = TRUE
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/storage/box/emps,
 					/obj/item/grenade/smokebomb,
 					/obj/item/grenade/smokebomb,
@@ -239,7 +240,7 @@
 /datum/supply_pack/emergency/weedcontrol
 	name = "Weed Control Crate"
 	desc = "Keep those invasive species OUT. Contains a scythe, gasmask, and two anti-weed chemical grenades. Warranty void if used on ambrosia. Requires Hydroponics access to open."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 2.5
 	access = ACCESS_HYDROPONICS
 	contains = list(/obj/item/scythe,
 					/obj/item/clothing/mask/gas,
@@ -260,7 +261,7 @@
 /datum/supply_pack/security/ammo
 	name = "Ammo Crate"
 	desc = "Contains two 20-round magazines for the WT-550 Auto Rifle, three boxes of buckshot ammo, three boxes of rubber ammo and special .38 speedloarders. Requires Security access to open."
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 5
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9,
@@ -278,7 +279,7 @@
 /datum/supply_pack/security/armor
 	name = "Armor Crate"
 	desc = "Three vests of well-rounded, decently-protective armor. Requires Security access to open."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/suit/armor/vest,
@@ -288,7 +289,7 @@
 /datum/supply_pack/security/disabler
 	name = "Disabler Crate"
 	desc = "Three stamina-draining disabler weapons. Requires Security access to open."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/gun/energy/disabler,
 					/obj/item/gun/energy/disabler,
@@ -298,7 +299,7 @@
 /datum/supply_pack/security/forensics
 	name = "Forensics Crate"
 	desc = "Stay hot on the criminal's heels with Nanotrasen's Detective Essentials(tm). Contains a forensics scanner, six evidence bags, camera, tape recorder, white crayon, and of course, a fedora. Requires Security access to open."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 2.5
 	access_view = ACCESS_MORGUE
 	contains = list(/obj/item/detective_scanner,
 					/obj/item/storage/box/evidence,
@@ -311,7 +312,7 @@
 /datum/supply_pack/security/helmets
 	name = "Helmets Crate"
 	desc = "Contains three standard-issue brain buckets. Requires Security access to open."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/clothing/head/helmet/sec,
 					/obj/item/clothing/head/helmet/sec,
 					/obj/item/clothing/head/helmet/sec)
@@ -320,7 +321,7 @@
 /datum/supply_pack/security/laser
 	name = "Lasers Crate"
 	desc = "Contains three lethal, high-energy laser guns. Requires Security access to open."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/gun/energy/laser,
 					/obj/item/gun/energy/laser,
@@ -337,13 +338,13 @@
 					/obj/item/grenade/barrier,
 					/obj/item/grenade/barrier,
 					/obj/item/grenade/barrier)
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 2
 	crate_name = "security barriers crate"
 
 /datum/supply_pack/security/securityclothes
 	name = "Security Clothing Crate"
 	desc = "Contains appropriate outfits for the station's private security force. Contains outfits for the Warden, Head of Security, and two Security Officers. Each outfit comes with a rank-appropriate jumpsuit, suit, and beret. Requires Security access to open."
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 3
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/clothing/under/rank/security/officer/formal,
 					/obj/item/clothing/under/rank/security/officer/formal,
@@ -362,7 +363,7 @@
 /datum/supply_pack/security/stingpack
 	name = "Stingbang Grenade Pack"
 	desc = "Contains five \"stingbang\" grenades, perfect for stopping riots and playing morally unthinkable pranks. Requires Security access to open."
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 5
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/storage/box/stingbangs)
 	crate_name = "stingbang grenade pack crate"
@@ -370,7 +371,7 @@
 /datum/supply_pack/security/supplies
 	name = "Security Supplies Crate"
 	desc = "Contains seven flashbangs, seven teargas grenades, six flashes, and seven handcuffs. Requires Security access to open."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 1.75
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/storage/box/flashbangs,
 					/obj/item/storage/box/teargas,
@@ -381,7 +382,7 @@
 /datum/supply_pack/security/firingpins
 	name = "Standard Firing Pins Crate"
 	desc = "Upgrade your arsenal with 10 standard firing pins. Requires Security access to open."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/storage/box/firingpins,
 					/obj/item/storage/box/firingpins)
@@ -390,7 +391,7 @@
 /datum/supply_pack/security/firingpins/paywall
 	name = "Paywall Firing Pins Crate"
 	desc = "Specialized firing pins with a built-in configurable paywall. Requires Security access to open."
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/storage/box/firingpins/paywall,
 					/obj/item/storage/box/firingpins/paywall)
@@ -399,7 +400,7 @@
 /datum/supply_pack/security/justiceinbound
 	name = "Standard Justice Enforcer Crate"
 	desc = "This is it. The Bee's Knees. The Creme of the Crop. The Pick of the Litter. The best of the best of the best. The Crown Jewel of Nanotrasen. The Alpha and the Omega of security headwear. Guaranteed to strike fear into the hearts of each and every criminal aboard the station. Also comes with a security gasmask. Requires Security access to open."
-	cost = 6000 //justice comes at a price. An expensive, noisy price.
+	cost = CARGO_CRATE_VALUE * 6 //justice comes at a price. An expensive, noisy price.
 	contraband = TRUE
 	contains = list(/obj/item/clothing/head/helmet/justice,
 					/obj/item/clothing/mask/gas/sechailer)
@@ -408,7 +409,7 @@
 /datum/supply_pack/security/baton
 	name = "Stun Batons Crate"
 	desc = "Arm the Civil Protection Forces with three stun batons. Batteries included. Requires Security access to open."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/loaded,
 					/obj/item/melee/baton/loaded,
@@ -418,7 +419,7 @@
 /datum/supply_pack/security/wall_flash
 	name = "Wall-Mounted Flash Crate"
 	desc = "Contains four wall-mounted flashes. Requires Security access to open."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/storage/box/wall_flash,
 					/obj/item/storage/box/wall_flash,
 					/obj/item/storage/box/wall_flash,
@@ -428,7 +429,7 @@
 /datum/supply_pack/security/constable
 	name = "Traditional Equipment Crate"
 	desc = "Spare equipment found in a warehouse."
-	cost = 1100
+	cost = CARGO_CRATE_VALUE * 2.2
 	contraband = TRUE
 	contains = list(/obj/item/clothing/under/rank/security/constable,
 					/obj/item/clothing/head/helmet/constable,
@@ -449,7 +450,7 @@
 /datum/supply_pack/security/armory/bulletarmor
 	name = "Bulletproof Armor Crate"
 	desc = "Contains three sets of bulletproof armor. Guaranteed to reduce a bullet's stopping power by over half. Requires Armory access to open."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/clothing/suit/armor/bulletproof)
@@ -458,7 +459,7 @@
 /datum/supply_pack/security/armory/bullethelmets
 	name = "Bulletproof Helmets Crate"
 	desc = "Contains three bulletproof helmets. Requires Armory access to open."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/clothing/head/helmet/alt,
 					/obj/item/clothing/head/helmet/alt,
 					/obj/item/clothing/head/helmet/alt)
@@ -467,14 +468,14 @@
 /datum/supply_pack/security/armory/chemimp
 	name = "Chemical Implants Crate"
 	desc = "Contains five Remote Chemical implants. Requires Armory access to open."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 1.25
 	contains = list(/obj/item/storage/box/chemimp)
 	crate_name = "chemical implant crate"
 
 /datum/supply_pack/security/armory/combatknives
 	name = "Combat Knives Crate"
 	desc = "Contains three sharpened combat knives. Each knife guaranteed to fit snugly inside any Nanotrasen-standard boot. Requires Armory access to open."
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/kitchen/knife/combat,
 					/obj/item/kitchen/knife/combat,
 					/obj/item/kitchen/knife/combat)
@@ -483,7 +484,7 @@
 /datum/supply_pack/security/armory/ballistic
 	name = "Combat Shotguns Crate"
 	desc = "For when the enemy absolutely needs to be replaced with lead. Contains three Aussec-designed Combat Shotguns, and three Shotgun Bandoliers. Requires Armory access to open."
-	cost = 8000
+	cost = CARGO_CRATE_VALUE * 12
 	contains = list(/obj/item/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/gun/ballistic/shotgun/automatic/combat,
@@ -495,7 +496,7 @@
 /datum/supply_pack/security/armory/dragnet
 	name = "DRAGnet Crate"
 	desc = "Contains three \"Dynamic Rapid-Apprehension of the Guilty\" netting devices, a recent breakthrough in law enforcement prisoner management technology. Requires armory access to open."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/gun/energy/e_gun/dragnet,
 					/obj/item/gun/energy/e_gun/dragnet,
 					/obj/item/gun/energy/e_gun/dragnet)
@@ -504,7 +505,7 @@
 /datum/supply_pack/security/armory/energy
 	name = "Energy Guns Crate"
 	desc = "Contains two Energy Guns, capable of firing both nonlethal and lethal blasts of light. Requires Armory access to open."
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/gun/energy/e_gun,
 					/obj/item/gun/energy/e_gun)
 	crate_name = "energy gun crate"
@@ -513,14 +514,14 @@
 /datum/supply_pack/security/armory/exileimp
 	name = "Exile Implants Crate"
 	desc = "Contains five Exile implants. Requires Armory access to open."
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/storage/box/exileimp)
 	crate_name = "exile implant crate"
 
 /datum/supply_pack/security/armory/fire
 	name = "Incendiary Weapons Crate"
 	desc = "Burn, baby burn. Contains three incendiary grenades, three plasma canisters, and a flamethrower. Requires Armory access to open."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 4
 	access = ACCESS_HEADS
 	contains = list(/obj/item/flamethrower/full,
 					/obj/item/tank/internals/plasma,
@@ -536,14 +537,14 @@
 /datum/supply_pack/security/armory/mindshield
 	name = "Mindshield Implants Crate"
 	desc = "Prevent against radical thoughts with three Mindshield implants. Requires Armory access to open."
-	cost = 4000
+	cost = CARGO_CRATE_VALUE * 6
 	contains = list(/obj/item/storage/lockbox/loyalty)
 	crate_name = "mindshield implant crate"
 
 /datum/supply_pack/security/armory/trackingimp
 	name = "Tracking Implants Crate"
 	desc = "Contains four tracking implants and three tracking speedloaders of tracing .38 ammo. Requires Armory access to open."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/storage/box/trackimp,
 					/obj/item/ammo_box/c38/trac,
 					/obj/item/ammo_box/c38/trac,
@@ -553,7 +554,7 @@
 /datum/supply_pack/security/armory/laserarmor
 	name = "Reflector Vest Crate"
 	desc = "Contains two vests of highly reflective material. Each armor piece diffuses a laser's energy by over half, as well as offering a good chance to reflect the laser entirely. Requires Armory access to open."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 3.5
 	contains = list(/obj/item/clothing/suit/armor/laserproof,
 					/obj/item/clothing/suit/armor/laserproof)
 	crate_name = "reflector vest crate"
@@ -562,7 +563,7 @@
 /datum/supply_pack/security/armory/riotarmor
 	name = "Riot Armor Crate"
 	desc = "Contains three sets of heavy body armor. Advanced padding protects against close-ranged weaponry, making melee attacks feel only half as potent to the user. Requires Armory access to open."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/clothing/suit/armor/riot,
 					/obj/item/clothing/suit/armor/riot,
 					/obj/item/clothing/suit/armor/riot)
@@ -571,7 +572,7 @@
 /datum/supply_pack/security/armory/riothelmets
 	name = "Riot Helmets Crate"
 	desc = "Contains three riot helmets. Requires Armory access to open."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/clothing/head/helmet/riot,
 					/obj/item/clothing/head/helmet/riot,
 					/obj/item/clothing/head/helmet/riot)
@@ -580,7 +581,7 @@
 /datum/supply_pack/security/armory/riotshields
 	name = "Riot Shields Crate"
 	desc = "For when the greytide gets really uppity. Contains three riot shields. Requires Armory access to open."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/shield/riot,
 					/obj/item/shield/riot,
 					/obj/item/shield/riot)
@@ -589,7 +590,7 @@
 /datum/supply_pack/security/armory/russian
 	name = "Russian Surplus Crate"
 	desc = "Hello Comrade, we have the most modern russian military equipment the black market can offer, for the right price of course. Sadly we couldnt remove the lock so it requires Armory access to open."
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 8
 	contraband = TRUE
 	contains = list(/obj/item/food/rationpack,
 					/obj/item/ammo_box/a762,
@@ -615,7 +616,7 @@
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof, pressurized suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, and combat gloves. Requires Armory access to open."
-	cost = 6000
+	cost = CARGO_CRATE_VALUE * 12
 	contains = list(/obj/item/clothing/head/helmet/swat/nanotrasen,
 					/obj/item/clothing/head/helmet/swat/nanotrasen,
 					/obj/item/clothing/suit/space/swat,
@@ -631,7 +632,7 @@
 /datum/supply_pack/security/armory/wt550
 	name = "WT-550 Auto Rifle Crate"
 	desc = "Contains two high-powered, semiautomatic rifles chambered in 4.6x30mm. Requires Armory access to open."
-	cost = 3500
+	cost = CARGO_CRATE_VALUE * 7
 	contains = list(/obj/item/gun/ballistic/automatic/wt550,
 					/obj/item/gun/ballistic/automatic/wt550)
 	crate_name = "auto rifle crate"
@@ -639,7 +640,7 @@
 /datum/supply_pack/security/armory/wt550ammo
 	name = "WT-550 Auto Rifle Ammo Crate"
 	desc = "Contains four 20-round magazine for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 3.5
 	contains = list(/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9,
@@ -657,7 +658,7 @@
 /datum/supply_pack/engineering/shieldgen
 	name = "Anti-breach Shield Projector Crate"
 	desc = "Hull breaches again? Say no more with the Nanotrasen Anti-Breach Shield Projector! Uses forcefield technology to keep the air in, and the space out. Contains two shield projectors."
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 3
 	access_view = ACCESS_ENGINE_EQUIP
 	contains = list(/obj/machinery/shieldgen,
 					/obj/machinery/shieldgen)
@@ -666,7 +667,7 @@
 /datum/supply_pack/engineering/ripley
 	name = "APLU MK-I Crate"
 	desc = "A do-it-yourself kit for building an ALPU MK-I \"Ripley\", designed for lifting and carrying heavy equipment, and other station tasks. Batteries not included."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	access_view = ACCESS_ROBOTICS
 	contains = list(/obj/item/mecha_parts/chassis/ripley,
 					/obj/item/mecha_parts/part/ripley_torso,
@@ -685,7 +686,7 @@
 /datum/supply_pack/engineering/conveyor
 	name = "Conveyor Assembly Crate"
 	desc = "Keep production moving along with thirty conveyor belts. Conveyor switch included. If you have any questions, check out the enclosed instruction book."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/stack/conveyor/thirty,
 					/obj/item/conveyor_switch_construct,
 					/obj/item/paper/guides/conveyor)
@@ -694,7 +695,7 @@
 /datum/supply_pack/engineering/engiequipment
 	name = "Engineering Gear Crate"
 	desc = "Gear up with three toolbelts, high-visibility vests, welding helmets, hardhats, and two pairs of meson goggles!"
-	cost = 1300
+	cost = CARGO_CRATE_VALUE * 2.6
 	access_view = ACCESS_ENGINE
 	contains = list(/obj/item/storage/belt/utility,
 					/obj/item/storage/belt/utility,
@@ -715,7 +716,7 @@
 /datum/supply_pack/engineering/powergamermitts
 	name = "Insulated Gloves Crate"
 	desc = "The backbone of modern society. Barely ever ordered for actual engineering. Contains three insulated gloves."
-	cost = 2000	//Made of pure-grade bullshittinium
+	cost = CARGO_CRATE_VALUE * 4	//Made of pure-grade bullshittinium
 	access_view = ACCESS_ENGINE_EQUIP
 	contains = list(/obj/item/clothing/gloves/color/yellow,
 					/obj/item/clothing/gloves/color/yellow,
@@ -723,14 +724,10 @@
 	crate_name = "insulated gloves crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
-/obj/item/stock_parts/cell/inducer_supply
-	maxcharge = 5000
-	charge = 5000
-
 /datum/supply_pack/engineering/inducers
 	name = "NT-75 Electromagnetic Power Inducers Crate"
 	desc = "No rechargers? No problem, with the NT-75 EPI, you can recharge any standard cell-based equipment anytime, anywhere. Contains two Inducers."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/inducer/sci {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}, /obj/item/inducer/sci {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}) //FALSE doesn't work in modified type paths apparently.
 	crate_name = "inducer crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
@@ -738,7 +735,7 @@
 /datum/supply_pack/engineering/pacman
 	name = "P.A.C.M.A.N Generator Crate"
 	desc = "Engineers can't set up the engine? Not an issue for you, once you get your hands on this P.A.C.M.A.N. Generator! Takes in plasma and spits out sweet sweet energy."
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 5
 	access_view = ACCESS_ENGINE
 	contains = list(/obj/machinery/power/port_gen/pacman)
 	crate_name = "PACMAN generator crate"
@@ -747,7 +744,7 @@
 /datum/supply_pack/engineering/power
 	name = "Power Cell Crate"
 	desc = "Looking for power overwhelming? Look no further. Contains three high-voltage power cells."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 1.75
 	contains = list(/obj/item/stock_parts/cell/high,
 					/obj/item/stock_parts/cell/high,
 					/obj/item/stock_parts/cell/high)
@@ -757,7 +754,7 @@
 /datum/supply_pack/engineering/shuttle_engine
 	name = "Shuttle Engine Crate"
 	desc = "Through advanced bluespace-shenanigans, our engineers have managed to fit an entire shuttle engine into one tiny little crate. Requires CE access to open."
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 6
 	access = ACCESS_CE
 	access_view = ACCESS_CE
 	contains = list(/obj/structure/shuttle/engine/propulsion/burst/cargo)
@@ -775,13 +772,13 @@
 					/obj/item/storage/toolbox/mechanical,
 					/obj/item/storage/toolbox/mechanical,
 					/obj/item/storage/toolbox/mechanical)
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2.5
 	crate_name = "toolbox crate"
 
 /datum/supply_pack/engineering/portapump
 	name = "Portable Air Pump Crate"
 	desc = "Did someone let the air out of the shuttle again? We've got you covered. Contains two portable air pumps."
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 4.5
 	access_view = ACCESS_ATMOSPHERICS
 	contains = list(/obj/machinery/portable_atmospherics/pump,
 					/obj/machinery/portable_atmospherics/pump)
@@ -790,7 +787,7 @@
 /datum/supply_pack/engineering/portascrubber
 	name = "Portable Scrubber Crate"
 	desc = "Clean up that pesky plasma leak with your very own set of two portable scrubbers."
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 4.5
 	access_view = ACCESS_ATMOSPHERICS
 	contains = list(/obj/machinery/portable_atmospherics/scrubber,
 					/obj/machinery/portable_atmospherics/scrubber)
@@ -799,7 +796,7 @@
 /datum/supply_pack/engineering/hugescrubber
 	name = "Huge Portable Scrubber Crate"
 	desc = "A huge portable scrubber for huge atmospherics mistakes."
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 7.5
 	access_view = ACCESS_ATMOSPHERICS
 	contains = list(/obj/machinery/portable_atmospherics/scrubber/huge/movable/cargo)
 	crate_name = "huge portable scrubber crate"
@@ -808,7 +805,7 @@
 /datum/supply_pack/engineering/bsa
 	name = "Bluespace Artillery Parts"
 	desc = "The pride of Nanotrasen Naval Command. The legendary Bluespace Artillery Cannon is a devastating feat of human engineering and testament to wartime determination. Highly advanced research is required for proper construction. "
-	cost = 15000
+	cost = CARGO_CRATE_VALUE * 30
 	special = TRUE
 	access_view = ACCESS_HEADS
 	contains = list(/obj/item/circuitboard/machine/bsa/front,
@@ -821,7 +818,7 @@
 /datum/supply_pack/engineering/dna_vault
 	name = "DNA Vault Parts"
 	desc = "Secure the longevity of the current state of humanity within this massive library of scientific knowledge, capable of granting superhuman powers and abilities. Highly advanced research is required for proper construction. Also contains five DNA probes."
-	cost = 12000
+	cost = CARGO_CRATE_VALUE * 24
 	special = TRUE
 	access_view = ACCESS_HEADS
 	contains = list(
@@ -837,7 +834,7 @@
 /datum/supply_pack/engineering/dna_probes
 	name = "DNA Vault Samplers"
 	desc = "Contains five DNA probes for use in the DNA vault."
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 6
 	special = TRUE
 	access_view = ACCESS_HEADS
 	contains = list(/obj/item/dna_probe,
@@ -852,7 +849,7 @@
 /datum/supply_pack/engineering/shield_sat
 	name = "Shield Generator Satellite"
 	desc = "Protect the very existence of this station with these Anti-Meteor defenses. Contains three Shield Generator Satellites."
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 6
 	special = TRUE
 	access_view = ACCESS_HEADS
 	contains = list(
@@ -866,7 +863,7 @@
 /datum/supply_pack/engineering/shield_sat_control
 	name = "Shield System Control Board"
 	desc = "A control system for the Shield Generator Satellite system."
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 10
 	special = TRUE
 	access_view = ACCESS_HEADS
 	contains = list(/obj/item/circuitboard/computer/sat_control)
@@ -885,7 +882,7 @@
 /datum/supply_pack/engine/emitter
 	name = "Emitter Crate"
 	desc = "Useful for powering forcefield generators while destroying locked crates and intruders alike. Contains two high-powered energy emitters. Requires CE access to open."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	access = ACCESS_CE
 	contains = list(/obj/machinery/power/emitter,
 					/obj/machinery/power/emitter)
@@ -896,7 +893,7 @@
 /datum/supply_pack/engine/field_gen
 	name = "Field Generator Crate"
 	desc = "Typically the only thing standing between the station and a messy death. Powered by emitters. Contains two field generators."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/machinery/field/generator,
 					/obj/machinery/field/generator)
 	crate_name = "field generator crate"
@@ -904,7 +901,7 @@
 /datum/supply_pack/engine/grounding_rods
 	name = "Grounding Rod Crate"
 	desc = "Four grounding rods guaranteed to keep any uppity tesla coil's lightning under control."
-	cost = 1700
+	cost = CARGO_CRATE_VALUE * 3.4
 	contains = list(/obj/machinery/power/grounding_rod,
 					/obj/machinery/power/grounding_rod,
 					/obj/machinery/power/grounding_rod,
@@ -915,7 +912,7 @@
 /datum/supply_pack/engine/collector
 	name = "Radiation Collector Crate"
 	desc = "Contains three radiation collectors. Useful for collecting energy off nearby Supermatter Crystals, Singularities or Teslas!"
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/machinery/power/rad_collector,
 					/obj/machinery/power/rad_collector,
 					/obj/machinery/power/rad_collector)
@@ -924,7 +921,7 @@
 /datum/supply_pack/engine/solar
 	name = "Solar Panel Crate"
 	desc = "Go green with this DIY advanced solar array. Contains twenty one solar assemblies, a solar-control circuit board, and tracker. If you have any questions, please check out the enclosed instruction book."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contains  = list(/obj/item/solar_assembly,
 					/obj/item/solar_assembly,
 					/obj/item/solar_assembly,
@@ -955,7 +952,7 @@
 /datum/supply_pack/engine/supermatter_shard
 	name = "Supermatter Shard Crate"
 	desc = "The power of the heavens condensed into a single crystal. Requires CE access to open."
-	cost = 10000
+	cost = CARGO_CRATE_VALUE * 20
 	access = ACCESS_CE
 	contains = list(/obj/machinery/power/supermatter_crystal/shard)
 	crate_name = "supermatter shard crate"
@@ -965,7 +962,7 @@
 /datum/supply_pack/engine/tesla_coils
 	name = "Tesla Coil Crate"
 	desc = "Whether it's high-voltage executions, creating research points, or just plain old assistant electrofrying: This pack of four Tesla coils can do it all!"
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/machinery/power/tesla_coil,
 					/obj/machinery/power/tesla_coil,
 					/obj/machinery/power/tesla_coil,
@@ -983,14 +980,14 @@
 /datum/supply_pack/materials/cardboard50
 	name = "50 Cardboard Sheets"
 	desc = "Create a bunch of boxes."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/stack/sheet/cardboard/fifty)
 	crate_name = "cardboard sheets crate"
 
 /datum/supply_pack/materials/license50
 	name = "50 Empty License Plates"
 	desc = "Create a bunch of boxes."
-	cost = 1000  // 50 * 25 + 700 - 1000 = 950 credits profit
+	cost = CARGO_CRATE_VALUE * 2  // 50 * 25 + 700 - 1000 = 950 credits profit
 	access_view = ACCESS_SEC_DOORS
 	contains = list(/obj/item/stack/license_plates/empty/fifty)
 	crate_name = "empty license plate crate"
@@ -998,56 +995,56 @@
 /datum/supply_pack/materials/glass50
 	name = "50 Glass Sheets"
 	desc = "Let some nice light in with fifty glass sheets!"
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/stack/sheet/glass/fifty)
 	crate_name = "glass sheets crate"
 
 /datum/supply_pack/materials/metal50
 	name = "50 Metal Sheets"
 	desc = "Any construction project begins with a good stack of fifty metal sheets!"
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/stack/sheet/metal/fifty)
 	crate_name = "metal sheets crate"
 
 /datum/supply_pack/materials/plasteel20
 	name = "20 Plasteel Sheets"
 	desc = "Reinforce the station's integrity with twenty plasteel sheets!"
-	cost = 7500
+	cost = CARGO_CRATE_VALUE * 15
 	contains = list(/obj/item/stack/sheet/plasteel/twenty)
 	crate_name = "plasteel sheets crate"
 
 /datum/supply_pack/materials/plasteel50
 	name = "50 Plasteel Sheets"
 	desc = "For when you REALLY have to reinforce something."
-	cost = 16500
+	cost = CARGO_CRATE_VALUE * 33
 	contains = list(/obj/item/stack/sheet/plasteel/fifty)
 	crate_name = "plasteel sheets crate"
 
 /datum/supply_pack/materials/plastic50
 	name = "50 Plastic Sheets"
 	desc = "Build a limitless amount of toys with fifty plastic sheets!"
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/stack/sheet/plastic/fifty)
 	crate_name = "plastic sheets crate"
 
 /datum/supply_pack/materials/sandstone30
 	name = "30 Sandstone Blocks"
 	desc = "Neither sandy nor stoney, these thirty blocks will still get the job done."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/stack/sheet/mineral/sandstone/thirty)
 	crate_name = "sandstone blocks crate"
 
 /datum/supply_pack/materials/wood50
 	name = "50 Wood Planks"
 	desc = "Turn cargo's boring metal groundwork into beautiful panelled flooring and much more with fifty wooden planks!"
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/stack/sheet/mineral/wood/fifty)
 	crate_name = "wood planks crate"
 
 /datum/supply_pack/materials/bz
 	name = "BZ Canister Crate"
 	desc = "Contains a canister of BZ. Requires Toxins access to open."
-	cost = 8000
+	cost = CARGO_CRATE_VALUE * 16
 	access = ACCESS_TOXINS
 	access_view = ACCESS_ATMOSPHERICS
 	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
@@ -1057,7 +1054,7 @@
 /datum/supply_pack/materials/carbon_dio
 	name = "Carbon Dioxide Canister"
 	desc = "Contains a canister of Carbon Dioxide."
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 6
 	access_view = ACCESS_ATMOSPHERICS
 	contains = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
 	crate_name = "carbon dioxide canister crate"
@@ -1066,7 +1063,7 @@
 /datum/supply_pack/materials/foamtank
 	name = "Firefighting Foam Tank Crate"
 	desc = "Contains a tank of firefighting foam. Also known as \"plasmaman's bane\"."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/structure/reagent_dispensers/foamtank)
 	crate_name = "foam tank crate"
 	crate_type = /obj/structure/closet/crate/large
@@ -1074,7 +1071,7 @@
 /datum/supply_pack/materials/fueltank
 	name = "Fuel Tank Crate"
 	desc = "Contains a welding fuel tank. Caution, highly flammable."
-	cost = 800
+	cost = CARGO_CRATE_VALUE * 1.6
 	contains = list(/obj/structure/reagent_dispensers/fueltank)
 	crate_name = "fuel tank crate"
 	crate_type = /obj/structure/closet/crate/large
@@ -1082,7 +1079,7 @@
 /datum/supply_pack/materials/hightank
 	name = "Large Water Tank Crate"
 	desc = "Contains a high-capacity water tank. Useful for botany or other service jobs."
-	cost = 1200
+	cost = CARGO_CRATE_VALUE * 2.4
 	contains = list(/obj/structure/reagent_dispensers/watertank/high)
 	crate_name = "high-capacity water tank crate"
 	crate_type = /obj/structure/closet/crate/large
@@ -1090,7 +1087,7 @@
 /datum/supply_pack/materials/hightankfuel
 	name = "Large Fuel Tank Crate"
 	desc = "Contains a high-capacity fuel tank. Keep contents away from open flame."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	access_view = ACCESS_ENGINE
 	contains = list(/obj/structure/reagent_dispensers/fueltank/large)
 	crate_name = "high-capacity fuel tank crate"
@@ -1099,7 +1096,7 @@
 /datum/supply_pack/materials/nitrogen
 	name = "Nitrogen Canister"
 	desc = "Contains a canister of Nitrogen."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/machinery/portable_atmospherics/canister/nitrogen)
 	crate_name = "nitrogen canister crate"
 	crate_type = /obj/structure/closet/crate/large
@@ -1107,7 +1104,7 @@
 /datum/supply_pack/materials/nitrous_oxide_canister
 	name = "Nitrous Oxide Canister"
 	desc = "Contains a canister of Nitrous Oxide. Requires Atmospherics access to open."
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 6
 	access = ACCESS_ATMOSPHERICS
 	access_view = ACCESS_ATMOSPHERICS
 	contains = list(/obj/machinery/portable_atmospherics/canister/nitrous_oxide)
@@ -1117,7 +1114,7 @@
 /datum/supply_pack/materials/oxygen
 	name = "Oxygen Canister"
 	desc = "Contains a canister of Oxygen. Canned in Druidia."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
 	crate_name = "oxygen canister crate"
 	crate_type = /obj/structure/closet/crate/large
@@ -1125,7 +1122,7 @@
 /datum/supply_pack/materials/watertank
 	name = "Water Tank Crate"
 	desc = "Contains a tank of dihydrogen monoxide... sounds dangerous."
-	cost = 600
+	cost = CARGO_CRATE_VALUE * 1.2
 	contains = list(/obj/structure/reagent_dispensers/watertank)
 	crate_name = "water tank crate"
 	crate_type = /obj/structure/closet/crate/large
@@ -1133,7 +1130,7 @@
 /datum/supply_pack/materials/water_vapor
 	name = "Water Vapor Canister"
 	desc = "Contains a canister of Water Vapor. I swear to god if you open this in the halls..."
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/machinery/portable_atmospherics/canister/water_vapor)
 	crate_name = "water vapor canister crate"
 	crate_type = /obj/structure/closet/crate/large
@@ -1150,7 +1147,7 @@
 /datum/supply_pack/medical/bloodpacks
 	name = "Blood Pack Variety Crate"
 	desc = "Contains eight different blood packs for reintroducing blood to patients."
-	cost = 3500
+	cost = CARGO_CRATE_VALUE * 7
 	contains = list(/obj/item/reagent_containers/blood,
 					/obj/item/reagent_containers/blood,
 					/obj/item/reagent_containers/blood/a_plus,
@@ -1167,7 +1164,7 @@
 /datum/supply_pack/medical/medipen_variety
 	name = "Medipen Variety-Pak"
 	desc = "Contains eight different medipens in three different varieties, to assist in quickly treating seriously injured patients."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 3.5
 	contains = list(/obj/item/reagent_containers/hypospray/medipen/,
 					/obj/item/reagent_containers/hypospray/medipen/,
 					/obj/item/reagent_containers/hypospray/medipen/ekit,
@@ -1182,7 +1179,7 @@
 /datum/supply_pack/medical/chemical
 	name = "Chemical Starter Kit Crate"
 	desc = "Contains thirteen different chemicals, for all the fun experiments you can make."
-	cost = 1700
+	cost = CARGO_CRATE_VALUE * 2.6
 	contains = list(/obj/item/reagent_containers/glass/bottle/hydrogen,
 					/obj/item/reagent_containers/glass/bottle/carbon,
 					/obj/item/reagent_containers/glass/bottle/nitrogen,
@@ -1204,7 +1201,7 @@
 /datum/supply_pack/medical/defibs
 	name = "Defibrillator Crate"
 	desc = "Contains two defibrillators for bringing the recently deceased back to life."
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/defibrillator/loaded,
 					/obj/item/defibrillator/loaded)
 	crate_name = "defibrillator crate"
@@ -1212,14 +1209,14 @@
 /datum/supply_pack/medical/iv_drip
 	name = "IV Drip Crate"
 	desc = "Contains a single IV drip for administering blood to patients."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/machinery/iv_drip)
 	crate_name = "iv drip crate"
 
 /datum/supply_pack/medical/supplies
 	name = "Medical Supplies Crate"
 	desc = "Contains several medical supplies. German doctor not included."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/reagent_containers/glass/bottle/multiver,
 					/obj/item/reagent_containers/glass/bottle/epinephrine,
 					/obj/item/reagent_containers/glass/bottle/morphine,
@@ -1254,7 +1251,7 @@
 /datum/supply_pack/medical/surgery
 	name = "Surgical Supplies Crate"
 	desc = "Do you want to perform surgery, but don't have one of those fancy shmancy degrees? Just get started with this crate containing a medical duffelbag, Sterilizine spray and collapsible roller bed."
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 6
 	contains = list(/obj/item/storage/backpack/duffelbag/med/surgery,
 					/obj/item/reagent_containers/medigel/sterilizine,
 					/obj/item/roller)
@@ -1263,14 +1260,14 @@
 /datum/supply_pack/medical/salglucanister
 	name = "Heavy-Duty Saline Canister"
 	desc = "Contains a bulk supply of saline-glucose condensed into a single canister that should last several days, with a large pump to fill containers with. Direct injection of saline should be left to medical professionals as the pump is capable of overdosing patients. Requires medbay access to open."
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 6
 	access = ACCESS_MEDICAL
 	contains = list(/obj/machinery/iv_drip/saline)
 
 /datum/supply_pack/medical/virus
 	name = "Virus Crate"
 	desc = "Contains twelve different bottles, containing several viral samples for virology research. Also includes seven beakers and syringes. Balled-up jeans not included. Requires CMO access to open."
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 5
 	access = ACCESS_CMO
 	access_view = ACCESS_VIROLOGY
 	contains = list(/obj/item/reagent_containers/glass/bottle/flu_virion,
@@ -1304,7 +1301,7 @@
 /datum/supply_pack/science/plasma
 	name = "Plasma Assembly Crate"
 	desc = "Everything you need to burn something to the ground, this contains three plasma assembly sets. Each set contains a plasma tank, igniter, proximity sensor, and timer! Warranty void if exposed to high temperatures. Requires Toxins access to open."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	access = ACCESS_TOXINS
 	access_view = ACCESS_TOXINS
 	contains = list(/obj/item/tank/internals/plasma,
@@ -1325,7 +1322,7 @@
 /datum/supply_pack/science/raw_flux_anomaly
 	name = "Raw Flux Anomaly"
 	desc = "The raw core of a flux anomaly, ready to be implosion-compressed into a powerful artifact."
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 10
 	access = ACCESS_TOXINS
 	access_view = ACCESS_TOXINS
 	contains = list(/obj/item/raw_anomaly_core/flux)
@@ -1335,7 +1332,7 @@
 /datum/supply_pack/science/raw_grav_anomaly
 	name = "Raw Gravitational Anomaly"
 	desc = "The raw core of a gravitational anomaly, ready to be implosion-compressed into a powerful artifact."
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 10
 	access = ACCESS_TOXINS
 	access_view = ACCESS_TOXINS
 	contains = list(/obj/item/raw_anomaly_core/grav)
@@ -1345,7 +1342,7 @@
 /datum/supply_pack/science/raw_vortex_anomaly
 	name = "Raw Vortex Anomaly"
 	desc = "The raw core of a vortex anomaly, ready to be implosion-compressed into a powerful artifact."
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 10
 	access = ACCESS_TOXINS
 	access_view = ACCESS_TOXINS
 	contains = list(/obj/item/raw_anomaly_core/vortex)
@@ -1355,7 +1352,7 @@
 /datum/supply_pack/science/raw_bluespace_anomaly
 	name = "Raw Bluespace Anomaly"
 	desc = "The raw core of a bluespace anomaly, ready to be implosion-compressed into a powerful artifact."
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 10
 	access = ACCESS_TOXINS
 	access_view = ACCESS_TOXINS
 	contains = list(/obj/item/raw_anomaly_core/bluespace)
@@ -1365,7 +1362,7 @@
 /datum/supply_pack/science/raw_pyro_anomaly
 	name = "Raw Pyro Anomaly"
 	desc = "The raw core of a pyro anomaly, ready to be implosion-compressed into a powerful artifact."
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 10
 	access = ACCESS_TOXINS
 	access_view = ACCESS_TOXINS
 	contains = list(/obj/item/raw_anomaly_core/pyro)
@@ -1375,7 +1372,7 @@
 /datum/supply_pack/science/robotics
 	name = "Robotics Assembly Crate"
 	desc = "The tools you need to replace those finicky humans with a loyal robot army! Contains four proximity sensors, two empty first aid kits, two health analyzers, two red hardhats, two mechanical toolboxes, and two cleanbot assemblies! Requires Robotics access to open."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	access = ACCESS_ROBOTICS
 	access_view = ACCESS_ROBOTICS
 	contains = list(/obj/item/assembly/prox_sensor,
@@ -1398,7 +1395,7 @@
 /datum/supply_pack/science/rped
 	name = "RPED crate"
 	desc = "Need to rebuild the ORM but science got annihialted after a bomb test? Buy this for the most advanced parts NT can give you."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	access_view = FALSE
 	contains = list(/obj/item/storage/part_replacer/cargo)
 	crate_name = "\improper RPED crate"
@@ -1406,7 +1403,7 @@
 /datum/supply_pack/science/shieldwalls
 	name = "Shield Generator Crate"
 	desc = "These high powered Shield Wall Generators are guaranteed to keep any unwanted lifeforms on the outside, where they belong! Contains four shield wall generators. Requires Teleporter access to open."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	access = ACCESS_TELEPORTER
 	access_view = ACCESS_TELEPORTER
 	contains = list(/obj/machinery/power/shieldwallgen,
@@ -1419,7 +1416,7 @@
 /datum/supply_pack/science/transfer_valves
 	name = "Tank Transfer Valves Crate"
 	desc = "The key ingredient for making a lot of people very angry very fast. Contains two tank transfer valves. Requires RD access to open."
-	cost = 6000
+	cost = CARGO_CRATE_VALUE * 12
 	access = ACCESS_RD
 	contains = list(/obj/item/transfer_valve,
 					/obj/item/transfer_valve)
@@ -1430,7 +1427,7 @@
 /datum/supply_pack/science/monkey_helmets
 	name = "Monkey Mind Magnification Helmet crate"
 	desc = "Some research is best done with monkeys, yet sometimes they're just too dumb to complete more complicated tasks. These helmets should help."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/clothing/head/helmet/monkey_sentience,
 					/obj/item/clothing/head/helmet/monkey_sentience)
 	crate_name = "monkey mind magnification crate"
@@ -1438,7 +1435,7 @@
 /datum/supply_pack/science/cytology
 	name = "Cytology supplies crate"
 	desc = "Did out of control specimens pulverize xenobiology? Here is some more supplies for further testing."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	access_view = ACCESS_XENOBIOLOGY
 	contains = list(/obj/structure/microscope,
 					/obj/item/biopsy_tool,
@@ -1458,7 +1455,7 @@
 /datum/supply_pack/service/cargo_supples
 	name = "Cargo Supplies Crate"
 	desc = "Sold everything that wasn't bolted down? You can get right back to work with this crate containing stamps, an export scanner, destination tagger, hand labeler and some package wrapping."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 1.75
 	contains = list(/obj/item/stamp,
 					/obj/item/stamp/denied,
 					/obj/item/export_scanner,
@@ -1470,7 +1467,7 @@
 /datum/supply_pack/service/noslipfloor
 	name = "High-traction Floor Tiles"
 	desc = "Make slipping a thing of the past with thirty industrial-grade anti-slip floor tiles!"
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	access_view = ACCESS_JANITOR
 	contains = list(/obj/item/stack/tile/noslip/thirty)
 	crate_name = "high-traction floor tiles crate"
@@ -1478,7 +1475,7 @@
 /datum/supply_pack/service/janitor
 	name = "Janitorial Supplies Crate"
 	desc = "Fight back against dirt and grime with Nanotrasen's Janitorial Essentials(tm)! Contains three buckets, caution signs, and cleaner grenades. Also has a single mop, broom, spray cleaner, rag, and trash bag."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_JANITOR
 	contains = list(/obj/item/reagent_containers/glass/bucket,
 					/obj/item/reagent_containers/glass/bucket,
@@ -1499,7 +1496,7 @@
 /datum/supply_pack/service/janitor/janicart
 	name = "Janitorial Cart and Galoshes Crate"
 	desc = "The keystone to any successful janitor. As long as you have feet, this pair of galoshes will keep them firmly planted on the ground. Also contains a janitorial cart."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/structure/janitorialcart,
 					/obj/item/clothing/shoes/galoshes)
 	crate_name = "janitorial cart crate"
@@ -1508,7 +1505,7 @@
 /datum/supply_pack/service/janitor/janitank
 	name = "Janitor Backpack Crate"
 	desc = "Call forth divine judgement upon dirt and grime with this high capacity janitor backpack. Contains 500 units of station-cleansing cleaner. Requires janitor access to open."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	access = ACCESS_JANITOR
 	contains = list(/obj/item/watertank/janitor)
 	crate_name = "janitor backpack crate"
@@ -1517,7 +1514,7 @@
 /datum/supply_pack/service/mule
 	name = "MULEbot Crate"
 	desc = "Pink-haired Quartermaster not doing her job? Replace her with this tireless worker, today!"
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/mob/living/simple_animal/bot/mulebot)
 	crate_name = "\improper MULEbot Crate"
 	crate_type = /obj/structure/closet/crate/large
@@ -1525,7 +1522,7 @@
 /datum/supply_pack/service/party
 	name = "Party Equipment"
 	desc = "Celebrate both life and death on the station with Nanotrasen's Party Essentials(tm)! Contains seven colored glowsticks, six beers, six sodas, two ales, and a bottle of patron, goldschlager, and shaker!"
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/storage/box/drinkingglasses,
 					/obj/item/reagent_containers/food/drinks/shaker,
 					/obj/item/reagent_containers/food/drinks/bottle/patron,
@@ -1546,7 +1543,7 @@
 /datum/supply_pack/service/carpet
 	name = "Premium Carpet Crate"
 	desc = "Plasteel floor tiles getting on your nerves? These stacks of extra soft carpet will tie any room together."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/stack/tile/carpet/fifty,
 					/obj/item/stack/tile/carpet/fifty,
 					/obj/item/stack/tile/carpet/black/fifty,
@@ -1556,7 +1553,7 @@
 /datum/supply_pack/service/carpet_exotic
 	name = "Exotic Carpet Crate"
 	desc = "Exotic carpets straight from Space Russia, for all your decorating needs. Contains 100 tiles each of 8 different flooring patterns."
-	cost = 4000
+	cost = CARGO_CRATE_VALUE * 8
 	contains = list(/obj/item/stack/tile/carpet/blue/fifty,
 					/obj/item/stack/tile/carpet/blue/fifty,
 					/obj/item/stack/tile/carpet/cyan/fifty,
@@ -1578,7 +1575,7 @@
 /datum/supply_pack/service/lightbulbs
 	name = "Replacement Lights"
 	desc = "May the light of Aether shine upon this station! Or at least, the light of forty two light tubes and twenty one light bulbs."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/storage/box/lights/mixed,
 					/obj/item/storage/box/lights/mixed,
 					/obj/item/storage/box/lights/mixed)
@@ -1587,7 +1584,7 @@
 /datum/supply_pack/service/minerkit
 	name = "Shaft Miner Starter Kit"
 	desc = "All the miners died too fast? Assistant wants to get a taste of life off-station? Either way, this kit is the best way to turn a regular crewman into an ore-producing, monster-slaying machine. Contains meson goggles, a pickaxe, advanced mining scanner, cargo headset, ore bag, gasmask, an explorer suit and a miner ID upgrade. Requires QM access to open."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	access = ACCESS_QM
 	access_view = ACCESS_MINING_STATION
 	contains = list(/obj/item/storage/backpack/duffelbag/mining_conscript)
@@ -1597,7 +1594,7 @@
 /datum/supply_pack/service/wedding
 	name = "Wedding Crate"
 	desc = "Everything you need to host a wedding! Now you just need an officiant."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/clothing/under/dress/wedding_dress,
 					/obj/item/clothing/under/suit/tuxedo,
 					/obj/item/storage/belt/cummerbund,
@@ -1611,14 +1608,14 @@
 /datum/supply_pack/service/emptycrate
 	name = "Empty Crate"
 	desc = "It's an empty crate, for all your storage needs."
-	cost = 700
+	cost = CARGO_CRATE_VALUE * 1.4 //Net Zero Profit.
 	contains = list()
 	crate_name = "crate"
 
 /datum/supply_pack/service/randomized/donkpockets
 	name = "Donk Pocket Variety Crate"
 	desc = "Featuring a line up of Donk Co.'s most popular pastry!"
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/storage/box/donkpockets/donkpocketspicy,
 	/obj/item/storage/box/donkpockets/donkpocketteriyaki,
 	/obj/item/storage/box/donkpockets/donkpocketpizza,
@@ -1645,7 +1642,7 @@
 /datum/supply_pack/organic/hydroponics/beekeeping_suits
 	name = "Beekeeper Suit Crate"
 	desc = "Bee business booming? Better be benevolent and boost botany by bestowing bi-Beekeeper-suits! Contains two beekeeper suits and matching headwear."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/clothing/head/beekeeper_head,
 					/obj/item/clothing/suit/beekeeper_suit,
 					/obj/item/clothing/head/beekeeper_head,
@@ -1656,7 +1653,7 @@
 /datum/supply_pack/organic/hydroponics/beekeeping_fullkit
 	name = "Beekeeping Starter Crate"
 	desc = "BEES BEES BEES. Contains three honey frames, a beekeeper suit and helmet, flyswatter, bee house, and, of course, a pure-bred Nanotrasen-Standardized Queen Bee!"
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/structure/beebox/unwrenched,
 					/obj/item/honey_frame,
 					/obj/item/honey_frame,
@@ -1671,7 +1668,7 @@
 /datum/supply_pack/organic/randomized/chef
 	name = "Excellent Meat Crate"
 	desc = "The best cuts in the whole galaxy."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/food/meat/slab/human/mutant/slime,
 					/obj/item/food/meat/slab/killertomato,
 					/obj/item/food/meat/slab/bear,
@@ -1692,7 +1689,7 @@
 /datum/supply_pack/organic/exoticseeds
 	name = "Exotic Seeds Crate"
 	desc = "Any entrepreneuring botanist's dream. Contains fourteen different seeds, including one replica-pod seed and two mystery seeds!"
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	access_view = ACCESS_HYDROPONICS
 	contains = list(/obj/item/seeds/nettle,
 					/obj/item/seeds/replicapod,
@@ -1712,7 +1709,7 @@
 /datum/supply_pack/organic/food
 	name = "Food Crate"
 	desc = "Get things cooking with this crate full of useful ingredients! Contains a dozen eggs, three bananas, and some flour, rice, milk, soymilk, salt, pepper, enzyme, sugar, and monkeymeat."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/reagent_containers/food/condiment/flour,
 					/obj/item/reagent_containers/food/condiment/rice,
 					/obj/item/reagent_containers/food/condiment/milk,
@@ -1731,7 +1728,7 @@
 /datum/supply_pack/organic/randomized/chef/fruits
 	name = "Fruit Crate"
 	desc = "Rich of vitamins, may contain oranges."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/food/grown/citrus/lime,
 					/obj/item/food/grown/citrus/orange,
 					/obj/item/food/grown/watermelon,
@@ -1743,7 +1740,7 @@
 /datum/supply_pack/organic/cream_piee
 	name = "High-yield Clown-grade Cream Pie Crate"
 	desc = "Designed by Aussec's Advanced Warfare Research Division, these high-yield, Clown-grade cream pies are powered by a synergy of performance and efficiency. Guaranteed to provide maximum results."
-	cost = 6000
+	cost = CARGO_CRATE_VALUE * 12
 	contains = list(/obj/item/storage/backpack/duffelbag/clown/cream_pie)
 	crate_name = "party equipment crate"
 	contraband = TRUE
@@ -1754,7 +1751,7 @@
 /datum/supply_pack/organic/hydroponics
 	name = "Hydroponics Crate"
 	desc = "Supplies for growing a great garden! Contains two bottles of ammonia, two Plant-B-Gone spray bottles, a hatchet, cultivator, plant analyzer, as well as a pair of leather gloves and a botanist's apron."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/reagent_containers/spray/plantbgone,
 					/obj/item/reagent_containers/spray/plantbgone,
 					/obj/item/reagent_containers/glass/bottle/ammonia,
@@ -1770,7 +1767,7 @@
 /datum/supply_pack/organic/hydroponics/hydrotank
 	name = "Hydroponics Backpack Crate"
 	desc = "Bring on the flood with this high-capacity backpack crate. Contains 500 units of life-giving H2O. Requires hydroponics access to open."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	access = ACCESS_HYDROPONICS
 	contains = list(/obj/item/watertank)
 	crate_name = "hydroponics backpack crate"
@@ -1779,7 +1776,7 @@
 /datum/supply_pack/organic/pizza
 	name = "Pizza Crate"
 	desc = "Best prices on this side of the galaxy. All deliveries are guaranteed to be 99% anomaly-free!"
-	cost = 6000 // Best prices this side of the galaxy.
+	cost = CARGO_CRATE_VALUE * 10 // Best prices this side of the galaxy.
 	contains = list(/obj/item/pizzabox/margherita,
 					/obj/item/pizzabox/mushroom,
 					/obj/item/pizzabox/meat,
@@ -1813,7 +1810,7 @@
 /datum/supply_pack/organic/potted_plants
 	name = "Potted Plants Crate"
 	desc = "Spruce up the station with these lovely plants! Contains a random assortment of five potted plants from Nanotrasen's potted plant research division. Warranty void if thrown."
-	cost = 700
+	cost = CARGO_CRATE_VALUE * 1.5
 	contains = list(/obj/item/kirbyplants/random,
 					/obj/item/kirbyplants/random,
 					/obj/item/kirbyplants/random,
@@ -1825,7 +1822,7 @@
 /datum/supply_pack/organic/seeds
 	name = "Seeds Crate"
 	desc = "Big things have small beginnings. Contains fourteen different seeds."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/seeds/chili,
 					/obj/item/seeds/cotton,
 					/obj/item/seeds/berry,
@@ -1846,7 +1843,7 @@
 /datum/supply_pack/organic/randomized/chef/vegetables
 	name = "Vegetables Crate"
 	desc = "Grown in vats."
-	cost = 1300
+	cost = CARGO_CRATE_VALUE * 1.8
 	contains = list(/obj/item/food/grown/chili,
 					/obj/item/food/grown/corn,
 					/obj/item/food/grown/tomato,
@@ -1860,7 +1857,7 @@
 /datum/supply_pack/organic/grill
 	name = "Grilling Starter Kit"
 	desc = "Hey dad I'm Hungry. Hi Hungry I'm THE NEW GRILLING STARTER KIT ONLY 5000 BUX GET NOW! Contains a grill and fuel."
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 8
 	crate_type = /obj/structure/closet/crate
 	contains = list(/obj/item/stack/sheet/mineral/coal/five,
 					/obj/machinery/grill/unwrenched,
@@ -1871,7 +1868,7 @@
 /datum/supply_pack/organic/grillfuel
 	name = "Grilling Fuel Kit"
 	desc = "Contains propane and propane accessories. (Note: doesn't contain any actual propane.)"
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	crate_type = /obj/structure/closet/crate
 	contains = list(/obj/item/stack/sheet/mineral/coal/ten,
 					/obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy
@@ -1889,7 +1886,7 @@
 /datum/supply_pack/critter/parrot
 	name = "Bird Crate"
 	desc = "Contains five expert telecommunication birds."
-	cost = 4000
+	cost = CARGO_CRATE_VALUE * 8
 	access_view = ACCESS_CE
 	contains = list(/mob/living/simple_animal/parrot)
 	crate_name = "parrot crate"
@@ -1903,7 +1900,7 @@
 	name = "Butterflies Crate"
 	desc = "Not a very dangerous insect, but they do give off a better image than, say, flies or cockroaches."//is that a motherfucking worm reference
 	contraband = TRUE
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 5
 	access_view = ACCESS_THEATRE
 	contains = list(/mob/living/simple_animal/butterfly)
 	crate_name = "entomology samples crate"
@@ -1916,7 +1913,7 @@
 /datum/supply_pack/critter/cat
 	name = "Cat Crate"
 	desc = "The cat goes meow! Comes with a collar and a nice cat toy! Cheeseburger not included."//i can't believe im making this reference
-	cost = 5000 //Cats are worth as much as corgis.
+	cost = CARGO_CRATE_VALUE * 10 //Cats are worth as much as corgis.
 	access_view = ACCESS_MEDICAL
 	contains = list(/mob/living/simple_animal/pet/cat,
 					/obj/item/clothing/neck/petcollar,
@@ -1933,7 +1930,7 @@
 /datum/supply_pack/critter/chick
 	name = "Chicken Crate"
 	desc = "The chicken goes bwaak!"
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	access_view = ACCESS_KITCHEN
 	contains = list( /mob/living/simple_animal/chick)
 	crate_name = "chicken crate"
@@ -1941,7 +1938,7 @@
 /datum/supply_pack/critter/corgi
 	name = "Corgi Crate"
 	desc = "Considered the optimal dog breed by thousands of research scientists, this Corgi is but one dog from the millions of Ian's noble bloodline. Comes with a cute collar!"
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 10
 	access_view = ACCESS_HOP
 	contains = list(/mob/living/simple_animal/pet/dog/corgi,
 					/obj/item/clothing/neck/petcollar)
@@ -1958,7 +1955,7 @@
 /datum/supply_pack/critter/cow
 	name = "Cow Crate"
 	desc = "The cow goes moo!"
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 6
 	access_view = ACCESS_HYDROPONICS
 	contains = list(/mob/living/simple_animal/cow)
 	crate_name = "cow crate"
@@ -1966,7 +1963,7 @@
 /datum/supply_pack/critter/crab
 	name = "Crab Rocket"
 	desc = "CRAAAAAAB ROCKET. CRAB ROCKET. CRAB ROCKET. CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB ROCKET. CRAFT. ROCKET. BUY. CRAFT ROCKET. CRAB ROOOCKET. CRAB ROOOOCKET. CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB ROOOOOOOOOOOOOOOOOOOOOOCK EEEEEEEEEEEEEEEEEEEEEEEEE EEEETTTTTTTTTTTTAAAAAAAAA AAAHHHHHHHHHHHHH. CRAB ROCKET. CRAAAB ROCKEEEEEEEEEGGGGHHHHTT CRAB CRAB CRAABROCKET CRAB ROCKEEEET."//fun fact: i actually spent like 10 minutes and transcribed the entire video.
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 8
 	access_view = ACCESS_HOS
 	contains = list(/mob/living/simple_animal/crab)
 	crate_name = "look sir free crabs"
@@ -1980,7 +1977,7 @@
 /datum/supply_pack/critter/corgis/exotic
 	name = "Exotic Corgi Crate"
 	desc = "Corgis fit for a king, these corgis come in a unique color to signify their superiority. Comes with a cute collar!"
-	cost = 5500
+	cost = CARGO_CRATE_VALUE * 11
 	contains = list(/mob/living/simple_animal/pet/dog/corgi/exoticcorgi,
 					/obj/item/clothing/neck/petcollar)
 	crate_name = "exotic corgi crate"
@@ -1988,7 +1985,7 @@
 /datum/supply_pack/critter/fox
 	name = "Fox Crate"
 	desc = "The fox goes...? Comes with a collar!"//what does the fox say
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 10
 	access_view = ACCESS_CAPTAIN
 	contains = list(/mob/living/simple_animal/pet/fox,
 					/obj/item/clothing/neck/petcollar)
@@ -1997,7 +1994,7 @@
 /datum/supply_pack/critter/goat
 	name = "Goat Crate"
 	desc = "The goat goes baa! Warranty void if used as a replacement for Pete."
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 5
 	access_view = ACCESS_KITCHEN
 	contains = list(/mob/living/simple_animal/hostile/retaliate/goat)
 	crate_name = "goat crate"
@@ -2005,7 +2002,7 @@
 /datum/supply_pack/critter/monkey
 	name = "Monkey Cube Crate"
 	desc = "Stop monkeying around! Contains seven monkey cubes. Just add water!"
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list (/obj/item/storage/box/monkeycubes)
 	crate_type = /obj/structure/closet/crate
 	crate_name = "monkey cube crate"
@@ -2013,7 +2010,7 @@
 /datum/supply_pack/critter/pug
 	name = "Pug Crate"
 	desc = "Like a normal dog, but... squished. Comes with a nice collar!"
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 10
 	contains = list(/mob/living/simple_animal/pet/dog/pug,
 					/obj/item/clothing/neck/petcollar)
 	crate_name = "pug crate"
@@ -2021,7 +2018,7 @@
 /datum/supply_pack/critter/bullterrier
 	name = "Bull Terrier Crate"
 	desc = "Like a normal dog, but with a head the shape of an egg. Comes with a nice collar!"
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 10
 	contains = list(/mob/living/simple_animal/pet/dog/bullterrier,
 					/obj/item/clothing/neck/petcollar)
 	crate_name = "bull terrier crate"
@@ -2029,7 +2026,7 @@
 /datum/supply_pack/critter/snake
 	name = "Snake Crate"
 	desc = "Tired of these MOTHER FUCKING snakes on this MOTHER FUCKING space station? Then this isn't the crate for you. Contains three poisonous snakes."
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 6
 	access_view = ACCESS_SECURITY
 	contains = list(/mob/living/simple_animal/hostile/retaliate/poison/snake,
 					/mob/living/simple_animal/hostile/retaliate/poison/snake,
@@ -2046,7 +2043,7 @@
 /datum/supply_pack/costumes_toys/randomised
 	name = "Collectable Hats Crate"
 	desc = "Flaunt your status with three unique, highly-collectable hats!"
-	cost = 20000
+	cost = CARGO_CRATE_VALUE * 40
 	var/num_contained = 3 //number of items picked to be contained in a randomised crate
 	contains = list(/obj/item/clothing/head/collectable/chef,
 					/obj/item/clothing/head/collectable/paper,
@@ -2076,7 +2073,7 @@
 	name = "Contraband Crate"
 	desc = "Psst.. bud... want some contraband? I can get you a poster, some nice cigs, dank, even some sponsored items...you know, the good stuff. Just keep it away from the cops, kay?"
 	contraband = TRUE
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 6
 	num_contained = 7
 	contains = list(/obj/item/poster/random_contraband,
 					/obj/item/poster/random_contraband,
@@ -2102,7 +2099,7 @@
 /datum/supply_pack/costumes_toys/foamforce
 	name = "Foam Force Crate"
 	desc = "Break out the big guns with eight Foam Force shotguns!"
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/gun/ballistic/shotgun/toy,
 					/obj/item/gun/ballistic/shotgun/toy,
 					/obj/item/gun/ballistic/shotgun/toy,
@@ -2117,7 +2114,7 @@
 	name = "Foam Force Pistols Crate"
 	desc = "Psst.. hey bud... remember those old foam force pistols that got discontinued for being too cool? Well I got two of those right here with your name on em. I'll even throw in a spare mag for each, waddya say?"
 	contraband = TRUE
-	cost = 4000
+	cost = CARGO_CRATE_VALUE * 8
 	contains = list(/obj/item/gun/ballistic/automatic/toy/pistol,
 					/obj/item/gun/ballistic/automatic/toy/pistol,
 					/obj/item/ammo_box/magazine/toy/pistol,
@@ -2127,7 +2124,7 @@
 /datum/supply_pack/costumes_toys/formalwear
 	name = "Formalwear Crate"
 	desc = "You're gonna like the way you look, I guaranteed it. Contains an asston of fancy clothing."
-	cost = 3000 //Lots of very expensive items. You gotta pay up to look good!
+	cost = CARGO_CRATE_VALUE * 4 //Lots of very expensive items. You gotta pay up to look good!
 	contains = list(/obj/item/clothing/under/dress/blacktango,
 					/obj/item/clothing/under/misc/assistantformal,
 					/obj/item/clothing/under/misc/assistantformal,
@@ -2160,7 +2157,7 @@
 /datum/supply_pack/costumes_toys/clownpin
 	name = "Hilarious Firing Pin Crate"
 	desc = "I uh... I'm not really sure what this does. Wanna buy it?"
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 10
 	contraband = TRUE
 	contains = list(/obj/item/firing_pin/clown)
 	crate_name = "toy crate" // It's /technically/ a toy. For the clown, at least.
@@ -2169,7 +2166,7 @@
 /datum/supply_pack/costumes_toys/lasertag
 	name = "Laser Tag Crate"
 	desc = "Foam Force is for boys. Laser Tag is for men. Contains three sets of red suits, blue suits, matching helmets, and matching laser tag guns."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/gun/energy/laser/redtag,
 					/obj/item/gun/energy/laser/redtag,
 					/obj/item/gun/energy/laser/redtag,
@@ -2193,7 +2190,7 @@
 /datum/supply_pack/costumes_toys/lasertag/pins
 	name = "Laser Tag Firing Pins Crate"
 	desc = "Three laser tag firing pins used in laser-tag units to ensure users are wearing their vests."
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 3.5
 	contraband = TRUE
 	contains = list(/obj/item/storage/box/lasertagpins)
 	crate_name = "laser tag crate"
@@ -2201,7 +2198,7 @@
 /datum/supply_pack/costumes_toys/mech_suits
 	name = "Mech Pilot's Suit Crate"
 	desc = "Suits for piloting big robots. Contains all three colors!"
-	cost = 1500 //state-of-the-art technology doesn't come cheap
+	cost = CARGO_CRATE_VALUE * 3 //state-of-the-art technology doesn't come cheap
 	contains = list(/obj/item/clothing/under/costume/mech_suit,
 					/obj/item/clothing/under/costume/mech_suit/white,
 					/obj/item/clothing/under/costume/mech_suit/blue)
@@ -2211,7 +2208,7 @@
 /datum/supply_pack/costumes_toys/costume_original
 	name = "Original Costume Crate"
 	desc = "Reenact Shakespearean plays with this assortment of outfits. Contains eight different costumes!"
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/clothing/head/snowman,
 					/obj/item/clothing/suit/snowman,
 					/obj/item/clothing/head/chicken,
@@ -2231,7 +2228,7 @@
 /datum/supply_pack/costumes_toys/costume
 	name = "Standard Costume Crate"
 	desc = "Supply the station's entertainers with the equipment of their trade with these Nanotrasen-approved costumes! Contains a full clown and mime outfit, along with a bike horn and a bottle of nothing."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	access = ACCESS_THEATRE
 	contains = list(/obj/item/storage/backpack/clown,
 					/obj/item/clothing/shoes/clown_shoes,
@@ -2252,7 +2249,7 @@
 /datum/supply_pack/costumes_toys/randomised/toys
 	name = "Toy Crate"
 	desc = "Who cares about pride and accomplishment? Skip the gaming and get straight to the sweet rewards with this product! Contains five random toys. Warranty void if used to prank research directors."
-	cost = 4000 // or play the arcade machines ya lazy bum
+	cost = CARGO_CRATE_VALUE * 8 // or play the arcade machines ya lazy bum
 	num_contained = 5
 	contains = list()
 	crate_name = "toy crate"
@@ -2270,7 +2267,7 @@
 /datum/supply_pack/costumes_toys/wizard
 	name = "Wizard Costume Crate"
 	desc = "Pretend to join the Wizard Federation with this full wizard outfit! Nanotrasen would like to remind its employees that actually joining the Wizard Federation is subject to termination of job and life."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/staff,
 					/obj/item/clothing/suit/wizrobe/fake,
 					/obj/item/clothing/shoes/sandal,
@@ -2287,7 +2284,7 @@
 /datum/supply_pack/costumes_toys/mafia
 	name = "Cosa Nostra Starter Pack"
 	desc = "This crate contains everything you need to set up your own ethnicity-based racketeering operation."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list()
 	contraband = TRUE
 
@@ -2323,7 +2320,7 @@
 /datum/supply_pack/misc/artsupply
 	name = "Art Supplies"
 	desc = "Make some happy little accidents with a rapid pipe cleaner layer, three spraycans, and lots of crayons!"
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 1.8
 	contains = list(/obj/item/rcl,
 					/obj/item/storage/toolbox/artistic,
 					/obj/item/toy/crayon/spraycan,
@@ -2338,7 +2335,7 @@
 /datum/supply_pack/misc/bicycle
 	name = "Bicycle"
 	desc = "Nanotrasen reminds all employees to never toy with powers outside their control."
-	cost = 1000000
+	cost = 1000000 //Special case, we don't want to make this in terms of crates because having bikes be a million credits is the whole meme.
 	contains = list(/obj/vehicle/ridden/bicycle)
 	crate_name = "Bicycle Crate"
 	crate_type = /obj/structure/closet/crate/large
@@ -2346,7 +2343,7 @@
 /datum/supply_pack/misc/bigband
 	name = "Big Band Instrument Collection"
 	desc = "Get your sad station movin' and groovin' with this fine collection! Contains nine different instruments!"
-	cost = 5000
+	cost = CARGO_CRATE_VALUE * 10
 	crate_name = "Big band musical instruments collection"
 	contains = list(/obj/item/instrument/violin,
 					/obj/item/instrument/guitar,
@@ -2362,7 +2359,7 @@
 /datum/supply_pack/misc/book_crate
 	name = "Book Crate"
 	desc = "Surplus from the Nanotrasen Archives, these seven books are sure to be good reads."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	access_view = ACCESS_LIBRARY
 	contains = list(/obj/item/book/codex_gigas,
 					/obj/item/book/manual/random/,
@@ -2376,7 +2373,7 @@
 /datum/supply_pack/misc/paper
 	name = "Bureaucracy Crate"
 	desc = "High stacks of papers on your desk Are a big problem - make it Pea-sized with these bureaucratic supplies! Contains six pens, some camera film, hand labeler supplies, a paper bin, a carbon paper bin, three folders, a laser pointer, two clipboards and two stamps."//that was too forced
-	cost = 1600
+	cost = CARGO_CRATE_VALUE * 3.2
 	contains = list(/obj/structure/filingcabinet/chestdrawer/wheeled,
 					/obj/item/camera_film,
 					/obj/item/hand_labeler,
@@ -2403,7 +2400,7 @@
 /datum/supply_pack/misc/fountainpens
 	name = "Calligraphy Crate"
 	desc = "Sign death warrants in style with these seven executive fountain pens."
-	cost = 700
+	cost = CARGO_CRATE_VALUE * 1.45
 	contains = list(/obj/item/storage/box/fountainpens)
 	crate_type = /obj/structure/closet/crate/wooden
 	crate_name = "calligraphy crate"
@@ -2411,7 +2408,7 @@
 /datum/supply_pack/misc/wrapping_paper
 	name = "Festive Wrapping Paper Crate"
 	desc = "Want to mail your loved ones gift-wrapped chocolates, stuffed animals, the Clown's severed head? You can do all that, with this crate full of wrapping paper."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 1.8
 	contains = list(/obj/item/stack/wrapping_paper)
 	crate_type = /obj/structure/closet/crate/wooden
 	crate_name = "festive wrapping paper crate"
@@ -2420,7 +2417,7 @@
 /datum/supply_pack/misc/funeral
 	name = "Funeral Supply crate"
 	desc = "At the end of the day, someone's gonna want someone dead. Give them a proper send-off with these funeral supplies! Contains a coffin with burial garmets and flowers."
-	cost = 800
+	cost = CARGO_CRATE_VALUE * 1.6
 	access_view = ACCESS_CHAPEL_OFFICE
 	contains = list(/obj/item/clothing/under/misc/burial,
 					/obj/item/food/grown/harebell,
@@ -2431,7 +2428,7 @@
 /datum/supply_pack/misc/empty
 	name = "Empty Supplypod"
 	desc = "Presenting the New Nanotrasen-Brand Bluespace Supplypod! Transport cargo with grace and ease! Call today and we'll shoot over a demo unit for just 300 credits!"
-	cost = 300 //Empty pod, so no crate refund
+	cost = CARGO_CRATE_VALUE * 0.6 //Empty pod, so no crate refund
 	contains = list()
 	DropPodOnly = TRUE
 	crate_type = null
@@ -2440,7 +2437,7 @@
 /datum/supply_pack/misc/religious_supplies
 	name = "Religious Supplies Crate"
 	desc = "Keep your local chaplain happy and well-supplied, lest they call down judgement upon your cargo bay. Contains two bottles of holywater, bibles, chaplain robes, and burial garmets."
-	cost = 4000	// it costs so much because the Space Church needs funding to build a cathedral
+	cost = CARGO_CRATE_VALUE * 6	// it costs so much because the Space Church needs funding to build a cathedral
 	access_view = ACCESS_CHAPEL_OFFICE
 	contains = list(/obj/item/reagent_containers/food/drinks/bottle/holywater,
 					/obj/item/reagent_containers/food/drinks/bottle/holywater,
@@ -2453,7 +2450,7 @@
 /datum/supply_pack/misc/toner
 	name = "Toner Crate"
 	desc = "Spent too much ink printing butt pictures? Fret not, with these six toner refills, you'll be printing butts 'till the cows come home!'"
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/toner,
 					/obj/item/toner,
 					/obj/item/toner,
@@ -2465,7 +2462,7 @@
 /datum/supply_pack/misc/toner_large
 	name = "Toner Crate (Large)"
 	desc = "Tired of changing toner cartridges? These six extra heavy duty refills contain roughly five times as much toner as the base model!"
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 6
 	contains = list(/obj/item/toner/large,
 					/obj/item/toner/large,
 					/obj/item/toner/large,
@@ -2477,7 +2474,7 @@
 /datum/supply_pack/misc/training_toolbox
 	name = "Training Toolbox Crate"
 	desc = "Hone your combat abiltities with two AURUMILL-Brand Training Toolboxes! Guarenteed to count hits made against living beings!"
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/training_toolbox,
 					/obj/item/training_toolbox
 					)
@@ -2486,7 +2483,7 @@
 /datum/supply_pack/misc/blackmarket_telepad
 	name = "Black Market LTSRBT"
 	desc = "Need a faster and better way of transporting your illegal goods from and to the station? Fear not, the Long-To-Short-Range-Bluespace-Transceiver (LTSRBT for short) is here to help. Contains a LTSRBT circuit, two bluespace crystals, and one ansible."
-	cost = 10000
+	cost = CARGO_CRATE_VALUE * 20
 	contraband = TRUE
 	contains = list(
 		/obj/item/circuitboard/machine/ltsrbt,
@@ -2530,7 +2527,7 @@
 /datum/supply_pack/vending/bartending
 	name = "Booze-o-mat and Coffee Supply Crate"
 	desc = "Bring on the booze and coffee vending machine refills."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/vending_refill/boozeomat,
 					/obj/item/vending_refill/coffee)
 	crate_name = "bartending supply crate"
@@ -2538,7 +2535,7 @@
 /datum/supply_pack/vending/cigarette
 	name = "Cigarette Supply Crate"
 	desc = "Don't believe the reports - smoke today! Contains a cigarette vending machine refill."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/vending_refill/cigarette)
 	crate_name = "cigarette supply crate"
 	crate_type = /obj/structure/closet/crate
@@ -2546,28 +2543,28 @@
 /datum/supply_pack/vending/dinnerware
 	name = "Dinnerware Supply Crate"
 	desc = "More knives for the chef."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/vending_refill/dinnerware)
 	crate_name = "dinnerware supply crate"
 
 /datum/supply_pack/vending/science/modularpc
 	name = "Deluxe Silicate Selections Restock"
 	desc = "What's a computer? Contains a Deluxe Silicate Selections restocking unit."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/vending_refill/modularpc)
 	crate_name = "computer supply crate"
 
 /datum/supply_pack/vending/engivend
 	name = "EngiVend Supply Crate"
 	desc = "The engineers are out of metal foam grenades? This should help."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/vending_refill/engivend)
 	crate_name = "engineering supply crate"
 
 /datum/supply_pack/vending/games
 	name = "Games Supply Crate"
 	desc = "Get your game on with this game vending machine refill."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/vending_refill/games)
 	crate_name = "games supply crate"
 	crate_type = /obj/structure/closet/crate
@@ -2575,7 +2572,7 @@
 /datum/supply_pack/vending/hydro_refills
 	name = "Hydroponics Vending Machines Refills"
 	desc = "When the clown takes all the banana seeds. Contains a NutriMax refill and a MegaSeed Servitor refill."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 4
 	crate_type = /obj/structure/closet/crate
 	contains = list(/obj/item/vending_refill/hydroseeds,
 					/obj/item/vending_refill/hydronutrients)
@@ -2584,7 +2581,7 @@
 /datum/supply_pack/vending/imported
 	name = "Imported Vending Machines"
 	desc = "Vending machines famous in other parts of the galaxy."
-	cost = 4000
+	cost = CARGO_CRATE_VALUE * 8
 	contains = list(/obj/item/vending_refill/sustenance,
 					/obj/item/vending_refill/robotics,
 					/obj/item/vending_refill/sovietsoda,
@@ -2594,7 +2591,7 @@
 /datum/supply_pack/vending/medical
 	name = "Medical Vending Crate"
 	desc = "Contains one NanoMed Plus refill, one NanoDrug Plus refill, and one wall-mounted NanoMed refill."
-	cost = 2500
+	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/vending_refill/medical,
 					/obj/item/vending_refill/drugs,
 					/obj/item/vending_refill/wallmed)
@@ -2603,14 +2600,14 @@
 /datum/supply_pack/vending/ptech
 	name = "PTech Supply Crate"
 	desc = "Not enough cartridges after half the crew lost their PDA to explosions? This may fix it."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/vending_refill/cart)
 	crate_name = "ptech supply crate"
 
 /datum/supply_pack/vending/sectech
 	name = "SecTech Supply Crate"
 	desc = "Officer Paul bought all the donuts? Then refill the security vendor with ths crate."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	access = ACCESS_SECURITY
 	contains = list(/obj/item/vending_refill/security)
 	crate_name = "SecTech supply crate"
@@ -2619,21 +2616,21 @@
 /datum/supply_pack/vending/snack
 	name = "Snack Supply Crate"
 	desc = "One vending machine refill of cavity-bringin' goodness! The number one dentist recommended order!"
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/vending_refill/snack)
 	crate_name = "snacks supply crate"
 
 /datum/supply_pack/vending/cola
 	name = "Softdrinks Supply Crate"
 	desc = "Got whacked by a toolbox, but you still have those pesky teeth? Get rid of those pearly whites with this soda machine refill, today!"
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/vending_refill/cola)
 	crate_name = "soft drinks supply crate"
 
 /datum/supply_pack/vending/vendomat
 	name = "Vendomat Supply Crate"
 	desc = "More tools for your IED testing facility."
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/vending_refill/assist)
 	crate_name = "vendomat supply crate"
 
@@ -2644,21 +2641,21 @@
 /datum/supply_pack/vending/wardrobes/autodrobe
 	name = "Autodrobe Supply Crate"
 	desc = "Autodrobe missing your favorite dress? Solve that issue today with this autodrobe refill."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/vending_refill/autodrobe)
 	crate_name = "autodrobe supply crate"
 
 /datum/supply_pack/vending/wardrobes/cargo
 	name = "Cargo Wardrobe Supply Crate"
 	desc = "This crate contains a refill for the CargoDrobe."
-	cost = 750
+	cost = CARGO_CRATE_VALUE * 1.5
 	contains = list(/obj/item/vending_refill/wardrobe/cargo_wardrobe)
 	crate_name = "cargo department supply crate"
 
 /datum/supply_pack/vending/wardrobes/engineering
 	name = "Engineering Wardrobe Supply Crate"
 	desc = "This crate contains refills for the EngiDrobe and AtmosDrobe."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/vending_refill/wardrobe/engi_wardrobe,
 					/obj/item/vending_refill/wardrobe/atmos_wardrobe)
 	crate_name = "engineering department wardrobe supply crate"
@@ -2666,7 +2663,7 @@
 /datum/supply_pack/vending/wardrobes/general
 	name = "General Wardrobes Supply Crate"
 	desc = "This crate contains refills for the CuraDrobe, BarDrobe, ChefDrobe, JaniDrobe, ChapDrobe."
-	cost = 3750
+	cost = CARGO_CRATE_VALUE * 7.5
 	contains = list(/obj/item/vending_refill/wardrobe/curator_wardrobe,
 					/obj/item/vending_refill/wardrobe/bar_wardrobe,
 					/obj/item/vending_refill/wardrobe/chef_wardrobe,
@@ -2677,14 +2674,14 @@
 /datum/supply_pack/vending/wardrobes/hydroponics
 	name = "Hydrobe Supply Crate"
 	desc = "This crate contains a refill for the Hydrobe."
-	cost = 750
+	cost = CARGO_CRATE_VALUE * 1.5
 	contains = list(/obj/item/vending_refill/wardrobe/hydro_wardrobe)
 	crate_name = "hydrobe supply crate"
 
 /datum/supply_pack/vending/wardrobes/medical
 	name = "Medical Wardrobe Supply Crate"
 	desc = "This crate contains refills for the MediDrobe, ChemDrobe, and ViroDrobe."
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 6
 	contains = list(/obj/item/vending_refill/wardrobe/medi_wardrobe,
 					/obj/item/vending_refill/wardrobe/chem_wardrobe,
 					/obj/item/vending_refill/wardrobe/viro_wardrobe)
@@ -2693,7 +2690,7 @@
 /datum/supply_pack/vending/wardrobes/science
 	name = "Science Wardrobe Supply Crate"
 	desc = "This crate contains refills for the SciDrobe, GeneDrobe, and RoboDrobe."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/vending_refill/wardrobe/robo_wardrobe,
 					/obj/item/vending_refill/wardrobe/gene_wardrobe,
 					/obj/item/vending_refill/wardrobe/science_wardrobe)
@@ -2702,7 +2699,7 @@
 /datum/supply_pack/vending/wardrobes/security
 	name = "Security Wardrobe Supply Crate"
 	desc = "This crate contains refills for the SecDrobe and LawDrobe."
-	cost = 1500
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/vending_refill/wardrobe/sec_wardrobe,
 					/obj/item/vending_refill/wardrobe/law_wardrobe)
 	crate_name = "security department supply crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -137,7 +137,7 @@
 /datum/supply_pack/emergency/atmostank
 	name = "Firefighting Tank Backpack"
 	desc = "Mow down fires with this high-capacity fire fighting tank backpack. Requires Atmospherics access to open."
-	cost = CARGO_CRATE_VALUE * 1.5
+	cost = CARGO_CRATE_VALUE * 1.8
 	access = ACCESS_ATMOSPHERICS
 	contains = list(/obj/item/watertank/atmos)
 	crate_name = "firefighting backpack crate"
@@ -146,7 +146,7 @@
 /datum/supply_pack/emergency/internals
 	name = "Internals Crate"
 	desc = "Master your life energy and control your breathing with three breath masks, three emergency oxygen tanks and three large air tanks."//IS THAT A
-	cost = CARGO_CRATE_VALUE * 1.25
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
@@ -165,14 +165,14 @@
 /datum/supply_pack/emergency/metalfoam
 	name = "Metal Foam Grenade Crate"
 	desc = "Seal up those pesky hull breaches with 7 Metal Foam Grenades."
-	cost = CARGO_CRATE_VALUE * 1.25
+	cost = CARGO_CRATE_VALUE * 2.4
 	contains = list(/obj/item/storage/box/metalfoam)
 	crate_name = "metal foam grenade crate"
 
 /datum/supply_pack/emergency/plasma_spacesuit
 	name = "Plasmaman Space Envirosuits"
 	desc = "Contains two space-worthy envirosuits for Plasmamen. Order now and we'll throw in two free helmets! Requires EVA access to open."
-	cost = CARGO_CRATE_VALUE * 2
+	cost = CARGO_CRATE_VALUE * 3.5
 	access = ACCESS_EVA
 	contains = list(/obj/item/clothing/suit/space/eva/plasmaman,
 					/obj/item/clothing/suit/space/eva/plasmaman,
@@ -184,7 +184,7 @@
 /datum/supply_pack/emergency/plasmaman
 	name = "Plasmaman Supply Kit"
 	desc = "Keep those Plasmamen alive with two sets of Plasmaman outfits. Each set contains a plasmaman jumpsuit, gloves, internals tank, and helmet."
-	cost = CARGO_CRATE_VALUE * 2
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/clothing/under/plasmaman,
 					/obj/item/clothing/under/plasmaman,
 					/obj/item/tank/internals/plasmaman/belt/full,
@@ -261,7 +261,7 @@
 /datum/supply_pack/security/ammo
 	name = "Ammo Crate"
 	desc = "Contains two 20-round magazines for the WT-550 Auto Rifle, three boxes of buckshot ammo, three boxes of rubber ammo and special .38 speedloarders. Requires Security access to open."
-	cost = CARGO_CRATE_VALUE * 5
+	cost = CARGO_CRATE_VALUE * 8
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9,
@@ -371,7 +371,7 @@
 /datum/supply_pack/security/supplies
 	name = "Security Supplies Crate"
 	desc = "Contains seven flashbangs, seven teargas grenades, six flashes, and seven handcuffs. Requires Security access to open."
-	cost = CARGO_CRATE_VALUE * 1.75
+	cost = CARGO_CRATE_VALUE * 3.5
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/storage/box/flashbangs,
 					/obj/item/storage/box/teargas,
@@ -468,7 +468,7 @@
 /datum/supply_pack/security/armory/chemimp
 	name = "Chemical Implants Crate"
 	desc = "Contains five Remote Chemical implants. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 1.25
+	cost = CARGO_CRATE_VALUE * 3.5
 	contains = list(/obj/item/storage/box/chemimp)
 	crate_name = "chemical implant crate"
 
@@ -484,7 +484,7 @@
 /datum/supply_pack/security/armory/ballistic
 	name = "Combat Shotguns Crate"
 	desc = "For when the enemy absolutely needs to be replaced with lead. Contains three Aussec-designed Combat Shotguns, and three Shotgun Bandoliers. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 12
+	cost = CARGO_CRATE_VALUE * 17.5
 	contains = list(/obj/item/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/gun/ballistic/shotgun/automatic/combat,
@@ -496,7 +496,7 @@
 /datum/supply_pack/security/armory/dragnet
 	name = "DRAGnet Crate"
 	desc = "Contains three \"Dynamic Rapid-Apprehension of the Guilty\" netting devices, a recent breakthrough in law enforcement prisoner management technology. Requires armory access to open."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/gun/energy/e_gun/dragnet,
 					/obj/item/gun/energy/e_gun/dragnet,
 					/obj/item/gun/energy/e_gun/dragnet)
@@ -505,7 +505,7 @@
 /datum/supply_pack/security/armory/energy
 	name = "Energy Guns Crate"
 	desc = "Contains two Energy Guns, capable of firing both nonlethal and lethal blasts of light. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 18
 	contains = list(/obj/item/gun/energy/e_gun,
 					/obj/item/gun/energy/e_gun)
 	crate_name = "energy gun crate"
@@ -514,14 +514,14 @@
 /datum/supply_pack/security/armory/exileimp
 	name = "Exile Implants Crate"
 	desc = "Contains five Exile implants. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 3.5
 	contains = list(/obj/item/storage/box/exileimp)
 	crate_name = "exile implant crate"
 
 /datum/supply_pack/security/armory/fire
 	name = "Incendiary Weapons Crate"
 	desc = "Burn, baby burn. Contains three incendiary grenades, three plasma canisters, and a flamethrower. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 7
 	access = ACCESS_HEADS
 	contains = list(/obj/item/flamethrower/full,
 					/obj/item/tank/internals/plasma,
@@ -544,7 +544,7 @@
 /datum/supply_pack/security/armory/trackingimp
 	name = "Tracking Implants Crate"
 	desc = "Contains four tracking implants and three tracking speedloaders of tracing .38 ammo. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 4.5
 	contains = list(/obj/item/storage/box/trackimp,
 					/obj/item/ammo_box/c38/trac,
 					/obj/item/ammo_box/c38/trac,
@@ -554,7 +554,7 @@
 /datum/supply_pack/security/armory/laserarmor
 	name = "Reflector Vest Crate"
 	desc = "Contains two vests of highly reflective material. Each armor piece diffuses a laser's energy by over half, as well as offering a good chance to reflect the laser entirely. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 3.5
+	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/clothing/suit/armor/laserproof,
 					/obj/item/clothing/suit/armor/laserproof)
 	crate_name = "reflector vest crate"
@@ -563,7 +563,7 @@
 /datum/supply_pack/security/armory/riotarmor
 	name = "Riot Armor Crate"
 	desc = "Contains three sets of heavy body armor. Advanced padding protects against close-ranged weaponry, making melee attacks feel only half as potent to the user. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 6
 	contains = list(/obj/item/clothing/suit/armor/riot,
 					/obj/item/clothing/suit/armor/riot,
 					/obj/item/clothing/suit/armor/riot)
@@ -572,7 +572,7 @@
 /datum/supply_pack/security/armory/riothelmets
 	name = "Riot Helmets Crate"
 	desc = "Contains three riot helmets. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/clothing/head/helmet/riot,
 					/obj/item/clothing/head/helmet/riot,
 					/obj/item/clothing/head/helmet/riot)
@@ -581,7 +581,7 @@
 /datum/supply_pack/security/armory/riotshields
 	name = "Riot Shields Crate"
 	desc = "For when the greytide gets really uppity. Contains three riot shields. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/shield/riot,
 					/obj/item/shield/riot,
 					/obj/item/shield/riot)
@@ -667,7 +667,7 @@
 /datum/supply_pack/engineering/ripley
 	name = "APLU MK-I Crate"
 	desc = "A do-it-yourself kit for building an ALPU MK-I \"Ripley\", designed for lifting and carrying heavy equipment, and other station tasks. Batteries not included."
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 10
 	access_view = ACCESS_ROBOTICS
 	contains = list(/obj/item/mecha_parts/chassis/ripley,
 					/obj/item/mecha_parts/part/ripley_torso,
@@ -686,7 +686,7 @@
 /datum/supply_pack/engineering/conveyor
 	name = "Conveyor Assembly Crate"
 	desc = "Keep production moving along with thirty conveyor belts. Conveyor switch included. If you have any questions, check out the enclosed instruction book."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 3.5
 	contains = list(/obj/item/stack/conveyor/thirty,
 					/obj/item/conveyor_switch_construct,
 					/obj/item/paper/guides/conveyor)
@@ -695,7 +695,7 @@
 /datum/supply_pack/engineering/engiequipment
 	name = "Engineering Gear Crate"
 	desc = "Gear up with three toolbelts, high-visibility vests, welding helmets, hardhats, and two pairs of meson goggles!"
-	cost = CARGO_CRATE_VALUE * 2.6
+	cost = CARGO_CRATE_VALUE * 4
 	access_view = ACCESS_ENGINE
 	contains = list(/obj/item/storage/belt/utility,
 					/obj/item/storage/belt/utility,
@@ -716,7 +716,7 @@
 /datum/supply_pack/engineering/powergamermitts
 	name = "Insulated Gloves Crate"
 	desc = "The backbone of modern society. Barely ever ordered for actual engineering. Contains three insulated gloves."
-	cost = CARGO_CRATE_VALUE * 4	//Made of pure-grade bullshittinium
+	cost = CARGO_CRATE_VALUE * 8	//Made of pure-grade bullshittinium
 	access_view = ACCESS_ENGINE_EQUIP
 	contains = list(/obj/item/clothing/gloves/color/yellow,
 					/obj/item/clothing/gloves/color/yellow,
@@ -744,7 +744,7 @@
 /datum/supply_pack/engineering/power
 	name = "Power Cell Crate"
 	desc = "Looking for power overwhelming? Look no further. Contains three high-voltage power cells."
-	cost = CARGO_CRATE_VALUE * 1.75
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/stock_parts/cell/high,
 					/obj/item/stock_parts/cell/high,
 					/obj/item/stock_parts/cell/high)
@@ -772,7 +772,7 @@
 					/obj/item/storage/toolbox/mechanical,
 					/obj/item/storage/toolbox/mechanical,
 					/obj/item/storage/toolbox/mechanical)
-	cost = CARGO_CRATE_VALUE * 2.5
+	cost = CARGO_CRATE_VALUE * 5
 	crate_name = "toolbox crate"
 
 /datum/supply_pack/engineering/portapump
@@ -882,7 +882,7 @@
 /datum/supply_pack/engine/emitter
 	name = "Emitter Crate"
 	desc = "Useful for powering forcefield generators while destroying locked crates and intruders alike. Contains two high-powered energy emitters. Requires CE access to open."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 4
 	access = ACCESS_CE
 	contains = list(/obj/machinery/power/emitter,
 					/obj/machinery/power/emitter)
@@ -901,7 +901,7 @@
 /datum/supply_pack/engine/grounding_rods
 	name = "Grounding Rod Crate"
 	desc = "Four grounding rods guaranteed to keep any uppity tesla coil's lightning under control."
-	cost = CARGO_CRATE_VALUE * 3.4
+	cost = CARGO_CRATE_VALUE * 8
 	contains = list(/obj/machinery/power/grounding_rod,
 					/obj/machinery/power/grounding_rod,
 					/obj/machinery/power/grounding_rod,
@@ -921,7 +921,7 @@
 /datum/supply_pack/engine/solar
 	name = "Solar Panel Crate"
 	desc = "Go green with this DIY advanced solar array. Contains twenty one solar assemblies, a solar-control circuit board, and tracker. If you have any questions, please check out the enclosed instruction book."
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 5
 	contains  = list(/obj/item/solar_assembly,
 					/obj/item/solar_assembly,
 					/obj/item/solar_assembly,
@@ -962,7 +962,7 @@
 /datum/supply_pack/engine/tesla_coils
 	name = "Tesla Coil Crate"
 	desc = "Whether it's high-voltage executions, creating research points, or just plain old assistant electrofrying: This pack of four Tesla coils can do it all!"
-	cost = CARGO_CRATE_VALUE * 5
+	cost = CARGO_CRATE_VALUE * 10
 	contains = list(/obj/machinery/power/tesla_coil,
 					/obj/machinery/power/tesla_coil,
 					/obj/machinery/power/tesla_coil,

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -372,6 +372,10 @@
 	if(!A.lightswitch || !A.light_power)
 		charge = 0 //For naturally depowered areas, we start with no power
 
+/obj/item/stock_parts/cell/inducer_supply
+	maxcharge = 5000
+	charge = 5000
+
 #undef CELL_DRAIN_TIME
 #undef CELL_POWER_GAIN
 #undef CELL_POWER_DRAIN


### PR DESCRIPTION
Merry Christmas from the Arconomy Man. 🎄 🎁 ⛄ 

## About The Pull Request

Does a value-wise refactor of crates and bounties in order to scale the value of these imports and exports to the value of crate exports (500 credits each). Then, I have adjusted the value of crate exports to 200 credits down from 500 to place the most standard unit of profit within cargo to a scale within that of roundstart paygrades currently on station. (350-1400 credits). 

This effectively balances one of the biggest disparities left within the in-game economy, which is that cargo's price scales have really never been re-balanced with the considerations of on station prices, and have been still to the same scale as when they were based on cargo points 3 years ago. While admittedly some prices in vendors were scale to those original cargo values, so many of them weren't that it warranted a massive rebalance PR in order to places the scale of these items within an appropriate range of their intended user's cost values.

Now, this means that the value of most crates on station are within the scale that cargo is now receiving 2.5 free crates every payday, in addition to the value they gain from doing bounties, with other departments getting 5 crates in their budgets, albeit that resource pool can only be used exclusively for imports as it stands, but more or less it places their buying power on par with each other as cargo can consistently pull additional profit during the shift should they choose to.

This also keeps the proportional value of most bounties the same, while still enabling the payout to crewmembers to be reasonable to their own department. In tilting this scale downwards, it also means that it's reasonable to give crewmembers a larger chunk than 10% for their exports, based on gratuitously provided feedback from players, so the 10% payout has been increased to a 30% increase. 
Eg: As an assistant, you collect a civilian bounty for 3 monkey cubes, with a payout of 800 credits for cargo. For the assistant, they'd be paid 240 credits for that. With the value of what's left over, in the new scale, that's enough for most of the cheaper style crates on-station, like carpet crates, janitorial supplies, cytology equipment, etc. . A reasonable trade that also feels like a sizable chunk of profit within a department if using bounties as a way to supplement your income mid-shift.

Additionally: I was told that I miiiight have left out a slightly important feature to the pricetag component that miiiiight have enabled some absurd amount of profiteering. This is now fixed. _As a reminder, once your civilian bounty is completed, all you need to do is take the golden bounty cube, and put it on the cargo shuttle to send off, as is. There's nothing else you need to do with it._

As a final note, some prices of crates, specifically crates that see excessively little use mid-round for the utility the provide, have been adjusted for accessibility. 

## Why It's Good For The Game

Consistency is good, and price consistency feels good to see and know that the values are based on a tangible figure in-game as opposed to being based on a random spaghetti value at the end of the day. This places export values in terms of a single, standard unit (crates moved) and should be easy to relate to for players.

Prices are now more appropriate for both cargo's level of effort, and for station-side access in terms of what should and shouldn't be available with minimal effort at a given paygrade.

Fixes a bug that allows you to collect 50% of a civilian bounty's value because I am a stupid dumb dumb idiot several months ago.
As a result of the prices being appropriate to the level of resources being provided to players, the payout for performing civilian bounties could be increased as a direct result.

## Changelog
:cl:
balance: Civilian Bounty Cubes now pay out 30% of the value of the cube, up from 10%.
balance: Cargo Crates are now worth 200 credits each. Cargo crate prices have seen some tweaks as well for more uncommonly ordered crates as well.
fix: You can no longer cheat the bounty system by slapping a new price tag over a bounty cube.
refactor: The values of cargo crates you can order are now scaled in terms of the value of cargo crates.
/:cl:
