### PR TITLE
tgui 4.3 hotfix 1

### DIFF
--- a/tgui/README.md
+++ b/tgui/README.md
@@ -126,6 +126,17 @@ variable, with a full path to BYOND cache.
 BYOND_CACHE="E:/Libraries/Documents/BYOND/cache"
 ```
 
+**Webpack errors out with some cryptic messages!**
+
+> Example: `No template for dependency: PureExpressionDependency`
+
+Webpack stores its cache on disk since tgui 4.3, and it is very sensitive
+to build configuration. So if you update webpack, or share the same cache
+directory between development and production build, it will start
+hallucinating.
+
+To fix this kind of problem, run `bin/tgui --clean` and try again.
+
 ## Developer Tools
 
 When developing with `tgui-dev-server`, you will have access to certain

--- a/tgui/packages/tgui-polyfill/index.js
+++ b/tgui/packages/tgui-polyfill/index.js
@@ -14,3 +14,8 @@ import './ie8';
 import './dom4';
 import './css-om';
 import './inferno';
+
+// Fetch is required for Webpack HMR
+if (module.hot) {
+  require('whatwg-fetch');
+}

--- a/tgui/packages/tgui-polyfill/package.json
+++ b/tgui/packages/tgui-polyfill/package.json
@@ -4,6 +4,7 @@
   "version": "4.3.0",
   "dependencies": {
     "core-js": "^3.8.2",
-    "regenerator-runtime": "^0.13.7"
+    "regenerator-runtime": "^0.13.7",
+    "whatwg-fetch": "^3.5.0"
   }
 }

--- a/tgui/packages/tgui/styles/components/Section.scss
+++ b/tgui/packages/tgui/styles/components/Section.scss
@@ -65,7 +65,7 @@ $shadow-offset: 0 0 !default;
   flex-grow: 1;
 }
 
-.Section--fill .Section__content {
+.Section--fill.Section--scrollable .Section__content {
   position: absolute;
   top: 0;
   left: 0;

--- a/tgui/webpack.config.js
+++ b/tgui/webpack.config.js
@@ -25,8 +25,9 @@ const createStats = verbose => ({
 });
 
 module.exports = (env = {}, argv) => {
+  const mode = argv.mode === 'production' ? 'production' : 'development';
   const config = {
-    mode: argv.mode === 'production' ? 'production' : 'development',
+    mode,
     context: path.resolve(__dirname),
     target: ['web', 'es3', 'browserslist:ie 8'],
     entry: {
@@ -58,9 +59,7 @@ module.exports = (env = {}, argv) => {
           use: [
             {
               loader: 'babel-loader',
-              options: createBabelConfig({
-                mode: argv.mode,
-              }),
+              options: createBabelConfig({ mode }),
             },
           ],
         },
@@ -105,7 +104,7 @@ module.exports = (env = {}, argv) => {
     devtool: false,
     cache: {
       type: 'filesystem',
-      cacheLocation: path.resolve(__dirname, '.yarn/webpack'),
+      cacheLocation: path.resolve(__dirname, `.yarn/webpack/${mode}`),
     },
     stats: createStats(true),
     plugins: [

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -5574,6 +5574,7 @@ fsevents@~2.3.1:
   dependencies:
     core-js: ^3.8.2
     regenerator-runtime: ^0.13.7
+    whatwg-fetch: ^3.5.0
   languageName: unknown
   linkType: soft
 
@@ -5966,6 +5967,13 @@ fsevents@~2.3.1:
   bin:
     webpack: bin/webpack.js
   checksum: ad6fbbbd926c6b16c5be737dad4edad369d05f08b262dded3162f5f5e7c87c3fec8f253b9617c58d4936c5ce487ef66e813b8d0c9dec231fc35f5e275201c19e
+  languageName: node
+  linkType: hard
+
+"whatwg-fetch@npm:^3.5.0":
+  version: 3.5.0
+  resolution: "whatwg-fetch@npm:3.5.0"
+  checksum: dd41999927e87c4cd0af572fe9976dcb1529c00b89c2074b0d1c02baa03670ff7b7cc45ca5b475c02a4a5b274cc1def56a9be7870df7af5c0f9b7d4fb4588ae6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## About The Pull Request

- Fixed Webpack hallucinations due to on-disk cache corruption
  - Currently this is solved by separating development cache from production cache in `.yarn/webpack` folder.
  - If issue persists, we can always use `bin/tgui --clean` (this case is documented in README).
  - If this keeps happening, we can revert back to in-memory cache (RIP fast rebuilds)
- Fixed a hot module reloading regression in `tgui-dev-server` by adding a `whatwg-fetch` polyfill
  - This does not give you a pass to use fetch in UIs. It only plugs the hole in Webpack HMR for now.
- Fixed a regression in some UIs (ExosuitFabricator) by reverting `fill` type sections to their original behavior.
  - `position: absolute` will now only apply to `scrollable` sections

## Changelog
:cl:
fix: Fixed broken UI in ExosuitFabricator interface.
/:cl:
