### PR TITLE
fixes the clusterfuck of projectile issues

### DIFF
--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/mob/blob.dmi'
 	light_range = 2
 	desc = "A thick wall of writhing tendrils."
-	density = FALSE //this being false causes two bugs, being able to attack blob tiles behind other blobs and being unable to move on blob tiles in no gravity, but turning it to 1 causes the blob mobs to be unable to path through blobs, which is probably worse.
+	density = TRUE
 	opacity = FALSE
 	anchored = TRUE
 	layer = BELOW_MOB_LAYER

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -13,7 +13,7 @@
 		return TRUE
 	if(ismob(mover) && (mover in buckled_mobs))
 		return TRUE
-	return !mover.density || (body_position == LYING_DOWN)
+	return !mover.density || body_position == LYING_DOWN
 
 /mob/living/toggle_move_intent()
 	. = ..()

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -8,12 +8,12 @@
 	if(.)
 		return
 	if(mover.throwing)
-		return (!density || body_position == LYING_DOWN || (mover.throwing.thrower == src && !ismob(mover)))
+		return (!density || (body_position == LYING_DOWN) || (mover.throwing.thrower == src && !ismob(mover)))
 	if(buckled == mover)
 		return TRUE
 	if(ismob(mover) && (mover in buckled_mobs))
 		return TRUE
-	return !mover.density || body_position == LYING_DOWN
+	return !mover.density || (body_position == LYING_DOWN)
 
 /mob/living/toggle_move_intent()
 	. = ..()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -188,15 +188,16 @@
 
 /obj/projectile/kinetic/prehit_pierce(atom/target)
 	. = ..()
-	if(.)
-		if(kinetic_gun)
-			var/list/mods = kinetic_gun.modkits
-			for(var/obj/item/borg/upgrade/modkit/M in mods)
-				M.projectile_prehit(src, target, kinetic_gun)
-		if(!pressure_decrease_active && !lavaland_equipment_pressure_check(get_turf(target)))
-			name = "weakened [name]"
-			damage = damage * pressure_decrease
-			pressure_decrease_active = TRUE
+	if(. == PROJECTILE_PIERCE_PHASE)
+		return
+	if(kinetic_gun)
+		var/list/mods = kinetic_gun.modkits
+		for(var/obj/item/borg/upgrade/modkit/M in mods)
+			M.projectile_prehit(src, target, kinetic_gun)
+	if(!pressure_decrease_active && !lavaland_equipment_pressure_check(get_turf(target)))
+		name = "weakened [name]"
+		damage = damage * pressure_decrease
+		pressure_decrease_active = TRUE
 
 /obj/projectile/kinetic/on_range()
 	strike_thing()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -192,8 +192,8 @@
 		return
 	if(kinetic_gun)
 		var/list/mods = kinetic_gun.modkits
-		for(var/obj/item/borg/upgrade/modkit/M in mods)
-			M.projectile_prehit(src, target, kinetic_gun)
+		for(var/obj/item/borg/upgrade/modkit/modkit in mods)
+			modkit.projectile_prehit(src, target, kinetic_gun)
 	if(!pressure_decrease_active && !lavaland_equipment_pressure_check(get_turf(target)))
 		name = "weakened [name]"
 		damage = damage * pressure_decrease

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -496,8 +496,14 @@
 		if(direct_target)
 			return TRUE
 		// If target not able to use items, move and stand - or if they're just dead, pass over.
-		if((L.stat == DEAD) || (!L.density) || ((L.body_position == LYING_DOWN) && (!hit_stunned_targets && HAS_TRAIT(L, TRAIT_IMMOBILIZED) && HAS_TRAIT(L, TRAIT_FLOORED) && HAS_TRAIT(L, TRAIT_HANDS_BLOCKED))))
+		if(L.stat == DEAD)
 			return FALSE
+		if(!L.density)
+			return FALSE
+		if(L.body_position != LYING_DOWN)
+			return TRUE
+		var/stunned = HAS_TRAIT(L, TRAIT_IMMOBILIZED) && HAS_TRAIT(L, TRAIT_FLOORED) && HAS_TRAIT(L, TRAIT_HANDS_BLOCKED)
+		return !stunned || hit_stunned_targets
 	return TRUE
 
 /**

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -441,14 +441,14 @@
  */
 /obj/projectile/proc/select_target(turf/T, atom/target, atom/bumped)
 	// 1. original
-	if(can_hit_target(original, TRUE, FALSE, target == bumped))
+	if(can_hit_target(original, TRUE, FALSE, original == bumped))
 		return original
 	var/list/atom/possible = list()		// let's define these ONCE
 	var/list/atom/considering = list()
 	// 2. mobs
 	possible = typecache_filter_list(T, GLOB.typecache_living)	// living only
 	for(var/i in possible)
-		if(!can_hit_target(i, i == original, TRUE, target == bumped))
+		if(!can_hit_target(i, i == original, TRUE, i == bumped))
 			continue
 		considering += i
 	if(considering.len)
@@ -457,13 +457,13 @@
 	considering.len = 0
 	// 3. objs and other dense things
 	for(var/i in T.contents)
-		if(!can_hit_target(i, i == original, TRUE, target == bumped))
+		if(!can_hit_target(i, i == original, TRUE, i == bumped))
 			continue
 		considering += i
 	if(considering.len)
 		return pick(considering)
 	// 4. turf
-	if(can_hit_target(T, T == original, TRUE, target == bumped))
+	if(can_hit_target(T, T == original, TRUE, T == bumped))
 		return T
 	// 5. nothing
 		// (returns null)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -573,7 +573,7 @@
  * Return PROJECTILE_DELETE_WITHOUT_HITTING to delete projectile without hitting at all!
  */
 /obj/projectile/proc/prehit_pierce(atom/A)
-	if((projectile_phasing & A.pass_flags_self) && (!phasing_ignore_direct_target || !(original == A)))
+	if((projectile_phasing & A.pass_flags_self) && (!phasing_ignore_direct_target || original != A))
 		return PROJECTILE_PIERCE_PHASE
 	if(projectile_piercing & A.pass_flags_self)
 		return PROJECTILE_PIERCE_HIT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see changelog for the damage report
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I mean, I did "test" my code, just not like.. as exhaustively as I probably should.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: 150 hours of testing
fix: projectiles can hit all clicked things above the hit threshold layer (see: windows) when you directly click on it, even if they usually pass through
fix: mechs are no longer immune to projectiles because **gee whiz, it turns out there's objects that are not items but are also not structures and machinery in the game!**
fix: spiderwebs block projectiles again
fix: beepsky and other non-dense mobs (vs laying down mobs) are no longer bullet sponges
fix: blobs no longer have lasers pass through them, except for the core, which then soaks up the lasers. fair and balanced, right?
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
