### PR TITLE
Soapstone messages voted beneath a certain score don't persist

### DIFF
--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -128,13 +128,16 @@ but only permamently removed with the curator's soapstone.
 
 	var/turf/original_turf
 
+	//Total vote count at or below which we delete ourselves.
+	var/delete_at = -5
+
 /obj/structure/chisel_message/Initialize(mapload)
 	. = ..()
 	SSpersistence.chisel_messages += src
 	var/turf/T = get_turf(src)
 	original_turf = T
 
-	if(!good_chisel_message_location(T))
+	if(!good_chisel_message_location(T) || like_keys.len - dislike_keys.len <= delete_at)
 		persists = FALSE
 		return INITIALIZE_HINT_QDEL
 
@@ -270,3 +273,9 @@ but only permamently removed with the curator's soapstone.
 			if(confirm == "Yes")
 				persists = FALSE
 				qdel(src)
+				return
+
+	if(like_keys.len - dislike_keys.len <= delete_at)
+		persists = FALSE
+	else
+		persists = TRUE

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -278,7 +278,4 @@ but only permamently removed with the curator's soapstone.
 				qdel(src)
 				return
 
-	if(like_keys.len - dislike_keys.len <= delete_at)
-		persists = FALSE
-	else
-		persists = TRUE
+	persists = like_keys.len - dislike_keys.len > delete_at

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -128,7 +128,7 @@ but only permamently removed with the curator's soapstone.
 
 	var/turf/original_turf
 
-	//Total vote count at or below which we delete ourselves.
+	//Total vote count at or below which we become ineligible for persistence.
 	var/delete_at = -5
 
 /obj/structure/chisel_message/Initialize(mapload)

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -128,7 +128,7 @@ but only permamently removed with the curator's soapstone.
 
 	var/turf/original_turf
 
-	//Total vote count at or below which we become ineligible for persistence.
+	//Total vote count at or below which we won't persist.
 	var/delete_at = -5
 
 /obj/structure/chisel_message/Initialize(mapload)
@@ -137,9 +137,12 @@ but only permamently removed with the curator's soapstone.
 	var/turf/T = get_turf(src)
 	original_turf = T
 
-	if(!good_chisel_message_location(T) || like_keys.len - dislike_keys.len <= delete_at)
+	if(!good_chisel_message_location(T))
 		persists = FALSE
 		return INITIALIZE_HINT_QDEL
+
+	if(like_keys.len - dislike_keys.len <= delete_at)
+		persists = FALSE
 
 /obj/structure/chisel_message/proc/register(mob/user, newmessage)
 	hidden_message = newmessage

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -128,7 +128,7 @@ but only permamently removed with the curator's soapstone.
 
 	var/turf/original_turf
 
-	//Total vote count at or below which we won't persist.
+	/// Total vote count at or below which we won't persist.
 	var/delete_at = -5
 
 /obj/structure/chisel_message/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Soapstone messages no longer persist if their total voting score is -5 or below (might change based on feedback). The game won't save them and old messages beneath the threshold will be set to non-persistent when they load, which means there's one round to save them (you could also just engrave them again).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

These have shit up the place for years now regardless of what the consensus on each one is. One of the reasons nobody looks at them is because there's so many, and they're usually of low quality.

At the moment only the soapstone or admins can delete them. I don't think that's been enough to keep them at a manageable amount and decent quality.

I like this feature a lot. I've just thought for years it needed this to make it worthwhile.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
tweak: Soapstone messages at or below -5 voting score won't persist. This is to reduce the amount and increase the overall quality. If this changelog wasn't here last round you may be able to save one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
