### PR TITLE
Tweaks lighting, adds preset lights for better mood lighting

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -227,7 +227,7 @@
 	var/static_power_used = 0
 	var/brightness = 8			// luminosity when on, also used in power calculation
 	var/bulb_power = 1			// basically the alpha of the emitted light source
-	var/bulb_colour = "#FFFFFF"	// befault colour of the light.
+	var/bulb_colour = "#f3fffa"	// befault colour of the light.
 	var/status = LIGHT_OK		// LIGHT_OK, _EMPTY, _BURNED or _BROKEN
 	var/flickering = FALSE
 	var/light_type = /obj/item/light/tube		// the type of light item
@@ -259,30 +259,6 @@
 	status = LIGHT_BROKEN
 	icon_state = "tube-broken"
 
-/obj/machinery/light/dim
-	nightshift_allowed = FALSE
-	bulb_colour = "#FFDDCC"
-	bulb_power = 0.8
-
-// the smaller bulb light fixture
-
-/obj/machinery/light/small
-	icon_state = "bulb"
-	base_state = "bulb"
-	fitting = "bulb"
-	brightness = 4
-	desc = "A small lighting fixture."
-	light_type = /obj/item/light/bulb
-
-/obj/machinery/light/small/broken
-	status = LIGHT_BROKEN
-	icon_state = "bulb-broken"
-
-/obj/machinery/light/Move()
-	if(status != LIGHT_BROKEN)
-		break_light_tube(1)
-	return ..()
-
 /obj/machinery/light/built
 	icon_state = "tube-empty"
 	start_with_cell = FALSE
@@ -291,6 +267,57 @@
 	. = ..()
 	status = LIGHT_EMPTY
 	update(0)
+
+
+/obj/machinery/light/no_nightlight
+	nightshift_enabled = FALSE
+
+/obj/machinery/light/warm
+	bulb_colour = "#fae5c1"
+
+/obj/machinery/light/warm/no_nightlight
+	nightshift_allowed = FALSE
+
+/obj/machinery/light/cold
+	bulb_colour = "#deefff"
+	nightshift_light_color = "#deefff"
+
+/obj/machinery/light/cold/no_nightlight
+	nightshift_allowed = FALSE
+
+/obj/machinery/light/red
+	bulb_colour = "#FF3232"
+	nightshift_allowed = FALSE
+	no_emergency = TRUE
+	brightness = 2
+	bulb_power = 0.7
+
+/obj/machinery/light/blacklight
+	bulb_colour = "#A700FF"
+	nightshift_allowed = FALSE
+	brightness = 2
+	bulb_power = 0.8
+
+/obj/machinery/light/dim
+	nightshift_allowed = FALSE
+	bulb_colour = "#FFDDCC"
+	bulb_power = 0.6
+
+// the smaller bulb light fixture
+
+/obj/machinery/light/small
+	icon_state = "bulb"
+	base_state = "bulb"
+	fitting = "bulb"
+	brightness = 4
+	nightshift_brightness = 4
+	bulb_colour = "#FFD6AA"
+	desc = "A small lighting fixture."
+	light_type = /obj/item/light/bulb
+
+/obj/machinery/light/small/broken
+	status = LIGHT_BROKEN
+	icon_state = "bulb-broken"
 
 /obj/machinery/light/small/built
 	icon_state = "bulb-empty"
@@ -301,7 +328,23 @@
 	status = LIGHT_EMPTY
 	update(0)
 
+/obj/machinery/light/small/red
+	bulb_colour = "#FF3232"
+	no_emergency = TRUE
+	nightshift_allowed = FALSE
+	brightness = 1
+	bulb_power = 0.8
 
+/obj/machinery/light/small/blacklight
+	bulb_colour = "#A700FF"
+	nightshift_allowed = FALSE
+	brightness = 1
+	bulb_power = 0.9
+
+/obj/machinery/light/Move()
+	if(status != LIGHT_BROKEN)
+		break_light_tube(1)
+	return ..()
 
 // create a new lighting fixture
 /obj/machinery/light/Initialize(mapload)
@@ -888,7 +931,7 @@
 /obj/item/light/on_reagent_change(changetype)
 	rigged = (reagents.has_reagent(/datum/reagent/toxin/plasma, LIGHT_REAGENT_CAPACITY)) //has_reagent returns the reagent datum
 	return ..()
-	
+
 #undef LIGHT_REAGENT_CAPACITY
 
 /obj/item/light/attack(mob/living/M, mob/living/user, def_zone)


### PR DESCRIPTION
## About The Pull Request
Tweaks existing lighting and adds some presets for mapping

Current list of presets is as follows:
Main Tube Lights:  normal, cold and warm with a subtype each that disables night lighting
Red & blacklight (purple) for tube & small lightbulb

## Why It's Good For The Game
Better support for more varied and interesting lighting. I made sure that the new presets are subtle and bright enough to not be distracting or made it harder to see

Changes to currently mapped lighting should be mostly unnoticeable, standard tube lights have a very faint greenish tint typical of fluorescent lights, while small lightbulbs have an orange tint reminiscent of tungsten lightbulbs

For mappers, I would suggest using types that disable nightlighting in work areas while keeping night lighting for hallways and other service/living areas. 
Normal lights for hallways,  cold lighting for medbay and science, warm lighting for bar, library and dorms, red lights for maintenance, maybe blacklight for server rooms etc.

![zz](https://user-images.githubusercontent.com/38563876/102019198-5bc2ef00-3d72-11eb-8a52-516fc219a802.png)

## Changelog
:cl:
tweak: Made some small tweaks to station lighting, added new preset lights for mapping
/:cl:
