### PR TITLE
NOTELEPORT checks that were atomized out of the medieval shuttle

### DIFF
--- a/code/datums/components/dejavu.dm
+++ b/code/datums/components/dejavu.dm
@@ -71,8 +71,12 @@
 
 	//comes after healing so new limbs comically drop to the floor
 	if(starting_turf)
-		var/atom/movable/master = parent
-		master.forceMove(starting_turf)
+		var/area/destination_area = starting_turf.loc
+		if(destination_area.area_flags & NOTELEPORT)
+			to_chat(parent, "<span class='warning'>For some reason, your head aches and fills with mental fog when you try to think of where you were... It feels like you're now going against some dull, unstoppable universal force.</span>")
+		else
+			var/atom/movable/master = parent
+			master.forceMove(starting_turf)
 
 	rewinds_remaining --
 	if(rewinds_remaining)

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -110,7 +110,10 @@
 		if(!isfloorturf(random_location))
 			continue
 		var/turf/open/floor/F = random_location
+		var/area/destination_area = F.loc
 
+		if(cycle < 300 && destination_area.area_flags & NOTELEPORT)//if the area is mostly NOTELEPORT (centcom) we gotta give up on this fantasy at some point.
+			continue
 		if(!F.air)
 			continue
 

--- a/code/game/objects/effects/phased_mob.dm
+++ b/code/game/objects/effects/phased_mob.dm
@@ -10,9 +10,22 @@
 
 /obj/effect/dummy/phased_mob/Destroy()
 	// Eject contents if deleted somehow
-	for(var/a in contents)
-		var/atom/movable/AM = a
-		AM.forceMove(drop_location())
+	var/area/destination_area = get_turf(src)
+	var/failed_areacheck = FALSE
+	if(destination_area.area_flags & NOTELEPORT)
+		failed_areacheck = TRUE
+	for(var/_phasing_in in contents)
+		var/atom/movable/phasing_in = _phasing_in
+		if(!failed_areacheck)
+			phasing_in.forceMove(drop_location())
+		else //this ONLY happens if someone uses a phasing effect to try to land in a NOTELEPORT zone after it is created, AKA trying to exploit.
+			if(isliving(phasing_in))
+				var/mob/living/living_cheaterson = phasing_in
+				to_chat(living_cheaterson, "<span class='userdanger'>This area has a heavy universal force occupying it, and you are scattered to the cosmos!</span>")
+				if(ishuman(living_cheaterson))
+					shake_camera(living_cheaterson, 20, 1)
+					addtimer(CALLBACK(living_cheaterson, /mob/living/carbon.proc/vomit), 2 SECONDS)
+			phasing_in.forceMove(find_safe_turf(z))
 	return ..()
 
 /obj/effect/dummy/phased_mob/ex_act()
@@ -34,12 +47,15 @@
 	if (movedelay > world.time || !direction)
 		return
 	var/turf/newloc = get_step(src,direction)
+	var/area/destination_area = newloc.loc
 	if(!newloc)
 		return
 	movedelay = world.time + movespeed
 	if(newloc.flags_1 & NOJAUNT_1)
 		to_chat(user, "<span class='warning'>Some strange aura is blocking the way.</span>")
 		return
+	if(destination_area.area_flags & NOTELEPORT)
+		to_chat(user, "<span class='danger'>Some dull, universal force is blocking the way. It's overwhelmingly oppressive force feels dangerous.</span>")
 	return newloc
 
 /// React to signals by deleting the effect. Used for bloodcrawl.

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1278,7 +1278,8 @@
 
 /obj/item/hierophant_club/proc/teleport_mob(turf/source, mob/M, turf/target, mob/user)
 	var/turf/turf_to_teleport_to = get_step(target, get_dir(source, M)) //get position relative to caster
-	if(!turf_to_teleport_to || turf_to_teleport_to.is_blocked_turf(TRUE))
+	var/area/destination_area = turf_to_teleport_to.loc
+	if(!turf_to_teleport_to || turf_to_teleport_to.is_blocked_turf(TRUE) || destination_area.area_flags & NOTELEPORT)
 		return
 	animate(M, alpha = 0, time = 2, easing = EASE_OUT) //fade out
 	sleep(1)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -694,7 +694,13 @@
 	if(phasing && get_charge() >= phasing_energy_drain && !throwing)
 		if(phase_state)
 			flick(phase_state, src)
-		forceMove(get_step(src,dir))//This is jank I hate it thanks, this should be done thrugh move not this dumb shit
+		var/turf/destination = get_step(src,dir)
+		var/area/destination_area = destination.loc
+		if(destination_area.area_flags & NOTELEPORT)
+			to_chat(occupants, "[icon2html(src, occupants)]<span class='warning'>A dull, universal force is preventing you from phasing here!</span>")
+			spark_system.start()
+		else
+			forceMove(destination)//This is jank I hate it thanks, this should be done thrugh move not this dumb shit
 		use_power(phasing_energy_drain)
 		addtimer(VARSET_CALLBACK(src, movedelay, TRUE), movedelay*3)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

These prevent some cheats or really low effort ways to get to where you really shouldn't be.

## Why It's Good For The Game

Mappers seriously fucking hate jaunting and phasing mechs, as they let you bypass their custom crafted ruins and the like. But it'll also stop more general "you shouldn't be here" stuff.

## Changelog
:cl:
fix: Some ways to teleport that snuck past NOTELEPORT checks are now properly checked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
