### PR TITLE
Adds bounty name, value and holder to bounty cube description

### DIFF
--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -95,11 +95,14 @@
 		stop_sending()
 	if(curr_bounty.can_claim())
 		//Pay for the bounty with the ID's department funds.
-		status_report += "Bounty Completed! Please send your completed bounty cube to cargo for your automated payout shortly."
+		status_report += "Bounty completed! Please give your bounty cube to cargo for your automated payout shortly."
 		inserted_scan_id.registered_account.reset_bounty()
 		SSeconomy.civ_bounty_tracker++
 		var/obj/item/bounty_cube/reward = new /obj/item/bounty_cube(drop_location())
 		reward.bounty_value = curr_bounty.reward
+		reward.bounty_name = curr_bounty.name
+		reward.bounty_holder = inserted_scan_id.registered_name
+		reward.desc += " [reward.bounty_holder]'s reward for completing the <i>[reward.bounty_name]</i> bounty. Worth [reward.bounty_value] cr."
 		reward.AddComponent(/datum/component/pricetag, inserted_scan_id.registered_account, 30)
 	pad.visible_message("<span class='notice'>[pad] activates!</span>")
 	flick(pad.sending_state,pad)
@@ -206,12 +209,16 @@
 
 ///Upon completion of a civilian bounty, one of these is created. It is sold to cargo to give the cargo budget bounty money, and the person who completed it cash.
 /obj/item/bounty_cube
-	name = "Bounty Cube"
+	name = "bounty cube"
 	desc = "A bundle of compressed hardlight data, containing a completed bounty. Sell this on the cargo shuttle to claim it!"
 	icon = 'icons/obj/economy.dmi'
 	icon_state = "bounty_cube"
 	///Value of the bounty that this bounty cube sells for.
 	var/bounty_value = 0
+	///Who completed the bounty.
+	var/bounty_holder
+	///What the bounty was for.
+	var/bounty_name
 
 ///Beacon to launch a new bounty setup when activated.
 /obj/item/civ_bounty_beacon

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -102,7 +102,8 @@
 		reward.bounty_value = curr_bounty.reward
 		reward.bounty_name = curr_bounty.name
 		reward.bounty_holder = inserted_scan_id.registered_name
-		reward.desc += " [reward.bounty_holder]'s reward for completing the <i>[reward.bounty_name]</i> bounty. Worth [reward.bounty_value] cr."
+		reward.name = "\improper [reward.bounty_value] cr" + " [reward.name]"
+		reward.desc += " The tag indicates it was [reward.bounty_holder]'s reward for completing the <i>[reward.bounty_name]</i> bounty and that it was created at [station_time_timestamp(format = "hh:mm")]."
 		reward.AddComponent(/datum/component/pricetag, inserted_scan_id.registered_account, 30)
 	pad.visible_message("<span class='notice'>[pad] activates!</span>")
 	flick(pad.sending_state,pad)

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -102,7 +102,7 @@
 		reward.bounty_value = curr_bounty.reward
 		reward.bounty_name = curr_bounty.name
 		reward.bounty_holder = inserted_scan_id.registered_name
-		reward.name = "\improper [reward.bounty_value] cr" + " [reward.name]"
+		reward.name = "\improper [reward.bounty_value] cr [reward.name]"
 		reward.desc += " The tag indicates it was [reward.bounty_holder]'s reward for completing the <i>[reward.bounty_name]</i> bounty and that it was created at [station_time_timestamp(format = "hh:mm")]."
 		reward.AddComponent(/datum/component/pricetag, inserted_scan_id.registered_account, 30)
 	pad.visible_message("<span class='notice'>[pad] activates!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Also adds the station time they were created and renames Bounty Cube to "[value] cr bounty cube".

![](https://i.imgur.com/yHxTxj3.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's useful and interesting for cargo to know who is completing bounties, how much they're worth and what they're for. It also motivates cargo to ship cubes when the value, creator and creation time are known to them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
add: Bounty cubes now have the bounty's name, value, fulfiller and creation time in the description
tweak: The Bounty Cube is now known as the "[value] cr bounty cube"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
