### PR TITLE
Fixes null-named painting issue

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -185,8 +185,6 @@
 
 /obj/item/canvas/proc/try_rename(mob/user)
 	var/new_name = stripped_input(user,"What do you want to name the painting?")
-	if(!new_name)
-		new_name = "Untitled Artwork"
 	if(new_name != painting_name && new_name && user.canUseTopic(src,BE_CLOSE))
 		painting_name = new_name
 		SStgui.update_uis(src)
@@ -326,6 +324,8 @@
 	var/author = chosen["ckey"]
 	var/png = "data/paintings/[persistence_id]/[chosen["md5"]].png"
 	if(!title)
+		title = "Untitled Artwork" //Should prevent NULL named art from loading as NULL, if you're still getting the admin log chances are persistence is broken
+	if(!title)
 		message_admins("<span class='notice'>Painting with NO TITLE loaded on a [persistence_id] frame in [get_area(src)]. Please delete it, it is saved in the database with no name and will create bad assets.</span>")
 	if(!fexists(png))
 		stack_trace("Persistent painting [chosen["md5"]].png was not found in [persistence_id] directory.")
@@ -355,7 +355,7 @@
 		stack_trace("Invalid persistence_id - [persistence_id]")
 		return
 	if(!C.painting_name)
-		return
+		C.painting_name = "Untitled Artwork"
 	var/data = C.get_data_string()
 	var/md5 = md5(lowertext(data))
 	var/list/current = SSpersistence.paintings[persistence_id]

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -324,6 +324,8 @@
 	var/author = chosen["ckey"]
 	var/png = "data/paintings/[persistence_id]/[chosen["md5"]].png"
 	if(!title)
+		title = "Untitled Artwork" //Prevents NO TITLE paintings. If the NO TITLE issue still comes up, it could be a DB-related issue.
+	if(!title)
 		message_admins("<span class='notice'>Painting with NO TITLE loaded on a [persistence_id] frame in [get_area(src)]. Please delete it, it is saved in the database with no name and will create bad assets.</span>")
 	if(!fexists(png))
 		stack_trace("Persistent painting [chosen["md5"]].png was not found in [persistence_id] directory.")

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -185,6 +185,8 @@
 
 /obj/item/canvas/proc/try_rename(mob/user)
 	var/new_name = stripped_input(user,"What do you want to name the painting?")
+	if(!new_name)
+		new_name = "Untitled Artwork"
 	if(new_name != painting_name && new_name && user.canUseTopic(src,BE_CLOSE))
 		painting_name = new_name
 		SStgui.update_uis(src)
@@ -323,8 +325,6 @@
 	var/title = chosen["title"]
 	var/author = chosen["ckey"]
 	var/png = "data/paintings/[persistence_id]/[chosen["md5"]].png"
-	if(!title)
-		title = "Untitled Artwork" //Prevents NO TITLE paintings. If the NO TITLE issue still comes up, it could be a DB-related issue.
 	if(!title)
 		message_admins("<span class='notice'>Painting with NO TITLE loaded on a [persistence_id] frame in [get_area(src)]. Please delete it, it is saved in the database with no name and will create bad assets.</span>")
 	if(!fexists(png))


### PR DESCRIPTION
## About The Pull Request

There was an issue where you could name paintings nothing, which would cause issues with persistency. This was because the stripped_input didn't actually check that you put something in, so the PR adds that check. It now ensures, both when saved and loaded, that there is a title. If not, it sets them to the default 'Untitled Artwork'

## Why It's Good For The Game

Bugs bad.

## Changelog
:cl:
fix: Paintings are now unable to have no name.
/:cl: