### PR TITLE
Fix Broodmother spider action button

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -336,7 +336,7 @@
 				if(ishuman(living_target) && (living_target.stat != DEAD || !consumed_mobs[living_target.tag])) //if they're not dead, you can consume them anyway
 					consumed_mobs[living_target.tag] = TRUE
 					fed++
-					lay_eggs.UpdateButtonIcon(TRUE)
+					lay_eggs_enriched.UpdateButtonIcon(TRUE)
 					visible_message("<span class='danger'>[src] sticks a proboscis into [living_target] and sucks a viscous substance out.</span>","<span class='notice'>You suck the nutriment out of [living_target], feeding you enough to lay a cluster of eggs.</span>")
 					living_target.death() //you just ate them, they're dead.
 				else


### PR DESCRIPTION
## About The Pull Request

Fixes an oversight and updates the Lay Enriched Eggs action button icon after a Broodmother spider consumes a suitable target.

## Why It's Good For The Game

Fixes an issue where the button wouldn't update, making it unclear that the spider was able to produce enriched eggs. Should result in less frustrating situations where first-timer broodmother players wouldn't make any enriched eggs because the button appears unavailable to use.

## Changelog
:cl: broodmother spider (746)
fix: Lay Enriched Eggs action button icon should now update properly
/:cl: