### PR TITLE
Fixes simple animal shoving message

### DIFF
--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -29,7 +29,7 @@
 			log_combat(M, src, "shoved", "pushing it")
 			M.visible_message("<span class='danger'>[M.name] shoves [src], pushing [p_them()]!</span>",
 				"<span class='danger'>You shove [src], pushing [p_them()]!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", COMBAT_MESSAGE_RANGE, list(src))
-			to_chat(src, "<span class='userdanger'>You're pushed by [name]!</span>")
+			to_chat(src, "<span class='userdanger'>You're pushed by [M.name]!</span>")
 			return TRUE
 
 		if("harm")


### PR DESCRIPTION
When you were a simple animal being shoved, you would get a message
along the lines of "You're pushed by Poly!", using you, the animal's
name, rather than the pusher.

This commit corrects that.