### PR TITLE
Fixes clowncar sucking up Armsy

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -141,6 +141,7 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 
 #define iseldritch(A) (istype(A, /mob/living/simple_animal/hostile/eldritch))
 
+#define isarmsy(A) (istype(A, /mob/living/simple_animal/hostile/eldritch/armsy))
 
 //Misc mobs
 #define isobserver(A) (istype(A, /mob/dead/observer))

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -139,6 +139,8 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 
 #define isclown(A) (istype(A, /mob/living/simple_animal/hostile/retaliate/clown))
 
+#define iseldritch(A) (istype(A, /mob/living/simple_animal/hostile/eldritch))
+
 
 //Misc mobs
 #define isobserver(A) (istype(A, /mob/dead/observer))

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -70,6 +70,8 @@
 	if(isliving(A))
 		if(ismegafauna(A))
 			return
+		if(iseldritch(A))
+			return
 		var/mob/living/L = A
 		if(iscarbon(L))
 			var/mob/living/carbon/C = L

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -70,7 +70,7 @@
 	if(isliving(A))
 		if(ismegafauna(A))
 			return
-		if(iseldritch(A))
+		if(isarmsy(A))
 			return
 		var/mob/living/L = A
 		if(iscarbon(L))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Prevents the Clown Car from sucking up Armsy
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because a clown car sucking up Armsy is pretty much the same issue with being able to suck up Megafauna.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
tweak: Clowncar can no longer suck up Armsy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
