### PR TITLE
[s]Fix inverted check where if permanent rank changes were disabled in the config, all rank changes would instead always go to the db, even bypassing DBRANK checks.

### DIFF
--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -402,7 +402,7 @@
 		return
 	var/m1 = "[key_name_admin(usr)] edited the permissions of [use_db ? " rank [D.rank.name] permanently" : "[admin_key] temporarily"]"
 	var/m2 = "[key_name(usr)] edited the permissions of [use_db ? " rank [D.rank.name] permanently" : "[admin_key] temporarily"]"
-	if(use_db || legacy_only)
+	if(use_db && !legacy_only)
 		var/rank_name = D.rank.name
 		var/old_flags
 		var/old_exclude_flags


### PR DESCRIPTION
As this is an admin (with `+PERMISSIONS`) accessible exploit bypassing the `+DBRANKS` permission flag, merge should be slightly rushed but not like "stop the presses" rushed.

@tgstation/commit-access 
@Jordie0608 