### PR TITLE
AIs no longer block the auto-shuttle call

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -320,13 +320,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/callShuttle = TRUE
 
 	for(var/thing in GLOB.shuttle_caller_list)
-		if(isAI(thing))
-			var/mob/living/silicon/ai/AI = thing
-			if(AI.deployed_shell && !AI.deployed_shell.client)
-				continue
-			if(AI.stat || !AI.client)
-				continue
-		else if(istype(thing, /obj/machinery/computer/communications))
+		if(istype(thing, /obj/machinery/computer/communications))
 			var/obj/machinery/computer/communications/C = thing
 			if(C.machine_stat & BROKEN)
 				continue

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -166,7 +166,6 @@
 		/mob/living/silicon/ai/proc/set_automatic_say_channel))
 
 	GLOB.ai_list += src
-	GLOB.shuttle_caller_list += src
 
 	builtInCamera = new (src)
 	builtInCamera.network = list("ss13")
@@ -197,7 +196,6 @@
 
 /mob/living/silicon/ai/Destroy()
 	GLOB.ai_list -= src
-	GLOB.shuttle_caller_list -= src
 	SSshuttle.autoEvac()
 	QDEL_NULL(eyeobj) // No AI, no Eye
 	QDEL_NULL(spark_system)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -196,7 +196,6 @@
 
 /mob/living/silicon/ai/Destroy()
 	GLOB.ai_list -= src
-	SSshuttle.autoEvac()
 	QDEL_NULL(eyeobj) // No AI, no Eye
 	QDEL_NULL(spark_system)
 	QDEL_NULL(malf_picker)

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -22,10 +22,6 @@
 		eyeobj.setLoc(get_turf(src))
 		set_eyeobj_visible(FALSE)
 
-
-	GLOB.shuttle_caller_list -= src
-	SSshuttle.autoEvac()
-
 	ShutOffDoomsdayDevice()
 
 	if(explosive)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
AIs will no longer add themselves to GLOB.shuttle_caller_list, and thus are no longer considered when the game decided if to auto-call the shuttle. Thus, smashing all communications consoles will call the shuttle even if the AI is still alive.

The actual ability for AIs to call the shuttle has not been affected.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Related to #56121, in terms of trying to call the shuttle by smashing all consoles, one no longer also needs to break into the AI's sat (or otherwise find the AI) and kill it to get the shuttle called.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The shuttle auto-call function no longer requires killing any on-station AIs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
