### PR TITLE
HFR can now output waste gases again

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hypertorus.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hypertorus.dm
@@ -925,7 +925,7 @@
 	else
 		internal_fusion.temperature -= heat_limiter_modifier * 0.01 * delta_time
 
-	var/datum/gas_mixture/internal_output
+	var/datum/gas_mixture/internal_output = new
 	//gas consumption and production
 	if(check_fuel())
 		var/fuel_consumption = clamp((fuel_injection_rate * 0.001) * 5 * power_level, 0.05, 30) * delta_time


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Commit 241e9cf broke HFR.

Leaving internal_output as null meant that execution would hit runtimes during process(), and never reach the end where changes were applied:
- No radiation was emitted. No nuclear particles were generated.
- No waste gases could be removed, neither by fusion waste removal nor by moderator filtering. Fusion would produce nothing.
- It could still enter meltdown, though.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This fixes the endless runtimes like the following:
[07:51:05] Runtime in hypertorus.dm,1067: Cannot execute null.total moles().
[07:52:09] Runtime in hypertorus.dm,957: Cannot execute null.assert gases().
[07:52:17] Runtime in hypertorus.dm,983: Cannot execute null.assert gases().
[07:53:21] Runtime in hypertorus.dm,1012: Cannot execute null.assert gases().

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: HFR can now output waste gases again.
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->