### PR TITLE
Disabled postinstall scripts until they're fixed in yarn

### DIFF
--- a/tgui/.yarnrc.yml
+++ b/tgui/.yarnrc.yml
@@ -4,12 +4,7 @@ logFilters:
   ## DISABLED_BUILD_SCRIPTS
   - code: YN0004
     level: discard
-  ## FETCH_NOT_CACHED
-  ## Too many cache misses on first install.
-  - code: YN0013
-    level: discard
-  ## INCOMPATIBLE_OS
-  ## fsevents are not supposed to build, they're macOS specific.
+  ## INCOMPATIBLE_OS - fsevents junk
   - code: YN0062
     level: discard
 
@@ -18,5 +13,9 @@ plugins:
     spec: "@yarnpkg/plugin-interactive-tools"
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
     spec: "@yarnpkg/plugin-workspace-tools"
+
+preferAggregateCacheInfo: true
+
+preferInteractive: true
 
 yarnPath: .yarn/releases/yarn-2.4.0.cjs

--- a/tgui/.yarnrc.yml
+++ b/tgui/.yarnrc.yml
@@ -1,8 +1,8 @@
+enableScripts: false
+
 logFilters:
-  ## MUST_BUILD
-  ## It's an opencollective advert in postinstall that is not even displayed
-  ## correctly in Yarn, who the fuck cares.
-  - code: YN0007
+  ## DISABLED_BUILD_SCRIPTS
+  - code: YN0004
     level: discard
   ## FETCH_NOT_CACHED
   ## Too many cache misses on first install.


### PR DESCRIPTION
## About The Pull Request

> Opencollective is at it again.

Plugs the following hole: https://github.com/yarnpkg/berry/issues/2397

We don't use packages that need building anyway. What fails is usually an opencollective advert.

Coders will be able to code on their cyrillic windows machines again.