### PR TITLE
Colocup Volume is respected in cups of Lean.

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -635,5 +635,5 @@
 	name = "lean"
 	desc = "A cup of that purple drank, the stuff that makes you go WHEEZY BABY."
 	icon_state = "lean"
-	list_reagents = list(/datum/reagent/consumable/lean = 50)
+	list_reagents = list(/datum/reagent/consumable/lean = 20)
 	random_sprite = FALSE


### PR DESCRIPTION

## About The Pull Request

Colocups are intended to hold 20 units. Cups of Lean pre-mapped are attempting to hold 50 units. Quick fix to make the two match ideally.

## Why It's Good For The Game

Fixes #56169. Bugs are the enemy of mankind.

## Changelog
:cl:
fix: Pre-mapped cups of lean will hold the correct amount now for sure.
/:cl:
