### PR TITLE
Fixes lack of Cameras in KiloStation Perma

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -90246,6 +90246,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/machinery/camera{
+	c_tag = "Prison Botany";
+	network = list("ss13","prison")
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "pSs" = (
@@ -90839,6 +90843,11 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
+/obj/machinery/camera{
+	c_tag = "Prison Cafeteria";
+	dir = 1;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "tCi" = (
@@ -91201,6 +91210,11 @@
 /mob/living/simple_animal/mouse/brown/tom{
 	name = "Jerm"
 	},
+/obj/machinery/camera{
+	c_tag = "Prison Maintenance";
+	dir = 4;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/plasteel/grimy,
 /area/security/prison/safe)
 "vAM" = (
@@ -91228,12 +91242,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/chemistry)
+"vGA" = (
+/obj/machinery/camera{
+	c_tag = "Prison Recreation";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vHi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/chemistry)
 "vIj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/camera{
+	c_tag = "Prison Labor";
+	network = list("ss13","prison")
+	},
 /turf/open/floor/plating,
 /area/security/prison)
 "vJw" = (
@@ -91526,6 +91552,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xzI" = (
+/obj/machinery/camera{
+	c_tag = "Prison Cells";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xFp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -97720,7 +97754,7 @@ aeu
 aeU
 aeU
 anu
-tFc
+xzI
 clN
 chR
 chR
@@ -97730,7 +97764,7 @@ gUp
 mBd
 iBG
 chR
-tFc
+vGA
 tFc
 chR
 qgG


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is a classic Son of Space mistake.

## Why It's Good For The Game

Being able to look into Perma from the monitor or as the AI is a good idea.

## Changelog
:cl: Son of Space

fix: Gave Perma on Kilo Cameras

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
