### PR TITLE
General Heretics Bugfixing Patch

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -72,8 +72,8 @@
 #define CONTRACT_UPLINK_PAGE_HUB "HUB"
 
 ///It is faster as a macro than a proc
-#define IS_HERETIC(mob) (mob.mind?.has_antag_datum(/datum/antagonist/heretic))
-#define IS_HERETIC_MONSTER(mob) (mob.mind?.has_antag_datum(/datum/antagonist/heretic_monster))
+#define IS_HERETIC(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/heretic))
+#define IS_HERETIC_MONSTER(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/heretic_monster))
 
 GLOBAL_LIST_INIT(heretic_start_knowledge,list(/datum/eldritch_knowledge/spell/basic,/datum/eldritch_knowledge/living_heart,/datum/eldritch_knowledge/codex_cicatrix))
 

--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 	if(alternate_appearances && alternate_appearances[key])
 		return
 	var/list/arguments = args.Copy(2)
-	new type(arglist(arguments))
+	return new type(arglist(arguments))
 
 /datum/atom_hud/alternate_appearance
 	var/appearance_key
@@ -192,7 +192,7 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 
 /datum/atom_hud/alternate_appearance/basic/heretics/New()
 	..()
-	for(var/mob in  GLOB.player_list)
+	for(var/mob in GLOB.player_list)
 		if(mobShouldSee(mob))
 			add_hud_to(mob)
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -37,13 +37,6 @@
 	current.log_message("has been converted to the cult of the forgotten ones!", LOG_ATTACK, color="#960000")
 	GLOB.reality_smash_track.Generate()
 
-	//We have to reload the alternative appearances since some influences WILL be invisible to us if we get heretic antag after they spawn... sad!
-	for(var/AA in GLOB.active_alternate_appearances)
-		if(!AA || !istype(AA,/datum/atom_hud/alternate_appearance/basic/heretics))
-			continue
-		var/datum/atom_hud/alternate_appearance/appearance = AA
-		appearance.onNewMob(src)
-
 	START_PROCESSING(SSprocessing,src)
 	RegisterSignal(owner.current,COMSIG_LIVING_DEATH,.proc/on_death)
 	if(give_equipment)

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -41,7 +41,7 @@
 	for(var/AA in GLOB.active_alternate_appearances)
 		if(!AA || !istype(AA,/datum/atom_hud/alternate_appearance/basic/heretics))
 			continue
-		var/datum/atom_hud/alternate_appearance/appearance = v
+		var/datum/atom_hud/alternate_appearance/appearance = AA
 		appearance.onNewMob(src)
 
 	START_PROCESSING(SSprocessing,src)

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -35,7 +35,7 @@
 		for(var/eldritch_knowledge in GLOB.heretic_start_knowledge)
 			gain_knowledge(eldritch_knowledge)
 	current.log_message("has been converted to the cult of the forgotten ones!", LOG_ATTACK, color="#960000")
-	GLOB.reality_smash_track.Generate()
+	GLOB.reality_smash_track.Generate(current)
 
 	START_PROCESSING(SSprocessing,src)
 	RegisterSignal(owner.current,COMSIG_LIVING_DEATH,.proc/on_death)
@@ -52,7 +52,7 @@
 	if(!silent)
 		to_chat(owner.current, "<span class='userdanger'>Your mind begins to flare as the otherwordly knowledge escapes your grasp!</span>")
 		owner.current.log_message("has renounced the cult of the old ones!", LOG_ATTACK, color="#960000")
-	GLOB.reality_smash_track.targets--
+
 	STOP_PROCESSING(SSprocessing,src)
 
 	on_death()

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -36,6 +36,14 @@
 			gain_knowledge(eldritch_knowledge)
 	current.log_message("has been converted to the cult of the forgotten ones!", LOG_ATTACK, color="#960000")
 	GLOB.reality_smash_track.Generate()
+
+	//We have to reload the alternative appearances since some influences WILL be invisible to us if we get heretic antag after they spawn... sad!
+	for(var/AA in GLOB.active_alternate_appearances)
+		if(!AA || !istype(AA,/datum/atom_hud/alternate_appearance/basic/heretics))
+			continue
+		var/datum/atom_hud/alternate_appearance/appearance = v
+		appearance.onNewMob(src)
+
 	START_PROCESSING(SSprocessing,src)
 	RegisterSignal(owner.current,COMSIG_LIVING_DEATH,.proc/on_death)
 	if(give_equipment)
@@ -87,7 +95,7 @@
 
 /datum/antagonist/heretic/process()
 
-	if(owner.current.stat == DEAD)
+	if(owner?.current?.stat == DEAD)
 		return
 
 	for(var/X in researched_knowledge)

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -7,11 +7,6 @@
 	layer = SIGIL_LAYER
 	///Used mainly for summoning ritual to prevent spamming the rune to create millions of monsters.
 	var/is_in_use = FALSE
-	///Added for the purpose of error tracking. Since knowledge breaking can be pretty elusive, this needs it's own way of knowing what the fuck broke.
-	var/last_use_time
-	///Added for the purpose of error tracking. Since knowledge breaking can be pretty elusive, this needs it's own way of knowing what the fuck broke.
-	var/last_rite
-
 /obj/effect/eldritch/Initialize()
 	. = ..()
 	var/image/I = image(icon = 'icons/effects/eldritch.dmi', icon_state = null, loc = src)
@@ -30,9 +25,6 @@
 	if(!is_in_use)
 		last_use = world.time
 		INVOKE_ASYNC(src, .proc/activate , user)
-	else if((world.time - last_use) > 30 SECONDS) // 30 seconds because if something didnt happen by this time we know for sure it is an error. We cannot do it instantly since stuff like PollGhosts takes like 30 seconds or something.
-		CRASH("Unterminated ritual in progress evoked by [user] in [loc] caused by [last rite]")
-		is_in_use = FALSE //Self fixing, just in case.
 
 /obj/effect/eldritch/attacked_by(obj/item/I, mob/living/user)
 	. = ..()
@@ -94,8 +86,6 @@
 			var/atom/atom_to_disappear = to_disappear
 			//temporary so we dont have to deal with the bs of someone picking those up when they may be deleted
 			atom_to_disappear.invisibility = INVISIBILITY_ABSTRACT
-
-		last_rite = current_eldritch_knowledge.name
 
 		if(current_eldritch_knowledge.on_finished_recipe(user,selected_atoms,loc))
 			current_eldritch_knowledge.cleanup_atoms(selected_atoms)

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -23,7 +23,6 @@
 	if(!IS_HERETIC(user))
 		return
 	if(!is_in_use)
-		last_use = world.time
 		INVOKE_ASYNC(src, .proc/activate , user)
 
 /obj/effect/eldritch/attacked_by(obj/item/I, mob/living/user)

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -240,7 +240,7 @@
 
 ///Custom effect that happens on destruction
 /obj/effect/reality_smash/proc/on_destroy()
-	GLOB.reality_smash_track.smashes--
+	GLOB.reality_smash_track.smashes -= src
 	var/obj/effect/broken_illusion/illusion = new /obj/effect/broken_illusion(drop_location())
 	illusion.name = pick("Researched","Siphoned","Analyzed","Emptied","Drained") + " " + name
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -115,9 +115,9 @@
  */
 /datum/reality_smash_tracker
 	///list of tracked reality smashes
-	var/smashes = 0
+	var/list/smashes = list()
 	///List of mobs with ability to see the smashes
-	var/targets = 0
+	var/list/targets = list()
 
 /datum/reality_smash_tracker/Destroy(force, ...)
 	if(GLOB.reality_smash_track == src)
@@ -129,20 +129,24 @@
  *
  * Automatically creates more reality smashes
  */
-/datum/reality_smash_tracker/proc/Generate()
-	targets++
-	var/number = max(targets * (4-(targets-1)) - smashes,1)
+/datum/reality_smash_tracker/proc/Generate(mob/caller)
+	if(!istype(caller))
+		stack_trace("Caller is of not the right type!")
+	targets += caller
+	var/number = max(targets.len * (4-(targets.len-1)) - smashes.len,1)
+
+	for(var/obj/effect/reality_smash/smash in smashes)
+		smash.alt_appearance.add_to_hud(caller)
 
 	for(var/i in 0 to number)
-
 		var/turf/chosen_location = get_safe_random_station_turf()
 		//we also dont want them close to each other, at least 1 tile of seperation
 		var/obj/effect/reality_smash/what_if_i_have_one = locate() in range(1, chosen_location)
 		var/obj/effect/broken_illusion/what_if_i_had_one_but_got_used = locate() in range(1, chosen_location)
 		if(what_if_i_have_one || what_if_i_had_one_but_got_used) //we dont want to spawn
 			continue
-		new /obj/effect/reality_smash(chosen_location)
-		smashes++
+		smashes += new /obj/effect/reality_smash(chosen_location)
+
 
 /obj/effect/broken_illusion
 	name = "pierced reality"
@@ -222,12 +226,13 @@
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	invisibility = INVISIBILITY_OBSERVER
+	var/datum/atom_hud/alternate_appearance/basic/heretics/alt_appearance
 
 /obj/effect/reality_smash/Initialize()
 	. = ..()
 	var/img = image(icon, src, "reality_smash", OBJ_LAYER)
 	generate_name()
-	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/heretics,"influence",img)
+	alt_appearance = add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/heretics,"influence",img)
 
 /obj/effect/reality_smash/Destroy()
 	on_destroy()

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -692,7 +692,7 @@
 	var/mob/living/mob_inside = locate() in target.contents - target
 
 	if(!mob_inside)
-		var/mob/living/simple_animal/hostile/eldritch/armsy/prime/outside = new(user.loc,TRUE,segment_length)
+		var/mob/living/simple_animal/hostile/eldritch/armsy/prime/outside = new(get_turf(user),TRUE,segment_length)
 		target.mind.transfer_to(outside, TRUE)
 		target.forceMove(outside)
 		target.apply_status_effect(STATUS_EFFECT_STASIS,STASIS_ASCENSION_EFFECT)
@@ -709,7 +709,7 @@
 	if(iscarbon(mob_inside))
 		var/mob/living/simple_animal/hostile/eldritch/armsy/prime/armsy = target
 		if(mob_inside.remove_status_effect(STATUS_EFFECT_STASIS,STASIS_ASCENSION_EFFECT))
-			mob_inside.forceMove(armsy.loc)
+			mob_inside.forceMove(get_turf(armsy))
 		armsy.mind.transfer_to(mob_inside, TRUE)
 		segment_length = armsy.get_length()
 		qdel(armsy)

--- a/code/modules/antagonists/eldritch_cult/eldritch_monster_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_monster_antag.dm
@@ -40,13 +40,6 @@
 	. = ..()
 	add_antag_hud(antag_hud_type, antag_hud_name, owner.current)
 
-	//We have to reload the alternative appearances since some things WILL be invisible to us if we get heretic antag after they spawn... sad!
-	for(var/AA in GLOB.active_alternate_appearances)
-		if(!AA || !istype(AA,/datum/atom_hud/alternate_appearance/basic/heretics))
-			continue
-		var/datum/atom_hud/alternate_appearance/appearance = AA
-		appearance.onNewMob(src)
-
 /datum/antagonist/heretic_monster/remove_innate_effects(mob/living/mob_override)
 	. = ..()
 	remove_antag_hud(antag_hud_type, owner.current)

--- a/code/modules/antagonists/eldritch_cult/eldritch_monster_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_monster_antag.dm
@@ -40,6 +40,13 @@
 	. = ..()
 	add_antag_hud(antag_hud_type, antag_hud_name, owner.current)
 
+	//We have to reload the alternative appearances since some things WILL be invisible to us if we get heretic antag after they spawn... sad!
+	for(var/AA in GLOB.active_alternate_appearances)
+		if(!AA || !istype(AA,/datum/atom_hud/alternate_appearance/basic/heretics))
+			continue
+		var/datum/atom_hud/alternate_appearance/appearance = v
+		appearance.onNewMob(src)
+
 /datum/antagonist/heretic_monster/remove_innate_effects(mob/living/mob_override)
 	. = ..()
 	remove_antag_hud(antag_hud_type, owner.current)

--- a/code/modules/antagonists/eldritch_cult/eldritch_monster_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_monster_antag.dm
@@ -44,7 +44,7 @@
 	for(var/AA in GLOB.active_alternate_appearances)
 		if(!AA || !istype(AA,/datum/atom_hud/alternate_appearance/basic/heretics))
 			continue
-		var/datum/atom_hud/alternate_appearance/appearance = v
+		var/datum/atom_hud/alternate_appearance/appearance = AA
 		appearance.onNewMob(src)
 
 /datum/antagonist/heretic_monster/remove_innate_effects(mob/living/mob_override)

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -24,13 +24,13 @@
 /datum/eldritch_knowledge/flesh_ghoul/on_finished_recipe(mob/living/user,list/atoms,loc)
 	var/mob/living/carbon/human/humie = locate() in atoms
 	if(QDELETED(humie) || humie.stat != DEAD)
-		return
+		return FALSE
 
 	if(length(ghouls) >= max_amt)
-		return
+		return FALSE
 
 	if(HAS_TRAIT(humie,TRAIT_HUSK))
-		return
+		return FALSE
 
 	humie.grab_ghost()
 
@@ -57,6 +57,7 @@
 	atoms -= humie
 	RegisterSignal(humie,COMSIG_LIVING_DEATH,.proc/remove_ghoul)
 	ghouls += humie
+	return TRUE
 
 /datum/eldritch_knowledge/flesh_ghoul/proc/remove_ghoul(datum/source)
 	var/mob/living/carbon/human/humie = source

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -43,7 +43,7 @@
 		humie.ghostize(0)
 		humie.key = C.key
 
-	ADD_TRAIT(humie,TRAIT_MUTE,MAGIC_TRAIT)
+	ADD_TRAIT(humie,TRAIT_MUTE,type)
 	log_game("[key_name_admin(humie)] has become a voiceless dead, their master is [user.real_name]")
 	humie.revive(full_heal = TRUE, admin_revive = TRUE)
 	humie.setMaxHealth(50)
@@ -62,6 +62,7 @@
 /datum/eldritch_knowledge/flesh_ghoul/proc/remove_ghoul(datum/source)
 	var/mob/living/carbon/human/humie = source
 	ghouls -= humie
+	REMOVE_TRAIT(humie,TRAIT_MUTE,type)
 	humie.mind.remove_antag_datum(/datum/antagonist/heretic_monster)
 	UnregisterSignal(source,COMSIG_LIVING_DEATH)
 

--- a/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
@@ -31,7 +31,7 @@
 	var/turf/open/turfie = get_turf(carbon_target)
 	turfie.TakeTemperature(-20)
 	carbon_target.adjust_bodytemperature(-40)
-	carbon_target.silent += 4
+	carbon_target.silent += 3
 	return TRUE
 
 /datum/eldritch_knowledge/void_grasp/on_eldritch_blade(atom/target, mob/user, proximity_flag, click_parameters)

--- a/code/modules/mob/living/simple_animal/eldritch_demons.dm
+++ b/code/modules/mob/living/simple_animal/eldritch_demons.dm
@@ -145,7 +145,7 @@
 	if(len < 3)
 		stack_trace("Eldritch Armsy created with invalid len ([len]). Reverting to 3.")
 		len = 3 //code breaks below 3, let's just not allow it.
-	oldloc = loc
+	oldloc = get_turf(src)
 	RegisterSignal(src,COMSIG_MOVABLE_MOVED,.proc/update_chain_links)
 	if(!spawn_more)
 		return
@@ -191,7 +191,7 @@
 ///Updates chain links to force move onto a single tile
 /mob/living/simple_animal/hostile/eldritch/armsy/proc/contract_next_chain_into_single_tile()
 	if(back)
-		back.forceMove(loc)
+		back.forceMove(get_turf(src))
 		back.contract_next_chain_into_single_tile()
 	return
 
@@ -199,18 +199,17 @@
 	. += 1
 	if(back)
 		. += back.get_length()
-
 ///Updates the next mob in the chain to move to our last location, fixed the worm if somehow broken.
 /mob/living/simple_animal/hostile/eldritch/armsy/proc/update_chain_links()
 	if(!follow)
 		return
 	gib_trail()
-	if(back && back.loc != oldloc)
+	if(back && get_turf(back) != oldloc)
 		back.Move(oldloc)
 	// self fixing properties if somehow broken
-	if(front && loc != front.oldloc)
+	if(front && get_turf(src) != get_turf(front))
 		forceMove(front.oldloc)
-	oldloc = loc
+	oldloc = get_turf(src)
 
 /mob/living/simple_animal/hostile/eldritch/armsy/proc/gib_trail()
 	if(front) // head makes gibs

--- a/code/modules/mob/living/simple_animal/eldritch_demons.dm
+++ b/code/modules/mob/living/simple_animal/eldritch_demons.dm
@@ -207,7 +207,7 @@
 	if(back && get_turf(back) != oldloc)
 		back.Move(oldloc)
 	// self fixing properties if somehow broken
-	if(front && get_turf(src) != get_turf(front))
+	if(front && get_turf(src) != front.oldloc)
 		forceMove(front.oldloc)
 	oldloc = get_turf(src)
 


### PR DESCRIPTION
## About The Pull Request

This pr fixes a few things if i remember correctly.

- Slightly reworks armsy to use get_turf() instead of .loc to avoid it's chain-link fuckery.
- Changes how reality_smash_tracker works so it reapplies huds to new heretics, so they can actually see the influences.
- Fixes a runtime caused by heretics getting gibbed.
- Fixes the transmutation rune breaking every time you made a voiceless dead.


this pr also slightly reduces Void Grasp's silence duration, the change was so small it didnt warrant it's own pr.

## Why It's Good For The Game

Fixes gud

## Changelog
:cl:
fix: Fixed armsy breaking sometimes.
fix: Fixed heretics not seeing some influences sometimes.
fix: Heretics will no longer runtime like crazy when they die.
fix: Voiceless dead should no longer break the voiceless ritual.
balance: slightly lowers void silent duration.
/:cl: