### PR TITLE
Adds wrench able on top of function to grinders

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -564,7 +564,10 @@
 /obj/proc/default_unfasten_wrench(mob/user, obj/item/I, time = 20) //try to unwrench an object in a WONDERFUL DYNAMIC WAY
 	if(!(flags_1 & NODECONSTRUCT_1) && I.tool_behaviour == TOOL_WRENCH)
 		var/turf/ground = get_turf(src)
-		if(!anchored && ground.is_blocked_turf(exclude_mobs = TRUE, excluded_object = src))
+		var/list/excluded_objects = list(src)
+		if(anchorables)
+			excluded_objects += anchorables
+		if(!anchored && ground.is_blocked_turf(exclude_mobs = TRUE, excluded_objects = excluded_objects))
 			to_chat(user, "<span class='notice'>You fail to secure [src].</span>")
 			return CANT_UNFASTEN
 		var/can_be_unfasten = can_be_unfasten_wrench(user)
@@ -576,7 +579,7 @@
 		var/prev_anchored = anchored
 		//as long as we're the same anchored state and we're either on a floor or are anchored, toggle our anchored state
 		if(I.use_tool(src, user, time, extra_checks = CALLBACK(src, .proc/unfasten_wrench_check, prev_anchored, user)))
-			if(!anchored && ground.is_blocked_turf(exclude_mobs = TRUE, excluded_object = src))//i know what you tryin to sneak in
+			if(!anchored && ground.is_blocked_turf(exclude_mobs = TRUE, excluded_objects = excluded_objects))//i know what you tryin to sneak in
 				to_chat(user, "<span class='notice'>You fail to secure [src].</span>")
 				return CANT_UNFASTEN
 			to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [src].</span>")

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -564,7 +564,7 @@
 /obj/proc/default_unfasten_wrench(mob/user, obj/item/I, time = 20) //try to unwrench an object in a WONDERFUL DYNAMIC WAY
 	if(!(flags_1 & NODECONSTRUCT_1) && I.tool_behaviour == TOOL_WRENCH)
 		var/turf/ground = get_turf(src)
-		var/list/excluded_objects = list(src)
+		var/list/excluded_objects = list(type)
 		if(anchorables)
 			excluded_objects += anchorables
 		if(!anchored && ground.is_blocked_turf(exclude_mobs = TRUE, excluded_objects = excluded_objects))

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -9,6 +9,7 @@
 	power_channel = AREA_USAGE_EQUIP
 	circuit = /obj/item/circuitboard/machine/cell_charger
 	pass_flags = PASSTABLE
+	anchorables = list(/obj/structure/table)
 	var/obj/item/stock_parts/cell/charging = null
 	var/charge_rate = 250
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -46,6 +46,9 @@
 	/// broadcasted to as long as the other guys network is on the same branch or above.
 	var/network_id = null
 
+	///List of object types that the item can be anchored on top of, such as a table
+	var/list/anchorables = null
+
 /obj/vv_edit_var(vname, vval)
 	if(vname == NAMEOF(src, obj_flags))
 		if ((obj_flags & DANGEROUS_POSSESSION) && !(vval & DANGEROUS_POSSESSION))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -64,6 +64,8 @@
 		stack_trace("Invalid type [armor.type] found in .armor during /obj Initialize()")
 	if(obj_integrity == null)
 		obj_integrity = max_integrity
+	if(anchorables)
+		anchorables = string_list(anchorables)
 
 	. = ..() //Do this after, else mat datums is mad.
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -171,10 +171,10 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	if(density)
 		return TRUE
 	for(var/i in contents)
-		var/atom/thing = i
+		var/atom/movable/thing = i
 		var/excuded = FALSE
 		for(var/excluded in excluded_objects)
-			if(ispath(thing.type, excluded))
+			if(istype(thing, excluded))
 				excuded = TRUE
 		if(!excuded && thing.density && (!exclude_mobs || !ismob(thing)))
 			return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -174,7 +174,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		var/atom/thing = i
 		var/excuded = FALSE
 		for(var/excluded in excluded_objects)
-			if(istype(thing, excluded))
+			if(ispath(thing.type, excluded))
 				excuded = TRUE
 		if(!excuded && thing.density && (!exclude_mobs || !ismob(thing)))
 			return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -167,12 +167,13 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	SEND_SIGNAL(src, COMSIG_TURF_MULTIZ_NEW, T, dir)
 
 ///returns if the turf has something dense inside it. if exclude_mobs is true, skips dense mobs like fat yoshi. if exclude_object is true, it will exclude the excluded_object you sent through
-/turf/proc/is_blocked_turf(exclude_mobs, excluded_object)
+/turf/proc/is_blocked_turf(exclude_mobs, list/excluded_objects = list())
 	if(density)
 		return TRUE
+	var/list/excluded_typecache = typecacheof(excluded_objects)
 	for(var/i in contents)
 		var/atom/thing = i
-		if(thing == excluded_object)
+		if(excluded_typecache[thing.type])
 			continue
 		if(thing.density && (!exclude_mobs || !ismob(thing)))
 			return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -170,12 +170,13 @@ GLOBAL_LIST_EMPTY(station_turfs)
 /turf/proc/is_blocked_turf(exclude_mobs, list/excluded_objects = list())
 	if(density)
 		return TRUE
-	var/list/excluded_typecache = typecacheof(excluded_objects)
 	for(var/i in contents)
 		var/atom/thing = i
-		if(excluded_typecache[thing.type])
-			continue
-		if(thing.density && (!exclude_mobs || !ismob(thing)))
+		var/excuded = FALSE
+		for(var/excluded in excluded_objects)
+			if(istype(thing, excluded))
+				excuded = TRUE
+		if(!excuded && thing.density && (!exclude_mobs || !ismob(thing)))
 			return TRUE
 	return FALSE
 

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -12,6 +12,7 @@
 	circuit = /obj/item/circuitboard/machine/reagentgrinder
 	pass_flags = PASSTABLE
 	resistance_flags = ACID_PROOF
+	anchorables = list(/obj/structure/table)
 	var/operating = FALSE
 	var/obj/item/reagent_containers/beaker = null
 	var/limit = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Grinders and the like could not be secured on to of a table.
This adds the ability to provide a list of type that the object can be secured on top of.

Fixes #56158

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Able to put cell charges and grinders on tables is max gameplay. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Able to secure grinders/cell chargers to tables.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
