### PR TITLE
Streamline marker beacons on maps

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -30411,9 +30411,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "bte" = (
-/obj/structure/marker_beacon{
-	icon_state = "markerburgundy-on"
-	},
+/obj/structure/marker_beacon/burgundy,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "btf" = (
@@ -31730,9 +31728,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bwm" = (
-/obj/structure/marker_beacon{
-	icon_state = "markerburgundy-on"
-	},
+/obj/structure/marker_beacon/burgundy,
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors)
@@ -31741,9 +31737,7 @@
 /turf/open/floor/plasteel,
 /area/storage/mining)
 "bwo" = (
-/obj/structure/marker_beacon{
-	icon_state = "markerburgundy-on"
-	},
+/obj/structure/marker_beacon/burgundy,
 /turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors)
 "bwp" = (
@@ -53649,9 +53643,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "pAz" = (
-/obj/structure/marker_beacon{
-	icon_state = "markerburgundy-on"
-	},
+/obj/structure/marker_beacon/burgundy,
 /obj/structure/fluff/fokoff_sign,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -21062,14 +21062,8 @@
 /area/hallway/primary/fore)
 "aIY" = (
 /obj/structure/lattice/catwalk,
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 2;
-	name = "landing marker";
-	picked_color = "Burgundy"
+/obj/structure/marker_beacon/burgundy{
+	name = "landing marker"
 	},
 /turf/open/floor/plating/airless,
 /area/hallway/secondary/entry)
@@ -60947,14 +60941,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 2;
-	name = "landing marker";
-	picked_color = "Burgundy"
+/obj/structure/marker_beacon/burgundy{
+	name = "landing marker"
 	},
 /turf/open/floor/plating/airless,
 /area/hallway/secondary/entry)
@@ -62279,19 +62267,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
 /area/hallway/secondary/entry)
-"bUG" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 2;
-	name = "landing marker";
-	picked_color = "Burgundy"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "bUH" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -62315,14 +62290,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 2;
-	name = "landing marker";
-	picked_color = "Burgundy"
+/obj/structure/marker_beacon/burgundy{
+	name = "landing marker"
 	},
 /obj/machinery/button/door{
 	id = "Arrival Shuttle Bay";
@@ -90324,6 +90293,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"qJs" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy{
+	name = "landing marker"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "qKa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -94469,7 +94445,7 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -98924,7 +98900,7 @@ ivj
 anu
 anu
 ivj
-bUG
+qJs
 aav
 kLr
 xFp
@@ -100204,7 +100180,7 @@ aaa
 acm
 aaa
 aaa
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -101376,7 +101352,7 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 bVu
 aeu
 aeu
@@ -101746,7 +101722,7 @@ ctb
 cEZ
 vfF
 ajd
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -102499,11 +102475,11 @@ aeu
 wDI
 aeu
 aeu
-bUG
+qJs
 acK
 acm
 acK
-bUG
+qJs
 aeu
 amR
 amA
@@ -108204,7 +108180,7 @@ anZ
 cmt
 agw
 aoc
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -109232,7 +109208,7 @@ anZ
 cmt
 aob
 aoe
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -109332,7 +109308,7 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 bVu
 aeu
 aeu
@@ -113186,7 +113162,7 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 bVu
 aeu
 aeu
@@ -114629,13 +114605,13 @@ akK
 anh
 bwu
 acm
-bUG
+qJs
 aaa
 aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -115657,13 +115633,13 @@ cJU
 cKi
 akK
 acm
-bUG
+qJs
 aaa
 aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 acm
 cow
 aaa
@@ -116685,13 +116661,13 @@ akK
 bwu
 akK
 acm
-bUG
+qJs
 aaa
 aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 aaa
 cow
 acm
@@ -131751,7 +131727,7 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 aDT
 agw
 akA
@@ -132779,7 +132755,7 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 aeZ
 aob
 akA
@@ -132834,7 +132810,7 @@ bju
 bhW
 acK
 acK
-bUG
+qJs
 blE
 bkN
 bIQ
@@ -132842,7 +132818,7 @@ bll
 bOg
 blH
 bmn
-bUG
+qJs
 acK
 bEg
 bEg
@@ -134110,13 +134086,13 @@ cbg
 cbk
 bfW
 bkd
-bUG
+qJs
 bin
 bhW
 aVN
 bhW
 bkc
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -134298,11 +134274,11 @@ cOp
 acm
 acm
 acm
-bUG
+qJs
 asJ
 cKG
 asJ
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -134769,7 +134745,7 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 bVu
 aeu
 aeu
@@ -134901,27 +134877,27 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 aaa
-bUG
+qJs
 bPe
 bSM
 bTl
 bXe
 bPe
-bUG
+qJs
 aaa
-bUG
+qJs
 bPe
 bXe
 bTl
 bXe
 bPe
-bUG
+qJs
 acm
 acm
 acm
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -134929,7 +134905,7 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 aeU
 aaa
 acm
@@ -136359,7 +136335,7 @@ cKw
 cKR
 asJ
 acm
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -136922,11 +136898,11 @@ ajH
 cmU
 aeU
 aof
-bUG
+qJs
 acK
 acm
 acK
-bUG
+qJs
 aeu
 aeu
 aeu
@@ -136937,13 +136913,13 @@ aaa
 acm
 aaa
 aaa
-bUG
+qJs
 acm
 acK
 acK
 acK
 acm
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -137130,7 +137106,7 @@ cKz
 asJ
 abq
 act
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -138415,7 +138391,7 @@ abq
 act
 act
 act
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -140429,7 +140405,7 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 bVu
 aeu
 aeu
@@ -143525,7 +143501,7 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 aeu
 aeu
 aeu
@@ -148426,7 +148402,7 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 aaa
 aaa
 aeu
@@ -150244,7 +150220,7 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -152326,14 +152302,14 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 aaa
 aaa
 aaa
@@ -152863,12 +152839,12 @@ aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 aaa
 aaa
 aaa
 aaa
-bUG
+qJs
 aaa
 aaa
 aaa

--- a/code/modules/mining/equipment/marker_beacons.dm
+++ b/code/modules/mining/equipment/marker_beacons.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_INIT(marker_beacon_colors, sortList(list(
 	novariants = TRUE
 	cost = 1
 	source = /datum/robot_energy_storage/beacon
-	var/picked_color = "random"
+	var/picked_color = "Random"
 
 /obj/item/stack/marker_beacon/ten //miners start with 10 of these
 	amount = 10
@@ -79,12 +79,14 @@ GLOBAL_LIST_INIT(marker_beacon_colors, sortList(list(
 	anchored = TRUE
 	light_range = 2
 	light_power = 3
+	var/icon_prefix = "marker"
 	var/remove_speed = 15
 	var/picked_color
 
 /obj/structure/marker_beacon/Initialize(mapload, set_color)
 	. = ..()
-	picked_color = set_color
+	if(set_color)
+		picked_color = set_color
 	update_icon()
 
 /obj/structure/marker_beacon/deconstruct(disassembled = TRUE)
@@ -101,7 +103,7 @@ GLOBAL_LIST_INIT(marker_beacon_colors, sortList(list(
 /obj/structure/marker_beacon/update_icon()
 	while(!picked_color || !GLOB.marker_beacon_colors[picked_color])
 		picked_color = pick(GLOB.marker_beacon_colors)
-	icon_state = "[initial(icon_state)][lowertext(picked_color)]-on"
+	icon_state = "[icon_prefix][lowertext(picked_color)]-on"
 	set_light(light_range, light_power, GLOB.marker_beacon_colors[picked_color])
 
 /obj/structure/marker_beacon/attack_hand(mob/living/user)
@@ -146,3 +148,11 @@ GLOBAL_LIST_INIT(marker_beacon_colors, sortList(list(
 	if(input_color)
 		picked_color = input_color
 		update_icon()
+
+
+/* Preset marker beacon types, for mapping */
+
+/obj/structure/marker_beacon/burgundy
+	picked_color = "Burgundy"
+	// set icon_state to make it clear for mappers
+	icon_state = "markerburgundy-on"


### PR DESCRIPTION
- A new map only subtype of burgundy marker beacons has been added.
- This new subtype is used for the marker beacons on IceBox, which were
  intended to be red, but were actually picking random colours.
- Landing markers on Kilostation are now burgundy marker beacons with
  different names, rather than anchored marker beacon stacks.