### PR TITLE
Fix Docker build failing on a clean checkout

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,7 +22,6 @@ tgstation.int
 tgstation.rsc
 tgstation.lk
 tgstation.dyn.rsc
-libmariadb.dll
-rust_g.dll
-BSQL.dll
+*.dll
 Dockerfile
+tools/bootstrap/.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,7 @@ RUN apt-get install -y --no-install-recommends \
 COPY . .
 
 RUN env TG_BOOTSTRAP_NODE_LINUX=1 tools/build/build \
-    && tools/deploy.sh /deploy \
-	&& rm /deploy/*.dll
+    && tools/deploy.sh /deploy
 
 # rust = base + rustc and i686 target
 FROM base AS rust

--- a/tools/bootstrap/node
+++ b/tools/bootstrap/node
@@ -32,6 +32,7 @@ if [ "$(uname)" = "Linux" ] || [ ! -f "$NodeExe" ]; then
 		NodeExe="$NodeDir/node"
 
 		if [ ! -f "$NodeExe" ]; then
+			mkdir -p "$Cache"
 			Archive="$(realpath "$Cache/node-v$NodeVersion.tar.gz")"
 			curl "https://nodejs.org/download/release/v$NodeVersion/$NodeFullVersion.tar.gz" -o "$Archive"
 			(cd "$Cache" && tar xf "$Archive")

--- a/tools/ci/run_server.sh
+++ b/tools/ci/run_server.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 tools/deploy.sh ci_test
-rm ci_test/*.dll
 mkdir ci_test/config
 
 #test config

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -32,4 +32,6 @@ cp -r strings/* $1/strings/
 #find $1/_maps -name "*.dm" -type f -delete
 
 #dlls on windows
-cp *.dll $1/ || true
+if [ "$(uname -o)" = "Msys" ]; then
+	cp ./*.dll $1/
+fi


### PR DESCRIPTION
Follow-up to #56175 which turned out to be accidentally relying on Node already being downloaded.