### PR TITLE
Update Dockerfile for CBT

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ indent_style = space
 
 [*.md]
 trim_trailing_whitespace = false
+
+[Dockerfile]
+indent_style = space

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,23 @@
-FROM tgstation/byond:513.1533 as base
+FROM i386/ubuntu:xenial as base
+
+WORKDIR /byond
+COPY dependencies.sh .
+RUN . ./dependencies.sh \
+    && apt-get update \
+    && apt-get install -y \
+        curl \
+        unzip \
+        make \
+        libstdc++6 \
+    && curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip \
+    && unzip byond.zip \
+    && cd byond \
+    && sed -i 's|install:|&\n\tmkdir -p $(MAN_DIR)/man6|' Makefile \
+    && make install \
+    && chmod 644 /usr/local/byond/man/man6/* \
+    && apt-get purge -y --auto-remove curl unzip make \
+    && cd .. \
+    && rm -rf byond byond.zip /var/lib/apt/lists/*
 
 FROM base as rust_g
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,18 +44,22 @@ RUN env TG_BOOTSTRAP_NODE_LINUX=1 tools/build/build \
     && tools/deploy.sh /deploy \
 	&& rm /deploy/*.dll
 
+# rust = base + rustc and i686 target
+FROM base AS rust
+RUN apt-get install -y --no-install-recommends \
+        curl && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal \
+    && ~/.cargo/bin/rustup target add i686-unknown-linux-gnu
+
 # rust_g = base + rust_g compiled to /rust_g
-FROM base AS rust_g
+FROM rust AS rust_g
 WORKDIR /rust_g
 
 RUN apt-get install -y --no-install-recommends \
         pkg-config:i386 \
         libssl-dev:i386 \
-        curl \
         gcc-multilib \
         git \
-    && curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal \
-    && ~/.cargo/bin/rustup target add i686-unknown-linux-gnu \
     && git init \
     && git remote add origin https://github.com/tgstation/rust-g
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/ubuntu:xenial as base
+FROM ubuntu:xenial as base
 
 WORKDIR /byond
 COPY dependencies.sh .
@@ -21,19 +21,21 @@ RUN . ./dependencies.sh \
 
 FROM base as rust_g
 
-RUN apt-get update \
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
     && apt-get install -y --no-install-recommends \
-    git \
-    ca-certificates
+        git \
+        ca-certificates
 
 WORKDIR /rust_g
 
 RUN apt-get install -y --no-install-recommends \
-    libssl-dev \
-    pkg-config \
-    curl \
-    gcc-multilib \
-    && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-host i686-unknown-linux-gnu \
+        pkg-config:i386 \
+        libssl-dev:i386 \
+        curl \
+        gcc-multilib \
+    && curl https://sh.rustup.rs -sSf | sh -s -- -y \
+    && ~/.cargo/bin/rustup target add i686-unknown-linux-gnu \
     && git init \
     && git remote add origin https://github.com/tgstation/rust-g
 
@@ -42,7 +44,7 @@ COPY dependencies.sh .
 RUN /bin/bash -c "source dependencies.sh \
     && git fetch --depth 1 origin \$RUST_G_VERSION" \
     && git checkout FETCH_HEAD \
-    && ~/.cargo/bin/cargo build --release
+    && env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo build --release --target i686-unknown-linux-gnu
 
 FROM base as dm_base
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,9 +71,8 @@ FROM byond
 WORKDIR /tgstation
 
 RUN apt-get install -y --no-install-recommends \
-        libmariadb2 \
-        mariadb-client \
-        libssl1.0.0
+        libssl1.0.0:i386 \
+        zlib1g:i386
 
 COPY --from=build /deploy ./
 COPY --from=rust_g /rust_g/target/i686-unknown-linux-gnu/release/librust_g.so ./librust_g.so

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -4,11 +4,8 @@
 #Final authority on what's required to fully build the project
 
 # byond version
-# Extracted from the Dockerfile. Change by editing Dockerfile's FROM command.
-LIST="$(sed -n 's/.*byond:\([0-9]\+\)\.\([0-9]\+\).*/\1 \2/p' Dockerfile)"
-export BYOND_MAJOR=${LIST% *}
-export BYOND_MINOR=${LIST#* }
-unset LIST
+export BYOND_MAJOR=513
+export BYOND_MINOR=1533
 
 #rust_g git tag
 export RUST_G_VERSION=0.4.7


### PR DESCRIPTION
Follow-up to #55373 to fix the failing Docker CI on master.

- Reorganize the entire Dockerfile to be more readable
- Inline the `tgstation/byond` Dockerfile into our own, so we can change the base distro at will
  - Also allows us to trash the `dependencies.sh`<->Dockerfile hack
- Use 32-bit libs on a 64-bit distro so that we can download and run recent 64-bit Node binaries
- Call `tools/build/build` rather than `DreamMaker` directly