### PR TITLE
Gives plushes on KiloStation names

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -9943,7 +9943,9 @@
 	name = "Psychology APC";
 	pixel_y = 24
 	},
-/obj/item/toy/plush/moth,
+/obj/item/toy/plush/moth{
+	name = "Big Moffer"
+	},
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "aqQ" = (
@@ -88205,7 +88207,7 @@
 /obj/effect/turf_decal/tile/red,
 /obj/item/toy/plush/pkplush{
 	desc = "Give HUG-E a hug!";
-	name = "Therapy Plush"
+	name = "TH3R4PY-X09"
 	},
 /obj/machinery/flasher{
 	id = "IsolationFlash";


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The moth plush in psych is "Big Moffer"
The pkplush in Isolation is "TH3R4PY-X09

## Why It's Good For The Game

All plushes must have names

## Changelog
:cl:
fix: Gave plushes on KiloStation names
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
