### PR TITLE
Make singularity dissipation use delta time

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -19,9 +19,12 @@
 	var/allowed_size = 1
 	var/energy = 100 //How strong are we?
 	var/dissipate = TRUE //Do we lose energy over time?
-	var/dissipate_delay = 10
-	var/dissipate_track = 0
-	var/dissipate_strength = 1 //How much energy do we lose?
+	/// How long should it take for us to dissipate?
+	var/dissipate_delay = 2 SECONDS
+	/// How much energy do we lose every dissipate_delay?
+	var/dissipate_strength = 1
+	/// How long its been (in deciseconds) since the last dissipation
+	var/time_since_last_dissipiation = 0
 	var/event_chance = 10 //Prob for event each tick
 	var/move_self = TRUE
 	var/consumed_supermatter = FALSE //If the singularity has eaten a supermatter shard and can go to stage six
@@ -129,21 +132,22 @@
 		if(3)
 			energy -= round(((energy+1)/4),1)
 
-/obj/singularity/process()
+/obj/singularity/process(delta_time)
 	if(current_size >= STAGE_TWO)
 		if(prob(event_chance))//Chance for it to run a special event TODO:Come up with one or two more that fit
 			event()
-	dissipate()
+	dissipate(delta_time)
 	check_energy()
 
-/obj/singularity/proc/dissipate()
-	if(!dissipate)
+/obj/singularity/proc/dissipate(delta_time)
+	if (!dissipate)
 		return
-	if(dissipate_track >= dissipate_delay)
-		src.energy -= dissipate_strength
-		dissipate_track = 0
-	else
-		dissipate_track++
+
+	time_since_last_dissipiation += delta_time
+
+	while (time_since_last_dissipiation >= dissipate_delay)
+		energy -= dissipate_strength
+		time_since_last_dissipiation -= dissipate_delay
 
 /obj/singularity/proc/expand(force_size)
 	var/temp_allowed_size = src.allowed_size
@@ -167,7 +171,7 @@
 			new_grav_pull = 4
 			new_consume_range = 0
 			dissipate_delay = 10
-			dissipate_track = 0
+			time_since_last_dissipiation = 0
 			dissipate_strength = 1
 		if(STAGE_TWO)
 			if(check_cardinals_range(1, TRUE))
@@ -179,7 +183,7 @@
 				new_grav_pull = 6
 				new_consume_range = 1
 				dissipate_delay = 5
-				dissipate_track = 0
+				time_since_last_dissipiation = 0
 				dissipate_strength = 5
 		if(STAGE_THREE)
 			if(check_cardinals_range(2, TRUE))
@@ -191,7 +195,7 @@
 				new_grav_pull = 8
 				new_consume_range = 2
 				dissipate_delay = 4
-				dissipate_track = 0
+				time_since_last_dissipiation = 0
 				dissipate_strength = 20
 		if(STAGE_FOUR)
 			if(check_cardinals_range(3, TRUE))
@@ -203,7 +207,7 @@
 				new_grav_pull = 10
 				new_consume_range = 3
 				dissipate_delay = 10
-				dissipate_track = 0
+				time_since_last_dissipiation = 0
 				dissipate_strength = 10
 		if(STAGE_FIVE)//this one also lacks a check for gens because it eats everything
 			current_size = STAGE_FIVE

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -19,11 +19,11 @@
 	var/allowed_size = 1
 	var/energy = 100 //How strong are we?
 	var/dissipate = TRUE //Do we lose energy over time?
-	/// How long should it take for us to dissipate?
-	var/dissipate_delay = 2 SECONDS
+	/// How long should it take for us to dissipate in seconds?
+	var/dissipate_delay = 20
 	/// How much energy do we lose every dissipate_delay?
 	var/dissipate_strength = 1
-	/// How long its been (in deciseconds) since the last dissipation
+	/// How long its been (in seconds) since the last dissipation
 	var/time_since_last_dissipiation = 0
 	var/event_chance = 10 //Prob for event each tick
 	var/move_self = TRUE
@@ -145,6 +145,7 @@
 
 	time_since_last_dissipiation += delta_time
 
+	// Uses a while in case of especially long delta times
 	while (time_since_last_dissipiation >= dissipate_delay)
 		energy -= dissipate_strength
 		time_since_last_dissipiation -= dissipate_delay


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Converts singularity's dissipation code to use delta time instead of assuming it'll always be the same.

Numbers were based on the previous code given a delta_time of 2.
