### PR TITLE
Holy water makes you magic-immune / adds holy water OD

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -222,7 +222,8 @@
 	glass_icon_state  = "glass_clear"
 	glass_name = "glass of holy water"
 	glass_desc = "A glass of holy water."
-	overdose_threshold = 20
+	overdose_threshold = 10
+	metabolization_rate = 2.5 * REAGENTS_METABOLISM //1 unit a tick
 	self_consuming = TRUE //divine intervention won't be limited by the lack of a liver
 
 	// Holy water. Mostly the same as water, it also heals the plant a little with the power of the spirits. Also ALSO increases instability.
@@ -260,7 +261,7 @@
 			to_chat(M, "<span class='cultlarge'>Your blood rites falter as holy water scours your body!</span>")
 			for(var/datum/action/innate/cult/blood_spell/BS in BM.spells)
 				qdel(BS)
-	if(data["misc"] >= 25)		// 10 units, 45 seconds @ metabolism 0.4 units & tick rate 1.8 sec
+	if(data["misc"] >= 10)		// 10 units, 18 seconds @ metabolism 1 unit & tick rate 1.8 sec
 		if(!M.stuttering)
 			M.stuttering = 1
 		M.stuttering = min(M.stuttering+4, 10)
@@ -272,14 +273,14 @@
 				M.Unconscious(120)
 				to_chat(M, "<span class='cultlarge'>[pick("Your blood is your bond - you are nothing without it", "Do not forget your place", \
 				"All that power, and you still fail?", "If you cannot scour this poison, I shall scour your meager life!")].</span>")
-	if(data["misc"] >= 60)	// 30 units, 135 seconds
+	if(data["misc"] >= 30)	// 30 units, 54 seconds
 		if(iscultist(M))
 			SSticker.mode.remove_cultist(M.mind, FALSE, TRUE)
 		M.jitteriness = 0
 		M.stuttering = 0
 		holder.remove_reagent(type, volume)	// maybe this is a little too perfect and a max() cap on the statuses would be better??
 		return
-	holder.remove_reagent(type, 0.4)	//fixed consumption to prevent balancing going out of whack
+	holder.remove_reagent(type, metabolization_rate)	//this line sucked and it is now fixed by Bug
 
 /datum/reagent/water/holywater/overdose_process(mob/living/M) //if overdosed, removes benificial aspect of antimagic and makes you shaky, confused, and religious.
 	if(ishuman(M))

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -235,9 +235,11 @@
 /datum/reagent/water/holywater/on_mob_metabolize(mob/living/L)
 	..()
 	ADD_TRAIT(L, TRAIT_HOLY, type)
+	ADD_TRAIT(L, TRAIT_ANTIMAGIC, type)
 
 /datum/reagent/water/holywater/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_HOLY, type)
+	REMOVE_TRAIT(L, TRAIT_ANTIMAGIC, type)
 	..()
 
 /datum/reagent/water/holywater/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -222,6 +222,7 @@
 	glass_icon_state  = "glass_clear"
 	glass_name = "glass of holy water"
 	glass_desc = "A glass of holy water."
+	overdose_threshold = 20
 	self_consuming = TRUE //divine intervention won't be limited by the lack of a liver
 
 	// Holy water. Mostly the same as water, it also heals the plant a little with the power of the spirits. Also ALSO increases instability.
@@ -279,6 +280,18 @@
 		holder.remove_reagent(type, volume)	// maybe this is a little too perfect and a max() cap on the statuses would be better??
 		return
 	holder.remove_reagent(type, 0.4)	//fixed consumption to prevent balancing going out of whack
+
+/datum/reagent/water/holywater/overdose_process(mob/living/M) //if overdosed, removes benificial aspect of antimagic and makes you shaky, confused, and religious.
+	if(ishuman(M))
+		REMOVE_TRAIT(M, TRAIT_ANTIMAGIC, type)
+		M.jitteriness = min(M.jitteriness+8,20)
+		M.Dizzy(15)
+		M.set_confusion(min(M.get_confusion() + 2, 5))
+		if(!iscultist(M)) //cultists wont speak religious as they already have their own shouts for being dosed with holy water. they hate god, anyway.
+			if(prob(10))
+				M.say(pick("Hallelujiah!!", "God hates spacemen!", "It's Adam and Eve, not Adam and Steve!", "Im Pope", "Waga baga bobo", "I'm saving myself until marriage." ), forced = /datum/reagent/water/holywater)
+	..()
+	return
 
 /datum/reagent/water/holywater/expose_turf(turf/exposed_turf, reac_volume)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Holy water makes you magic immune (when it's in your system).
To counteract power-gaming and the hard-counter aspect of this change, holy water now has an OD threshold of 10u, and a metabolism rate of 1u per tick. The overdose causes screen shake, confusion and makes you say religious stuff. This is harmless outside of combat, but makes it so powergamers and validhunters will not be popping pills so easily for infinite magic resist.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The chaplain, being holy, is immune to magic. Holding (but not eating) holymelons gives immunity to magics. Clearly, in the game's fiction, the power of 'holy' gives magic immunity, and holy water is the prime way of receiving this power. This change adds value to the chaplain (and botanists) to provide holy water to the crew in the case of a wizard, or cult. It also provides a much-needed counter to magic, arguably one of the most dangerous hazards on station.

## Changelog
bugstep :cl:
balance: holy water gives players the trait antimagic
balance: adds holy water OD threshold and effect
balance: increases holy water metabolization rate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
