### PR TITLE
slaughter demons and laughter demons now get health huds

### DIFF
--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -108,6 +108,8 @@
 		bloodspell.phased = TRUE
 	if(bloodpool)
 		bloodpool.RegisterSignal(src, list(COMSIG_LIVING_AFTERPHASEIN,COMSIG_PARENT_QDELETING), /obj/effect/dummy/phased_mob/.proc/deleteself)
+	var/datum/atom_hud/easypickings = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+	easypickings.add_hud_to(src)
 
 /mob/living/simple_animal/hostile/imp/slaughter/CtrlShiftClickOn(atom/A)
 	if(!isliving(A))


### PR DESCRIPTION
## About The Pull Request

See the title.

## Why It's Good For The Game

A large part of (s)laughter demon gameplay is seizing opportunities to finish off weakened/wounded creatures, so they should be able to tell who is close to death/vulnerable at a glance. In addition, they have an ability (nomming on people for health) that specifically requires their victims to be either dead or in crit, which means that they should probably be able to easily distinguish between dying people and people who're just lying down/knocked down.

## Changelog
:cl: ATHATH
balance: Slaughter demons and laughter demons now have innate health HUDs (they can see health bars).
/:cl: