### PR TITLE
Mythril ore is no longer speciesist

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -839,12 +839,12 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 
 	var/skill_modifier = 1
 
-	if(tool_behaviour == TOOL_MINING && ishuman(user))
+	if(tool_behaviour == TOOL_MINING && isliving(user))
 		if(user.mind)
 			skill_modifier = user.mind.get_skill_modifier(/datum/skill/mining, SKILL_SPEED_MODIFIER)
 
-			if(user.mind.get_skill_level(/datum/skill/mining) >= SKILL_LEVEL_JOURNEYMAN && prob(user.mind.get_skill_modifier(/datum/skill/mining, SKILL_PROBS_MODIFIER))) // we check if the skill level is greater than Journeyman and then we check for the probality for that specific level.
-				mineral_scan_pulse(get_turf(user), SKILL_LEVEL_JOURNEYMAN - 2) //SKILL_LEVEL_JOURNEYMAN = 3 So to get range of 1+ we have to subtract 2 from it,.
+			if(user.mind.get_skill_level(/datum/skill/mining) >= SKILL_LEVEL_JOURNEYMAN && prob(user.mind.get_skill_modifier(/datum/skill/mining, SKILL_PROBS_MODIFIER))) // we check if the skill level is greater than Journeyman and then we check for the probability for that specific level.
+				mineral_scan_pulse(get_turf(user), SKILL_LEVEL_JOURNEYMAN - 2) //SKILL_LEVEL_JOURNEYMAN = 3, so to get a range of 1+ we have to subtract 2 from it.
 
 	delay *= toolspeed * skill_modifier
 

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -135,12 +135,12 @@
 			decreaseUses(user)
 
 	else if(ishuman(target) && user.zone_selected == BODY_ZONE_PRECISE_MOUTH)
-		var/mob/living/carbon/human/human_user = user
-		user.visible_message("<span class='warning'>\the [user] washes \the [target]'s mouth out with [src.name]!</span>", "<span class='notice'>You wash \the [target]'s mouth out with [src.name]!</span>") //washes mouth out with soap sounds better than 'the soap' here			if(user.zone_selected == "mouth")
-		if(human_user.lip_style)
+		var/mob/living/carbon/human/human_target = target
+		user.visible_message("<span class='warning'>\the [user] washes \the [target]'s mouth out with [src.name]!</span>", "<span class='notice'>You wash \the [target]'s mouth out with [src.name]!</span>") //washes mouth out with soap sounds better than 'the soap' here
+		if(human_target.lip_style)
 			user.mind?.adjust_experience(/datum/skill/cleaning, CLEAN_SKILL_GENERIC_WASH_XP)
-			human_user.lip_style = null //removes lipstick
-			human_user.update_body()
+			human_target.lip_style = null //removes lipstick
+			human_target.update_body()
 		decreaseUses(user)
 		return
 	else if(istype(target, /obj/structure/window))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -651,9 +651,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if("SkillReward")
 				var/type = text2path(href_list["skill"])
 				var/datum/skill/S = GetSkillRef(type)
-				var/datum/mind/mind = U.mind
-				var/new_level = mind.get_skill_level(type)
-				S.try_skill_reward(mind, new_level)
+				if(U.mind)
+					S.try_skill_reward(U.mind, U.mind.get_skill_level(type))
 
 //LINK FUNCTIONS===================================
 

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -84,13 +84,13 @@
 	if (mineralType && (mineralAmt > 0))
 		new mineralType(src, mineralAmt)
 		SSblackbox.record_feedback("tally", "ore_mined", mineralAmt, mineralType)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(give_exp)
+	if(isliving(user))
+		var/mob/living/L = user
+		if(give_exp && L.mind)
 			if (mineralType && (mineralAmt > 0))
-				H.mind.adjust_experience(/datum/skill/mining, initial(mineralType.mine_experience) * mineralAmt)
+				L.mind.adjust_experience(/datum/skill/mining, initial(mineralType.mine_experience) * mineralAmt)
 			else
-				H.mind.adjust_experience(/datum/skill/mining, 4)
+				L.mind.adjust_experience(/datum/skill/mining, 4)
 
 	for(var/obj/effect/temp_visual/mining_overlay/M in src)
 		qdel(M)
@@ -768,8 +768,7 @@
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_BORDER
 
 /turf/closed/mineral/strong/attackby(obj/item/I, mob/user, params)
-	if(!ishuman(user))
-		to_chat(usr, "<span class='warning'>Only a more advanced species could break a rock such as this one!</span>")
+	if(!isliving(user))
 		return FALSE
 	if(user.mind?.get_skill_level(/datum/skill/mining) >= SKILL_LEVEL_MASTER)
 		. = ..()
@@ -778,26 +777,22 @@
 
 
 /turf/closed/mineral/strong/gets_drilled(mob/user)
-	if(!ishuman(user))
+	if(!isliving(user))
 		return // see attackby
-	var/mob/living/carbon/human/H = user
-	if(!(H.mind?.get_skill_level(/datum/skill/mining) >= SKILL_LEVEL_MASTER))
+	if(!(user.mind?.get_skill_level(/datum/skill/mining) >= SKILL_LEVEL_MASTER))
 		return
 	drop_ores()
-	H.client.give_award(/datum/award/achievement/skill/legendary_miner, H)
+	user.client.give_award(/datum/award/achievement/skill/legendary_miner, user)
 	var/flags = NONE
 	if(defer_change) // TODO: make the defer change var a var for any changeturf flag
 		flags = CHANGETURF_DEFER_CHANGE
 	ScrapeAway(flags=flags)
 	addtimer(CALLBACK(src, .proc/AfterChange), 1, TIMER_UNIQUE)
 	playsound(src, 'sound/effects/break_stone.ogg', 50, TRUE) //beautiful destruction
-	H.mind?.adjust_experience(/datum/skill/mining, 100) //yay!
+	user.mind?.adjust_experience(/datum/skill/mining, 100) //yay!
 
 /turf/closed/mineral/strong/proc/drop_ores()
-	if(prob(10))
-		new /obj/item/stack/sheet/mineral/mythril(src, 5)
-	else
-		new /obj/item/stack/sheet/mineral/adamantine(src, 5)
+	new /obj/item/stack/sheet/mineral/mythril(src, 5)
 
 /turf/closed/mineral/strong/acid_melt()
 	return

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -219,13 +219,13 @@
 	if(ismineralturf(target_turf))
 		var/turf/closed/mineral/M = target_turf
 		M.gets_drilled(firer, TRUE)
-		if(iscarbon(firer))
-			var/mob/living/carbon/carbon_firer = firer
+		if(isliving(firer))
+			var/mob/living/living_firer = firer
 			var/skill_modifier = 1
 			// If there is a mind, check for skill modifier to allow them to reload faster.
-			if(carbon_firer.mind)
-				skill_modifier = carbon_firer.mind.get_skill_modifier(/datum/skill/mining, SKILL_SPEED_MODIFIER)
-			kinetic_gun.attempt_reload(kinetic_gun.overheat_time * skill_modifier) //If you hit a mineral, you might get a quicker reload. epic gamer style.
+			if(living_firer.mind)
+				skill_modifier = living_firer.mind.get_skill_modifier(/datum/skill/mining, SKILL_SPEED_MODIFIER)
+			kinetic_gun.attempt_reload(kinetic_gun.overheat_time * skill_modifier) //If you hit a mineral, you might get a quicker reload. epic gamer style. //I'm not sure if this actually works (don't other things call attempt_reload() before we get to this proc?), but that's something for another PR to check/fix.
 	var/obj/effect/temp_visual/kinetic_blast/K = new /obj/effect/temp_visual/kinetic_blast(target_turf)
 	K.color = color
 

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -517,15 +517,33 @@
 
 /datum/reagent/consumable/pwr_game/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
-	if(exposed_mob?.mind?.get_skill_level(/datum/skill/gaming) >= SKILL_LEVEL_LEGENDARY && (methods & INGEST) && !HAS_TRAIT(exposed_mob, TRAIT_GAMERGOD))
+	if(exposed_mob?.mind?.get_skill_level(/datum/skill/gaming) >= SKILL_LEVEL_LEGENDARY && !HAS_TRAIT(exposed_mob, TRAIT_GAMERGOD))
+		if(iscyborg(exposed_mob))
+			var/mob/living/silicon/robot/R = exposed_mob
+			if(R.opened) //I'm intentionally not using wiresexposed here, because wiresexposed just determines if someone's hand/arm can reach a cyborg's wiring (while having enough room to maneuver in to actually repair/interact with it), not whether or not a liquid can reach it
+				to_chat(exposed_mob, "<span class='nicegreen'>As the Pwr Game seeps into your circuits, your gaming third sensor opens...</span>")
+			else
+				to_chat(exposed_mob, "<span class='warning'>The Pwr Game fails to penetrate your hardened, metallic exterior!</span>")
+				return //yeah, metallic simplemobs can ascend using Pwr Game just fine, but damnit, I just love the image of a roboticist popping open a cyborg's cover and dumping a soft drink onto their motherboard
+		else if(methods & INGEST)
+			to_chat(exposed_mob, "<span class='nicegreen'>As you imbibe the Pwr Game, your gaming third eye opens...</span>")
+		else if(methods & INJECT)
+			to_chat(exposed_mob, "<span class='nicegreen'>As the Pwr Game is directly injected into your bloodstream, your gaming third eye opens...</span>")
+		else
+			to_chat(exposed_mob, "<span class='nicegreen'>As the Pwr Game makes contact with your body, your gaming third eye opens...</span>")
+
+		to_chat(exposed_mob, "<span class='nicegreen'>You feel as though great secrets of the universe have been made known to you.</span>")
 		ADD_TRAIT(exposed_mob, TRAIT_GAMERGOD, "pwr_game")
-		to_chat(exposed_mob, "<span class='nicegreen'>As you imbibe the Pwr Game, your gamer third eye opens... \
-		You feel as though a great secret of the universe has been made known to you...</span>")
+		
 
 /datum/reagent/consumable/pwr_game/on_mob_life(mob/living/carbon/M)
 	M.adjust_bodytemperature(-8 * TEMPERATURE_DAMAGE_COEFFICIENT, M.get_body_temp_normal())
 	if(prob(10))
 		M.mind?.adjust_experience(/datum/skill/gaming, 5)
+	if(M.mind?.get_skill_level(/datum/skill/gaming) >= SKILL_LEVEL_LEGENDARY && !HAS_TRAIT(exposed_mob, TRAIT_GAMERGOD)) //they crossed the legendary gaming skill threshold after the Pwr Game entered their system but before the Pwr Game left their system
+		to_chat(exposed_mob, "<span class='nicegreen'>You suddenly become acutely aware of the Pwr Game flowing through your veins, and your gaming third eye opens...</span>")
+		to_chat(exposed_mob, "<span class='nicegreen'>You feel as though great secrets of the universe have been made known to you.</span>")
+		ADD_TRAIT(exposed_mob, TRAIT_GAMERGOD, "pwr_game")
 	..()
 
 /datum/reagent/consumable/shamblers

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -540,10 +540,10 @@
 	M.adjust_bodytemperature(-8 * TEMPERATURE_DAMAGE_COEFFICIENT, M.get_body_temp_normal())
 	if(prob(10))
 		M.mind?.adjust_experience(/datum/skill/gaming, 5)
-	if(M.mind?.get_skill_level(/datum/skill/gaming) >= SKILL_LEVEL_LEGENDARY && !HAS_TRAIT(exposed_mob, TRAIT_GAMERGOD)) //they crossed the legendary gaming skill threshold after the Pwr Game entered their system but before the Pwr Game left their system
-		to_chat(exposed_mob, "<span class='nicegreen'>You suddenly become acutely aware of the Pwr Game flowing through your veins, and your gaming third eye opens...</span>")
-		to_chat(exposed_mob, "<span class='nicegreen'>You feel as though great secrets of the universe have been made known to you.</span>")
-		ADD_TRAIT(exposed_mob, TRAIT_GAMERGOD, "pwr_game")
+	if(M.mind?.get_skill_level(/datum/skill/gaming) >= SKILL_LEVEL_LEGENDARY && !HAS_TRAIT(M, TRAIT_GAMERGOD)) //they crossed the legendary gaming skill threshold after the Pwr Game entered their system but before the Pwr Game left their system
+		to_chat(M, "<span class='nicegreen'>You suddenly become acutely aware of the Pwr Game flowing through your veins, and your gaming third eye opens...</span>")
+		to_chat(M, "<span class='nicegreen'>You feel as though great secrets of the universe have been made known to you.</span>")
+		ADD_TRAIT(M, TRAIT_GAMERGOD, "pwr_game")
 	..()
 
 /datum/reagent/consumable/shamblers


### PR DESCRIPTION
## About The Pull Request

Multiple ishuman() and iscarbon() checks related to skills have been replaced with isliving() checks, since whether or not you have skills is tied to whether or not you have a mind, not whether or not you're a humanoid. This means that cyborgs and monkeys can properly gain mining EXP for pickaxing stuff (and use said mining EXP for finding ores and such).

Mythril ore now has a 100% chance to drop mythril sheets instead of its former 10% chance to drop mythril and a 90% chance to drop adamantine sheets.  In addition, nonhumanoids who happen to have a master skill level in mining can now mine mythril ore (instead of receiving a "Only a more advanced species could break a rock such as this one!" message when attempting to do so).

Washing someone else's mouth out with soap no longer washes YOUR mouth out with soap instead.

Pwr Game can now awaken your gaming third eye via any means of exposure, not just ingestion. This means that non-carbons can now ascend to gamer godhood, although ascension-seeking cyborgs will have to have their cover open when they're exposed to Pwr Game so that the drink can properly reach their delicate internal circuits.

Pwr Game also performs its gaming third eye awakening check in its on_life() effect, in case you reach legendary gamer status while it's still metabolizing in your system.

## Why It's Good For The Game

Monkeys and cyborgs can already gain cleaning EXP, so why not mining EXP?

Mythril ore (aka "strong rock") doesn't spawn using the usual methods for ore. Instead, it's actually the centerpiece of a 3x3 lavaland "ruin" that's just a single tile of strong ore surrounded by a 3x3 ring of empty tiles. In order to mine it, you need a mining skill of legendary, which pretty much requires intentionally grinding the skill instead of hunting fauna/megafauna/tendrils, plasmacuttering your way through large swathes of lavaland, interacting with other players, having fun, etc. Your reward for finding this ruin, grinding your way up to legendary mining EXP, and mining this ore should not have a 90% chance to be something that Xenobio can make via 30 minutes of typical gameplay. Also, I don't see any reason why monkeys and cyborgs should be unable to mine mythril- I suspect that the person who coded strong ore simply didn't understand that skills weren't human-only.

The soap thing is just a dumb bug that I noticed while combing through skill code for this PR, so I fixed it.

While they sadly can't get gaming skillcapes (perhaps something for a future PR?), cyborgs should still be allowed to get in on the gaming third eye fun.

The Pwr Game on_life() effect thing is just covering for an edge case that could cause some confusion.

## Changelog
:cl: ATHATH
tweak: Cyborgs, monkeys, and other nonhumanoids can now properly gain and receive the benefits of mining EXP.
balance: Strong rock now has a 100% chance to drop mythril sheets instead of its former 10% chance to drop mythril and a 90% chance to drop adamantine sheets. 
fix: Washing someone else's mouth out with soap no longer washes YOUR mouth out with soap instead.
balance: Cyborgs who have achieved legendary status in the gaming skill can have their gaming third sensors awoken by having someone dump Pwr Game onto their circuits (aka being exposed to Pwr Game while their covers are open).
add: Pwr Game's gaming third eye-awakening effect can now occur when it comes into contact with a legendary gamer (whose gaming third eye hasn't yet been awoken) via any method of exposure, not just ingestion.
fix: If you achieve legendary gamer status while Pwr Game is metabolizing in your system, you do not need to drink more Pwr Game in order to awaken your gaming third eye.
/:cl: