### PR TITLE
Fixes Digitigrade Lizards

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -356,13 +356,13 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	if(C.hud_used)
 		C.hud_used.update_locked_slots()
 
+	fix_non_native_limbs(C)
+
 	// this needs to be FIRST because qdel calls update_body which checks if we have DIGITIGRADE legs or not and if not then removes DIGITIGRADE from species_traits
 	if(C.dna.species.mutant_bodyparts["legs"] && C.dna.features["legs"] == "Digitigrade Legs")
 		species_traits += DIGITIGRADE
 	if(DIGITIGRADE in species_traits)
 		C.Digitigrade_Leg_Swap(FALSE)
-
-	fix_non_native_limbs(C)
 
 	C.mob_biotypes = inherent_biotypes
 


### PR DESCRIPTION
## About The Pull Request

Fixes ash walkers and lizards with digitigrade preference selected so they have their proper legs on spawn.

`fix_non_native_limbs` was called AFTER the `on_species_gain` proc gives the lizards their legs, and because digitigrade legs are not in their `bodypart_overides` list it was immediately replaced with normal legs.

CC @Qustinnus so they can provide some insight about better possible fixes or w/e

Fixes #55851

## Why It's Good For The Game

Falling on glass shards is god-given right.

## Changelog
:cl: Melbert
fix: Ashwalkers and Lizardpeople can now have digitigrade legs again 
/:cl:
