### PR TITLE
Fix redundancy in /mob/living/silicon/Login

### DIFF
--- a/code/modules/mob/living/silicon/login.dm
+++ b/code/modules/mob/living/silicon/login.dm
@@ -1,9 +1,6 @@
 /mob/living/silicon/Login()
-	if(mind && SSticker.mode)
-		SSticker.mode.remove_cultist(mind, 0, 0)
-		var/datum/antagonist/rev/rev = mind.has_antag_datum(/datum/antagonist/rev)
-		if(rev)
-			rev.remove_revolutionary(TRUE)
+	if(mind)
+		SSticker.mode?.remove_antag_for_borging(mind)
 	return ..()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
/mob/living/silicon/Login had duplicated code encapsulated in a "remove_antag_for_borging" proc:

```
/datum/game_mode/proc/remove_antag_for_borging(datum/mind/newborgie)
	SSticker.mode.remove_cultist(newborgie, 0, 0)
	var/datum/antagonist/rev/rev = newborgie.has_antag_datum(/datum/antagonist/rev)
	if(rev)
		rev.remove_revolutionary(TRUE)
```

I think this is kind of silly too, but the goal of this PR is just to reduce code C+P.