### PR TITLE
Make eye(s) of god NODROP only when equipped

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -483,8 +483,8 @@
 		if(!double)
 			var/obj/item/clothing/glasses/godeye/double/T = /obj/item/clothing/glasses/godeye/double
 
-			src.icon_state = initial(T.icon_state)
-			src.inhand_icon_state = initial(T.inhand_icon_state)
+			icon_state = initial(T.icon_state)
+			inhand_icon_state = initial(T.inhand_icon_state)
 
 			if(iscarbon(user))
 				var/mob/living/carbon/C = user
@@ -494,9 +494,9 @@
 				if(C.glasses == src)
 					pain(C)
 
-			src.name = initial(T.name)
-			src.desc = initial(T.desc)
-			src.double = TRUE
+			name = initial(T.name)
+			desc = initial(T.desc)
+			double = TRUE
 		else
 			to_chat(user, "<span class='notice'>[W] winks at you and vanishes into the abyss, you feel really unlucky.</span>")
 		qdel(W)
@@ -505,11 +505,7 @@
 /obj/item/clothing/glasses/godeye/proc/pain(mob/living/victim)
 	// If pain/pain immunity ever implemented, check for it here.
 
-	var/verbs = "burrows"
-	if(src.double)
-		verbs = "burrow"
-
-	to_chat(victim, "<span class='userdanger'>You experience blinding pain, as [src] [verbs] into your skull.</span>")
+	to_chat(victim, "<span class='userdanger'>You experience blinding pain, as [src] [double ? "burrow" : "burrows"] into your skull.</span>")
 	victim.emote("scream")
 	victim.flash_act()
 

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -54,6 +54,39 @@
 				H.blur_eyes(5)
 				eyes.applyOrganDamage(5)
 
+/obj/item/clothing/glasses/AltClick(mob/user)
+	if(glass_colour_type && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.client)
+			if(H.client.prefs)
+				if(src == H.glasses)
+					H.client.prefs.uses_glasses_colour = !H.client.prefs.uses_glasses_colour
+					if(H.client.prefs.uses_glasses_colour)
+						to_chat(H, "<span class='notice'>You will now see glasses colors.</span>")
+					else
+						to_chat(H, "<span class='notice'>You will no longer see glasses colors.</span>")
+					H.update_glasses_color(src, 1)
+	else
+		return ..()
+
+/obj/item/clothing/glasses/proc/change_glass_color(mob/living/carbon/human/H, datum/client_colour/glass_colour/new_color_type)
+	var/old_colour_type = glass_colour_type
+	if(!new_color_type || ispath(new_color_type)) //the new glass colour type must be null or a path.
+		glass_colour_type = new_color_type
+		if(H && H.glasses == src)
+			if(old_colour_type)
+				H.remove_client_colour(old_colour_type)
+			if(glass_colour_type)
+				H.update_glasses_color(src, 1)
+
+
+/mob/living/carbon/human/proc/update_glasses_color(obj/item/clothing/glasses/G, glasses_equipped)
+	if(client?.prefs.uses_glasses_colour && glasses_equipped)
+		add_client_colour(G.glass_colour_type)
+	else
+		remove_client_colour(G.glass_colour_type)
+
+
 /obj/item/clothing/glasses/meson
 	name = "optical meson scanner"
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting conditions."
@@ -434,57 +467,60 @@
 	darkness_view = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
+	custom_materials = null
 	clothing_flags = SCAN_REAGENTS
+	var/double = FALSE
 
-/obj/item/clothing/glasses/godeye/Initialize()
+/obj/item/clothing/glasses/godeye/equipped(mob/user, slot)
 	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, EYE_OF_GOD_TRAIT)
+	if(ishuman(user) && slot == ITEM_SLOT_EYES)
+		ADD_TRAIT(src, TRAIT_NODROP, EYE_OF_GOD_TRAIT)
+
+		pain(user)
 
 /obj/item/clothing/glasses/godeye/attackby(obj/item/W as obj, mob/user as mob, params)
-	if(istype(W, src) && W != src && W.loc == user)
-		if(W.icon_state == "godeye")
-			W.icon_state = "doublegodeye"
-			W.inhand_icon_state = "doublegodeye"
-			W.desc = "A pair of strange eyes, said to have been torn from an omniscient creature that used to roam the wastes. There's no real reason to have two, but that isn't stopping you."
+	if(istype(W, /obj/item/clothing/glasses/godeye) && W != src && W.loc == user)
+		if(!double)
+			var/obj/item/clothing/glasses/godeye/double/T = /obj/item/clothing/glasses/godeye/double
+
+			src.icon_state = initial(T.icon_state)
+			src.inhand_icon_state = initial(T.inhand_icon_state)
+
 			if(iscarbon(user))
 				var/mob/living/carbon/C = user
-				C.update_inv_wear_mask()
+				C.update_inv_glasses()
+
+				// Apply pain now, so message is still for solo eye bore
+				if(C.glasses == src)
+					pain(C)
+
+			src.name = initial(T.name)
+			src.desc = initial(T.desc)
+			src.double = TRUE
 		else
-			to_chat(user, "<span class='notice'>The eye winks at you and vanishes into the abyss, you feel really unlucky.</span>")
-		qdel(src)
+			to_chat(user, "<span class='notice'>[W] winks at you and vanishes into the abyss, you feel really unlucky.</span>")
+		qdel(W)
 	..()
 
-/obj/item/clothing/glasses/AltClick(mob/user)
-	if(glass_colour_type && ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.client)
-			if(H.client.prefs)
-				if(src == H.glasses)
-					H.client.prefs.uses_glasses_colour = !H.client.prefs.uses_glasses_colour
-					if(H.client.prefs.uses_glasses_colour)
-						to_chat(H, "<span class='notice'>You will now see glasses colors.</span>")
-					else
-						to_chat(H, "<span class='notice'>You will no longer see glasses colors.</span>")
-					H.update_glasses_color(src, 1)
-	else
-		return ..()
+/obj/item/clothing/glasses/godeye/proc/pain(mob/living/victim)
+	// If pain/pain immunity ever implemented, check for it here.
 
-/obj/item/clothing/glasses/proc/change_glass_color(mob/living/carbon/human/H, datum/client_colour/glass_colour/new_color_type)
-	var/old_colour_type = glass_colour_type
-	if(!new_color_type || ispath(new_color_type)) //the new glass colour type must be null or a path.
-		glass_colour_type = new_color_type
-		if(H && H.glasses == src)
-			if(old_colour_type)
-				H.remove_client_colour(old_colour_type)
-			if(glass_colour_type)
-				H.update_glasses_color(src, 1)
+	var/verbs = "burrows"
+	if(src.double)
+		verbs = "burrow"
 
+	to_chat(victim, "<span class='userdanger'>You experience blinding pain, as [src] [verbs] into your skull.</span>")
+	victim.emote("scream")
+	victim.flash_act()
 
-/mob/living/carbon/human/proc/update_glasses_color(obj/item/clothing/glasses/G, glasses_equipped)
-	if(client?.prefs.uses_glasses_colour && glasses_equipped)
-		add_client_colour(G.glass_colour_type)
-	else
-		remove_client_colour(G.glass_colour_type)
+/obj/item/clothing/glasses/godeye/double
+	name = "eyes of god"
+	desc = "A pair of strange eyes, said to have been torn from an omniscient creature that used to roam the wastes. There's no real reason to have two, but that isn't stopping you."
+	icon_state = "doublegodeye"
+	inhand_icon_state = "doublegodeye"
+
+	double = TRUE
+
 
 /obj/item/clothing/glasses/debug
 	name = "debug glasses"

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -478,6 +478,12 @@
 
 		pain(user)
 
+/obj/item/clothing/glasses/godeye/dropped(mob/user)
+	. = ..()
+	// Behead someone, their "glasses" drop on the floor
+	// and thus, the god eye should no longer be sticky
+	REMOVE_TRAIT(src, TRAIT_NODROP, EYE_OF_GOD_TRAIT)
+
 /obj/item/clothing/glasses/godeye/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/clothing/glasses/godeye) && W != src && W.loc == user)
 		if(!double)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -288,7 +288,7 @@
 		//Drop all worn head items
 		for(var/X in list(owner.glasses, owner.ears, owner.wear_mask, owner.head))
 			var/obj/item/I = X
-			owner.dropItemToGround(I, TRUE)
+			owner.dropItemToGround(I, force = TRUE)
 
 	qdel(owner.GetComponent(/datum/component/creamed)) //clean creampie overlay
 


### PR DESCRIPTION
:cl: coiax
tweak: The "eye of god" only becomes unremovable when put in your eye.
/:cl:

- The lavaland chest reward "eye of god", will only become NODROP (ie.
  unremovable) when actually placed in someone's glasses slot, rather
  than becoming immediately stuck in your hand.
- Eyes of god now hurt when implanted, causing temporary blindness and
  screaming.
- A pre-doubled eye of god is now a typepath.
- Eyes of god are no longer made out of glass.
- Glasses colouring procs have been moved to the top of the glasses
  file, but unchanged.

---
## Why It's Good For The Game

Thematically, it makes more sense that the eyes are unremovable only when implanted or "worn", and not that they're just made of magical superglue.
They're made of glass only because the basic glasses type are made of glass, but they're... fleshy eyes cut from a monster.
More screaming and messages gives the item a tiny bit more thematic colour.
A "doubled" type makes it easier for mappers and admins, if they care about such things.