### PR TITLE
Fixes crab meat sprites.

### DIFF
--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -856,6 +856,7 @@
 /obj/item/food/meat/rawcrab
 	name = "raw crab meat"
 	desc = "A pile of raw crab meat."
+	icon_state = "crabmeatraw"
 	microwaved_type = /obj/item/food/meat/crab
 	bite_consumption = 3
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 3, /datum/reagent/consumable/cooking_oil = 3)


### PR DESCRIPTION
## About The Pull Request

Crab meat had it's icon_state unassigned at some point. Simple fix to just give it the correct sprite yet again.

## Why It's Good For The Game

I can't see invisible sprites and it's ERRORing. Easy fix.
Fixes #56272.

## Changelog
:cl:
fix: Crab meat is now visible yet again.
/:cl:

