### PR TITLE
Fixes GC for observers and new players, and tons of loose references to stuff that shouldnt be

### DIFF
--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -57,6 +57,8 @@ GLOBAL_LIST_INIT(huds, list(
 	if (absolute || !--hudusers[M])
 		UnregisterSignal(M, COMSIG_PARENT_QDELETING)
 		hudusers -= M
+		if(next_time_allowed[M])
+			next_time_allowed -= M
 		if(queued_to_see[M])
 			queued_to_see -= M
 		else

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -51,10 +51,11 @@ GLOBAL_LIST_INIT(huds, list(
 	GLOB.all_huds -= src
 	return ..()
 
-/datum/atom_hud/proc/remove_hud_from(mob/M)
+/datum/atom_hud/proc/remove_hud_from(mob/M, absolute = FALSE)
 	if(!M || !hudusers[M])
 		return
-	if (!--hudusers[M])
+	if (absolute || !--hudusers[M])
+		UnregisterSignal(M, COMSIG_PARENT_QDELETING)
 		hudusers -= M
 		if(queued_to_see[M])
 			queued_to_see -= M
@@ -81,6 +82,7 @@ GLOBAL_LIST_INIT(huds, list(
 		return
 	if(!hudusers[M])
 		hudusers[M] = 1
+		RegisterSignal(M, COMSIG_PARENT_QDELETING, .proc/unregister_mob)
 		if(next_time_allowed[M] > world.time)
 			if(!queued_to_see[M])
 				addtimer(CALLBACK(src, .proc/show_hud_images_after_cooldown, M), next_time_allowed[M] - world.time)
@@ -91,6 +93,10 @@ GLOBAL_LIST_INIT(huds, list(
 				add_to_single_hud(M, A)
 	else
 		hudusers[M]++
+
+/datum/atom_hud/proc/unregister_mob(datum/source, force)
+	SIGNAL_HANDLER
+	remove_hud_from(source, TRUE)
 
 /datum/atom_hud/proc/hide_single_atomhud_from(hud_user,hidden_atom)
 	if(hudusers[hud_user])

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -160,6 +160,9 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 10)
 
 /mob/dead/observer/Destroy()
+	if(data_huds_on)
+		remove_data_huds()
+
 	// Update our old body's medhud since we're abandoning it
 	if(mind?.current)
 		mind.current.med_hud_set_status()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I've done this on a signal because atom_hud is applied very loosely in some contexes, and the objects themselves dont have an easy way to track back into what huds they're affected by, so this seemed the best. Properly cleans up `next_time_allowed`, which was missing.

Update: I discovered this is also an issue for a lot of simple mobs, such as slimes and bots and such. So fixing this is huge
![obraz](https://user-images.githubusercontent.com/6381979/102311532-52ea3d00-3f6d-11eb-8abb-32e6254eb421.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![2020-12-16_05-31-03](https://user-images.githubusercontent.com/6381979/102307093-1d8d2180-3f64-11eb-86c1-f9187c61fc04.png)
![2020-12-16_05-31-32](https://user-images.githubusercontent.com/6381979/102307100-1fef7b80-3f64-11eb-8a89-34038aa049b0.png)
Faster game!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed garbage collection of ghosts and lobby players, making the game run faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
