### PR TITLE
Allow Markdown files to have trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ indent_size = 2
 
 [*.py]
 indent_style = space
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows markdown files to have trailing whitespace preceding newline characters.
This enables non-paragraph newlines to be used, as they are made in markdown by ending a line with two space characters.
Example:
![image](https://user-images.githubusercontent.com/6952402/103592402-42d1d780-4ef3-11eb-93f1-2e86c4caf9b1.png)


Please see the [original markdown specification](https://daringfireball.net/projects/markdown/syntax#p) for more details.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not good for the game, but having access to non-paragraph newlines would be really nice to make prettier readmes and whatnot.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
