### PR TITLE
Attempts to fix addictions being utterly broken and almost impossible to obtain.

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -34,7 +34,7 @@
 #define TRACK_MAX_SHARE	//Allows max share tracking, for use in the atmos debugging ui
 #endif //ifdef TESTING
 
-//#define UNIT_TESTS			//If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
+#define UNIT_TESTS			//If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 
 #ifndef PRELOAD_RSC				//set to:
 #define PRELOAD_RSC	2			//	0 to allow using external resources or on-demand behaviour;

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -34,7 +34,7 @@
 #define TRACK_MAX_SHARE	//Allows max share tracking, for use in the atmos debugging ui
 #endif //ifdef TESTING
 
-#define UNIT_TESTS			//If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
+//#define UNIT_TESTS			//If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 
 #ifndef PRELOAD_RSC				//set to:
 #define PRELOAD_RSC	2			//	0 to allow using external resources or on-demand behaviour;

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -565,7 +565,6 @@
  */
 /datum/reagents/proc/metabolize(mob/living/carbon/C, can_overdose = FALSE, liverless = FALSE)
 	var/list/cached_reagents = reagent_list
-	var/list/cached_addictions = addiction_list
 	if(C)
 		expose_temperature(C.bodytemperature, 0.25)
 	var/need_mob_update = 0
@@ -590,18 +589,18 @@
 							R.overdosed = TRUE
 							need_mob_update += R.overdose_start(C)
 							log_game("[key_name(C)] has started overdosing on [R.name] at [R.volume] units.")
-					var/is_addicted_to = cached_addictions && is_type_in_list(R, cached_addictions)
+					var/is_addicted_to = addiction_list && is_type_in_list(R, addiction_list)
 					if(R.addiction_threshold)
 						if(R.volume >= R.addiction_threshold && !is_addicted_to)
 							var/datum/reagent/new_reagent = new R.addiction_type()
-							LAZYADD(cached_addictions, new_reagent)
+							LAZYADD(addiction_list, new_reagent)
 							is_addicted_to = TRUE
 							log_game("[key_name(C)] has become addicted to [R.name] at [R.volume] units.")
 					if(R.overdosed)
 						need_mob_update += R.overdose_process(C)
 					var/datum/reagent/addiction_type = new R.addiction_type()
 					if(is_addicted_to)
-						for(var/addiction in cached_addictions)
+						for(var/addiction in addiction_list)
 							var/datum/reagent/A = addiction
 							if(istype(addiction_type, A))
 								A.addiction_stage = -15 // you're satisfied for a good while.
@@ -610,7 +609,7 @@
 	if(can_overdose)
 		if(addiction_tick == 6)
 			addiction_tick = 1
-			for(var/addiction in cached_addictions)
+			for(var/addiction in addiction_list)
 				var/datum/reagent/R = addiction
 				if(!C)
 					break

--- a/code/modules/unit_tests/metabolizing.dm
+++ b/code/modules/unit_tests/metabolizing.dm
@@ -57,7 +57,7 @@
 
 	pill_user.Life()
 
-	TEST_ASSERT(pill_user.reagents.addiction_list && is_type_in_list(meth, pill_user.reagents.addiction_list), "User is not addicted to meth after eating consuming the addiction threshold")
+	TEST_ASSERT(pill_user.reagents.addiction_list && is_type_in_list(meth, pill_user.reagents.addiction_list), "User is not addicted to meth after ingesting the addiction threshold")
 
 	// Then injected metabolism
 	syringe.volume = initial(meth.addiction_threshold)
@@ -87,4 +87,4 @@
 
 	pill_syringe_user.Life()
 
-	TEST_ASSERT(pill_syringe_user.reagents.addiction_list && is_type_in_list(meth, pill_syringe_user.reagents.addiction_list), "User is not addicted to meth after injecting the addiction threshold")
+	TEST_ASSERT(pill_syringe_user.reagents.addiction_list && is_type_in_list(meth, pill_syringe_user.reagents.addiction_list), "User is not addicted to meth after injecting and ingesting half the addiction threshold each")

--- a/code/modules/unit_tests/metabolizing.dm
+++ b/code/modules/unit_tests/metabolizing.dm
@@ -53,7 +53,7 @@
 
 	pill_user.Life()
 
-	TEST_ASSERT(pill_user.addiction_list && is_type_in_list(meth, pill_user.addiction_list), "User is not addicted to meth after eating consuming the addiction threshold")
+	TEST_ASSERT(pill_user.reagents.addiction_list && is_type_in_list(meth, pill_user.reagents.addiction_list), "User is not addicted to meth after eating consuming the addiction threshold")
 
 	// Then injected metabolism
 	syringe.volume = initial(meth.addiction_threshold)
@@ -64,7 +64,7 @@
 
 	syringe_user.Life()
 
-	TEST_ASSERT(syringe_user.addiction_list && is_type_in_list(meth, syringe_user.addiction_list), "User is not addicted to meth after injecting the addiction threshold")
+	TEST_ASSERT(syringe_user.reagents.addiction_list && is_type_in_list(meth, syringe_user.reagents.addiction_list), "User is not addicted to meth after injecting the addiction threshold")
 
 	// One half syringe
 	syringe.reagents.clear_reagents()
@@ -79,4 +79,4 @@
 
 	pill_syringe_user.Life()
 
-	TEST_ASSERT(pill_syringe_user.addiction_list && is_type_in_list(meth, pill_syringe_user.addiction_list), "User is not addicted to meth after injecting the addiction threshold")
+	TEST_ASSERT(pill_syringe_user.reagents.addiction_list && is_type_in_list(meth, pill_syringe_user.reagents.addiction_list), "User is not addicted to meth after injecting the addiction threshold")

--- a/code/modules/unit_tests/metabolizing.dm
+++ b/code/modules/unit_tests/metabolizing.dm
@@ -51,6 +51,10 @@
 	pill.reagents.add_reagent(meth, initial(meth.addiction_threshold))
 	pill.attack(pill_user, pill_user)
 
+	// Set the metabolism efficiency to 1.0 so it transfers all reagents to the body in one go.
+	var/obj/item/organ/stomach/pill_belly = pill_user.getorganslot(ORGAN_SLOT_STOMACH)
+	pill_belly.metabolism_efficiency = 1
+
 	pill_user.Life()
 
 	TEST_ASSERT(pill_user.reagents.addiction_list && is_type_in_list(meth, pill_user.reagents.addiction_list), "User is not addicted to meth after eating consuming the addiction threshold")
@@ -76,6 +80,10 @@
 
 	syringe.attack(pill_syringe_user, pill_syringe_user)
 	pill_two.attack(pill_syringe_user, pill_syringe_user)
+
+	// Set the metabolism efficiency to 1.0 so it transfers all reagents to the body in one go.
+	pill_belly = pill_syringe_user.getorganslot(ORGAN_SLOT_STOMACH)
+	pill_belly.metabolism_efficiency = 1
 
 	pill_syringe_user.Life()
 

--- a/code/modules/unit_tests/metabolizing.dm
+++ b/code/modules/unit_tests/metabolizing.dm
@@ -43,12 +43,13 @@
 	var/obj/item/reagent_containers/pill/pill = allocate(/obj/item/reagent_containers/pill)
 	var/obj/item/reagent_containers/pill/pill_two = allocate(/obj/item/reagent_containers/pill)
 
-	var/obj/item/reagent_containers/syringe = allocate(/obj/item/reagent_containers/syringe)
+	var/obj/item/reagent_containers/syringe/syringe = allocate(/obj/item/reagent_containers/syringe)
 
-	var/datum/reagent/drug/methamphetamine/meth = /datum/reagent/drug/methamphetamine
+	var/datum/reagent/drug/methamphetamine/meth = allocate(/datum/reagent/drug/methamphetamine)
+
 
 	// Let's start with stomach metabolism
-	pill.reagents.add_reagent(meth, initial(meth.addiction_threshold))
+	pill.reagents.add_reagent(meth.type, meth.addiction_threshold)
 	pill.attack(pill_user, pill_user)
 
 	// Set the metabolism efficiency to 1.0 so it transfers all reagents to the body in one go.
@@ -60,26 +61,31 @@
 	TEST_ASSERT(pill_user.reagents.addiction_list && is_type_in_list(meth, pill_user.reagents.addiction_list), "User is not addicted to meth after ingesting the addiction threshold")
 
 	// Then injected metabolism
-	syringe.volume = initial(meth.addiction_threshold)
-	syringe.amount_per_transfer_from_this = initial(meth.addiction_threshold)
-	syringe.reagents.add_reagent(meth, initial(meth.addiction_threshold))
+	syringe.volume = meth.addiction_threshold
+	syringe.amount_per_transfer_from_this = meth.addiction_threshold
+	syringe.reagents.add_reagent(meth.type, meth.addiction_threshold)
 
-	syringe.attack(syringe_user, syringe_user)
+	syringe.mode = SYRINGE_INJECT
+	syringe_user.a_intent = INTENT_HARM
+	syringe.afterattack(syringe_user, syringe_user, TRUE)
 
 	syringe_user.Life()
 
 	TEST_ASSERT(syringe_user.reagents.addiction_list && is_type_in_list(meth, syringe_user.reagents.addiction_list), "User is not addicted to meth after injecting the addiction threshold")
 
 	// One half syringe
-	syringe.reagents.clear_reagents()
-	syringe.reagents.add_reagent(meth, (initial(meth.addiction_threshold) * 0.5) + 1)
+	syringe.reagents.remove_all()
+	syringe.volume = meth.addiction_threshold
+	syringe.amount_per_transfer_from_this = meth.addiction_threshold
+	syringe.reagents.add_reagent(meth.type, (meth.addiction_threshold * 0.5) + 1)
 
 	// One half pill
-	pill_two.reagents.add_reagent(meth, (initial(meth.addiction_threshold) * 0.5) + 1)
+	pill_two.reagents.add_reagent(meth.type, (meth.addiction_threshold * 0.5) + 1)
 	pill_two.attack(pill_syringe_user, pill_syringe_user)
 
-	syringe.attack(pill_syringe_user, pill_syringe_user)
-	pill_two.attack(pill_syringe_user, pill_syringe_user)
+	pill_syringe_user.a_intent = INTENT_HARM
+	syringe.mode = SYRINGE_INJECT
+	syringe.afterattack(pill_syringe_user, pill_syringe_user, TRUE)
 
 	// Set the metabolism efficiency to 1.0 so it transfers all reagents to the body in one go.
 	pill_belly = pill_syringe_user.getorganslot(ORGAN_SLOT_STOMACH)

--- a/code/modules/unit_tests/metabolizing.dm
+++ b/code/modules/unit_tests/metabolizing.dm
@@ -34,3 +34,49 @@
 
 	TEST_ASSERT(!user.reagents.has_reagent(meth), "User still has meth in their system when it should've finished metabolizing")
 	TEST_ASSERT(!user.has_movespeed_modifier(/datum/movespeed_modifier/reagent/methamphetamine), "User still has movespeed modifier despite not containing any more meth")
+
+/datum/unit_test/addictions/Run()
+	var/mob/living/carbon/human/pill_user = allocate(/mob/living/carbon/human)
+	var/mob/living/carbon/human/syringe_user = allocate(/mob/living/carbon/human)
+	var/mob/living/carbon/human/pill_syringe_user = allocate(/mob/living/carbon/human)
+
+	var/obj/item/reagent_containers/pill/pill = allocate(/obj/item/reagent_containers/pill)
+	var/obj/item/reagent_containers/pill/pill_two = allocate(/obj/item/reagent_containers/pill)
+
+	var/obj/item/reagent_containers/syringe = allocate(/obj/item/reagent_containers/syringe)
+
+	var/datum/reagent/drug/methamphetamine/meth = /datum/reagent/drug/methamphetamine
+
+	// Let's start with stomach metabolism
+	pill.reagents.add_reagent(meth, initial(meth.addiction_threshold))
+	pill.attack(pill_user, pill_user)
+
+	pill_user.Life()
+
+	TEST_ASSERT(pill_user.addiction_list && is_type_in_list(meth, pill_user.addiction_list), "User is not addicted to meth after eating consuming the addiction threshold")
+
+	// Then injected metabolism
+	syringe.volume = initial(meth.addiction_threshold)
+	syringe.amount_per_transfer_from_this = initial(meth.addiction_threshold)
+	syringe.reagents.add_reagent(meth, initial(meth.addiction_threshold))
+
+	syringe.attack(syringe_user, syringe_user)
+
+	syringe_user.Life()
+
+	TEST_ASSERT(syringe_user.addiction_list && is_type_in_list(meth, syringe_user.addiction_list), "User is not addicted to meth after injecting the addiction threshold")
+
+	// One half syringe
+	syringe.reagents.clear_reagents()
+	syringe.reagents.add_reagent(meth, (initial(meth.addiction_threshold) * 0.5) + 1)
+
+	// One half pill
+	pill_two.reagents.add_reagent(meth, (initial(meth.addiction_threshold) * 0.5) + 1)
+	pill_two.attack(pill_syringe_user, pill_syringe_user)
+
+	syringe.attack(pill_syringe_user, pill_syringe_user)
+	pill_two.attack(pill_syringe_user, pill_syringe_user)
+
+	pill_syringe_user.Life()
+
+	TEST_ASSERT(pill_syringe_user.addiction_list && is_type_in_list(meth, pill_syringe_user.addiction_list), "User is not addicted to meth after injecting the addiction threshold")

--- a/code/modules/unit_tests/metabolizing.dm
+++ b/code/modules/unit_tests/metabolizing.dm
@@ -17,6 +17,8 @@
 	return ..()
 
 /datum/unit_test/on_mob_end_metabolize/Run()
+	SSmobs.pause()
+
 	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
 	var/obj/item/reagent_containers/pill/pill = allocate(/obj/item/reagent_containers/pill)
 	var/datum/reagent/drug/methamphetamine/meth = /datum/reagent/drug/methamphetamine
@@ -35,7 +37,13 @@
 	TEST_ASSERT(!user.reagents.has_reagent(meth), "User still has meth in their system when it should've finished metabolizing")
 	TEST_ASSERT(!user.has_movespeed_modifier(/datum/movespeed_modifier/reagent/methamphetamine), "User still has movespeed modifier despite not containing any more meth")
 
+/datum/unit_test/on_mob_end_metabolize/Destroy()
+	SSmobs.ignite()
+	return ..()
+
 /datum/unit_test/addictions/Run()
+	SSmobs.pause()
+
 	var/mob/living/carbon/human/pill_user = allocate(/mob/living/carbon/human)
 	var/mob/living/carbon/human/syringe_user = allocate(/mob/living/carbon/human)
 	var/mob/living/carbon/human/pill_syringe_user = allocate(/mob/living/carbon/human)
@@ -94,3 +102,7 @@
 	pill_syringe_user.Life()
 
 	TEST_ASSERT(pill_syringe_user.reagents.addiction_list && is_type_in_list(meth, pill_syringe_user.reagents.addiction_list), "User is not addicted to meth after injecting and ingesting half the addiction threshold each")
+
+/datum/unit_test/addictions/Destroy()
+	SSmobs.ignite()
+	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #55245

The broken functionality is LAZYADDing to the cache when the cache is null (caused by addiction_list being null) creates a new list that is never assigned back to addiction_list.

For whatever reason, metabolism takes the addiction_list and caches it. Only it really doesn't cache it. It just... Assigns the addiction_list's ref to another list and uses that var instead of addiction_list. But addiction_list and cached_addictions both share the same ref except when addiction_list is null, in which case functionality breaks entirely.

Because addiction_list is a lazylist, it's very, very, VERY often null.

I opted to completely remove the cache, because it is ordinarily just a ref straight back to the local addiction_list var and thus doesn't actually do anything, beyond break gaining addictions through metabolism that is.

I have no clue what it was trying to accomplish in the first place by copying the ref to a list local to the var and calling it a cache. This may not even be **the** fix, but it's the core reason behind why addictions currently do not work.

Adds a series of unit tests to make sure the expected behaviour re: addictions actually happens.
 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Addictions actually work again.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can once again get addicted to chems through metabolism.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
