### PR TITLE
Adds Quirk-Related "Special Pool" to obsessed for Chaplain, Clown, and Mime targets.

### DIFF
--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -117,6 +117,7 @@
 /datum/brain_trauma/special/obsessed/proc/find_obsession()
 	var/list/viable_minds = list() //The first list, which excludes hijinks
 	var/list/possible_targets = list() //The second list, which filters out silicons and simplemobs
+	var/static/list/trait_obsessions = list(TRAIT_FAN_MIME = "Mime", TRAIT_FAN_CLOWN = "Clown", TRAIT_SPIRITUAL = "Chaplain") //Quirks and their corresponding jobs
 	var/list/special_pool = list() //The special list, for quirk-based
 	var/chosen_victim  //The obsession target
 
@@ -125,15 +126,10 @@
 			viable_minds += Player.mind
 	for(var/datum/mind/possible_target in viable_minds)
 		if(possible_target != owner && ishuman(possible_target.current))
-			if(HAS_TRAIT(owner, TRAIT_FAN_MIME) && possible_target.assigned_role == "Mime")
-				special_pool += possible_target.current
-				continue
-			if(HAS_TRAIT(owner, TRAIT_FAN_CLOWN) && possible_target.assigned_role == "Clown")
-				special_pool += possible_target.current
-				continue
-			if(HAS_TRAIT(owner, TRAIT_SPIRITUAL) && possible_target.assigned_role == "Chaplain")
-				special_pool += possible_target.current
-				continue
+			for(var/trait in trait_obsessions)
+				if(HAS_TRAIT(owner, trait) && possible_target.assigned_role == trait_obsessions[trait])
+					special_pool += possible_target.current
+					break
 			possible_targets += possible_target.current
 
 	//Do we have any special target?

--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -117,7 +117,7 @@
 /datum/brain_trauma/special/obsessed/proc/find_obsession()
 	var/list/viable_minds = list() //The first list, which excludes hijinks
 	var/list/possible_targets = list() //The second list, which filters out silicons and simplemobs
-	var/static/list/trait_obsessions = list(TRAIT_FAN_MIME = "Mime", TRAIT_FAN_CLOWN = "Clown", TRAIT_SPIRITUAL = "Chaplain") //Quirks and their corresponding jobs
+	var/static/list/trait_obsessions = list("Mime" = TRAIT_FAN_MIME, "Clown" = TRAIT_FAN_CLOWN, "Chaplain" = TRAIT_SPIRITUAL) //Jobs and their corresponding quirks
 	var/list/special_pool = list() //The special list, for quirk-based
 	var/chosen_victim  //The obsession target
 
@@ -126,10 +126,9 @@
 			viable_minds += Player.mind
 	for(var/datum/mind/possible_target in viable_minds)
 		if(possible_target != owner && ishuman(possible_target.current))
-			for(var/trait in trait_obsessions)
-				if(HAS_TRAIT(owner, trait) && possible_target.assigned_role == trait_obsessions[trait])
-					special_pool += possible_target.current
-					break
+			var/job = possible_target.assigned_role
+			if (trait_obsessions[job] != null && HAS_TRAIT(owner, trait_obsessions[job]))
+				special_pool += possible_target.current
 			possible_targets += possible_target.current
 
 	//Do we have any special target?

--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -115,15 +115,33 @@
 	return COMSIG_BLOCK_EYECONTACT
 
 /datum/brain_trauma/special/obsessed/proc/find_obsession()
-	var/chosen_victim
-	var/list/possible_targets = list()
-	var/list/viable_minds = list()
+	var/list/viable_minds = list() //The first list, which excludes hijinks
+	var/list/possible_targets = list() //The second list, which filters out silicons and simplemobs
+	var/list/special_pool = list() //The special list, for quirk-based
+	var/chosen_victim  //The obsession target
+
 	for(var/mob/Player in GLOB.player_list)//prevents crewmembers falling in love with nuke ops they never met, and other annoying hijinks
 		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) && !isbrain(Player) && Player.client && Player != owner && SSjob.GetJob(Player.mind.assigned_role))
 			viable_minds += Player.mind
 	for(var/datum/mind/possible_target in viable_minds)
 		if(possible_target != owner && ishuman(possible_target.current))
+			if(HAS_TRAIT(owner, TRAIT_FAN_MIME) && possible_target.assigned_role == "Mime")
+				special_pool += possible_target.current
+				continue
+			if(HAS_TRAIT(owner, TRAIT_FAN_CLOWN) && possible_target.assigned_role == "Clown")
+				special_pool += possible_target.current
+				continue
+			if(HAS_TRAIT(owner, TRAIT_SPIRITUAL) && possible_target.assigned_role == "Chaplain")
+				special_pool += possible_target.current
+				continue
 			possible_targets += possible_target.current
+
+	//Do we have any special target?
+	if(length(special_pool))
+		chosen_victim = pick(special_pool)
+		return chosen_victim
+
+	//If not, pick any other ordinary target
 	if(possible_targets.len > 0)
 		chosen_victim = pick(possible_targets)
 	return chosen_victim


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a special pool to the obsessed target picker, making it so if the obsessed has the Spiritual, Clown Fan, or Mime Fan quirks that they will pick from a smaller pool of Chaplains and Clowns/Mimes if they have the respective quirks.

Thanks to @Timberpoes for help with putting this together.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes sense that if you're a fan of these jobs that you would likely have them as your obsession target, it also adds to the texture of these jobs. They are all RP-centric, so you're more likely to get some good interactions with them rather than trying to spend your whole shift clawing at the viro airlock so you can get a picture with the reclusive disease person. Adds more texture to the quirks involved.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: If you're a Clown/Mime fan and you become obsessed, you'll have them as your target. Also works for Spiritual with the Chaplain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
