### PR TITLE
Fix /obj/throw_at, giving bolas sound and facehuggers throwing sprites

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -78,7 +78,7 @@
 
 
 /obj/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, gentle = FALSE, quickstart = TRUE)
-	..()
+	. = ..()
 	if(obj_flags & FROZEN)
 		visible_message("<span class='danger'>[src] shatters into a million pieces!</span>")
 		qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
/obj/throw_at was not properly passing down the return value. Thus anything that checked for this later down the chain (/obj/item) would fail. The two places this was used were for bolas to make a sound when thrown and facehuggers to have a sprite when thrown.


![dreammaker_2020-12-19T14-05-18](https://user-images.githubusercontent.com/35135081/102700570-78907400-4203-11eb-929c-dff0764ccbcb.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Bolas will now make sounds and facehuggers now have a special sprite when thrown, as was intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
