### PR TITLE
Fixes dead people not looking dead

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -125,11 +125,13 @@
 				. += "<span class='warning'>[t_He] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>"
 
 			var/mob/dead/observer/ghost = get_ghost(TRUE, TRUE)
-			if(getorgan(/obj/item/organ/brain) && !key)
+			if(getorgan(/obj/item/organ/brain))
 				if(!ghost) //There's no ghost with a mind matching the body's, the ghost has likely disconnected
 					. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has departed...</span>"
 				else if (!ghost.can_reenter_corpse || ghost.pushed_do_not_resuscitate) //There is a ghost with a matching mind but they pushed DNR or otherwise can't reenter
 					. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has lost the will to live...</span>"
+				else
+					. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life...</span>"
 			else
 				. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life...</span>"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -126,7 +126,7 @@
 
 			var/mob/dead/observer/ghost = get_ghost(TRUE, TRUE)
 			if(getorgan(/obj/item/organ/brain))
-				if(!ghost) //There's no ghost with a mind matching the body's, the ghost has likely disconnected
+				if(!ghost && !client) //There's no ghost with a mind matching the body's (and there's no client still in the body, if they haven't left the body once yet), the ghost has likely disconnected
 					. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has departed...</span>"
 				else if (!ghost.can_reenter_corpse || ghost.pushed_do_not_resuscitate) //There is a ghost with a matching mind but they pushed DNR or otherwise can't reenter
 					. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has lost the will to live...</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
#55399 had a silly little error where dead bodies with a brain but no ghost actively inhabiting it would fall through the cracks of the conditionals and not appear dead at all. For example,

[![dreamseeker_2020-12-23_19-13-44.png](https://cdn.discordapp.com/attachments/326831214667235328/792227364280729630/unknown.png)](https://cdn.discordapp.com/attachments/326831214667235328/792227364280729630/unknown.png)

In the top examine, there's a ghost in the body. In the bottom, there isn't. This fixes that by making sure that bodies that don't fulfill those special cases still look dead
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Only the clown is supposed to be dumb enough to make this mistake, and even he can still tell the dead guy's unconscious
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Dead bodies with a brain but no ghost actively inside the body will once again appear dead when examined
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
