### PR TITLE
Removes vestigial code

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -1,5 +1,0 @@
-/mob/living/carbon/alien/humanoid/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, silent = FALSE)
-	. = ..()
-	if(!. || !I)
-		return
-

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2318,7 +2318,6 @@
 #include "code\modules\mob\living\carbon\alien\humanoid\humanoid.dm"
 #include "code\modules\mob\living\carbon\alien\humanoid\humanoid_defense.dm"
 #include "code\modules\mob\living\carbon\alien\humanoid\humanoid_update_icons.dm"
-#include "code\modules\mob\living\carbon\alien\humanoid\inventory.dm"
 #include "code\modules\mob\living\carbon\alien\humanoid\life.dm"
 #include "code\modules\mob\living\carbon\alien\humanoid\queen.dm"
 #include "code\modules\mob\living\carbon\alien\humanoid\caste\drone.dm"


### PR DESCRIPTION
- Apparently this has been useless since _2014_

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
There exists one proc override all by itself in one file in this codebase. That proc override does nothing except call parent and then check whether it should early return before hitting the end of scope and returning anyway. Apparently it's been this way since xeno pockets were removed in 2014. It's time for it to go.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Removes literally useless code

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Removed legacy code that was rendered completely useless six years ago. A round of applause for oldcode everyone!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
