### PR TITLE
[s] fixes damage multiplicative exploit with foam darts

### DIFF
--- a/code/modules/projectiles/projectile/reusable/foam_dart.dm
+++ b/code/modules/projectiles/projectile/reusable/foam_dart.dm
@@ -20,8 +20,9 @@
 	newcasing.modified = modified
 	var/obj/projectile/bullet/reusable/foam_dart/newdart = newcasing.BB
 	newdart.modified = modified
-	newdart.damage = damage
-	newdart.nodamage = nodamage
+	if(modified)
+		newdart.damage = 5
+		newdart.nodamage = FALSE
 	newdart.damage_type = damage_type
 	if(pen)
 		newdart.pen = pen


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes a pretty bad exploit with foam darts
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- Modify a dart with a pen, giving it 5 damage
- Target someone's mouth (or a monkeyman)
- Fire
- Firing sequence for handle_suicide multiplies damage by 5 on the projectile instance
- Dropped projectile has 25
- Repeat 1 more time for 125 instacrit dart, or another time after that for 600 instakill dart
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

all discovery credits go to @necromanceranne, this was brought to my attention

## Changelog
Probably doesn't need one
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
