### PR TITLE
WireArt: Fixed and improved

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -33,6 +33,7 @@
 #define COLOR_OLIVE						"#808000"
 #define COLOR_VIBRANT_LIME				"#00FF00"
 #define COLOR_LIME						"#32CD32"
+#define COLOR_DARK_LIME					"#00aa00"
 #define COLOR_VERY_PALE_LIME_GREEN		"#DDFFD3"
 #define COLOR_VERY_DARK_LIME_GREEN		"#003300"
 #define COLOR_GREEN						"#008000"
@@ -42,6 +43,7 @@
 #define COLOR_DARK_CYAN					"#00A2FF"
 #define COLOR_TEAL						"#008080"
 #define COLOR_BLUE						"#0000FF"
+#define COLOR_STRONG_BLUE				"#1919c8"
 #define COLOR_BRIGHT_BLUE				"#2CB2E8"
 #define COLOR_MODERATE_BLUE				"#555CC2"
 #define COLOR_BLUE_LIGHT				"#33CCFF"
@@ -49,6 +51,7 @@
 #define COLOR_BLUE_GRAY					"#75A2BB"
 
 #define COLOR_PINK						"#FFC0CB"
+#define COLOR_LIGHT_PINK				"#ff3cc8"
 #define COLOR_MOSTLY_PURE_PINK			"#E4005B"
 #define COLOR_MAGENTA					"#FF00FF"
 #define COLOR_STRONG_MAGENTA			"#B800B8"
@@ -57,6 +60,7 @@
 #define COLOR_STRONG_VIOLET				"#6927c5"
 
 #define COLOR_ORANGE					"#FF9900"
+#define COLOR_MOSTLY_PURE_ORANGE		"#ff8000"
 #define COLOR_TAN_ORANGE				"#FF7B00"
 #define COLOR_BRIGHT_ORANGE				"#E2853D"
 #define COLOR_LIGHT_ORANGE				"#ffc44d"

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -198,7 +198,7 @@
 		if(last)
 			if(get_dist(last, user) == 1) //hacky, but it works
 				var/turf/T = get_turf(user)
-				if(T.intact || !T.can_have_cabling())
+				if(!T.can_have_cabling())
 					last = null
 					return
 				if(get_dir(last, user) == last.d2)
@@ -210,7 +210,8 @@
 					return //If we've run out, display message and exit
 			else
 				last = null
-		loaded.pipe_cleaner_color = colors[current_color_index]
+		loaded.color = GLOB.pipe_cleaner_colors[colors[current_color_index]]
+		loaded.update_icon()
 		last = loaded.place_turf(get_turf(src), user, turn(user.dir, 180))
 		is_empty(user) //If we've run out, display message
 	update_icon()
@@ -223,13 +224,13 @@
 		return
 
 	T = get_turf(user)
-	if(T.intact || !T.can_have_cabling())
+	if(!T.can_have_cabling())
 		return
 
 	for(var/obj/structure/pipe_cleaner/C in T)
 		if(!C)
 			continue
-		if(C.pipe_cleaner_color != GLOB.pipe_cleaner_colors[colors[current_color_index]])
+		if(C.color != GLOB.pipe_cleaner_colors[colors[current_color_index]])
 			continue
 		if(C.d1 == 0)
 			return C
@@ -280,10 +281,11 @@
 		return
 
 	var/turf/T = get_turf(user)
-	if(T.intact || !T.can_have_cabling())
+	if(!T.can_have_cabling())
 		return
 
-	loaded.pipe_cleaner_color = colors[current_color_index]
+	loaded.color = GLOB.pipe_cleaner_colors[colors[current_color_index]]
+	loaded.update_icon()
 
 	var/obj/structure/pipe_cleaner/linkingCable = findLinkingCable(user)
 	if(linkingCable)
@@ -316,7 +318,8 @@
 		var/cwname = colors[current_color_index]
 		to_chat(user, "Color changed to [cwname]!")
 		if(loaded)
-			loaded.pipe_cleaner_color = colors[current_color_index]
+			loaded.color = GLOB.pipe_cleaner_colors[colors[current_color_index]]
+			loaded.update_icon()
 		if(wiring_gui_menu)
 			wiringGuiUpdate(user)
 	else if(istype(action, /datum/action/item_action/rcl_gui))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR changes a few things regarding WireArt, namely pipe cleaners and RCL.

- Cyborg's pipe cleaner is now using a radial menu for choosing it's colors instead of a clumsy input one.

![PipeCleanerRadial](https://user-images.githubusercontent.com/43862960/102667665-3bd46680-418a-11eb-87a3-84406f7a927a.png)

- RCL now properly updates it's pipe cleaner holder's color, so you can actually see the color when using RCL radial menu.

- RCL is now able to put cables down on floors seemlessly, as there is no reason to restrict it to just a plating and catwalks anymore due to the fact that pipe cleaner coils no longer function as a power carriers, but are merely visual entities for players to play with.

<details>
  <summary>Example RCL video</summary>

![finalrcl](https://user-images.githubusercontent.com/43862960/102667764-763e0380-418a-11eb-98f9-283b005b7167.gif)

</details>

And lastly, pipe cleaners now use color defines and are setting its color directly instead of having redundant variable do it for them, which was needlessly complicating it.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Better WireArt, code improvement.

## Changelog
:cl: Arkatos
tweak: Cyborg's pipe cleaner now uses a radial menu for choosing it's color variants.
tweak: RCL is now able to put cables down on floors seemlessly.
fix: RCL radial menu will now properly show it's currently set color for pipe cleaner.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
