### PR TITLE
Fixes removing AIs from mechs

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -803,13 +803,12 @@
 				to_chat(user, "<span class='warning'>[name] must have maintenance protocols active in order to allow a transfer.</span>")
 				return
 			var/list/ai_pilots = list()
-			for(var/mob/occupant in occupants)
-				if(isAI(occupant))
-					ai_pilots += occupant
+			for(var/mob/living/silicon/ai/aipilot in occupants)
+				ai_pilots += aipilot
 			if(!ai_pilots.len) //Mech does not have an AI for a pilot
 				to_chat(user, "<span class='warning'>No AI detected in the [name] onboard computer.</span>")
 				return
-			if(ai_pilots.len > 1)
+			if(ai_pilots.len > 1) //Input box for multiple AIs, but if there's only one we'll default to them.
 				AI = input(user,"Which AI do you wish to card?", "AI Selection") as null|anything in sortList(ai_pilots)
 			else
 				AI = ai_pilots[1]

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -809,10 +809,15 @@
 			if(!ai_pilots.len) //Mech does not have an AI for a pilot
 				to_chat(user, "<span class='warning'>No AI detected in the [name] onboard computer.</span>")
 				return
-			AI = input(user,"Which AI do you wish to card?", "AI Selection") in sortList(ai_pilots)
+			if(ai_pilots.len > 1)
+				AI = input(user,"Which AI do you wish to card?", "AI Selection") as null|anything in sortList(ai_pilots)
+			else
+				AI = ai_pilots[1]
 			if(!AI)
-				to_chat(user, "<span class='warning'>No AI selected.</span>")
 				return
+			if(!(AI in occupants) || !user.Adjacent(src))
+				return //User sat on the selection window and things changed.
+
 			AI.ai_restore_power()//So the AI initially has power.
 			AI.control_disabled = TRUE
 			AI.radio_enabled = FALSE

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -813,7 +813,6 @@
 			if(!AI)
 				to_chat(user, "<span class='warning'>No AI selected.</span>")
 				return
-			for(var/mob/living/silicon/ai in occupants)
 			AI.ai_restore_power()//So the AI initially has power.
 			AI.control_disabled = TRUE
 			AI.radio_enabled = FALSE

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -802,8 +802,16 @@
 			if(!construction_state) //Mech must be in maint mode to allow carding.
 				to_chat(user, "<span class='warning'>[name] must have maintenance protocols active in order to allow a transfer.</span>")
 				return
-			if(!locate(AI) in occupants) //Mech does not have an AI for a pilot
+			var/list/ai_pilots = list()
+			for(var/mob/occupant in occupants)
+				if(isAI(occupant))
+					ai_pilots += occupant
+			if(!ai_pilots.len) //Mech does not have an AI for a pilot
 				to_chat(user, "<span class='warning'>No AI detected in the [name] onboard computer.</span>")
+				return
+			AI = input(user,"Which AI do you wish to card?", "AI Selection") in sortList(ai_pilots)
+			if(!AI)
+				to_chat(user, "<span class='warning'>No AI selected.</span>")
 				return
 			for(var/mob/living/silicon/ai in occupants)
 			AI.ai_restore_power()//So the AI initially has power.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Basically the old code attempted to use `locate(AI)`, but the `AI` in this case is a ref that is supposed to be provided by the card. Since the card is initially empty when removing AIs from the mech, it couldn't find the null in the `occupants` list and thus failed with a report that there was no AI in the mech.

Now it checks all occupants and makes a list of any AIs it finds, then gives the user the option to pick an AI (though since we don't have any multi-pilot mechs yet the most you can get is one AI, and `input` with one option just auto-chooses).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Removing AIs from mechs via intellicard works again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
