### PR TITLE
Gives plushes on MetaStation Names

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -219,7 +219,7 @@
 	},
 /obj/item/toy/plush/beeplushie{
 	desc = "Maybe hugging this will make you feel better about yourself.";
-	name = "therapy plush"
+	name = "Therabee"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -46104,7 +46104,9 @@
 "csa" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs/cable/white,
-/obj/item/toy/plush/pkplush,
+/obj/item/toy/plush/pkplush{
+	name = "C.H.E.R.U.B."
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "csb" = (
@@ -51844,7 +51846,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small,
 /obj/structure/table/greyscale,
-/obj/item/toy/plush/slimeplushie,
+/obj/item/toy/plush/slimeplushie{
+	name = "Nanners"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cTY" = (
@@ -63997,7 +64001,9 @@
 	pixel_y = 32
 	},
 /obj/structure/chair/sofa/right,
-/obj/item/toy/plush/moth,
+/obj/item/toy/plush/moth{
+	name = "Mender Moff"
+	},
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "jIy" = (
@@ -68731,7 +68737,9 @@
 "nGT" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/bed/roller,
-/obj/item/toy/plush/snakeplushie,
+/obj/item/toy/plush/snakeplushie{
+	name = "Boa Ben"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},


### PR DESCRIPTION
All plushies must have a name

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Renames the plush in therapy to "Therabee"
The pkplush in abandoned medbay is "C.H.E.R.U.B."
The slime plush in xenobio maint is "Nanners"
The moth plush in therapy is "Mender Moff"
The snake plush in maint is "Boa Ben"

## Why It's Good For The Game

Plushies must have names

## Changelog
:cl:
fix: Gives plushes on MetaStation names
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
