### PR TITLE
Removes directional windows stacked on machinery on KiloStation

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -10140,12 +10140,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "ard" = (
@@ -18856,9 +18850,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/cryo)
 "aFs" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -28573,9 +28564,6 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "aUn" = (
@@ -29300,10 +29288,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "aVp" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -31031,9 +31015,6 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 4
 	},
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
@@ -34765,9 +34746,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bdA" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	pixel_x = -28
 	},
@@ -34836,10 +34814,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 4
 	},
@@ -34945,7 +34919,6 @@
 	pixel_x = 30;
 	receive_ore_updates = 1
 	},
-/obj/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "bdN" = (
@@ -34998,7 +34971,6 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/box/corners,
 /obj/structure/water_source/puddle,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -35704,7 +35676,6 @@
 /area/medical/storage)
 "beR" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
-/obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -43420,9 +43391,6 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
 	name = "Atmospherics Blast Door"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
@@ -56646,9 +56614,6 @@
 	input_dir = 4;
 	output_dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "bLH" = (
@@ -61245,7 +61210,6 @@
 /obj/machinery/door/firedoor,
 /obj/item/folder/blue,
 /obj/item/pen,
-/obj/structure/window/reinforced,
 /obj/machinery/door/window/westright{
 	name = "Control Desk";
 	req_one_access_txt = "19"
@@ -64181,9 +64145,6 @@
 /obj/machinery/door/firedoor,
 /obj/item/folder/yellow,
 /obj/item/pen,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/door/window/westleft{
 	dir = 2;
 	name = "Cargo Desk";
@@ -88313,9 +88274,6 @@
 /area/maintenance/port)
 "don" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes a decent amount of directional windows that were stacked on top of machinery.

## Why It's Good For The Game

Directional windows and anchored structures generally do not mix. We want players to be able to accurately reconstruct as much of the map as possible.

## Changelog
:cl:
fix: several invalid game states on Kilo have been fixed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
