### PR TITLE
Resonator rework

### DIFF
--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -17,7 +17,8 @@
 	throwforce = 10
 
 	var/mode = RESONATOR_MODE_AUTO
-	var/quick_burst_mod = 0.8 //How efficient it is in manual mode. Yes, we lower the damage cuz it's gonna be used for mobhunt
+	//How efficient it is in manual mode. Yes, we lower the damage cuz it's gonna be used for mobhunt
+	var/quick_burst_mod = 0.8
 	var/fieldlimit = 4
 	var/list/fields = list()
 
@@ -51,7 +52,7 @@
 	desc = "A resonating field that significantly damages anything inside of it when the field eventually ruptures. More damaging in low pressure environments."
 	icon_state = "shield1"
 	layer = ABOVE_ALL_MOB_LAYER
-	duration = 600
+	duration = 60 SECONDS
 	var/resonance_damage = 20
 	var/damage_multiplier = 1
 	var/creator
@@ -60,7 +61,7 @@
 
 /obj/effect/temp_visual/resonance/Initialize(mapload, set_creator, set_resonator, mode)
 	if(mode == RESONATOR_MODE_AUTO)
-		duration = 20
+		duration = 2 SECONDS
 	if(mode == RESONATOR_MODE_MATRIX)
 		icon_state = "shield2"
 		name = "resonance matrix"
@@ -71,7 +72,7 @@
 	if(res)
 		res.fields += src
 	playsound(src,'sound/weapons/resonator_fire.ogg',50,TRUE)
-	if(mode == 1)
+	if(mode == RESONATOR_MODE_AUTO)
 		transform = matrix()*0.75
 		animate(src, transform = matrix()*1.5, time = duration)
 	deltimer(timerid)
@@ -144,3 +145,7 @@
 	else
 		to_chat(user, "<span class='info'>You set the resonator's fields to automatically detonate after 2 seconds.</span>")
 		mode = RESONATOR_MODE_AUTO
+
+#undef RESONATOR_MODE_AUTO
+#undef RESONATOR_MODE_MANUAL
+#undef RESONATOR_MODE_MATRIX

--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -17,7 +17,7 @@
 	throwforce = 10
 
 	var/mode = RESONATOR_MODE_AUTO
-	//How efficient it is in manual mode. Yes, we lower the damage cuz it's gonna be used for mobhunt
+	/// How efficient it is in manual mode. Yes, we lower the damage cuz it's gonna be used for mobhunt
 	var/quick_burst_mod = 0.8
 	var/fieldlimit = 4
 	var/list/fields = list()

--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -164,17 +164,16 @@
 	desc = "A resonating field that significantly damages anything inside of it when the field eventually ruptures. More damaging in low pressure environments."
 	icon_state = "shield1"
 	layer = ABOVE_ALL_MOB_LAYER
-	duration = 50
+	duration = 600
 	var/resonance_damage = 20
 	var/damage_multiplier = 1
 	var/creator
 	var/obj/item/resonator/res
+	var/rupturing = FALSE //So it won't recurse
 
 /obj/effect/temp_visual/resonance/Initialize(mapload, set_creator, set_resonator, mode)
 	if(mode == 1)
 		duration = 20
-	else
-		duration = 600 //Up to a minute
 	if(mode == 3)
 		icon_state = "shield2"
 		name = "resonance matrix"
@@ -210,6 +209,7 @@
 	resonance_damage *= damage_multiplier
 
 /obj/effect/temp_visual/resonance/proc/burst()
+	rupturing = TRUE
 	var/turf/T = get_turf(src)
 	new /obj/effect/temp_visual/resonance_crush(T)
 	if(ismineralturf(T))
@@ -224,9 +224,9 @@
 		L.apply_damage(resonance_damage, BRUTE)
 		L.add_movespeed_modifier(/datum/movespeed_modifier/resonance)
 		addtimer(CALLBACK(L, /mob/proc/remove_movespeed_modifier, /datum/movespeed_modifier/resonance), 10 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
-	for(var/obj/effect/temp_visual/resonance/fields in range(1, src))
-		if(fields != src)
-			fields.burst()
+	for(var/obj/effect/temp_visual/resonance/field in range(1, src))
+		if(field != src && !field.rupturing)
+			field.burst()
 	qdel(src)
 
 /obj/effect/temp_visual/resonance_crush

--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -1,4 +1,5 @@
 /**********************Resonator**********************/
+/*
 /obj/item/resonator
 	name = "resonator"
 	icon = 'icons/obj/mining.dmi'
@@ -114,3 +115,145 @@
 	. = ..()
 	transform = matrix()*1.5
 	animate(src, transform = matrix()*0.1, alpha = 50, time = 4)
+*/
+
+/obj/item/resonator
+	name = "resonator"
+	icon = 'icons/obj/mining.dmi'
+	icon_state = "resonator"
+	inhand_icon_state = "resonator"
+	lefthand_file = 'icons/mob/inhands/equipment/mining_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
+	desc = "A handheld device that creates small fields of energy that resonate until they detonate, crushing rock. It does increased damage in low pressure. It has two modes: Automatic and manual detonation."
+	w_class = WEIGHT_CLASS_NORMAL
+	force = 15
+	throwforce = 10
+
+	var/mode = 1
+	var/quick_burst_mod = 0.8 //How efficient it is in manual mode. Yes, we lower the damage cuz it's gonna be used for mobhunt
+	var/fieldlimit = 4
+	var/list/fields = list()
+
+/obj/item/resonator/attack_self(mob/user)
+	if(mode == 1)
+		to_chat(user, "<span class='info'>You set the resonator's fields to detonate only after you hit one with it.</span>")
+		mode = 2
+	else
+		to_chat(user, "<span class='info'>You set the resonator's fields to automatically detonate after 2 seconds.</span>")
+		mode = 1
+
+/obj/item/resonator/proc/CreateResonance(target, mob/user)
+	var/turf/T = get_turf(target)
+	var/obj/effect/temp_visual/resonance/R = locate(/obj/effect/temp_visual/resonance) in T
+	if(R)
+		R.damage_multiplier = quick_burst_mod
+		R.burst()
+		return
+	if(LAZYLEN(fields) < fieldlimit)
+		new /obj/effect/temp_visual/resonance(T, user, src, mode)
+		user.changeNext_move(CLICK_CD_MELEE)
+
+/obj/item/resonator/pre_attack(atom/target, mob/user, params)
+	if(check_allowed_items(target, 1))
+		CreateResonance(target, user)
+	. = ..()
+
+//resonance field, crushes rock, damages mobs
+/obj/effect/temp_visual/resonance
+	name = "resonance field"
+	desc = "A resonating field that significantly damages anything inside of it when the field eventually ruptures. More damaging in low pressure environments."
+	icon_state = "shield1"
+	layer = ABOVE_ALL_MOB_LAYER
+	duration = 50
+	var/resonance_damage = 20
+	var/damage_multiplier = 1
+	var/creator
+	var/obj/item/resonator/res
+
+/obj/effect/temp_visual/resonance/Initialize(mapload, set_creator, set_resonator, mode)
+	if(mode == 1)
+		duration = 20
+	else
+		duration = 600 //Up to a minute
+	if(mode == 3)
+		icon_state = "shield2"
+		name = "resonance matrix"
+		RegisterSignal(src, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/burst)
+	. = ..()
+	creator = set_creator
+	res = set_resonator
+	if(res)
+		res.fields += src
+	playsound(src,'sound/weapons/resonator_fire.ogg',50,TRUE)
+	if(mode == 1)
+		transform = matrix()*0.75
+		animate(src, transform = matrix()*1.5, time = duration)
+	deltimer(timerid)
+	timerid = addtimer(CALLBACK(src, .proc/burst), duration, TIMER_STOPPABLE)
+
+/obj/effect/temp_visual/resonance/Destroy()
+	if(res)
+		res.fields -= src
+		res = null
+	creator = null
+	. = ..()
+
+/obj/effect/temp_visual/resonance/proc/check_pressure(turf/proj_turf)
+	if(!proj_turf)
+		proj_turf = get_turf(src)
+	resonance_damage = initial(resonance_damage)
+	if(lavaland_equipment_pressure_check(proj_turf))
+		name = "strong [initial(name)]"
+		resonance_damage *= 3
+	else
+		name = initial(name)
+	resonance_damage *= damage_multiplier
+
+/obj/effect/temp_visual/resonance/proc/burst()
+	var/turf/T = get_turf(src)
+	new /obj/effect/temp_visual/resonance_crush(T)
+	if(ismineralturf(T))
+		var/turf/closed/mineral/M = T
+		M.gets_drilled(creator)
+	check_pressure(T)
+	playsound(T,'sound/weapons/resonator_blast.ogg',50,TRUE)
+	for(var/mob/living/L in T)
+		if(creator)
+			log_combat(creator, L, "used a resonator field on", "resonator")
+		to_chat(L, "<span class='userdanger'>[src] ruptured with you in it!</span>")
+		L.apply_damage(resonance_damage, BRUTE)
+		L.add_movespeed_modifier(/datum/movespeed_modifier/resonance)
+		addtimer(CALLBACK(L, /mob/proc/remove_movespeed_modifier, /datum/movespeed_modifier/resonance), 10 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+	for(var/obj/effect/temp_visual/resonance/fields in range(1, src))
+		if(fields != src)
+			fields.burst()
+	qdel(src)
+
+/obj/effect/temp_visual/resonance_crush
+	icon_state = "shield1"
+	layer = ABOVE_ALL_MOB_LAYER
+	duration = 4
+
+/obj/effect/temp_visual/resonance_crush/Initialize()
+	. = ..()
+	transform = matrix()*1.5
+	animate(src, transform = matrix()*0.1, alpha = 50, time = 4)
+
+/obj/item/resonator/upgraded
+	name = "upgraded resonator"
+	desc = "An upgraded version of the resonator that can produce more fields at once, as well as having no damage penalty for bursting a resonance field early. It also allows you to set 'Resonance matrixes', that detonate after someone(or something) walks over it."
+	icon_state = "resonator_u"
+	inhand_icon_state = "resonator_u"
+	fieldlimit = 6
+	quick_burst_mod = 1
+
+/obj/item/resonator/upgraded/attack_self(mob/user)
+	if(mode == 1)
+		to_chat(user, "<span class='info'>You set the resonator's fields to detonate only after you hit one with it.</span>")
+		mode = 2
+	else if(mode == 2)
+		to_chat(user, "<span class='info'>You set the resonator's fields to work as matrix traps.</span>")
+		mode = 3
+	else
+		to_chat(user, "<span class='info'>You set the resonator's fields to automatically detonate after 2 seconds.</span>")
+		mode = 1

--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -1,121 +1,8 @@
+#define RESONATOR_MODE_AUTO   1
+#define RESONATOR_MODE_MANUAL 2
+#define RESONATOR_MODE_MATRIX 3
+
 /**********************Resonator**********************/
-/*
-/obj/item/resonator
-	name = "resonator"
-	icon = 'icons/obj/mining.dmi'
-	icon_state = "resonator"
-	inhand_icon_state = "resonator"
-	lefthand_file = 'icons/mob/inhands/equipment/mining_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
-	desc = "A handheld device that creates small fields of energy that resonate until they detonate, crushing rock. It does increased damage in low pressure."
-	w_class = WEIGHT_CLASS_NORMAL
-	force = 15
-	throwforce = 10
-	var/burst_time = 30
-	var/fieldlimit = 4
-	var/list/fields = list()
-	var/quick_burst_mod = 0.8
-
-/obj/item/resonator/upgraded
-	name = "upgraded resonator"
-	desc = "An upgraded version of the resonator that can produce more fields at once, as well as having no damage penalty for bursting a resonance field early."
-	icon_state = "resonator_u"
-	inhand_icon_state = "resonator_u"
-	fieldlimit = 6
-	quick_burst_mod = 1
-
-/obj/item/resonator/attack_self(mob/user)
-	if(burst_time == 50)
-		burst_time = 30
-		to_chat(user, "<span class='info'>You set the resonator's fields to detonate after 3 seconds.</span>")
-	else
-		burst_time = 50
-		to_chat(user, "<span class='info'>You set the resonator's fields to detonate after 5 seconds.</span>")
-
-/obj/item/resonator/proc/CreateResonance(target, mob/user)
-	var/turf/T = get_turf(target)
-	var/obj/effect/temp_visual/resonance/R = locate(/obj/effect/temp_visual/resonance) in T
-	if(R)
-		R.damage_multiplier = quick_burst_mod
-		R.burst()
-		return
-	if(LAZYLEN(fields) < fieldlimit)
-		new /obj/effect/temp_visual/resonance(T, user, src, burst_time)
-		user.changeNext_move(CLICK_CD_MELEE)
-
-/obj/item/resonator/pre_attack(atom/target, mob/user, params)
-	if(check_allowed_items(target, 1))
-		CreateResonance(target, user)
-	. = ..()
-
-//resonance field, crushes rock, damages mobs
-/obj/effect/temp_visual/resonance
-	name = "resonance field"
-	desc = "A resonating field that significantly damages anything inside of it when the field eventually ruptures. More damaging in low pressure environments."
-	icon_state = "shield1"
-	layer = ABOVE_ALL_MOB_LAYER
-	duration = 50
-	var/resonance_damage = 20
-	var/damage_multiplier = 1
-	var/creator
-	var/obj/item/resonator/res
-
-/obj/effect/temp_visual/resonance/Initialize(mapload, set_creator, set_resonator, set_duration)
-	duration = set_duration
-	. = ..()
-	creator = set_creator
-	res = set_resonator
-	if(res)
-		res.fields += src
-	playsound(src,'sound/weapons/resonator_fire.ogg',50,TRUE)
-	transform = matrix()*0.75
-	animate(src, transform = matrix()*1.5, time = duration)
-	deltimer(timerid)
-	timerid = addtimer(CALLBACK(src, .proc/burst), duration, TIMER_STOPPABLE)
-
-/obj/effect/temp_visual/resonance/Destroy()
-	if(res)
-		res.fields -= src
-		res = null
-	creator = null
-	. = ..()
-
-/obj/effect/temp_visual/resonance/proc/check_pressure(turf/proj_turf)
-	if(!proj_turf)
-		proj_turf = get_turf(src)
-	resonance_damage = initial(resonance_damage)
-	if(lavaland_equipment_pressure_check(proj_turf))
-		name = "strong [initial(name)]"
-		resonance_damage *= 3
-	else
-		name = initial(name)
-	resonance_damage *= damage_multiplier
-
-/obj/effect/temp_visual/resonance/proc/burst()
-	var/turf/T = get_turf(src)
-	new /obj/effect/temp_visual/resonance_crush(T)
-	if(ismineralturf(T))
-		var/turf/closed/mineral/M = T
-		M.gets_drilled(creator)
-	check_pressure(T)
-	playsound(T,'sound/weapons/resonator_blast.ogg',50,TRUE)
-	for(var/mob/living/L in T)
-		if(creator)
-			log_combat(creator, L, "used a resonator field on", "resonator")
-		to_chat(L, "<span class='userdanger'>[src] ruptured with you in it!</span>")
-		L.apply_damage(resonance_damage, BRUTE)
-	qdel(src)
-
-/obj/effect/temp_visual/resonance_crush
-	icon_state = "shield1"
-	layer = ABOVE_ALL_MOB_LAYER
-	duration = 4
-
-/obj/effect/temp_visual/resonance_crush/Initialize()
-	. = ..()
-	transform = matrix()*1.5
-	animate(src, transform = matrix()*0.1, alpha = 50, time = 4)
-*/
 
 /obj/item/resonator
 	name = "resonator"
@@ -129,18 +16,18 @@
 	force = 15
 	throwforce = 10
 
-	var/mode = 1
+	var/mode = RESONATOR_MODE_AUTO
 	var/quick_burst_mod = 0.8 //How efficient it is in manual mode. Yes, we lower the damage cuz it's gonna be used for mobhunt
 	var/fieldlimit = 4
 	var/list/fields = list()
 
 /obj/item/resonator/attack_self(mob/user)
-	if(mode == 1)
+	if(mode == RESONATOR_MODE_AUTO)
 		to_chat(user, "<span class='info'>You set the resonator's fields to detonate only after you hit one with it.</span>")
-		mode = 2
+		mode = RESONATOR_MODE_MANUAL
 	else
 		to_chat(user, "<span class='info'>You set the resonator's fields to automatically detonate after 2 seconds.</span>")
-		mode = 1
+		mode = RESONATOR_MODE_AUTO
 
 /obj/item/resonator/proc/CreateResonance(target, mob/user)
 	var/turf/T = get_turf(target)
@@ -172,9 +59,9 @@
 	var/rupturing = FALSE //So it won't recurse
 
 /obj/effect/temp_visual/resonance/Initialize(mapload, set_creator, set_resonator, mode)
-	if(mode == 1)
+	if(mode == RESONATOR_MODE_AUTO)
 		duration = 20
-	if(mode == 3)
+	if(mode == RESONATOR_MODE_MATRIX)
 		icon_state = "shield2"
 		name = "resonance matrix"
 		RegisterSignal(src, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/burst)
@@ -248,12 +135,12 @@
 	quick_burst_mod = 1
 
 /obj/item/resonator/upgraded/attack_self(mob/user)
-	if(mode == 1)
+	if(mode == RESONATOR_MODE_AUTO)
 		to_chat(user, "<span class='info'>You set the resonator's fields to detonate only after you hit one with it.</span>")
-		mode = 2
-	else if(mode == 2)
+		mode = RESONATOR_MODE_MANUAL
+	else if(mode == RESONATOR_MODE_MANUAL)
 		to_chat(user, "<span class='info'>You set the resonator's fields to work as matrix traps.</span>")
-		mode = 3
+		mode = RESONATOR_MODE_MATRIX
 	else
 		to_chat(user, "<span class='info'>You set the resonator's fields to automatically detonate after 2 seconds.</span>")
-		mode = 1
+		mode = RESONATOR_MODE_AUTO

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -15,7 +15,7 @@
 
 /datum/movespeed_modifier/slaughter
 	multiplicative_slowdown = -1
-    
+
 /datum/movespeed_modifier/resonance
 	multiplicative_slowdown = 0.75
 

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -15,6 +15,9 @@
 
 /datum/movespeed_modifier/slaughter
 	multiplicative_slowdown = -1
+    
+/datum/movespeed_modifier/resonance
+	multiplicative_slowdown = 0.75
 
 /datum/movespeed_modifier/damage_slowdown
 	blacklisted_movetypes = FLOATING|FLYING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR slightly reworks resonators so they aren't completely useless as a mining tool. It now has 2 modes: Automatic detonation after 2 seconds, or manual which triggers after you hit a field with resonator. The main change is that now field can chain detonate. Upgraded detonator also posesses a third mode: Matrix traps, which detonate after someone walks over them. This will turn resonators into a handy tool for all the fauna hunters.

## Why It's Good For The Game

Currently resonators are utterly useless and nobody gonna use em(except golems who are forced to start with it)

## Changelog
:cl:
tweak: Resonators can now chain detonate fields and set matrix traps that activate upon someone walking over them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
