### PR TITLE
fix Telekinesis teleporting some items

### DIFF
--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -24,7 +24,9 @@
 /obj/machinery/blackbox_recorder/attack_hand(mob/living/user)
 	. = ..()
 	if(stored)
-		stored.forceMove(get_turf(src))
+		stored.forceMove(drop_location())
+		if(Adjacent(user))
+			user.put_in_hands(stored)
 		stored = null
 		to_chat(user, "<span class='notice'>You remove the blackbox from [src]. The tapes stop spinning.</span>")
 		update_icon()

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -24,7 +24,7 @@
 /obj/machinery/blackbox_recorder/attack_hand(mob/living/user)
 	. = ..()
 	if(stored)
-		user.put_in_hands(stored)
+		stored.forceMove(get_turf(src))
 		stored = null
 		to_chat(user, "<span class='notice'>You remove the blackbox from [src]. The tapes stop spinning.</span>")
 		update_icon()

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -8,7 +8,7 @@
 	var/unfoldedbag_path = /obj/structure/closet/body_bag
 
 /obj/item/bodybag/attack_self(mob/user)
-	deploy_bodybag(user, user.loc)
+	deploy_bodybag(user, src.loc)
 
 /obj/item/bodybag/afterattack(atom/target, mob/user, proximity)
 	. = ..()

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -9,9 +9,9 @@
 
 /obj/item/bodybag/attack_self(mob/user)
 	if(user.is_holding(src))
-		deploy_bodybag(user, user.loc)
+		deploy_bodybag(user, get_turf(user))
 	else
-		deploy_bodybag(user, src.loc)
+		deploy_bodybag(user, get_turf(src))
 
 /obj/item/bodybag/afterattack(atom/target, mob/user, proximity)
 	. = ..()

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -8,7 +8,10 @@
 	var/unfoldedbag_path = /obj/structure/closet/body_bag
 
 /obj/item/bodybag/attack_self(mob/user)
-	deploy_bodybag(user, src.loc)
+	if(user.is_holding(src))
+		deploy_bodybag(user, user.loc)
+	else
+		deploy_bodybag(user, src.loc)
 
 /obj/item/bodybag/afterattack(atom/target, mob/user, proximity)
 	. = ..()

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -120,7 +120,9 @@
 	brain.brainmob = brainmob //Set the brain to use the brainmob
 	log_game("[key_name(user)] has ejected the brain of [key_name(brainmob)] from an MMI at [AREACOORD(src)]")
 	brainmob = null //Set mmi brainmob var to null
-	brain.forceMove(get_turf(src))
+	brain.forceMove(drop_location())
+	if(Adjacent(user))
+		user.put_in_hands(brain)
 	brain.organ_flags &= ~ORGAN_FROZEN
 	brain = null //No more brain in here
 

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -120,10 +120,7 @@
 	brain.brainmob = brainmob //Set the brain to use the brainmob
 	log_game("[key_name(user)] has ejected the brain of [key_name(brainmob)] from an MMI at [AREACOORD(src)]")
 	brainmob = null //Set mmi brainmob var to null
-	if(user)
-		user.put_in_hands(brain) //puts brain in the user's hand or otherwise drops it on the user's turf
-	else
-		brain.forceMove(get_turf(src))
+	brain.forceMove(get_turf(src))
 	brain.organ_flags &= ~ORGAN_FROZEN
 	brain = null //No more brain in here
 


### PR DESCRIPTION
Fixed telekinesis from teleporting the Blackbox, bodybags and all its contents, and brains from MMIs - Nari

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

as outlined in issue #55885, telekinesis was teleporting stuff like the blackbox, brains from an MMI, bodybags (including all the contents if bluespace) when activated with a telekinetic hand

fixed by simply having them drop onto the tile its on when using telekinesis, rather than enter the users hand

(the conflicts is caused by a broken PR that got merged, its not to do with my code so e)
https://user-images.githubusercontent.com/40489693/103470740-f85e2880-4d43-11eb-8f19-112a09b4d0a2.mp4


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

as neato as it is for a way to teleport your objective right to you, among other things, this is a bug with the way TK functions, and TK is just not feasible to overhaul for this

fixes #55885
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: Telekinesis no longer teleports the Blackbox, brains from an MMI, or bodybags with all its contents, directly to you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
