### PR TITLE
Fixes food/slime processor being able to be turned on when empty

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -14,6 +14,7 @@
 	var/processing = FALSE
 	var/rating_speed = 1
 	var/rating_amount = 1
+	var/list/processor_contents
 
 /obj/machinery/processor/RefreshParts()
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
@@ -35,6 +36,7 @@
 		themob.gib(TRUE,TRUE,TRUE)
 	else
 		qdel(what)
+	LAZYREMOVE(processor_contents, what)
 
 /obj/machinery/processor/proc/select_recipe(X)
 	for (var/type in subtypesof(/datum/food_processor_process) - /datum/food_processor_process/mob)
@@ -79,6 +81,7 @@
 		user.visible_message("<span class='notice'>[user] put [O] into [src].</span>", \
 			"<span class='notice'>You put [O] into [src].</span>")
 		user.transferItemToLoc(O, src, TRUE)
+		LAZYADD(processor_contents, O)
 		return 1
 	else
 		if(user.a_intent != INTENT_HARM)
@@ -98,9 +101,10 @@
 		var/mob/living/pushed_mob = user.pulling
 		visible_message("<span class='warning'>[user] stuffs [pushed_mob] into [src]!</span>")
 		pushed_mob.forceMove(src)
+		LAZYADD(processor_contents, pushed_mob)
 		user.stop_pulling()
 		return
-	if(contents.len == 0)
+	if(!LAZYLEN(processor_contents))
 		to_chat(user, "<span class='warning'>[src] is empty!</span>")
 		return TRUE
 	processing = TRUE
@@ -110,7 +114,7 @@
 	playsound(src.loc, 'sound/machines/blender.ogg', 50, TRUE)
 	use_power(500)
 	var/total_time = 0
-	for(var/O in src.contents)
+	for(var/O in processor_contents)
 		var/datum/food_processor_process/P = select_recipe(O)
 		if (!P)
 			log_admin("DEBUG: [O] in processor doesn't have a suitable recipe. How did it get in there? Please report it immediately!!!")
@@ -119,7 +123,7 @@
 	var/offset = prob(50) ? -2 : 2
 	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = (total_time / rating_speed)*5) //start shaking
 	sleep(total_time / rating_speed)
-	for(var/atom/movable/O in src.contents)
+	for(var/atom/movable/O in processor_contents)
 		var/datum/food_processor_process/P = select_recipe(O)
 		if (!P)
 			log_admin("DEBUG: [O] in processor doesn't have a suitable recipe. How do you put it in?")
@@ -141,6 +145,11 @@
 			return
 	dump_inventory_contents()
 	add_fingerprint(usr)
+
+/obj/machinery/processor/dump_inventory_contents()
+	. = ..()
+	if(!LAZYLEN(processor_contents))
+		processor_contents.Cut()
 
 /obj/machinery/processor/container_resist_act(mob/living/user)
 	user.forceMove(drop_location())
@@ -183,6 +192,7 @@
 		return
 
 	visible_message("<span class='notice'>[picked_slime] is sucked into [src].</span>")
+	LAZYADD(processor_contents, picked_slime)
 	picked_slime.forceMove(src)
 
 /obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what)
@@ -191,6 +201,7 @@
 		var/C = S.cores
 		if(S.stat != DEAD)
 			S.forceMove(drop_location())
+			LAZYREMOVE(processor_contents, S)
 			S.visible_message("<span class='notice'>[C] crawls free of the processor!</span>")
 			return
 		for(var/i in 1 to (C+rating_amount-1))

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -200,8 +200,8 @@
 	if (istype(S))
 		var/C = S.cores
 		if(S.stat != DEAD)
-			S.forceMove(drop_location())
 			LAZYREMOVE(processor_contents, S)
+			S.forceMove(drop_location())
 			S.visible_message("<span class='notice'>[C] crawls free of the processor!</span>")
 			return
 		for(var/i in 1 to (C+rating_amount-1))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes #55786 

As predicted by Jared-Fogle, suffered a similar issue to #55044 and #54884
4884 where it was trying to check for the machine's contents, but components are now part of the machine's contents too.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Grinding while empty is bad for the mechanism!
## Changelog
:cl:
fix: Food/slime processor should no longer be able to turned on while empty.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
