### PR TITLE
Uranium Golems: Punch to Irradiate, not Exist to Irradiate

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -186,6 +186,7 @@
 	equip_delay_other = 40
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes
 	lace_time = 8 SECONDS
+	species_exception = list(/datum/species/golem/uranium)
 
 /obj/item/clothing/shoes/workboots/mining
 	name = "mining boots"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -634,6 +634,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 20, FIRE = 30, ACID = 45)
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/t_scanner, /obj/item/construction/rcd, /obj/item/pipe_dispenser, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/engineering
+	species_exception = list(/datum/species/golem/uranium)
 
 /obj/item/clothing/head/hooded/winterhood/engineering
 	icon_state = "winterhood_engineer"

--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -47,6 +47,7 @@
 	inhand_icon_state = "engi_suit"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 10, FIRE = 60, ACID = 20)
 	resistance_flags = NONE
+	species_exception = list(/datum/species/golem/uranium)
 
 /obj/item/clothing/under/rank/engineering/engineer/hazard
 	name = "engineer's hazard jumpsuit"

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -331,6 +331,14 @@
 	punchstunthreshold = 9
 	prefix = "Uranium"
 	special_names = list("Oxide", "Rod", "Meltdown", "235")
+	COOLDOWN_DECLARE(radiation_emission_cooldown)
+
+/datum/species/golem/uranium/proc/radiation_emission(mob/living/carbon/human/H)
+	if(!COOLDOWN_FINISHED(src, radiation_emission_cooldown))
+		return
+	else
+		radiation_pulse(H, 50)
+		COOLDOWN_START(src, radiation_emission_cooldown, 2 SECONDS)
 
 /datum/species/golem/uranium/spec_unarmedattacked(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	. = ..()
@@ -339,6 +347,21 @@
 	///standard damage roll for use in determining how much you irradiate per punch
 	var/attacker_irradiate_value = rand(user.dna.species.punchdamagelow, user.dna.species.punchdamagehigh)
 	target.apply_effect(attacker_irradiate_value*5, EFFECT_IRRADIATE, radiation_block)
+
+/datum/species/golem/uranium/spec_attack_hand(mob/living/carbon/human/M, mob/living/carbon/human/H, datum/martial_art/attacker_style)
+	..()
+	if(COOLDOWN_FINISHED(src, radiation_emission_cooldown) && M != H &&  M.a_intent != INTENT_HELP)
+		radiation_emission(H)
+
+/datum/species/golem/uranium/spec_attacked_by(obj/item/I, mob/living/user, obj/item/bodypart/affecting, intent, mob/living/carbon/human/H)
+	..()
+	if(COOLDOWN_FINISHED(src, radiation_emission_cooldown) && user != H)
+		radiation_emission(H)
+
+/datum/species/golem/uranium/on_hit(obj/projectile/P, mob/living/carbon/human/H)
+	..()
+	if(COOLDOWN_FINISHED(src, radiation_emission_cooldown))
+		radiation_emission(H)
 
 //Immune to physical bullets and resistant to brute, but very vulnerable to burn damage. Dusts on death.
 /datum/species/golem/sand

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -312,13 +312,13 @@
 		H.reagents.remove_reagent(chem.type, REAGENTS_METABOLISM)
 		return 1
 
-//Radioactive puncher, slightly more durable against brute but less against everything else
+//Radioactive puncher, hits for burn but only as hard as human, slightly more durable against brute but less against everything else
 /datum/species/golem/uranium
 	name = "Uranium Golem"
 	id = "uranium golem"
 	fixed_mut_color = "7f0"
 	meat = /obj/item/stack/ore/uranium
-	info_text = "As an <span class='danger'>Uranium Golem</span>, your very touch burns and irradiates organic lifeforms. You don't hit as hard as most golems, but you are far more durable."
+	info_text = "As an <span class='danger'>Uranium Golem</span>, your very touch burns and irradiates organic lifeforms. You don't hit as hard as most golems, but you are far more durable against blunt force trauma."
 	attack_verb = "burn"
 	attack_sound = 'sound/weapons/sear.ogg'
 	attack_type = BURN
@@ -336,7 +336,7 @@
 	. = ..()
 	var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(user.zone_selected))
 	var/radiation_block = target.run_armor_check(affecting, RAD)
-	///standard damage roll for use to determine how much you irradiate per punch
+	///standard damage roll for use in determining how much you irradiate per punch
 	var/attacker_irradiate_value = rand(user.dna.species.punchdamagelow, user.dna.species.punchdamagehigh)
 	target.apply_effect(attacker_irradiate_value*5, EFFECT_IRRADIATE, radiation_block)
 

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -312,27 +312,33 @@
 		H.reagents.remove_reagent(chem.type, REAGENTS_METABOLISM)
 		return 1
 
-//Radioactive
+//Radioactive puncher, slightly more durable against brute but less against everything else
 /datum/species/golem/uranium
 	name = "Uranium Golem"
 	id = "uranium golem"
 	fixed_mut_color = "7f0"
 	meat = /obj/item/stack/ore/uranium
-	info_text = "As an <span class='danger'>Uranium Golem</span>, you emit radiation pulses every once in a while. It won't harm fellow golems, but organic lifeforms will be affected."
-
+	info_text = "As an <span class='danger'>Uranium Golem</span>, your very touch burns and irradiates organic lifeforms. You don't hit as hard as most golems, but you are far more durable."
+	attack_verb = "burn"
+	attack_sound = 'sound/weapons/sear.ogg'
+	attack_type = BURN
 	var/last_event = 0
 	var/active = null
+	armor = 40
+	brutemod = 0.5
+	punchdamagelow = 1
+	punchdamagehigh = 10
+	punchstunthreshold = 9
 	prefix = "Uranium"
 	special_names = list("Oxide", "Rod", "Meltdown", "235")
 
-/datum/species/golem/uranium/spec_life(mob/living/carbon/human/H)
-	if(!active)
-		if(world.time > last_event+30)
-			active = 1
-			radiation_pulse(H, 50)
-			last_event = world.time
-			active = null
-	..()
+/datum/species/golem/uranium/spec_unarmedattacked(mob/living/carbon/human/user, mob/living/carbon/human/target)
+	. = ..()
+	var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(user.zone_selected))
+	var/radiation_block = target.run_armor_check(affecting, RAD)
+	///standard damage roll for use to determine how much you irradiate per punch
+	var/attacker_irradiate_value = rand(user.dna.species.punchdamagelow, user.dna.species.punchdamagehigh)
+	target.apply_effect(attacker_irradiate_value*5, EFFECT_IRRADIATE, radiation_block)
 
 //Immune to physical bullets and resistant to brute, but very vulnerable to burn damage. Dusts on death.
 /datum/species/golem/sand


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the uranium golems **passive** uranium emission. This results in uranium golems no longer irradiating people around them **_passively._**

Uranium golems now irradiate when they punch carbons, dealing 5-50 radiation damage per punch, rolled based on their punch values. These values are 1-10, like a humans, with a punch stun threshold of 9, like a humans. They also do burn punches, like an Ethereal.

Uranium golems now take a significantly lower amount of brute damage from brute sources (it's approximate to 70-90% given species armor is also at play), but take more damage from every other source compared to regular golems (40% armor compared to 55%).

Upon being hit by a projectile, object or a punch, a uranium golem releases a radiation pulse.

Uranium golems now can wear engineering clothing to show their true allegiance. To Engitopia, home of the Supermatter, Beacon of Atom.

## Why It's Good For The Game

The following thread was largely why I made this pr: https://tgstation13.org/phpBB/viewtopic.php?f=33&t=28082

I felt the discussed topic to be pretty ridiculous, but agreed with oranges that the golem species simply attacking things around it by existing was probably not worth keeping around. I also felt like people in the thread have a very poor understanding of how radiation worked, but I digress.

Instead, I felt it was best to give them a bit of a rework to something more manageable for everyone around them while filling a small durability niche. There are more durable golems, but I felt since they're made from uranium it made sense for them to be a bit harder to break.

The clothing options are only able to provide armor for effects golems are straight immune against, like fire and radiation, so there isn't a significant departure from other clothing options that I gave golems in a previous PR.

## Changelog
:cl:
balance: Uranium golems now no longer irradiate things around them passively.
balance: Uranium golems now irradiate targets they punch, while also doing burn damage with punches. They only hit as hard a human, however.
balance: Uranium golems are significantly resistant to brute, but less resistant to all other damage types compared to typical golems.
balance: Uranium golems release their radiation pulse when hit by attacks. Or objects.
add: Uranium golems can now wear engineering jumpsuits, work boots and wintercoats.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
