### PR TITLE
Removes the ANIMATION_PARALLEL flag from floating and fixes another issue with the refactor.

### DIFF
--- a/code/datums/elements/movetype_handler.dm
+++ b/code/datums/elements/movetype_handler.dm
@@ -1,8 +1,12 @@
+#define DO_FLOATING_ANIM(target) \
+	animate(target, pixel_y = 2, time = 10, loop = -1, flags = ANIMATION_RELATIVE);\
+	animate(pixel_y = -2, time = 10, loop = -1, flags = ANIMATION_RELATIVE)
+
 /**
- * An element that enables and disables movetype bitflags as movetype traits are added and removed.
+ * An element that enables and disables movetype bitflags whenever the relative traits are added or removed.
  * It also handles the +2/-2 pixel y anim loop typical of mobs possessing the FLYING or FLOATING movetypes.
- * This element is necessary for the TRAIT_MOVE_ traits to work correctly. So make sure to include it when
- * manipulating those traits on non-living movables.
+ * This element is necessary for the TRAIT_MOVE_ traits to work correctly, so make sure to attach this element
+ * before adding them to non-living movables.
  */
 /datum/element/movetype_handler
 	element_flags = ELEMENT_DETACH
@@ -26,7 +30,7 @@
 	attached_atoms[movable_target] = TRUE
 
 	if(movable_target.movement_type & (FLOATING|FLYING) && !HAS_TRAIT(movable_target, TRAIT_NO_FLOATING_ANIM))
-		float(movable_target)
+		DO_FLOATING_ANIM(movable_target)
 
 /datum/element/movetype_handler/Detach(datum/source)
 	UnregisterSignal(source, list(
@@ -48,7 +52,7 @@
 	if(source.movement_type & flag)
 		return
 	if(!(source.movement_type & (FLOATING|FLYING)) && (trait == TRAIT_MOVE_FLYING || trait == TRAIT_MOVE_FLOATING) && !paused_floating_anim_atoms[source] && !HAS_TRAIT(source, TRAIT_NO_FLOATING_ANIM))
-		float(source)
+		DO_FLOATING_ANIM(source)
 	source.movement_type |= flag
 	SEND_SIGNAL(source, COMSIG_MOVETYPE_FLAG_ENABLED, flag)
 
@@ -72,7 +76,7 @@
 /datum/element/movetype_handler/proc/on_no_floating_anim_trait_loss(atom/movable/source, trait)
 	SIGNAL_HANDLER
 	if(source.movement_type & (FLOATING|FLYING) && !paused_floating_anim_atoms[source])
-		float(source)
+		DO_FLOATING_ANIM(source)
 
 ///Pauses the floating animation for the duration of the timer... plus [tickrate - (world.time + timer) % tickrate] to be precise.
 /datum/element/movetype_handler/proc/pause_floating_anim(atom/movable/source, timer)
@@ -86,19 +90,12 @@
 /datum/element/movetype_handler/process()
 	for(var/_paused in paused_floating_anim_atoms)
 		var/atom/movable/paused = _paused
-		if(!paused)
-			paused_floating_anim_atoms -= paused
-		else if(paused_floating_anim_atoms[paused] < world.time)
+		if(paused_floating_anim_atoms[paused] < world.time)
 			if(paused.movement_type & (FLOATING|FLYING) && !HAS_TRAIT(paused, TRAIT_NO_FLOATING_ANIM))
-				float(paused)
+				DO_FLOATING_ANIM(paused)
 			paused_floating_anim_atoms -= paused
 	if(!length(paused_floating_anim_atoms))
 		STOP_PROCESSING(SSdcs, src)
-
-///Floats the movable up and down. Not a comsig proc.
-/datum/element/movetype_handler/proc/float(atom/movable/target)
-	animate(target, pixel_y = 2, time = 10, loop = -1, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
-	animate(pixel_y = -2, time = 10, loop = -1, flags = ANIMATION_RELATIVE)
 
 /// Stops the above. Also not a comsig proc.
 /datum/element/movetype_handler/proc/stop_floating(atom/movable/target)
@@ -107,3 +104,5 @@
 		var/mob/living/living_target = target
 		final_pixel_y += living_target.body_position_pixel_y_offset
 	animate(target, pixel_y = final_pixel_y, time = 1 SECONDS)
+
+#undef DO_FLOATING_ANIM

--- a/code/datums/elements/movetype_handler.dm
+++ b/code/datums/elements/movetype_handler.dm
@@ -1,6 +1,6 @@
 #define DO_FLOATING_ANIM(target) \
-	animate(target, pixel_y = 2, time = 10, loop = -1, flags = ANIMATION_RELATIVE);\
-	animate(pixel_y = -2, time = 10, loop = -1, flags = ANIMATION_RELATIVE)
+	animate(target, pixel_y = 2, time = 1 SECONDS, loop = -1, flags = ANIMATION_RELATIVE);\
+	animate(pixel_y = -2, time = 1 SECONDS, flags = ANIMATION_RELATIVE)
 
 /**
  * An element that enables and disables movetype bitflags whenever the relative traits are added or removed.

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -60,9 +60,8 @@
 			ADD_TRAIT(src, TRAIT_IMMOBILIZED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
 
 /mob/living/carbon/on_movement_type_flag_enabled(datum/source, flag)
-	var/old_movetype = movement_type
 	. = ..()
-	if(flag & (FLYING | FLOATING) && !(old_movetype & (FLYING | FLOATING)))
+	if(flag & (FLYING | FLOATING) && (movement_type & (FLYING | FLOATING) == flag))
 		remove_movespeed_modifier(/datum/movespeed_modifier/limbless)
 		REMOVE_TRAIT(src, TRAIT_FLOORED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
 		REMOVE_TRAIT(src, TRAIT_IMMOBILIZED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -1,4 +1,4 @@
-sues//IMPORTANT: Multiple animate() calls do not stack well, so try to do them all at once if you can.
+//IMPORTANT: Multiple animate() calls do not stack well, so try to do them all at once if you can.
 /mob/living/carbon/update_transform()
 	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
 	var/final_pixel_y = pixel_y


### PR DESCRIPTION
## About The Pull Request
Lemon/Potato was kind enough to further stress test the refactor for me yesterday, and we came to the conclusion that the source of the constant crashes was the aforecited flag: The dozens and dozens of animate() calls with the flag enabled running in the same tick to be speficic. Typical grav gen going out scenario. It doesn't hurt to TM this before though, just to be sure.

I'm also fixing an oversight in `/mob/living/carbon/on_movement_type_flag_enabled`. Thanks for the issue report.
Also made the float() proc into a macro because of its simplicity. And edited a doc comment.

## Why It's Good For The Game
This will likely fix the constant gravgen related crashes, and surely close #55912.

## Changelog
:cl:
fix: Fixed high pop server crashes caused by the gravity generator going out.
fix: Paraplegics can once again stand up and shout! in zero G.
/:cl:
