### PR TITLE
Fix elevators movement when called via button

### DIFF
--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -190,8 +190,13 @@
 		return
 	lift.visible_message("<span class='notice'>[src] clinks and whirrs into automated motion, locking controls.</span")
 	lift.lift_master_datum.set_controls(LOCKED)
-	var/difference = abs(z - lift.z)
-	var/direction = lift.z > z ? UP : DOWN
+	///The z level to which the elevator should travel
+	var/targetZ = (abs(loc.z)) //The target Z (where the elevator should move to) is not our z level (we are just some assembly in nullspace) but actually the Z level of whatever we are contained in (e.g. elevator button)
+	///The amount of z levels between the our and targetZ
+	var/difference = abs(targetZ - lift.z)
+	///Direction (up/down) needed to go to reach targetZ
+	var/direction = lift.z < targetZ ? UP : DOWN
+	///How long it will/should take us to reach the target Z level
 	var/travel_duration = FLOOR_TRAVEL_TIME * difference //100 / 2 floors up = 50 seconds on every floor, will always reach destination in the same time
 	addtimer(VARSET_CALLBACK(src, cooldown, FALSE), travel_duration)
 	for(var/i in 1 to difference)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently elevators are broken since they try to use the z level of the assembly inside the button to determine how to move
The assemblies z level is however always 0 and instead the z level of the button containing the assembly must be used
This fixes this
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Elevators now no longer try to move when already at the target z (causing runtimes)
![image](https://user-images.githubusercontent.com/33846895/104229324-6b565600-544c-11eb-8f59-7017898e493f.png)

Elevators now also can actually move down (if someone ever maps a lift with a button at the bottom)
## Why It's Good For The Game
Fixes bugs / runtimes 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Elevators / Lifts can now move down via an elevator button and also no longer try to move when already at the target floor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
