### PR TITLE
Flypeople say "s" as "z" and dont get disgusted by toxic food

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -7,6 +7,7 @@
 	meat = /obj/item/food/meat/slab/human/mutant/fly
 	disliked_food = null
 	liked_food = GROSS
+	toxic_food = NONE
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/fly
 	payday_modifier = 0.75

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -103,10 +103,14 @@
 /obj/item/organ/tongue/fly/handle_speech(datum/source, list/speech_args)
 	var/static/regex/fly_buzz = new("z+", "g")
 	var/static/regex/fly_buZZ = new("Z+", "g")
+	var/static/regex/fly_buss = new("s+", "g")
+	var/static/regex/fly_buSS = new("S+", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = fly_buzz.Replace(message, "zzz")
 		message = fly_buZZ.Replace(message, "ZZZ")
+		message = fly_buss.Replace(message, "z")
+		message = fly_buSS.Replace(message, "Z")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/fly/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Flypeople will now say "s" as "z" (They already say "z" as "zzz", but s -/> zzz) and arent disgusted by toxic food anymore. 

I'm hoping that by the end of my changes, Flypeople could be considered a unique and viable race, being actually worth something other than "that one unmaintained race we have disabled" (best-case scenario is they become fit to be a proper roundstart race)

## Why It's Good For The Game

Flypeople is the forgotten race of /tg/, this makes them more unique and fits for them.
Not being disgusted by toxic food fits well due to Flypeople being considered disgusting and vile creatures.
![Screenshot (429)](https://user-images.githubusercontent.com/53777086/103260163-b0698b00-496a-11eb-8c80-79d08cc241d2.png)

## Changelog
:cl: JohnWillard
tweak: Flypeople pronounce 's' as 'z'
balance: Flypeople arent affected by toxic food
/:cl:
