### PR TITLE
Fixes non-clowns being able to steer/drive clown cars

### DIFF
--- a/code/modules/vehicles/cars/car.dm
+++ b/code/modules/vehicles/cars/car.dm
@@ -77,7 +77,7 @@
 	return ..()
 
 /obj/vehicle/sealed/car/relaymove(mob/living/user, direction)
-	if(canmove && (!key_type || istype(inserted_key, key_type)))
+	if(is_driver(user) && canmove && (!key_type || istype(inserted_key, key_type)))
 		vehicle_move(direction)
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In my riding refactor and the handful of PR's that have come out since, I made some incorrect guesses about how clown cars worked, and as a result caused issues with them. This PR addresses the last issue with them, which was caused by erroneously removing a check to see if someone was actually qualified to drive the clown car (AKA they're a clown in full clown regalia), meaning that anyone in the car could drive it, including the ~~unwilling~~ passengers. That check has been restored, so only clowns can drive again, as intended.

Fixes: #55849
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sorry floyd!!!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Clowns are once again the only beings capable of controlling the clown car, it should be fully functional again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
