### PR TITLE
Shows bounty splits on the civilian bounty console UI.

### DIFF
--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -1,3 +1,5 @@
+#define CIV_BOUNTY_SPLIT 30
+
 ///Pad for the Civilian Bounty Control.
 /obj/machinery/piratepad/civilian
 	name = "civilian bounty pad"
@@ -104,7 +106,7 @@
 		reward.bounty_holder = inserted_scan_id.registered_name
 		reward.name = "\improper [reward.bounty_value] cr [reward.name]"
 		reward.desc += " The tag indicates it was [reward.bounty_holder]'s reward for completing the <i>[reward.bounty_name]</i> bounty and that it was created at [station_time_timestamp(format = "hh:mm")]."
-		reward.AddComponent(/datum/component/pricetag, inserted_scan_id.registered_account, 30)
+		reward.AddComponent(/datum/component/pricetag, inserted_scan_id.registered_account, CIV_BOUNTY_SPLIT)
 	pad.visible_message("<span class='notice'>[pad] activates!</span>")
 	flick(pad.sending_state,pad)
 	pad.icon_state = pad.idle_state
@@ -159,15 +161,15 @@
 		if(inserted_scan_id.registered_account.civilian_bounty)
 			data["id_bounty_info"] = inserted_scan_id.registered_account.civilian_bounty.description
 			data["id_bounty_num"] = inserted_scan_id.registered_account.bounty_num()
-			data["id_bounty_value"] = inserted_scan_id.registered_account.civilian_bounty.reward
+			data["id_bounty_value"] = (inserted_scan_id.registered_account.civilian_bounty.reward) * (CIV_BOUNTY_SPLIT/100)
 		if(inserted_scan_id.registered_account.bounties)
 			data["picking"] = TRUE
 			data["id_bounty_names"] = list(inserted_scan_id.registered_account.bounties[1].name,
 											inserted_scan_id.registered_account.bounties[2].name,
 											inserted_scan_id.registered_account.bounties[3].name)
-			data["id_bounty_values"] = list(inserted_scan_id.registered_account.bounties[1].reward,
-											inserted_scan_id.registered_account.bounties[2].reward,
-											inserted_scan_id.registered_account.bounties[3].reward)
+			data["id_bounty_values"] = list(inserted_scan_id.registered_account.bounties[1].reward * (CIV_BOUNTY_SPLIT/100),
+											inserted_scan_id.registered_account.bounties[2].reward * (CIV_BOUNTY_SPLIT/100),
+											inserted_scan_id.registered_account.bounties[3].reward * (CIV_BOUNTY_SPLIT/100))
 		else
 			data["picking"] = FALSE
 


### PR DESCRIPTION
## About The Pull Request

I could have sworn this was originally on the UI at least two changes ago, and it must have been removed in the chaos.
Moves the split that bounties are adjusted by to a define, then makes the UI show the FULFILLER'S profit, not cargo's profit.

## Why It's Good For The Game

The Ui should probably not lie to the players, ya know? Plus it was likely unintionally removed with the triple pick changes.

## Changelog
:cl:
fix: Civilian Bounties now show the fulfillment value, instead of the value of the cube total. The UI is not lying anymore!
/:cl:
