### PR TITLE
[Port] Atmos components now nullifies node properly

### DIFF
--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -73,18 +73,18 @@
 // Pipenet stuff; housekeeping
 
 /obj/machinery/atmospherics/components/nullifyNode(i)
-	if(parents[i])
-		nullifyPipenet(parents[i])
-		QDEL_NULL(airs[i])
-	..()
+	// Every node has a parent pipeline and an air associated with it.
+	nullifyPipenet(parents[i])
+	QDEL_NULL(airs[i])
+	return ..()
 
 /obj/machinery/atmospherics/components/on_construction()
-	..()
+	. = ..()
 	update_parents()
 
 /obj/machinery/atmospherics/components/build_network()
 	for(var/i in 1 to device_type)
-		if(!parents[i])
+		if(QDELETED(parents[i]))
 			parents[i] = new /datum/pipeline()
 			var/datum/pipeline/P = parents[i]
 			P.build_pipeline(src)
@@ -95,6 +95,15 @@
 	var/i = parents.Find(reference)
 	reference.other_airs -= airs[i]
 	reference.other_atmosmch -= src
+	/**
+	 *  We explicitly qdel pipeline when this particular pipeline
+	 *  is projected to have no member and cause GC problems.
+	 *  We have to do this because components don't qdel pipelines
+	 *  while pipes must and will happily wreck and rebuild everything again
+	 *  every time they are qdeleted.
+	 */
+	if(!(reference.other_atmosmch.len || reference.members.len || QDESTROYING(reference)))
+		qdel(reference)
 	parents[i] = null
 
 /obj/machinery/atmospherics/components/returnPipenetAir(datum/pipeline/reference)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -74,7 +74,8 @@
 
 /obj/machinery/atmospherics/components/nullifyNode(i)
 	// Every node has a parent pipeline and an air associated with it.
-	nullifyPipenet(parents[i])
+	if(parents[i])
+		nullifyPipenet(parents[i])
 	QDEL_NULL(airs[i])
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
port of BeeStation/BeeStation-Hornet#3089 and fix BeeStation/BeeStation-Hornet#3090
thanks to @park66665

Components didn't nullify its pipeline datum (a.k.a. pipenets or pipenetworks) properly. There were two things wrong in that:

Every node, by default, has air and associated pipeline datum, but when the node is unconnected (i.e. having null as nodes[i]) those two didn't get cleaned up and cause harddels.
1.1. And yes, that means that components has been happily creating a pipeline datum for its unconnected nodes.
And components nullifyPipenet didn't consider cases where the pipeline becomes memberless, (and should be qdelled) and let them live.
2.1. Since SSair.networks exists, such unfortunate memberless pipeline datum won't get GCed, like, ever, so we have some memory leak happening here.
2.2. Pipes, in contrast, won't cause such problems since they will qdel and rebuild every related pipenets. As long as pipeline_expansion stays commutative and disconnect and other de-noding procedures are accurate, this behavior, while being costly, prevents fucky wucky.
This PR aims to fix both and prevent harddels and memory leaks in case where components with unconnected nodes are being deconstructed (and qdelled).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nobody likes broken pipenet code, harddels, nor memory leaks.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed some memory leak and harddels in atmos pipenet code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
