### PR TITLE
Fixes an issue in pipenet code caused by poor conversion

### DIFF
--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -182,7 +182,7 @@
 			var/self_temperature_delta = 0
 			var/sharer_temperature_delta = 0
 
-			if((sharer_heat_capacity <= 0) && (partial_heat_capacity <= 0))
+			if((sharer_heat_capacity <= 0) || (partial_heat_capacity <= 0))
 				return TRUE
 			var/heat = thermal_conductivity * delta_temperature * (partial_heat_capacity * sharer_heat_capacity / (partial_heat_capacity + sharer_heat_capacity))
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

We want to return if either sharer or partial is equal to or less then 0, not if they both are
Fixes a linter error introduced in #55514 by my web-edit

## Why It's Good For The Game

Fixes my undying shame
