### PR TITLE
A handful of Kilo Station fixes.

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -45652,7 +45652,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
-	req_access_txt = "1"
+	req_access_txt = null;
+	req_one_access_txt = "1;4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -51138,7 +51139,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
-	req_access_txt = "1"
+	req_access_txt = null;
+	req_one_access_txt = "1;4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -55664,8 +55666,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
-	req_access_txt = null;
-	req_one_access_txt = "1;4"
+	req_access_txt = "64";
+	req_one_access_txt = null
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55696,8 +55698,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
-	req_access_txt = null;
-	req_one_access_txt = "1;4"
+	req_access_txt = "64";
+	req_one_access_txt = null
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -9671,6 +9671,12 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/leafybush,
+/obj/machinery/camera{
+	c_tag = "Genetics Monkey Pen";
+	dir = 4;
+	name = "science camera";
+	network = list("ss13","rd")
+	},
 /turf/open/floor/grass,
 /area/science/genetics)
 "aqr" = (
@@ -18835,7 +18841,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Sleepers";
+	c_tag = "Medbay Stasis Beds";
 	name = "medical camera";
 	network = list("ss13","medical")
 	},
@@ -34484,14 +34490,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bde" = (
-/obj/structure/sign/warning/fire{
-	pixel_y = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Experimenter Chamber";
-	name = "science camera";
-	network = list("ss13","rd")
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -36692,7 +36690,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Experimenter Lab";
+	c_tag = "Genetics";
 	dir = 8;
 	name = "science camera";
 	network = list("ss13","rd")

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -32812,7 +32812,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "bat" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_access_txt = null;
+	req_one_access_txt = "12;25"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -52121,7 +52122,8 @@
 /area/maintenance/starboard/aft)
 "bEi" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_access_txt = null;
+	req_one_access_txt = "12;25"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -53824,7 +53824,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/camera{
-	c_tag = "Recreation VR Sleepers";
+	c_tag = "Recreation Arcade";
 	name = "recreation camera"
 	},
 /obj/effect/decal/cleanable/cobweb,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -27358,7 +27358,8 @@
 /area/medical/medbay/central)
 "aSv" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12;70"
+	req_access_txt = null;
+	req_one_access_txt = "12;22;25;26;28;35;37;38;46;70"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -40088,7 +40089,8 @@
 /area/quartermaster/storage)
 "blq" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_access_txt = null;
+	req_one_access_txt = "12;22;25;26;28;35;37;38;46;70"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -46960,7 +46962,7 @@
 "bvV" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Service Production";
-	req_one_access_txt = "25;26;35;28;22;37;46;38;70"
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -64271,7 +64273,8 @@
 /area/hallway/primary/aft)
 "bXK" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_access_txt = null;
+	req_one_access_txt = "12;35"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -78509,8 +78512,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8;
-	name = "scrubbers pipe"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -79001,7 +79003,6 @@
 	environment_smash = 0;
 	health = 160;
 	maxHealth = 160;
-	melee_damage_lower = 15;
 	melee_damage_upper = 25;
 	name = "hungry show bear"
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -55664,8 +55664,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
-	req_access_txt = "64";
-	req_one_access_txt = null
+	req_access_txt = null;
+	req_one_access_txt = "1;4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55692,15 +55692,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"bJU" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office";
-	req_access_txt = "64";
-	req_one_access_txt = null
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "bJV" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -70974,7 +70965,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "security maintenance";
-	req_access_txt = "1"
+	req_access_txt = "1;4"
 	},
 /obj/structure/sign/directions/evac{
 	pixel_y = -24
@@ -111105,7 +111096,7 @@ cxJ
 agS
 agS
 bJS
-bJU
+bCv
 agS
 cmP
 cub

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -151,7 +151,10 @@
 
 	. = list()
 
-	. = src.minimal_access.Copy()
+	if(CONFIG_GET(flag/jobs_have_minimal_access))
+		. = src.minimal_access.Copy()
+	else
+		. = src.access.Copy()
 
 	if(CONFIG_GET(flag/everyone_has_maint_access)) //Config has global maint access set
 		. |= list(ACCESS_MAINT_TUNNELS)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -151,10 +151,7 @@
 
 	. = list()
 
-	if(CONFIG_GET(flag/jobs_have_minimal_access))
-		. = src.minimal_access.Copy()
-	else
-		. = src.access.Copy()
+	. = src.minimal_access.Copy()
 
 	if(CONFIG_GET(flag/everyone_has_maint_access)) //Config has global maint access set
 		. |= list(ACCESS_MAINT_TUNNELS)


### PR DESCRIPTION
## About The Pull Request

Renamed cameras in genetics and medbay to account for genetics move and sleeper removal, removed an outdated fire warning sign from genetic's monkey pen..
Renamed camera in room next to holodeck from "Recreation VR sleepers" to "Recreation Arcade".
Added detective access to the left side timed jail cell hallway, leading to the sec office.
And most importantly, **the service lathe hallway and room is now accessible to all service jobs, and the bartender and botanist have access to their little separate sections of maints.**


## Why It's Good For The Game

Kilo Station best station.

## Changelog
:cl:
fix: On Kilo Station all service jobs have access to the service lathe hallway and room again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
