### PR TITLE
Fixes Densified Chemicals 

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -406,7 +406,7 @@
 
 /datum/plant_gene/trait/maxchem/on_new(obj/item/food/grown/G, newloc)
 	..()
-	G.reagents.maximum_volume *= rate
+	G.max_volume *= rate
 
 /datum/plant_gene/trait/repeated_harvest
 	name = "Perennial Growth"


### PR DESCRIPTION
## About The Pull Request

Densified Chemicals broke with the food refactor. Food has a `max_volume` var that it uses to create the reagent container which was overriding the `reagents.maximum_volume` change. Now it changes the proper var and works again.

## Why It's Good For The Game

840u omega weed is a god given right (?)

## Changelog
:cl: Melbert
fix: The Densified Chemicals trait in plants works again.
/:cl:

