### PR TITLE
Add inacusiate to syndicate medical borgs

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -180,12 +180,17 @@ Borg Hypospray
 
 /obj/item/reagent_containers/borghypo/syndicate
 	name = "syndicate cyborg hypospray"
-	desc = "An experimental piece of Syndicate technology used to produce powerful restorative nanites used to very quickly restore injuries of all types. Also metabolizes potassium iodide, for radiation poisoning, and morphine, for offense."
+	desc = "An experimental piece of Syndicate technology used to produce powerful restorative nanites used to very quickly restore injuries of all types. Also metabolizes potassium iodide for radiation poisoning, inacusiate for ear damage and morphine for offense."
 	icon_state = "borghypo_s"
 	charge_cost = 20
 	recharge_time = 2
-	reagent_ids = list(/datum/reagent/medicine/syndicate_nanites, /datum/reagent/medicine/potass_iodide, /datum/reagent/medicine/morphine)
-	bypass_protection = 1
+	reagent_ids = list(
+		/datum/reagent/medicine/syndicate_nanites,
+		/datum/reagent/medicine/inacusiate,
+		/datum/reagent/medicine/potass_iodide,
+		/datum/reagent/medicine/morphine,
+	)
+	bypass_protection = TRUE
 	accepts_reagent_upgrades = FALSE
 
 /*

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -106,14 +106,14 @@
 /obj/item/organ/ears/cybernetic
 	name = "cybernetic ears"
 	icon_state = "ears-c"
-	desc = "a basic cybernetic designed to mimic the operation of ears."
+	desc = "A basic cybernetic organ designed to mimic the operation of ears."
 	damage_multiplier = 0.9
 	organ_flags = ORGAN_SYNTHETIC
 
 /obj/item/organ/ears/cybernetic/upgraded
 	name = "upgraded cybernetic ears"
 	icon_state = "ears-c-u"
-	desc = "an advanced cybernetic ear, surpassing the performance of organic ears"
+	desc = "An advanced cybernetic ear, surpassing the performance of organic ears."
 	damage_multiplier = 0.5
 
 /obj/item/organ/ears/cybernetic/emp_act(severity)


### PR DESCRIPTION
:cl: coiax
balance: Syndicate medical borgs now have access to inacusiate.
/:cl:

Giving syndicate medical cyborgs access to the ear healing chemical
allos them to heal one of the most crippling problems that can afflict
an op; being unable to communicate effectively (through ear damage).
Being unable to communicate because they are a bad player is uncurable
through in-game methods however.

- In addition, makes some tiny tweaks to the grammar of cyber ears.