### PR TITLE
Adds feedback messages to AI's borg factory, code improvements

### DIFF
--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -1,3 +1,4 @@
+#define MSGSPAM_CD_DURATION 60
 /obj/machinery/transformer
 	name = "\improper Automatic Robotic Factory 5000"
 	desc = "A large metallic machine with an entrance and an exit. A sign on \
@@ -42,8 +43,8 @@
 
 /obj/machinery/transformer/Bumped(atom/movable/AM)
 	if(!COOLDOWN_FINISHED(src, transform_cooldown) && COOLDOWN_FINISHED(src, messagespam_cooldown))
-		say("WARNING: Equipment reconfiguration in progess. Please wait \[[DisplayTimeText(cooldown_timer - world.time)]\].")
-		COOLDOWN_START(src, messagespam_cooldown, 60) //Message every 6 seconds
+		say("ERROR: Equipment recalibration in progess. Please wait \[[DisplayTimeText(cooldown_timer - world.time)]\].")
+		COOLDOWN_START(src, messagespam_cooldown, MSGSPAM_CD_DURATION) //Message every 6 seconds
 		return
 
 	// Crossed didn't like people lying down.
@@ -51,10 +52,13 @@
 		// Only humans can enter from the west side, while lying down.
 		var/move_dir = get_dir(loc, AM.loc)
 		var/mob/living/carbon/human/H = AM
-		if((transform_standing || H.body_position == LYING_DOWN) && move_dir == EAST)// || move_dir == WEST)
-			AM.forceMove(drop_location())
-			do_transform(AM)
-
+		if(move_dir == EAST)// || move_dir == WEST)
+			if((transform_standing || H.body_position == LYING_DOWN))
+				AM.forceMove(drop_location())
+				do_transform(AM)
+			else if (COOLDOWN_FINISHED(src, messagespam_cooldown))
+				say("ERROR: Target lifeform must be lying down for successful transformation protocol operation.")
+				COOLDOWN_START(src, messagespam_cooldown, MSGSPAM_CD_DURATION) //Message every 6 seconds
 
 /obj/machinery/transformer/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
@@ -76,6 +80,7 @@
 
 	if(!transform_dead && H.stat == DEAD)
 		playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
+		say("ERROR: Target lifeform must be alive for successful transformation protocol operation.")
 		return
 
 	// Activate the cooldown

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -1,4 +1,4 @@
-#define MSGSPAM_CD_DURATION 60
+#define MSGSPAM_CD_DURATION 200
 /obj/machinery/transformer
 	name = "\improper Automatic Robotic Factory 5000"
 	desc = "A large metallic machine with an entrance and an exit. A sign on \
@@ -29,7 +29,8 @@
 /obj/machinery/transformer/examine(mob/user)
 	. = ..()
 	if(!COOLDOWN_FINISHED(src, transform_cooldown))
-		. += "<b>It will be ready in [DisplayTimeText(COOLDOWN_TIMELEFT(src, transform_cooldown))].</b>"
+		var/timeleft = DisplayTimeText(round(COOLDOWN_TIMELEFT(src, transform_cooldown)))
+		. += "It will be ready in <b>[timeleft]</b>."
 
 /obj/machinery/transformer/Destroy()
 	QDEL_NULL(countdown)
@@ -43,8 +44,9 @@
 
 /obj/machinery/transformer/Bumped(atom/movable/AM)
 	if(!COOLDOWN_FINISHED(src, transform_cooldown) && COOLDOWN_FINISHED(src, messagespam_cooldown))
-		say("ERROR: Equipment recalibration in progess. Please wait \[[DisplayTimeText(COOLDOWN_TIMELEFT(src, transform_cooldown))]\].")
-		COOLDOWN_START(src, messagespam_cooldown, MSGSPAM_CD_DURATION) //Message every 6 seconds
+		var/timeleft = DisplayTimeText(round(COOLDOWN_TIMELEFT(src, transform_cooldown)))
+		say("ERROR: Equipment recalibration in progess. Please wait [timeleft].")
+		COOLDOWN_START(src, messagespam_cooldown, MSGSPAM_CD_DURATION)
 		return
 
 	// Crossed didn't like people lying down.
@@ -58,7 +60,7 @@
 				do_transform(AM)
 			else if (COOLDOWN_FINISHED(src, messagespam_cooldown))
 				say("ERROR: Target lifeform must be lying down for successful transformation protocol operation.")
-				COOLDOWN_START(src, messagespam_cooldown, MSGSPAM_CD_DURATION) //Message every 6 seconds
+				COOLDOWN_START(src, messagespam_cooldown, MSGSPAM_CD_DURATION)
 
 /obj/machinery/transformer/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -29,7 +29,7 @@
 /obj/machinery/transformer/examine(mob/user)
 	. = ..()
 	if(!COOLDOWN_FINISHED(src, transform_cooldown))
-		. += "<b>It will be ready in [DisplayTimeText(cooldown_timer - world.time)].</b>"
+		. += "<b>It will be ready in [DisplayTimeText(COOLDOWN_TIMELEFT(src, transform_cooldown))].</b>"
 
 /obj/machinery/transformer/Destroy()
 	QDEL_NULL(countdown)
@@ -43,7 +43,7 @@
 
 /obj/machinery/transformer/Bumped(atom/movable/AM)
 	if(!COOLDOWN_FINISHED(src, transform_cooldown) && COOLDOWN_FINISHED(src, messagespam_cooldown))
-		say("ERROR: Equipment recalibration in progess. Please wait \[[DisplayTimeText(cooldown_timer - world.time)]\].")
+		say("ERROR: Equipment recalibration in progess. Please wait \[[DisplayTimeText(COOLDOWN_TIMELEFT(src, transform_cooldown))]\].")
 		COOLDOWN_START(src, messagespam_cooldown, MSGSPAM_CD_DURATION) //Message every 6 seconds
 		return
 

--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -106,8 +106,8 @@
 	var/obj/machinery/transformer/T = attached_to
 	if(!istype(T))
 		return
-	else if(T.cooldown)
-		var/seconds_left = max(0, (T.cooldown_timer - world.time) / 10)
+	if(!COOLDOWN_FINISHED(T, transform_cooldown))
+		var/seconds_left = COOLDOWN_TIMELEFT(T, transform_cooldown)
 		return "[round(seconds_left)]"
 
 /obj/effect/countdown/doomsday

--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -107,7 +107,7 @@
 	if(!istype(T))
 		return
 	if(!COOLDOWN_FINISHED(T, transform_cooldown))
-		var/seconds_left = COOLDOWN_TIMELEFT(T, transform_cooldown)
+		var/seconds_left = COOLDOWN_TIMELEFT(T, transform_cooldown) / 10
 		return "[round(seconds_left)]"
 
 /obj/effect/countdown/doomsday


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a feedback message to the borg factory when trying to borg a standing person, a dead person, or a person before the machine is down cooling down. 

Also, makes it so anyone can see how long the borg factory has until the cooldown is over, instead of just silicon and ghosts. (This change is because the cooldown feedback messages are visible to everyone, so it doesn't really make sense to hide the examine text from people at this point.)

Finally, this replaces the process timer in the borg factory with cooldown macros
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently if you try to put a dead person in a borg factory, or someone standing up, or someone in before the CD is finished, you get literally 0 feedback from the machine as to what you're doing wrong. This is particularly bad on the borg factory because often new players will get borged then have no idea how to borg others
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The borg factory will now display feedback messages when silicons incorrectly attempt to borgify someone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
