### PR TITLE
Rot component no longer makes miasma on planetary turfs, and has a time limit of 5 minutes

### DIFF
--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -20,8 +20,8 @@
 /datum/component/rot/process(delta_time)
 	var/atom/A = parent
 	
-	//SSprocessing goes off per 1 second, so just subtract delta time
-	time_remaining -= delta_time
+	//SSprocessing goes off per 1 second
+	time_remaining -= delta_time * 1 SECONDS
 	if(time_remaining <= 0)
 		qdel(src)
 		return

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -1,5 +1,8 @@
 /datum/component/rot
+	/// Amount of miasma we're spawning per tick
 	var/amount = 1
+	/// Time remaining before we remove the component
+	var/time_remaining = 3 MINUTES
 
 /datum/component/rot/Initialize(new_amount)
 	if(!isatom(parent))
@@ -16,6 +19,12 @@
 
 /datum/component/rot/process(delta_time)
 	var/atom/A = parent
+	
+	//SSprocessing goes off per 1 second, so just subtract delta time
+	time_remaining -= delta_time
+	if(time_remaining <= 0)
+		qdel(src)
+		return
 
 	var/turf/open/T = get_turf(A)
 	if(!istype(T) || T.planetary_atmos || T.return_air().return_pressure() > (WARNING_HIGH_PRESSURE - 10))

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -18,7 +18,7 @@
 	var/atom/A = parent
 
 	var/turf/open/T = get_turf(A)
-	if(!istype(T) || T.return_air().return_pressure() > (WARNING_HIGH_PRESSURE - 10))
+	if(!istype(T) || T.planetary_atmos || T.return_air().return_pressure() > (WARNING_HIGH_PRESSURE - 10))
 		return
 
 	var/datum/gas_mixture/stank = new

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -2,7 +2,7 @@
 	/// Amount of miasma we're spawning per tick
 	var/amount = 1
 	/// Time remaining before we remove the component
-	var/time_remaining = 3 MINUTES
+	var/time_remaining = 5 MINUTES
 
 /datum/component/rot/Initialize(new_amount)
 	if(!isatom(parent))
@@ -39,6 +39,7 @@
 
 /datum/component/rot/corpse
 	amount = MIASMA_CORPSE_MOLES
+	time_remaining = 7 MINUTES //2 minutes more to compensate for the delay
 
 /datum/component/rot/corpse/Initialize()
 	if(!iscarbon(parent))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
What happens is miners gib like 20 faunas, which then make 5 gibs with that component, so 100 gibs, which then spawn miasma that makes 100 AT's which are resolved soon after, but appear again, and are just kinda hogging processing for no gameplay impact

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Rotting gibs no longer make miasma on planetary turfs, to save on processing as it quickly dissipiates into planetary atmos anyway. They'll also stop rotting after some time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
