### PR TITLE
phylactery now makes items stationloving

### DIFF
--- a/code/modules/spells/spell_types/lichdom.dm
+++ b/code/modules/spells/spell_types/lichdom.dm
@@ -53,6 +53,7 @@
 		marked_item.name = "ensouled [marked_item.name]"
 		marked_item.desc += "\nA terrible aura surrounds this item, its very existence is offensive to life itself..."
 		marked_item.add_atom_colour("#003300", ADMIN_COLOUR_PRIORITY)
+		marked_item.AddComponent(/datum/component/stationloving, FALSE, TRUE)
 
 		new /obj/item/phylactery(marked_item, M.mind)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
phylacteries now make items stationloving, so they cant escape station z level
~~i think this is a fix? the stationloving component has
RegisterSignal(parent, list(COMSIG_ITEM_IMBUE_SOUL), .proc/check_soul_imbue)
which is the signal of phylacteries, but they never do it so either someone forgot to add that or they accidentally removed it~~
ok apparently this is for nuke disk sorry

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
~~probably a fix, also~~ wizard having phylactery on another z is cancer, it eliminates all the counterbalance against it and wizard can infinitely revive

## Changelog
:cl:
balance: phylactery now makes items stationloving
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
