### PR TITLE
Fix rare HFR moderator filter removal failure

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hypertorus.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hypertorus.dm
@@ -1090,7 +1090,6 @@
 		if(filtering && moderator_internal.gases[filter_type])
 			var/datum/gas_mixture/removed = moderator_internal.remove_specific(filter_type, 20)
 			if(removed)
-				removed.temperature = moderator_internal.temperature
 				linked_output.airs[1].merge(removed)
 
 		var/datum/gas_mixture/internal_remove

--- a/code/modules/atmospherics/machinery/components/fusion/hypertorus.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hypertorus.dm
@@ -1089,8 +1089,9 @@
 				filtering = FALSE
 		if(filtering && moderator_internal.gases[filter_type])
 			var/datum/gas_mixture/removed = moderator_internal.remove_specific(filter_type, 20)
-			removed.temperature = moderator_internal.temperature
-			linked_output.airs[1].merge(removed)
+			if(removed)
+				removed.temperature = moderator_internal.temperature
+				linked_output.airs[1].merge(removed)
 
 		var/datum/gas_mixture/internal_remove
 		if(internal_fusion.gases[/datum/gas/helium][MOLES] > 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I cannot reliably reproduce this.

Looking at gas_mixture.dm, remove_specific appears to be able to return null if the amount of a gas becomes exactly zero or negative, somehow.
Adding a null check seems safe, and should prevent this from reoccurring.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This fixes runtimes of the form:

> [03:10:12] Runtime in hypertorus.dm,1092: Cannot modify null.temperature.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fix a rare case where setting the HFR moderator filter to a gas not present in the moderator mix would cause parts of HFR to stop functioning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
