### PR TITLE
Added SQL Game logging

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,12 +1,28 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.12; The query to update the schema revision table is:
+The latest database version is 5.13; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 12);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 13);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 12);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 13);
 
 In any query remember to add a prefix to the table names if you use one.
+
+-----------------------------------------------------
+
+Version 5.13, 11 January 2021, by Missfox
+Create table game_log to upgrade the flat file logging to SQL, to support FoxBus in future. or some other webpanel for log searching.
+
+CREATE TABLE `game_log` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `datetime` datetime NOT NULL,
+  `round_id` int(11) NOT NULL,
+  `ckey` varchar(32) NOT NULL,
+  `loc` varchar(60) NOT NULL,
+  `type` varchar(10) NOT NULL,
+  `message` varchar(1000) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -----------------------------------------------------
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -591,6 +591,19 @@ CREATE TABLE `discord_links` (
   	`valid` BOOLEAN NOT NULL DEFAULT FALSE,
 	PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
+---
+---Table structure for table `game_log`
+---
+CREATE TABLE `game_log` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `datetime` datetime NOT NULL,
+  `round_id` int(11) NOT NULL,
+  `ckey` varchar(32) NOT NULL,
+  `loc` varchar(60) NOT NULL,
+  `type` varchar(10) NOT NULL,
+  `message` varchar(1000) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -502,3 +502,5 @@
 /datum/config_entry/string/centcom_ban_db	// URL for the CentCom Galactic Ban DB API
 
 /datum/config_entry/string/centcom_source_whitelist
+
+/datum/config_entry/flag/sql_game_log //enables game logging to SQL, and disables log to file


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds some basic support for logging game logs to SQL. Its a little rough. and would welcome any improvements.
Also this does require that `/atom/proc/log_message` is used for logging. if anything is using the old log directly to file, this code will miss it and it wont get logged to SQL. (But, while SQL logging is running, anything using log_message won't write to file, so makes it easyer to find those straggling log calls, and update them to use log_message)

This is for adding support for my FoxBus admin panel, or any future webpanel that wants to log search, with out have filesystem access to read the file logs.

The table itself is also rather basic, and some indexing and automatic cleanup scripts might want adding in future to prevent the table from getting too huge. 

I'll leave this as draft for a while, until i get feedback on it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Admins hate log diving, here is a demo of the web panel i made to make that a thing of the past (The UI is quite old now, i have done some updates to the UI, but have not got round to making a new demo)
![demo3](https://user-images.githubusercontent.com/4310446/104224227-fb909d00-5444-11eb-9624-5180c45f3a93.gif)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Miss Fox
server: Added support to log game logs to SQL
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
