### PR TITLE
Cuban Pete will no longer tolerate cheating at his arcade game.

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -277,6 +277,8 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 
 	if (!blocked && !gameover)
 		var/attackamt = rand(5,7) + rand(0, gamerSkill)
+		if(obj_flags & EMAGGED) // no cheating for your maxcaps
+			attackamt = rand(5,7)
 
 		if(finishing_move) //time to bonk that fucker,cuban pete will sometime survive a finishing move.
 			attackamt *= 100


### PR DESCRIPTION
## About The Pull Request

Your Gamer skill no longer gives you bonus damage during the fight against Cuban Pete.

## Why It's Good For The Game

Beating Cuban Pete gives you a max cap explosive. You need to earn these now.

## Changelog
:cl:
balance: Cuban Pete will no longer entertain Gamers :tm: doing more damage to him.
/:cl:


