### PR TITLE
Fixes cryo not "connecting" to pipenet.

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -322,6 +322,8 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 
 		if(air1.temperature > 2000)
 			take_damage(clamp((air1.temperature)/200, 10, 20), BURN)
+		
+		update_parents()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/relaymove(mob/living/user, direction)
 	if(message_cooldown <= world.time)


### PR DESCRIPTION
## About The Pull Request
There was a bug that makes cryo unable to work in tandem with heat exchanger pipes because update_parents() isn't called. This isn't evident with thermomachines because the thermomachines call update_parents() on temperature differences. This fixes that.

## Why It's Good For The Game
bugfix good, more cooling sources good.

## Changelog
:cl:
fix: Cryogenics now properly update to pipenets and can work with HE setups.
/:cl:
