### PR TITLE
Scroll of teleportation tweaks

### DIFF
--- a/code/game/objects/items/scrolls.dm
+++ b/code/game/objects/items/scrolls.dm
@@ -4,49 +4,42 @@
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll"
 	worn_icon_state = "scroll"
-	var/uses = 4
 	w_class = WEIGHT_CLASS_SMALL
 	inhand_icon_state = "paper"
 	throw_speed = 3
 	throw_range = 7
 	resistance_flags = FLAMMABLE
+	/// Number of uses remaining
+	var/uses = 4
 
 /obj/item/teleportation_scroll/apprentice
 	name = "lesser scroll of teleportation"
 	uses = 1
 
-
+/obj/item/teleportation_scroll/examine(mob/user)
+	. = ..()
+	if(uses > 0)
+		. += "It has [uses] use\s remaining."
 
 /obj/item/teleportation_scroll/attack_self(mob/user)
-	user.set_machine(src)
-	var/dat = "<B>Teleportation Scroll:</B><BR>"
-	dat += "Number of uses: [src.uses]<BR>"
-	dat += "<HR>"
-	dat += "<B>Four uses, use them wisely:</B><BR>"
-	dat += "<A href='byond://?src=[REF(src)];spell_teleport=1'>Teleport</A><BR>"
-	dat += "Kind regards,<br>Wizards Federation<br><br>P.S. Don't forget to bring your gear, you'll need it to cast most spells.<HR>"
-	user << browse(dat, "window=scroll")
-	onclose(user, "scroll")
-	return
-
-/obj/item/teleportation_scroll/Topic(href, href_list)
-	..()
-	if (usr.stat != CONSCIOUS || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED) || src.loc != usr)
+	if(!uses)
 		return
-	if (!ishuman(usr))
-		return 1
-	var/mob/living/carbon/human/H = usr
-	if(H.is_holding(src))
-		H.set_machine(src)
-		if (href_list["spell_teleport"])
-			if(uses)
-				teleportscroll(H)
-	if(H)
-		attack_self(H)
-	return
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/human_user = user
+	if(human_user.incapacitated())
+		return
+	if(!human_user.is_holding(src))
+		return
+	teleportscroll(human_user)
 
+/**
+ * Shows a list of a possible teleport destinations to a user and then teleports him to to his chosen destination
+ *
+ * Arguments:
+ * * user The mob that is being teleported
+ */
 /obj/item/teleportation_scroll/proc/teleportscroll(mob/user)
-
 	var/A
 
 	A = input(user, "Area to jump to", "BOOYEA", A) as null|anything in GLOB.teleportlocs
@@ -64,11 +57,16 @@
 			L += T
 
 	if(!L.len)
-		to_chat(user, "The spell matrix was unable to locate a suitable teleport destination for an unknown reason. Sorry.")
+		to_chat(user, "<span class='warning'>The spell matrix was unable to locate a suitable teleport destination for an unknown reason. Sorry.</span>")
 		return
 
 	if(do_teleport(user, pick(L), forceMove = TRUE, channel = TELEPORT_CHANNEL_MAGIC, forced = TRUE))
 		smoke.start()
 		uses--
+		if(!uses)
+			to_chat(user, "<span class='warning'>[src] has run out of uses and crumbles to dust!</span>")
+			qdel(src)
+		else
+			to_chat(user, "<span class='notice'>[src] has [uses] use\s remaining.</span>")
 	else
-		to_chat(user, "The spell matrix was disrupted by something near the destination.")
+		to_chat(user, "<span class='warning'>The spell matrix was disrupted by something near the destination.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR makes a few changes regarding scrolls of teleportation.

- Scrolls of teleportation no longer use outdated HTML based interface and will take you straight into a list of a possible destinations upon use. That interface had a very little point of existing in the first place, the only possibly useful information was number of remaining uses, which is solved by a point below.

- Scrolls of teleportation now show a number of remaining uses upon examination and also give proper feedback messages upon teleportation.

- Scrolls of teleportation now crumble to dust when out of uses. They are a consumable item and cannot be recharged, which made them utterly useless when out of uses, creating only clutter.

For completeness, below is an image of the removed interface mentioned above:

<details>
  <summary>Old Scroll UI</summary>

![OldScroll](https://user-images.githubusercontent.com/43862960/102619147-4536e200-413c-11eb-9862-37e7aa55ff11.png)

</details>

Documentation of a relevant proc and variable included in the package.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Less outdated HTML interfaces, documentation and QoL.

## Changelog
:cl: Arkatos
tweak: Scrolls of teleportation no longer use outdated interface and will take you straight into a list of a possible destinations upon use.
tweak: Scrolls of teleportation now show number of remaining uses upon examination and also give proper feedback messages upon teleportation.
tweak: Scrolls of teleportation now crumble to dust when out of uses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
