### PR TITLE
Shuttle Catastrope can no longer grab shuttles with prerequisites not satisfied

### DIFF
--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -28,7 +28,7 @@
 	var/list/valid_shuttle_templates = list()
 	for(var/shuttle_id in SSmapping.shuttle_templates)
 		var/datum/map_template/shuttle/template = SSmapping.shuttle_templates[shuttle_id]
-		if(template.can_be_bought && template.credit_cost < INFINITY) //if we could get it from the communications console, it's cool for us to get it here
+		if(template.can_be_bought && template.credit_cost < INFINITY && template.prerequisites_met()) //if we could get it from the communications console, it's cool for us to get it here
 			valid_shuttle_templates += template
 	new_shuttle = pick(valid_shuttle_templates)
 


### PR DESCRIPTION
## About The Pull Request

The Shuttle Catastrophe event can no longer grab shuttles which do not have their prerequisites satisfied. As of now this only affects The Arena, Shuttle 667, and Transporter Zeta.

## Why It's Good For The Game

Two of these shuttles are just awful grief shuttles so this aims to cut back on the amount of times they show up randomly.

## Changelog
:cl: Melbert
tweak: Shuttle Catastrophe can no longer pick shuttles which do not have prerequisites satisfied. This affects The Arena, Shuttle 667, and Transporter Zeta (They can still be picked AFTER their prerequisites are done).
/:cl:

