### PR TITLE
buffs the surgical toolset implant

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -117,9 +117,8 @@
 	return (MANUAL_SUICIDE)
 
 /obj/item/surgicaldrill/augment
-	desc = "Effectively a small power drill contained within your arm, edges dulled to prevent tissue damage. May or may not pierce the heavens."
+	desc = "Effectively a small power drill contained within your arm. May or may not pierce the heavens."
 	hitsound = 'sound/weapons/circsawhit.ogg'
-	force = 10
 	w_class = WEIGHT_CLASS_SMALL
 	toolspeed = 0.5
 
@@ -192,9 +191,8 @@
 	AddComponent(/datum/component/butchering, 40 * toolspeed, 100, 5, 'sound/weapons/circsawhit.ogg') //saws are very accurate and fast at butchering
 
 /obj/item/circular_saw/augment
-	desc = "A small but very fast spinning saw. Edges dulled to prevent accidental cutting inside of the surgeon."
-	w_class = WEIGHT_CLASS_SMALL
-	force = 10
+	desc = "A small but very fast spinning saw. It rips and tears until it is done."
+	w_class = WEIGHT_CLASS_SMALL	
 	toolspeed = 0.5
 
 


### PR DESCRIPTION
## About The Pull Request

The surgical toolset implant's circular saw and surgical drill now both have a force of 15 (as is normal for surgical tools of their respective types), instead of 10.

## Why It's Good For The Game

I don't really see any reason why these tools should be "dulled" for the surgical toolset implant, especially seeing how the integrated toolset implant (which contains much more generally-usefull tools than what the surgical toolset implant has) contains a 40u welder that has a force of 15, and that's not causing any balance problems. For combat purposes, both of these implants are outclassed by replacing your arm with a chainsaw (which has a force of 24).

Whirring saws and spinning drills that you can extend from your arm like wolverine and shank a guy with are fucking badass, and if a doctor wants to defend themselves with their integrated tools instead of carrying around an extra "normal" saw/drill in their backpack just for combat purposes, then by god, we shouldn't arbitrarily penalize them for doing that.

## Changelog
:cl: ATHATH
balance: The surgical toolset implant's circular saw and surgical drill now both have a force of 15 (as is normal for surgical tools of their respective types), instead of 10.
/:cl: