### PR TITLE
The cursed hot spring no longer polymorphs incorporeal critters.

### DIFF
--- a/code/modules/ruins/icemoonruin_code/hotsprings.dm
+++ b/code/modules/ruins/icemoonruin_code/hotsprings.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_EMPTY(cursed_minds)
 	if(!isliving(thing))
 		return
 	var/mob/living/L = thing
-	if(!L.client)
+	if(!L.client || L.incorporeal_move)
 		return
 	if(GLOB.cursed_minds[L.mind])
 		return


### PR DESCRIPTION
## About The Pull Request
Title. They are not corporeal entities. If they want to be polymorphed they gotta manifest.

## Why It's Good For The Game
This will close #55729.

## Changelog
:cl:
fix: The cursed hot spring no longer polymorphs incorporeal critters such as unrevealed revenants.
/:cl:
