### PR TITLE
Replaces bounty cubes with direct deposits

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -32,6 +32,8 @@
 #define ACCOUNT_SEC "SEC"
 #define ACCOUNT_SEC_NAME "Defense Budget"
 
+#define ACCOUNT_CENT "CENT"
+#define ACCOUNT_CENT_NAME "Centcom Budget" //Adding this for Nanotrasen payouts (e.g. bounties) as I believe money should always come from existing financial assets (e.g. bank balances, cash)
 #define NO_FREEBIES "commies go home"
 
 //Defines that set what kind of civilian bounties should be applied mid-round.

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -12,6 +12,8 @@ SUBSYSTEM_DEF(economy)
 										ACCOUNT_SRV = ACCOUNT_SRV_NAME,
 										ACCOUNT_CAR = ACCOUNT_CAR_NAME,
 										ACCOUNT_SEC = ACCOUNT_SEC_NAME)
+	/// Accounts with deep pockets that are expected to be able to pay out whatever coders charge them with. Only used for bounties at the moment. Remove if unexpanded on.
+	var/list/banker_accounts = list(ACCOUNT_CENT = ACCOUNT_CENT_NAME)
 	var/list/generated_accounts = list()
 	var/full_ancap = FALSE // Enables extra money charges for things that normally would be free, such as sleepers/cryo/cloning.
 							//Take care when enabling, as players will NOT respond well if the economy is set up for low cash flows.
@@ -41,6 +43,8 @@ SUBSYSTEM_DEF(economy)
 	var/budget_to_hand_out = round(budget_pool / department_accounts.len)
 	for(var/A in department_accounts)
 		new /datum/bank_account/department(A, budget_to_hand_out)
+	for(var/A in banker_accounts)
+		new /datum/bank_account/department(A, INFINITY)
 	return ..()
 
 /datum/controller/subsystem/economy/fire(resumed = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When you complete a cargo bounty, instead of a bounty cube being spawned your account and cargo's budget will be credited immediately.

Adds a Centcom account with InFinInTE MONEY because my non-economist assumption is it's better for the game's economy if money comes from somewhere rather than thin air if only because it means sources of money can be tracked. This PR only uses it for bounty payouts but I think in future any payments that involve money from thin air should be changed to use accounts that can cover the costs. Here Centcom is a stand-in for the stations issuing bounties (that detail isn't needed) and they're possibly the broker of the deals anyway.

Adds a list of "banker" accounts because I needed it to make my limited code work honestly but also I believe entities with theoretically unlimited pockets like the Syndicate should have accounts on this list they pay out from (e.g. when sending uplink cash).

Fulfilled bounties will be reported over Supply radio using the same variables as what was described on the cubes, e.g. "Mark Wahlberg completed the 2000 cr <i>Vietnamese eye</i> bounty. Cargo's cut is 1400 cr."

I haven't had the chance to test this because after compiling with Visual Studio Code the BYOND pager just sends me dots now. I also would like to immortalise the bounty cube's greed-inducing sprite as some kind of toy.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I consider bounty cubes to be tedious busywork that frustrates bounty holders and keeps the ever-unreliable cargo staff sidetracked doing nothing of interest or meaning.

I assume cubes were added to split the difference between cargo having to load bounties on the shuttle manually (which I guess was deemed undesirable for whatever reason and probably was) and money simply being credited to the player's account, in order to combat naysayers insisting that replacing the need to send bounties on the shuttle with a telepad would leave cargo with nothing to do.  

If you've played cargo you may agree with me this isn't the case but I think it's a moot point anyway as endlessly calling and sending the shuttle to deliver one or two cubes is not interesting gameplay and inevitably leads to bounties taking longer than players find desirable to pay out, which disincentivises them from performing further bounties.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
del: The gilded bounty cube has been replaced with the mundane direct deposit, leading to mass lay-offs in Nanotrasen's logistics sector
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
