### PR TITLE
Fix Botany chemical gene grafts

### DIFF
--- a/code/modules/hydroponics/grafts.dm
+++ b/code/modules/hydroponics/grafts.dm
@@ -11,7 +11,7 @@
 	attack_verb_continuous = list("plants", "vegitizes", "crops", "reaps", "farms")
 	attack_verb_simple = list("plant", "vegitize", "crop", "reap", "farm")
 	///The stored trait taken from the parent plant. Defaults to perenial growth.
-	var/datum/plant_gene/trait/stored_trait
+	var/datum/plant_gene/stored_trait
 	///Determines the appearance of the graft. Rudimentary right now so it just picks randomly.
 	var/graft_appearance
 	///Seed that the graft was taken from, used for applying parent stats. Can be unexpectedly nulled by the parent plant getting deleted.

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -634,7 +634,7 @@
  * - [snip][/obj/item/graft]: The graft being used applied to this plant.
  */
 /obj/item/seeds/proc/apply_graft(obj/item/graft/snip)
-	var/datum/plant_gene/trait/new_trait = snip.stored_trait
+	var/datum/plant_gene/new_trait = snip.stored_trait
 	if(new_trait?.can_add(src))
 		genes += new_trait.Copy()
 
@@ -645,5 +645,8 @@
 	src.weed_rate	= round(clamp(max(src.weed_rate,	(src.weed_rate	+(2/3)*(snip.weed_rate	-src.weed_rate)		)),0,100))
 	src.weed_chance	= round(clamp(max(src.weed_chance,	(src.weed_chance+(2/3)*(snip.weed_chance-src.weed_chance)	)),0,100))
 	src.yield		= round(clamp(max(src.yield,		(src.yield		+(2/3)*(snip.yield		-src.yield)			)),0,10	))
+
+	// Add in any reagents, too.
+	reagents_from_genes()
 
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Fixes chemical grafts in botany so their seeds actually gain the reagents they offer.

 For those who didn't know, Spaceman's Trumpet is the only plant (for now) that allows you you graft it and get a chemical instead of a trait (Polypyrylium Oligomers). Only this graft doesn't work. It shows up in the plant, but on harvest there is none of that chemical inside of it. Now it works.

## Why It's Good For The Game

If a plant is gonna be special, the special thing should actually work.

## Changelog
:cl: Melbert
fix: Grafts of chemical genes in botany now actually work
/:cl:

