### PR TITLE
Rework AI status displays with emote and radials

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -397,3 +397,25 @@
 #define SQUASHED_SHOULD_BE_DOWN (1<<0)
 ///Whether or not to gib when the squashed mob is moved over
 #define SQUASHED_SHOULD_BE_GIBBED (1<<0)
+
+/*
+ * Defines for "AI emotions", allowing the AI to expression emotions
+ * with status displays via emotes.
+ */
+
+#define AI_EMOTION_VERY_HAPPY "Very Happy"
+#define AI_EMOTION_HAPPY "Happy"
+#define AI_EMOTION_NEUTRAL "Neutral"
+#define AI_EMOTION_UNSURE "Unsure"
+#define AI_EMOTION_CONFUSED "Confused"
+#define AI_EMOTION_SAD "Sad"
+#define AI_EMOTION_BSOD "BSOD"
+#define AI_EMOTION_BLANK "Blank"
+#define AI_EMOTION_PROBLEMS "Problems?"
+#define AI_EMOTION_AWESOME "Awesome"
+#define AI_EMOTION_FACEPALM "Facepalm"
+#define AI_EMOTION_THINKING "Thinking"
+#define AI_EMOTION_FRIEND_COMPUTER "Friend Computer"
+#define AI_EMOTION_DORFY "Dorfy"
+#define AI_EMOTION_BLUE_GLOW "Blue Glow"
+#define AI_EMOTION_RED_GLOW "Red Glow"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -160,8 +160,7 @@
 	deploy_action.Grant(src)
 
 	if(isturf(loc))
-		add_verb(src, list(/mob/living/silicon/ai/proc/ai_network_change, \
-		/mob/living/silicon/ai/proc/ai_statuschange, /mob/living/silicon/ai/proc/ai_hologram_change, \
+		add_verb(src, list(/mob/living/silicon/ai/proc/ai_network_change, /mob/living/silicon/ai/proc/ai_hologram_change, \
 		/mob/living/silicon/ai/proc/botcall, /mob/living/silicon/ai/proc/control_integrated_radio, \
 		/mob/living/silicon/ai/proc/set_automatic_say_channel))
 
@@ -619,28 +618,6 @@
 				break
 	to_chat(src, "<span class='notice'>Switched to the \"[uppertext(network)]\" camera network.</span>")
 //End of code by Mord_Sith
-
-/mob/living/silicon/ai/proc/ai_statuschange()
-	set category = "AI Commands"
-	set name = "AI Status"
-
-	if(incapacitated())
-		return
-	var/list/ai_emotions = list("Very Happy", "Happy", "Neutral", "Unsure", "Confused", "Sad", "BSOD", "Blank", "Problems?", "Awesome", "Facepalm", "Thinking", "Friend Computer", "Dorfy", "Blue Glow", "Red Glow")
-	var/emote = input("Please, select a status!", "AI Status", null, null) in sortList(ai_emotions)
-	for (var/each in GLOB.ai_status_displays) //change status of displays
-		var/obj/machinery/status_display/ai/M = each
-		M.emotion = emote
-		M.update()
-	if (emote == "Friend Computer")
-		var/datum/radio_frequency/frequency = SSradio.return_frequency(FREQ_STATUS_DISPLAYS)
-
-		if(!frequency)
-			return
-
-		var/datum/signal/status_signal = new(list("command" = "friendcomputer"))
-		frequency.post_signal(src, status_signal)
-	return
 
 //I am the icon meister. Bow fefore me.	//>fefore
 /mob/living/silicon/ai/proc/ai_hologram_change()

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -2,6 +2,10 @@
 	if(stat == DEAD)
 		return
 
+	if(!gibbed)
+		// Will update all AI status displays with a blue screen of death
+		INVOKE_ASYNC(src, .proc/emote, "bsod")
+
 	. = ..()
 
 	cut_overlays() //remove portraits
@@ -30,12 +34,6 @@
 
 	if(explosive)
 		addtimer(CALLBACK(GLOBAL_PROC, .proc/explosion, loc, 3, 6, 12, 15), 1 SECONDS)
-
-	if(src.key)
-		for(var/each in GLOB.ai_status_displays) //change status
-			var/obj/machinery/status_display/ai/O = each
-			O.mode = 2
-			O.update()
 
 	if(istype(loc, /obj/item/aicard/aitater))
 		loc.icon_state = "aitater-404"

--- a/code/modules/mob/living/silicon/ai/emote.dm
+++ b/code/modules/mob/living/silicon/ai/emote.dm
@@ -1,0 +1,101 @@
+/datum/emote/ai
+	mob_type_allowed_typecache = /mob/living/silicon/ai
+	mob_type_blacklist_typecache = list()
+
+
+/datum/emote/ai/emotion_display
+	key = "blank"
+	var/emotion = AI_EMOTION_BLANK
+
+/datum/emote/ai/emotion_display/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	if(!.)
+		return
+	var/mob/living/silicon/ai/ai = user
+	var/turf/ai_turf = get_turf(ai)
+
+	for(var/_display in GLOB.ai_status_displays)
+		var/obj/machinery/status_display/ai/ai_display = _display
+		var/turf/display_turf = get_turf(ai_display)
+
+		// Derelict AIs can't affect station displays.
+		// TODO does this need to be made multiZ aware?
+		if(ai_turf.z != display_turf.z)
+			continue
+
+		ai_display.emotion = emotion
+		ai_display.update()
+
+/datum/emote/ai/emotion_display/very_happy
+	key = "veryhappy"
+	emotion = AI_EMOTION_VERY_HAPPY
+
+/datum/emote/ai/emotion_display/happy
+	key = "happy"
+	emotion = AI_EMOTION_HAPPY
+
+/datum/emote/ai/emotion_display/neutral
+	key = "neutral"
+	emotion = AI_EMOTION_NEUTRAL
+
+/datum/emote/ai/emotion_display/unsure
+	key = "unsure"
+	emotion = AI_EMOTION_UNSURE
+
+/datum/emote/ai/emotion_display/confused
+	key = "confused"
+	emotion = AI_EMOTION_CONFUSED
+
+/datum/emote/ai/emotion_display/sad
+	key = "sad"
+	emotion = AI_EMOTION_SAD
+
+/datum/emote/ai/emotion_display/bsod
+	key = "bsod"
+	emotion = AI_EMOTION_BSOD
+
+/datum/emote/ai/emotion_display/trollface
+	key = "trollface"
+	emotion = AI_EMOTION_PROBLEMS
+
+/datum/emote/ai/emotion_display/awesome
+	key = "awesome"
+	emotion = AI_EMOTION_AWESOME
+
+/datum/emote/ai/emotion_display/dorfy
+	key = "dorfy"
+	emotion = AI_EMOTION_DORFY
+
+/datum/emote/ai/emotion_display/thinking
+	key = "thinking"
+	emotion = AI_EMOTION_THINKING
+
+/datum/emote/ai/emotion_display/facepalm
+	key = "facepalm"
+	key_third_person = "facepalms"
+	emotion = AI_EMOTION_FACEPALM
+
+/datum/emote/ai/emotion_display/friend_computer
+	key = "friendcomputer"
+	emotion = AI_EMOTION_FRIEND_COMPUTER
+
+/datum/emote/ai/emotion_display/friend_computer/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	if(!.)
+		return
+
+	var/datum/radio_frequency/frequency = SSradio.return_frequency(FREQ_STATUS_DISPLAYS)
+
+	if(!frequency)
+		return
+
+	var/datum/signal/status_signal = new(list("command" = "friendcomputer"))
+	frequency.post_signal(src, status_signal)
+
+/datum/emote/ai/emotion_display/blue_glow
+	key = "blueglow"
+	emotion = AI_EMOTION_BLUE_GLOW
+
+/datum/emote/ai/emotion_display/red_glow
+	key = "redglow"
+	emotion = AI_EMOTION_RED_GLOW

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -3,11 +3,6 @@
 	if(!. || !client)
 		return FALSE
 	if(stat != DEAD)
-		for(var/each in GLOB.ai_status_displays) //change status
-			var/obj/machinery/status_display/ai/O = each
-			O.mode = 1
-			O.emotion = "Neutral"
-			O.update()
 		if(lacks_power() && apc_override) //Placing this in Login() in case the AI doesn't have this link for whatever reason.
 			to_chat(usr, "<span class='warning'>Main power is unavailable, backup power in use. Diagnostics scan complete.</span> <A HREF='?src=[REF(src)];emergencyAPC=[TRUE]'>Local APC ready for connection.</A>")
 	set_eyeobj_visible(TRUE)

--- a/code/modules/mob/living/silicon/ai/logout.dm
+++ b/code/modules/mob/living/silicon/ai/logout.dm
@@ -1,8 +1,4 @@
 /mob/living/silicon/ai/Logout()
 	..()
-	for(var/each in GLOB.ai_status_displays) //change status
-		var/obj/machinery/status_display/ai/O = each
-		O.mode = 0
-		O.update()
 	set_eyeobj_visible(FALSE)
 	view_core()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2416,6 +2416,7 @@
 #include "code\modules\mob\living\silicon\ai\ai_portrait_picker.dm"
 #include "code\modules\mob\living\silicon\ai\ai_say.dm"
 #include "code\modules\mob\living\silicon\ai\death.dm"
+#include "code\modules\mob\living\silicon\ai\emote.dm"
 #include "code\modules\mob\living\silicon\ai\examine.dm"
 #include "code\modules\mob\living\silicon\ai\laws.dm"
 #include "code\modules\mob\living\silicon\ai\life.dm"


### PR DESCRIPTION
:cl: coiax
tweak: AI status displays are now controlled either by emotes (like
`*happy`), or by clicking on the status display as an AI.
/:cl:

The code that deals with AI status displays is very old, and was hooked
into events like Login() and Logout(). This reworks the code to
something resembling modern standards.

AIs can control their AI status boards in the same way that slimes can
do with things like `*slimesneak`, and can also use the radial menu to
preview what emotion they will be sending to the world.

By removing the Login()/Logout() code as well, the final BSOD of the AI
will now no longer disappear the instant that the AI leaves their corpse
(calling a Logout()).

---

This may also qualify as a refactor?

Demonstration video:

https://imgur.com/a/h7QN26h