### PR TITLE
tweaks lrtbbq blackmarket thing cooldown timers

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_telepad.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_telepad.dm
@@ -27,7 +27,7 @@
 	/// Current recharge progress.
 	var/recharge_cooldown = 0
 	/// Base recharge time in seconds which is used to get recharge_time.
-	var/base_recharge_time = 200
+	var/base_recharge_time = 100
 	/// Current /datum/blackmarket_purchase being received.
 	var/receiving
 	/// Current /datum/blackmarket_purchase being sent to the target uplink.


### PR DESCRIPTION
:cl:
tweak: Long-To-Short-Range-Bluespace-Transceiver timers changed from T1: 90s -> 40s  T2: 70s -> 30s  T3: 60s -> 20s  T4: 60s -> 10s 
/:cl:
when i asked chosen a while back why is this thing so slow he said he did math wrong as proof on comment in line 54: tier 4 was 120 instead of 20 processing ticks aka 60s instead of 10s
he probably forgot about it so i ll pr it myself