### PR TITLE
Replaces invisible tables in the research away mission

### DIFF
--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -4236,19 +4236,6 @@
 	dir = 1
 	},
 /area/awaymission/research/interior/dorm)
-"jp" = (
-/obj/structure/barricade/wooden{
-	desc = "A wooden table hastily flipped over for cover.";
-	icon = 'icons/obj/smooth_structures/wood_table.dmi';
-	icon_state = "wood_table";
-	max_integrity = 55;
-	name = "flipped table";
-	obj_integrity = 55
-	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
-/area/awaymission/research/interior/dorm)
 "jq" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -4413,17 +4400,6 @@
 	},
 /area/awaymission/research/interior/dorm)
 "jF" = (
-/turf/open/floor/plasteel,
-/area/awaymission/research/interior/dorm)
-"jG" = (
-/obj/structure/barricade/wooden{
-	desc = "A wooden table hastily flipped over for cover.";
-	icon = 'icons/obj/smooth_structures/wood_table.dmi';
-	icon_state = "wood_table";
-	max_integrity = 55;
-	name = "flipped table";
-	obj_integrity = 55
-	},
 /turf/open/floor/plasteel,
 /area/awaymission/research/interior/dorm)
 "jH" = (
@@ -4605,17 +4581,6 @@
 /area/awaymission/research/interior/dorm)
 "ka" = (
 /turf/open/floor/plasteel/yellowsiding/corner,
-/area/awaymission/research/interior/dorm)
-"kb" = (
-/obj/structure/barricade/wooden{
-	desc = "A wooden table hastily flipped over for cover.";
-	icon = 'icons/obj/smooth_structures/wood_table.dmi';
-	icon_state = "wood_table";
-	max_integrity = 55;
-	name = "flipped table";
-	obj_integrity = 55
-	},
-/turf/open/floor/plasteel/yellowsiding,
 /area/awaymission/research/interior/dorm)
 "kc" = (
 /turf/open/floor/plasteel/yellowsiding,
@@ -42994,9 +42959,9 @@ id
 id
 eH
 iX
-jp
-jG
-kb
+jn
+jF
+kc
 iX
 iX
 iX

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -5948,6 +5948,16 @@
 	},
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
+"IO" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/yellowsiding,
+/area/awaymission/research/interior/dorm)
+"Jc" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 1
+	},
+/area/awaymission/research/interior/dorm)
 "Km" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
@@ -42959,9 +42969,9 @@ id
 id
 eH
 iX
-jn
-jF
-kc
+Jc
+kR
+IO
 iX
 iX
 iX


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
There was a row of invisible tables in the research mission. This replaces them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #55378
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: The invisible flipped tables in the research away mission are now visible unflipped tables
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
