### PR TITLE
Fixes for the invasive spreading trait

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -488,29 +488,32 @@
 /datum/plant_gene/trait/invasive
 	name = "Invasive Spreading"
 
-/datum/plant_gene/trait/invasive/on_grow(obj/machinery/hydroponics/H)
+/datum/plant_gene/trait/invasive/on_grow(obj/machinery/hydroponics/our_tray)
 	for(var/step_dir in GLOB.alldirs)
-		var/obj/machinery/hydroponics/HY = locate() in get_step(H, step_dir)
-		if(HY && prob(15))
-			if(HY.myseed) // check if there is something in the tray.
-				if(HY.myseed.type == H.myseed.type && HY.dead != 0)
-					continue //It should not destroy its owm kind.
-				qdel(HY.myseed)
-				HY.myseed = null
-			HY.myseed = H.myseed.Copy()
-			HY.age = 0
-			HY.dead = 0
-			HY.plant_health = HY.myseed.endurance
-			HY.lastcycle = world.time
-			HY.harvest = 0
-			HY.weedlevel = 0 // Reset
-			HY.pestlevel = 0 // Reset
-			HY.update_icon()
-			HY.visible_message("<span class='warning'>The [H.myseed.plantname] spreads!</span>")
-			if(HY.myseed)
-				HY.name = "[initial(HY.name)] ([HY.myseed.plantname])"
+		var/obj/machinery/hydroponics/spread_tray = locate() in get_step(our_tray, step_dir)
+		if(spread_tray && prob(15))
+			if(!our_tray.Adjacent(spread_tray))
+				continue //Don't spread through things we can't go through.
+
+			if(spread_tray.myseed) // Check if there's another seed in the next tray.
+				if(spread_tray.myseed.type == our_tray.myseed.type && !spread_tray.dead)
+					continue // It should not destroy its own kind.
+				spread_tray.visible_message("<span class='warning'>The [spread_tray.myseed.plantname] is overtaken by [our_tray.myseed.plantname]!</span>")
+				QDEL_NULL(spread_tray.myseed)
+			spread_tray.myseed = our_tray.myseed.Copy()
+			spread_tray.age = 0
+			spread_tray.dead = FALSE
+			spread_tray.plant_health = spread_tray.myseed.endurance
+			spread_tray.lastcycle = world.time
+			spread_tray.harvest = FALSE
+			spread_tray.weedlevel = 0 // Reset
+			spread_tray.pestlevel = 0 // Reset
+			spread_tray.update_icon()
+			spread_tray.visible_message("<span class='warning'>The [our_tray.myseed.plantname] spreads!</span>")
+			if(spread_tray.myseed)
+				spread_tray.name = "[initial(spread_tray.name)] ([spread_tray.myseed.plantname])"
 			else
-				HY.name = initial(HY.name)
+				spread_tray.name = initial(spread_tray.name)
 
 /**
  * A plant trait that causes the plant's food reagents to ferment instead.


### PR DESCRIPTION
## About The Pull Request

- Fixes invasive spreading overtaking same type plants (It was checking for dead plants instead of alive ones)
- Fixes invasive spreading going through glass (It only checked plants one step away, regardless of adjacency) 
- Better var names (HY -> spread_tray, H -> our_tray)
- Slight visual feedback when plants are destroyed
- TRUE / FALSE instead of 1 / 0 

## Why It's Good For The Game

Invasive has been pretty buggy. Now it is less buggy.

## Changelog
:cl: Melbert
fix: Fixes invasive spreading overtaking plants of the same type
fix: Fixes invasive spreading going through windows
/:cl:

