### PR TITLE
Replaces deprecated access syntax in github_webhook_processor.php

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -967,7 +967,7 @@ function checkchangelog($payload, $compile = true) {
 
 function game_server_send($addr, $port, $str) {
 	// All queries must begin with a question mark (ie "?players")
-	if($str{0} != '?') $str = ('?' . $str);
+	if($str[0] != '?') $str = ('?' . $str);
 	
 	/* --- Prepare a packet to send to the server (based on a reverse-engineered packet structure) --- */
 	$query = "\x00\x83" . pack('n', strlen($str) + 6) . "\x00\x00\x00\x00\x00" . $str . "\x00";
@@ -997,23 +997,23 @@ function game_server_send($addr, $port, $str) {
 	socket_close($server); // we don't need this anymore
 	
 	if($result != "") {
-		if($result{0} == "\x00" || $result{1} == "\x83") { // make sure it's the right packet format
+		if($result[0] == "\x00" || $result[1] == "\x83") { // make sure it's the right packet format
 			
 			// Actually begin reading the output:
-			$sizebytes = unpack('n', $result{2} . $result{3}); // array size of the type identifier and content
+			$sizebytes = unpack('n', $result[2] . $result[3]); // array size of the type identifier and content
 			$size = $sizebytes[1] - 1; // size of the string/floating-point (minus the size of the identifier byte)
 			
-			if($result{4} == "\x2a") { // 4-byte big-endian floating-point
-				$unpackint = unpack('f', $result{5} . $result{6} . $result{7} . $result{8}); // 4 possible bytes: add them up together, unpack them as a floating-point
+			if($result[4] == "\x2a") { // 4-byte big-endian floating-point
+				$unpackint = unpack('f', $result[5] . $result[6] . $result[7] . $result[8]); // 4 possible bytes: add them up together, unpack them as a floating-point
 				return $unpackint[1];
 			}
-			else if($result{4} == "\x06") { // ASCII string
+			else if($result[4] == "\x06") { // ASCII string
 				$unpackstr = ""; // result string
 				$index = 5; // string index
 				
 				while($size > 0) { // loop through the entire ASCII string
 					$size--;
-					$unpackstr .= $result{$index}; // add the string position to return string
+					$unpackstr .= $result[$index]; // add the string position to return string
 					$index++;
 				}
 				return $unpackstr;


### PR DESCRIPTION
## About The Pull Request
`PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported in ./tools/WebhookProcessor/github_webhook_processor.php on line 972` on line 17 of the Run Linters job of the CI Suite workflow.

## Why It's Good For The Game
Something, something the PHP version updated to 7.x and dropped curly brackets support.

## Changelog
No/A.