### PR TITLE
HFR: Respect moderator heat_output effects

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hypertorus.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hypertorus.dm
@@ -919,12 +919,6 @@
 	//The amount of heat that is finally emitted, based on the power output. Min and max are variables that depends of the modifier
 	heat_output = clamp(internal_instability * power_output * heat_modifier / 100, - heat_limiter_modifier * 0.01, heat_limiter_modifier)
 
-	//Modifies the internal_fusion temperature with the amount of heat output
-	if(internal_fusion.temperature <= FUSION_MAXIMUM_TEMPERATURE)
-		internal_fusion.temperature = clamp(internal_fusion.temperature + heat_output,TCMB,FUSION_MAXIMUM_TEMPERATURE)
-	else
-		internal_fusion.temperature -= heat_limiter_modifier * 0.01 * delta_time
-
 	var/datum/gas_mixture/internal_output = new
 	//gas consumption and production
 	if(check_fuel())
@@ -1064,6 +1058,12 @@
 							critical_threshold_proximity = max(critical_threshold_proximity - (m_healium / 100 * delta_time ), 0)
 							moderator_internal.gases[/datum/gas/healium][MOLES] -= min(moderator_internal.gases[/datum/gas/healium][MOLES], scaled_production * 20)
 					internal_fusion.gases[/datum/gas/antinoblium][MOLES] += 0.01 * (scaled_helium / (fuel_injection_rate * 0.0095)) * delta_time
+
+	//Modifies the internal_fusion temperature with the amount of heat output
+	if(internal_fusion.temperature <= FUSION_MAXIMUM_TEMPERATURE)
+		internal_fusion.temperature = clamp(internal_fusion.temperature + heat_output,TCMB,FUSION_MAXIMUM_TEMPERATURE)
+	else
+		internal_fusion.temperature -= heat_limiter_modifier * 0.01 * delta_time
 
 	//heat up and output what's in the internal_output into the linked_output port
 	if(internal_output.total_moles() > 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The additional heat users were supposed to deal with when producing
higher tier gases with Proto-Nitrate, and the reduced heat output that
came from managing to run a mix with enough Freon without also killing
the reaction, was being silently discarded because the temperature
adjustment was applied before heat_output was modified.

The changed value would still show up in the UI, but would have no effect
since the application used the pre-modification value.

While internal_fusion has gases added and removed directly as part of
the gas consumption and producion process, no reference to temperature
is made, so it's safe to just move the application of internal_fusion's
temperature change to immediately after the gas consumption and production
process, instead of immediately before it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Making higher tier gases now comes with the cost it was meant to have, and managing to add Freon without utterly killing your moderator mix's energy now has the payoff it was supposed to have.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: HFR moderator reactions which increase or decrease heat output now actually increase or decrease the heat applied to the fusion mix, rather than just modifying the number shown in the interface.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
