### PR TITLE
Fix startup double runtimes again

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -21,6 +21,9 @@
 	var/motd
 	var/policy
 
+	/// If the configuration is loaded
+	var/loaded = FALSE
+
 	var/static/regex/ic_filter_regex
 
 /datum/controller/configuration/proc/admin_reload()
@@ -52,6 +55,8 @@
 	LoadMOTD()
 	LoadPolicy()
 	LoadChatFilter()
+
+	loaded = TRUE
 
 	if (Master)
 		Master.OnConfigLoad()

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -118,7 +118,7 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 		var/const/viewtext = "\[view]" // Nesting these in other brackets went poorly
 		//log_debug("Runtime in <b>[e.file]</b>, line <b>[e.line]</b>: <b>[html_encode(e.name)]</b> [error_entry.make_link(viewtext)]")
 		var/err_msg_delay
-		if(config)
+		if(config?.loaded)
 			err_msg_delay = CONFIG_GET(number/error_msg_delay)
 		else
 			var/datum/config_entry/CE = /datum/config_entry/number/error_msg_delay


### PR DESCRIPTION
Prevents runtimes that occur before /world/New is called from runtiming in /world/Error due to lack of the config being loaded.