### PR TITLE
Makes the monkey mutation remember your species through transformations

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -183,20 +183,12 @@
 /datum/mutation/human/race/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
-	if(!ismonkey(owner))
-		original_species = owner.dna.species.type
-		owner.Immobilize(2 SECONDS)
-		owner.do_alert_animation()
-		owner.emote("scream")
-		owner.set_species(/datum/species/monkey)
+	original_species = owner.dna.species.type
+	. = owner.monkeyize()
 
 /datum/mutation/human/race/on_losing(mob/living/carbon/human/owner)
 	if(owner && owner.stat != DEAD && (owner.dna.mutations.Remove(src)) && ismonkey(owner))
-		owner.set_species(original_species)
-		owner.Immobilize(2 SECONDS)
-		owner.do_alert_animation()
-		owner.emote("scream")
-		original_species = /datum/species/human
+		. = owner.humanize(original_species)
 
 /datum/mutation/human/glow
 	name = "Glowy"

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -173,18 +173,30 @@
 /datum/mutation/human/race
 	name = "Monkified"
 	desc = "A strange genome, believing to be what differentiates monkeys from humans."
+	text_gain_indication = "You feel unusually monkey-like."
+	text_lose_indication = "You feel like your old self."
 	quality = NEGATIVE
 	time_coeff = 2
 	locked = TRUE //Species specific, keep out of actual gene pool
+	var/datum/species/original_species = /datum/species/human
 
 /datum/mutation/human/race/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
-	. = owner.monkeyize()
+	if(!ismonkey(owner))
+		original_species = owner.dna.species.type
+		owner.Immobilize(2 SECONDS)
+		owner.do_alert_animation()
+		owner.emote("scream")
+		owner.set_species(/datum/species/monkey)
 
 /datum/mutation/human/race/on_losing(mob/living/carbon/human/owner)
 	if(owner && owner.stat != DEAD && (owner.dna.mutations.Remove(src)) && ismonkey(owner))
-		. = owner.humanize()
+		owner.set_species(original_species)
+		owner.Immobilize(2 SECONDS)
+		owner.do_alert_animation()
+		owner.emote("scream")
+		original_species = /datum/species/human
 
 /datum/mutation/human/glow
 	name = "Glowy"

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -30,7 +30,7 @@
 //////////////////////////           Humanize               //////////////////////////////
 //Could probably be merged with monkeyize but other transformations got their own procs, too
 
-/mob/living/carbon/proc/humanize()
+/mob/living/carbon/proc/humanize(species = /datum/species/human)
 	if (notransform || transformation_timer)
 		return
 
@@ -45,15 +45,15 @@
 	invisibility = INVISIBILITY_MAXIMUM
 
 	new /obj/effect/temp_visual/monkeyify/humanify(loc)
-	transformation_timer = addtimer(CALLBACK(src, .proc/finish_humanize), TRANSFORMATION_DURATION, TIMER_UNIQUE)
+	transformation_timer = addtimer(CALLBACK(src, .proc/finish_humanize, species), TRANSFORMATION_DURATION, TIMER_UNIQUE)
 
-/mob/living/carbon/proc/finish_humanize()
+/mob/living/carbon/proc/finish_humanize(species = /datum/species/human)
 	transformation_timer = null
 	to_chat(src, "<B>You are now a human.</B>")
 	notransform = FALSE
 	icon = initial(icon)
 	invisibility = 0
-	set_species(/datum/species/human)
+	set_species(species)
 	return src
 
 /mob/living/carbon/human/AIize(transfer_after = TRUE, client/preference_source)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Originally, if you get made into a monkey, you would transform back into your original species upon resetting the mutation. The change of monkeys from weird carbons to a human species broke this somewhat, so this restores this functionality to prevent weirdness that might result. 

~~This is specifically fixing the mutation, not anything that uses the Humanize proc. That...does what it says on the tin, so I don't see a reason to fix that, just distance the mutation from that proc.~~ It work better now.

Fixes https://github.com/tgstation/tgstation/issues/55837

## Why It's Good For The Game

I can only imagine how silly this would get and how annoying it probably would be for lings. Doesn't fix the weird hairloss from being monkified, but if someone can tell me why that might be happening I'd appreciate it. It's 6am and I'm blind and dumb and need helpies.

## Changelog
:cl:
fix: Monkey mutation remembers your species across transformations once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
