### PR TITLE
HFR: Fix activation after deconstruction

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hypertorus.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hypertorus.dm
@@ -466,7 +466,7 @@
 		for(var/obj/machinery/hypertorus/corner/corner in corners)
 			corner.active = FALSE
 			corner.update_icon()
-		corners = null
+		corners = list()
 	QDEL_NULL(soundloop)
 
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/check_fuel()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

core/var/corners is assumed to be a list at all times.

Previously, deconstructing then reconstructing the HFR would get one
stuck where:
 - "Activate the machine first by using a multitool on the interface." when attempting to use the interface
 - "You already activated the machine." when attempting to use a multitool on the interface

All components, except the core, would show as correctly inactive.

This situation can be worked around by deconstructing and reconstructing
the core, or varediting the core to have active = 0 and corners = list().

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This fixes runtimes of the form:
> [21:03:06] Runtime in hypertorus.dm,368: type mismatch: 0 |= HFR corner (/obj/machinery/hypertorus/corner)
>   proc name: check part connectivity (/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/check_part_connectivity)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The HFR can now be reactivated after partial reconstruction without first needing to reconstruct the core, and will not get stuck in a state where attempting to use the interface says "Activate the machine first by using a multitool on the interface.", and using a multitool says "You already activated the machine."
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
