### PR TITLE
Fix moth aheal runtime

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -88,6 +88,6 @@
 	if(H.dna.features["original_moth_antennae"] != null)
 		H.dna.features["moth_antennae"] = H.dna.features["original_moth_antennae"]
 
-	if(H.dna.features["original_moth_antennae"] == null && H.dna.features["moth_antennae" == "Burnt Off"])
+	else
 		H.dna.features["moth_antennae"] = "Plain"
 	handle_mutant_bodyparts(H)

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -88,6 +88,6 @@
 	if(H.dna.features["original_moth_antennae"] != null)
 		H.dna.features["moth_antennae"] = H.dna.features["original_moth_antennae"]
 
-	else
+	if(H.dna.features["original_moth_antennae"] == null && H.dna.features["moth_antennae"] == "Burnt Off")
 		H.dna.features["moth_antennae"] = "Plain"
 	handle_mutant_bodyparts(H)


### PR DESCRIPTION
## About The Pull Request

Moths don't have "Burnt Off" antennas, which caused a runtime to appear.
![image](https://user-images.githubusercontent.com/53223414/104161231-ec412d80-540b-11eb-9a3b-704f50ef26a5.png)


## Why It's Good For The Game

We don't like runtimes.

## Changelog
:cl:
fix: removes a runtime when ahealing moths
/:cl:
