### PR TITLE
Fixes #55670, AIs will be able to see clearly after getting un-pied

### DIFF
--- a/code/datums/components/creamed.dm
+++ b/code/datums/components/creamed.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 	A.add_overlay(creamface)
 
 /datum/component/creamed/Destroy(force, silent)
-	var/mob/living/A = parent
+	var/atom/A = parent
 	A.cut_overlay(creamface)
 	qdel(creamface)
 	if(ishuman(A))

--- a/code/datums/components/creamed.dm
+++ b/code/datums/components/creamed.dm
@@ -42,7 +42,8 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 	var/mob/living/A = parent
 	A.cut_overlay(creamface)
 	qdel(creamface)
-	A.adjust_blurriness(-1)
+	if(isAI(A))
+		A.adjust_blurriness(-1)
 	if(ishuman(A))
 		SEND_SIGNAL(A, COMSIG_CLEAR_MOOD_EVENT, "creampie")
 	return ..()

--- a/code/datums/components/creamed.dm
+++ b/code/datums/components/creamed.dm
@@ -42,6 +42,9 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 	var/atom/A = parent
 	A.cut_overlay(creamface)
 	qdel(creamface)
+	if(isAI(A))
+		var/mob/living/silicon/AI/M
+		M.adjust_blurriness(-1)
 	if(ishuman(A))
 		SEND_SIGNAL(A, COMSIG_CLEAR_MOOD_EVENT, "creampie")
 	return ..()

--- a/code/datums/components/creamed.dm
+++ b/code/datums/components/creamed.dm
@@ -42,8 +42,6 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 	var/mob/living/A = parent
 	A.cut_overlay(creamface)
 	qdel(creamface)
-	if(isAI(A))
-		A.adjust_blurriness(-1)
 	if(ishuman(A))
 		SEND_SIGNAL(A, COMSIG_CLEAR_MOOD_EVENT, "creampie")
 	return ..()

--- a/code/datums/components/creamed.dm
+++ b/code/datums/components/creamed.dm
@@ -39,12 +39,10 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 	A.add_overlay(creamface)
 
 /datum/component/creamed/Destroy(force, silent)
-	var/atom/A = parent
+	var/mob/living/A = parent
 	A.cut_overlay(creamface)
 	qdel(creamface)
-	if(isAI(A))
-		var/mob/living/silicon/AI/M
-		M.adjust_blurriness(-1)
+	A.adjust_blurriness(-1)
 	if(ishuman(A))
 		SEND_SIGNAL(A, COMSIG_CLEAR_MOOD_EVENT, "creampie")
 	return ..()

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -8,6 +8,8 @@
 
 		handle_status_effects()
 
+		handle_traits()
+
 		if(malfhack?.aidisabled)
 			deltimer(malfhacking)
 			// This proc handles cleanup of screen notifications and


### PR DESCRIPTION
## About The Pull Request

Fixes #55670. There was a bug where AIs wouldn't have their blurriness lowered after getting cleaned up. This fixes it by enabling the system that allows living things to lower blurriness on AIs.

## Why It's Good For The Game

Bugs are bad, this one is particularly frustrating for AIs that do happen to get pied.

## Changelog
:cl:
fix:  AIs are now able to see clearly after getting un-pied
/:cl: