### PR TITLE
Fixes double catwalks on Delta Station.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -7172,11 +7172,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
-"asj" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "ask" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -106144,12 +106139,6 @@
 	},
 /turf/open/floor/glass,
 /area/maintenance/space_hut/observatory)
-"eVg" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "eVx" = (
 /obj/machinery/light{
 	dir = 8
@@ -171193,7 +171182,7 @@ ajr
 aaa
 hUm
 vpk
-asj
+vVc
 wIU
 aaa
 aaa
@@ -171708,8 +171697,8 @@ aaa
 kUH
 jwg
 yhJ
-eVg
-asj
+vVc
+vVc
 vVc
 vVc
 abj
@@ -171964,7 +171953,7 @@ aaa
 aaa
 pCQ
 xBA
-asj
+vVc
 ybr
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/53223414/104165681-2a8e1b00-5413-11eb-9f8f-57c6cf78a955.png)
Removes double and triple catwalks from DeltaStation map.

## Why It's Good For The Game

Runtimes = Bad.

## Changelog
:cl:
fix: removes double/triple catwalks on DeltaStation.
/:cl:
