### PR TITLE
Barrels work with science goggles

### DIFF
--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -12,7 +12,7 @@
 
 /obj/structure/fermenting_barrel/Initialize()
 	// Bluespace beakers, but without the portability or efficiency in circuits.
-	create_reagents(300, DRAINABLE | AMOUNT_VISIBLE)
+	create_reagents(300, DRAINABLE)
 	. = ..()
 
 /obj/structure/fermenting_barrel/examine(mob/user)
@@ -60,11 +60,11 @@
 	open = !open
 	if(open)
 		reagents.flags &= ~(DRAINABLE)
-		reagents.flags |= REFILLABLE
+		reagents.flags |= REFILLABLE | TRANSPARENT
 		to_chat(user, "<span class='notice'>You open [src], letting you fill it.</span>")
 	else
 		reagents.flags |= DRAINABLE
-		reagents.flags &= ~(REFILLABLE)
+		reagents.flags &= ~(REFILLABLE | TRANSPARENT)
 		to_chat(user, "<span class='notice'>You close [src], letting you draw from its tap.</span>")
 	update_icon()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Barrel have TRANSPARENT flag when open instead of AMOUNT_VISIBLE letting you see the contents with reagent scanners
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Weird that the barrel wouldn't work like nearly every other reagent container
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed science goggles not displaying fermenting barrel contents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
