### PR TITLE
[bounty code moment] Adds a way to view the 'Server's Last Round'

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -359,20 +359,39 @@
 /client/proc/roundend_report_file()
 	return "data/roundend_reports/[ckey].html"
 
-/datum/controller/subsystem/ticker/proc/show_roundend_report(client/C, previous = FALSE)
+/datum/controller/subsystem/ticker/proc/log_roundend_report()
+	var/filename = "[GLOB.log_directory]/round_end_data.html"
+	var/list/parts = list()
+	parts += "<div class='panel stationborder'>"
+	parts += GLOB.survivor_report
+	parts += "</div>"
+	parts += GLOB.common_report
+	var/content = parts.Join()
+	//Log the rendered HTML in the round log directory
+	fdel(filename)
+	text2file(content, filename)
+	//Place a copy in the root folder, to be overwritten each round. 
+	filename = "data/last_roundend/server_last_roundend_report.html"
+	fdel(filename)
+	text2file(content, filename)
+
+/datum/controller/subsystem/ticker/proc/show_roundend_report(client/C, your_last_round = FALSE, server_last_round = FALSE)
 	var/datum/browser/roundend_report = new(C, "roundend")
 	roundend_report.width = 800
 	roundend_report.height = 600
 	var/content
 	var/filename = C.roundend_report_file()
-	if(!previous)
+	if(your_last_round) //Look at this player's last round
+		content = file2text(filename)
+	else if (server_last_round) //Look at the last round that this server has seen
+		content = file2text("data/last_roundend/server_last_roundend_report.html")
+	else //Make a new report based on the current round and show that to the player
 		var/list/report_parts = list(personal_report(C), GLOB.common_report)
 		content = report_parts.Join()
 		remove_verb(C, /client/proc/show_previous_roundend_report)
 		fdel(filename)
 		text2file(content, filename)
-	else
-		content = file2text(filename)
+
 	roundend_report.set_content(content)
 	roundend_report.stylesheets = list()
 	roundend_report.add_stylesheet("roundend", 'html/browser/roundend.css')
@@ -409,8 +428,9 @@
 /datum/controller/subsystem/ticker/proc/display_report(popcount)
 	GLOB.common_report = build_roundend_report()
 	GLOB.survivor_report = survivor_report(popcount)
+	log_roundend_report()
 	for(var/client/C in GLOB.clients)
-		show_roundend_report(C, FALSE)
+		show_roundend_report(C)
 		give_show_report_button(C)
 		CHECK_TICK
 
@@ -581,7 +601,7 @@
 
 /datum/action/report/Trigger()
 	if(owner && GLOB.common_report && SSticker.current_state == GAME_STATE_FINISHED)
-		SSticker.show_roundend_report(owner.client, FALSE)
+		SSticker.show_roundend_report(owner.client)
 
 /datum/action/report/IsAvailable()
 	return 1

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -359,6 +359,15 @@
 /client/proc/roundend_report_file()
 	return "data/roundend_reports/[ckey].html"
 
+/**
+ * Log the round-end report as an HTML file
+ *
+ * Composits the roundend report, and saves it in two locations.
+ * The report is first saved along with the round's logs
+ * Then, the report is copied to a fixed directory specifically for 
+ * housing the server's last roundend report. In this location, 
+ * the file will be overwritten at the end of each shift.
+ */
 /datum/controller/subsystem/ticker/proc/log_roundend_report()
 	var/filename = "[GLOB.log_directory]/round_end_data.html"
 	var/list/parts = list()

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -382,7 +382,7 @@
 	fdel(filename)
 	text2file(content, filename)
 	//Place a copy in the root folder, to be overwritten each round. 
-	filename = "data/last_roundend/server_last_roundend_report.html"
+	filename = "data/server_last_roundend_report.html"
 	fdel(filename)
 	text2file(content, filename)
 
@@ -395,7 +395,7 @@
 	if(report_type == PERSONAL_LAST_ROUND) //Look at this player's last round
 		content = file2text(filename)
 	else if (report_type == SERVER_LAST_ROUND) //Look at the last round that this server has seen
-		content = file2text("data/last_roundend/server_last_roundend_report.html")
+		content = file2text("data/server_last_roundend_report.html")
 	else //report_type is null, so make a new report based on the current round and show that to the player
 		var/list/report_parts = list(personal_report(C), GLOB.common_report)
 		content = report_parts.Join()

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -1,6 +1,8 @@
 #define POPCOUNT_SURVIVORS "survivors"					//Not dead at roundend
 #define POPCOUNT_ESCAPEES "escapees"					//Not dead and on centcom/shuttles marked as escaped
 #define POPCOUNT_SHUTTLE_ESCAPEES "shuttle_escapees" 	//Emergency shuttle only.
+#define PERSONAL_LAST_ROUND "personal last round"
+#define SERVER_LAST_ROUND "server last round"
 
 /datum/controller/subsystem/ticker/proc/gather_roundend_feedback()
 	gather_antag_data()
@@ -384,17 +386,17 @@
 	fdel(filename)
 	text2file(content, filename)
 
-/datum/controller/subsystem/ticker/proc/show_roundend_report(client/C, your_last_round = FALSE, server_last_round = FALSE)
+/datum/controller/subsystem/ticker/proc/show_roundend_report(client/C, report_type = null)
 	var/datum/browser/roundend_report = new(C, "roundend")
 	roundend_report.width = 800
 	roundend_report.height = 600
 	var/content
 	var/filename = C.roundend_report_file()
-	if(your_last_round) //Look at this player's last round
+	if(report_type == PERSONAL_LAST_ROUND) //Look at this player's last round
 		content = file2text(filename)
-	else if (server_last_round) //Look at the last round that this server has seen
+	else if (report_type == SERVER_LAST_ROUND) //Look at the last round that this server has seen
 		content = file2text("data/last_roundend/server_last_roundend_report.html")
-	else //Make a new report based on the current round and show that to the player
+	else //report_type is null, so make a new report based on the current round and show that to the player
 		var/list/report_parts = list(personal_report(C), GLOB.common_report)
 		content = report_parts.Join()
 		remove_verb(C, /client/proc/show_previous_roundend_report)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -253,6 +253,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(fexists(roundend_report_file()))
 		add_verb(src, /client/proc/show_previous_roundend_report)
 
+	if(fexists("data/last_roundend/server_last_roundend_report.html"))
+		add_verb(src, /client/proc/show_servers_last_roundend_report)
+
 	var/full_version = "[byond_version].[byond_build ? byond_build : "xxx"]"
 	log_access("Login: [key_name(src)] from [address ? address : "localhost"]-[computer_id] || BYOND v[full_version]")
 

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -339,7 +339,14 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	set category = "OOC"
 	set desc = "View the last round end report you've seen"
 
-	SSticker.show_roundend_report(src, TRUE)
+	SSticker.show_roundend_report(src, your_last_round=TRUE)
+
+/client/proc/show_servers_last_roundend_report()
+	set name = "Server's Last Round"
+	set category = "OOC"
+	set desc = "View the last round end report from this server"
+
+	SSticker.show_roundend_report(src, server_last_round=TRUE)
 
 /client/verb/fit_viewport()
 	set name = "Fit Viewport"

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -339,14 +339,14 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	set category = "OOC"
 	set desc = "View the last round end report you've seen"
 
-	SSticker.show_roundend_report(src, your_last_round=TRUE)
+	SSticker.show_roundend_report(src, report_type = PERSONAL_LAST_ROUND)
 
 /client/proc/show_servers_last_roundend_report()
 	set name = "Server's Last Round"
 	set category = "OOC"
 	set desc = "View the last round end report from this server"
 
-	SSticker.show_roundend_report(src, server_last_round=TRUE)
+	SSticker.show_roundend_report(src, report_type = SERVER_LAST_ROUND)
 
 /client/verb/fit_viewport()
 	set name = "Fit Viewport"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds an option to view the last round of a given server, rather than the last round by your own client. This is accomplished by logging the HTML round-end reports, and placing a copy representing the last one in a fixed directory (to be overwritten each shift).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More logging, per headmin request
https://tgstation13.org/phpBB/viewtopic.php?f=41&t=27656#p577600
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now view a server's last round (not just yours specifically) via the OOC tab > Server's Last Round
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

I want to make sure this is done the right way, as modifying logs is a first for me. I've gotten maintainer go-ahead to add the round-end reports to our logs, but I want to make sure this specific implementation for the whole 'track the last round-end report" thing is solid. I fiddled with dynamically finding the last round's report by writing a weird recursive filebrowser algorithm, but so many edge-cases started popping up that I pivoted to storing a copy of the file in a fixed space, which turned out to be much cleaner.
