### PR TITLE
Gives plushes on DeltaStation Names

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -580,7 +580,9 @@
 /area/hallway/secondary/entry)
 "abr" = (
 /obj/item/kirbyplants/random,
-/obj/item/toy/plush/snakeplushie,
+/obj/item/toy/plush/snakeplushie{
+	name = "Quetzie"
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -5462,7 +5464,9 @@
 /area/maintenance/starboard/fore)
 "aow" = (
 /obj/structure/table/wood,
-/obj/item/toy/plush/carpplushie,
+/obj/item/toy/plush/carpplushie{
+	name = "Nemo"
+	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -81546,7 +81550,9 @@
 	pixel_y = 32
 	},
 /obj/structure/chair/sofa/left,
-/obj/item/toy/plush/moth,
+/obj/item/toy/plush/moth{
+	name = "Moffee"
+	},
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "deQ" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The moth plush in psych is now Moffee
The snake in the curator's office is Quetzie
The carp in arcade is Nemo

## Why It's Good For The Game

All plushies must have names

## Changelog
:cl:
fix: Gave plushies names on Delta
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
