### PR TITLE
Stops encrypted report spam

### DIFF
--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -71,7 +71,7 @@
 
 /obj/item/inspector/attack_self(mob/user)
 	. = ..()
-	if(do_after(user, 50, target = user, progress=TRUE))
+	if(do_after(user, 5 SECONDS, target = user, progress=TRUE))
 		print_report()
 
 ///Prints out a report for bounty purposes, and plays a short audio blip.

--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -69,13 +69,10 @@
 	throw_range = 1
 	throw_speed = 1
 
-/obj/item/inspector/attack(mob/living/M, mob/living/user)
-	. = ..()
-	print_report()
-
 /obj/item/inspector/attack_self(mob/user)
 	. = ..()
-	print_report()
+	if(do_after(user, 50, target = user, progress=TRUE))
+		print_report()
 
 ///Prints out a report for bounty purposes, and plays a short audio blip.
 /obj/item/inspector/proc/print_report()
@@ -86,19 +83,17 @@
 
 /obj/item/report
 	name = "encrypted station inspection"
-	desc = "Contains detailed information about the station's current status, too bad you can't really read it. You can almost make out some of the words..."
+	desc = "Contains detailed information about the station's current status, too bad you can't really read it."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "slipfull"
 	///What area the inspector scanned when the report was made. Used to verify the security bounty.
 	var/area/scanned_area
 
-/obj/item/report/examine_more(mob/user)
+/obj/item/report/examine(mob/user)
 	. = ..()
-	var/list/msg = list("<span class='notice'><i>You examine [src] closer, and note the following...</i></span>")
 	if(scanned_area?.name)
-		msg += "\the [src] contains data on [scanned_area.name]."
+		. += "<span class='notice'>\The [src] contains data on [scanned_area.name].</span>"
 	else if(scanned_area)
-		msg += "\the [src] contains data on an vague area on station, you should throw it away."
+		. += "<span class='notice'>\The [src] contains data on a vague area on station, you should throw it away.</span>"
 	else
-		msg += "Wait a minute, this thing's blank! You should throw it away."
-	return msg
+		. += "<span class='notice'>Wait a minute, this thing's blank! You should throw it away.</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a do_after() to the in-spect scanner, and moves its examine_more() into examine(). Removes an unneeded second way to print a report using attack()

## Why It's Good For The Game

Prevents admins having to clean up thousands of useless encrypted reports, and players having to listen to a device screaming WOODY multiple times per second. The examine_more() is completely unnecessary for a single line of text, so this has been appended onto the regular examine() to save users a click while they check where the report was taken from.

## Changelog
:cl: Thunder12345
tweak: In-spect scanner now takes a few seconds to produce a report.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
