### PR TITLE
Fix observers not being able to read from afar

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -152,7 +152,7 @@
 		// Are we on fire?  Hard ot read if so
 	if(resistance_flags & ON_FIRE)
 		return UI_CLOSE
-	if(!in_range(user,src))
+	if(!in_range(user, src) && !isobserver(user))
 		return UI_CLOSE
 	if(user.incapacitated(TRUE, TRUE) || (isobserver(user) && !isAdminGhostAI(user)))
 		return UI_UPDATE


### PR DESCRIPTION
:cl: coiax
fix: Observers can now read paper documents without having to be
adjacent.
/:cl:

From the examine() code it's clear that this was intended, just a check
in `ui_status` meant that the range check was being applied to them
anyway.