### PR TITLE
Shuttle Manipulator now gives admins the option to prevent shuttle purchases when they change the emergency shuttle.

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -925,3 +925,7 @@ SUBSYSTEM_DEF(shuttle)
 					log_admin("[key_name(usr)] load/replaced [mdp] with the shuttle manipulator.</span>")
 					SSblackbox.record_feedback("text", "shuttle_manipulator", 1, "[mdp.name]")
 				shuttle_loading = FALSE
+				if(emergency == mdp) //you just changed the emergency shuttle, there are events in game + captains that can change your snowflake choice.
+					var/set_purchase = alert(usr, "Do you want to also disable shuttle purchases/random events that would change the shuttle?", "Butthurt Admin Prevention", "Yes, disable purchases/events", "No, I want to possibly get owned")
+					if(set_purchase == "Yes, disable purchases/events")
+						SSshuttle.shuttle_purchased = SHUTTLEPURCHASE_FORCED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It's a story as old as time itself. Admin loads a new shuttle, decorates it, and then shuttle catastrophe triggers and the admin gets deeply, deeply owned. With this, you can set what emergency shuttle they picked and prevent any more changes to the shuttle!

## Why It's Good For The Game

Okay it's pretty funny but i'm supposed to be helping these admin fellows or something

## Changelog
:cl:
admin: Changing the emergency shuttle now gives the option for disabling shuttlechanging purchases/events
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
