### PR TITLE
HFR: Fix softlock when live without cooling on

### DIFF
--- a/tgui/packages/tgui/interfaces/Hypertorus.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus.js
@@ -69,7 +69,7 @@ export const Hypertorus = (props, context) => {
               <Button
                 disabled={start_fuel === 1
                     || start_power === 0
-                    || data.power_level > 0}
+                    || (start_cooling && data.power_level > 0)}
                 icon={data.start_cooling ? 'power-off' : 'times'}
                 content={data.start_cooling ? 'On' : 'Off'}
                 selected={data.start_cooling}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You continue to not be able to disable cooling once fusion is started.

If you manage to start fusion without cooling, you can now start
cooling, and control the process as usual without being locked out of the
interface.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #56149

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: If you manage to start fusion in the HFR without starting the cooling process, you can now start cooling and interact with the process as usual, rather than being softlocked. You still aren't able to disable cooling once fusion has started.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
