### PR TITLE
Buffs the Blastcannon

### DIFF
--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -64,18 +64,19 @@
 	. = ..()
 	icon_state = bomb ? icon_state_loaded : initial(icon_state)
 
-/obj/item/gun/blastcannon/attackby(obj/item/transfer_valve/_bomb, mob/user)
-	if(!istype(_bomb))
+/obj/item/gun/blastcannon/attackby(obj/item/transfer_valve/bomb_to_attach, mob/user)
+	if(!istype(bomb_to_attach))
 		return ..()
 
-	if(!_bomb.tank_one || !_bomb.tank_two)
+	if(!bomb_to_attach.tank_one || !bomb_to_attach.tank_two)
 		to_chat(user, "<span class='warning'>What good would an incomplete bomb do?</span>")
 		return FALSE
-	if(!user.transferItemToLoc(_bomb, src))
-		to_chat(user, "<span class='warning'>[_bomb] seems to be stuck to your hand!</span>")
+	if(!user.transferItemToLoc(bomb_to_attach, src))
+		to_chat(user, "<span class='warning'>[bomb_to_attach] seems to be stuck to your hand!</span>")
 		return FALSE
-	user.visible_message("<span class='warning'>[user] attaches [_bomb] to [src]!</span>")
-	bomb = _bomb
+
+	user.visible_message("<span class='warning'>[user] attaches [bomb_to_attach] to [src]!</span>")
+	bomb = bomb_to_attach
 	name = "blast cannon"
 	desc = "A makeshift device used to concentrate a bomb's blast energy to a narrow wave."
 	update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

If you don't know what the blastcannon is (Honestly, who would? I've never seen anyone else pick it; probably because it's garbage.) the blastcannon is a 14 TC traitor weapon available to scientists. It uses TTVs for ammunition and, in exchange for sacrificing all of the splash radius of the TTV, basically generates an immovable rod that carves a trench through the station. At least, that's what it's intended to do.

As it turns out, the blastcannon has two problems. Firstly, it could never do the looping immovable rod thing that the wiki and most game sources claim it could because it's range has always been capped to 150. Secondly, it has literally been hugboxed, and as carries little of the destructive power of the weapon used to create it. As such it is generally considered to be an utter waste of TC by the people who actually know that it exists.

This PR attempts to change this. Firstly, it unhugboxes the blastcannon which lets it use most of the destructive power of the bomb used to fire it. Secondly, it makes the blastcannon's range scale with the explosive power of the bomb used to create it. Hopefully it will actually see some use after this change! It's no fun expending more than half of your TC on an item that sounds fun, but turns out to be almost complete trash.

I also fixed a minor runtime where the blastcannon would hand SSexplosions a null when it hit its max range. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: <i>You press your ear to the barrel and hear a faint rumba beat...</i> The blastcannon has been buffed!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
