### PR TITLE
Fixes an unlawful call to Destroy()

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -154,7 +154,7 @@
 	L.setDir(dir)
 	L.Stun(20, ignore_canstun = TRUE)
 	visible_message("<span class='notice'>[src] grows up into [L].</span>")
-	Destroy()
+	qdel(src)
 
 //Gutlunch udder
 /obj/item/udder/gutlunch


### PR DESCRIPTION
`Destroy()` should (almost) never be called directly, it is called by `qdel()` to clean up references and avoid hard deletions.
It is a shame we don't have private methods.