### PR TITLE
Add Designs Unit Test

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -690,6 +690,7 @@
 	name = "Tend Wounds"
 	desc = "An upgraded version of the original surgery."
 	id = "surgery_healing_base" //holder because CI cries otherwise. Not used in techweb unlocks.
+	surgery = /datum/surgery/healing
 	research_icon_state = "surgery_chest"
 
 /datum/design/surgery/healing/brute_upgrade

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -40,6 +40,7 @@
 #include "combat.dm"
 #include "component_tests.dm"
 #include "confusion.dm"
+#include "designs.dm"
 #include "emoting.dm"
 #include "heretic_knowledge.dm"
 #include "holidays.dm"

--- a/code/modules/unit_tests/designs.dm
+++ b/code/modules/unit_tests/designs.dm
@@ -1,0 +1,38 @@
+/datum/unit_test/designs
+
+/datum/unit_test/designs/Run()
+	var/datum/design/defaultDesign = new /datum/design()
+	var/datum/design/nanites/defaultDesignNanites = new /datum/design/nanites()
+	var/datum/design/surgery/defaultDesignSurgery = new /datum/design/surgery()
+
+	for(var/path in subtypesof(/datum/design))
+		if (ispath(path, /datum/design/nanites) || ispath(path, /datum/design/surgery)) //We are checking nanites and surgery design separatly later since they work differently
+			continue
+		var/datum/design/currentDesign = new path //Create an instance of each design
+		if (currentDesign.id == DESIGN_ID_IGNORE) //Don't check designs with ignore ID
+			continue
+		if (isnull(currentDesign.name) || currentDesign.name == defaultDesign.name) //Designs with ID must have non default/null Name
+			Fail("Design [currentDesign.type] has default or null name var but has an ID")
+		if ((!isnull(currentDesign.materials) && currentDesign.materials.len != 0) || (!isnull(currentDesign.reagents_list) && currentDesign.reagents_list.len != 0)) //Design requires materials
+			if ((isnull(currentDesign.build_path) || currentDesign.build_path == defaultDesign.build_path) && (isnull(currentDesign.make_reagents) || currentDesign.make_reagents == defaultDesign.make_reagents)) //Check if design gives any output
+				Fail("Design [currentDesign.type] requires materials but does not have have any build_path or make_reagents set")
+		else //Design requires no materials
+			if (!isnull(currentDesign.build_path) || !isnull(currentDesign.build_path)) //But gives stuff
+				Fail("Design [currentDesign.type] requires NO materials but has build_path or make_reagents set")
+
+	for(var/path in subtypesof(/datum/design/nanites))
+		var/datum/design/nanites/currentDesign = new path //Create an instance of each design
+		if (isnull(currentDesign.program_type) || currentDesign.program_type == defaultDesignNanites.program_type) //Check if the Nanite design provides a program
+			Fail("Nanite Design [currentDesign.type] does not have have any program_type set")
+
+	for(var/path in subtypesof(/datum/design/surgery))
+		var/datum/design/surgery/currentDesign = new path //Create an instance of each design
+		if (isnull(currentDesign.id) || currentDesign.id == defaultDesignSurgery.id) //Check if ID was not set
+			Fail("Surgery Design [currentDesign.type] has no ID set")
+		if (isnull(currentDesign.id) || currentDesign.name == defaultDesignSurgery.name ) //Check if name was not set
+			Fail("Surgery Design [currentDesign.type] has default or null name var")
+		if (isnull(currentDesign.desc) || currentDesign.desc == defaultDesignSurgery.desc) //Check if desc was not set
+			Fail("Surgery Design [currentDesign.type] has default or null desc var")
+		if (isnull(currentDesign.surgery) || currentDesign.surgery == defaultDesignSurgery.surgery) //Check if surgery was not set
+			Fail("Surgery Design [currentDesign.type] has default or null surgery var")
+

--- a/code/modules/unit_tests/designs.dm
+++ b/code/modules/unit_tests/designs.dm
@@ -1,38 +1,37 @@
 /datum/unit_test/designs
 
 /datum/unit_test/designs/Run()
-	var/datum/design/defaultDesign = new /datum/design()
-	var/datum/design/nanites/defaultDesignNanites = new /datum/design/nanites()
-	var/datum/design/surgery/defaultDesignSurgery = new /datum/design/surgery()
+	var/datum/design/default_design = new /datum/design()
+	var/datum/design/nanites/default_design_nanites = new /datum/design/nanites()
+	var/datum/design/surgery/default_design_surgery = new /datum/design/surgery()
 
 	for(var/path in subtypesof(/datum/design))
 		if (ispath(path, /datum/design/nanites) || ispath(path, /datum/design/surgery)) //We are checking nanites and surgery design separatly later since they work differently
 			continue
-		var/datum/design/currentDesign = new path //Create an instance of each design
-		if (currentDesign.id == DESIGN_ID_IGNORE) //Don't check designs with ignore ID
+		var/datum/design/current_design = new path //Create an instance of each design
+		if (current_design.id == DESIGN_ID_IGNORE) //Don't check designs with ignore ID
 			continue
-		if (isnull(currentDesign.name) || currentDesign.name == defaultDesign.name) //Designs with ID must have non default/null Name
-			Fail("Design [currentDesign.type] has default or null name var but has an ID")
-		if ((!isnull(currentDesign.materials) && currentDesign.materials.len != 0) || (!isnull(currentDesign.reagents_list) && currentDesign.reagents_list.len != 0)) //Design requires materials
-			if ((isnull(currentDesign.build_path) || currentDesign.build_path == defaultDesign.build_path) && (isnull(currentDesign.make_reagents) || currentDesign.make_reagents == defaultDesign.make_reagents)) //Check if design gives any output
-				Fail("Design [currentDesign.type] requires materials but does not have have any build_path or make_reagents set")
-		else //Design requires no materials
-			if (!isnull(currentDesign.build_path) || !isnull(currentDesign.build_path)) //But gives stuff
-				Fail("Design [currentDesign.type] requires NO materials but has build_path or make_reagents set")
+		if (isnull(current_design.name) || current_design.name == default_design.name) //Designs with ID must have non default/null Name
+			Fail("Design [current_design.type] has default or null name var but has an ID")
+		if ((!isnull(current_design.materials) && LAZYLEN(current_design.materials)) || (!isnull(current_design.reagents_list) && LAZYLEN(current_design.reagents_list))) //Design requires materials
+			if ((isnull(current_design.build_path) || current_design.build_path == default_design.build_path) && (isnull(current_design.make_reagents) || current_design.make_reagents == default_design.make_reagents)) //Check if design gives any output
+				Fail("Design [current_design.type] requires materials but does not have have any build_path or make_reagents set")
+		else if (!isnull(current_design.build_path) || !isnull(current_design.build_path)) // //Design requires no materials but creates stuff
+			Fail("Design [current_design.type] requires NO materials but has build_path or make_reagents set")
 
 	for(var/path in subtypesof(/datum/design/nanites))
-		var/datum/design/nanites/currentDesign = new path //Create an instance of each design
-		if (isnull(currentDesign.program_type) || currentDesign.program_type == defaultDesignNanites.program_type) //Check if the Nanite design provides a program
-			Fail("Nanite Design [currentDesign.type] does not have have any program_type set")
+		var/datum/design/nanites/current_design = new path //Create an instance of each design
+		if (isnull(current_design.program_type) || current_design.program_type == default_design_nanites.program_type) //Check if the Nanite design provides a program
+			Fail("Nanite Design [current_design.type] does not have have any program_type set")
 
 	for(var/path in subtypesof(/datum/design/surgery))
-		var/datum/design/surgery/currentDesign = new path //Create an instance of each design
-		if (isnull(currentDesign.id) || currentDesign.id == defaultDesignSurgery.id) //Check if ID was not set
-			Fail("Surgery Design [currentDesign.type] has no ID set")
-		if (isnull(currentDesign.id) || currentDesign.name == defaultDesignSurgery.name ) //Check if name was not set
-			Fail("Surgery Design [currentDesign.type] has default or null name var")
-		if (isnull(currentDesign.desc) || currentDesign.desc == defaultDesignSurgery.desc) //Check if desc was not set
-			Fail("Surgery Design [currentDesign.type] has default or null desc var")
-		if (isnull(currentDesign.surgery) || currentDesign.surgery == defaultDesignSurgery.surgery) //Check if surgery was not set
-			Fail("Surgery Design [currentDesign.type] has default or null surgery var")
+		var/datum/design/surgery/current_design = new path //Create an instance of each design
+		if (isnull(current_design.id) || current_design.id == default_design_surgery.id) //Check if ID was not set
+			Fail("Surgery Design [current_design.type] has no ID set")
+		if (isnull(current_design.id) || current_design.name == default_design_surgery.name) //Check if name was not set
+			Fail("Surgery Design [current_design.type] has default or null name var")
+		if (isnull(current_design.desc) || current_design.desc == default_design_surgery.desc) //Check if desc was not set
+			Fail("Surgery Design [current_design.type] has default or null desc var")
+		if (isnull(current_design.surgery) || current_design.surgery == default_design_surgery.surgery) //Check if surgery was not set
+			Fail("Surgery Design [current_design.type] has default or null surgery var")
 

--- a/code/modules/unit_tests/designs.dm
+++ b/code/modules/unit_tests/designs.dm
@@ -1,6 +1,7 @@
 /datum/unit_test/designs
 
 /datum/unit_test/designs/Run()
+//Can't use allocate because of bug with certain datums
 	var/datum/design/default_design = new /datum/design()
 	var/datum/design/nanites/default_design_nanites = new /datum/design/nanites()
 	var/datum/design/surgery/default_design_surgery = new /datum/design/surgery()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a unit test for the design datum.
This unit tests checks for:
- Designs that have a custom ID but no name
- Designs that require materials to craft but don't provide anything
- Designs that requiere NO materials but give output
- Checks for any nanite designs that provide have no program_type
- Surgery designs with null or default ID/name/desc/surgery

Output looks like this:
![image](https://user-images.githubusercontent.com/33846895/103159513-a872e500-47ca-11eb-8416-cd6b40b208ee.png)
The baddesign was a test datum I created
The shotgun stuff will go away once https://github.com/tgstation/tgstation/pull/55739 gets merged
Im not sure about the surgery warning, all surgery designs expect that single one have the "surgery" var set
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Detects broken design datums
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
