### PR TITLE
Mechanical Curtains

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -1,6 +1,7 @@
 GLOBAL_LIST_EMPTY(cable_list)					    //Index for all cables, so that powernets don't have to look through the entire world all the time
 GLOBAL_LIST_EMPTY(portals)					        //list of all /obj/effect/portal
 GLOBAL_LIST_EMPTY(airlocks)					        //list of all airlocks
+GLOBAL_LIST_EMPTY(curtains)							//list of all curtains
 GLOBAL_LIST_EMPTY(mechas_list)				        //list of all mechs. Used by hostile mobs target tracking.
 GLOBAL_LIST_EMPTY(shuttle_caller_list)  		    //list of all communication consoles and AIs, for automatic shuttle calls when there are none.
 GLOBAL_LIST_EMPTY(machines)					        //NOTE: this is a list of ALL machines now. The processing machines list is SSmachine.processing !

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -277,6 +277,13 @@
 	skin = "launcher"
 	device_type = /obj/item/assembly/control/flasher
 
+/obj/machinery/button/curtain
+	name = "curtain button"
+	desc = "A remote control switch for a mechanical curtain."
+	icon_state = "launcher"
+	skin = "launcher"
+	device_type = /obj/item/assembly/control/curtain
+
 /obj/machinery/button/flasher/indestructible
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -621,6 +621,10 @@
 	/// if it can be seen through when closed
 	var/opaque_closed = FALSE
 
+/obj/structure/curtain/Initialize()
+	. = ..()
+	GLOB.curtains += src
+
 /obj/structure/curtain/proc/toggle()
 	open = !open
 	update_icon()
@@ -677,6 +681,7 @@
 	new /obj/item/stack/sheet/plastic (loc, 2)
 	new /obj/item/stack/rods (loc, 1)
 	qdel(src)
+	GLOB.curtains -= src
 
 /obj/structure/curtain/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)
@@ -704,7 +709,34 @@
 	new /obj/item/stack/sheet/cloth (loc, 4)
 	new /obj/item/stack/rods (loc, 1)
 	qdel(src)
+	GLOB.curtains -= src
 
 /obj/structure/curtain/cloth/fancy
 	icon_type = "cur_fancy"
 	icon_state = "cur_fancy-open"
+
+/obj/structure/curtain/cloth/fancy/mechanical
+	var/id = 1
+	icon_type = "cur_fancy"
+	icon_state = "cur_fancy-open"
+
+/obj/structure/curtain/cloth/fancy/mechanical/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
+	id = "[port.id]_[id]"
+
+/obj/structure/curtain/cloth/fancy/mechanical/proc/open()
+	icon_state = "[icon_type]-open"
+	layer = SIGN_LAYER
+	density = FALSE
+	open = TRUE
+	set_opacity(FALSE)
+
+/obj/structure/curtain/cloth/fancy/mechanical/proc/close()
+	icon_state = "[icon_type]-closed"
+	layer = WALL_OBJ_LAYER
+	density = TRUE
+	open = FALSE
+	if(opaque_closed)
+		set_opacity(TRUE)
+
+/obj/structure/curtain/cloth/fancy/mechanical/attack_hand(mob/user)
+		return

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -711,8 +711,6 @@
 
 /obj/structure/curtain/cloth/fancy/mechanical
 	var/id = null
-	icon_type = "cur_fancy"
-	icon_state = "cur_fancy-open"
 
 /obj/structure/curtain/cloth/fancy/mechanical/Destroy()
 	GLOB.curtains -= src

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -677,7 +677,6 @@
 	new /obj/item/stack/sheet/plastic (loc, 2)
 	new /obj/item/stack/rods (loc, 1)
 	qdel(src)
-	GLOB.curtains -= src
 
 /obj/structure/curtain/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)
@@ -705,16 +704,19 @@
 	new /obj/item/stack/sheet/cloth (loc, 4)
 	new /obj/item/stack/rods (loc, 1)
 	qdel(src)
-	GLOB.curtains -= src
 
 /obj/structure/curtain/cloth/fancy
 	icon_type = "cur_fancy"
 	icon_state = "cur_fancy-open"
 
 /obj/structure/curtain/cloth/fancy/mechanical
-	var/id = NULL
+	var/id = null
 	icon_type = "cur_fancy"
 	icon_state = "cur_fancy-open"
+
+/obj/structure/curtain/cloth/fancy/mechanical/Destroy()
+	GLOB.curtains -= src
+	return ..()
 
 /obj/structure/curtain/cloth/fancy/mechanical/Initialize()
 	. = ..()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -621,10 +621,6 @@
 	/// if it can be seen through when closed
 	var/opaque_closed = FALSE
 
-/obj/structure/curtain/Initialize()
-	. = ..()
-	GLOB.curtains += src
-
 /obj/structure/curtain/proc/toggle()
 	open = !open
 	update_icon()
@@ -716,9 +712,13 @@
 	icon_state = "cur_fancy-open"
 
 /obj/structure/curtain/cloth/fancy/mechanical
-	var/id = 1
+	var/id = NULL
 	icon_type = "cur_fancy"
 	icon_state = "cur_fancy-open"
+
+/obj/structure/curtain/cloth/fancy/mechanical/Initialize()
+	. = ..()
+	GLOB.curtains += src
 
 /obj/structure/curtain/cloth/fancy/mechanical/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	id = "[port.id]_[id]"

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -25,6 +25,27 @@
 			INVOKE_ASYNC(M, openclose ? /obj/machinery/door/poddoor.proc/open : /obj/machinery/door/poddoor.proc/close)
 	addtimer(VARSET_CALLBACK(src, cooldown, FALSE), 10)
 
+/obj/item/assembly/control/curtain
+	name = "curtain controller"
+	desc = "A small electronic device able to control a mechanical curtain remotely."
+
+/obj/item/assembly/control/curtain/examine(mob/user)
+	. = ..()
+	if(id)
+		. += "<span class='notice'>Its channel ID is '[id]'.</span>"
+
+/obj/item/assembly/control/curtain/activate()
+	var/openclose
+	if(cooldown)
+		return
+	cooldown = TRUE
+	for(var/obj/structure/curtain/cloth/fancy/mechanical/M in GLOB.curtains)
+		if(M.id == src.id)
+			if(openclose == null || !sync_doors)
+				openclose = M.density
+			INVOKE_ASYNC(M, openclose ? /obj/structure/curtain/cloth/fancy/mechanical.proc/open : /obj/structure/curtain/cloth/fancy/mechanical.proc/close)
+	addtimer(VARSET_CALLBACK(src, cooldown, FALSE), 5)
+
 
 /obj/item/assembly/control/airlock
 	name = "airlock controller"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds a new variant of fancy curtains that are button operated only
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

good for better mapping, I have seen some mappers wish to utilize fancy curtains on their rooms windows (for example, a psychologist office) but wanted to be able to have privacy when with a patient, which curtains can be opened from either side of the window, and shutters just dont fit the theme, this way mappers can add in curtains which are button operated and cant be opened manually, basically, it functions like a shutter, only it looks and acts like curtains (can be destroyed like one, etc... it is literally a curtain subtype)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
add: Mechanical Curtains, a button only operated variant of Fancy Curtains
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
