### PR TITLE
Correctly transfer skillchips when ahealing someone

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -288,6 +288,8 @@
 
 		// Directly change the new holding_brain.
 		skillchip.holding_brain = replacement_brain
+		//And move the actual obj into the new brain (contents)
+		skillchip.forceMove(replacement_brain)
 
 		// Directly add them to the skillchip list in the new brain.
 		LAZYADD(replacement_brain.skillchips, skillchip)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When ahealing someone via the player panel their skillchips weren't transfered correctly.
The actually skillchip object was left in the old brain and eventually hard deleted.
This caused a runtime when ahealing someone a second time (after the harddel).
This then caused the target to actually have 2 brains because of the runtime while ahealing
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a bug that caused aheal to runtime / transfers skillchip correctly when ahealing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Skillchips are now transferred correctly when ahealing someone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
