### PR TITLE
Fix briochecake icon, add tastes and foodtypes

### DIFF
--- a/code/game/objects/items/food/cake.dm
+++ b/code/game/objects/items/food/cake.dm
@@ -444,6 +444,8 @@
 	desc = "A ring of sweet, glazed buns."
 	icon_state = "briochecake"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 20, /datum/reagent/consumable/nutriment/vitamin = 5)
+	tastes = list("cake" = 4, "butter" = 2, "cream" = 1)
+	foodtypes = GRAIN | DAIRY | SUGAR
 
 /obj/item/food/cake/brioche/MakeProcessable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/brioche, 6, 30)
@@ -453,3 +455,5 @@
 	desc = "Delicious sweet-bread. Who needs anything else?"
 	icon_state = "briochecake_slice"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 1)
+	tastes = list("cake" = 4, "butter" = 2, "cream" = 1)
+	foodtypes = GRAIN | DAIRY | SUGAR

--- a/code/game/objects/items/food/cake.dm
+++ b/code/game/objects/items/food/cake.dm
@@ -442,6 +442,7 @@
 /obj/item/food/cake/brioche
 	name = "brioche cake"
 	desc = "A ring of sweet, glazed buns."
+	icon_state = "briochecake"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 20, /datum/reagent/consumable/nutriment/vitamin = 5)
 
 /obj/item/food/cake/brioche/MakeProcessable()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Adds a missing `icon_state` to the full brioche cake
- Adds `SUGAR` to the brioche cake's and slice's `foodtypes`, as they're glazed (according to the description)
- Adds butter and cream to the `tastes` as well
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Less visible errors
- Brioche is quite sweet and buttery, the taste mirrors that now
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Avunia Takiya
fix: Brioche cakes don't look like errors anymore, visually
add: Brioche cakes and its slices have a specific taste now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
