### PR TITLE
Telekinesis can throw non items (vending machines, lockers) only 1 tile far

### DIFF
--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -93,6 +93,7 @@
 	layer = ABOVE_HUD_LAYER
 	plane = ABOVE_HUD_PLANE
 
+	///Object focused / selected by the TK user
 	var/atom/movable/focus
 	var/mob/living/carbon/tk_user
 
@@ -171,7 +172,11 @@
 	else
 		. = TRUE
 		apply_focus_overlay()
-		focus.throw_at(target, 10, 1,user)
+		//Only items can be thrown 10 tiles everything else only 1 tile
+		if (isitem(focus))
+			focus.throw_at(target, 10, 1,user)
+		else
+			focus.throw_at(target, 1, 1,user)
 	user.changeNext_move(CLICK_CD_MELEE)
 	update_icon()
 

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -173,10 +173,7 @@
 		. = TRUE
 		apply_focus_overlay()
 		//Only items can be thrown 10 tiles everything else only 1 tile
-		if (isitem(focus))
-			focus.throw_at(target, 10, 1,user)
-		else
-			focus.throw_at(target, 1, 1,user)
+		focus.throw_at(target, focus.tk_throw_range, 1,user)
 	user.changeNext_move(CLICK_CD_MELEE)
 	update_icon()
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -11,6 +11,8 @@
 	var/datum/thrownthing/throwing = null
 	var/throw_speed = 2 //How many tiles to move per ds when being thrown. Float values are fully supported
 	var/throw_range = 7
+	///Max range this atom can be thrown via telekinesis
+	var/tk_throw_range = 1
 	var/mob/pulledby = null
 	var/initial_language_holder = /datum/language_holder
 	var/datum/language_holder/language_holder	// Mindless mobs and objects need language too, some times. Mind holder takes prescedence.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -138,6 +138,8 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 
 	///Who threw the item
 	var/mob/thrownby = null
+	///Items can by default thrown up to 10 tiles by TK users
+	tk_throw_range = 10
 
 	///the icon to indicate this object is being dragged
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1012,7 +1012,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	return ..()
 
 /obj/machinery/vending/attack_tk_grab(mob/user)
-	to_chat(user, "<span class='warning'>The vending machine is too heavy.</span>")
+	to_chat(user, "<span class='warning'>[src] is too heavy.</span>")
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/vending/custom

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1011,6 +1011,10 @@ GLOBAL_LIST_EMPTY(vending_products)
 		tilt(fatty=hit_atom)
 	return ..()
 
+/obj/machinery/vending/attack_tk_grab(mob/user)
+	to_chat(user, "<span class='warning'>The vending machine is too heavy.</span>")
+	return COMPONENT_CANCEL_ATTACK_CHAIN
+
 /obj/machinery/vending/custom
 	name = "Custom Vendor"
 	icon_state = "robotics"

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1011,10 +1011,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 		tilt(fatty=hit_atom)
 	return ..()
 
-/obj/machinery/vending/attack_tk_grab(mob/user)
-	to_chat(user, "<span class='warning'>[src] is too heavy.</span>")
-	return COMPONENT_CANCEL_ATTACK_CHAIN
-
 /obj/machinery/vending/custom
 	name = "Custom Vendor"
 	icon_state = "robotics"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Telekinesis users can now only throw items 10 tiles, everything else can only be thrown 1 tile
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This balances the fact that you can throw vending machines at people and crush them
It also is a bit more realistic that you can only throw heavy stuff like lockers by 1 tile

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Gamer025
tweak: Telekinesis users can now only throw items 10 tiles far, everything else (like lockers, machines, etc) can only be thrown 1 tile far
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
