### PR TITLE
Fixes early removals of beakers from reagent grinders

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -86,6 +86,8 @@
 	. = ..()
 	if(!can_interact(user) || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		return
+	if(operating)//Prevent alt click early removals
+		return
 	replace_beaker(user)
 
 /obj/machinery/reagentgrinder/handle_atom_del(atom/A)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Presently you can early remove a beaker/reagent_holder from a grinder by using alt click on it. This makes it so that grinders have to finish grinding before you can do that.

## Why It's Good For The Game

It's, presumably, a bug to be able to remove beakers from active grinders.

## Changelog
:cl:
fix: Fixes grinders giving out beakers before they're done grinding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
