### PR TITLE
Gives plushes on IceBox names

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -48840,7 +48840,9 @@
 /area/science/genetics)
 "ddD" = (
 /obj/structure/table,
-/obj/item/toy/plush/slimeplushie,
+/obj/item/toy/plush/slimeplushie{
+	name = "Gish"
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -55209,7 +55211,9 @@
 /area/science/misc_lab)
 "tGa" = (
 /obj/structure/chair/sofa/right,
-/obj/item/toy/plush/moth,
+/obj/item/toy/plush/moth{
+	name = "Dr. Moff"
+	},
 /turf/open/floor/carpet/blue,
 /area/medical/psychology)
 "tGE" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The moth plush in psych is "Dr. Moff"
The slime plush in science is "Gish"

## Why It's Good For The Game

plushes must have names

## Changelog
:cl:
fix: Gave plushes on IceBox names
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
