### PR TITLE
Rename chunk to bundle in build.js

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -23,7 +23,7 @@ const taskTgui = new Task('tgui')
   .depends('tgui/packages/**/*.jsx')
   .provides('tgui/public/tgui.bundle.css')
   .provides('tgui/public/tgui.bundle.js')
-  .provides('tgui/public/tgui-common.chunk.js')
+  .provides('tgui/public/tgui-common.bundle.js')
   .provides('tgui/public/tgui-panel.bundle.css')
   .provides('tgui/public/tgui-panel.bundle.js')
   .build(async () => {


### PR DESCRIPTION
## About The Pull Request

Chunks are now called bundles for consistency, missed it in `build.js`.

Without it, CBT will rebuild the game more than necessary.