### PR TITLE
Adds Waitangi Day and ANZAC Day to holidays.dm

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -262,6 +262,26 @@
 /datum/holiday/usa/getStationPrefix()
 	return pick("Independent","American","Burger","Bald Eagle","Star-Spangled", "Fireworks")
 
+/datum/holiday/nz
+	name = "Waitangi Day"
+	begin_day = 6
+	begin_month = FEBRUARY
+
+/datum/holiday/nz/getStationPrefix()
+	return pick("Aotearoa","Kiwi","Fish 'n' Chips","Kākāpō","Southern Cross")
+
+/datum/holiday/nz/greet()
+	var/nz_age = text2num(time2text(world.timeofday, "YYYY")) - 1840 //is this work
+	return "On this day [nz_age] years ago, New Zealand's Treaty of Waitangi, the founding document of the nation, was signed!" //thus creating much controversy
+
+/datum/holiday/anz
+	name = "ANZAC Day"
+	begin_day = 25
+	begin_month = APRIL
+
+/datum/holiday/anz/getStationPrefix()
+	return pick("Australian","New Zealand","Poppy", "Southern Cross")
+
 /datum/holiday/writer
 	name = "Writer's Day"
 	begin_day = 8

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -278,6 +278,7 @@
 	name = "ANZAC Day"
 	begin_day = 25
 	begin_month = APRIL
+	drone_hat = /obj/item/food/grown/poppy
 
 /datum/holiday/anz/getStationPrefix()
 	return pick("Australian","New Zealand","Poppy", "Southern Cross")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds NZ's national day, Waitangi Day, as well as the Australian/New Zealand holiday that commemorates all who have served in our wars and peacekeeping operations.

I would've assumed the country was too small and unimportant for this but He Who Must Not Be Named [requested this](https://tgstation13.org/phpBB/viewtopic.php?f=2&t=27844&p=583711#p583642) and it's something I'd like to see in the game as well.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This helps American players feel a little bit closer to New Zealand, i.e. Liberal American Heaven.

If you too are from a small, irrelevant country Americans know approximately three things about and want your holidays represented, you can try making your own pull request.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: New Zealand
add: Added Waitangi Day and ANZAC day holidays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
