### PR TITLE
var/hacked now actually does something in vendor spawners

### DIFF
--- a/code/game/objects/effects/spawners/vending.dm
+++ b/code/game/objects/effects/spawners/vending.dm
@@ -11,7 +11,7 @@
 
 	var/random_vendor = pick(subtypesof(/obj/machinery/vending/snack))
 	var/obj/machinery/vending/snack/vend = new random_vendor(loc)
-	vend.extended_inventory = TRUE
+	vend.extended_inventory = hacked
 
 	return INITIALIZE_HINT_QDEL
 
@@ -29,6 +29,6 @@
 
 	var/random_vendor = pick(subtypesof(/obj/machinery/vending/cola))
 	var/obj/machinery/vending/cola/vend = new random_vendor(loc)
-	vend.extended_inventory = TRUE
+	vend.extended_inventory = hacked
 
 	return INITIALIZE_HINT_QDEL


### PR DESCRIPTION
## About The Pull Request

Oversight made by @TiviPlus when making #55147
var/hacked wasn't actually used in code and instead, all spawner vendors were instantly hacked.
fixes #56101

## Why It's Good For The Game

Bugs are bad!

## Changelog
:cl:
fix: Not every single vendor is round-start hacked anymore.
/:cl: