### PR TITLE
Refactors how bees ignoring mobs works

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -2187,6 +2187,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"ks" = (
+/obj/item/clothing/suit/beekeeper_suit,
+/obj/item/clothing/head/beekeeper_head,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -2208,6 +2213,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"lE" = (
+/obj/item/toy/plush/beeplushie,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -2408,6 +2417,10 @@
 "wU" = (
 /turf/closed/wall/r_wall,
 /area/science/nanite)
+"ya" = (
+/obj/item/clothing/suit/hooded/bee_costume,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "yK" = (
 /obj/structure/fans/tiny/invisible,
 /obj/effect/turf_decal/stripes/line{
@@ -2673,6 +2686,11 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/medical/medbay)
+"Sl" = (
+/obj/effect/turf_decal/stripes/line,
+/mob/living/simple_animal/hostile/poison/bees,
+/turf/open/floor/plasteel,
+/area/construction)
 "Td" = (
 /obj/machinery/light{
 	dir = 4
@@ -6438,7 +6456,7 @@ cA
 bE
 bE
 ef
-cY
+Sl
 dn
 dn
 dn
@@ -6527,8 +6545,8 @@ XC
 co
 bA
 wS
-bE
-bE
+ks
+lE
 cN
 dW
 dn
@@ -6619,7 +6637,7 @@ cd
 bu
 bu
 cB
-bE
+ya
 bE
 cN
 cY

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -254,6 +254,15 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 */
 #define TRAIT_DONUT_LOVER "donut_lover"
 
+/*
+* Trait that renders you immune to both to targeting and attacks from bees.
+*
+* Scoped to /mob/living. Generally granted by wearing thick clothing, or being
+* something that bees don't see as a threat (other bees, drones, butterflies,
+* podperson).
+*/
+#define TRAIT_BEE_FRIENDLY "bee_friendly"
+
 // METABOLISMS
 // Various jobs on the station have historically had better reactions
 // to various drinks and foodstuffs. Security liking donuts is a classic

--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -19,7 +19,7 @@ GLOBAL_VAR_INIT(tinted_weldhelh, TRUE)
 // Debug is used exactly once (in living.dm) but is commented out in a lot of places.  It is not set anywhere and only checked.
 // Debug2 is used in conjunction with a lot of admin verbs and therefore is actually legit.
 GLOBAL_VAR_INIT(Debug, FALSE)	// global debug switch
-GLOBAL_VAR_INIT(Debug2, FALSE)
+GLOBAL_VAR_INIT(Debug2, TRUE)
 
 //This was a define, but I changed it to a variable so it can be changed in-game.(kept the all-caps definition because... code...) -Errorage
 //Protecting these because the proper way to edit them is with the config/secrets

--- a/code/datums/elements/bee_protection.dm
+++ b/code/datums/elements/bee_protection.dm
@@ -1,0 +1,34 @@
+/**
+ * Bee protection element, added to clothing that is THICKMATERIAL.
+ */
+
+/datum/element/bee_protection/Attach(datum/target)
+	. = ..()
+	if(!istype(target, /obj/item/clothing))
+		return ELEMENT_INCOMPATIBLE
+
+	RegisterSignal(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED), .proc/on_change_of_clothes)
+
+/* Signal handler for a mob equipping/dropping some bee protective clothing.
+ *
+ * Checks to see if the given mob has THICKMATERIAL suit clothing and head
+ * clothing, grants TRAIT_BEE_FRIENDLY if so, removes it otherwise.
+ */
+/datum/element/bee_protection/proc/on_change_of_clothes(obj/item/clothing/clothing, mob/user)
+	SIGNAL_HANDLER
+
+	if(!ishuman(user))
+		return
+
+	var/mob/living/carbon/human/human = user
+
+	REMOVE_TRAIT(human, TRAIT_BEE_FRIENDLY, ELEMENT_TRAIT)
+
+	if(!istype(/obj/item/clothing, human.head) || !istype(/obj/item/clothing, human.wear_suit))
+		return
+
+	var/obj/item/clothing/hat = human.head
+	var/obj/item/clothing/suit = human.wear_suit
+
+	if(hat.clothing_flags & THICKMATERIAL && suit.clothing_flags & THICKMATERIAL)
+		ADD_TRAIT(human, TRAIT_BEE_FRIENDLY, ELEMENT_TRAIT)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -469,7 +469,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	if(item_flags & DROPDEL)
 		qdel(src)
 	item_flags &= ~IN_INVENTORY
-	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED,user)
+	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
 	if(!silent)
 		playsound(src, drop_sound, DROP_SOUND_VOLUME, ignore_walls = FALSE)
 	user?.update_equipment_speed_mods()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -69,6 +69,8 @@
 		LoadComponent(/datum/component/bloodysoles)
 	if(!icon_state)
 		item_flags |= ABSTRACT
+	if(clothing_flags & THICKMATERIAL)
+		AddElement(/datum/element/bee_protection)
 
 /obj/item/clothing/MouseDrop(atom/over_object)
 	. = ..()

--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -5,27 +5,6 @@
 #define BEE_RESOURCE_HONEYCOMB_COST		100		//The amount of bee_resources for a new honeycomb to be produced, percentage cost 1-100
 #define BEE_RESOURCE_NEW_BEE_COST		50		//The amount of bee_resources for a new bee to be produced, percentage cost 1-100
 
-
-
-/mob/proc/bee_friendly()
-	return 0
-
-
-/mob/living/simple_animal/hostile/poison/bees/bee_friendly()
-	return 1
-
-
-/mob/living/carbon/human/bee_friendly()
-	if(dna && dna.species && dna.species.id == "pod") //bees pollinate plants, duh.
-		return 1
-	if (wear_suit && head && istype(wear_suit, /obj/item/clothing) && istype(head, /obj/item/clothing))
-		var/obj/item/clothing/CS = wear_suit
-		var/obj/item/clothing/CH = head
-		if (CS.clothing_flags & CH.clothing_flags & THICKMATERIAL)
-			return 1
-	return 0
-
-
 /obj/structure/beebox
 	name = "apiary"
 	desc = "Dr. Miles Manners is just your average wasp-themed super hero by day, but by night he becomes DR. BEES!"
@@ -197,7 +176,7 @@
 
 /obj/structure/beebox/interact(mob/user)
 	. = ..()
-	if(!user.bee_friendly())
+	if(!HAS_TRAIT(user, TRAIT_BEE_FRIENDLY))
 		//Time to get stung!
 		var/bees = FALSE
 		for(var/b in bees) //everyone who's ever lived here now instantly hates you, suck it assistant!

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -3,7 +3,8 @@
 	name = "Podperson"
 	id = "pod"
 	default_color = "59CE00"
-	species_traits = list(MUTCOLORS,EYECOLOR, HAS_FLESH, HAS_BONE)
+	species_traits = list(MUTCOLORS, EYECOLOR, HAS_FLESH, HAS_BONE)
+	inherent_traits = list(TRAIT_BEE_FRIENDLY)
 	inherent_factions = list("plants", "vines")
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slice.ogg'

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -181,6 +181,7 @@
 		path_hud.add_to_hud(src)
 		path_hud.add_hud_to(src)
 
+	ADD_TRAIT(src, TRAIT_BEE_FRIENDLY, INNATE_TRAIT)
 
 /mob/living/simple_animal/bot/Destroy()
 	if(path_hud)
@@ -193,9 +194,6 @@
 	qdel(access_card)
 	qdel(bot_core)
 	return ..()
-
-/mob/living/simple_animal/bot/bee_friendly()
-	return TRUE
 
 /mob/living/simple_animal/bot/death(gibbed)
 	explode()

--- a/code/modules/mob/living/simple_animal/friendly/butterfly.dm
+++ b/code/modules/mob/living/simple_animal/friendly/butterfly.dm
@@ -34,5 +34,5 @@
 	var/newcolor = rgb(rand(0, 255), rand(0, 255), rand(0, 255))
 	add_atom_colour(newcolor, FIXED_COLOUR_PRIORITY)
 
-/mob/living/simple_animal/butterfly/bee_friendly()
-	return TRUE //treaty signed at the Beeneeva convention
+	// treaty signed at the Beeneeva convention
+	ADD_TRAIT(src, TRAIT_BEE_FRIENDLY, INNATE_TRAIT)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -143,6 +143,9 @@
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)
 		diag_hud.add_to_hud(src)
 
+	// Why would bees pay attention to drones?
+	ADD_TRAIT(src, TRAIT_BEE_FRIENDLY, INNATE_TRAIT)
+
 /mob/living/simple_animal/drone/med_hud_set_health()
 	var/image/holder = hud_list[DIAG_HUD]
 	var/icon/I = icon(icon, icon_state, dir)
@@ -315,10 +318,6 @@
 
 /mob/living/simple_animal/drone/experience_pressure_difference(pressure_difference, direction)
 	return
-
-/mob/living/simple_animal/drone/bee_friendly()
-	// Why would bees pay attention to drones?
-	return TRUE
 
 /mob/living/simple_animal/drone/electrocute_act(shock_damage, source, siemens_coeff, flags = NONE)
 	return FALSE //So they don't die trying to fix wiring

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -63,6 +63,7 @@
 /mob/living/simple_animal/hostile/poison/bees/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
+	ADD_TRAIT(src, TRAIT_BEE_FRIENDLY, INNATE_TRAIT) // no friendly fire
 	generate_bee_visuals()
 	AddComponent(/datum/component/swarming)
 
@@ -134,20 +135,19 @@
 	add_overlay("[icon_base]_wings")
 
 
-//We don't attack beekeepers/people dressed as bees//Todo: bee costume
+//We don't attack beekeepers/people dressed as bees
 /mob/living/simple_animal/hostile/poison/bees/CanAttack(atom/the_target)
 	. = ..()
 	if(!.)
 		return FALSE
 	if(isliving(the_target))
-		var/mob/living/H = the_target
-		return !H.bee_friendly()
+		return !HAS_TRAIT(the_target, TRAIT_BEE_FRIENDLY)
 
 
 /mob/living/simple_animal/hostile/poison/bees/Found(atom/A)
 	if(isliving(A))
-		var/mob/living/H = A
-		return !H.bee_friendly()
+		var/mob/living/living_target = A
+		return !HAS_TRAIT(living_target, TRAIT_BEE_FRIENDLY)
 	if(istype(A, /obj/machinery/hydroponics))
 		var/obj/machinery/hydroponics/Hydro = A
 		if(Hydro.myseed && !Hydro.dead && !Hydro.recent_bee_visit)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -590,6 +590,7 @@
 #include "code\datums\elements\atmos_sensitive.dm"
 #include "code\datums\elements\backblast.dm"
 #include "code\datums\elements\bed_tucking.dm"
+#include "code\datums\elements\bee_protection.dm"
 #include "code\datums\elements\bsa_blocker.dm"
 #include "code\datums\elements\caltrop.dm"
 #include "code\datums\elements\cleaning.dm"


### PR DESCRIPTION
:cl: coiax
refactor: The code of how bees ignore people has been reworked.
/:cl:

Instead of the `bee_friendly` proc being based on the `/mob` typepath,
bees ignoring people (and being unable to attack them), is now
implemented with the new `TRAIT_BEE_FRIENDLY` trait.

This removes a random `/mob` level proc to implement a small feature of
bees ignoring people (and makes it easier to implement temporary bee
ignoring).

---

The mechanism for how a human awearing THICKMATERIAL head
and suit, I am not 100% sure if that's the best way to implement it
currently.

Opening a draft for comment and help with the human clothing
aspect, it's also stopped working at this time, but I don't think
I've changed anything?

- [ ] Ensure that the bee costume hood toggle makes you bee friendly properly.
Noticed in testing that if you used the action button of a
bee costume to retract the hood, you remained BEE_FRIENDLY
erroneously.
- [ ] Remove bee testing equipment from runtime station.
- [ ] Remove DEBUG2 default variable.