### PR TITLE
Fixes 2 really annoying cytology virus bugs.

### DIFF
--- a/code/datums/elements/swabbable.dm
+++ b/code/datums/elements/swabbable.dm
@@ -12,7 +12,7 @@ This element is used in vat growing to allow for the object to be
 	var/virus_define
 	///Amount of cell lines on a single sample
 	var/cell_line_amount
-	///Amount of viruses on a single sample
+	///The chance the sample will be infected with a virus.
 	var/virus_chance
 
 ///Listens for the swab signal and then generate a sample based on pre-determined lists that are saved as GLOBs. this allows us to have very few swabbable element instances.

--- a/code/modules/research/xenobiology/vatgrowing/samples/_micro_organism.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/_micro_organism.dm
@@ -63,7 +63,7 @@
 		reagents.remove_reagent(i, REAGENTS_METABOLISM)
 
 	//Handle debuffing growth based on viruses here.
-	for(var/datum/micro_organism/cell_line/virus in biological_sample.micro_organisms)
+	for(var/datum/micro_organism/virus/active_virus in biological_sample.micro_organisms)
 		if(reagents.has_reagent(/datum/reagent/medicine/spaceacillin, REAGENTS_METABOLISM))
 			reagents.remove_reagent(/datum/reagent/medicine/spaceacillin, REAGENTS_METABOLISM)
 			continue //This virus is stopped, We have antiviral stuff

--- a/code/modules/research/xenobiology/vatgrowing/samples/_sample.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/_sample.dm
@@ -16,7 +16,7 @@
 		var/datum/micro_organism/chosen_type = pickweight(temp_weight_list)
 		temp_weight_list -= chosen_type
 		micro_organisms += new chosen_type
-	if(virus_chance)
+	if(prob(virus_chance))
 		if(!GLOB.cell_virus_tables[virus_define])
 			return
 		var/datum/micro_organism/chosen_type = pickweight(GLOB.cell_virus_tables[virus_define])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes the generate_sample proc so it properly uses virus_chance to determine when to generate a virus. Now most samples will be virus free as intended.

It also fixes the bug where virus penalty and spaceacillin consumption would be multiplied by the number of cell lines, rather than the  number of viruses, as intended.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
 
You no longer have to spend all your money on spaceacillin if you want to do cytology,

These bugs caused cytology to be very confusing and frustrating,  getting them fixed is essential for cytology's future as a mechanic. !-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed a bug that caused every cytological sample to contain a virus.
Fix: Fixed a bug that multiplied the cytology virus growth penalty and spaceacillin consumption.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
