### PR TITLE
You can no longer use the in-spect scanner to create an infinite flood of paper and noise hell.

### DIFF
--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -68,6 +68,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_range = 1
 	throw_speed = 1
+	COOLDOWN_DECLARE(beeping_cooldown)
 
 /obj/item/inspector/attack(mob/living/M, mob/living/user)
 	. = ..()
@@ -79,9 +80,12 @@
 
 ///Prints out a report for bounty purposes, and plays a short audio blip.
 /obj/item/inspector/proc/print_report()
+	if(!COOLDOWN_FINISHED(src, beeping_cooldown))
+		return
 	// Create our report
 	var/obj/item/report/slip = new(get_turf(src))
 	slip.scanned_area = get_area(src)
+	COOLDOWN_START(src, beeping_cooldown, 3 SECONDS)
 	playsound(src, 'sound/items/biddledeep.ogg', 50, FALSE)
 
 /obj/item/report


### PR DESCRIPTION

## About The Pull Request

Oranges once said, any time you play a sound on an item, make sure that you put a cooldown on it.
Whoops.

## Why It's Good For The Game

You could spam an infinite number of objects onto the flood limited by how quickly you can hammer the z button.
It can also break your eardrums.
Feex.

## Changelog
:cl:
fix: In-spect scanners now have a cooldown to how quickly you can use it.
/:cl:
