### PR TITLE
Fixes some bugs involving regal rats

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -79,29 +79,36 @@
 			. += "<span class='notice'>This is your king. Long live his majesty!</span>"
 		else
 			. += "<span class='warning'>This is a false king! Strike him down!</span>"
-	else if(istype(user,/mob/living/simple_animal/hostile/regalrat))
+	else if(user != src && istype(user,/mob/living/simple_animal/hostile/regalrat))
 		. += "<span class='warning'>Who is this foolish false king? This will not stand!</span>"
 
 /mob/living/simple_animal/hostile/regalrat/AttackingTarget()
 	. = ..()
-	if(health >= maxHealth)
-		to_chat(src, "<span class='warning'>You feel fine, no need to eat anything!</span>")
-		return
 	if(istype(target, /obj/item/food/cheesewedge))
-		to_chat(src, "<span class='green'>You eat [src], restoring some health.</span>")
-		heal_bodypart_damage(MINOR_HEAL)
+		cheese_heal(target, MINOR_HEAL, "<span class='green'>You eat [target], restoring some health.</span>")
+
+	else if(istype(target, /obj/item/food/cheesewheel))
+		cheese_heal(target, MEDIUM_HEAL, "<span class='green'>You eat [target], restoring some health.</span>")
+
+	else if(istype(target, /obj/item/food/royalcheese))
+		cheese_heal(target, MAJOR_HEAL, "<span class='green'>You eat [target], revitalizing your royal resolve completely.</span>")
+
+/**
+ * Conditionally "eat" cheese object and heal, if injured.
+ *
+ * A private proc for sending a message to the mob's chat about them
+ * eating some sort of cheese, then healing them, then deleting the cheese.
+ * The "eating" is only conditional on the mob being injured in the first
+ * place.
+ */
+/mob/living/simple_animal/hostile/regalrat/proc/cheese_heal(var/obj/item/target, amount, message)
+	if(health < maxHealth)
+		to_chat(src, message)
+		heal_bodypart_damage(amount)
 		qdel(target)
-		return
-	if(istype(target, /obj/item/food/cheesewheel))
-		to_chat(src, "<span class='green'>You eat [src], restoring some health.</span>")
-		heal_bodypart_damage(MEDIUM_HEAL)
-		qdel(target)
-		return
-	if(istype(target, /obj/item/food/royalcheese))
-		to_chat(src, "<span class='green'>You eat [src], revitalizing your royal resolve completely.</span>")
-		heal_bodypart_damage(MAJOR_HEAL)
-		qdel(target)
-		return
+	else
+		to_chat(src, "<span class='warning'>You feel fine, no need to eat anything!</span>")
+
 
 /mob/living/simple_animal/hostile/regalrat/controlled
 	name = "regal rat"

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -101,7 +101,7 @@
  * The "eating" is only conditional on the mob being injured in the first
  * place.
  */
-/mob/living/simple_animal/hostile/regalrat/proc/cheese_heal(var/obj/item/target, amount, message)
+/mob/living/simple_animal/hostile/regalrat/proc/cheese_heal(obj/item/target, amount, message)
 	if(health < maxHealth)
 		to_chat(src, message)
 		heal_bodypart_damage(amount)


### PR DESCRIPTION
:cl: coiax
fix: Regal rats no longer see themselves as an interloper on examine.
fix: Regal rats no longer think they are consuming themselves when
eating cheese.
/:cl:

- Regal rats are supposed to, when examing other regal rats, see them as
  false kings. There was however, no check to see if you were looking at
  yourself.
- When clicking on anything when at full health, you would get a message
  about how you didn't need to eat anything. But you should only get
  those messages, when you're attempting to consume cheese.