### PR TITLE
[Port] Sanitizes layer manifolds SetInitDirections()

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -70,9 +70,9 @@
 
 /obj/machinery/atmospherics/pipe/layer_manifold/SetInitDirections()
 	switch(dir)
-		if(NORTH || SOUTH)
+		if(NORTH, SOUTH)
 			initialize_directions = NORTH|SOUTH
-		if(EAST || WEST)
+		if(EAST, WEST)
 			initialize_directions = EAST|WEST
 
 /obj/machinery/atmospherics/pipe/layer_manifold/isConnectable(obj/machinery/atmospherics/target, given_layer)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
port of BeeStation/BeeStation-Hornet#3082 , thanks to @park66665

normalize_cardinal_directions() should've autonormalized the dir and short-circuiting of || operator could've prevented this (since short circuited || in if makes them able to handle NORTH and EAST) but, due to how New() and mapping work, on map load, normalize_cardinal_directions() does not work and non-autonormalized dir gets passed to SetInitDirections(), which cannot handle SOUTH and WEST, thereby causing some problems when map has layer manifolds with initial dir of SOUTH and WEST; if normalize_cardinal_directions() worked as intended, this wouldn't have caused the dreaded noncommutativity of pipeline_expansion(), and I couldn't have discovered it via dynamic analysis.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This reduces weird node and pipeline situations related to layer manifolds, which ultimately stems from noncommutativity of pipeline_expansion() caused by inappropriate initialize_directions. These probably include but not limited to:

duplicate pipelines
some pipelines clinging on components since build_pipeline code isn't very robust
both of above has potential to cause some hard dels
tbh I still have no idea how things exactly happen but I am sure this PR should be merged ASAP
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: layer manifolds are now saner
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
