### PR TITLE
tgui: Fix section fill not stretching its contents to 100%

### DIFF
--- a/tgui/packages/tgui/interfaces/CentcomPodLauncher.js
+++ b/tgui/packages/tgui/interfaces/CentcomPodLauncher.js
@@ -424,7 +424,7 @@ const ViewTabHolder = (props, context) => {
   const { mapRef } = data;
   const TabPageComponent = TABPAGES[tabPageIndex].component();
   return (
-    <Section title="View" fill buttons={(
+    <Section fill title="View" buttons={(
       <>
         {(!!data.customDropoff && data.effectReverse===1) && (
           <Button
@@ -489,15 +489,13 @@ const ViewTabHolder = (props, context) => {
           <TabPageComponent />
         </Stack.Item>
         <Stack.Item grow>
-          <Section fill>
-            <ByondUi
-              fillPositionedParent
-              params={{
-                zoom: 0,
-                id: mapRef,
-                type: 'map',
-              }} />
-          </Section>
+          <ByondUi
+            height="100%"
+            params={{
+              zoom: 0,
+              id: mapRef,
+              type: 'map',
+            }} />
         </Stack.Item>
       </Stack>
     </Section>

--- a/tgui/packages/tgui/styles/components/Section.scss
+++ b/tgui/packages/tgui/styles/components/Section.scss
@@ -63,6 +63,10 @@ $shadow-offset: 0 0 !default;
 
 .Section--fill .Section__rest {
   flex-grow: 1;
+
+  .Section__content {
+    height: 100%;
+  }
 }
 
 .Section--fill.Section--scrollable .Section__content {


### PR DESCRIPTION
## About The Pull Request

Turns this:

![image](https://user-images.githubusercontent.com/1516236/105076944-70428780-5a94-11eb-8dc4-faad09470b23.png)

Into this:

![image](https://user-images.githubusercontent.com/1516236/105076966-79cbef80-5a94-11eb-9cc7-7bdeece49374.png)

## Changelog
:cl:
fix: Fixed map display in Centcom Pod Launcher UI to not collapse into a tiny square.
/:cl:

