### PR TITLE
Fixes body temp damage to dead mobs

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1624,9 +1624,13 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	if(humi.stat < DEAD && !IS_IN_STASIS(humi))
 		body_temperature_core(humi)
 
+	//These do run in statis
 	body_temperature_skin(humi)
 	body_temperature_alerts(humi)
-	body_temperature_damage(humi)
+
+	//Do not cause more damage in statis
+	if(!IS_IN_STASIS(humi))
+		body_temperature_damage(humi)
 
 /**
  * Used to stabilize the core temperature back to normal on living mobs

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1619,14 +1619,14 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	//when in a cryo unit we suspend all natural body regulation
 	if(istype(humi.loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
 		return
-	//when dead the air still effects your skin temp
-	if(humi.stat == DEAD || IS_IN_STASIS(humi))
-		body_temperature_skin(humi)
-	else //when alive do all the things
+
+	//Only stabilise core temp when alive and not in statis
+	if(humi.stat < DEAD && !IS_IN_STASIS(humi))
 		body_temperature_core(humi)
-		body_temperature_skin(humi)
-		body_temperature_alerts(humi)
-		body_temperature_damage(humi)
+
+	body_temperature_skin(humi)
+	body_temperature_alerts(humi)
+	body_temperature_damage(humi)
 
 /**
  * Used to stabilize the core temperature back to normal on living mobs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Body and pressure damage were not intended to be skipped by dead mobs.
Fixed the checks and temp handles, they should react as follows
 - Core temp only happens when alive and not in statis
 - Skin temp always interacts with the air even in statis
 - Temperature alerts always happen
 - Damage from temperature when not in statis
 - All of the above skipped when in cryo (it has separate temp handling code)

This will fix bodies not husking properly, and give alerts to body temp at all times.

Fixes #55206 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixed body temp bugs.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed mob temperature damage when dead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
