### PR TITLE
Fixes camera name on icebox genetics.

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -52475,7 +52475,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Experimentor Lab";
+	c_tag = "Genetics Lab";
 	network = list("ss13","rd")
 	},
 /obj/structure/cable,


### PR DESCRIPTION
## About The Pull Request

Quick little map fix, the camera in icebox genetics was still called the experimentation lab.

## Why It's Good For The Game

Fixes #56251.

## Changelog
:cl:
fix: The genetics camera now has the correct name.
/:cl:

