### PR TITLE
The garbage collector doesn't waste time anymore

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -139,7 +139,8 @@ SUBSYSTEM_DEF(garbage)
 
 	lastlevel = level
 
-	for (var/refID in queue)
+	for (var/i in 1 to length(queue))
+		var/refID = queue[i]
 		if (!refID)
 			count++
 			if (MC_TICK_CHECK)

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -139,6 +139,8 @@ SUBSYSTEM_DEF(garbage)
 
 	lastlevel = level
 
+	//We do this rather then for(var/refID in queue) because that sort of for loop copies the whole list.
+	//Normally this isn't expensive, but the gc queue can grow to 40k items, and that gets costly/causes overrun.
 	for (var/i in 1 to length(queue))
 		var/refID = queue[i]
 		if (!refID)

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -148,7 +148,7 @@ SUBSYSTEM_DEF(garbage)
 			if (MC_TICK_CHECK)
 				return
 			continue
-		
+
 		var/GCd_at_time = L[1]
 		if(GCd_at_time > cut_off_time)
 			break // Everything else is newer, skip them

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -142,18 +142,18 @@ SUBSYSTEM_DEF(garbage)
 	//We do this rather then for(var/refID in queue) because that sort of for loop copies the whole list.
 	//Normally this isn't expensive, but the gc queue can grow to 40k items, and that gets costly/causes overrun.
 	for (var/i in 1 to length(queue))
-		var/refID = queue[i]
-		if (!refID)
+		var/list/L = queue[i]
+		if (length(L) < 2)
 			count++
 			if (MC_TICK_CHECK)
 				return
 			continue
-
-		var/GCd_at_time = queue[refID]
+		
+		var/GCd_at_time = L[1]
 		if(GCd_at_time > cut_off_time)
 			break // Everything else is newer, skip them
 		count++
-
+		var/refID = L[2]
 		var/datum/D
 		D = locate(refID)
 
@@ -224,10 +224,8 @@ SUBSYSTEM_DEF(garbage)
 
 	D.gc_destroyed = gctime
 	var/list/queue = queues[level]
-	if (queue[refid])
-		queue -= refid // Removing any previous references that were GC'd so that the current object will be at the end of the list.
 
-	queue[refid] = gctime
+	queue[++queue.len] = list(gctime, refid) // not += for byond reasons
 
 //this is mainly to separate things profile wise.
 /datum/controller/subsystem/garbage/proc/HardDelete(datum/D)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the garbage collectors for loop from a `for(var/thing in list)` to `for(var/i in 1 to length(list))`
Converts the garbage queues from an assoc list of id to time, to a list of lists containing the same info.

## Why It's Good For The Game

Did you know that `for(var/thing in list)` scales in cost with the size of the list?
Did you know that assoc accesses are slower then indexed accesses scaling with the size of the list?
Did you know that the garbage collector queue balloons to massive size quite easily?

Note, this means harddels will happen more often, but that's only because the gc list will actually fully process more often.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
