### PR TITLE
Makes icon changes and changes to centcom cause a rebuild

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -31,9 +31,11 @@ const taskTgui = new Task('tgui')
   });
 
 const taskDm = new Task('dm')
+  .depends('_maps/map_files/generic/**')
   .depends('code/**')
   .depends('goon/**')
   .depends('html/**')
+  .depends('icons/**')
   .depends('interface/**')
   .depends('tgui/public/tgui.html')
   .depends('tgui/public/*.bundle.*')


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Why It's Good For The Game

Edits to maps we always compile, or icons should cause rebuilds so people don't need to futz about with forcing them manually.

