### PR TITLE
Refactor card scaling into an element for general item scaling

### DIFF
--- a/code/datums/components/storage/concrete/trading_cards.dm
+++ b/code/datums/components/storage/concrete/trading_cards.dm
@@ -12,12 +12,6 @@
 	. = ..()
 	set_holdable(list(/obj/item/tcgcard))
 
-/datum/component/storage/concrete/tcg/can_be_inserted(obj/item/I, stop_messages, mob/M)
-	if(istype(I, /obj/item/tcgcard))
-		var/obj/item/tcgcard/nu_card = I
-		nu_card.zoom_out()
-	return ..()
-
 /datum/component/storage/concrete/tcg/PostTransfer()
 	. = ..()
 	handle_empty_deck()
@@ -39,13 +33,6 @@
 	card_contents = shuffle(card_contents)
 
 /datum/component/storage/concrete/tcg/mass_remove_from_storage(atom/target, list/things, datum/progressbar/progress, trigger_on_found)
-	for(var/item in 1 to things.len)
-		if(istype(things[item], /obj/item/tcgcard))
-			var/obj/item/tcgcard/card = things[item]
-			if(isturf(target))
-				card.zoom_out()
-			else
-				card.zoom_in()
 	. = ..()
 	if(!things.len)
 		qdel(parent)
@@ -59,8 +46,4 @@
 		card.forceMove(card.drop_location())
 		card.flipped = deck.flipped
 		card.update_icon_state()
-		if(isturf(card.drop_location()))
-			card.zoom_out()
-		else
-			card.zoom_in()
 		qdel(parent)

--- a/code/datums/components/storage/concrete/trading_cards.dm
+++ b/code/datums/components/storage/concrete/trading_cards.dm
@@ -43,7 +43,7 @@
 	if(contents.len <= 1)
 		var/obj/item/tcgcard_deck/deck = parent
 		var/obj/item/tcgcard/card = contents[1]
-		card.forceMove(card.drop_location())
+		remove_from_storage(card, card.drop_location())
 		card.flipped = deck.flipped
 		card.update_icon_state()
 		qdel(parent)

--- a/code/datums/components/storage/concrete/trading_cards.dm
+++ b/code/datums/components/storage/concrete/trading_cards.dm
@@ -40,7 +40,7 @@
 /datum/component/storage/concrete/tcg/proc/handle_empty_deck()
 	var/list/contents = contents()
 	//You can't have a deck of one card!
-	if(contents.len <= 1)
+	if(contents.len == 1)
 		var/obj/item/tcgcard_deck/deck = parent
 		var/obj/item/tcgcard/card = contents[1]
 		remove_from_storage(card, card.drop_location())

--- a/code/datums/elements/item_scaling.dm
+++ b/code/datums/elements/item_scaling.dm
@@ -10,16 +10,16 @@
 	. = ..()
 	if(!isatom(target))
 		return ELEMENT_INCOMPATIBLE
-	///Initial scaling set to overworld_scaling, being placed in storage should resize to storage_scaling.
+	///Initial scaling set to overworld_scaling when item is spawned.
 	scale(target, overworld_scaling)
 
 	src.overworld_scaling = overworld_scaling
 	src.storage_scaling = storage_scaling
 
-	RegisterSignal(target, COMSIG_ITEM_EQUIPPED, .proc/scale_storage) //Object added to an inventory/hand slot.
-	RegisterSignal(target, COMSIG_ITEM_DROPPED, .proc/scale_overworld) //Object dropped or thrown on a turf.
-	RegisterSignal(target, COMSIG_STORAGE_ENTERED, .proc/scale_storage) //Object placed in a storage component.
-	RegisterSignal(target, COMSIG_STORAGE_EXITED, .proc/scale_overworld) //Object removed from a storage component.
+	///Object scaled when placed in an equipment slot OR when entering a storage component.
+	RegisterSignal(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_STORAGE_ENTERED), .proc/scale_storage)
+	///Object scaled when dropped/thrown OR when exiting a storage component.
+	RegisterSignal(target, list(COMSIG_ITEM_DROPPED, COMSIG_STORAGE_EXITED), .proc/scale_overworld)
 
 /datum/element/item_scaling/Detach(datum/target)
 	. = ..()

--- a/code/datums/elements/item_scaling.dm
+++ b/code/datums/elements/item_scaling.dm
@@ -37,11 +37,3 @@
 	SIGNAL_HANDLER
 
 	scale(source, storage_scaling)
-
-/obj/item/flashlight/seclite/Initialize()
-	. = ..()
-	AddElement(/datum/element/item_scaling, 0.5, 1)
-
-/obj/item/melee/baton/loaded/Initialize()
-	. = ..()
-	AddElement(/datum/element/item_scaling, 0.5, 1)

--- a/code/datums/elements/item_scaling.dm
+++ b/code/datums/elements/item_scaling.dm
@@ -22,9 +22,9 @@
 	RegisterSignal(target, list(COMSIG_ITEM_DROPPED, COMSIG_STORAGE_EXITED), .proc/scale_overworld)
 
 /datum/element/item_scaling/Detach(datum/target)
-	. = ..()
 	UnregisterSignal(target, list(COMSIG_ITEM_PICKUP, COMSIG_ITEM_DROPPED, COMSIG_STORAGE_ENTERED,\
 	COMSIG_STORAGE_EXITED))
+	return ..()
 
 ///Applies a scale transform to an identity matrix and replaces the object's tranform matrix.
 /datum/element/item_scaling/proc/scale(datum/source, scaling)

--- a/code/datums/elements/item_scaling.dm
+++ b/code/datums/elements/item_scaling.dm
@@ -1,26 +1,55 @@
-///Bespoke element for scaling items in hand/inventory and in the overworld (on turfs).
+/**
+ * Element for scaling item appearances in the overworld or in inventory/storage.
+ *
+ * This bespoke element allows for items to have varying sizes depending on their location.
+ * The overworld simply refers to items being on a turf.  Inventory includes HUD item slots,
+ * and storage is anywhere a storage component is used.
+ * Scaling should affect the item's icon and all attached overlays (such as blood decals).
+ *
+ */
 /datum/element/item_scaling
 	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
+	/// Scaling value when the attached item is in the overworld (on a turf).
 	var/overworld_scaling
+	/// Scaling value when the attached item is in a storage component or inventory slot.
 	var/storage_scaling
 
-///Adds the scaling values set in AddElement to the bespoke element and registers relevant signals.
+/**
+ * Attach proc for the item_scaling element
+ *
+ * The proc checks the target's type before attaching.  It then initializes
+ * the target to overworld scaling.  The target should then rescale if it is placed
+ * in inventory/storage on initialization.  Relevant signals are registered to listen
+ * for pickup/drop or storage events.  Scaling values of 1 will result in items
+ * returning to their original size.
+ * Arguments:
+ * * target - Datum to attach the element to.
+ * * overworld_scaling - Integer or float to scale the item in the overworld.
+ * * storage_scaling - Integer or float to scale the item in storage/inventory.
+ */
 /datum/element/item_scaling/Attach(datum/target, overworld_scaling, storage_scaling)
 	. = ..()
 	if(!isatom(target))
 		return ELEMENT_INCOMPATIBLE
-	///Initial scaling set to overworld_scaling when item is spawned.
+	// Initial scaling set to overworld_scaling when item is spawned.
 	scale(target, overworld_scaling)
 
 	src.overworld_scaling = overworld_scaling
 	src.storage_scaling = storage_scaling
 
-	///Object scaled when placed in an equipment slot OR when entering a storage component.
-	RegisterSignal(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_STORAGE_ENTERED), .proc/scale_storage)
-	///Object scaled when dropped/thrown OR when exiting a storage component.
+	// Object scaled when dropped/thrown OR when exiting a storage component.
 	RegisterSignal(target, list(COMSIG_ITEM_DROPPED, COMSIG_STORAGE_EXITED), .proc/scale_overworld)
+	// Object scaled when placed in an inventory slot OR when entering a storage component.
+	RegisterSignal(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_STORAGE_ENTERED), .proc/scale_storage)
 
+/**
+ * Detach proc for the item_scaling element.
+ *
+ * All registered signals are unregistered, and the attached element is removed from the target datum.
+ * Arguments:
+ * * target - Datum which the element is attached to.
+ */
 /datum/element/item_scaling/Detach(datum/target)
 	UnregisterSignal(target, list(
 		COMSIG_ITEM_PICKUP,
@@ -30,19 +59,42 @@
 	))
 	return ..()
 
-///Applies a scale transform to an identity matrix and replaces the object's tranform matrix.
+/**
+ * Scales the attached item's matrix.
+ *
+ * The proc first narrows the type of the source to (datums do not have a transform matrix).
+ * It then creates an identity matrix, M, which is transformed by the scaling value.
+ * The object's transform variable (matrix) is then set to the resulting value of M.
+ * Arguments:
+ * * source - Source datum which sent the signal.
+ * * scaling - Integer or float to scale the item's matrix.
+ */
 /datum/element/item_scaling/proc/scale(datum/source, scaling)
 	var/atom/scalable_object = source
 	var/matrix/M = matrix()
 	scalable_object.transform = M.Scale(scaling)
 
-///Scales the object sprite to overworld_scaling
+/**
+ * Signal handler for COMSIG_ITEM_DROPPED or COMSIG_STORAGE_EXITED
+ *
+ * Longer detailed paragraph about the proc
+ * including any relevant detail
+ * Arguments:
+ * * source - Source datum which sent the signal.
+ */
 /datum/element/item_scaling/proc/scale_overworld(datum/source)
 	SIGNAL_HANDLER
 
 	scale(source, overworld_scaling)
 
-///Scales the object sprite to storage_scaling
+/**
+ * Signal handler for COMSIG_ITEM_EQUIPPED or COMSIG_STORAGE_ENTERED.
+ *
+ * Longer detailed paragraph about the proc
+ * including any relevant detail
+ * Arguments:
+ * * source - Source datum which sent the signal.
+ */
 /datum/element/item_scaling/proc/scale_storage(datum/source)
 	SIGNAL_HANDLER
 

--- a/code/datums/elements/item_scaling.dm
+++ b/code/datums/elements/item_scaling.dm
@@ -22,8 +22,12 @@
 	RegisterSignal(target, list(COMSIG_ITEM_DROPPED, COMSIG_STORAGE_EXITED), .proc/scale_overworld)
 
 /datum/element/item_scaling/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_ITEM_PICKUP, COMSIG_ITEM_DROPPED, COMSIG_STORAGE_ENTERED,\
-	COMSIG_STORAGE_EXITED))
+	UnregisterSignal(target, list(
+		COMSIG_ITEM_PICKUP,
+		 COMSIG_ITEM_DROPPED,
+		 COMSIG_STORAGE_ENTERED,
+		COMSIG_STORAGE_EXITED,
+	))
 	return ..()
 
 ///Applies a scale transform to an identity matrix and replaces the object's tranform matrix.

--- a/code/datums/elements/item_scaling.dm
+++ b/code/datums/elements/item_scaling.dm
@@ -1,38 +1,44 @@
+///Bespoke element for scaling items in hand/inventory and in the overworld (on turfs).
 /datum/element/item_scaling
 	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	var/overworld_scaling
 	var/storage_scaling
 
+///Adds the scaling values set in AddElement to the bespoke element and registers relevant signals.
 /datum/element/item_scaling/Attach(datum/target, overworld_scaling, storage_scaling)
 	. = ..()
 	if(!isatom(target))
 		return ELEMENT_INCOMPATIBLE
+	///Initial scaling set to overworld_scaling, being placed in storage should resize to storage_scaling.
 	scale(target, overworld_scaling)
 
 	src.overworld_scaling = overworld_scaling
 	src.storage_scaling = storage_scaling
 
-	RegisterSignal(target, COMSIG_ITEM_EQUIPPED, .proc/scale_storage)
-	RegisterSignal(target, COMSIG_ITEM_DROPPED, .proc/scale_overworld)
-	RegisterSignal(target, COMSIG_STORAGE_ENTERED, .proc/scale_storage)
-	RegisterSignal(target, COMSIG_STORAGE_EXITED, .proc/scale_overworld)
+	RegisterSignal(target, COMSIG_ITEM_EQUIPPED, .proc/scale_storage) //Object added to an inventory/hand slot.
+	RegisterSignal(target, COMSIG_ITEM_DROPPED, .proc/scale_overworld) //Object dropped or thrown on a turf.
+	RegisterSignal(target, COMSIG_STORAGE_ENTERED, .proc/scale_storage) //Object placed in a storage component.
+	RegisterSignal(target, COMSIG_STORAGE_EXITED, .proc/scale_overworld) //Object removed from a storage component.
 
 /datum/element/item_scaling/Detach(datum/target)
 	. = ..()
 	UnregisterSignal(target, list(COMSIG_ITEM_PICKUP, COMSIG_ITEM_DROPPED, COMSIG_STORAGE_ENTERED,\
 	COMSIG_STORAGE_EXITED))
 
+///Applies a scale transform to an identity matrix and replaces the object's tranform matrix.
 /datum/element/item_scaling/proc/scale(datum/source, scaling)
 	var/atom/scalable_object = source
 	var/matrix/M = matrix()
 	scalable_object.transform = M.Scale(scaling)
 
+///Scales the object sprite to overworld_scaling
 /datum/element/item_scaling/proc/scale_overworld(datum/source)
 	SIGNAL_HANDLER
 
 	scale(source, overworld_scaling)
 
+///Scales the object sprite to storage_scaling
 /datum/element/item_scaling/proc/scale_storage(datum/source)
 	SIGNAL_HANDLER
 

--- a/code/datums/elements/item_scaling.dm
+++ b/code/datums/elements/item_scaling.dm
@@ -24,8 +24,8 @@
 /datum/element/item_scaling/Detach(datum/target)
 	UnregisterSignal(target, list(
 		COMSIG_ITEM_PICKUP,
-		 COMSIG_ITEM_DROPPED,
-		 COMSIG_STORAGE_ENTERED,
+		COMSIG_ITEM_DROPPED,
+		COMSIG_STORAGE_ENTERED,
 		COMSIG_STORAGE_EXITED,
 	))
 	return ..()

--- a/code/datums/elements/item_scaling.dm
+++ b/code/datums/elements/item_scaling.dm
@@ -1,0 +1,47 @@
+/datum/element/item_scaling
+	element_flags = ELEMENT_BESPOKE
+	id_arg_index = 2
+	var/overworld_scaling
+	var/storage_scaling
+
+/datum/element/item_scaling/Attach(datum/target, overworld_scaling, storage_scaling)
+	. = ..()
+	if(!isatom(target))
+		return ELEMENT_INCOMPATIBLE
+	scale(target, overworld_scaling)
+
+	src.overworld_scaling = overworld_scaling
+	src.storage_scaling = storage_scaling
+
+	RegisterSignal(target, COMSIG_ITEM_EQUIPPED, .proc/scale_storage)
+	RegisterSignal(target, COMSIG_ITEM_DROPPED, .proc/scale_overworld)
+	RegisterSignal(target, COMSIG_STORAGE_ENTERED, .proc/scale_storage)
+	RegisterSignal(target, COMSIG_STORAGE_EXITED, .proc/scale_overworld)
+
+/datum/element/item_scaling/Detach(datum/target)
+	. = ..()
+	UnregisterSignal(target, list(COMSIG_ITEM_PICKUP, COMSIG_ITEM_DROPPED, COMSIG_STORAGE_ENTERED,\
+	COMSIG_STORAGE_EXITED))
+
+/datum/element/item_scaling/proc/scale(datum/source, scaling)
+	var/atom/scalable_object = source
+	var/matrix/M = matrix()
+	scalable_object.transform = M.Scale(scaling)
+
+/datum/element/item_scaling/proc/scale_overworld(datum/source)
+	SIGNAL_HANDLER
+
+	scale(source, overworld_scaling)
+
+/datum/element/item_scaling/proc/scale_storage(datum/source)
+	SIGNAL_HANDLER
+
+	scale(source, storage_scaling)
+
+/obj/item/flashlight/seclite/Initialize()
+	. = ..()
+	AddElement(/datum/element/item_scaling, 0.5, 1)
+
+/obj/item/melee/baton/loaded/Initialize()
+	. = ..()
+	AddElement(/datum/element/item_scaling, 0.5, 1)

--- a/code/game/objects/items/tcg/tcg.dm
+++ b/code/game/objects/items/tcg/tcg.dm
@@ -26,9 +26,7 @@ GLOBAL_LIST_EMPTY(cached_cards)
 
 /obj/item/tcgcard/Initialize(mapload, datum_series, datum_id)
 	. = ..()
-	zoom_out()
-	RegisterSignal(src, COMSIG_STORAGE_ENTERED, .proc/zoom_in)
-	RegisterSignal(src, COMSIG_STORAGE_EXITED, .proc/zoom_out)
+	AddElement(/datum/element/item_scaling, 0.3, 1)
 	//If they are passed as null let's replace them with the vars on the card. this also means we can allow for map loaded ccards
 	if(!datum_series)
 		datum_series = series
@@ -102,14 +100,6 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 	. = ..()
 	flip_card(user)
 
-/obj/item/tcgcard/equipped(mob/user, slot, initial)
-	. = ..()
-	zoom_in()
-
-/obj/item/tcgcard/dropped(mob/user, silent)
-	. = ..()
-	zoom_out()
-
 /obj/item/tcgcard/update_icon_state()
 	. = ..()
 	if(!flipped)
@@ -129,9 +119,7 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 		var/obj/item/tcgcard_deck/new_deck = new /obj/item/tcgcard_deck(drop_location())
 		new_deck.flipped = flipped
 		user.transferItemToLoc(second_card, new_deck)//Start a new pile with both cards, in the order of card placement.
-		second_card.zoom_in()
 		user.transferItemToLoc(src, new_deck)
-		zoom_in()
 		new_deck.update_icon_state()
 		user.put_in_hands(new_deck)
 	if(istype(I, /obj/item/tcgcard_deck))
@@ -141,7 +129,6 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 			return
 		user.transferItemToLoc(src, old_deck)
 		flipped = old_deck.flipped
-		zoom_in()
 		old_deck.update_icon()
 		update_icon()
 	return ..()
@@ -161,18 +148,6 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 		ntransform.TurnTo(UNTAPPED_ANGLE , TAPPED_ANGLE)
 	tapped = !tapped
 	animate(src, transform = ntransform, time = 2, easing = (EASE_IN|EASE_OUT))
-
-/**
- * Transforms the card's sprite to look like a small, paper card. Use when outside of inventory
- */
-/obj/item/tcgcard/proc/zoom_in()
-	transform = matrix()
-
-/**
- * Transforms the card's sprite to look like a large, detailed, illustrated paper card. Use when inside of inventory/storage.
- */
-/obj/item/tcgcard/proc/zoom_out()
-	transform = matrix(0.3,0,0,0,0.3,0)
 
 /obj/item/tcgcard/proc/flip_card(mob/user)
 	to_chat(user, "<span_class='notice'>You turn the card over.</span>")
@@ -249,7 +224,6 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 	for(var/card in 1 to contents.len)
 		var/obj/item/tcgcard/stored_card = contents[card]
 		stored_card.forceMove(drop_location())
-		stored_card.zoom_out()
 	. = ..()
 
 /obj/item/tcgcard_deck/proc/check_menu(mob/living/user)
@@ -268,7 +242,6 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 		var/obj/item/tcgcard/new_card = I
 		new_card.flipped = flipped
 		new_card.forceMove(src)
-		new_card.zoom_in()
 
 
 /obj/item/tcgcard_deck/attack_self(mob/living/carbon/user)
@@ -290,7 +263,6 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 	if(contents.len <= 1)
 		var/obj/item/tcgcard/final_card = contents[1]
 		user.transferItemToLoc(final_card, drop_location())
-		final_card.zoom_out()
 		qdel(src)
 
 
@@ -320,7 +292,6 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 	//Now flip the cards to their opposite positions.
 	for(var/a in 1 to contents.len)
 		var/obj/item/tcgcard/nu_card = contents[a]
-		nu_card.zoom_in()
 		nu_card.flipped = flipped
 		nu_card.update_icon_state()
 	update_icon_state()
@@ -377,9 +348,7 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 
 /obj/item/cardpack/Initialize()
 	. = ..()
-	zoom_out()
-	RegisterSignal(src, COMSIG_STORAGE_ENTERED, .proc/zoom_in)
-	RegisterSignal(src, COMSIG_STORAGE_EXITED, .proc/zoom_out)
+	AddElement(/datum/element/item_scaling, 0.4, 1)
 	//Pass by refrance moment
 	//This lets us only have one rarity table per pack, badmins beware
 	if(GLOB.cached_rarity_table[type])
@@ -390,20 +359,6 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 		guar_rarity = GLOB.cached_guar_rarity[type]
 	else
 		GLOB.cached_guar_rarity[type] = guar_rarity
-
-/obj/item/cardpack/equipped(mob/user, slot, initial)
-	. = ..()
-	zoom_in()
-
-/obj/item/cardpack/dropped(mob/user, silent)
-	. = ..()
-	zoom_out()
-
-/obj/item/cardpack/proc/zoom_in()
-	transform = matrix()
-
-/obj/item/cardpack/proc/zoom_out()
-	transform = matrix(0.4,0,0,0,0.4,0)
 
 /obj/item/cardpack/attack_self(mob/user)
 	. = ..()
@@ -430,15 +385,7 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 
 /obj/item/coin/thunderdome/Initialize()
 	. = ..()
-	transform = matrix(0.4,0,0,0,0.4,0)
-
-/obj/item/coin/thunderdome/equipped(mob/user, slot, initial)
-	. = ..()
-	transform = matrix()
-
-/obj/item/coin/thunderdome/dropped(mob/user, silent)
-	. = ..()
-	transform = matrix(0.4,0,0,0,0.4,0)
+	AddElement(/datum/element/item_scaling, 0.4, 1)
 
 /obj/item/storage/card_binder
 	name = "card binder"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -600,6 +600,7 @@
 #include "code\datums\elements\empprotection.dm"
 #include "code\datums\elements\firestacker.dm"
 #include "code\datums\elements\forced_gravity.dm"
+#include "code\datums\elements\item_scaling.dm"
 #include "code\datums\elements\light_blocking.dm"
 #include "code\datums\elements\movetype_handler.dm"
 #include "code\datums\elements\obj_regen.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The current TCG code had some code for scaling its cards down when they're on the ground and then scaling them back in hand/inventory.  This element aims to preserve this functionality and to allow it work for other items.

While the TCG makes the cards smaller on the ground, this element allows for items to be scaled up OR down when on the floor or in inventory.

While this particular element has to do with scaling, I am looking at ways to expand this sort of icon change functionality to `icon_state` as well, but there are additional issues with blood decals needing to be redrawn and possibly `vis_contents`.

This is my first time making an element, so any critiques would be appreciated.

Known issues:
<strike>Currently, cards seems to properly resize when being removed from storage, however there is an issue with the card pile. If you draw a card from the pile and place it back into the pile; then, when performing a click drag on the pile to remove all cards, the drawn card will not scale down (but all the other cards scale properly).  
This only seems to occur with the last card drawn and put back into the pile.  If you don't draw any cards and place them back, then every card scales properly.  This likely has something to do with `handle_empty_deck`.</strike>

Found the issue.  There was a `forceMove` performed on the last card which doesn't send any signal I'm looking for.  Changed it to `remove_from_storage` to get proper signals.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This will not only reduce the amount of code inside of the TCG system, but it will also generalize item scaling to be added to any item.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
refactor: TCG item scaling refactored into an element
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
