### PR TITLE
sanitize_hexcolor can now convert inputs between 12-bit and 24-bit RGB formats plus alpha channel.

### DIFF
--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -60,8 +60,7 @@
 	var/len = length(color)
 	var/char = ""
 	// Used for conversion between RGBA hex formats.
-	var/denominator = length_char(color)-(start-1)
-	var/format_input_ratio = denominator ? desired_format / denominator : -1
+	var/format_input_ratio = "[desired_format]:[length_char(color)-(start-1)]"
 
 	. = ""
 	var/i = start
@@ -79,14 +78,14 @@
 			else
 				break
 		switch(format_input_ratio)
-			if(0 to 0.67) //skip next one. RRGGBB(AA) -> RGB(A)
+			if("3:8", "4:8", "3:6", "4:6") //skip next one. RRGGBB(AA) -> RGB(A)
 				i += length(color[i])
-			if(1.5 to INFINITY) //add current char again. RGB(A) -> RRGGBB(AA)
+			if("6:4", "6:3", "8:4", "8:3") //add current char again. RGB(A) -> RRGGBB(AA)
 				. += char
 
 	if(length_char(.) == desired_format)
 		return crunch + .
-	switch("[desired_format]:[denominator]") //add or remove alpha channel depending on desired format.
+	switch(format_input_ratio) //add or remove alpha channel depending on desired format.
 		if("3:8", "3:4", "6:4")
 			return copytext(., 1, desired_format+1)
 		if("4:6", "4:3", "8:3")

--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -51,7 +51,6 @@
 				return default
 	return default
 
-
 /proc/sanitize_hexcolor(color, desired_format = 3, include_crunch = FALSE, default)
 	var/crunch = include_crunch ? "#" : ""
 	if(!istext(color))
@@ -67,21 +66,21 @@
 	var/i = start
 	while(i <= len)
 		char = color[i]
+		i += length(char)
 		switch(text2ascii(char))
 			if(48 to 57)		//numbers 0 to 9
-				char = char
+				. += char
 			if(97 to 102)		//letters a to f
-				char = char
+				. += char
 			if(65 to 70)		//letters A to F
 				char = lowertext(char)
+				. += char
 			else
 				break
-		i += length(char)
-		. += char
 		switch(format_input_ratio)
 			if(0 to 4/6) //skip next one. RRGGBB(AA) -> RGB(A)
 				i += length(color[i])
-			if(6/4 to INFINITY) //repeat current one. RGB(A) -> RRGGBB(AA)
+			if(6/4 to INFINITY) //Add current char again. RGB(A) -> RRGGBB(AA)
 				. += char
 
 	if(length_char(.) == desired_format)

--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -60,7 +60,7 @@
 	var/len = length(color)
 	var/char = ""
 	// Used for conversion between RGBA hex formats.
-	var/format_input_ratio = len ? desired_format / (length_char(color)-(start-1)) : -1
+	var/format_input_ratio = len ? round(desired_format / (length_char(color)-(start-1)), 0.01) : -1
 
 	. = ""
 	var/i = start
@@ -78,21 +78,21 @@
 			else
 				break
 		switch(format_input_ratio)
-			if(0 to 4/6) //skip next one. RRGGBB(AA) -> RGB(A)
+			if(0 to 0.67) //from 0 to 4:6. skip next one. RRGGBB(AA) -> RGB(A)
 				i += length(color[i])
-			if(6/4 to INFINITY) //Add current char again. RGB(A) -> RRGGBB(AA)
+			if(1.5 to INFINITY) //from 6:4 to inf. Add current char again. RGB(A) -> RRGGBB(AA)
 				. += char
 
 	if(length_char(.) == desired_format)
 		return crunch + .
 	switch(format_input_ratio) //Add or remove alpha channel depending on desired format.
-		if(3/8, 3/4, 6/4)
+		if(0.38, 0.75, 1.5) // 3:8, 3:4, 6:4
 			return copytext(., 1, desired_format+1)
-		if(4/6)
+		if(0.67) // 4:6
 			return . + "f"
-		if(4/3, 8/3)
+		if(1.33, 2.67) // 4:3, 8:3
 			return . + ((desired_format == 4) ? "f" : "ff")
-		else
+		else // not an hex color.
 			return default ? default : crunch + repeat_string(desired_format, "0")
 
 /// Makes sure the input color is text with a # at the start followed by 6 hexadecimal characters. Examples: "#ff1234", "#A38321", COLOR_GREEN_GRAY

--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -51,7 +51,8 @@
 				return default
 	return default
 
-/proc/sanitize_hexcolor(color, desired_format=3, include_crunch=0, default)
+
+/proc/sanitize_hexcolor(color, desired_format = 3, include_crunch = FALSE, default)
 	var/crunch = include_crunch ? "#" : ""
 	if(!istext(color))
 		color = ""
@@ -59,8 +60,8 @@
 	var/start = 1 + (text2ascii(color, 1) == 35)
 	var/len = length(color)
 	var/char = ""
-	// RRGGBB -> RGB but awful
-	var/convert_to_shorthand = desired_format == 3 && length_char(color) > 3
+	// Used for conversion between RGBA hex formats.
+	var/format_input_ratio = len ? desired_format / (length_char(color)-(start-1)) : -1
 
 	. = ""
 	var/i = start
@@ -68,23 +69,32 @@
 		char = color[i]
 		switch(text2ascii(char))
 			if(48 to 57)		//numbers 0 to 9
-				. += char
+				char = char
 			if(97 to 102)		//letters a to f
-				. += char
+				char = char
 			if(65 to 70)		//letters A to F
-				. += lowertext(char)
+				char = lowertext(char)
 			else
 				break
 		i += length(char)
-		if(convert_to_shorthand && i <= len) //skip next one
-			i += length(color[i])
+		. += char
+		switch(format_input_ratio)
+			if(0 to 4/6) //skip next one. RRGGBB(AA) -> RGB(A)
+				i += length(color[i])
+			if(6/4 to INFINITY) //repeat current one. RGB(A) -> RRGGBB(AA)
+				. += char
 
-	if(length_char(.) != desired_format)
-		if(default)
-			return default
-		return crunch + repeat_string(desired_format, "0")
-
-	return crunch + .
+	if(length_char(.) == desired_format)
+		return crunch + .
+	switch(format_input_ratio) //Add or remove alpha channel depending on desired format.
+		if(3/8, 3/4, 6/4)
+			return copytext(., 1, desired_format+1)
+		if(4/6)
+			return . + "f"
+		if(4/3, 8/3)
+			return . + ((desired_format == 4) ? "f" : "ff")
+		else
+			return default ? default : crunch + repeat_string(desired_format, "0")
 
 /// Makes sure the input color is text with a # at the start followed by 6 hexadecimal characters. Examples: "#ff1234", "#A38321", COLOR_GREEN_GRAY
 /proc/sanitize_ooccolor(color)

--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -60,7 +60,8 @@
 	var/len = length(color)
 	var/char = ""
 	// Used for conversion between RGBA hex formats.
-	var/format_input_ratio = len ? round(desired_format / (length_char(color)-(start-1)), 0.01) : -1
+	var/denominator = length_char(color)-(start-1)
+	var/format_input_ratio = denominator ? desired_format / denominator : -1
 
 	. = ""
 	var/i = start
@@ -78,21 +79,19 @@
 			else
 				break
 		switch(format_input_ratio)
-			if(0 to 0.67) //from 0 to 4:6. skip next one. RRGGBB(AA) -> RGB(A)
+			if(0 to 0.67) //skip next one. RRGGBB(AA) -> RGB(A)
 				i += length(color[i])
-			if(1.5 to INFINITY) //from 6:4 to inf. Add current char again. RGB(A) -> RRGGBB(AA)
+			if(1.5 to INFINITY) //add current char again. RGB(A) -> RRGGBB(AA)
 				. += char
 
 	if(length_char(.) == desired_format)
 		return crunch + .
-	switch(format_input_ratio) //Add or remove alpha channel depending on desired format.
-		if(0.38, 0.75, 1.5) // 3:8, 3:4, 6:4
+	switch("[desired_format]:[denominator]") //add or remove alpha channel depending on desired format.
+		if("3:8", "3:4", "6:4")
 			return copytext(., 1, desired_format+1)
-		if(0.67) // 4:6
-			return . + "f"
-		if(1.33, 2.67) // 4:3, 8:3
+		if("4:6", "4:3", "8:3")
 			return . + ((desired_format == 4) ? "f" : "ff")
-		else // not an hex color.
+		else //not a supported hex color format.
 			return default ? default : crunch + repeat_string(desired_format, "0")
 
 /// Makes sure the input color is text with a # at the start followed by 6 hexadecimal characters. Examples: "#ff1234", "#A38321", COLOR_GREEN_GRAY


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
sanitize_hexcolor was previously only capable of shorthanding RRGGBB to RGB. I assume that's also why we have been stuck using 12-bit colors for prefs hair color & co for so long.
Tested.

## Changelog
N/A