### PR TITLE
Fixes blob strain reroll listing current strain

### DIFF
--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -361,6 +361,8 @@
 	var/list/choices = list()
 	while (length(choices) < 6)
 		var/datum/blobstrain/bs = pick((GLOB.valid_blobstrains))
+		if(initial(bs.name) == blobstrain.name) // Don't have current strain as an option please
+			continue
 		choices[initial(bs.name)] = bs
 
 	var/choice = input(usr, "Please choose a new strain","Strain") as anything in sortList(choices, /proc/cmp_typepaths_asc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When you (spend points to) reroll a strain as blob, it can happen that your current strain shows up in the list of strains to reroll to. This would take your points and give you nothing in return.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Your current blob strain can no longer show up in the strain reroll list.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
