### PR TITLE
Fixes AI laws being eaten by the garbage collector in certain conditions

### DIFF
--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -237,6 +237,7 @@
 
 						if (brain.overrides_aicore_laws)
 							A = new /mob/living/silicon/ai(loc, brain.laws, B)
+							brain.laws = null //Brain's law datum is being donated, so we need the brain to let it go or the GC will eat it
 						else
 							A = new /mob/living/silicon/ai(loc, laws, B)
 							laws = null //we're giving the new AI this datum, so let's not delete it when we qdel(src) 5 lines from now

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -239,6 +239,7 @@
 							A = new /mob/living/silicon/ai(loc, brain.laws, B)
 						else
 							A = new /mob/living/silicon/ai(loc, laws, B)
+							laws = null //we're giving the new AI this datum, so let's not delete it when we qdel(src) 5 lines from now
 
 						if(brain.force_replace_ai_name)
 							A.fully_replace_character_name(A.name, brain.replacement_ai_name())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## About The Pull Request
"Certain conditions" means "when an AI is made by a player";

- When making an AI mid-round, you start with an empty AI core. The empty AI core has a laws datum, because you can apply laws directly to the core and the new AI will receive them.
- When you perform the final step of securing the glass after inserting an MMI or posi into the core, a new AI is created. The core spawns in this AI and gives it the core's own law datum.
- Five lines later, the core qdels itself because it's just a prop; the AI sits on the ground like all AIs do.
- ~Five minutes later, the law datum is GC'd because it was still referenced by the core.

The core now sets `laws = null` immediately after giving its law datum to the new AI. When it is later deleted, the datum is not killed by the GC, and the AI will not have its law datum unexpectedly set to null.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Extra AIs created by players will no longer lose their laws shortly after they are created.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

*Might* be a fix for #54122, as the root cause for that issue was an AI not having a law datum.
