### PR TITLE
Remove problem matchers from Build All

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,10 +7,6 @@
 			"windows": {
 				"command": ".\\tools\\build\\build.bat"
 			},
-			"problemMatcher": [
-				"$dreammaker",
-				"$eslint-stylish"
-			],
 			"group": {
 				"kind": "build",
 				"isDefault": true


### PR DESCRIPTION
## About The Pull Request

Fixes the following:

![deb6eb2bf897158a7eca1bf69dde466c](https://user-images.githubusercontent.com/1516236/104872674-299b4300-5957-11eb-9cfc-7f7c89d8ffc6.png)

The better fix would be to make dm matcher smarter, but I simply plugged the hole for now.