### PR TITLE
Fixes checking a person's inventory requiring a do_after and causing a buckle notification.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1041,11 +1041,13 @@
 
 	//If they dragged themselves to you and you're currently aggressively grabbing them try to piggyback
 	if(user == M && can_piggyback(M))
-		return piggyback(M)
+		piggyback(M)
+		return TRUE
 
 	//If you dragged them to you and you're aggressively grabbing try to fireman carry them
 	if(can_be_firemanned(M))
-		return fireman_carry(M)
+		fireman_carry(M)
+		return TRUE
 
 //src is the user that will be carrying, target is the mob to be carried
 /mob/living/carbon/human/proc/can_piggyback(mob/living/carbon/target)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1029,25 +1029,23 @@
 			message_admins(msg)
 			admin_ticket_log(src, msg)
 
-
-/mob/living/carbon/human/MouseDrop_T(mob/living/target, mob/living/user)
-	if(pulling != target || grab_state != GRAB_AGGRESSIVE || stat != CONSCIOUS || a_intent != INTENT_GRAB)
-		return ..()
-
-	//If they dragged themselves and we're currently aggressively grabbing them try to piggyback
-	if(user == target)
-		if(can_piggyback(target))
-			piggyback(target)
-	//If you dragged them to you and you're aggressively grabbing try to fireman carry them
-	else if(can_be_firemanned(target))
-		fireman_carry(target)
-
 /mob/living/carbon/human/limb_attack_self()
 	var/obj/item/bodypart/arm = hand_bodyparts[active_hand_index]
 	if(arm)
 		arm.attack_self(src)
 	return ..()
 
+/mob/living/carbon/human/mouse_buckle_handling(mob/living/M, mob/living/user)
+	if(pulling != M || grab_state != GRAB_AGGRESSIVE || stat != CONSCIOUS || a_intent != INTENT_GRAB)
+		return FALSE
+
+	//If they dragged themselves to you and you're currently aggressively grabbing them try to piggyback
+	if(user == M && can_piggyback(M))
+		return piggyback(M)
+
+	//If you dragged them to you and you're aggressively grabbing try to fireman carry them
+	if(can_be_firemanned(M))
+		return fireman_carry(M)
 
 //src is the user that will be carrying, target is the mob to be carried
 /mob/living/carbon/human/proc/can_piggyback(mob/living/carbon/target)
@@ -1090,7 +1088,7 @@
 		density = old_density
 
 	if(target.loc == loc)
-		buckle_mob(target, TRUE, TRUE, CARRIER_NEEDS_ARM)
+		return buckle_mob(target, TRUE, TRUE, CARRIER_NEEDS_ARM)
 
 /mob/living/carbon/human/proc/piggyback(mob/living/carbon/target)
 	if(!can_piggyback(target))
@@ -1106,7 +1104,7 @@
 		target.visible_message("<span class='warning'>[target] can't hang onto [src]!</span>")
 		return
 
-	buckle_mob(target, TRUE, TRUE, RIDER_NEEDS_ARMS)
+	return buckle_mob(target, TRUE, TRUE, RIDER_NEEDS_ARMS)
 
 /mob/living/carbon/human/buckle_mob(mob/living/target, force = FALSE, check_loc = TRUE, buckle_mob_flags= NONE)
 	if(!is_type_in_typecache(target, can_ride_typecache))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -817,6 +817,12 @@
  */
 /mob/MouseDrop_T(atom/dropping, atom/user)
 	. = ..()
+
+	// Our mouse drop has already been handled by something else. Most likely buckling code.
+	// Since it has already been handled, we don't need to show inventory.
+	if(.)
+		return
+
 	if(ismob(dropping) && src == user && dropping != user)
 		var/mob/M = dropping
 		var/mob/U = user


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Direct alternative to #56119
Closes #56119
Fixes #55933

`/atom/movable/proc/mouse_buckle_handling(mob/living/M, mob/living/user)` has functionality that is too generic for `/mob/living/carbon/human/`

`/mob/living/carbon/human/MouseDrop_T(mob/living/target, mob/living/user)` contains code that is better suited for `mouse_buckle_handling()`

`/mob/living/carbon/human/MouseDrop_T()` results in a call stack that calls the generic `/atom/movable/proc/mouse_buckle_handling()` when the prerequisites for piggybacking or fireman carrying are not satisfied. But this makes no sense and means that when the game state is such that you should be inspecting the inventory, the game state is ALSO such that you are attempting to erroneously buckle a player to yourself.

In addition, `MouseDrop_T()` should really not be holding mouse buckling logic in this scenario. As a result, this proc override has been removed from /living/carbon/human entirely. All functionality has been shifted into an overriden `mouse_buckle_handling()` at the /living/carbon/human level.

Piggybacking and fireman carrying now actually return a value on success.

Finally, if we have successfully handled the MouseDrop_T event through a parent proc call chain, we no longer go on to show the mob's inventory.

All these tweaks combined mean that you can now click-drag to view inventories without a do_after and without attempting buckling, /mob/living/carbon/human buckling logic is now appropriately in `mouse_buckle_handling()` and no longer falls through to generic buckling checks, which is not relevant when trying to air quotes "buckle" a mob to a /mob/living/carbon/human. Successfully buckling a player to yourself (in this scenario through fireman carrying) no longer opens the inventory window.

I have tested the following behaviours and they work as intended.

- [x] Piggybacking
- [x] Fireman carrying
- [x] Inspecting inventory of /mob/living/carbon/human
- [x] Inspecting inventory of /mob/living/simple_animal/pet/dog/corgi/ian
- [x] Buckling /mob/living/carbon/human to a chair.
- [x] Buckling /mob/living/simple_animal/pet/dog/corgi/ian to a dog bed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes broken behaviour. Makes code more sane?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You should no longer attempt to buckle people to yourself when all you really want to do is inspect their inventories.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
