### PR TITLE
Emagging Siliconnect allows for sending messages to borgs without an ID

### DIFF
--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -9,12 +9,19 @@
 	size = 5
 	tgui_id = "NtosCyborgRemoteMonitor"
 	program_icon = "project-diagram"
+	var/emagged = FALSE
+
+/datum/computer_file/program/borg_monitor/run_emag()
+	if(emagged)
+		return FALSE
+	emagged = TRUE
+	return TRUE
 
 /datum/computer_file/program/borg_monitor/ui_data(mob/user)
 	var/list/data = get_header_data()
 
 	data["card"] = FALSE
-	if(checkID())
+	if(checkID() || emagged)
 		data["card"] = TRUE
 
 	data["cyborgs"] = list()
@@ -82,6 +89,8 @@
 /datum/computer_file/program/borg_monitor/proc/checkID()
 	var/obj/item/card/id/ID = computer.GetID()
 	if(!ID)
+		if(emagged)
+			return "STDERR:UNDF"
 		return FALSE
 	return ID.registered_name
 
@@ -96,6 +105,9 @@
 	available_on_syndinet = TRUE
 	transfer_access = null
 	tgui_id = "NtosCyborgRemoteMonitorSyndicate"
+
+/datum/computer_file/program/borg_monitor/syndicate/run_emag()
+	return FALSE
 
 /datum/computer_file/program/borg_monitor/syndicate/evaluate_borg(mob/living/silicon/robot/R)
 	if((get_turf(computer)).z != (get_turf(R)).z)

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -21,7 +21,7 @@
 	var/list/data = get_header_data()
 
 	data["card"] = FALSE
-	if(checkID() || emagged)
+	if(checkID())
 		data["card"] = TRUE
 
 	data["cyborgs"] = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
SiliConnect (the tablet app for managing borgs) requires an ID to send messages to borgs in order for the user's name to be attached to the message. This change allows anyone with an emag to remove this requirement, and instead send messages without the sender's name attached. The borg will instead see "STDERR:UNDF" as the name.

No change for the nuke ops version Roboverlord.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows for the user to use SiliConnect for alternative purposes. Keep the borgs busy with an anonymous threat against the CMO, or send a tip about an upcoming hit on the captain to get rid of a rival traitor. Maybe shitpost your best just to make someone actually download WireCarp for once.

Anyway, adds a neat emag function to another ModPC app.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: SiliConnect users can now emag their device to send anonymous messages to borgs. Remember to remove your ID before hitting send!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
