### PR TITLE
Effects can no longer trigger landmines

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -42,6 +42,8 @@
 
 	if(AM.movement_type & FLYING)
 		return
+	if(iseffect(AM))
+		return
 
 	triggermine(AM)
 

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -40,9 +40,7 @@
 		return
 	. = ..()
 
-	if(AM.movement_type & FLYING)
-		return
-	if(iseffect(AM))
+	if(AM.movement_type & FLYING || iseffect(AM))
 		return
 
 	triggermine(AM)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes it so /obj/effect's can no longer trigger landmines since things like directional lights and countdowns shouldn't be doing that
Fixes: #55382
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Flashlight lights shouldn't be triggering landmines
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Effects like flashlight lights will no longer trigger landmines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
