### PR TITLE
Fixing yet another item that can be remotely put in hands with TK.

### DIFF
--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -60,8 +60,9 @@
 		for(var/S in stamped)
 			. += "paperplane_[S]"
 
-/obj/item/paperplane/attack_self(mob/user) //[/obj/item/paperplane/Exited()] will delete src as the internal paper is moved out.
+/obj/item/paperplane/attack_self(mob/user)
 	to_chat(user, "<span class='notice'>You unfold [src].</span>")
+	// We don't have to qdel the paperplane here; it shall be done once the internal paper object is moved out of src anyway.
 	if(user.Adjacent(internalPaper))
 		user.put_in_hands(internalPaper)
 	else

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -32,15 +32,6 @@
 		internalPaper = new(src)
 	update_icon()
 
-/obj/item/paperplane/handle_atom_del(atom/A)
-	if(A == internalPaper)
-		var/obj/item/paper/P = internalPaper
-		internalPaper = null
-		P.moveToNullspace() //So we're not deleting it twice when deleting our contents.
-		if(!QDELETED(src))
-			qdel(src)
-	return ..()
-
 /obj/item/paperplane/Exited(atom/movable/AM, atom/newLoc)
 	. = ..()
 	if (AM == internalPaper)
@@ -69,14 +60,12 @@
 		for(var/S in stamped)
 			. += "paperplane_[S]"
 
-/obj/item/paperplane/attack_self(mob/user)
+/obj/item/paperplane/attack_self(mob/user) //[/obj/item/paperplane/Exited()] will delete src as the internal paper is moved out.
 	to_chat(user, "<span class='notice'>You unfold [src].</span>")
-	var/obj/item/paper/internal_paper_tmp = internalPaper
-	internal_paper_tmp.forceMove(loc)
-	internalPaper = null
-	qdel(src)
-	if(user.Adjacent(internal_paper_tmp))
-		user.put_in_hands(internal_paper_tmp)
+	if(user.Adjacent(internalPaper))
+		user.put_in_hands(internalPaper)
+	else
+		internalPaper.forceMove(loc)
 
 /obj/item/paperplane/attackby(obj/item/P, mob/living/carbon/human/user, params)
 	if(burn_paper_product_attackby_check(P, user))

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -75,7 +75,8 @@
 	internal_paper_tmp.forceMove(loc)
 	internalPaper = null
 	qdel(src)
-	user.put_in_hands(internal_paper_tmp)
+	if(user.Adjacent(internal_paper_tmp))
+		user.put_in_hands(internal_paper_tmp)
 
 /obj/item/paperplane/attackby(obj/item/P, mob/living/carbon/human/user, params)
 	if(burn_paper_product_attackby_check(P, user))
@@ -137,5 +138,6 @@
 	if(origami_action?.active)
 		plane_type = /obj/item/paperplane/syndicate
 
-	I = new plane_type(user, src)
-	user.put_in_hands(I)
+	I = new plane_type(loc, src)
+	if(user.Adjacent(I))
+		user.put_in_hands(I)


### PR DESCRIPTION
## About The Pull Request
I'm adding adjacency checks to paperplane folding and unfolding so the resulting item doesn't get put in hands from afar.

## Why It's Good For The Game
Fixing an issue. This will close Skyrat-SS13/Skyrat-tg#2036 once it's mirrored there.

## Changelog
:cl:
fix: Folding and unfolding paper from afar with TK won't teleport the resulting item in your hands anymore.
/:cl:
