### PR TITLE
Fix tgui being built too often/not often enough

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -17,8 +17,11 @@ const taskTgui = new Task('tgui')
   .depends('tgui/**/package.json')
   .depends('tgui/packages/**/*.js')
   .depends('tgui/packages/**/*.jsx')
-  .provides('tgui/public/*.bundle.*')
-  .provides('tgui/public/*.chunk.*')
+  .provides('tgui/public/tgui.bundle.css')
+  .provides('tgui/public/tgui.bundle.js')
+  .provides('tgui/public/tgui-common.chunk.js')
+  .provides('tgui/public/tgui-panel.bundle.css')
+  .provides('tgui/public/tgui-panel.bundle.js')
   .build(async () => {
     if (process.platform === 'win32') {
       await exec('powershell.exe',

--- a/tools/build/cbt/fs.js
+++ b/tools/build/cbt/fs.js
@@ -56,7 +56,7 @@ const compareFiles = nodes => {
           }
         } catch {
           // Always needs a rebuild if any target doesn't exist.
-          return true;
+          return `target '${node.path}' is missing`;
         }
         continue;
       }
@@ -83,14 +83,21 @@ const compareFiles = nodes => {
   }
   // Doesn't need rebuild if there is no source, but target exists.
   if (!bestSource) {
-    return !bestTarget;
+    if (bestTarget) {
+      return false;
+    } else {
+      return 'no known sources or targets';
+    }
   }
   // Always needs a rebuild if no targets were specified (e.g. due to GLOB).
   if (!bestTarget) {
-    return true;
+    return 'no targets were specified';
   }
   // Needs rebuild if source is newer than target
-  return bestSource.mtime > bestTarget.mtime;
+  if (bestSource.mtime > bestTarget.mtime) {
+    return `source '${bestSource.path}' is newer than target '${bestTarget.path}'`;
+  }
+  return false;
 };
 
 /**

--- a/tools/build/cbt/task.js
+++ b/tools/build/cbt/task.js
@@ -35,8 +35,9 @@ class Task {
   async run() {
     // Consider dependencies first, and skip the task if it
     // doesn't need a rebuild.
+    let needsRebuild = 'empty dependency list';
     if (this.deps.length > 0) {
-      const needsRebuild = compareFiles(this.deps);
+      needsRebuild = compareFiles(this.deps);
       if (!needsRebuild) {
         console.warn(` => Skipping '${this.name}'`);
         return;
@@ -45,7 +46,7 @@ class Task {
     if (!this.script) {
       return;
     }
-    console.warn(` => Starting '${this.name}'`);
+    console.warn(` => Starting '${this.name}': ${needsRebuild}`);
     const startedAt = Date.now();
     await this.script();
     const time = ((Date.now() - startedAt) / 1000) + 's';


### PR DESCRIPTION
Caused by the output list containing globs, meaning that:
- an extraneous file that matched the globs caused eternal rebuilds
- removing one file that matched the globs failed to cause a rebuild

Also adds logging to make similar issues easier to debug.