### PR TITLE
Metalgen imprinted things don't recycle for anything

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2266,7 +2266,7 @@
 	color = "#b000aa"
 	taste_mult = 0 // oderless and tasteless
 	var/applied_material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR
-	var/minumum_material_amount = 100
+	var/minimum_material_amount = 0
 
 /datum/reagent/metalgen/expose_obj(obj/exposed_obj, volume)
 	. = ..()
@@ -2282,7 +2282,7 @@
 	if(!metal_ref)
 		return
 	var/list/metal_dat = list()
-	metal_dat[metal_ref] = minumum_material_amount //if we pass the list directly, byond turns metal_ref into "metal_ref" kjewrg8fwcyvf
+	metal_dat[metal_ref] = minimum_material_amount //if we pass the list directly, byond turns metal_ref into "metal_ref" kjewrg8fwcyvf
 
 	A.material_flags = applied_material_flags
 	A.set_custom_materials(metal_dat)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2281,16 +2281,8 @@
 	var/metal_ref = data["material"]
 	if(!metal_ref)
 		return
-	var/metal_amount = 0
-
-	for(var/B in A.custom_materials) //list with what they're made of
-		metal_amount += A.custom_materials[B]
-
-	if(!metal_amount)
-		metal_amount = minumum_material_amount //some stuff doesn't have materials at all. To still give them properties, we give them a material. Basically doesnt exist
-
 	var/list/metal_dat = list()
-	metal_dat[metal_ref] = metal_amount //if we pass the list directly, byond turns metal_ref into "metal_ref" kjewrg8fwcyvf
+	metal_dat[metal_ref] = minumum_material_amount //if we pass the list directly, byond turns metal_ref into "metal_ref" kjewrg8fwcyvf
 
 	A.material_flags = applied_material_flags
 	A.set_custom_materials(metal_dat)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This keeps metalgen's material altering abilities but removes the material amount from it making them recycle for nothing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
no more fucking up the economy ^-^
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: metalgen imprinted things don't recycle for anything
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
