### PR TITLE
Stationloving objects now buzz when their stationloving component teleports them back to the station

### DIFF
--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -35,6 +35,7 @@
 			CRASH("Unable to find a blobstart landmark")
 
 	var/atom/movable/AM = parent
+	playsound(AM, 'sound/machines/synth_no.ogg', 5, TRUE) //hey dumbass, you failed at your MOST IMPORTANT JOB, maybe you should check your chat log to see what could have caused that strange buzzing noise
 	AM.forceMove(targetturf)
 	to_chat(get(parent, /mob), "<span class='danger'>You can't help but feel that you just lost something back there...</span>")
 	// move the disc, so ghosts remain orbiting it even if it's "destroyed"


### PR DESCRIPTION
## About The Pull Request

The buzzing noise is pretty much just copied from the one MMIs make if you put a damaged brain in 'em.

## Why It's Good For The Game

This should draw your attention to the chat log, which should in turn draw your attention to the absence of the stationloving item from your inventory.

## Changelog
:cl:
add: Nuke disks (and other station-loving items) now make a buzzing noise when they get teleported out of your inventory due to being taken to an area they're not supposed to be in (deep space, lavaland, etc.).
/:cl: