### PR TITLE
Fixes cleaving saw + whetstone interaction

### DIFF
--- a/code/game/objects/items/melee/transforming.dm
+++ b/code/game/objects/items/melee/transforming.dm
@@ -15,6 +15,8 @@
 	var/list/nemesis_factions //Any mob with a faction that exists in this list will take bonus damage/effects
 	var/w_class_on = WEIGHT_CLASS_BULKY
 	var/clumsy_check = TRUE
+	/// If we get sharpened with a whetstone, save the bonus here for later use if we un/redeploy
+	var/sharpened_bonus
 
 /obj/item/melee/transforming/Initialize()
 	. = ..()
@@ -28,6 +30,7 @@
 			updateEmbedding()
 	if(sharpness)
 		AddComponent(/datum/component/butchering, 50, 100, 0, hitsound)
+	RegisterSignal(src, COMSIG_ITEM_SHARPEN_ACT, .proc/on_sharpen)
 
 /obj/item/melee/transforming/attack_self(mob/living/carbon/user)
 	if(transform_weapon(user))
@@ -49,8 +52,8 @@
 /obj/item/melee/transforming/proc/transform_weapon(mob/living/user, supress_message_text)
 	active = !active
 	if(active)
-		force = force_on
-		throwforce = throwforce_on
+		force = force_on + sharpened_bonus
+		throwforce = throwforce_on + sharpened_bonus
 		hitsound = hitsound_on
 		throw_speed = 4
 		if(attack_verb_on.len)
@@ -60,7 +63,7 @@
 		if(embedding)
 			updateEmbedding()
 	else
-		force = initial(force)
+		force = initial(force) + (get_sharpness() ? sharpened_bonus : 0)
 		throwforce = initial(throwforce)
 		hitsound = initial(hitsound)
 		throw_speed = initial(throw_speed)
@@ -87,3 +90,10 @@
 	if(clumsy_check && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 		to_chat(user, "<span class='warning'>You accidentally cut yourself with [src], like a doofus!</span>")
 		user.take_bodypart_damage(5,5)
+
+/obj/item/melee/transforming/proc/on_sharpen(datum/source, increment, max)
+	SIGNAL_HANDLER
+
+	if(sharpened_bonus)
+		return COMPONENT_BLOCK_SHARPEN_ALREADY
+	sharpened_bonus = increment

--- a/code/game/objects/items/melee/transforming.dm
+++ b/code/game/objects/items/melee/transforming.dm
@@ -64,7 +64,7 @@
 			updateEmbedding()
 	else
 		force = initial(force) + (get_sharpness() ? sharpened_bonus : 0)
-		throwforce = initial(throwforce)
+		throwforce = initial(throwforce) + (get_sharpness() ? sharpened_bonus : 0)
 		hitsound = initial(hitsound)
 		throw_speed = initial(throw_speed)
 		if(attack_verb_off.len)
@@ -96,4 +96,6 @@
 
 	if(sharpened_bonus)
 		return COMPONENT_BLOCK_SHARPEN_ALREADY
+	if(force_on + increment > max)
+		return COMPONENT_BLOCK_SHARPEN_MAXED
 	sharpened_bonus = increment


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can't use whetstones on most one-handed transforming weapons (anything in /obj/item/melee/transforming/energy), but there is one type of transforming weapon that can use it, the cleaving saw. However, since transforming weapons reset their force whenever activated/deactivated, and force is how whetstones track if something has been sharpened already, you could repeatedly enable/disable the saw to allow it to be sharpened again and again, allowing you to continually boost the wound_bonus each time (and also make the name really long). While the very limited number of whetstones in the game means this isn't a practical exploit, it's still worth fixing. This also lets the saw keep its sharpened damage bonus between reactivations.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If anyone adds any other transforming weapons that can be sharpened, they'll be covered now.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Cleaving saws will no longer lose their sharpened damage boost when deactivated, and can no longer be sharpened infinitely
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
