### PR TITLE
Fixes runtime when Cyborgs spawn with AI present

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -140,6 +140,9 @@
 
 	create_modularInterface()
 
+	module = new /obj/item/robot_module(src)
+	module.rebuild_modules()
+
 	if(lawupdate)
 		make_laws()
 		if(!TryConnectToAI())
@@ -152,8 +155,6 @@
 		builtInCamera.internal_light = FALSE
 		if(wires.is_cut(WIRE_CAMERA))
 			builtInCamera.status = 0
-	module = new /obj/item/robot_module(src)
-	module.rebuild_modules()
 	update_icons()
 	. = ..()
 


### PR DESCRIPTION
Prevents runtime in TryConnectAi

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
Currently when a Cyborg is spawned while an AI is present it will cause a runtime:
![image](https://user-images.githubusercontent.com/33846895/104127698-eee84800-5363-11eb-88f2-56c35ec50c75.png)
This is caused by Initialize trying to link the Cyborg to an AI, when this is done successfully toggle_headlamp is called
Toggle_headlamp however calls update_icons which tries to set icon_state to module.cyborg_base_icon however module at this point is null because the default module is assigned later in Initialize.
This PR moves the module creation up inside Initialize to prevent this.
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents common runtime
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Borgs will no longer cause a runtime when created while an AI is present
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
