### PR TITLE
Halves the time required for a changeling to absorb someone

### DIFF
--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -43,7 +43,7 @@
 				target.take_overall_damage(40)
 
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Absorb DNA", "[i]"))
-		if(!do_mob(user, target, 150))
+		if(!do_mob(user, target, 7.5 SECONDS))
 			to_chat(user, "<span class='warning'>Our absorption of [target] has been interrupted!</span>")
 			changeling.isabsorbing = 0
 			return


### PR DESCRIPTION
## About The Pull Request

This PR reduces the amount of time required for a changeling to absorb someone they have in a kill grab from 45 seconds to 22.5 seconds.

## Why It's Good For The Game

Changelings receive special benefits for absorbing other changelings (an increased number of points to spend on powers, a larger maximum chem storage capacity, etc.), incentivizing changelings to kill each other instead of working as a big happy family (or at least to not trust other changelings as easily). While this is a nice concept, there's a problem with it.

It takes only 40 seconds for a changeling to be able to resurrect themselves after (faking their) death, but it takes 53 seconds (8 seconds to go from not grabbing up to a kill grab, then 45 seconds to perform the succ after obtaining a kill grab) for a changeling trying to absorb them to successfully do so. This leads to an awkward meta of changelings handcuffing their changeling victims before absorbing them so that their victims won't just get up and walk away. Even if you handcuff them, a changeling with enough chems (and spare gene points) can escape an absorption attempt by activating Biodegrade, which could give them enough time to break your grip and force you to start the looooooooooong absorption process all over again.

With this PR, it will only take 30.5 seconds to go from not grabbing someone to having finished absorbing them, which will give you 9.5 seconds (or more, if your opponent is slow on the draw) of leeway if you try to kill and then absorb another changeling.

Also, sitting on a body in maint waiting for a _45 second long_ series of do_afters() to complete is not what I'd exactly call thrilling antagonist gameplay. Maybe now absorption will be slightly less outclassed by just stripping off someone's jumpsuit, stuffing them in a locker, and calling it a day.

## Changelog
:cl: ATHATH
balance: The amount of time required for a changeling to absorb someone they have in a kill grab has been reduced from 45 seconds to 22.5 seconds.
/:cl: