### PR TITLE
Lower Friendly cost from 4 to 2

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -111,7 +111,7 @@
 /datum/quirk/friendly
 	name = "Friendly"
 	desc = "You give the best hugs, especially when you're in the right mood."
-	value = 4
+	value = 2
 	mob_trait = TRAIT_FRIENDLY
 	gain_text = "<span class='notice'>You want to hug someone.</span>"
 	lose_text = "<span class='danger'>You no longer feel compelled to hug others.</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lowers cost of the Friendly quirk from 4 to 2 points. Approved by Floyd.

![image](https://user-images.githubusercontent.com/35135081/105477036-34efb680-5c56-11eb-809f-392579832e14.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Floyd agrees that a quirk that exists to aide exclusively other people should not cost as much as something that aids exclusively you. This fits in terms of power for the existing 2 point quirks: Clown/Mime Fan and Musician.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Friendly quirk has been lowered from 4 to 2 points.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
