### PR TITLE
increases shotgun slug damage

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,6 +1,6 @@
 /obj/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 30
+	damage = 50
 	sharpness = SHARP_POINTY
 	wound_bonus = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Buffs the shotgun slug's damage from 30 to 50, as it is effectively a nukeop-only ammo type.
## Why It's Good For The Game
Recently in #55663, shotgun slugs (and buckshot) were removed from the autolathe, and slugs had their damage reduced from 50 to 30. Aside from a rare mining loot tech disk, this ammunition type has been effectively removed from the game, except in one gamemode: Nuclear Emergency. 

The syndicate Bulldog shotgun's slug drum, costing 3TC each, is now a significantly worse option than the 9mm pistols - which cost 1tc less (nukeops get one for free in their belt slot!), has the same ammo capacity, with magazines that cost 2TC less, and also does 30 damage.

By restoring its damage, I believe the slug shotgun meets the original PR's intended vision of "syndicate ballistics, NT lasers, as it is a specialized and expensive ammo type. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: shotgun slug damage increased 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
