### PR TITLE
Fixes zombies being immune to wounds/dismemberment

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -46,7 +46,7 @@
 /datum/species/zombie/infectious/spec_stun(mob/living/carbon/human/H,amount)
 	. = min(20, amount)
 
-/datum/species/zombie/infectious/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked, mob/living/carbon/human/H, forced = FALSE, wound_bonus = 0, bare_wound_bonus = 0, sharpness = SHARP_NONE)
+/datum/species/zombie/infectious/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked, mob/living/carbon/human/H, spread_damage = FALSE, forced = FALSE, wound_bonus = 0, bare_wound_bonus = 0, sharpness = SHARP_NONE)
 	. = ..()
 	if(.)
 		regen_cooldown = world.time + REGENERATION_DELAY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Stop me if you've heard this one before: infectious zombies specifically were immune to being wounded and thus dismembered. I'm not sure how this happened or when, but the definition for apply_damage() on their species was missing an argument for spread_damage and thus I think it tried defaulting to spreading out any damage taken, which is obviously problematic for trying to remove specific bodyparts (IE the head). This fixes that, and here's proof you can dismember these bastards

Fixes: #55161

[![dreamseeker_2020-12-30_04-10-15.png](https://i.imgur.com/e3sRA4al.jpg)](https://i.imgur.com/e3sRA4a.png)
[![dreamseeker_2020-12-30_04-10-55.png](https://i.imgur.com/3EPpnhLl.jpg)](https://i.imgur.com/3EPpnhL.png)

The body reverts to normal human sprites after being decapitated, I think because getting decapitated triggers spec_death() which deletes the tumor, but I assume that's on purpose?
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Zombies function properly
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Infectious zombies (from romerol) can actually be wounded and dismembered (and thus decapitated) properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
