### PR TITLE
Add griddles to prison kitchens

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -16930,7 +16930,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/mob/living/simple_animal/mouse/white,
+/obj/structure/table,
+/obj/machinery/microwave,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "aNO" = (
@@ -108303,10 +108304,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jWa" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 7
-	},
+/obj/machinery/griddle,
 /turf/open/floor/plating,
 /area/security/prison)
 "jZv" = (
@@ -109848,6 +109846,10 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"neL" = (
+/mob/living/simple_animal/mouse/white,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "nhw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -170596,7 +170598,7 @@ gRM
 aKV
 jWa
 wtx
-aNK
+neL
 aPu
 aKZ
 aKZ
@@ -170851,10 +170853,10 @@ pmV
 lsG
 uoy
 aKV
-wDi
+aPv
 plN
 aNM
-aPv
+wDi
 aKZ
 aSI
 aUD

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1343,9 +1343,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "ada" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "adb" = (
@@ -2026,6 +2024,10 @@
 "aer" = (
 /obj/structure/window,
 /obj/effect/decal/cleanable/food/flour,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -11
+	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "aes" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -88979,8 +88979,8 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
@@ -90323,18 +90323,13 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
 /obj/item/radio/intercom{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
 	},
-/obj/effect/spawner/lootdrop/donkpockets,
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "qgG" = (
@@ -91065,9 +91060,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 9;
+	pixel_y = 3
 	},
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "uKN" = (
@@ -91207,13 +91205,13 @@
 /obj/structure/sink{
 	pixel_y = 29
 	},
-/mob/living/simple_animal/mouse/brown/tom{
-	name = "Jerm"
-	},
 /obj/machinery/camera{
 	c_tag = "Prison Maintenance";
 	dir = 4;
 	network = list("ss13","prison")
+	},
+/mob/living/simple_animal/mouse/brown/tom{
+	name = "Jerm"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/prison/safe)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -8208,13 +8208,11 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "aso" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "asp" = (
@@ -70368,6 +70366,10 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -11
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds griddles to prison kitchens on all stations.
I had to rearrange some things and move stuff around to make space for griddles, but in the end I think it turned out nice.

Fixes #55598 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Microwaves can no longer prepare meat which renders all raw meat in prison kitchens useless.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Dex
add: Added griddles to prison kitchens. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
