### PR TITLE
Syringe gun and rapid fire syringe gun nerfs, uplink reagent gun buffs.

### DIFF
--- a/code/modules/projectiles/ammunition/special/syringe.dm
+++ b/code/modules/projectiles/ammunition/special/syringe.dm
@@ -34,8 +34,8 @@
 
 /obj/item/ammo_casing/chemgun
 	name = "dart synthesiser"
-	desc = "A high-power spring, linked to an energy-based dart synthesiser."
-	projectile_type = /obj/projectile/bullet/dart
+	desc = "A high-power spring, linked to an energy-based piercing dart synthesiser."
+	projectile_type = /obj/projectile/bullet/dart/piercing
 	firing_effect_type = null
 
 /obj/item/ammo_casing/chemgun/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
@@ -46,7 +46,7 @@
 		if(CG.syringes_left <= 0)
 			return
 		CG.reagents.trans_to(BB, 15, transfered_by = user)
-		BB.name = "chemical dart"
+		BB.name = "piercing chemical dart"
 		CG.syringes_left--
 	return ..()
 

--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -60,6 +60,9 @@
 	return TRUE
 
 /obj/item/gun/syringe/attackby(obj/item/A, mob/user, params, show_msg = TRUE)
+	if(istype(A, /obj/item/reagent_containers/syringe/bluespace))
+		to_chat(user, "<span class='notice'>\The [A] is too big to load into \the [src].</span>")
+		return TRUE
 	if(istype(A, /obj/item/reagent_containers/syringe))
 		if(syringes.len < max_syringes)
 			if(!user.transferItemToLoc(A, src))

--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -61,7 +61,7 @@
 
 /obj/item/gun/syringe/attackby(obj/item/A, mob/user, params, show_msg = TRUE)
 	if(istype(A, /obj/item/reagent_containers/syringe/bluespace))
-		to_chat(user, "<span class='notice'>\The [A] is too big to load into \the [src].</span>")
+		to_chat(user, "<span class='notice'>[A] is too big to load into [src].</span>")
 		return TRUE
 	if(istype(A, /obj/item/reagent_containers/syringe))
 		if(syringes.len < max_syringes)

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -37,3 +37,6 @@
 /obj/projectile/bullet/dart/syringe
 	name = "syringe"
 	icon_state = "syringeproj"
+
+/obj/projectile/bullet/dart/piercing
+	piercing = TRUE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -576,14 +576,6 @@
 	design_ids = list("nuclear_gun")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
-/datum/techweb_node/medical_weapons
-	id = "medical_weapons"
-	display_name = "Medical Weaponry"
-	description = "Weapons using medical technology."
-	prereq_ids = list("adv_biotech", "weaponry")
-	design_ids = list("rapidsyringe")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-
 /datum/techweb_node/beam_weapons
 	id = "beam_weapons"
 	display_name = "Beam Weaponry"
@@ -620,7 +612,7 @@
 	id = "exotic_ammo"
 	display_name = "Exotic Ammunition"
 	description = "They won't know what hit em."
-	prereq_ids = list("adv_weaponry", "medical_weapons")
+	prereq_ids = list("adv_weaponry")
 	design_ids = list("techshotshell", "c38_hotshot", "c38_iceblox")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
@@ -962,7 +954,7 @@
 	display_name = "Illegal Technology"
 	description = "Dangerous research used to create dangerous objects."
 	prereq_ids = list("adv_engi", "adv_weaponry", "explosive_weapons")
-	design_ids = list("decloner", "borg_syndicate_module", "ai_cam_upgrade", "suppressor", "largecrossbow", "donksofttoyvendor", "donksoft_refill", "advanced_camera")
+	design_ids = list("decloner", "borg_syndicate_module", "ai_cam_upgrade", "suppressor", "largecrossbow", "donksofttoyvendor", "donksoft_refill", "advanced_camera", "rapidsyringe")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	hidden = TRUE
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1897,7 +1897,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A heavily modified syringe gun which is capable of synthesizing its own chemical darts using input reagents. Can hold 100u of reagents."
 	item = /obj/item/gun/chem
 	cost = 12
-	restricted_roles = list("Chemist", "Chief Medical Officer")
+	restricted_roles = list("Chemist", "Chief Medical Officer", "Botanist")
 
 /datum/uplink_item/role_restricted/reverse_bear_trap
 	name = "Reverse Bear Trap"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Direct alternative to #55627 - See that PR for a ton of discussion to give context to this PR.

1. Uplink reagent gun gets piercing darts.
2. Botanists get access to the uplink reagent gun.
3. All syringe guns can no longer chamber bluespace syringes.
4. Rapidfire syringe guns will be locked behind illegal tech.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

> 1. Uplink reagent gun gets piercing darts.

I originally thought this thing synthesises chems. It does not. It synthesises darts. It's a lot of TC to spend on an item that's worse than using a syringe gun with bluespace syringes in almost every single way and could use a QoL tweak on its own to make it a worthwhile purchase.

Rather than bringing the TC cost down, I've raised its power level by giving it piercing darts. I don't personally think there is an issue with traitors having the ability to spend 12TC to deliver 15u piercing darts filled with chems compared to spending no TC and just using the ordinary syringe guns with 10u piercing/15u ordinary syringes instead.

> 2. Botanists get access to the uplink reagent gun.

Botanists now work with tons of chems. Could potentially enable some antag botanists an additional option for using the chems they make. Makes sense in my head?

> 3. All syringe guns can no longer chamber bluespace syringes.

Some of the problem areas highlighted with syringe guns included a number of comments on how 60u bluespace syringes are what can tip syringe guns from being a useful self defense weapon to the ultimate one-click validhunting tool.

We have been trying to do away with 1-click combat roulette in favour of longer fights with more room for individual player skill beyond who clicks first. I think this change adds enough room for syringe guns to be an effective self defense weapon while restricting their raw 1-click kill potential. See also changes to flashes which limited their offensive potential and focused on their utility as a defensive tool. Chem-related antags can still trade 12TC for an improved gun that generates its own 15u piercing syringes.

Syringe guns in general can continue to chamber 50u lethal injection syringes which are limited in quantity on any shift and only available from secure areas.

> 4. Rapidfire syringe guns will be locked behind illegal tech.

Incredibly powerful chemistry tool that is capable of mass production at any med techfab once researched.

Locking this behind illegal tech I believe illustrates its raw power as a chemistry weapon. It also gates the number of dart guns behind a fairly advanced tech tree node that requires a special unlock method, making them available to the crew en masse both less often and later in the shift.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Botanists get access to the uplink traitor reagent gun.
balance: Uplink traitor reagent gun for CMO/Chemist/Botanist now has piercing darts.
balance: All syringe guns can no longer chamber bluespace syringes.
balance: Rapid fire syringe guns are now locked behind illegal tech.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
