### PR TITLE
Get hearers in view faster with 0 range

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -217,34 +217,8 @@
 
 	return
 
-/proc/get_hearers_in_view_old(R, atom/source)
-	// Returns a list of hearers in view(R) from source (ignoring luminosity). Used in saycode.
-	var/turf/T = get_turf(source)
-	. = list()
-	if(!T)
-		return
-	var/list/processing_list = list()
-	if (R == 0) // if the range is zero, we know exactly where to look for, we can skip view
-		processing_list += T.contents // We can shave off one iteration by assuming turfs cannot hear
-	else  // A variation of get_hear inlined here to take advantage of the compiler's fastpath for obj/mob in view
-		var/lum = T.luminosity
-		T.luminosity = 6 // This is the maximum luminosity
-		for(var/mob/M in view(R, T))
-			processing_list += M
-		for(var/obj/O in view(R, T))
-			processing_list += O
-		T.luminosity = lum
-
-	var/i = 0
-	while(i < length(processing_list)) // recursive_hear_check inlined here
-		var/atom/A = processing_list[++i]
-		if(A.flags_1 & HEAR_1)
-			. += A
-			SEND_SIGNAL(A, COMSIG_ATOM_HEARER_IN_VIEW, .)
-		processing_list += A.contents
-
+///Returns a list of hearers in view(R) from source (ignoring luminosity). Used in saycode.
 /proc/get_hearers_in_view(range, atom/source)
-	// Returns a list of hearers in view(R) from source (ignoring luminosity). Used in saycode.
 	var/turf/T = get_turf(source)
 
 	if (range == 0) // if the range is zero, we know exactly where to look for, we can skip view
@@ -265,20 +239,6 @@
 		if(A.flags_1 & HEAR_1)
 			SEND_SIGNAL(A, COMSIG_ATOM_HEARER_IN_VIEW, .)
 		. += A.contents
-
-/client/verb/brbrb()
-	set category = "sss"
-	set name = "sssss"
-	for(var/i=1 to 5000)
-		get_hearers_in_view(5, get_turf(mob))
-		get_hearers_in_view_old(5, get_turf(mob))
-
-/client/verb/ddd()
-	set category = "ddd"
-	set name = "dddddd"
-	for(var/i=1 to 5000)
-		get_hearers_in_view(0, get_turf(mob))
-		get_hearers_in_view_old(0, get_turf(mob))
 
 /proc/get_mobs_in_radio_ranges(list/obj/item/radio/radios)
 	. = list()

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -217,7 +217,7 @@
 
 	return
 
-/proc/get_hearers_in_view(R, atom/source)
+/proc/get_hearers_in_view_old(R, atom/source)
 	// Returns a list of hearers in view(R) from source (ignoring luminosity). Used in saycode.
 	var/turf/T = get_turf(source)
 	. = list()
@@ -240,8 +240,45 @@
 		var/atom/A = processing_list[++i]
 		if(A.flags_1 & HEAR_1)
 			. += A
-			SEND_SIGNAL(A, COMSIG_ATOM_HEARER_IN_VIEW, processing_list, .)
+			SEND_SIGNAL(A, COMSIG_ATOM_HEARER_IN_VIEW, .)
 		processing_list += A.contents
+
+/proc/get_hearers_in_view(range, atom/source)
+	// Returns a list of hearers in view(R) from source (ignoring luminosity). Used in saycode.
+	var/turf/T = get_turf(source)
+
+	if (range == 0) // if the range is zero, we know exactly where to look for, we can skip view
+		. = T.contents.Copy() // We can shave off one iteration by assuming turfs cannot hear
+	else  // A variation of get_hear inlined here to take advantage of the compiler's fastpath for obj/mob in view
+		. = list()
+		var/lum = T.luminosity
+		T.luminosity = 6 // This is the maximum luminosity
+		for(var/mob/M in view(range, T))
+			. += M
+		for(var/obj/O in view(range, T))
+			. += O
+		T.luminosity = lum
+
+	var/i = 0
+	while(i < length(.)) // recursive_hear_check inlined here
+		var/atom/A = .[++i]
+		if(A.flags_1 & HEAR_1)
+			SEND_SIGNAL(A, COMSIG_ATOM_HEARER_IN_VIEW, .)
+		. += A.contents
+
+/client/verb/brbrb()
+	set category = "sss"
+	set name = "sssss"
+	for(var/i=1 to 5000)
+		get_hearers_in_view(5, get_turf(mob))
+		get_hearers_in_view_old(5, get_turf(mob))
+
+/client/verb/ddd()
+	set category = "ddd"
+	set name = "dddddd"
+	for(var/i=1 to 5000)
+		get_hearers_in_view(0, get_turf(mob))
+		get_hearers_in_view_old(0, get_turf(mob))
 
 /proc/get_mobs_in_radio_ranges(list/obj/item/radio/radios)
 	. = list()

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -238,6 +238,9 @@
 		var/atom/A = .[++i]
 		if(A.flags_1 & HEAR_1)
 			SEND_SIGNAL(A, COMSIG_ATOM_HEARER_IN_VIEW, .)
+		else
+			. -= A
+			i--
 		. += A.contents
 
 /proc/get_mobs_in_radio_ranges(list/obj/item/radio/radios)

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -138,7 +138,7 @@
 		return COMPONENT_ALLOW_EXAMINATE
 
 //Adds the owner to the list of hearers in hearers_in_view(), for visible/hearable on top of say messages
-/obj/item/dullahan_relay/proc/include_owner(datum/source, list/processing_list, list/hearers)
+/obj/item/dullahan_relay/proc/include_owner(datum/source, list/hearers)
 	if(!QDELETED(owner))
 		hearers += owner
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
0 Range:
![image](https://user-images.githubusercontent.com/57223640/103694150-be3a9400-4f9a-11eb-813a-52964f7c8ae2.png)
8 and 5 range are a teeny bit faster in the profiler but not too much
https://github.com/tgstation/TerraGov-Marine-Corps/pull/5436/files
## Changelog
:cl:
code: Made get_hearers_in_view faster
/:cl:


