### PR TITLE
Fixes empty gaslist entries, jesus fuck

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -298,7 +298,7 @@
 	if(cached_gases[/datum/gas/hydrogen])
 		gas_change = TRUE
 		var/pulse_strength = min(strength, cached_gases[/datum/gas/hydrogen][MOLES] * 1000)
-		cached_gases[/datum/gas/hydrogen] -= pulse_strength / 1000
+		cached_gases[/datum/gas/hydrogen][MOLES] -= pulse_strength / 1000
 		ASSERT_GAS(/datum/gas/tritium, air_contents)
 		cached_gases[/datum/gas/tritium][MOLES] += pulse_strength / 1000
 		strength -= pulse_strength

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -277,7 +277,7 @@
 	if(cached_gases[/datum/gas/hydrogen])
 		gas_change = TRUE
 		var/pulse_strength = min(strength, cached_gases[/datum/gas/hydrogen][MOLES] * 1000)
-		cached_gases[/datum/gas/hydrogen] -= pulse_strength / 1000
+		cached_gases[/datum/gas/hydrogen][MOLES] -= pulse_strength / 1000
 		ASSERT_GAS(/datum/gas/tritium, air)
 		cached_gases[/datum/gas/tritium][MOLES] += pulse_strength / 1000
 		strength -= pulse_strength

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -178,7 +178,7 @@
 	if(cached_gases[/datum/gas/hydrogen])
 		gas_change = TRUE
 		var/pulse_strength = min(strength, cached_gases[/datum/gas/hydrogen][MOLES] * 1000)
-		cached_gases[/datum/gas/hydrogen] -= pulse_strength / 1000
+		cached_gases[/datum/gas/hydrogen][MOLES] -= pulse_strength / 1000
 		ASSERT_GAS(/datum/gas/tritium, air_contents)
 		cached_gases[/datum/gas/tritium][MOLES] += pulse_strength / 1000
 		strength -= pulse_strength


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When cleaning up rad_act code in #55923, temporal forgot to add [MOLES] to the hydrogen bit of code. I believe this to be causing the hydrogen gaslist to be emptied depending on the strength of the radiation.

In other news, I am fucking blind.

## Why It's Good For The Game

This causes the dreaded big runtime, and breaks almost all of atmos code, since it totally trusts the gaslist indexes to exist for the sake of pref.

Pls sped merg
