### PR TITLE
Add nanite lab to Runtime Station

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -499,6 +499,9 @@
 /obj/item/storage/backpack/holding,
 /turf/open/floor/plasteel,
 /area/bridge)
+"bL" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/aft)
 "bM" = (
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/tile/blue,
@@ -1550,11 +1553,9 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "fd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/obj/structure/sign/departments/nanites,
+/turf/closed/wall/r_wall,
+/area/construction)
 "fe" = (
 /obj/machinery/button/door{
 	id = "cargounload";
@@ -2180,6 +2181,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kp" = (
+/obj/machinery/computer/rdconsole{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "kQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -2207,6 +2214,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "nq" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -2250,9 +2263,22 @@
 /obj/machinery/door/airlock,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"qd" = (
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "qQ" = (
 /turf/open/floor/engine,
 /area/quartermaster/miningoffice)
+"rn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "rK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2264,6 +2290,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"sr" = (
+/obj/machinery/public_nanite_chamber,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "sE" = (
 /obj/machinery/power/rtg/advanced,
 /obj/structure/cable,
@@ -2311,9 +2342,17 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"uQ" = (
+/obj/machinery/nanite_programmer,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "vm" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/aft)
+/obj/machinery/computer/nanite_cloud_controller,
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "vv" = (
 /obj/machinery/door/airlock,
 /turf/open/floor/plating,
@@ -2366,6 +2405,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wU" = (
+/turf/closed/wall/r_wall,
+/area/science/nanite)
 "yK" = (
 /obj/structure/fans/tiny/invisible,
 /obj/effect/turf_decal/stripes/line{
@@ -2378,6 +2420,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"AE" = (
+/obj/item/disk/tech_disk/debug,
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "AP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -2414,11 +2460,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"CT" = (
+/obj/machinery/computer/nanite_chamber_control{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "CV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"Df" = (
+/mob/living/carbon/human,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "DW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -2476,6 +2535,10 @@
 /obj/machinery/rnd/production/techfab/department,
 /turf/open/floor/plasteel,
 /area/science)
+"Ir" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/nanite)
 "Iy" = (
 /obj/structure/closet/secure_closet/research_director{
 	locked = 0
@@ -2521,6 +2584,14 @@
 /obj/machinery/chem_dispenser/chem_synthesizer,
 /turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
+"LH" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/nanite)
 "LW" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -2540,6 +2611,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"Nb" = (
+/obj/machinery/nanite_chamber,
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "Ns" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/cable,
@@ -2549,10 +2624,21 @@
 /obj/machinery/rnd/production/protolathe/department,
 /turf/open/floor/plasteel,
 /area/science)
+"Ov" = (
+/obj/machinery/nanite_program_hub,
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "OU" = (
 /obj/item/disk/tech_disk/debug,
 /turf/open/floor/plasteel,
 /area/science)
+"Qi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "Qt" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -2620,6 +2706,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"Vr" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "Vy" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel,
@@ -2679,6 +2773,18 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science)
+"XN" = (
+/obj/structure/table,
+/obj/item/nanite_remote{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/nanite_scanner{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "XR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -2692,6 +2798,11 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"Ym" = (
+/obj/structure/table,
+/obj/item/storage/box/disks_nanite,
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "Yy" = (
 /obj/machinery/light{
 	dir = 1
@@ -2705,6 +2816,9 @@
 /obj/machinery/suit_storage_unit/ce,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ZP" = (
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 
 (1,1,1) = {"
 aa
@@ -5775,17 +5889,17 @@ ei
 ei
 ei
 ei
-eL
-eL
-eL
-fd
-eL
-eL
-eL
-eL
-eL
-eL
-eL
+ei
+ei
+ei
+gu
+ei
+ei
+ei
+ei
+ei
+ei
+Qi
 fZ
 eh
 dY
@@ -5877,8 +5991,8 @@ eh
 eh
 eh
 eh
-eh
-eh
+rn
+sr
 eh
 ge
 aa
@@ -5969,11 +6083,11 @@ cN
 cN
 cN
 cN
-fI
-dY
+LH
+en
 dY
 ge
-aa
+dY
 aa
 aa
 aa
@@ -6061,11 +6175,11 @@ dy
 dm
 dM
 cN
-Tt
+Vr
 vm
-fg
-aa
-aa
+uQ
+Ov
+Ir
 aa
 aa
 aa
@@ -6152,12 +6266,12 @@ dn
 dn
 dn
 dL
-cN
-Tt
-vm
-fg
-aa
-aa
+ef
+nn
+ZP
+ZP
+ZP
+Ir
 aa
 aa
 aa
@@ -6244,12 +6358,12 @@ dn
 dn
 dn
 dL
-cN
-Tt
-vm
-fg
-aa
-aa
+ef
+AE
+kp
+XN
+Ym
+Ir
 aa
 aa
 aa
@@ -6337,11 +6451,11 @@ dn
 dn
 dL
 cN
-Tt
-vm
-fg
-aa
-aa
+qd
+ZP
+ZP
+ZP
+Ir
 aa
 aa
 aa
@@ -6428,12 +6542,12 @@ dn
 dn
 dn
 dL
-cN
-Tt
-vm
-fg
-aa
-aa
+fd
+ZP
+Df
+Nb
+CT
+Ir
 aa
 aa
 aa
@@ -6521,11 +6635,11 @@ dn
 dn
 dL
 cN
-Tt
-vm
-fg
-aa
-aa
+fI
+wU
+wU
+wU
+wU
 aa
 aa
 aa
@@ -6614,7 +6728,7 @@ dn
 dZ
 cN
 Tt
-Rb
+bL
 fg
 aa
 aa
@@ -6706,7 +6820,7 @@ dn
 dL
 cN
 Tt
-Rb
+bL
 fg
 aa
 aa
@@ -6798,7 +6912,7 @@ dn
 dL
 cN
 Tt
-Rb
+bL
 fg
 aa
 aa


### PR DESCRIPTION
:cl: coiax
code: Runtime Station now has a small nanite lab, south of the
construction area.
/:cl:

Doing any testing of new nanite stuff involves spawning in a bunch of
machinery and equipment, so including it on Runtime helps with
development.

---

![image](https://user-images.githubusercontent.com/609465/104057007-4615dd80-51e9-11eb-834f-74c04852fde8.png)
(Ingame screenshot, although some stuff has been moved, and the tiles are consistent.)