### PR TITLE
Adds 25 person pop requirement for Sleeping Carp

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -597,6 +597,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat \
 			and gain the ability to swat bullets from the air, but you will also refuse to use dishonorable ranged weaponry."
 	item = /obj/item/book/granter/martial/carp
+	player_minimum = 25
 	cost = 13
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)


### PR DESCRIPTION
## About The Pull Request
!!IDED TERRITORY YE HATH ENTERED THY SALT ZONE!!
Adds a 25 person purchasing limit to the Sleeping Carp scroll. This brings it in line with a other murderbone items like deswords.

## Why It's Good For The Game

As of late, I've noticed a trend on lowpop. Some will buy carp and kill the majority of the station, unable to be opposed as there are very few able to. This is unfun and I find it to be unbalanced, given how strong carp is in one-on-one engagements.

## Changelog
:cl:
balance: Sleeping Carp now needs 25 pop to buy.
/:cl: