### PR TITLE
1:1 HUD layout fix

### DIFF
--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -8,8 +8,3 @@
 
 /// Used in show_hud(); Please ensure this is the same as the maximum index.
 #define HUD_VERSIONS 3
-
-//1:1 HUD layout stuff
-#define UI_BOXCRAFT "EAST-4:22,SOUTH+1:6"
-#define UI_BOXAREA "EAST-4:6,SOUTH+1:6"
-#define UI_BOXLANG "EAST-5:22,SOUTH+1:6"

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -55,30 +55,21 @@
 /datum/hud/human/New(mob/living/carbon/human/owner)
 	..()
 
-	var/widescreen_layout = FALSE
-	if(owner.client?.prefs?.widescreenpref)
-		widescreen_layout = TRUE
-
 	var/atom/movable/screen/using
 	var/atom/movable/screen/inventory/inv_box
 
 	using = new/atom/movable/screen/language_menu
 	using.icon = ui_style
-	if(!widescreen_layout)
-		using.screen_loc = UI_BOXLANG
 	using.hud = src
 	static_inventory += using
 
 	using = new/atom/movable/screen/skills
 	using.icon = ui_style
-	if(!widescreen_layout)
-		using.screen_loc = UI_BOXLANG
+	using.hud = src
 	static_inventory += using
 
 	using = new /atom/movable/screen/area_creator
 	using.icon = ui_style
-	if(!widescreen_layout)
-		using.screen_loc = UI_BOXAREA
 	using.hud = src
 	static_inventory += using
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR fixes 1:1 HUD layout for four small icons that are next to the intent selection, so they are not sticking out and are neatly organized in a box. 

Original intent might have been to create space for a new possible slot, but that is not currently the case, and it would also be problematic - icons are currently overlapping with the storage menu when opened (think bags), so they would have to be moved elsewhere either way. Also adds a proper hud owner for the skills button when it is created, which I guess was a simple oversight.

Fixes #50760

Before:
![OldNotWidescreen](https://user-images.githubusercontent.com/43862960/105351070-587e1700-5bec-11eb-8132-ef91a0a99b12.png)

After:
![HUDFixedNotWidescreen](https://user-images.githubusercontent.com/43862960/105351314-b14daf80-5bec-11eb-849f-409ea35a3f45.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugfix.

## Changelog
:cl: Arkatos
fix: Fixed a layout for four misc icons next to the intent selection in non-widescreen HUDs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
