### PR TITLE
fixes high confusion levels blocking rev conversions and removes help intent disabling the usage of tacticool flashing

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -157,21 +157,16 @@
 			if(M.get_confusion() < power)
 				var/diff = power * CONFUSION_STACK_MAX_MULTIPLIER - M.get_confusion()
 				M.add_confusion(min(power, diff))
-				// Special check for if we're a revhead. Special cases to attempt conversion.
-				if(converter)
-					// Did we try to flash them from behind?
-					if(deviation == DEVIATION_FULL)
-						// If we did and we're on help intent, fail with a feedback message and return.
-						if(converter.owner.current.a_intent == INTENT_HELP)
-							to_chat(user, "<span class='notice'>You try to use the tacticool tier, lean over the shoulder technique to blind [M] from behind but your poor combat stance causes you to stumble!</span>")
-							visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>","<span class='danger'>[user] fails to blind you with the flash!</span>")
-							return
-						// Otherwise, tacticool leaning technique engaged for sideways-stun power.
-						to_chat(user, "<span class='notice'>You use the tacticool tier, lean over the shoulder technique to blind [M] with a flash!</span>")
-						deviation = DEVIATION_PARTIAL
-					// Convert them. Terribly.
-					terrible_conversion_proc(M, user)
-					visible_message("<span class='danger'>[user] blinds [M] with the flash!</span>","<span class='userdanger'>[user] blinds you with the flash!</span>")
+			// Special check for if we're a revhead. Special cases to attempt conversion.
+			if(converter)
+				// Did we try to flash them from behind?
+				if(deviation == DEVIATION_FULL)
+					// Headrevs can use a tacticool leaning technique so that they don't have to worry about facing for their conversions.
+					to_chat(user, "<span class='notice'>You use the tacticool tier, lean over the shoulder technique to blind [M] with a flash!</span>")
+					deviation = DEVIATION_PARTIAL
+				// Convert them. Terribly.
+				terrible_conversion_proc(M, user)
+				visible_message("<span class='danger'>[user] blinds [M] with the flash!</span>","<span class='userdanger'>[user] blinds you with the flash!</span>")
 			//easy way to make sure that you can only long stun someone who is facing in your direction
 			M.adjustStaminaLoss(rand(80,120)*(1-(deviation*0.5)))
 			M.Paralyze(rand(25,50)*(1-(deviation*0.5)))


### PR DESCRIPTION
## About The Pull Request

Due to some incorrect indentation, people who had high enough confusion values could avoid being converted when flashed by a revhead. This issue has been fixed.

The ability to fake NOT being able to use the tacticool tier, lean over the shoulder technique by being on help intent when you flashed someone from behind has been removed.

## Why It's Good For The Game

When flashes were nerfed, revheads received the ability to still flash people from behind so that they could convert fleeing people. To keep this from being used as an antag check, a feature was added that allowed revheads to intentionally fail a behind-the-back conversion by being on help intent while performing the deed. The problem is that this is a very niche ability/feature that is very easy to invoke accidentally, resulting in some embarassing moments.

I really don't think that sec is going to take the time to uncuff possible revheads and hand them flashes just so that they can do revhead checks on them (more often than revheads will accidentally use this feature and embarass themselves, anyway), which is why I'm removing this feature.

## Changelog
:cl: ATHATH
fix: Being incredibly confused no longer makes you immune to being converted into a revolutionary.
del: Revheads will no longer fail their over-the-shoulder conversions if they're on help intent.
/:cl:
