### PR TITLE
More Kilo fixes and Pubby cleanup

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -91183,9 +91183,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating/asteroid/airless,
 /area/space/nearstation)
-"vQL" = (
-/turf/open/floor/plating/airless,
-/area/solar/starboard/aft)
 "vSd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -135699,7 +135696,7 @@ cDr
 cFh
 cDr
 cDr
-vQL
+ctQ
 cDr
 cDr
 cDr

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -15524,13 +15524,12 @@
 	},
 /area/maintenance/starboard)
 "azH" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
+/area/maintenance/starboard/fore)
 "azI" = (
 /obj/effect/turf_decal/loading_area,
 /obj/effect/turf_decal/tile/purple{
@@ -18924,8 +18923,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary";
-	req_access_txt = null;
-	req_one_access_txt = "1;4"
+	req_access_txt = "63"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -76791,9 +76789,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "ctw" = (
@@ -123707,8 +123702,8 @@ aaa
 aaa
 aaa
 aaa
-acm
-acm
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -123965,7 +123960,7 @@ aaa
 aaa
 aaa
 aaa
-bUG
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -3000,7 +3000,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/vending/wallmed/pubby{
+/obj/machinery/vending/wallmed{
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -4671,7 +4671,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/siding/red,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aia" = (
@@ -4687,20 +4686,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel,
-/area/security/main)
-"aib" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/siding/red/corner,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aic" = (
@@ -39411,19 +39396,6 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bkp" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel,
-/area/security/main)
 "bkq" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -49310,31 +49282,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"bzN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/red/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "bzO" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
@@ -57581,9 +57528,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/siding/red/corner{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "bMR" = (
@@ -57838,7 +57782,7 @@
 /area/security/processing)
 "bNo" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "12;101"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -60145,9 +60089,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "bQM" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -60383,9 +60325,7 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/central)
 "bRe" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -63484,7 +63424,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bWy" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "12;101"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -64678,7 +64618,7 @@
 /area/maintenance/port/aft)
 "bYt" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "12;101"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -73179,7 +73119,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/siding/red/corner,
 /turf/open/floor/plasteel,
 /area/security/main)
 "cnh" = (
@@ -74101,13 +74040,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/aft)
-"coS" = (
-/obj/machinery/power/solar{
-	id = "aftport";
-	name = "Aft-Port Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/aft)
 "coT" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -74953,7 +74885,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/siding/red/corner,
 /turf/open/floor/plasteel,
 /area/security/main)
 "cqp" = (
@@ -75467,9 +75398,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/red/corner{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "crg" = (
@@ -75505,9 +75433,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75547,9 +75472,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/red/corner{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "crl" = (
@@ -75585,9 +75507,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/red/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -80198,9 +80117,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/red/corner{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "czb" = (
@@ -84793,9 +84709,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/red{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "cHB" = (
@@ -85010,12 +84923,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/red/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/red/corner{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "cHQ" = (
@@ -85165,9 +85072,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/effect/turf_decal/siding/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -86429,9 +86333,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/red{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "cKo" = (
@@ -86445,9 +86346,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -90655,6 +90553,12 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall,
 /area/maintenance/port)
+"scJ" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;101"
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/aft)
 "slN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -103376,7 +103280,7 @@ bAU
 slN
 eZR
 cxi
-atk
+scJ
 cxl
 cuT
 bYq
@@ -103910,11 +103814,11 @@ oUy
 aau
 aeU
 cmU
-coS
-coS
-coS
-coS
-coS
+nMl
+nMl
+nMl
+nMl
+nMl
 ckj
 nMl
 nMl
@@ -104167,11 +104071,11 @@ cQM
 aau
 aeU
 cmU
-coS
-coS
-coS
-coS
-coS
+nMl
+nMl
+nMl
+nMl
+nMl
 ckj
 nMl
 nMl
@@ -105172,7 +105076,7 @@ bMq
 cqc
 bAq
 aLf
-atk
+scJ
 cJB
 bJg
 bTP
@@ -109565,7 +109469,7 @@ aix
 ajc
 aiH
 amS
-bzN
+cri
 ajV
 avM
 cJj
@@ -110075,7 +109979,7 @@ afE
 bCv
 cvL
 cwx
-aib
+aic
 buJ
 aiJ
 bym
@@ -110332,7 +110236,7 @@ aeg
 agS
 aQS
 cwK
-bkp
+aic
 aiy
 aiK
 ajf
@@ -110589,7 +110493,7 @@ crt
 anw
 aLe
 cwK
-bkp
+aic
 aiz
 ajo
 cHY

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -7876,11 +7876,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
-"ans" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating/airless,
-/area/solar/port/fore)
 "ant" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
@@ -10839,11 +10834,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"ase" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating/airless,
-/area/solar/starboard/fore)
 "asf" = (
 /obj/machinery/power/tracker,
 /obj/effect/turf_decal/box,
@@ -84182,11 +84172,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"cGG" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating/airless,
-/area/solar/starboard/aft)
 "cGH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -103999,7 +103984,7 @@ ahG
 ahG
 ahG
 cjl
-ans
+cjl
 cjl
 ahG
 ahG
@@ -134668,7 +134653,7 @@ cDr
 cDr
 cDr
 ctQ
-cGG
+ctQ
 ctQ
 cDr
 cDr
@@ -137925,7 +137910,7 @@ ajH
 ajH
 ajH
 cMU
-ase
+cMU
 cMU
 ajH
 ajH

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -455,7 +455,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/vending/wallmed/pubby{
+/obj/machinery/vending/wallmed{
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/white,

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -60,28 +60,6 @@
 	desc = "A technological marvel, supposedly able to mix just the mixture you'd like to drink the moment you ask for one. This model appears to have no access restrictions."
 	req_access = null
 
-/obj/machinery/vending/boozeomat/pubby_maint //abandoned bar on Pubbystation
-	products = list(/obj/item/reagent_containers/food/drinks/bottle/whiskey = 1,
-			/obj/item/reagent_containers/food/drinks/bottle/absinthe = 1,
-			/obj/item/reagent_containers/food/drinks/bottle/limejuice = 1,
-			/obj/item/reagent_containers/food/drinks/bottle/cream = 1,
-			/obj/item/reagent_containers/food/drinks/soda_cans/tonic = 1,
-			/obj/item/reagent_containers/food/drinks/drinkingglass = 10,
-			/obj/item/reagent_containers/food/drinks/ice = 3,
-			/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 6,
-			/obj/item/reagent_containers/food/drinks/flask = 1)
-	req_access = null
-	age_restrictions = FALSE
-
-/obj/machinery/vending/boozeomat/pubby_captain //Captain's quarters on Pubbystation
-	products = list(/obj/item/reagent_containers/food/drinks/bottle/rum = 1,
-					/obj/item/reagent_containers/food/drinks/bottle/wine = 1,
-					/obj/item/reagent_containers/food/drinks/ale = 1,
-					/obj/item/reagent_containers/food/drinks/drinkingglass = 6,
-					/obj/item/reagent_containers/food/drinks/ice = 1,
-					/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 4);
-	req_access = list(ACCESS_CAPTAIN)
-
 /obj/machinery/vending/boozeomat/syndicate_access
 	req_access = list(ACCESS_SYNDICATE)
 	age_restrictions = FALSE

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -28,9 +28,3 @@
 /obj/item/vending_refill/wallmed
 	machine_name = "NanoMed"
 	icon_state = "refill_medical"
-
-/obj/machinery/vending/wallmed/pubby
-	products = list(/obj/item/reagent_containers/syringe = 3,
-					/obj/item/reagent_containers/pill/patch/libital = 1,
-					/obj/item/reagent_containers/pill/patch/aiuri = 1,
-					/obj/item/reagent_containers/medigel/sterilizine = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Requested by @LemonInTheDark. This removes all pubby specific items and code I was able to locate. Also rolled some fixes discussed in mapping general in here: ERT dock access, minor decal changes, and some solar wires that somehow escaped my first pass at them.

## Why It's Good For The Game

Removing unused old code and making Kilo a better station.

## Changelog
:cl:
del: PubbyStation subtypes of booze-o-mat and wallmed
fix: ERT shuttle access on Kilostation. Interns and other livestock may board again.
fix: Misplaced solar wires on Kilo have been corrected
fix: Some more minor decals/grille placement on Kilo
fix: Spiders will no longer spawn in space on Kilo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
