### PR TITLE
Explosive lance icons update properly

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -29,6 +29,7 @@
 	AddComponent(/datum/component/butchering, 100, 70) //decent in a pinch, but pretty bad.
 	AddComponent(/datum/component/jousting)
 	AddComponent(/datum/component/two_handed, force_unwielded=10, force_wielded=18, icon_wielded="[icon_prefix]1")
+	update_icon()
 
 /obj/item/spear/update_icon_state()
 	icon_state = "[icon_prefix]0"
@@ -59,7 +60,6 @@
 	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, .proc/on_wield)
 	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, .proc/on_unwield)
 	set_explosive(new /obj/item/grenade/iedcasing/spawned()) //For admin-spawned explosive lances
-	update_icon()
 
 /obj/item/spear/explosive/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -59,6 +59,7 @@
 	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, .proc/on_wield)
 	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, .proc/on_unwield)
 	set_explosive(new /obj/item/grenade/iedcasing/spawned()) //For admin-spawned explosive lances
+	update_icon()
 
 /obj/item/spear/explosive/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Fixes #56154. Spears were missing an update_icon on initialize, this adds one. Now, spears will show their grenade upon construction. Works just fine in testing.

## Why It's Good For The Game

Bugs bad.

## Changelog
:cl:
fix: Explosive lances will properly show the grenade on them at construction.
/:cl: