### PR TITLE
Icebox Xenobio maint fixes

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -30,9 +30,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"ah" = (
-/turf/closed/mineral/random/snow,
-/area/icemoon/underground/unexplored/rivers)
 "ai" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5558,10 +5555,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
-"PS" = (
-/obj/structure/closet/decay,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "PY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -48084,9 +48077,9 @@ Fa
 Fa
 CG
 sX
-ah
 Fa
-PS
+Fa
+oi
 hM
 hM
 hM
@@ -48341,7 +48334,7 @@ Fa
 Fa
 Fa
 Fa
-ah
+Fa
 Fa
 Fa
 Fa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fills in a hole in Icebox lower Xenobio maint causing active turfs and replaces a magic locker that I'm told is unintentional with a regular one.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Icebox xenobio maint no longer has a roundstart hole in it, no more mysterious green locker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
