### PR TITLE
Favorite cigarette brand is now put in notes

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -646,7 +646,7 @@
 		/obj/item/storage/fancy/cigarettes/cigpack_robust,
 		/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
 		/obj/item/storage/fancy/cigarettes/cigpack_carp)
-	quirk_holder?.mind.store_memory("Your favorite cigarette packets are [initial(drug_container_type.name)]s.")
+	quirk_holder?.mind?.store_memory("Your favorite cigarette packets are [initial(drug_container_type.name)]s.")
 	. = ..()
 
 /datum/quirk/junkie/smoker/announce_drugs()

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -646,6 +646,7 @@
 		/obj/item/storage/fancy/cigarettes/cigpack_robust,
 		/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
 		/obj/item/storage/fancy/cigarettes/cigpack_carp)
+	quirk_holder?.mind.store_memory("Your favorite cigarette packets are [initial(drug_container_type.name)]s.")
 	. = ..()
 
 /datum/quirk/junkie/smoker/announce_drugs()


### PR DESCRIPTION
## About The Pull Request

This makes it so, on spawn, smokers get their favorite cigarette brand in their notes.

## Why It's Good For The Game

If you lose your cigarettes, it's annoying to have to deal with a negative moodlet because the chatlog saying which brand you need expired. This is just  for convenience.

## Changelog
:cl:
tweak: Smokers now get their favorite cigarette brand in their notes.
/:cl: