### PR TITLE
Changes foam dart descriptions to be more lore friendly

### DIFF
--- a/code/modules/projectiles/ammunition/caseless/foam.dm
+++ b/code/modules/projectiles/ammunition/caseless/foam.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_casing/caseless/foam_dart
 	name = "foam dart"
-	desc = "It's nerf or nothing! Ages 8 and up."
+	desc = "It's Donk or Don't! Ages 8 and up."
 	projectile_type = /obj/projectile/bullet/reusable/foam_dart
 	caliber = "foam_force"
 	icon = 'icons/obj/guns/toy.dmi'
@@ -13,12 +13,12 @@
 	..()
 	if (modified)
 		icon_state = "foamdart_empty"
-		desc = "It's nerf or nothing! ... Although, this one doesn't look too safe."
+		desc = "It's Donk or Don't! ... Although, this one doesn't look too safe."
 		if(BB)
 			BB.icon_state = "foamdart_empty"
 	else
 		icon_state = initial(icon_state)
-		desc = "It's nerf or nothing! Ages 8 and up."
+		desc = "It's Donk or Don't! Ages 8 and up."
 		if(BB)
 			BB.icon_state = initial(BB.icon_state)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The descriptions of the foam darts used in donksoft guns use the slogan of their real life dart blaster counterpart, "It's nerf or nothing". This PR changes that tagline to one that I think is funnier and actually uses the in-universe manufacturer's name: "It's Donk or Don't!"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I don't wanna toot my own horn or nothin', but I think that's a pretty funny line
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
