### PR TITLE
Refactor outfit skillchips

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -96,10 +96,10 @@
 	var/list/implants = null
 
 	/**
-      * Any skillchips the mob should have in their brain.
-      *
-      * Format of this list is (typepath, typepath, typepath)
-      */
+	  * Any skillchips the mob should have in their brain.
+	  *
+	  * Format of this list is (typepath, typepath, typepath)
+	  */
 	var/list/skillchips = null
 
 	/// Any undershirt. While on humans it is a string, here we use paths to stay consistent with the rest of the equips.

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -95,6 +95,13 @@
 	  */
 	var/list/implants = null
 
+	/**
+      * Any skillchips the mob should have in their brain.
+      *
+      * Format of this list is (typepath, typepath, typepath)
+      */
+	var/list/skillchips = null
+
 	/// Any undershirt. While on humans it is a string, here we use paths to stay consistent with the rest of the equips.
 	var/datum/sprite_accessory/undershirt = null
 
@@ -233,6 +240,21 @@
 				var/obj/item/implant/I = new implant_type(H)
 				I.implant(H, null, TRUE)
 
+		// Insert the skillchips associated with this outfit into the target.
+		if(skillchips)
+			for(var/skillchip_path in skillchips)
+				var/obj/item/skillchip/skillchip_instance = new skillchip_path()
+				var/implant_msg = H.implant_skillchip(skillchip_instance)
+				if(implant_msg)
+					stack_trace("Failed to implant [H] with [skillchip_instance], on job [src]. Failure message: [implant_msg]")
+					qdel(skillchip_instance)
+					return
+
+				var/activate_msg = skillchip_instance.try_activate_skillchip(TRUE, TRUE)
+				if(activate_msg)
+					CRASH("Failed to activate [H]'s [skillchip_instance], on job [src]. Failure message: [activate_msg]")
+
+
 	H.update_body()
 	return TRUE
 
@@ -288,6 +310,7 @@
 /datum/outfit/proc/get_chameleon_disguise_info()
 	var/list/types = list(uniform, suit, back, belt, gloves, shoes, head, mask, neck, ears, glasses, id, l_pocket, r_pocket, suit_store, r_hand, l_hand)
 	types += chameleon_extras
+	types += skillchips
 	listclearnulls(types)
 	return types
 

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -38,16 +38,6 @@
 /datum/antagonist/ert/proc/update_name()
 	owner.current.fully_replace_character_name(owner.current.real_name,"[role] [pick(name_source)]")
 
-/datum/antagonist/ert/deathsquad/New()
-	. = ..()
-	name_source = GLOB.commando_names
-
-/datum/antagonist/ert/deathsquad/apply_innate_effects(mob/living/mob_override)
-	ADD_TRAIT(owner, TRAIT_DISK_VERIFIER, DEATHSQUAD_TRAIT)
-
-/datum/antagonist/ert/deathsquad/remove_innate_effects(mob/living/mob_override)
-	REMOVE_TRAIT(owner, TRAIT_DISK_VERIFIER, DEATHSQUAD_TRAIT)
-
 /datum/antagonist/ert/security // kinda handled by the base template but here for completion
 
 /datum/antagonist/ert/security/red
@@ -79,6 +69,17 @@
 	outfit = /datum/outfit/centcom/death_commando
 	role = "Trooper"
 	rip_and_tear = TRUE
+
+/datum/antagonist/ert/deathsquad/New()
+	. = ..()
+	name_source = GLOB.commando_names
+
+/datum/antagonist/ert/deathsquad/apply_innate_effects(mob/living/mob_override)
+	ADD_TRAIT(owner, TRAIT_DISK_VERIFIER, DEATHSQUAD_TRAIT)
+
+/datum/antagonist/ert/deathsquad/remove_innate_effects(mob/living/mob_override)
+	REMOVE_TRAIT(owner, TRAIT_DISK_VERIFIER, DEATHSQUAD_TRAIT)
+
 
 /datum/antagonist/ert/medic/inquisitor
 	outfit = /datum/outfit/centcom/ert/medic/inquisitor

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -230,8 +230,6 @@
 
 	var/pda_slot = ITEM_SLOT_BELT
 
-	var/skillchip_path = null
-
 /datum/outfit/job/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	switch(H.backpack)
 		if(GBACKPACK)
@@ -291,18 +289,6 @@
 	if(H.client?.prefs.playtime_reward_cloak)
 		neck = /obj/item/clothing/neck/cloak/skill_reward/playing
 
-	// Insert the skillchip associated with this job into the target.
-	if(skillchip_path && istype(H))
-		var/obj/item/skillchip/skillchip_instance = new skillchip_path()
-		var/implant_msg = H.implant_skillchip(skillchip_instance)
-		if(implant_msg)
-			stack_trace("Failed to implant [H] with [skillchip_instance], on job [src]. Failure message: [implant_msg]")
-			qdel(skillchip_instance)
-			return
-
-		var/activate_msg = skillchip_instance.try_activate_skillchip(TRUE, TRUE)
-		if(activate_msg)
-			CRASH("Failed to activate [H]'s [skillchip_instance], on job [src]. Failure message: [activate_msg]")
 
 /datum/outfit/job/get_chameleon_disguise_info()
 	var/list/types = ..()
@@ -310,8 +296,6 @@
 	types += backpack
 	types += satchel
 	types += duffelbag
-	if(skillchip_path)
-		types += skillchip_path
 	return types
 
 //Warden and regular officers add this result to their get_access()

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -24,6 +24,7 @@
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/civilian/janitor
 	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1)
+	skillchips = list(/obj/item/skillchip/job/engineer, /obj/item/skillchip/light_remover)
 
 /datum/outfit/job/janitor/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -24,7 +24,6 @@
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/civilian/janitor
 	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1)
-	skillchips = list(/obj/item/skillchip/job/engineer, /obj/item/skillchip/light_remover)
 
 /datum/outfit/job/janitor/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -36,4 +36,4 @@
 
 	pda_slot = ITEM_SLOT_LPOCKET
 
-	skillchip_path = /obj/item/skillchip/job/roboticist
+	skillchips = list(/obj/item/skillchip/job/roboticist)

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -40,7 +40,7 @@
 	pda_slot = ITEM_SLOT_LPOCKET
 	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1)
 
-	skillchip_path = /obj/item/skillchip/job/engineer
+	skillchips = list(/obj/item/skillchip/job/engineer)
 
 /datum/outfit/job/engineer/gloved
 	name = "Station Engineer (Gloves)"


### PR DESCRIPTION
- Skillchips now are on /datum/outfit, rather than /datum/outfit/job,
  since we may want other roles to start with skillchips in the future.
- Skillchips are now a list of types to install, rather than a single
  one.
- Traits for the deathsquad are now listed just below the deathsquad
  initial antag datum definition.