### PR TITLE
Fixes vehicles like skateboards and wheelys moving multiple times.

### DIFF
--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -6,6 +6,9 @@
 
 /obj/vehicle/ridden/scooter/Initialize()
 	. = ..()
+	make_ridable()
+
+/obj/vehicle/ridden/scooter/proc/make_ridable()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/scooter)
 
 /obj/vehicle/ridden/scooter/wrench_act(mob/living/user, obj/item/I)
@@ -53,11 +56,12 @@
 
 /obj/vehicle/ridden/scooter/skateboard/Initialize()
 	. = ..()
-	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/scooter/skateboard)
 	sparks = new
 	sparks.set_up(1, 0, src)
 	sparks.attach(src)
 
+/obj/vehicle/ridden/scooter/skateboard/make_ridable()
+	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/scooter/skateboard)
 
 /obj/vehicle/ridden/scooter/skateboard/Destroy()
 	if(sparks)
@@ -251,8 +255,7 @@
 	///Name of the wheels, for visible messages
 	var/wheel_name = "wheels"
 
-/obj/vehicle/ridden/scooter/skateboard/wheelys/Initialize()
-	. = ..()
+/obj/vehicle/ridden/scooter/skateboard/wheelys/make_ridable()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/scooter/skateboard/wheelys)
 
 /obj/vehicle/ridden/scooter/skateboard/wheelys/post_unbuckle_mob(mob/living/M)
@@ -279,8 +282,7 @@
 	desc = "An EightO brand pair of roller skates. Vintage, yet functional!"
 	instability = 8
 
-/obj/vehicle/ridden/scooter/skateboard/wheelys/rollerskates/Initialize()
-	. = ..()
+/obj/vehicle/ridden/scooter/skateboard/wheelys/rollerskates/make_ridable()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/scooter/skateboard/wheelys/rollerskates)
 
 /obj/vehicle/ridden/scooter/skateboard/wheelys/skishoes
@@ -289,6 +291,5 @@
 	instability = 8
 	wheel_name = "skis"
 
-/obj/vehicle/ridden/scooter/skateboard/wheelys/skishoes/Initialize()
-	. = ..()
+/obj/vehicle/ridden/scooter/skateboard/wheelys/skishoes/make_ridable()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/scooter/skateboard/wheelys/skishoes)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #56071
![Screenshot_758](https://user-images.githubusercontent.com/15794172/104111051-cba19800-5292-11eb-8574-7b7f79eeba86.png)
![Screenshot_757](https://user-images.githubusercontent.com/15794172/104111054-cf351f00-5292-11eb-923a-460e613323cd.png)
![Screenshot_756](https://user-images.githubusercontent.com/15794172/104111056-d1977900-5292-11eb-9d9f-52ec89f8c105.png)
So wheelys would have 3 instances of the riding component attached on initialize with a different argument, causing them to move 3 tiles at once instead of 1. Skateboards will have 2 attached and move 2, etc.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Vehicles derived from scooters work correctly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: skateboards and wheelys dont move multiple tiles anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
