### PR TITLE
DNA Vault PR Attempt 3: No Nerf November-less Edition

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -207,6 +207,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_PERMANENTLY_ONFIRE	"permanently_onfire" //overrides the update_fire proc to always add fire (for lava)
 #define TRAIT_SIGN_LANG				"sign_language" //Galactic Common Sign Language
 #define TRAIT_NANITE_MONITORING	"nanite_monitoring" //The mob's nanites are sending a monitoring signal visible on diag HUD
+#define TRAIT_AUGMENTED_DNA "augmented_dna" //this mob has received a power from a DNA vault, so it's been marked as being unable to gain another power
+#define TRAIT_NOWOUND "no_wound" //this mob can't receive new wounds
 
 //SKILLS
 #define TRAIT_UNDERWATER_BASKETWEAVING_KNOWLEDGE "underwater_basketweaving"

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -114,6 +114,9 @@
 		qdel(src)
 		return
 
+	if(HAS_TRAIT(L.owner, TRAIT_NOWOUND))
+		return
+
 	if(ishuman(L.owner))
 		var/mob/living/carbon/human/H = L.owner
 		if(((wound_flags & BONE_WOUND) && !(HAS_BONE in H.dna.species.species_traits)) || ((wound_flags & FLESH_WOUND) && !(HAS_FLESH in H.dna.species.species_traits)))

--- a/code/modules/actionspeed/modifiers/status_effects.dm
+++ b/code/modules/actionspeed/modifiers/status_effects.dm
@@ -3,3 +3,6 @@
 
 /datum/actionspeed_modifier/blunt_wound
 	variable = TRUE
+
+/datum/actionspeed_modifier/dnavault //this isn't really a status effect, but this is the closest file that fits
+	multiplicative_slowdown = -0.20 //I am speed

--- a/code/modules/actionspeed/modifiers/status_effects.dm
+++ b/code/modules/actionspeed/modifiers/status_effects.dm
@@ -5,4 +5,4 @@
 	variable = TRUE
 
 /datum/actionspeed_modifier/dnavault //this isn't really a status effect, but this is the closest file that fits
-	multiplicative_slowdown = -0.20 //I am speed
+	multiplicative_slowdown = -0.30 //I am speed

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -288,6 +288,6 @@
 			H.add_movespeed_modifier(/datum/movespeed_modifier/dna_vault_speedup) //short and sweet- movement speed buffs are stronk
 		if(VAULT_QUICK)
 			to_chat(H, "<span class='notice'>Your arms move as fast as lightning.</span>")
-			H.next_move_modifier *= 0.5
-			H.add_actionspeed_modifier(/datum/actionspeed_modifier/dnavault) //multiplies the lengths of your do_after()s by 0.8
+			H.next_move_modifier *= 0.7 //a next_move_modifier of 0.5 is quite frankly TOO insane, even for a DNA vault ability, so you'll have to settle for a next_move_modifier of "merely" 0.7 (which'll still let you ORA ORA with a faster attack speed than that of a standard holoparasite, mind you)
+			H.add_actionspeed_modifier(/datum/actionspeed_modifier/dnavault) //multiplies the lengths of your do_after()s by 0.7
 	power_lottery[H] = list()

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -288,6 +288,6 @@
 			H.add_movespeed_modifier(/datum/movespeed_modifier/dna_vault_speedup) //short and sweet- movement speed buffs are stronk
 		if(VAULT_QUICK)
 			to_chat(H, "<span class='notice'>Your arms move as fast as lightning.</span>")
-			H.next_move_modifier *= 0.7 //a next_move_modifier of 0.5 is quite frankly TOO insane, even for a DNA vault ability, so you'll have to settle for a next_move_modifier of "merely" 0.7 (which'll still let you ORA ORA with a faster attack speed than that of a standard holoparasite, mind you)
+			H.next_move_modifier *= 0.5
 			H.add_actionspeed_modifier(/datum/actionspeed_modifier/dnavault) //multiplies the lengths of your do_after()s by 0.7
 	power_lottery[H] = list()

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -249,11 +249,20 @@
 /obj/machinery/dna_vault/proc/upgrade(mob/living/carbon/human/H,upgrade_type)
 	if(!(upgrade_type in power_lottery[H]))
 		return
+	if(!istype(H))
+		return
+	power_lottery[H] = list()
+	if(HAS_TRAIT(H, TRAIT_AUGMENTED_DNA)) //no double dipping (with the same body, anyway)
+		to_chat(H, "<span class='alert'>Your body has already been improved by a DNA vault!</span>")
+		return
+	ADD_TRAIT(H, TRAIT_AUGMENTED_DNA, "dna_vault")
 	switch(upgrade_type)
 		if(VAULT_TOXIN)
 			to_chat(H, "<span class='notice'>You feel resistant to toxins and radiation.</span>")
 			H.setToxLoss(0, TRUE, TRUE)
 			ADD_TRAIT(H, TRAIT_TOXIMMUNE, "dna_vault")
+			ADD_TRAIT(H, TRAIT_NOCLONELOSS, "dna_vault")
+			ADD_TRAIT(H, TRAIT_STABLELIVER, "dna_vault") //large volumes of toxins can make your liver go kaput, so we'll just make you not need a liver!
 			ADD_TRAIT(H, TRAIT_RADIMMUNE, "dna_vault") //now you, too, can vibe next to the SM
 		if(VAULT_ORGANS)
 			to_chat(H, "<span class='notice'>You feel enlightened.</span>") //these options are a bit all over the place, but none of these would be valuable enough on their own to be worth spending your dna vault power choice on
@@ -263,18 +272,20 @@
 			ADD_TRAIT(H, TRAIT_XRAY_VISION, "dna_vault") //if the code for the knowledge devil boon was still in the game, I'd invoke it here to give the vault-ee the ability to expand their view range, since that's a pretty rare and unique ability
 			H.update_sight()
 			ADD_TRAIT(H, TRAIT_NOHUNGER, "dna_vault")
-			H.set_safe_hunger_level() //I've left out hearts and bleed_mod here because they don't really fit with the enlightened monk "theme" I'm going for with this option
+			H.set_safe_hunger_level()
+			ADD_TRAIT(H, TRAIT_STABLEHEART, "dna_vault") //something something enlightened eating decisions
 		if(VAULT_FIREPROOF)
 			to_chat(H, "<span class='notice'>You feel fireproof.</span>")
 			H.physiology.burn_mod *= 0.5
 			ADD_TRAIT(H, TRAIT_RESISTHEAT, "dna_vault")
 			ADD_TRAIT(H, TRAIT_NOFIRE, "dna_vault")
-			ADD_TRAIT(H, TRAIT_RESISTCOLD, "dna_vault")
+			ADD_TRAIT(H, TRAIT_RESISTCOLD, "dna_vault") //I was tempted to add low/high pressure immunity to this, but I'm not sure if it'd fit the theme well. Plus, you'll still probably need a source of air anyway.
 			ADD_TRAIT(H, TRAIT_SHOCKIMMUNE, "dna_vault") //you're, uh, insulated
 		if(VAULT_STUNTIME)
 			to_chat(H, "<span class='notice'>Nothing can keep you down for long.</span>")
 			H.physiology.stun_mod *= 0.5
 			H.physiology.stamina_mod *= 0.5
+			H.add_movespeed_mod_immunities("dna_vault", /datum/movespeed_modifier/damage_slowdown)
 			ADD_TRAIT(H, TRAIT_STUNRESISTANCE, "dna_vault") //yeah, this isn't actually general stun resistance, but hey, every little bit helps
 		if(VAULT_ARMOUR)
 			to_chat(H, "<span class='notice'>You feel like you can keep it together.</span>")
@@ -282,12 +293,11 @@
 			H.physiology.bleed_mod = 0 //your veins run through your adamantium bones now or something, so you don't/can't bleed anymore (but can still jab a syringe into your bones or something to draw blood). this is to keep with the "shrug off wounds" theme of this option.
 			ADD_TRAIT(H, TRAIT_NODISMEMBER, "dna_vault")
 			ADD_TRAIT(H, TRAIT_NOLIMBDISABLE, "dna_vault")
-			ADD_TRAIT(H, TRAIT_HARDLIMBWOUND, "dna_vault")
+			ADD_TRAIT(H, TRAIT_NOWOUND, "dna_vault")
 		if(VAULT_SPEED)
 			to_chat(H, "<span class='notice'>Your legs feel faster.</span>")
-			H.add_movespeed_modifier(/datum/movespeed_modifier/dna_vault_speedup) //short and sweet- movement speed buffs are stronk
+			H.add_movespeed_modifier(/datum/movespeed_modifier/dna_vault_speedup) //short and sweet- movement speed buffs are stronk (and have every day utility!)
 		if(VAULT_QUICK)
 			to_chat(H, "<span class='notice'>Your arms move as fast as lightning.</span>")
 			H.next_move_modifier *= 0.5
 			H.add_actionspeed_modifier(/datum/actionspeed_modifier/dnavault) //multiplies the lengths of your do_after()s by 0.7
-	power_lottery[H] = list()


### PR DESCRIPTION
## About The Pull Request

See https://github.com/tgstation/tgstation/pull/54807, but with some additional changes (most notably, the addition of slowdown immunity to VAULT_STUNTIME and the addition of TRAIT_NOWOUND to VAULT_ARMOR).

I also incorporated the anti-double dipping trait from https://github.com/tgstation/tgstation/pull/54808.

We also now have a TRAIT_NOWOUND trait that prevents you from receiving wounds, in case something in the future needs to have an immunity to wounds (without being species-dependent).

## Why It's Good For The Game

You shouldn't lose some of your vault powers when you change species, especially since the physiology system exists.

The vault powers now all feel powerful and worth the effort required to actually finish the DNA vault, instead of some of them feeling like debuffs instead of buffs (looking at you, VAULT_ARMOR). To quote my previous PR:

"some of the vault options are just really, really sad and underwhelming (especially considering the amount of effort required to construct and collect the required samples for a DNA vault)".

"Also, a DNA vault option should not be able to be replicated with a single virus symptom (seriously, what the fuck?), nor should it actively hinder you by making you immune to the good virus that the virologist made or by making you unable to be directly healed by sutures, ointment, etc."

## Changelog
:cl: ATHATH
fix: DNA vault options should play more nicely with resistances that you already have from your species now.
balance: The DNA vault powers have been rebalanced, and are in general much stronger than they were before.
balance: You can no longer receive DNA vault powers from multiple DNA vaults (with a single body, anyway).
/:cl: