### PR TITLE
Merry Christmas! Mechs receive damage from Xenos using their actual damage, instead of a hardcoded value (15).

### DIFF
--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -67,7 +67,7 @@
 /obj/vehicle/sealed/mecha/attack_alien(mob/living/user)
 	log_message("Attack by alien. Attacker - [user].", LOG_MECHA, color="red")
 	playsound(src.loc, 'sound/weapons/slash.ogg', 100, TRUE)
-	attack_generic(user, 15, BRUTE, MELEE, 0)
+	attack_generic(user, rand(user.melee_damage_lower, user.melee_damage_upper), BRUTE, MELEE, 0)
 
 /obj/vehicle/sealed/mecha/attack_animal(mob/living/simple_animal/user)
 	log_message("Attack by simple animal. Attacker - [user].", LOG_MECHA, color="red")


### PR DESCRIPTION
## About The Pull Request
• Mechs will now take the melee_lower_damage and melee_upper_damage variables of the attacking xenomorph and will pick a random number between the two instead of always taking 15 damage.
• Potentially endangers the next Christmas by allowing Santa's mechs receive more boo-boos from xenos. I guess the xenos are black because Santa kept putting coal in their stockings?

## Why It's Good For The Game
If someone comes in the future and wishes to make lets say the xenomorph Queen deal more than 20 damage, which is the amount of damage a drone does, they will find that the Queen deals 15 damage to mechs. Even if they're made to do 50 damage or something, they'll run up to the front of a Durand, and deal 4.5 damage to it instead. This changes it so the mechs actually respect the xenomorph's damage values when receiving damage instead of just saying "nah dawg giant alien does 15, tiny alien drone does 15".
This makes things more consistent. Mechs will calculate their damage the same way humans will, except the mech has a directional armor multiplier (1.5x front, 1x sides, 0.5x back) and a whole lot of melee armor as well as having 200 health.

## Changelog
:cl:
code: Mechs receive damage from Xenomorphs in a non-hardcoded fashion, and will take the amount of damage. Merry Christmas!
/:cl:

## Merry Christmas!
![image](https://user-images.githubusercontent.com/53862927/103139043-1ab2cf00-46d0-11eb-88ff-a1b56486c89f.png)
This is from one attack from the side on a Durand that has 0 melee armour (varedited). When var-editing my damage to 200, the mech receives 200 damage, so this works.
When attacking from the front, it receives 133.333r. That's the directional armor multiplier working still.
When attacking from the back, well, that's double damage so it kinda broke the Durand.
I'm not sure why I bothered testing if a normal Durand with it's natural 40% melee armor still works as expected but yeah, for those curious, this is a buff from 9 damage to 12 damage against a Durand. I guess instead of clicking on a Durand 45 times to destroy it (_That's a lotta clicking!_) you now only have to click on it 34 times.