### PR TITLE
Replaces disposals pipe in Kilo Robotics

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -15497,6 +15497,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "azI" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -31808,12 +31808,12 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/storage)
 "aZg" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "aZh" = (


### PR DESCRIPTION
Replaces a pipe in Kilostation

## About The Pull Request
I swear I have fixed this at least twice before.
Fixes #56284

Also adds a sci-drobe to R&D. Don't know how we missed that one. Thank you Mothblocks.

## Why It's Good For The Game
A complete disposals loop is important on the map. 

## Changelog
:cl:
fix: Missing disposals pipe in Kilostation's robotics lab is replaced
fix: Missing sci-drobe added to R&D
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
