### PR TITLE
Fixes clown cars + Fixes mechs not being able to open doors

### DIFF
--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -201,28 +201,10 @@
 	set_vehicle_dir_offsets(EAST, -18, 0)
 	set_vehicle_dir_offsets(WEST, -18, 0)
 
-
-/datum/component/riding/vehicle/car
-	vehicle_move_delay = 1
-	COOLDOWN_DECLARE(enginesound_cooldown)
-
-/datum/component/riding/vehicle/car/handle_ride(mob/user, direction)
-	. = ..()
-	if(!.)
-		return
-	var/obj/vehicle/sealed/car/car_parent = parent
-	if(!COOLDOWN_FINISHED(src, enginesound_cooldown))
-		return
-	COOLDOWN_START(src, enginesound_cooldown, car_parent.engine_sound_length)
-	playsound(car_parent, car_parent.engine_sound, 100, TRUE)
-
-/datum/component/riding/vehicle/car/clowncar
-	keytype = /obj/item/bikehorn
-
-/datum/component/riding/vehicle/car/speedwagon
+/datum/component/riding/vehicle/speedwagon
 	vehicle_move_delay = 0
 
-/datum/component/riding/vehicle/car/speedwagon/handle_specials()
+/datum/component/riding/vehicle/speedwagon/handle_specials()
 	. = ..()
 	set_riding_offsets(1, list(TEXT_NORTH = list(-10, -4), TEXT_SOUTH = list(16, 3), TEXT_EAST = list(-4, 30), TEXT_WEST = list(4, -3)))
 	set_riding_offsets(2, list(TEXT_NORTH = list(19, -5, 4), TEXT_SOUTH = list(-13, 3, 4), TEXT_EAST = list(-4, -3, 4.1), TEXT_WEST = list(4, 28, 3.9)))

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -148,13 +148,3 @@
 	if(trailer && .)
 		var/dir_to_move = get_dir(trailer.loc, newloc)
 		step(trailer, dir_to_move)
-
-// handles vehicles without riding components such as mechs bumping into things and having their access checked
-/obj/vehicle/Bump(atom/A)
-	. = ..()
-	if(GetComponent(/datum/component/riding)) // if we're a ridable vehicle, this is already handled in the riding component
-		return
-	if(istype(A, /obj/machinery/door))
-		var/obj/machinery/door/conditionalwall = A
-		for(var/m in occupants)
-			conditionalwall.bumpopen(m)

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -148,3 +148,13 @@
 	if(trailer && .)
 		var/dir_to_move = get_dir(trailer.loc, newloc)
 		step(trailer, dir_to_move)
+
+// handles vehicles without riding components such as mechs bumping into things and having their access checked
+/obj/vehicle/Bump(atom/A)
+	. = ..()
+	if(GetComponent(/datum/component/riding)) // if we're a ridable vehicle, this is already handled in the riding component
+		return
+	if(istype(A, /obj/machinery/door))
+		var/obj/machinery/door/conditionalwall = A
+		for(var/m in occupants)
+			conditionalwall.bumpopen(m)

--- a/code/modules/vehicles/cars/car.dm
+++ b/code/modules/vehicles/cars/car.dm
@@ -7,11 +7,10 @@
 	var/engine_sound_length = 2 SECONDS
 	///Time it takes to break out of the car.
 	var/escape_time = 6 SECONDS
+	/// How long it takes to move, cars don't use the riding component similar to mechs so we handle it ourselves
+	var/vehicle_move_delay = 1
+	/// How long it takes to rev (vrrm vrrm!)
 	COOLDOWN_DECLARE(enginesound_cooldown)
-
-/obj/vehicle/sealed/car/Initialize()
-	. = ..()
-	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/car)
 
 /obj/vehicle/sealed/car/generate_actions()
 	. = ..()
@@ -76,3 +75,28 @@
 	explosion(loc, 0, 1, 2, 3, 0)
 	log_message("[src] exploded due to destruction", LOG_ATTACK)
 	return ..()
+
+/obj/vehicle/sealed/car/relaymove(mob/living/user, direction)
+	if(canmove && (!key_type || istype(inserted_key, key_type)))
+		vehicle_move(direction)
+	return TRUE
+
+/// The car version of [/obj/vehicle/sealed/mecha/proc/vehicle_move], cars handle their driving manually since the riders/driver aren't buckled and thus can't use the riding component
+/obj/vehicle/sealed/car/proc/vehicle_move(direction)
+	if(!COOLDOWN_FINISHED(src, cooldown_vehicle_move))
+		return FALSE
+	COOLDOWN_START(src, cooldown_vehicle_move, vehicle_move_delay)
+
+	if(COOLDOWN_FINISHED(src, enginesound_cooldown))
+		COOLDOWN_START(src, enginesound_cooldown, engine_sound_length)
+		playsound(get_turf(src), engine_sound, 100, TRUE)
+
+	if(trailer)
+		var/dir_to_move = get_dir(trailer.loc, loc)
+		var/did_move = step(src, direction)
+		if(did_move)
+			step(trailer, dir_to_move)
+		return did_move
+	else
+		after_move(direction)
+		return step(src, direction)

--- a/code/modules/vehicles/cars/car.dm
+++ b/code/modules/vehicles/cars/car.dm
@@ -81,8 +81,7 @@
 		vehicle_move(direction)
 	return TRUE
 
-/// The car version of [/obj/vehicle/sealed/mecha/proc/vehicle_move], cars handle their driving manually since the riders/driver aren't buckled and thus can't use the riding component
-/obj/vehicle/sealed/car/proc/vehicle_move(direction)
+/obj/vehicle/sealed/car/vehicle_move(direction)
 	if(!COOLDOWN_FINISHED(src, cooldown_vehicle_move))
 		return FALSE
 	COOLDOWN_START(src, cooldown_vehicle_move, vehicle_move_delay)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -608,7 +608,7 @@
 		vehicle_move(direction)
 	return TRUE
 
-/obj/vehicle/sealed/mecha/proc/vehicle_move(direction, forcerotate = FALSE)
+/obj/vehicle/sealed/mecha/vehicle_move(direction, forcerotate = FALSE)
 	if(!COOLDOWN_FINISHED(src, cooldown_vehicle_move))
 		return FALSE
 	COOLDOWN_START(src, cooldown_vehicle_move, movedelay)

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -25,6 +25,13 @@
 	if(ismob(AM))
 		remove_occupant(AM)
 
+// so that we can check the access of the vehicle's occupants. Ridden vehicles do this in the riding component, but these don't have that
+/obj/vehicle/sealed/Bump(atom/A)
+	. = ..()
+	if(istype(A, /obj/machinery/door))
+		var/obj/machinery/door/conditionalwall = A
+		for(var/m in occupants)
+			conditionalwall.bumpopen(m)
 
 /obj/vehicle/sealed/after_add_occupant(mob/M)
 	. = ..()
@@ -127,4 +134,13 @@
 
 
 /obj/vehicle/sealed/AllowDrop()
+	return FALSE
+
+/obj/vehicle/sealed/relaymove(mob/living/user, direction)
+	if(canmove)
+		vehicle_move(direction)
+	return TRUE
+
+/// Sinced sealed vehicles (cars and mechs) don't have riding components, the actual movement is handled here from [/obj/vehicle/sealed/proc/relaymove]
+/obj/vehicle/sealed/proc/vehicle_move(direction)
 	return FALSE

--- a/code/modules/vehicles/speedbike.dm
+++ b/code/modules/vehicles/speedbike.dm
@@ -46,7 +46,7 @@
 /obj/vehicle/ridden/space/speedwagon/Initialize()
 	. = ..()
 	add_overlay(overlay)
-	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/car/speedwagon)
+	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/speedwagon)
 
 /obj/vehicle/ridden/space/speedwagon/Bump(atom/A)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I didn't pay enough attention to clown cars specifically in my riding refactor (#54778). The riding component only initializes when someone is buckled to the vehicle, but the clown car differs from most other vehicles in that rather having the passengers buckle to it, they act like mechs and insert their occupants directly inside of them. Since no one ever gets buckled to it, the riding component never gets made, and no one can ever drive it. This reverts clown cars back to having their own driving controls, so they can once again be properly driven.

Also fixes mechs not being able to open doors by bumping into them, since I accidentally the code for that
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Honk honk!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: The clown car can once again be driven
fix: Mechs can once again open doors by bumping into them (assuming the rider has access, obviously)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
