### PR TITLE
Fixes comms console runtime that stops you paying off pirates (and reply to any other messages)

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -96,8 +96,15 @@
 		if ("answerMessage")
 			if (!authenticated(usr))
 				return
+
 			var/answer_index = params["answer"]
 			var/message_index = params["message"]
+
+			// If either of these aren't numbers, then bad voodoo.
+			if(!isnum(answer_index) || !isnum(message_index))
+				message_admins("[ADMIN_LOOKUPFLW(usr)] provided an invalid index type when replying to a message on [src] [ADMIN_JMP(src)]. This should not happen. Please check with a maintainer and/or consult tgui logs.")
+				CRASH("Non-numeric index provided when answering comms console message.")
+
 			if (!answer_index || !message_index || answer_index < 1 || message_index < 1)
 				return
 			var/datum/comm_message/message = messages[message_index]

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -96,8 +96,8 @@
 		if ("answerMessage")
 			if (!authenticated(usr))
 				return
-			var/answer_index = text2num(params["answer"])
-			var/message_index = text2num(params["message"])
+			var/answer_index = params["answer"]
+			var/message_index = params["message"]
 			if (!answer_index || !message_index || answer_index < 1 || message_index < 1)
 				return
 			var/datum/comm_message/message = messages[message_index]

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -635,7 +635,7 @@ const PageMessages = (props, context) => {
               color={message.answered === answerIndex + 1 ? "good" : undefined}
               key={answerIndex}
               onClick={message.answered ? undefined : () => act("answerMessage", {
-                message: messageIndex + 1,
+                message: parseInt(messageIndex) + 1,
                 answer: answerIndex + 1,
               })}
             />

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -635,7 +635,7 @@ const PageMessages = (props, context) => {
               color={message.answered === answerIndex + 1 ? "good" : undefined}
               key={answerIndex}
               onClick={message.answered ? undefined : () => act("answerMessage", {
-                message: parseInt(messageIndex) + 1,
+                message: parseInt(messageIndex, 10) + 1,
                 answer: answerIndex + 1,
               })}
             />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/104377950-23ecca00-551f-11eb-9a77-4740b485e41b.png)
![image](https://user-images.githubusercontent.com/24975989/104378334-bd1be080-551f-11eb-8321-15150f298523.png)

The above image is what happens when the user tries to reply to a message with the index 2. Instead, it outputs the index 11.

![image](https://user-images.githubusercontent.com/24975989/104377444-6e217b80-551e-11eb-8da5-85fb67ad7501.png)

The above image is what I get when I attempt to reply to a message with the index 3. Instead, it outputs the index 21.

This is because JS-side it does a string concat instead of integer addition at messageIndex + 1, as messageIndex is a string and nothing in JS is typed because it is an evil programming language that is a cross between Hitler and Skeletor, with piss of pure liquid malevolence.

We appropriately parse the messageIndex to an int radix 10 before adding 1, and everything just works.

Also removes two text2num conversions following a recent tgui change that made this no longer necessary.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You can now pay off pirates without the console silently rejecting your every attempt.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can once again pay off the pirate event from the communications console without it silently failing for no obvious reason.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
