### PR TITLE
Line change to fix monkeys never devolving into humans if they started as a monkey

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -183,7 +183,8 @@
 /datum/mutation/human/race/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
-	original_species = owner.dna.species.type
+	if(!ismonkey(owner))
+		original_species = owner.dna.species.type
 	. = owner.monkeyize()
 
 /datum/mutation/human/race/on_losing(mob/living/carbon/human/owner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I wondered if this would be a problem when I originally made https://github.com/tgstation/tgstation/pull/55844 since I only tested on humans devolving into monkeys and back, but not monkeys into humans if the monkey spawned as one. Nyoops.

## Why It's Good For The Game

fixes https://github.com/tgstation/tgstation/issues/55997

## Changelog
:cl:
fix: Line change to fix monkeys never devolving into humans.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
