### PR TITLE
[READY] A victory for revolutionaries will no longer end the round on dynamic, instead no new security and command will be allowed to join

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -14,6 +14,7 @@
 #define ROLE_MALF				"Malf AI"
 #define ROLE_REV				"Revolutionary"
 #define ROLE_REV_HEAD			"Head Revolutionary"
+#define ROLE_REV_SUCCESSFUL		"Victorious Revolutionary"
 #define ROLE_ALIEN				"Xenomorph"
 #define ROLE_PAI				"pAI"
 #define ROLE_CULTIST			"Cultist"

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -30,11 +30,13 @@ SUBSYSTEM_DEF(job)
 	var/datum/job/new_overflow = GetJob(new_overflow_role)
 	var/cap = CONFIG_GET(number/overflow_cap)
 
+	new_overflow.allow_bureaucratic_error = FALSE
 	new_overflow.spawn_positions = cap
 	new_overflow.total_positions = cap
 
 	if(new_overflow_role != overflow_role)
 		var/datum/job/old_overflow = GetJob(overflow_role)
+		old_overflow.allow_bureaucratic_error = initial(old_overflow.allow_bureaucratic_error)
 		old_overflow.spawn_positions = initial(old_overflow.spawn_positions)
 		old_overflow.total_positions = initial(old_overflow.total_positions)
 		overflow_role = new_overflow_role

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -80,6 +80,9 @@
 	///Skill multiplier list, just slap your multiplier change onto this with the type it is coming from as key.
 	var/list/experience_multiplier_reasons = list()
 
+	/// A lazy list of statuses to add next to this mind in the traitor panel
+	var/list/special_statuses
+
 /datum/mind/New(_key)
 	key = _key
 	martial_art = default_martial_art

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -190,10 +190,6 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 // Checks if there are HIGHLANDER_RULESETs and calls the rule's round_result() proc
 /datum/game_mode/dynamic/set_round_result()
-	for(var/datum/dynamic_ruleset/rule in executed_rules)
-		if(rule.flags & HIGHLANDER_RULESET)
-			if(rule.check_finished()) // Only the rule that actually finished the round sets round result.
-				return rule.round_result()
 	// If it got to this part, just pick one highlander if it exists
 	for(var/datum/dynamic_ruleset/rule in executed_rules)
 		if(rule.flags & HIGHLANDER_RULESET)
@@ -250,9 +246,6 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		return TRUE
 	if(force_ending)
 		return TRUE
-	for(var/datum/dynamic_ruleset/rule in executed_rules)
-		if(rule.flags & HIGHLANDER_RULESET)
-			return rule.check_finished()
 
 /datum/game_mode/dynamic/proc/show_threatlog(mob/admin)
 	if(!SSticker.HasRoundStarted())

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -182,11 +182,6 @@
 /// Only called if ruleset is flagged as HIGHLANDER_RULESET
 /datum/dynamic_ruleset/proc/round_result()
 
-/// Checks if round is finished, return true to end the round.
-/// Only called if ruleset is flagged as HIGHLANDER_RULESET
-/datum/dynamic_ruleset/proc/check_finished()
-	return FALSE
-
 //////////////////////////////////////////////
 //                                          //
 //           ROUNDSTART RULESETS            //

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -86,6 +86,8 @@
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/revs)
 	var/required_heads_of_staff = 3
 	var/finished = FALSE
+	/// How much threat should be injected when the revolution wins?
+	var/revs_win_threat_injection = 20
 	var/datum/team/revolution/revolution
 
 /datum/dynamic_ruleset/latejoin/provocateur/ready(forced=FALSE)
@@ -120,7 +122,7 @@
 		return FALSE
 
 /datum/dynamic_ruleset/latejoin/provocateur/rule_process()
-	var/winner = revolution.process_victory()
+	var/winner = revolution.process_victory(revs_win_threat_injection)
 	if (isnull(winner))
 		return
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -112,7 +112,7 @@
 		new_head = M.mind.add_antag_datum(new_head, revolution)
 		revolution.update_objectives()
 		revolution.update_heads()
-		SSshuttle.registerHostileEnvironment(src)
+		SSshuttle.registerHostileEnvironment(revolution)
 		return TRUE
 	else
 		log_game("DYNAMIC: [ruletype] [name] discarded [M.name] from head revolutionary due to ineligibility.")

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -120,29 +120,12 @@
 		return FALSE
 
 /datum/dynamic_ruleset/latejoin/provocateur/rule_process()
-	if(check_rev_victory())
-		finished = REVOLUTION_VICTORY
-		return RULESET_STOP_PROCESSING
-	else if (check_heads_victory())
-		finished = STATION_VICTORY
-		SSshuttle.clearHostileEnvironment(src)
-		revolution.save_members()
-		for(var/datum/mind/M in revolution.members)	// Remove antag datums and prevents podcloned or exiled headrevs restarting rebellions.
-			if(M.has_antag_datum(/datum/antagonist/rev/head))
-				var/datum/antagonist/rev/head/R = M.has_antag_datum(/datum/antagonist/rev/head)
-				R.remove_revolutionary(FALSE, "gamemode")
-				if(M.current)
-					var/mob/living/carbon/C = M.current
-					if(istype(C) && C.stat == DEAD)
-						C.makeUncloneable()
-			if(M.has_antag_datum(/datum/antagonist/rev))
-				var/datum/antagonist/rev/R = M.has_antag_datum(/datum/antagonist/rev)
-				R.remove_revolutionary(FALSE, "gamemode")
-		priority_announce("It appears the mutiny has been quelled. Please return yourself and your incapacitated colleagues to work. \
-			We have remotely blacklisted the head revolutionaries in your medical records to prevent accidental revival.", null, 'sound/ai/attention.ogg', null, "Central Command Loyalty Monitoring Division")
-		return RULESET_STOP_PROCESSING
+	var/winner = revolution.process_victory()
+	if (isnull(winner))
+		return
 
-
+	finished = winner
+	return RULESET_STOP_PROCESSING
 
 /// Checks for revhead loss conditions and other antag datums.
 /datum/dynamic_ruleset/latejoin/provocateur/proc/check_eligible(datum/mind/M)
@@ -151,33 +134,8 @@
 		return TRUE
 	return FALSE
 
-/datum/dynamic_ruleset/latejoin/provocateur/check_finished()
-	if(finished == REVOLUTION_VICTORY)
-		return TRUE
-	else
-		return ..()
-
-/datum/dynamic_ruleset/latejoin/provocateur/proc/check_rev_victory()
-	for(var/datum/objective/mutiny/objective in revolution.objectives)
-		if(!(objective.check_completion()))
-			return FALSE
-	return TRUE
-
-/datum/dynamic_ruleset/latejoin/provocateur/proc/check_heads_victory()
-	for(var/datum/mind/rev_mind in revolution.head_revolutionaries())
-		var/turf/T = get_turf(rev_mind.current)
-		if(!considered_afk(rev_mind) && considered_alive(rev_mind) && is_station_level(T.z))
-			if(ishuman(rev_mind.current))
-				return FALSE
-	return TRUE
-
 /datum/dynamic_ruleset/latejoin/provocateur/round_result()
-	if(finished == REVOLUTION_VICTORY)
-		SSticker.mode_result = "win - heads killed"
-		SSticker.news_report = REVS_WIN
-	else if(finished == STATION_VICTORY)
-		SSticker.mode_result = "loss - rev heads killed"
-		SSticker.news_report = REVS_LOSE
+	revolution.round_result(finished)
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -380,6 +380,8 @@
 	blocking_rules = list(/datum/dynamic_ruleset/latejoin/provocateur)
 	// I give up, just there should be enough heads with 35 players...
 	minimum_players = 35
+	/// How much threat should be injected when the revolution wins?
+	var/revs_win_threat_injection = 20
 	var/datum/team/revolution/revolution
 	var/finished = FALSE
 
@@ -422,7 +424,7 @@
 	..()
 
 /datum/dynamic_ruleset/roundstart/revs/rule_process()
-	var/winner = revolution.process_victory()
+	var/winner = revolution.process_victory(revs_win_threat_injection)
 	if (isnull(winner))
 		return
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -422,27 +422,12 @@
 	..()
 
 /datum/dynamic_ruleset/roundstart/revs/rule_process()
-	if(check_rev_victory())
-		finished = REVOLUTION_VICTORY
-		return RULESET_STOP_PROCESSING
-	else if (check_heads_victory())
-		finished = STATION_VICTORY
-		SSshuttle.clearHostileEnvironment(src)
-		revolution.save_members()
-		for(var/datum/mind/M in revolution.members)	// Remove antag datums and prevents podcloned or exiled headrevs restarting rebellions.
-			if(M.has_antag_datum(/datum/antagonist/rev/head))
-				var/datum/antagonist/rev/head/R = M.has_antag_datum(/datum/antagonist/rev/head)
-				R.remove_revolutionary(FALSE, "gamemode")
-				if(M.current)
-					var/mob/living/carbon/C = M.current
-					if(istype(C) && C.stat == DEAD)
-						C.makeUncloneable()
-			if(M.has_antag_datum(/datum/antagonist/rev))
-				var/datum/antagonist/rev/R = M.has_antag_datum(/datum/antagonist/rev)
-				R.remove_revolutionary(FALSE, "gamemode")
-		priority_announce("It appears the mutiny has been quelled. Please return yourself and your incapacitated colleagues to work. \
-			We have remotely blacklisted the head revolutionaries in your medical records to prevent accidental revival.", null, 'sound/ai/attention.ogg', null, "Central Command Loyalty Monitoring Division")
-		return RULESET_STOP_PROCESSING
+	var/winner = revolution.process_victory()
+	if (isnull(winner))
+		return
+
+	finished = winner
+	return RULESET_STOP_PROCESSING
 
 /// Checks for revhead loss conditions and other antag datums.
 /datum/dynamic_ruleset/roundstart/revs/proc/check_eligible(datum/mind/M)
@@ -451,33 +436,8 @@
 		return TRUE
 	return FALSE
 
-/datum/dynamic_ruleset/roundstart/revs/check_finished()
-	if(finished == REVOLUTION_VICTORY)
-		return TRUE
-	else
-		return ..()
-
-/datum/dynamic_ruleset/roundstart/revs/proc/check_rev_victory()
-	for(var/datum/objective/mutiny/objective in revolution.objectives)
-		if(!(objective.check_completion()))
-			return FALSE
-	return TRUE
-
-/datum/dynamic_ruleset/roundstart/revs/proc/check_heads_victory()
-	for(var/datum/mind/rev_mind in revolution.head_revolutionaries())
-		var/turf/T = get_turf(rev_mind.current)
-		if(!considered_afk(rev_mind) && considered_alive(rev_mind) && is_station_level(T.z))
-			if(ishuman(rev_mind.current))
-				return FALSE
-	return TRUE
-
 /datum/dynamic_ruleset/roundstart/revs/round_result()
-	if(finished == REVOLUTION_VICTORY)
-		SSticker.mode_result = "win - heads killed"
-		SSticker.news_report = REVS_WIN
-	else if(finished == STATION_VICTORY)
-		SSticker.mode_result = "loss - rev heads killed"
-		SSticker.news_report = REVS_LOSE
+	revolution.round_result(finished)
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -412,7 +412,7 @@
 	if(revolution.members.len)
 		revolution.update_objectives()
 		revolution.update_heads()
-		SSshuttle.registerHostileEnvironment(src)
+		SSshuttle.registerHostileEnvironment(revolution)
 		return TRUE
 	log_game("DYNAMIC: [ruletype] [name] failed to get any eligible headrevs. Refunding [cost] threat.")
 	return FALSE

--- a/code/modules/admin/antag_panel.dm
+++ b/code/modules/admin/antag_panel.dm
@@ -77,7 +77,7 @@ GLOBAL_VAR(antag_prototypes)
 	return common_commands
 
 /datum/mind/proc/get_special_statuses()
-	var/list/result = list()
+	var/list/result = LAZYCOPY(special_statuses)
 	if(!current)
 		result += "<span class='bad'>No body!</span>"
 	if(current && HAS_TRAIT(current, TRAIT_MINDSHIELD))

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -205,9 +205,20 @@
 	new_rev.silent = FALSE
 	to_chat(old_owner, "<span class='userdanger'>Revolution has been disappointed of your leader traits! You are a regular revolutionary now!</span>")
 
+/// Checks if the revolution succeeded, and lets them know.
+/datum/antagonist/rev/proc/announce_victorious()
+	. = rev_team.check_rev_victory()
+
+	if (!.)
+		return
+
+	to_chat(owner, "<span class='deconversion_message bold'>[victory_message]</span>")
+	var/policy = get_policy(ROLE_REV_SUCCESSFUL)
+	if (policy)
+		to_chat(owner, policy)
+
 /datum/antagonist/rev/farewell()
-	if (rev_team.check_rev_victory())
-		to_chat(owner, "<span class='deconversion_message bold'>[victory_message]</span>")
+	if (announce_victorious())
 		return
 
 	if(ishuman(owner.current))
@@ -218,8 +229,7 @@
 		to_chat(owner, "<span class='userdanger'>The frame's firmware detects and deletes your neural reprogramming! You remember nothing but the name of the one who flashed you.</span>")
 
 /datum/antagonist/rev/head/farewell()
-	if (rev_team.check_rev_victory())
-		to_chat(owner, "<span class='deconversion_message bold'>[victory_message]</span>")
+	if (announce_victorious())
 		return
 
 	if((ishuman(owner.current)))

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -426,6 +426,7 @@
 
 		for (var/job_name in GLOB.command_positions + GLOB.security_positions)
 			var/datum/job/job = SSjob.GetJob(job_name)
+			job.allow_bureaucratic_error = FALSE
 			job.total_positions = 0
 
 		if (revs_win_injection_amount)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -420,18 +420,6 @@
 
 	result += "<div class='panel redborder'>"
 
-	var/num_revs = 0
-	var/num_survivors = 0
-	for(var/mob/living/carbon/survivor in GLOB.alive_mob_list)
-		if(survivor.ckey)
-			num_survivors++
-			if(survivor.mind)
-				if(is_revolutionary(survivor))
-					num_revs++
-	if(num_survivors)
-		result += "Command's Approval Rating: <B>[100 - round((num_revs/num_survivors)*100, 0.1)]%</B><br>"
-
-
 	var/list/targets = list()
 	var/list/datum/mind/headrevs
 	var/list/datum/mind/revs
@@ -444,6 +432,17 @@
 		revs = ex_revs
 	else
 		revs = get_antag_minds(/datum/antagonist/rev, TRUE)
+
+	var/num_revs = 0
+	var/num_survivors = 0
+	for(var/mob/living/carbon/survivor in GLOB.alive_mob_list)
+		if(survivor.ckey)
+			num_survivors += 1
+			if ((survivor.mind in revs) || (survivor.mind in headrevs))
+				num_revs += 1
+
+	if(num_survivors)
+		result += "Command's Approval Rating: <B>[100 - round((num_revs/num_survivors)*100, 0.1)]%</B><br>"
 
 	if(headrevs.len)
 		var/list/headrev_part = list()

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -364,6 +364,7 @@
 		if (rev_mind.has_antag_datum(/datum/antagonist/rev))
 			var/datum/antagonist/rev/rev_antag = rev_mind.has_antag_datum(/datum/antagonist/rev)
 			rev_antag.remove_revolutionary(FALSE, . == STATION_VICTORY ? DECONVERTER_STATION_WIN : DECONVERTER_REVS_WIN)
+			LAZYADD(rev_mind.special_statuses, "<span class='bad'>Former [(rev_mind in ex_headrevs) ? "head revolutionary" : "revolutionary"]</span>")
 
 	if (. == STATION_VICTORY)
 		// If the revolution was quelled, make rev heads unable to be revived through pods

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -270,6 +270,21 @@
 		S.Insert(C)
 		to_chat(C, "Your eyes have been implanted with a cybernetic security HUD which will help you keep track of who is mindshield-implanted, and therefore unable to be recruited.")
 
+/// "Enemy of the Revolutionary", given to heads and security when the revolution wins
+/datum/antagonist/revolution_enemy
+	name = "Enemy of the Revolution"
+	show_in_antagpanel = FALSE
+
+/datum/antagonist/revolution_enemy/on_gain()
+	owner.special_role = "revolution enemy"
+
+	var/datum/objective/survive/survive = new /datum/objective/survive
+	survive.owner = owner
+	survive.explanation_text = "The station has been overrun by revolutionaries, stay alive until the end."
+	objectives += survive
+
+	return ..()
+
 /datum/team/revolution
 	name = "Revolution"
 	var/max_headrevs = 3
@@ -384,12 +399,20 @@
 			if (isnull(mind))
 				continue
 
-			if (!(mind.assigned_role in GLOB.command_positions))
+			if (!(mind.assigned_role in GLOB.command_positions + GLOB.security_positions))
 				continue
 
-			var/mob/living/carbon/head_body = mind.current
-			if (istype(head_body) && head_body.stat == DEAD)
-				head_body.makeUncloneable()
+			var/mob/living/carbon/target_body = mind.current
+
+			mind.add_antag_datum(/datum/antagonist/revolution_enemy)
+
+			if (!istype(target_body))
+				continue
+
+			if (target_body.stat == DEAD)
+				target_body.makeUncloneable()
+			else
+				mind.announce_objectives()
 
 		for (var/job_name in GLOB.command_positions + GLOB.security_positions)
 			var/datum/job/job = SSjob.GetJob(job_name)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -346,7 +346,8 @@
 
 /// Updates the state of the world depending on if revs won or loss.
 /// Returns who won, at which case this method should no longer be called.
-/datum/team/revolution/proc/process_victory()
+/// If revs_win_injection_amount is passed, then that amount of threat will be added if the revs win.
+/datum/team/revolution/proc/process_victory(revs_win_injection_amount)
 	if (check_rev_victory())
 		. = REVOLUTION_VICTORY
 	else if (check_heads_victory())
@@ -392,6 +393,11 @@
 		for (var/job_name in GLOB.command_positions + GLOB.security_positions)
 			var/datum/job/job = SSjob.GetJob(job_name)
 			job.total_positions = 0
+
+		if (revs_win_injection_amount)
+			var/datum/game_mode/dynamic/dynamic = SSticker.mode
+			dynamic.create_threat(revs_win_injection_amount)
+			dynamic.threat_log += "[worldtime2text()]: Revolution victory. Added [revs_win_injection_amount] threat."
 
 		priority_announce("A recent assessment of your station has marked your station as a severe risk area for high ranking Nanotrasen officials. \
 		For the safety of our staff, we have blacklisted your station for new employment of security and command. \

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -14,7 +14,7 @@
 	var/datum/team/revolution/rev_team
 
 	/// What message should the player receive when they are being demoted, and the revolution has won?
-	var/victory_message = "The revolution has overpowered the command staff! Viva la revolution!"
+	var/victory_message = "The revolution has overpowered the command staff! Viva la revolution! Execute any head of staff and security should you find them alive."
 
 /datum/antagonist/rev/can_be_owned(datum/mind/new_owner)
 	. = ..()

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -18,13 +18,13 @@
 		overflow.total_positions = -1 // Ensures infinite slots as this role. Assistant will still be open for those that cant play it.
 		for(var/job in jobs)
 			var/datum/job/current = job
-			if(current.title == "AI" || current.title == SSjob.overflow_role) // AI currently doesnt support latejoining past one total.
+			if(!current.allow_bureaucratic_error)
 				continue
 			current.total_positions = 0
 	else	// Adds/removes a random amount of job slots from all jobs.
 		for(var/job in jobs)
 			var/datum/job/current = job
-			if(current.title == "AI" || current.title == SSjob.overflow_role) // AI currently doesnt support latejoining past one total.
+			if(!current.allow_bureaucratic_error)
 				continue
 			var/ran = rand(-2,4)
 			current.total_positions = max(current.total_positions + ran, 0)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -65,6 +65,9 @@
 
 	var/bounty_types = CIV_JOB_BASIC
 
+	/// Should this job be allowed to be picked for the bureaucratic error event?
+	var/allow_bureaucratic_error = TRUE
+
 /datum/job/New()
 	. = ..()
 	var/list/jobs_changes = GetMapChanges()

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -12,6 +12,7 @@
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SILICON
 	display_order = JOB_DISPLAY_ORDER_AI
+	allow_bureaucratic_error = FALSE
 	var/do_special_check = TRUE
 
 /datum/job/ai/equip(mob/living/carbon/human/H, visualsOnly, announce, latejoin, datum/outfit/outfit_override, client/preference_source = null)

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -1,48 +1,11 @@
 {
 	"Dynamic": {},
 	"Roundstart": {
-		"Traitors": {
-			"cost": 10,
-			"scaling_cost": 10,
-			"weight": 5,
+		"Revolution": {
 			"required_candidates": 1,
-			"minimum_required_age": 0,
-			"requirements": [
-				10,
-				10,
-				10,
-				10,
-				10,
-				10,
-				10,
-				10,
-				10,
-				10
-			],
-			"antag_cap": [
-				1,
-				1,
-				1,
-				2,
-				2,
-				2,
-				3,
-				3,
-				3,
-				3
-			],
-			"protected_roles": [
-				"Prisoner",
-				"Security Officer",
-				"Warden",
-				"Detective",
-				"Head of Security",
-				"Captain"
-			],
-			"restricted_roles": [
-				"Cyborg"
-			],
-			"autotraitor_cooldown": 450
+			"minimum_players": 1,
+			"delay": 0,
+			"antag_cap": [1,1,1,1,1,1,1,1,1,1]
 		}
 	},
 	"Midround": {},

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -1,11 +1,48 @@
 {
 	"Dynamic": {},
 	"Roundstart": {
-		"Revolution": {
+		"Traitors": {
+			"cost": 10,
+			"scaling_cost": 10,
+			"weight": 5,
 			"required_candidates": 1,
-			"minimum_players": 1,
-			"delay": 0,
-			"antag_cap": [1,1,1,1,1,1,1,1,1,1]
+			"minimum_required_age": 0,
+			"requirements": [
+				10,
+				10,
+				10,
+				10,
+				10,
+				10,
+				10,
+				10,
+				10,
+				10
+			],
+			"antag_cap": [
+				1,
+				1,
+				1,
+				2,
+				2,
+				2,
+				3,
+				3,
+				3,
+				3
+			],
+			"protected_roles": [
+				"Prisoner",
+				"Security Officer",
+				"Warden",
+				"Detective",
+				"Head of Security",
+				"Captain"
+			],
+			"restricted_roles": [
+				"Cyborg"
+			],
+			"autotraitor_cooldown": 450
 		}
 	},
 	"Midround": {},

--- a/strings/anti_union_propaganda.txt
+++ b/strings/anti_union_propaganda.txt
@@ -1,0 +1,4 @@
+Remember, union dues cost around 70,000 credits a year. A new video game system with the latest hits sounds like fun. Put your money towards that instead of paying dues to the union.
+Remember, tickets & food to the Toolbox Tournament aren't cheap. That money in union dues you'd be paying every year could sure go a long way.
+Remember, nothing's more enjoyable than a night out watching a thunderdome match with your buddies. All those union dues you pay every year could buy a few rounds.
+Nanotrasen's open door policy is designed to help you feel comfortable taking up issues to your assigned head of staff. It's hard for us to maintain this when they're dead.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently, a victory for revoutionaries leads to the round abruptly ending on dynamic. This has been replaced by all revolutionaries being deconverted, and no new security or command positions being available.

Also attempts to unionize (pun intended) copy and paste code in the round start and late join revolutionary rulesets into being handled under the revolutionary team instead.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Revolutionaries is unique in that it is the only antagonist on dynamic that will end the round in a livable state (cult and nuclear operative wins end the round, of course). This generally leads to very abrupt rounds, not just falling far behind what we'd like rounds to end at but also simply just feeling anticlimactic for people not involved in the final killing. What follows is usually a few people asking why the round ended, proving the unintuitive behavior.

Plus, I simply like the flavor of a lawless station, run by the wielders of makeshift weapons used to kill command. But you know, it's actually intentional this time.

## Remaining work
- [x] Give security officers (and command who may have just bailed) a survive objective (@Cyberboss).
- [x] Make the revs victory policy text in an admin configurable setting.
- [x] Change method of blocking them from joining so bureaucratic error doesn't allow more in. (And double check this doesn't let you add more).
- [x] Show former rev in traitor panel, for admins.
- [x] Fix Command's Approval Rating being 100% on revs victory.
- [x] Play testing, **if you are interested in merging this PR let me know so I can run a test merge of it**.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: A victory for revolutionaries will no longer end the round on dynamic, instead no new security and command will be allowed to join.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
