### PR TITLE
Vending machines use slow throws

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -616,7 +616,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	transform = M
 
 	if(get_turf(fatty) != get_turf(src))
-		throw_at(get_turf(fatty), 1, 1, spin=FALSE)
+		throw_at(get_turf(fatty), 1, 1, spin=FALSE, quickstart=FALSE)
 
 /obj/machinery/vending/proc/untilt(mob/user)
 	user.visible_message("<span class='notice'>[user] rights [src].</span>", \


### PR DESCRIPTION
quickstart acts by ticking the first throw right away, but this can lead to stack overflows if this throw happens to trigger another throw. it should really be moved to a default off argument, as only user initiated throws should use it, but throws that themselves can be triggered by throws (like this) should definitely not use it.

fixes #56002 a stack over flow that crashes the mc until fallback restarts it.