### PR TITLE
Makes excited breakdowns independent of adding new turfs

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -49,10 +49,18 @@
 
 
 //EXCITED GROUPS
+/**
+ * Some further context on breakdown. Unlike dismantle, the breakdown ticker doesn't reset itself when a tile is added
+ * This is because we cannot expect maps to have small spaces, so we need to even ourselves out often
+ * We do this to avoid equalizing a large space in one tick, with some significant amount of say heat diff
+ * This way large areas don't suddenly all become cold at once, it acts more like a wave
+ *
+ * Because of this and the behavior of share(), the breakdown cycles value can be tweaked directly to effect how fast we want gas to move
+ */
 /// number of FULL air controller ticks before an excited group breaks down (averages gas contents across turfs)
-#define EXCITED_GROUP_BREAKDOWN_CYCLES				4
+#define EXCITED_GROUP_BREAKDOWN_CYCLES				5
 /// number of FULL air controller ticks before an excited group dismantles and removes its turfs from active
-#define EXCITED_GROUP_DISMANTLE_CYCLES				9 //Reset after 2 breakdowns
+#define EXCITED_GROUP_DISMANTLE_CYCLES				(EXCITED_GROUP_BREAKDOWN_CYCLES * 2) + 1 //Reset after 2 breakdowns
 /// Ratio of air that must move to/from a tile to reset group processing
 #define MINIMUM_AIR_RATIO_TO_SUSPEND				0.1
 /// Minimum ratio of air that must move to/from a tile

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -424,7 +424,7 @@
 /datum/excited_group/proc/add_turf(turf/open/T)
 	turf_list += T
 	T.excited_group = src
-	reset_cooldowns()
+	dismantle_cooldown = 0
 	if(should_display || SSair.display_all_groups)
 		display_turf(T)
 
@@ -439,14 +439,14 @@
 		if(should_display || SSair.display_all_groups)
 			E.hide_turfs()
 			display_turfs()
-		reset_cooldowns()
+		dismantle_cooldown = 0
 	else
 		SSair.excited_groups -= src
 		for(var/t in turf_list)
 			var/turf/open/T = t
 			T.excited_group = E
 			E.turf_list += T
-		E.reset_cooldowns()
+		E.dismantle_cooldown = 0
 		E.should_display = E.should_display | should_display
 		if(E.should_display || SSair.display_all_groups)
 			hide_turfs()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This prevents the dreaded station-wide firelock, at least mostly, and moves us away from being dependent on room size. As a downside, we're closer then ever to ZAS, and the transition between pre-breakdown and post-breakdown is a lot more visible. This also allows us to raise the breakdown timer and decrease the amount of overtime experienced in each tick.

See video, I'm not sure I'm happy with the current rate, it does look somewhat shit. I'm considering tweaking the alpha curve for gas visuals to try and make it look less not good. [Video](https://cdn.discordapp.com/attachments/326831214667235328/797766078389813298/2021-01-10_01-55-53.mp4)

Closes #56066

## Why It's Good For The Game

Station spanning excited groups are rarer, and will settle down more often. Cold things like space will cool down their group faster, preventing station spanning non updating excited groups.

## Changelog
:cl:
tweak: Atmos code has changed, again! Groups of air will equalize faster, something something go read my documentation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
