### PR TITLE
Buffs Void heretic carving knife into a good throw weapon

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -294,7 +294,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	wound_bonus = 20
 	force = 10
-	throwforce = 5
+	throwforce = 20
+	embedding = list(embed_chance=75, jostle_chance=2, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=3, jostle_pain_mult=5, rip_time=15)
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "rend")

--- a/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
@@ -99,7 +99,7 @@
 /datum/eldritch_knowledge/rune_carver
 	name = "Carving Knife"
 	gain_text = "Etched, carved... eternal. I can carve the monolith and evoke their powers!"
-	desc = "You can create a carving knife, which allows you to create up to 3 carvings on the floor that have various effects on nonbelievers who walk over them, to create the carving knife transmute a knife with a glass shard and a piece of paper."
+	desc = "You can create a carving knife, which allows you to create up to 3 carvings on the floor that have various effects on nonbelievers who walk over them. You can also use them as a good throw weapon, to create the carving knife transmute a knife with a glass shard and a piece of paper."
 	cost = 1
 	next_knowledge = list(/datum/eldritch_knowledge/spell/void_phase,/datum/eldritch_knowledge/summon/raw_prophet)
 	required_atoms = list(/obj/item/kitchen/knife,/obj/item/shard,/obj/item/paper)

--- a/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
@@ -99,7 +99,7 @@
 /datum/eldritch_knowledge/rune_carver
 	name = "Carving Knife"
 	gain_text = "Etched, carved... eternal. I can carve the monolith and evoke their powers!"
-	desc = "You can create a carving knife, which allows you to create up to 3 carvings on the floor that have various effects on nonbelievers who walk over them. You can also use them as a good throw weapon, to create the carving knife transmute a knife with a glass shard and a piece of paper."
+	desc = "You can create a carving knife, which allows you to create up to 3 carvings on the floor that have various effects on nonbelievers who walk over them. They make quite a handy throwing weapon. To create the carving knife transmute a knife with a glass shard and a piece of paper."
 	cost = 1
 	next_knowledge = list(/datum/eldritch_knowledge/spell/void_phase,/datum/eldritch_knowledge/summon/raw_prophet)
 	required_atoms = list(/obj/item/kitchen/knife,/obj/item/shard,/obj/item/paper)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs carving knife into a good throw weapon, 5 damage less than cult dagger. It now has slightly higher embed chance than a combat knife and can become quite a pain to deal with. I believe that its worth it for an item quite far in the research tree.  

## Why It's Good For The Game

Fills in a niche in heresy for throwable weapons.

## Changelog
:cl: Sparkezelpl
balance: Carving knife now deals more damage on throw and can embed in your enemies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
