### PR TITLE
Nearsightness, Blindness, Tongue-tied on_spawn() code improvements, bug fixes

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -318,9 +318,8 @@
 /datum/quirk/nearsighted/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/clothing/glasses/regular/glasses = new(get_turf(H))
-	H.put_in_hands(glasses)
-	H.equip_to_slot(glasses, ITEM_SLOT_EYES)
-	H.regenerate_icons() //this is to remove the inhand icon, which persists even if it's not in their hands
+	if(!H.equip_to_slot_if_possible(glasses, ITEM_SLOT_EYES))
+		H.put_in_hands(glasses)
 
 /datum/quirk/nyctophobia
 	name = "Nyctophobia"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -57,7 +57,6 @@
 	var/obj/item/clothing/glasses/blindfold/white/B = new(get_turf(H))
 	if(!H.equip_to_slot_if_possible(B, ITEM_SLOT_EYES, bypass_equip_delay_self = TRUE)) //if you can't put it on the user's eyes, put it in their hands, otherwise put it on their eyes
 		H.put_in_hands(B)
-	H.regenerate_icons()
 
 	/* A couple of brain tumor stats for anyone curious / looking at this quirk for balancing:
 	 * - It takes less 16 minute 40 seconds to die from brain death due to a brain tumor.
@@ -318,7 +317,7 @@
 /datum/quirk/nearsighted/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/clothing/glasses/regular/glasses = new(get_turf(H))
-	if(!H.equip_to_slot_if_possible(glasses, ITEM_SLOT_EYES))
+	if(!H.equip_to_slot_if_possible(glasses, ITEM_SLOT_EYES, bypass_equip_delay_self = TRUE))
 		H.put_in_hands(glasses)
 
 /datum/quirk/nyctophobia

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -257,15 +257,12 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/organ/tongue/old_tongue = locate() in H.internal_organs
 	var/obj/item/organ/tongue/tied/new_tongue = new(get_turf(H))
-	var/obj/item/clothing/gloves/old_gloves = locate() in H
 	var/obj/item/clothing/gloves/radio/gloves = new(get_turf(H))
 	old_tongue.Remove(H)
 	new_tongue.Insert(H)
 	qdel(old_tongue)
-	qdel(old_gloves)
-	H.put_in_hands(gloves)
-	H.equip_to_slot(gloves, ITEM_SLOT_GLOVES)
-	H.regenerate_icons()
+	if(!H.equip_to_slot_if_possible(gloves, ITEM_SLOT_GLOVES, bypass_equip_delay_self = TRUE))
+		H.put_in_hands(gloves)
 
 /datum/quirk/tongue_tied/post_add()
 	to_chat(quirk_holder, "<span class='boldannounce'>Because you speak with your hands, having them full hinders your ability to communicate!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
equip_to_slot() is an unsafe proc, plus using it could not help you with nearsightness, forcing you to re-equip it for it to work.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Safe and not buggy code good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Spawning equipment for nearsighted or tongue-tied people is now safe code-wise, and shouldnt do any bugs, nor will they delete your previous equipment. Also blindness doesn't call a redundant expensive proc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
