### PR TITLE
Fixes two bugs with Blob strain rerolling

### DIFF
--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -94,7 +94,7 @@
 /atom/movable/screen/blob/readapt_strain
 	icon_state = "ui_chemswap"
 	name = "Readapt Strain"
-	desc = "Allows you to choose a new strain from 4 random choices for 40 resources."
+	desc = "Allows you to choose a new strain from 6 random choices for 40 resources."
 
 /atom/movable/screen/blob/readapt_strain/MouseEntered(location,control,params)
 	if(hud?.mymob && isovermind(hud.mymob))

--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -364,8 +364,7 @@
 	if (!strain_choices)
 		strain_choices = list()
 
-		var/list/new_strains = GLOB.valid_blobstrains.Copy()
-		LAZYREMOVE(new_strains, blobstrain.type)
+		var/list/new_strains = GLOB.valid_blobstrains.Copy() - blobstrain.type
 		for (var/_ in 1 to BLOB_REROLL_CHOICES)
 			var/datum/blobstrain/strain = pick_n_take(new_strains)
 

--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -365,6 +365,7 @@
 		strain_choices = list()
 
 		var/list/new_strains = GLOB.valid_blobstrains.Copy()
+		LAZYREMOVE(new_strains, blobstrain.type)
 		for (var/_ in 1 to BLOB_REROLL_CHOICES)
 			var/datum/blobstrain/strain = pick_n_take(new_strains)
 
@@ -398,6 +399,7 @@
 				free_strain_rerolls -= 1
 
 			last_reroll_time = world.time
+			strain_choices = null
 
 			return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Your own current strain could appear as a reroll option
2. After picking a strain and rerolling, the same six options would appear, instead of 6 new options

Also updates info in the reroll power description
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
less bugs more good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Your current blob strain no longer shows up as reroll option
fix: The blob strain selection actually gets refreshed now after rerolling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
