### PR TITLE
Removes the gen_turfs from icebox arrivals

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -57030,9 +57030,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ydz" = (
-/turf/open/genturf,
-/area/icemoon/surface/outdoors)
 "ydA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -65716,11 +65713,11 @@ boP
 boP
 boP
 boP
-asE
+boP
 asE
 xzN
 asE
-asE
+boP
 boP
 boP
 boP
@@ -65973,12 +65970,12 @@ boP
 boP
 boP
 boP
-asU
+boP
 bgl
 auP
 bgl
-asU
-asU
+boP
+boP
 boP
 boP
 boP
@@ -66235,7 +66232,7 @@ arB
 sHE
 asE
 aAC
-asU
+boP
 boP
 boP
 boP
@@ -67264,7 +67261,7 @@ aQH
 azz
 aAF
 awW
-ydz
+boP
 boP
 boP
 boP
@@ -67521,7 +67518,7 @@ ayl
 ayl
 aAE
 awW
-ydz
+boP
 boP
 boP
 boP
@@ -67778,7 +67775,7 @@ ayl
 ayl
 bgi
 awW
-ydz
+boP
 boP
 boP
 boP
@@ -68035,7 +68032,7 @@ ayn
 azA
 bgh
 awW
-ydz
+boP
 boP
 boP
 boP
@@ -69062,8 +69059,8 @@ awZ
 aQH
 azB
 awW
-asU
-ydz
+boP
+boP
 boP
 boP
 boP
@@ -69319,8 +69316,8 @@ bbb
 ayl
 beN
 arB
-asU
-ydz
+boP
+boP
 boP
 boP
 boP
@@ -69576,8 +69573,8 @@ aDD
 ayl
 beM
 aAC
-asU
-ydz
+boP
+boP
 boP
 boP
 boP
@@ -69833,8 +69830,8 @@ aIK
 ayl
 beM
 asE
-ydz
-ydz
+boP
+boP
 boP
 boP
 boP


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

They don't god damn do anything because they are literally just placeholders for areas, and they aren't in the right fucking area. Also gets rid of some dumb plating/walls that makes the area looks worse imo

## Why It's Good For The Game

Pain

## Changelog
:cl:
fix: Fixes the map-gen turfs in icebox arrivals 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
