### PR TITLE
Fix single space area in maint on metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -57860,7 +57860,7 @@
 	},
 /obj/item/seeds/cannabis/ultimate,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard/aft)
 "cPg" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes a single tile inside the starboard aft maintenance actually maintenance instead of space.

![image](https://user-images.githubusercontent.com/6952402/103457547-8dd7c900-4d00-11eb-82c7-6b830327447f.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Roundstart holes in stations aren't *that* common.
Except if it's intended. 👉👈 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: No more single space area in metastation starboard maint
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
