### PR TITLE
Fixes AIs being unable to access their local APC when out of power

### DIFF
--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -144,9 +144,9 @@
 				sleep(50)
 				to_chat(src, "<span class='notice'>Receiving control information from APC.</span>")
 				sleep(2)
-				apc_override = 1
-				theAPC.ui_interact(src)
-				apc_override = 0
+				to_chat(src, "<A HREF=?src=[REF(src)];emergencyAPC=[TRUE]>APC ready for connection.</A>")
+				apc_override = theAPC
+				apc_override.ui_interact(src)
 				setAiRestorePowerRoutine(POWER_RESTORATION_APC_FOUND)
 		sleep(50)
 		theAPC = null
@@ -155,10 +155,13 @@
 	if(aiRestorePowerRoutine)
 		if(aiRestorePowerRoutine == POWER_RESTORATION_APC_FOUND)
 			to_chat(src, "<span class='notice'>Alert cancelled. Power has been restored.</span>")
+			if(apc_override)
+				to_chat(src, "<span class='notice'>APC backdoor has been closed.</span>") //Fluff for why we have to hack every time.
 		else
 			to_chat(src, "<span class='notice'>Alert cancelled. Power has been restored without our assistance.</span>")
 		setAiRestorePowerRoutine(POWER_RESTORATION_OFF)
 		set_blindness(0)
+		apc_override = null
 		update_sight()
 
 /mob/living/silicon/ai/proc/ai_lose_power()

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -8,6 +8,8 @@
 			O.mode = 1
 			O.emotion = "Neutral"
 			O.update()
+		if(lacks_power() && apc_override) //Placing this in Login() in case the AI doesn't have this link for whatever reason.
+			to_chat(usr, "<span class='warning'>Main power is unavailable, backup power in use. Diagnostics scan complete.</span> <A HREF='?src=[REF(src)];emergencyAPC=[TRUE]'>Local APC ready for connection.</A>")
 	set_eyeobj_visible(TRUE)
 	if(multicam_on)
 		end_multicam()

--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -78,6 +78,8 @@
 
 /mob/living/silicon/ai/shared_ui_interaction(src_object)
 	// Disable UIs if the AI is unpowered.
+	if(apc_override == src_object) //allows AI to (eventually) use the interface for their own APC even when out of power
+		return UI_INTERACTIVE
 	if(lacks_power())
 		return UI_DISABLED
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- When an AI runs out of power, they get a short fluff text story about hacking into their own APC through the powernet or whatever, before having the APC's interface open. The intention is that an AI can re-enable their own breaker after a bit if something flipped it off. However, one of the many checks in TGUI will fail if the AI has no power (specifically, if `incapacitated()` returns TRUE), making this whole feature not work. In fact, it's probably been broken since TGUI APCs were done. I have fixed it by adding a check in the very same proc to return UI_INTERACTIVE if the UI's source object is the same object referenced in the AIs `apc_override` variable. Closes #52548
- The `apc_override` variable is now an APC object reference rather than a boolean. It is set to the AI's local APC when the hack flufftext completes, and is null'd when power is restored. This reference is used by the above, so that the AI only gets access to this one APC rather than any APC in general.
- AIs now also get a hyperlink in their chatbox, allowing them to open the APC interface should they have closed it. If they have had power restored, the `apc_override` reference var will be null, and using the hyperlink will simply result in text stating the backdoor to the APC is closed. 
- If the AI reconnects into a state where it has no power and `apc_override` is set, it will get a hyperlink to the APC, in case the AI player had been reconnecting when the window would have popped up or otherwise does not have the link for whatever reason.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes bug, adds QoL.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: AIs that lose power can access their APC once more (after the same short hacking delay is complete).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->