### PR TITLE
Void Finisher now survives the Void

### DIFF
--- a/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
@@ -162,6 +162,8 @@
 	var/mob/living/carbon/human/H = user
 	H.physiology.brute_mod *= 0.5
 	H.physiology.burn_mod *= 0.5
+	ADD_TRAIT(H, TRAIT_RESISTLOWPRESSURE, "space_adaptation")
+	ADD_TRAIT(H, TRAIT_NOBREATH, "space_adaptation")
 	H.client?.give_award(/datum/award/achievement/misc/void_ascension, H)
 	priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# The nobleman of void [H.real_name] has arrived, step along the Waltz that ends worlds! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", 'sound/ai/spanomalies.ogg')
 

--- a/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
@@ -162,8 +162,8 @@
 	var/mob/living/carbon/human/H = user
 	H.physiology.brute_mod *= 0.5
 	H.physiology.burn_mod *= 0.5
-	ADD_TRAIT(H, TRAIT_RESISTLOWPRESSURE, "space_adaptation")
-	ADD_TRAIT(H, TRAIT_NOBREATH, "space_adaptation")
+	ADD_TRAIT(H, TRAIT_RESISTLOWPRESSURE, MAGIC_TRAIT)
+	ADD_TRAIT(H, TRAIT_NOBREATH, MAGIC_TRAIT)
 	H.client?.give_award(/datum/award/achievement/misc/void_ascension, H)
 	priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# The nobleman of void [H.real_name] has arrived, step along the Waltz that ends worlds! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", 'sound/ai/spanomalies.ogg')
 

--- a/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
@@ -56,10 +56,12 @@
 /datum/eldritch_knowledge/cold_snap/on_gain(mob/user)
 	. = ..()
 	ADD_TRAIT(user,TRAIT_RESISTCOLD,MAGIC_TRAIT)
+	ADD_TRAIT(user, TRAIT_NOBREATH, MAGIC_TRAIT)
 
 /datum/eldritch_knowledge/cold_snap/on_lose(mob/user)
 	. = ..()
 	REMOVE_TRAIT(user,TRAIT_RESISTCOLD,MAGIC_TRAIT)
+	REMOVE_TRAIT(user, TRAIT_NOBREATH, MAGIC_TRAIT)
 
 /datum/eldritch_knowledge/void_cloak
 	name = "Void Cloak"
@@ -163,7 +165,6 @@
 	H.physiology.brute_mod *= 0.5
 	H.physiology.burn_mod *= 0.5
 	ADD_TRAIT(H, TRAIT_RESISTLOWPRESSURE, MAGIC_TRAIT)
-	ADD_TRAIT(H, TRAIT_NOBREATH, MAGIC_TRAIT)
 	H.client?.give_award(/datum/award/achievement/misc/void_ascension, H)
 	priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# The nobleman of void [H.real_name] has arrived, step along the Waltz that ends worlds! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", 'sound/ai/spanomalies.ogg')
 

--- a/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
@@ -47,7 +47,7 @@
 
 /datum/eldritch_knowledge/cold_snap
 	name = "Aristocrat's Way"
-	desc = "Makes you immune to cold temperatures, you can still take damage from lack of pressure."
+	desc = "Makes you immune to cold temperatures, and you no longer need to breathe, you can still take damage from lack of pressure."
 	gain_text = "I found a thread of cold breath. It lead me to a strange shrine, all made of crystals. Translucent and white, a depiction of a nobleman stood before me."
 	cost = 1
 	route = PATH_VOID


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It makes it so when you finish the Void Path as a Heretic, you can actually survive in the void (as well as not suffocate in your own storm), you no longer need to breathe, and you resist low pressure (but not high pressure). (the add_traits show a reference to space_adaptation, it doesnt seem to work if i change the reference, and it doesnt seem to have any issues referencing that, so it should be fine as is)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I originally setout to fix a really severe issue with the Void finisher, namely that the cold air it produces brings the oxygen levels around the Heretic so low, that you would actually suffocate. How odd it is that you do all that work for the Void Path, just to suffocate with your own finisher. during the fixing of this issue (making it so the heretic who finishes the Void Path no longer needs to breathe), i felt it was also odd that the Void is still deadly to the Aristocrat of the Void.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
tweak: Heretics who finish the Void Path and become an Aristocrat of the Void can now survive in the Void (space).
fix: Heretics who research Aristocrats Way on the Void Path will no longer suffocate in their own storm when they ascend (no longer breathes).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
