### PR TITLE
Tweak nanite subdermal ID to include pulled cards

### DIFF
--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -212,24 +212,23 @@
 
 //Syncs the nanites with the cumulative current mob's access level. Can potentially wipe existing access.
 /datum/nanite_program/access/on_trigger(comm_message)
-	var/list/new_access = list()
-	var/obj/item/current_item
-	current_item = host_mob.get_active_held_item()
-	if(current_item)
-		new_access += current_item.GetAccess()
-	current_item = host_mob.get_inactive_held_item()
-	if(current_item)
-		new_access += current_item.GetAccess()
+	var/list/potential_items = list()
+
+	potential_items += host_mob.get_active_held_item()
+	potential_items += host_mob.get_inactive_held_item()
+	potential_items += host_mob.pulling
+
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
-		current_item = H.wear_id
-		if(current_item)
-			new_access += current_item.GetAccess()
+		potential_items += H.wear_id
 	else if(isanimal(host_mob))
 		var/mob/living/simple_animal/A = host_mob
-		current_item = A.access_card
-		if(current_item)
-			new_access += current_item.GetAccess()
+		potential_items += A.access_card
+
+	var/list/new_access = list()
+	for(var/obj/item/I in potential_items)
+		new_access += I.GetAccess()
+
 	access = new_access
 
 /datum/nanite_program/spreading


### PR DESCRIPTION
:cl: coiax
tweak: The nanite program "Subdermal ID" will now also scan ID cards
that the host is pulling when triggered.
/:cl:

Some mobs which are capable of hosting nanites have no hands to hold ID
cards to be scanned, such as unexpectedly sentient Captain Ian. But now,
give them subdermal ID nanites, pull the ID card, and then you have a
full-access simple mob.

Note that this DOES NOT scan the ID cards of pulled mobs, only if you
are pulling an actual ID card. It is not possible to grab the captain to
leech his access.