### PR TITLE
Fixes mothman wing reconstruction bug

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -609,7 +609,11 @@
 			return
 		if(exposed_carbon.dna.species.has_innate_wings)
 			to_chat(exposed_carbon, "<span class='userdanger'>A terrible pain travels down your back as your wings change shape!</span>")
+			if(!exposed_carbon.dna.features["original_moth_wings"]) //Stores their wings for later possible reconstruction
+				exposed_carbon.dna.features["original_moth_wings"] = exposed_carbon.dna.features["moth_wings"]
 			exposed_carbon.dna.features["moth_wings"] = "None"
+			if(!exposed_carbon.dna.features["original_moth_antennae"]) //Stores their antennae type as well
+				exposed_carbon.dna.features["original_moth_antennae"] = exposed_carbon.dna.features["moth_antennae"]
 			exposed_carbon.dna.features["moth_antennae"] = "Regal"
 		else
 			to_chat(exposed_carbon, "<span class='userdanger'>A terrible pain travels down your back as wings burst out!</span>")

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -43,9 +43,11 @@
 		return
 	if(H.dna.features["moth_wings"] != "Burnt Off" && H.bodytemperature >= 800 && H.fire_stacks > 0) //do not go into the extremely hot light. you will not survive
 		to_chat(H, "<span class='danger'>Your precious wings burn to a crisp!</span>")
-		H.dna.features["original_moth_wings"] = H.dna.features["moth_wings"] //Fire apparently destroys DNA, so let's preserve that elsewhere
+		if(!H.dna.features["original_moth_wings"]) //Fire apparently destroys DNA, so let's preserve that elsewhere, checks if an original was already stored to prevent bugs
+			H.dna.features["original_moth_wings"] = H.dna.features["moth_wings"]
 		H.dna.features["moth_wings"] = "Burnt Off"
-		H.dna.features["original_moth_antennae"] = H.dna.features["moth_antennae"]
+		if(!H.dna.features["original_moth_antennae"]) //Stores antennae type for if they get restored later
+			H.dna.features["original_moth_antennae"] = H.dna.features["moth_antennae"]
 		H.dna.features["moth_antennae"] = "Burnt Off"
 		if(flying_species) //This is all exclusive to if the person has the effects of a potion of flight
 			if(H.movement_type & FLYING)


### PR DESCRIPTION
## About The Pull Request

Moths that drink a potion of flight have their moth wings set to none, which their handle fire would store as their original, and that would be applied from reconstructive surgery. 

Now potions of flight store an original, and handle fire checks to see if something was stored before, so it doesn't overwrite that.

fixes https://github.com/tgstation/tgstation/issues/54905

## Why It's Good For The Game

Moths don't go through surgery just to be surprised that they have no wings.
Crew don't get subjected to seeing this abomination
![image](https://user-images.githubusercontent.com/51932756/102819911-968bdf00-4391-11eb-993b-5b4c46760f5b.png)

## Changelog
:cl:
fix: Mothpeople that consume a potion of flight and then their wings get burnt off will no longer fail to have wings after going through reconstructive surgery.
/:cl: