### PR TITLE
Toy hot potatoes no longer trigger allergies.

### DIFF
--- a/code/game/objects/items/hot_potato.dm
+++ b/code/game/objects/items/hot_potato.dm
@@ -68,9 +68,10 @@
 	return ..()
 
 /obj/item/hot_potato/process()
-	if(stimulant)
-		if(isliving(loc))
-			var/mob/living/L = loc
+	if(isliving(loc))
+		var/mob/living/L = loc
+		colorize(L)
+		if(stimulant)
 			L.SetStun(0)
 			L.SetKnockdown(0)
 			L.SetSleeping(0)
@@ -78,7 +79,7 @@
 			L.SetParalyzed(0)
 			L.SetUnconscious(0)
 			L.reagents.add_reagent(/datum/reagent/medicine/muscle_stimulant, clamp(5 - L.reagents.get_reagent_amount(/datum/reagent/medicine/muscle_stimulant), 0, 5))	//If you don't have legs or get bola'd, tough luck!
-			colorize(L)
+
 
 /obj/item/hot_potato/examine(mob/user)
 	. = ..()
@@ -172,3 +173,4 @@
 	sticky = FALSE
 	reusable = TRUE
 	forceful_attachment = FALSE
+	stimulant = FALSE

--- a/code/game/objects/items/hot_potato.dm
+++ b/code/game/objects/items/hot_potato.dm
@@ -68,17 +68,19 @@
 	return ..()
 
 /obj/item/hot_potato/process()
-	if(isliving(loc))
-		var/mob/living/L = loc
-		colorize(L)
-		if(stimulant)
-			L.SetStun(0)
-			L.SetKnockdown(0)
-			L.SetSleeping(0)
-			L.SetImmobilized(0)
-			L.SetParalyzed(0)
-			L.SetUnconscious(0)
-			L.reagents.add_reagent(/datum/reagent/medicine/muscle_stimulant, clamp(5 - L.reagents.get_reagent_amount(/datum/reagent/medicine/muscle_stimulant), 0, 5))	//If you don't have legs or get bola'd, tough luck!
+	if(!isliving(loc))
+		return
+	var/mob/living/L = loc
+	colorize(L)
+	if(!stimulant)
+		return
+	L.SetStun(0)
+	L.SetKnockdown(0)
+	L.SetSleeping(0)
+	L.SetImmobilized(0)
+	L.SetParalyzed(0)
+	L.SetUnconscious(0)
+	L.reagents.add_reagent(/datum/reagent/medicine/muscle_stimulant, clamp(5 - L.reagents.get_reagent_amount(/datum/reagent/medicine/muscle_stimulant), 0, 5))	//If you don't have legs or get bola'd, tough luck!
 
 
 /obj/item/hot_potato/examine(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hot potatoes currently dose the holder with muscle stimulants. This is fine until someone who has an extreme allergy to muscle stims gets handed a toy potato from an arcade prize.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Getting utterly murdered by toys that give you no indication they are dosing you with chems is generally not great.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Toy hot potatoes no longer inadvertently trigger allergic responses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
