### PR TITLE
Fix briefcause launchpads qdelling their internal launchpad on creation

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -226,7 +226,7 @@
 
 /obj/machinery/launchpad/briefcase/Initialize(mapload, _briefcase)
 	. = ..()
-	if(!briefcase)
+	if(!_briefcase)
 		log_game("[src] has been spawned without a briefcase.")
 		return INITIALIZE_HINT_QDEL
 	briefcase = _briefcase


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tivi broke them with #54850

![image](https://user-images.githubusercontent.com/24975989/101975893-fe2a8780-3c37-11eb-89b7-651a10b00745.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Briefcase Launchpads will no longer delete themselves from the game when you attempt to place them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
