### PR TITLE
Adds custom icon mapping helper.

### DIFF
--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -77,8 +77,8 @@
 #define RUSTG_HTTP_METHOD_PATCH "patch"
 #define RUSTG_HTTP_METHOD_HEAD "head"
 #define RUSTG_HTTP_METHOD_POST "post"
-#define rustg_http_request_blocking(method, url, body, headers) call(RUST_G, "http_request_blocking")(method, url, body, headers)
-#define rustg_http_request_async(method, url, body, headers) call(RUST_G, "http_request_async")(method, url, body, headers)
+#define rustg_http_request_blocking(method, url, body, headers, options) call(RUST_G, "http_request_blocking")(method, url, body, headers, options)
+#define rustg_http_request_async(method, url, body, headers, options) call(RUST_G, "http_request_async")(method, url, body, headers, options)
 #define rustg_http_check_request(req_id) call(RUST_G, "http_check_request")(req_id)
 
 #define RUSTG_JOB_NO_RESULTS_YET "NO RESULTS YET"

--- a/code/datums/http.dm
+++ b/code/datums/http.dm
@@ -6,10 +6,12 @@
 	var/body
 	var/headers
 	var/url
+	/// If present response body will be saved to this file.
+	var/output_file
 
 	var/_raw_response
 
-/datum/http_request/proc/prepare(method, url, body = "", list/headers)
+/datum/http_request/proc/prepare(method, url, body = "", list/headers , output_file)
 	if (!length(headers))
 		headers = ""
 	else
@@ -19,21 +21,27 @@
 	src.url = url
 	src.body = body
 	src.headers = headers
+	src.output_file = output_file
 
 /datum/http_request/proc/execute_blocking()
-	_raw_response = rustg_http_request_blocking(method, url, body, headers)
+	_raw_response = rustg_http_request_blocking(method, url, body, headers, build_options())
 
 /datum/http_request/proc/begin_async()
 	if (in_progress)
 		CRASH("Attempted to re-use a request object.")
 
-	id = rustg_http_request_async(method, url, body, headers)
+	id = rustg_http_request_async(method, url, body, headers, build_options())
 
 	if (isnull(text2num(id)))
 		stack_trace("Proc error: [id]")
 		_raw_response = "Proc error: [id]"
 	else
 		in_progress = TRUE
+
+/datum/http_request/proc/build_options()
+	if(output_file)
+		return json_encode(list("output_filename"=output_file,"body_filename"=null))
+	return null
 
 /datum/http_request/proc/is_complete()
 	if (isnull(id))

--- a/code/datums/http.dm
+++ b/code/datums/http.dm
@@ -11,7 +11,7 @@
 
 	var/_raw_response
 
-/datum/http_request/proc/prepare(method, url, body = "", list/headers , output_file)
+/datum/http_request/proc/prepare(method, url, body = "", list/headers, output_file)
 	if (!length(headers))
 		headers = ""
 	else

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -501,3 +501,57 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 		stack_trace("Trait mapper found no targets at ([x], [y], [z]). First Match Only: [first_match_only ? "true" : "false"] target type: [target_type] | target name: [target_name] | trait name: [trait_name]")
 	qdel(src)
 
+/// Fetches an external dmi and applies to the target object
+/obj/effect/mapping_helpers/custom_icon
+	name = "Custom Icon Helper"
+	icon_state = "trait"
+	late = TRUE
+	///Will inject into all fitting the criteria if false, otherwise first found.
+	var/first_match_only = TRUE
+	///Will inject into atoms of this type.
+	var/target_type
+	///Will inject into atoms with this name.
+	var/target_name
+	/// This is the var tha will be set with the fetched icon. In case you want to set some secondary icon sheets like inhands and such.
+	var/target_variable = "icon"
+	/// This should return raw dmi in response to http get request. For example: "https://github.com/tgstation/SS13-sprites/raw/master/mob/medu.dmi"
+	var/icon_url
+
+/obj/effect/mapping_helpers/custom_icon/LateInitialize()
+	///TODO put this injector stuff under common root
+	var/I = fetch_icon(icon_url)
+	var/turf/target_turf = get_turf(src)
+	var/matches_found = 0
+	for(var/a in target_turf.GetAllContents())
+		var/atom/atom_on_turf = a
+		if(atom_on_turf == src)
+			continue
+		if(target_name && atom_on_turf.name != target_name)
+			continue
+		if(target_type && !istype(atom_on_turf,target_type))
+			continue
+		atom_on_turf.vars[target_variable] = I
+		matches_found++
+		if(first_match_only)
+			qdel(src)
+			return
+	if(!matches_found)
+		stack_trace("[src] found no targets at ([x], [y], [z]). First Match Only: [first_match_only ? "true" : "false"] target type: [target_type] | target name: [target_name]")
+	qdel(src)
+
+/obj/effect/mapping_helpers/custom_icon/proc/fetch_icon(url)
+	var/static/icon_cache = list()
+	if(icon_cache[url])
+		return icon_cache[url]
+	log_asset("Custom Icon Helper fetching dmi from: [url]")
+	var/datum/http_request/request = new()
+	var/file_name = "tmp/custom_map_icon.dmi"
+	request.prepare(RUSTG_HTTP_METHOD_GET, url , "", "", file_name)
+	request.begin_async()
+	UNTIL(request.is_complete())
+	var/datum/http_response/response = request.into_response()
+	if(response.errored || response.status_code != 200)
+		stack_trace("Failed to fetch mapped custom icon from url [url], code: [response.status_code]")
+	var/icon/I = new(file_name)
+	icon_cache[url] = I
+	return I

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -92,6 +92,10 @@ if ls _maps/*.json | grep -P "[A-Z]"; then
     echo "Uppercase in a map json detected, these must be all lowercase."
     st=1
 fi;
+if grep -i '/obj/effect/mapping_helpers/custom_icon' _maps/**/*.dmm; then
+    echo "Custom icon helper found. Please include dmis as standard assets instead for built-in maps."
+    st=1
+fi;
 for json in _maps/*.json
 do
     map_path=$(jq -r '.map_path' $json)


### PR DESCRIPTION
Allows embedding icon edits in your maps by fetching them from external host.
This is intended for use with live-loaded away/event maps not standard ones.

Also updates rustg defines to expose the additional options arguments. (https://github.com/tgstation/rust-g/pull/59)
