### PR TITLE
You can now make damp rags by dipping a bolt of cloth in a sink

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -377,10 +377,10 @@
 		return
 
 	if(istype(O, /obj/item/stack/sheet/cloth))
-		var/obj/item/stack/sheet/cloth/C = O
+		var/obj/item/stack/sheet/cloth/cloth = O
 		new /obj/item/reagent_containers/glass/rag(loc)
 		to_chat(user, "<span class='notice'>You tear off a strip of cloth and make a rag.</span>")
-		C.use(1)
+		cloth.use(1)
 		return
 
 	if(istype(O, /obj/item/stack/ore/glass))
@@ -562,10 +562,10 @@
 		return
 
 	if(istype(O, /obj/item/stack/sheet/cloth))
-		var/obj/item/stack/sheet/cloth/C = O
+		var/obj/item/stack/sheet/cloth/cloth = O
 		new /obj/item/reagent_containers/glass/rag(loc)
 		to_chat(user, "<span class='notice'>You tear off a strip of cloth and make a rag.</span>")
-		C.use(1)
+		cloth.use(1)
 		return
 
 	if(istype(O, /obj/item/stack/ore/glass))

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -563,7 +563,7 @@
 
 	if(istype(O, /obj/item/stack/sheet/cloth))
 		var/obj/item/stack/sheet/cloth/C = O
-		new /obj/item/reagent_containers/glass/rag(src.loc)
+		new /obj/item/reagent_containers/glass/rag(loc)
 		to_chat(user, "<span class='notice'>You tear off a strip of cloth and make a rag.</span>")
 		C.use(1)
 		return

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -378,7 +378,7 @@
 
 	if(istype(O, /obj/item/stack/sheet/cloth))
 		var/obj/item/stack/sheet/cloth/C = O
-		new /obj/item/reagent_containers/glass/rag(src.loc)
+		new /obj/item/reagent_containers/glass/rag(loc)
 		to_chat(user, "<span class='notice'>You tear off a strip of cloth and make a rag.</span>")
 		C.use(1)
 		return

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -376,6 +376,13 @@
 		G.use(1)
 		return
 
+	if(istype(O, /obj/item/stack/sheet/cloth))
+		var/obj/item/stack/sheet/cloth/C = O
+		new /obj/item/reagent_containers/glass/rag(src.loc)
+		to_chat(user, "<span class='notice'>You tear off a strip of cloth and make a rag.</span>")
+		C.use(1)
+		return
+
 	if(istype(O, /obj/item/stack/ore/glass))
 		new /obj/item/stack/sheet/sandblock(loc)
 		to_chat(user, "<span class='notice'>You wet the sand in the sink and form it into a block.</span>")
@@ -552,6 +559,13 @@
 		new /obj/item/reagent_containers/glass/rag(loc)
 		to_chat(user, "<span class='notice'>You tear off a strip of gauze and make a rag.</span>")
 		G.use(1)
+		return
+
+	if(istype(O, /obj/item/stack/sheet/cloth))
+		var/obj/item/stack/sheet/cloth/C = O
+		new /obj/item/reagent_containers/glass/rag(src.loc)
+		to_chat(user, "<span class='notice'>You tear off a strip of cloth and make a rag.</span>")
+		C.use(1)
 		return
 
 	if(istype(O, /obj/item/stack/ore/glass))


### PR DESCRIPTION
## About The Pull Request

You can now make damp rags by dipping a bolt of cloth in a sink, like how you can already make damp rags by dipping a strip of gauze in a sink.

This PR does NOT remove the other existing methods of creating damp rags.

## Why It's Good For The Game

You can already make a damp rag (two of them, in fact- the method added by this PR is somewhat inefficient!) from a bolt of cloth by just turning it into improvised gauze and dipping that into a sink. This just makes the process of making damp rags slightly more intuitive for players who don't know that they specifically need gauze (and its subtypes), not cloth.

EDIT: You can also just directly craft cloth into rags. Well, this is embarassing. Still, this is nice for consistency's sake, I guess.

## Changelog
:cl: ATHATH
add: You can now make a damp rag from a bolt of cloth by using it on a sink, just like how you can make a damp rag by using a strip of gauze on a sink. The ability to stackcraft damp rags from bolts of cloth has not been removed.
/:cl: