### PR TITLE
Fix lava boats not accepting oars and remove unimplemented vehicle subtype.

### DIFF
--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -9,6 +9,7 @@
 	var/allowed_turf = /turf/open/lava
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	can_buckle = TRUE
+	key_type = /obj/item/oar
 
 /obj/vehicle/ridden/lavaboat/Initialize()
 	. = ..()

--- a/code/modules/vehicles/speedbike.dm
+++ b/code/modules/vehicles/speedbike.dm
@@ -1,12 +1,4 @@
-
-/obj/vehicle/ridden/space
-	name = "Generic Space Vehicle!"
-
-/obj/vehicle/ridden/space/Initialize()
-	. = ..()
-	// ryll fix this//
-
-/obj/vehicle/ridden/space/speedbike
+/obj/vehicle/ridden/speedbike
 	name = "Speedbike"
 	icon = 'icons/obj/bike.dmi'
 	icon_state = "speedbike_blue"
@@ -14,24 +6,24 @@
 	var/overlay_state = "cover_blue"
 	var/mutable_appearance/overlay
 
-/obj/vehicle/ridden/space/speedbike/Initialize()
+/obj/vehicle/ridden/speedbike/Initialize()
 	. = ..()
 	overlay = mutable_appearance(icon, overlay_state, ABOVE_MOB_LAYER)
 	add_overlay(overlay)
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/speedbike)
 
-/obj/vehicle/ridden/space/speedbike/Move(newloc,move_dir)
+/obj/vehicle/ridden/speedbike/Move(newloc,move_dir)
 	if(has_buckled_mobs())
 		new /obj/effect/temp_visual/dir_setting/speedbike_trail(loc,move_dir)
 	return ..()
 
-/obj/vehicle/ridden/space/speedbike/red
+/obj/vehicle/ridden/speedbike/red
 	icon_state = "speedbike_red"
 	overlay_state = "cover_red"
 
 //BM SPEEDWAGON
 
-/obj/vehicle/ridden/space/speedwagon
+/obj/vehicle/ridden/speedwagon
 	name = "BM Speedwagon"
 	desc = "Push it to the limit, walk along the razor's edge."
 	icon = 'icons/obj/car.dmi'
@@ -43,12 +35,12 @@
 	pixel_y = -48
 	pixel_x = -48
 
-/obj/vehicle/ridden/space/speedwagon/Initialize()
+/obj/vehicle/ridden/speedwagon/Initialize()
 	. = ..()
 	add_overlay(overlay)
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/car/speedwagon)
 
-/obj/vehicle/ridden/space/speedwagon/Bump(atom/A)
+/obj/vehicle/ridden/speedwagon/Bump(atom/A)
 	. = ..()
 	if(!A.density || !has_buckled_mobs())
 		return
@@ -70,7 +62,7 @@
 			visible_message("<span class='danger'>[src] crashes into [H]!</span>")
 			playsound(src, 'sound/effects/bang.ogg', 50, TRUE)
 
-/obj/vehicle/ridden/space/speedwagon/Moved()
+/obj/vehicle/ridden/speedwagon/Moved()
 	. = ..()
 	if(!has_buckled_mobs())
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Clears up an unimplemented vehicle subtype and fixes an issue where lava boats didn't have a key_type set appropriately and thus couldn't be driven as they wouldn't accept oars.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can once again put oars into lava boats in order to use them to cross lava.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
