### PR TITLE
Laughter demons now eject spontaneous revivals

### DIFF
--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -273,18 +273,23 @@
 	consumed_mobs += victim
 	RegisterSignal(victim, COMSIG_MOB_STATCHANGE, .proc/on_victim_statchange)
 
-/mob/living/simple_animal/hostile/imp/slaughter/laughter/proc/on_victim_statchange(mob/victim, new_stat)
-	if(!isliving(victim))
-		return
+/* Handle signal from a consumed mob changing stat.
+ *
+ * A signal handler for if one of the laughter demon's consumed mobs has
+ * changed stat. If they're no longer dead (because they were dead when
+ * swallowed), eject them so they can't rip their way out from the inside.
+ */
+/mob/living/simple_animal/hostile/imp/slaughter/laughter/proc/on_victim_statchange(mob/living/victim, new_stat)
+	SIGNAL_HANDLER
 
-	var/mob/living/living_victim = victim
-	if(new_stat != DEAD)
-		// Someone we've eaten has spontaneously revived; maybe nanites, maybe a ling
-		living_victim.forceMove(get_turf(src))
-		living_victim.exit_blood_effect()
-		living_victim.visible_message("<span class='warning'>[victim] falls out of the air, covered in blood, with a confused look on their face.</span>")
-		consumed_mobs -= living_victim
-		UnregisterSignal(living_victim, COMSIG_MOB_STATCHANGE)
+	if(new_stat == DEAD)
+		return
+	// Someone we've eaten has spontaneously revived; maybe nanites, maybe a changeling
+	victim.forceMove(get_turf(src))
+	victim.exit_blood_effect()
+	victim.visible_message("<span class='warning'>[victim] falls out of the air, covered in blood, with a confused look on their face.</span>")
+	consumed_mobs -= victim
+	UnregisterSignal(victim, COMSIG_MOB_STATCHANGE)
 
 /mob/living/simple_animal/hostile/imp/slaughter/engine_demon
 	name = "engine demon"


### PR DESCRIPTION
:cl: coiax
tweak: If you are luckily enough to revive while still inside the
stomach of a laughter demon, you will be immediately ejected. Whether
you will be able to get away before the demon then kills and eats you
again, is up to you.
/:cl:

Very occasionally, a laughter demon will eat a changeling, or someone
with very strong nanites, and then are rendered helpless as someone
punches their way out.

Instead, now they will be confusingly ejected from the laughter demon's
internal hammerspace pocket, where they can than then attempt to make
their escape.