### PR TITLE
Add playtime tracking to notes

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -13,7 +13,7 @@ In any query remember to add a prefix to the table names if you use one.
 Version 5.12, 29 December 2020, by Missfox
 Modified table `messages`, adding column `playtime` to show the user's playtime when the note was created.
 
-ALTER TABLE `messages` ADD `playtime` INT NULL DEFAULT(NULL)
+ALTER TABLE `messages` ADD `playtime` INT(11) NULL DEFAULT(NULL) AFTER `severity`
 
 -----------------------------------------------------
 

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,12 +1,14 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.11; The query to update the schema revision table is:
+The latest database version is 5.12; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 11);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 12);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 11);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 12);
 
 In any query remember to add a prefix to the table names if you use one.
+
+-----------------------------------------------------
 
 Version 5.12, 29 December 2020, by Missfox
 Modified table `messages`, adding column `playtime` to show the user's playtime when the note was created.

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -8,6 +8,11 @@ INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 11);
 
 In any query remember to add a prefix to the table names if you use one.
 
+Version 5.12, 29 December 2020, by Missfox
+Modified table `messages`, adding column `playtime` to show the user's playtime when the note was created.
+
+ALTER TABLE `messages` ADD `playtime` INT NULL DEFAULT(NULL)
+
 -----------------------------------------------------
 
 Version 5.11, 7 September 2020, by bobbahbrown, MrStonedOne, and Jordie0608

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -255,6 +255,7 @@ CREATE TABLE `messages` (
   `secret` tinyint(1) unsigned NOT NULL,
   `expire_timestamp` datetime DEFAULT NULL,
   `severity` enum('high','medium','minor','none') DEFAULT NULL,
+  `playtime` int(11) unsigned NULL,
   `lasteditor` varchar(32) DEFAULT NULL,
   `edits` text,
   `deleted` tinyint(1) unsigned NOT NULL DEFAULT '0',

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -255,7 +255,7 @@ CREATE TABLE `messages` (
   `secret` tinyint(1) unsigned NOT NULL,
   `expire_timestamp` datetime DEFAULT NULL,
   `severity` enum('high','medium','minor','none') DEFAULT NULL,
-  `playtime` int(11) unsigned NULL,
+  `playtime` int(11) unsigned NULL DEFAULT NULL,
   `lasteditor` varchar(32) DEFAULT NULL,
   `edits` text,
   `deleted` tinyint(1) unsigned NOT NULL DEFAULT '0',

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -255,7 +255,7 @@ CREATE TABLE `SS13_messages` (
   `secret` tinyint(1) unsigned NOT NULL,
   `expire_timestamp` datetime DEFAULT NULL,
   `severity` enum('high','medium','minor','none') DEFAULT NULL,
-  `playtime` int(11) unsigned NULL,
+  `playtime` int(11) unsigned NULL DEFAULT NULL,
   `lasteditor` varchar(32) DEFAULT NULL,
   `edits` text,
   `deleted` tinyint(1) unsigned NOT NULL DEFAULT '0',

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -255,6 +255,7 @@ CREATE TABLE `SS13_messages` (
   `secret` tinyint(1) unsigned NOT NULL,
   `expire_timestamp` datetime DEFAULT NULL,
   `severity` enum('high','medium','minor','none') DEFAULT NULL,
+  `playtime` int(11) unsigned NULL,
   `lasteditor` varchar(32) DEFAULT NULL,
   `edits` text,
   `deleted` tinyint(1) unsigned NOT NULL DEFAULT '0',

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -20,7 +20,7 @@
  *
  * make sure you add an update to the schema_version stable in the db changelog
  */
-#define DB_MINOR_VERSION 11
+#define DB_MINOR_VERSION 12
 
 
 //! ## Timing subsystem

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -76,18 +76,9 @@
 		note_severity = input("Set the severity of the note.", "Severity", null, null) as null|anything in list("High", "Medium", "Minor", "None")
 		if(!note_severity)
 			return
-
-	var/playtime = 0
-	var/datum/db_query/playtime_read = SSdbcore.NewQuery("SELECT minutes FROM [format_table_name("role_time")] WHERE ckey = '[target_ckey]' and job = 'Living'")
-	if(!playtime_read.warn_execute())
-		qdel(playtime_read)
-		return
-	while(playtime_read.NextRow())
-		playtime = playtime_read.item[1]
-
 	var/datum/db_query/query_create_message = SSdbcore.NewQuery({"
-		INSERT INTO [format_table_name("messages")] (type, targetckey, adminckey, text, timestamp, server, server_ip, server_port, round_id, secret, expire_timestamp, severity)
-		VALUES (:type, :target_ckey, :admin_ckey, :text, :timestamp, :server, INET_ATON(:internet_address), :port, :round_id, :secret, :expiry, :note_severity)
+		INSERT INTO [format_table_name("messages")] (type, targetckey, adminckey, text, timestamp, server, server_ip, server_port, round_id, secret, expire_timestamp, severity, playtime)
+		VALUES (:type, :target_ckey, :admin_ckey, :text, :timestamp, :server, INET_ATON(:internet_address), :port, :round_id, :secret, :expiry, :note_severity, :playtime)
 	"}, list(
 		"type" = type,
 		"target_ckey" = target_ckey,
@@ -101,7 +92,7 @@
 		"secret" = secret,
 		"expiry" = expiry || null,
 		"note_severity" = note_severity,
-		"playtime" = playtime,
+		"playtime" = "(SELECT minutes FROM [format_table_name("role_time")] WHERE ckey = '[target_ckey]' AND job = 'Living')",
 	))
 	var/pm = "[key_name(usr)] has created a [type][(type == "note" || type == "message" || type == "watchlist entry") ? " for [target_key]" : ""]: [text]"
 	var/header = "[key_name_admin(usr)] has created a [type][(type == "note" || type == "message" || type == "watchlist entry") ? " for [target_key]" : ""]"
@@ -443,7 +434,7 @@
 			output += "<b>"
 			if(type == "watchlist entry")
 				output += "[t_key] | "
-			output += "[timestamp] | [server] | [admin_key] | [get_exp_format(text2num(playtime))]"
+			output += "[timestamp] | [server] | [admin_key] | [get_exp_format(text2num(playtime))] Living Playtime"
 			if(expire_timestamp)
 				output += " | Expires [expire_timestamp]"
 			output += "</b>"

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -439,7 +439,7 @@
 			var/server = query_get_type_messages.item[7]
 			var/editor_key = query_get_type_messages.item[8]
 			var/expire_timestamp = query_get_type_messages.item[9]
-			var/playtime = query_get_messages.item[10]
+			var/playtime = query_get_type_messages.item[10]
 			output += "<b>"
 			if(type == "watchlist entry")
 				output += "[t_key] | "

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -78,7 +78,7 @@
 			return
 
 	var/playtime = 0
-	var/datum/DBQuery/playtime_read = SSdbcore.NewQuery("SELECT minutes FROM [format_table_name("role_time")] WHERE ckey = '[target_ckey]' and job = 'Living'")
+	var/datum/db_query/playtime_read = SSdbcore.NewQuery("SELECT minutes FROM [format_table_name("role_time")] WHERE ckey = '[target_ckey]' and job = 'Living'")
 	if(!playtime_read.warn_execute())
 		qdel(playtime_read)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds playtime tracking to notes when creating a new note on a player.
Thank you to Akrilla for the original code, I just ported it over to TG base from the old skyrat base.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows staff to see how long a player has been playing between notes as the datestamp is not always a good picture of the players playtime on the server.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Added playtime tracking to notes
server: Added playtime to messages SQL table
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
