### PR TITLE
Allows you to tuck the nuclear authentication disk (and plushes) into bed.

### DIFF
--- a/code/datums/elements/bed_tucking.dm
+++ b/code/datums/elements/bed_tucking.dm
@@ -1,0 +1,61 @@
+/// Tucking element, for things that can be tucked into bed.
+/datum/element/bed_tuckable
+	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	id_arg_index = 2
+	/// our pixel_x offset - how much the item moves x when in bed (+x is closer to the pillow)
+	var/x_offset = 0
+	/// our pixel_y offset - how much the item move y when in bed (-y is closer to the middle)
+	var/y_offset = 0
+	/// our rotation degree - how much the item turns when in bed (+degrees turns it more parallel)
+	var/rotation_degree = 0
+
+/datum/element/bed_tuckable/Attach(obj/target, x = 0, y = 0, rotation = 0)
+	. = ..()
+	if(!isobj(target))
+		return ELEMENT_INCOMPATIBLE
+
+	x_offset = x
+	y_offset = y
+	rotation_degree = rotation
+	RegisterSignal(target, COMSIG_ITEM_ATTACK_OBJ, .proc/tuck_into_bed)
+	if(rotation_degree)
+		RegisterSignal(target, COMSIG_ATOM_ATTACK_HAND, .proc/untuck)
+
+/datum/element/bed_tuckable/Detach(obj/target)
+	. = ..()
+	UnregisterSignal(target, COMSIG_ITEM_ATTACK_OBJ)
+	if(rotation_degree)
+		UnregisterSignal(target, COMSIG_ATOM_ATTACK_HAND)
+
+/** Tuck our object into bed.
+  *
+  * tucked - the object being tucked
+  * target_bed - the bed we're tucking them into
+  * tucker - the guy doing the tucking
+  */
+/datum/element/bed_tuckable/proc/tuck_into_bed(obj/item/tucked, obj/structure/bed/target_bed, mob/living/tucker)
+	SIGNAL_HANDLER
+
+	if(!istype(target_bed))
+		return
+
+	if(!tucker.transferItemToLoc(tucked, target_bed.drop_location()))
+		return
+
+	to_chat(tucker, "<span class='notice'>You lay [tucked] out on [target_bed].</span>")
+	tucked.pixel_x = x_offset
+	tucked.pixel_y = y_offset
+	if(rotation_degree)
+		tucked.transform = turn(tucked.transform, rotation_degree)
+
+	return COMPONENT_NO_AFTERATTACK
+
+/** If we specify a rotation for our object, then we need to un-rotate it when it's picked up
+  *
+  * tucked - the object that is tucked
+  */
+/datum/element/bed_tuckable/proc/untuck(obj/item/tucked)
+	SIGNAL_HANDLER
+
+	if(tucked.transform)
+		tucked.transform = null

--- a/code/datums/elements/bed_tucking.dm
+++ b/code/datums/elements/bed_tucking.dm
@@ -11,7 +11,7 @@
 
 /datum/element/bed_tuckable/Attach(obj/target, x = 0, y = 0, rotation = 0)
 	. = ..()
-	if(!isobj(target))
+	if(!isitem(target))
 		return ELEMENT_INCOMPATIBLE
 
 	x_offset = x

--- a/code/datums/elements/bed_tucking.dm
+++ b/code/datums/elements/bed_tucking.dm
@@ -18,21 +18,17 @@
 	y_offset = y
 	rotation_degree = rotation
 	RegisterSignal(target, COMSIG_ITEM_ATTACK_OBJ, .proc/tuck_into_bed)
-	if(rotation_degree)
-		RegisterSignal(target, COMSIG_ATOM_ATTACK_HAND, .proc/untuck)
 
 /datum/element/bed_tuckable/Detach(obj/target)
 	. = ..()
 	UnregisterSignal(target, COMSIG_ITEM_ATTACK_OBJ)
-	if(rotation_degree)
-		UnregisterSignal(target, COMSIG_ATOM_ATTACK_HAND)
 
 /** Tuck our object into bed.
-  *
-  * tucked - the object being tucked
-  * target_bed - the bed we're tucking them into
-  * tucker - the guy doing the tucking
-  */
+ *
+ * tucked - the object being tucked
+ * target_bed - the bed we're tucking them into
+ * tucker - the guy doing the tucking
+ */
 /datum/element/bed_tuckable/proc/tuck_into_bed(obj/item/tucked, obj/structure/bed/target_bed, mob/living/tucker)
 	SIGNAL_HANDLER
 
@@ -47,15 +43,16 @@
 	tucked.pixel_y = y_offset
 	if(rotation_degree)
 		tucked.transform = turn(tucked.transform, rotation_degree)
+		RegisterSignal(tucked, COMSIG_ITEM_PICKUP, .proc/untuck)
 
 	return COMPONENT_NO_AFTERATTACK
 
-/** If we specify a rotation for our object, then we need to un-rotate it when it's picked up
-  *
-  * tucked - the object that is tucked
-  */
+/** If we rotate our object, then we need to un-rotate it when it's picked up
+ *
+ * tucked - the object that is tucked
+ */
 /datum/element/bed_tuckable/proc/untuck(obj/item/tucked)
 	SIGNAL_HANDLER
 
-	if(tucked.transform)
-		tucked.transform = null
+	tucked.transform = turn(tucked.transform, -rotation_degree)
+	UnregisterSignal(tucked, COMSIG_ITEM_PICKUP)

--- a/code/datums/elements/bed_tucking.dm
+++ b/code/datums/elements/bed_tucking.dm
@@ -21,7 +21,7 @@
 
 /datum/element/bed_tuckable/Detach(obj/target)
 	. = ..()
-	UnregisterSignal(target, COMSIG_ITEM_ATTACK_OBJ)
+	UnregisterSignal(target, list(COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_PICKUP))
 
 /**
  * Tuck our object into bed.

--- a/code/datums/elements/bed_tucking.dm
+++ b/code/datums/elements/bed_tucking.dm
@@ -23,7 +23,8 @@
 	. = ..()
 	UnregisterSignal(target, COMSIG_ITEM_ATTACK_OBJ)
 
-/** Tuck our object into bed.
+/**
+ * Tuck our object into bed.
  *
  * tucked - the object being tucked
  * target_bed - the bed we're tucking them into
@@ -47,7 +48,8 @@
 
 	return COMPONENT_NO_AFTERATTACK
 
-/** If we rotate our object, then we need to un-rotate it when it's picked up
+/**
+ * If we rotate our object, then we need to un-rotate it when it's picked up
  *
  * tucked - the object that is tucked
  */

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -37,6 +37,7 @@
 /obj/item/toy/plush/Initialize()
 	. = ..()
 	AddComponent(/datum/component/squeak, squeak_override)
+	AddElement(/datum/element/bed_tuckable, 6, -5, 90)
 
 	//have we decided if Pinocchio goes in the blue or pink aisle yet?
 	if(gender == NEUTER)

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -40,16 +40,6 @@
 	if(W.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1))
 		W.play_tool_sound(src)
 		deconstruct(TRUE)
-	else if(istype(W, /obj/item/bedsheet))
-		if(user.transferItemToLoc(W, drop_location()))
-			to_chat(user, "<span class='notice'>You make \the [src] with [W].</span>")
-			W.pixel_x = 0
-			W.pixel_y = 0
-	else if(istype(W, /obj/item/disk/nuclear))
-		if(user.transferItemToLoc(W, drop_location()))
-			to_chat(user, "<span class='notice'>You lay [W] out on \the [src].</span>")
-			W.pixel_x = 6 //make sure they reach the pillow
-			W.pixel_y = -6
 	else
 		return ..()
 

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -41,15 +41,15 @@
 		W.play_tool_sound(src)
 		deconstruct(TRUE)
 	else if(istype(W, /obj/item/bedsheet))
-		to_chat(user, "<span class='notice'>You make \the [src] with [W].</span>")
-		user.transferItemToLoc(W, drop_location())
-		W.pixel_x = 0
-		W.pixel_y = 0
+		if(user.transferItemToLoc(W, drop_location()))
+			to_chat(user, "<span class='notice'>You make \the [src] with [W].</span>")
+			W.pixel_x = 0
+			W.pixel_y = 0
 	else if(istype(W, /obj/item/disk/nuclear))
-		to_chat(user, "<span class='notice'>You lay [W] out on \the [src].</span>")
-		user.transferItemToLoc(W, drop_location())
-		W.pixel_x = 6
-		W.pixel_y = -6
+		if(user.transferItemToLoc(W, drop_location()))
+			to_chat(user, "<span class='notice'>You lay [W] out on \the [src].</span>")
+			W.pixel_x = 6 //make sure they reach the pillow
+			W.pixel_y = -6
 	else
 		return ..()
 

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -40,6 +40,16 @@
 	if(W.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1))
 		W.play_tool_sound(src)
 		deconstruct(TRUE)
+	else if(istype(W, /obj/item/bedsheet))
+		to_chat(user, "<span class='notice'>You make \the [src] with [W].</span>")
+		user.transferItemToLoc(W, drop_location())
+		W.pixel_x = 0
+		W.pixel_y = 0
+	else if(istype(W, /obj/item/disk/nuclear))
+		to_chat(user, "<span class='notice'>You lay [W] out on \the [src].</span>")
+		user.transferItemToLoc(W, drop_location())
+		W.pixel_x = 6
+		W.pixel_y = -6
 	else
 		return ..()
 

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -27,6 +27,7 @@ LINEN BINS
 /obj/item/bedsheet/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/surgery_initiator, null)
+	AddElement(/datum/element/bed_tuckable, 0, 0, 0)
 
 /obj/item/bedsheet/attack_self(mob/user)
 	if(!user.CanReach(src))		//No telekenetic grabbing.

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -653,8 +653,6 @@ This is here to make the tiles around the station mininuke change when it's arme
 	var/turf/newturf = get_turf(src)
 
 	if(newturf && lastlocation == newturf)
-		/// Probability of ticking up lone op weight
-		var/lone_op_prob = 0.0001
 		/// How comfy is our disk?
 		var/disk_comfort_level = 0
 
@@ -663,19 +661,13 @@ This is here to make the tiles around the station mininuke change when it's arme
 			if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
 				disk_comfort_level++
 
-		//Sleep tight, disky.
-		if(disk_comfort_level >= 2)
-			if(SSticker.totalPlayers > 20)
-				lone_op_prob *= 2
-			else
-				lone_op_prob *= 0.5
-		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*lone_op_prob))
+		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 			if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
 				loneop.weight += 1
 				if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
 					if(disk_comfort_level >= 2)
-						message_admins("[src] is currently tucked in. The probability of Lone Operative ticking up has [(SSticker.totalPlayers > 20)? "doubled." : "halved."]")
+						visible_message("<span class='notice'> [src] sleeps soundly. Sleep tight, disky.</span>")
 					message_admins("[src] is stationary in [ADMIN_VERBOSEJMP(newturf)]. The weight of Lone Operative is now [loneop.weight].")
 				log_game("[src] is stationary for too long in [loc_name(newturf)], and has increased the weight of the Lone Operative event to [loneop.weight].")
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -667,7 +667,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 				loneop.weight += 1
 				if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
 					if(disk_comfort_level >= 2)
-						visible_message("<span class='notice'> [src] sleeps soundly. Sleep tight, disky.</span>")
+						visible_message("<span class='notice'>[src] sleeps soundly. Sleep tight, disky.</span>")
 					message_admins("[src] is stationary in [ADMIN_VERBOSEJMP(newturf)]. The weight of Lone Operative is now [loneop.weight].")
 				log_game("[src] is stationary for too long in [loc_name(newturf)], and has increased the weight of the Lone Operative event to [loneop.weight].")
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -649,7 +649,6 @@ This is here to make the tiles around the station mininuke change when it's arme
 		STOP_PROCESSING(SSobj, src)
 		CRASH("A fake nuke disk tried to call process(). Who the fuck and how the fuck")
 	var/turf/newturf = get_turf(src)
-	var/area/currentarea = get_area(newturf)
 
 	if(newturf && lastlocation == newturf)
 		/// How comfy is our disk?
@@ -659,10 +658,6 @@ This is here to make the tiles around the station mininuke change when it's arme
 		for(var/obj/comfort_item in loc)
 			if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
 				disk_comfort_level++
-
-		//Nice rooms count, too
-		if(currentarea?.beauty >= BEAUTY_LEVEL_GOOD)
-			disk_comfort_level++
 
 		if(disk_comfort_level >= 2) //Sleep tight, disky.
 			return

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -663,7 +663,8 @@ This is here to make the tiles around the station mininuke change when it's arme
 			if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
 				disk_comfort_level++
 
-		if(disk_comfort_level >= 2) //Sleep tight, disky.
+ 		//Sleep tight, disky.
+		if(disk_comfort_level >= 2)
 			if(SSticker.totalPlayers > 20)
 				lone_op_prob *= 2
 			else
@@ -673,6 +674,8 @@ This is here to make the tiles around the station mininuke change when it's arme
 			if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
 				loneop.weight += 1
 				if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
+					if(disk_comfort_level >= 2)
+						message_admins("[src] currently tucked in. The probability of Lone Operative ticking up has [(SSticker.totalPlayers > 20)? "Doubled." : "Halved."]")
 					message_admins("[src] is stationary in [ADMIN_VERBOSEJMP(newturf)]. The weight of Lone Operative is now [loneop.weight].")
 				log_game("[src] is stationary for too long in [loc_name(newturf)], and has increased the weight of the Lone Operative event to [loneop.weight].")
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -635,6 +635,8 @@ This is here to make the tiles around the station mininuke change when it's arme
 
 /obj/item/disk/nuclear/Initialize()
 	. = ..()
+	AddElement(/datum/element/bed_tuckable, 6, -6, 0)
+
 	if(!fake)
 		GLOB.poi_list |= src
 		last_disk_move = world.time
@@ -651,6 +653,8 @@ This is here to make the tiles around the station mininuke change when it's arme
 	var/turf/newturf = get_turf(src)
 
 	if(newturf && lastlocation == newturf)
+		/// Probability of ticking up lone op weight
+		var/lone_op_prob = 0.0001
 		/// How comfy is our disk?
 		var/disk_comfort_level = 0
 
@@ -660,8 +664,11 @@ This is here to make the tiles around the station mininuke change when it's arme
 				disk_comfort_level++
 
 		if(disk_comfort_level >= 2) //Sleep tight, disky.
-			return
-		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
+			if(SSticker.totalPlayers > 20)
+				lone_op_prob *= 2
+			else
+				lone_op_prob *= 0.5
+		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*lone_op_prob))
 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 			if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
 				loneop.weight += 1

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -663,7 +663,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 			if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
 				disk_comfort_level++
 
- 		//Sleep tight, disky.
+		//Sleep tight, disky.
 		if(disk_comfort_level >= 2)
 			if(SSticker.totalPlayers > 20)
 				lone_op_prob *= 2
@@ -675,7 +675,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 				loneop.weight += 1
 				if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
 					if(disk_comfort_level >= 2)
-						message_admins("[src] currently tucked in. The probability of Lone Operative ticking up has [(SSticker.totalPlayers > 20)? "Doubled." : "Halved."]")
+						message_admins("[src] is currently tucked in. The probability of Lone Operative ticking up has [(SSticker.totalPlayers > 20)? "doubled." : "halved."]")
 					message_admins("[src] is stationary in [ADMIN_VERBOSEJMP(newturf)]. The weight of Lone Operative is now [loneop.weight].")
 				log_game("[src] is stationary for too long in [loc_name(newturf)], and has increased the weight of the Lone Operative event to [loneop.weight].")
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -649,7 +649,23 @@ This is here to make the tiles around the station mininuke change when it's arme
 		STOP_PROCESSING(SSobj, src)
 		CRASH("A fake nuke disk tried to call process(). Who the fuck and how the fuck")
 	var/turf/newturf = get_turf(src)
+	var/area/currentarea = get_area(newturf)
+
 	if(newturf && lastlocation == newturf)
+		/// How comfy is our disk?
+		var/disk_comfort_level = 0
+
+		//Go through and check for items that make disk comfy
+		for(var/obj/comfort_item in loc)
+			if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
+				disk_comfort_level++
+
+		//Nice rooms count, too
+		if(currentarea?.beauty >= BEAUTY_LEVEL_GOOD)
+			disk_comfort_level++
+
+		if(disk_comfort_level >= 2) //Sleep tight, disky.
+			return
 		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 			if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -571,6 +571,7 @@
 #include "code\datums\diseases\advance\symptoms\youth.dm"
 #include "code\datums\elements\_element.dm"
 #include "code\datums\elements\art.dm"
+#include "code\datums\elements\bed_tucking.dm"
 #include "code\datums\elements\bsa_blocker.dm"
 #include "code\datums\elements\cleaning.dm"
 #include "code\datums\elements\decal.dm"


### PR DESCRIPTION
## About The Pull Request

Adds an element, the tuckable element. Objects with this element can be tucked into bed by hitting a bed with it.

You can now make beds by hitting them with a blanket.
You can now tuck plushes into bed.
You can now tuck the disk into bed, too.

![image](https://user-images.githubusercontent.com/51863163/103595308-b3abcc00-4ec0-11eb-88bc-92c6e1d78af5.png)


## Why It's Good For The Game

Disky has been on watch for almost two decades, and no one has allowed them to rest. Sleep tight, disky.

## Changelog
:cl: Melbert
add: You can now make beds with blankets.
add: You can now tuck plushes into bed. 
add: You can also tuck the nuclear authentication disk into bed. Sleep tight, disky.
/:cl:

