### PR TITLE
Readd festive paper hat in Metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3723,6 +3723,7 @@
 /obj/structure/closet,
 /obj/item/clothing/gloves/color/fyellow,
 /obj/effect/spawner/lootdrop/maintenance/two,
+/obj/item/clothing/head/festive,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ajP" = (


### PR DESCRIPTION
The recent Brig map overhaul lost a precious festive party hat near
security maintenance. It has been readded in one of the lockers.