### PR TITLE
Patches gene shears click stack exploit

### DIFF
--- a/code/__DEFINES/botany.dm
+++ b/code/__DEFINES/botany.dm
@@ -3,6 +3,7 @@
 #define YIELD_WEED_MINIMUM 3
 #define YIELD_WEED_MAXIMUM 10
 #define STATIC_NUTRIENT_CAPACITY 10
+#define GENE_SHEAR_MIN_HEALTH 15
 
 //Both available scanning modes for the plant analyzer.
 #define PLANT_SCANMODE_STATS		0

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -673,6 +673,8 @@
 			return
 		if(!user.canUseTopic(src, BE_CLOSE))
 			return
+		if(plant_health <= 15) //Check health again to make sure they're not keeping inputs open to get free shears.
+			return
 		for(var/datum/plant_gene/gene in myseed.genes)
 			if(gene.name == removed_trait)
 				if(myseed.genes.Remove(gene))

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -673,6 +673,8 @@
 			return
 		if(!user.canUseTopic(src, BE_CLOSE))
 			return
+		if(!myseed)
+			return
 		if(plant_health <= 15) //Check health again to make sure they're not keeping inputs open to get free shears.
 			return
 		for(var/datum/plant_gene/gene in myseed.genes)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -657,7 +657,7 @@
 		if(!myseed)
 			to_chat(user, "<span class='notice'>The tray is empty.</span>")
 			return
-		if(plant_health <= 15)
+		if(plant_health <= GENE_SHEAR_MIN_HEALTH)
 			to_chat(user, "<span class='notice'>This plant looks too unhealty to be sheared right now.</span>")
 			return
 
@@ -675,7 +675,7 @@
 			return
 		if(!myseed)
 			return
-		if(plant_health <= 15) //Check health again to make sure they're not keeping inputs open to get free shears.
+		if(plant_health <= GENE_SHEAR_MIN_HEALTH) //Check health again to make sure they're not keeping inputs open to get free shears.
 			return
 		for(var/datum/plant_gene/gene in myseed.genes)
 			if(gene.name == removed_trait)


### PR DESCRIPTION
## About The Pull Request

Fixes #55390 by checking the plant's heath again after the input is done and before the gene is removed. I'm not sure if it's the _cleanest_ way to get around stacking inputs to exploit the health, but it works?

## Why It's Good For The Game

No more exploiting botany to prepare empty omega-weed or mutated plants in seconds.

## Changelog
:cl: Melbert
fix: Fixes the botany gene-shear click-stacking input exploit to get around health requirements.
/:cl:
