### PR TITLE
Wooden tables now obey The Law of Conservation of Mass

### DIFF
--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -108,6 +108,6 @@
 				return
 			to_chat(user, "<span class='notice'>You start adding [material] to [src]...</span>")
 			if(do_after(user, 20, target = src) && material.use(1))
-				make_new_table(toConstruct, null, type)
+				make_new_table(toConstruct, null, null)
 	else
 		return ..()

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -64,11 +64,13 @@
 	return ..()
 
 
-/obj/structure/table_frame/proc/make_new_table(table_type, custom_materials, _buildstack) //makes sure the new table made retains what we had as a frame
-	var/obj/structure/table/T = new table_type(loc, _buildstack)
+/obj/structure/table_frame/proc/make_new_table(table_type, custom_materials, carpet_type) //makes sure the new table made retains what we had as a frame
+	var/obj/structure/table/T = new table_type(loc)
 	T.frame = type
 	T.framestack = framestack
 	T.framestackamount = framestackamount
+	if (carpet_type)
+		T.buildstack = carpet_type
 	if(custom_materials)
 		T.set_custom_materials(custom_materials)
 	qdel(src)
@@ -97,17 +99,18 @@
 	if (istype(I, /obj/item/stack))
 		var/obj/item/stack/material = I
 		var/toConstruct // stores the table variant
+		var/carpet_type // stores the carpet type used for construction in case of poker tables
 		if(istype(I, /obj/item/stack/sheet/mineral/wood))
 			toConstruct = /obj/structure/table/wood
 		else if(istype(I, /obj/item/stack/tile/carpet))
 			toConstruct = /obj/structure/table/wood/poker
-
+			carpet_type = I.type
 		if (toConstruct)
 			if(material.get_amount() < 1)
 				to_chat(user, "<span class='warning'>You need one [material.name] sheet to do this!</span>")
 				return
 			to_chat(user, "<span class='notice'>You start adding [material] to [src]...</span>")
 			if(do_after(user, 20, target = src) && material.use(1))
-				make_new_table(toConstruct, null, null)
+				make_new_table(toConstruct, null, carpet_type)
 	else
 		return ..()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -37,11 +37,6 @@
 	smoothing_groups = list(SMOOTH_GROUP_TABLES)
 	canSmoothWith = list(SMOOTH_GROUP_TABLES)
 
-/obj/structure/table/Initialize(mapload, _buildstack)
-	. = ..()
-	if(_buildstack)
-		buildstack = _buildstack
-
 /obj/structure/table/examine(mob/user)
 	. = ..()
 	. += deconstruction_hints(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## About The Pull Request
Fixes Issue https://github.com/tgstation/tgstation/issues/56152 making wood tables deconstruct at they should be.

Bug vivisection:
Okay, see here? This is the proc for creating a table, we can introduce three arguments. One of them is _buildstack. _buildstack overrides Buildstack on initialize, a variable used for storing the type of raw "ore" that the table is supposed to drop in deconstruction. Here is supposed to be null unless we want to override the buildstack with another ore.

```DM
/obj/structure/table_frame/proc/make_new_table(table_type, custom_materials, _buildstack) 
	var/obj/structure/table/T = new table_type(loc, _buildstack)
	T.frame = type
	T.framestack = framestack
	T.framestackamount = framestackamount
	if(custom_materials)
		T.set_custom_materials(custom_materials)
	qdel(src)
```

What happened? The proc for building a wood table from a wooden frame, shown below, passed the "type" variable, used for storing the type of table_frame, as a _buildstack argument to the make_new_table proc. This overrides the buildstack variable of the final wooden table, causing it to drop a wooden frame as it was an ore on deconstruction. 

```DM
/obj/structure/table_frame/wood/attackby(obj/item/I, mob/user, params)
[...]
		if (toConstruct)
			if(material.get_amount() < 1)
				to_chat(user, "<span class='warning'>You need one [material.name] sheet to do this!</span>")
				return
			to_chat(user, "<span class='notice'>You start adding [material] to [src]...</span>")
			if(do_after(user, 20, target = src) && material.use(1))
				make_new_table(toConstruct, null, type)
```
This is funnier (not very much, to be honest) when we consider that deconstructing with a screwdriver would drop a frame normally, causing it to drop two frames. We could repeat this ad nauseam, essentially cloning wood frames in place as we pleased.

So TL;DR: this is another of those simple but hard to hunt bugs that would be prevented with testing and a null on its right place.

If this PR description is too long blame @LemonInTheDark 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A bugfix a day keeps the spaguetti chef away
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed wood table and poker table construction/deconstruction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
