### PR TITLE
Monkeys drop forced two handed items

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -315,6 +315,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_T_RAY_VISIBLE		"t-ray-visible" // Visible on t-ray scanners if the atom/var/level == 1
 #define TRAIT_NO_TELEPORT		"no-teleport" //you just can't
 #define TRAIT_FOOD_GRILLED 		"food_grilled"
+#define TRAIT_NEEDS_TWO_HANDS	"needstwohands" //The items needs two hands to be carried
 
 //quirk traits
 #define TRAIT_ALCOHOL_TOLERANCE	"alcohol_tolerance"

--- a/code/datums/ai/monkey/monkey_behaviors.dm
+++ b/code/datums/ai/monkey/monkey_behaviors.dm
@@ -25,6 +25,10 @@
 		finish_action(controller, FALSE)
 		return
 
+	if(HAS_TRAIT(target, TRAIT_NEEDS_TWO_HANDS)) //Can't carry items that need two hands as a monkey
+		finish_action(controller, FALSE)
+		return
+
 	if(target.anchored) //Can't pick it up, so stop trying.
 		finish_action(controller, FALSE)
 		return

--- a/code/datums/ai/monkey/monkey_behaviors.dm
+++ b/code/datums/ai/monkey/monkey_behaviors.dm
@@ -25,10 +25,6 @@
 		finish_action(controller, FALSE)
 		return
 
-	if(HAS_TRAIT(target, TRAIT_NEEDS_TWO_HANDS)) //Can't carry items that need two hands as a monkey
-		finish_action(controller, FALSE)
-		return
-
 	if(target.anchored) //Can't pick it up, so stop trying.
 		finish_action(controller, FALSE)
 		return

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -112,9 +112,16 @@ have ways of interacting with a specific mob and control it.
 	if(!locate(/obj/item) in living_pawn.held_items)
 		blackboard[BB_MONKEY_BEST_FORCE_FOUND] = 0
 
-	var/obj/item/W = locate(/obj/item) in oview(2, living_pawn)
+	var/obj/item/W
+	for(var/obj/item/i in oview(2, living_pawn))
+		if(!istype(i))
+			continue
+		if(HAS_TRAIT(i, TRAIT_NEEDS_TWO_HANDS) || blackboard[BB_MONKEY_BLACKLISTITEMS][i] || i.force > blackboard[BB_MONKEY_BEST_FORCE_FOUND])
+			continue
+		W = i
+		break
 
-	if(W && !blackboard[BB_MONKEY_BLACKLISTITEMS][W] && W.force > blackboard[BB_MONKEY_BEST_FORCE_FOUND])
+	if(W)
 		blackboard[BB_MONKEY_PICKUPTARGET] = W
 		current_movement_target = W
 		current_behaviors += GET_AI_BEHAVIOR(/datum/ai_behavior/monkey_equip/ground)
@@ -123,7 +130,7 @@ have ways of interacting with a specific mob and control it.
 		var/mob/living/carbon/human/H = locate(/mob/living/carbon/human/) in oview(2,living_pawn)
 		if(H)
 			W = pick(H.held_items)
-			if(W && !blackboard[BB_MONKEY_BLACKLISTITEMS][W] && W.force > blackboard[BB_MONKEY_BEST_FORCE_FOUND])
+			if(W && !blackboard[BB_MONKEY_BLACKLISTITEMS][W] && W.force > blackboard[BB_MONKEY_BEST_FORCE_FOUND] && !HAS_TRAIT(W, TRAIT_NEEDS_TWO_HANDS))
 				blackboard[BB_MONKEY_PICKUPTARGET] = W
 				current_movement_target = W
 				current_behaviors += GET_AI_BEHAVIOR(/datum/ai_behavior/monkey_equip/pickpocket)

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -45,6 +45,9 @@
 	src.force_unwielded = force_unwielded
 	src.icon_wielded = icon_wielded
 
+	if(require_twohands)
+		ADD_TRAIT(parent, TRAIT_NEEDS_TWO_HANDS, ABSTRACT_ITEM_TRAIT)
+
 // Inherit the new values passed to the component
 /datum/component/two_handed/InheritComponent(datum/component/two_handed/new_comp, original, require_twohands, wieldsound, unwieldsound, \
 											force_multiplier, force_wielded, force_unwielded, icon_wielded)

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -126,10 +126,11 @@
 	if(wielded)
 		return
 	if(ismonkey(user))
-		to_chat(user, "<span class='warning'>It's too heavy for you to wield fully.</span>")
 		if(require_twohands)
-			to_chat(user, "<span class='notice'>[parent] is too cumbersome to carry in one hand!</span>")
+			to_chat(user, "<span class='notice'>[parent] is too heavy and cumbersome for you to carry!</span>")
 			user.dropItemToGround(parent, force=TRUE)
+		else
+			to_chat(user, "<span class='notice'>It's too heavy for you to wield fully.</span>")
 		return
 	if(user.get_inactive_held_item())
 		if(require_twohands)

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -127,6 +127,9 @@
 		return
 	if(ismonkey(user))
 		to_chat(user, "<span class='warning'>It's too heavy for you to wield fully.</span>")
+		if(require_twohands)
+			to_chat(user, "<span class='notice'>[parent] is too cumbersome to carry in one hand!</span>")
+			user.dropItemToGround(parent, force=TRUE)
 		return
 	if(user.get_inactive_held_item())
 		if(require_twohands)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Monkeys cannot wield twohanded items.
But are not forced to drop items that must be wielded two handed.
This forces monkeys to drop items if they need to be two handed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes monkeys...

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Monkeys are no longer able to hold items that require two hands.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
