### PR TITLE
Grant medical HUD to Artificers

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -276,6 +276,12 @@
 						and shells to place those soulstones into.</b>"
 	can_repair_constructs = TRUE
 	can_repair_self = TRUE
+	var/health_hud = DATA_HUD_MEDICAL_ADVANCED
+
+/mob/living/simple_animal/hostile/construct/artificer/Initialize()
+	. = ..()
+	var/datum/atom_hud/datahud = GLOB.huds[health_hud]
+	datahud.add_hud_to(src)
 
 /mob/living/simple_animal/hostile/construct/artificer/Found(atom/A) //what have we found here?
 	if(isconstruct(A)) //is it a construct?

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -276,6 +276,7 @@
 						and shells to place those soulstones into.</b>"
 	can_repair_constructs = TRUE
 	can_repair_self = TRUE
+	///The health HUD applied to this mob.
 	var/health_hud = DATA_HUD_MEDICAL_ADVANCED
 
 /mob/living/simple_animal/hostile/construct/artificer/Initialize()


### PR DESCRIPTION
## About The Pull Request

Adds a medical HUD to Artificer constructs, allowing them to see the health of their fellow constructs at a glance.

## Why It's Good For The Game

Helps Artificers know which of their fellow constructs are damaged, so that they can do their support duties more efficiently. It's hard to know who is calling for repairs in a crowded cult fortress.

## Changelog
:cl: The Space Wizard Federation
add: Artificers now have medical HUDs.
/:cl: