### PR TITLE
throw_at() will not quickstart a throw if the throw was triggered from the same stack as SSthrowing/fire()

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -738,7 +738,7 @@
 	if(pulledby)
 		pulledby.stop_pulling()
 	if (quickstart && (throwing || SSthrowing.state == SS_RUNNING)) //Avoid stack overflow edgecases.
-		quickstart = false
+		quickstart = FALSE
 	throwing = TT
 	if(spin)
 		SpinAnimation(5, 1)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -737,7 +737,8 @@
 
 	if(pulledby)
 		pulledby.stop_pulling()
-
+	if (quickstart && (throwing || SSthrowing.state == SS_RUNNING)) //Avoid stack overflow edgecases.
+		quickstart = false
 	throwing = TT
 	if(spin)
 		SpinAnimation(5, 1)


### PR DESCRIPTION
Infinite throwing loops are fine, as long as they don't loop at the stack level.
