### PR TITLE
Yellow slime core and Cakehats not directional light now

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -388,7 +388,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_BELT
 	custom_materials = null
-	light_range = 6 //luminosity when on
+	light_range = 7 //luminosity when on
+	light_system = MOVABLE_LIGHT
 
 /obj/item/flashlight/emp
 	var/emp_max_charges = 4

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -53,6 +53,7 @@
 	flags_inv = HIDEEARS|HIDEHAIR
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)
 	light_range = 2 //luminosity when on
+	light_system = MOVABLE_LIGHT
 	flags_cover = HEADCOVERSEYES
 	heat = 999
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Yellow slime core when turn on is 360deg as at should be and not directional light and slightly brighter.
Cakehats also get there 360deg light.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes https://github.com/tgstation/tgstation/issues/55985
## Why It's Good For The Game
Fix over oversight problem when directional lights was introduced. Slightly buffs of brightens (same as security flashlight) for amount of work we done as xenobiologist.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Yellow slime core slightly brighter
fix: Yellow slime core and cakehats light is 360° as it should be
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
