### PR TITLE
Fixes Doctor Hilbert breaking crew monitors.

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -114,10 +114,20 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 	var/list/results = list()
 	for(var/tracked_mob in GLOB.suit_sensors_list | GLOB.nanite_sensors_list)
+		if(!tracked_mob)
+			stack_trace("Null entry in suit sensors or nanite sensors list.")
+			continue
+
 		var/mob/living/carbon/human/H = tracked_mob
 
 		// Check if z-level is correct
 		var/turf/pos = get_turf(H)
+
+		// Is our target in nullspace for some reason?
+		if(!pos)
+			stack_trace("Tracked mob has no loc and is likely in nullspace: [tracked_mob] ([tracked_mob.type])")
+			continue
+
 		if (pos.z != z)
 			continue
 

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -135,18 +135,24 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		// in which case the sensors are always set to full detail
 		var/using_nanites = (tracked_living_mob in GLOB.nanite_sensors_list)
 
-		// Check for a uniform if not using nanites
-		var/mob/living/carbon/human/tracked_human = tracked_living_mob
-		if(!istype(tracked_human))
-			continue
+		if(!using_nanites)
+			var/mob/living/carbon/human/tracked_human = tracked_living_mob
 
-		var/obj/item/clothing/under/uniform = tracked_human.w_uniform
-		if (!using_nanites && !uniform)
-			continue
+			// Check their humanity.
+			if(!ishuman(tracked_human))
+				stack_trace("Non-human mob is in suit_sensors_list: [tracked_living_mob] ([tracked_living_mob.type])")
+				continue
 
-		// Check that sensors are present and active
-		if (!using_nanites && (!uniform.has_sensor || !uniform.sensor_mode))
-			continue
+			// Check they have a uniform
+			var/obj/item/clothing/under/uniform = tracked_human.w_uniform
+			if (!uniform)
+				stack_trace("Human without a uniform is in suit_sensors_list: [tracked_human] ([tracked_human.type])")
+				continue
+
+			// Check if their uniform is in a compatible mode.
+			if(!uniform.has_sensor || !uniform.sensor_mode)
+				stack_trace("Human without active suit sensors is in suit_sensors_list: [tracked_human] ([tracked_human.type])")
+				continue
 
 		// The entry for this human
 		var/list/entry = list(

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -118,14 +118,14 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			stack_trace("Null entry in suit sensors or nanite sensors list.")
 			continue
 
-		var/mob/living/carbon/human/H = tracked_mob
+		var/mob/living/tracked_living_mob = tracked_mob
 
 		// Check if z-level is correct
-		var/turf/pos = get_turf(H)
+		var/turf/pos = get_turf(tracked_living_mob)
 
 		// Is our target in nullspace for some reason?
 		if(!pos)
-			stack_trace("Tracked mob has no loc and is likely in nullspace: [tracked_mob] ([tracked_mob.type])")
+			stack_trace("Tracked mob has no loc and is likely in nullspace: [tracked_living_mob] ([tracked_living_mob.type])")
 			continue
 
 		if (pos.z != z)
@@ -133,10 +133,14 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 		// Determine if this person is using nanites for sensors,
 		// in which case the sensors are always set to full detail
-		var/using_nanites = (H in GLOB.nanite_sensors_list)
+		var/using_nanites = (tracked_living_mob in GLOB.nanite_sensors_list)
 
 		// Check for a uniform if not using nanites
-		var/obj/item/clothing/under/uniform = H.w_uniform
+		var/mob/living/carbon/human/tracked_human = tracked_living_mob
+		if(!istype(tracked_human))
+			continue
+
+		var/obj/item/clothing/under/uniform = tracked_human.w_uniform
 		if (!using_nanites && !uniform)
 			continue
 
@@ -146,13 +150,13 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 		// The entry for this human
 		var/list/entry = list(
-			"ref" = REF(H),
+			"ref" = REF(tracked_living_mob),
 			"name" = "Unknown",
 			"ijob" = UNKNOWN_JOB_ID
 		)
 
 		// ID and id-related data
-		var/obj/item/card/id/id_card = H.get_idcard(hand_first = FALSE)
+		var/obj/item/card/id/id_card = tracked_living_mob.get_idcard(hand_first = FALSE)
 		if (id_card)
 			entry["name"] = id_card.registered_name
 			entry["assignment"] = id_card.assignment
@@ -160,23 +164,23 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 		// Binary living/dead status
 		if (using_nanites || uniform.sensor_mode >= SENSOR_LIVING)
-			entry["life_status"] = !H.stat
+			entry["life_status"] = !tracked_living_mob.stat
 
 		// Damage
 		if (using_nanites || uniform.sensor_mode >= SENSOR_VITALS)
 			entry += list(
-				"oxydam" = round(H.getOxyLoss(), 1),
-				"toxdam" = round(H.getToxLoss(), 1),
-				"burndam" = round(H.getFireLoss(), 1),
-				"brutedam" = round(H.getBruteLoss(), 1)
+				"oxydam" = round(tracked_living_mob.getOxyLoss(), 1),
+				"toxdam" = round(tracked_living_mob.getToxLoss(), 1),
+				"burndam" = round(tracked_living_mob.getFireLoss(), 1),
+				"brutedam" = round(tracked_living_mob.getBruteLoss(), 1)
 			)
 
 		// Location
 		if (pos && (using_nanites || uniform.sensor_mode >= SENSOR_COORDS))
-			entry["area"] = get_area_name(H, format_text = TRUE)
+			entry["area"] = get_area_name(tracked_living_mob, format_text = TRUE)
 
 		// Trackability
-		entry["can_track"] = H.can_track()
+		entry["can_track"] = tracked_living_mob.can_track()
 
 		results[++results.len] = entry
 

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -131,13 +131,11 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		if (pos.z != z)
 			continue
 
-		// Determine if this person is using nanites for sensors,
-		// in which case the sensors are always set to full detail.
-		var/sensor_level
+		var/sensor_mode
 
 		// Set sensor level based on whether we're in the nanites list or the suit sensor list.
 		if(tracked_living_mob in GLOB.nanite_sensors_list)
-			sensor_level = SENSOR_COORDS
+			sensor_mode = SENSOR_COORDS
 		else
 			var/mob/living/carbon/human/tracked_human = tracked_living_mob
 
@@ -157,7 +155,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				stack_trace("Human without active suit sensors is in suit_sensors_list: [tracked_human] ([tracked_human.type]) ([uniform.type])")
 				continue
 
-			sensor_level = uniform.sensor_mode
+			sensor_mode = uniform.sensor_mode
 
 		// The entry for this human
 		var/list/entry = list(
@@ -174,11 +172,11 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			entry["ijob"] = jobs[id_card.assignment]
 
 		// Binary living/dead status
-		if (sensor_level >= SENSOR_LIVING)
+		if (sensor_mode >= SENSOR_LIVING)
 			entry["life_status"] = !tracked_living_mob.stat
 
 		// Damage
-		if (sensor_level >= SENSOR_VITALS)
+		if (sensor_mode >= SENSOR_VITALS)
 			entry += list(
 				"oxydam" = round(tracked_living_mob.getOxyLoss(), 1),
 				"toxdam" = round(tracked_living_mob.getToxLoss(), 1),
@@ -187,7 +185,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			)
 
 		// Location
-		if (sensor_level >= SENSOR_COORDS)
+		if (sensor_mode >= SENSOR_COORDS)
 			entry["area"] = get_area_name(tracked_living_mob, format_text = TRUE)
 
 		// Trackability

--- a/code/modules/clothing/under/jobs/rnd.dm
+++ b/code/modules/clothing/under/jobs/rnd.dm
@@ -13,6 +13,7 @@
 /obj/item/clothing/under/rank/rnd/research_director/doctor_hilbert
 	desc = "A Research Director jumpsuit belonging to the late and great Doctor Hilbert. The suit sensors have long since fizzled out from the stress of the Hilbert's Hotel."
 	has_sensor = NO_SENSORS
+	random_sensor = FALSE
 
 /obj/item/clothing/under/rank/rnd/research_director/skirt
 	name = "research director's vest suitskirt"

--- a/code/modules/clothing/under/jobs/rnd.dm
+++ b/code/modules/clothing/under/jobs/rnd.dm
@@ -10,6 +10,10 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 10, BIO = 10, RAD = 0, FIRE = 0, ACID = 35)
 	can_adjust = FALSE
 
+/obj/item/clothing/under/rank/rnd/research_director/doctor_hilbert
+	desc = "A Research Director jumpsuit belonging to the late and great Doctor Hilbert. The suit sensors have long since fizzled out from the stress of the Hilbert's Hotel."
+	has_sensor = NO_SENSORS
+
 /obj/item/clothing/under/rank/rnd/research_director/skirt
 	name = "research director's vest suitskirt"
 	desc = "It's a suitskirt worn by those with the know-how to achieve the position of \"Research Director\". Its fabric provides minor protection from biological contaminants."

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -499,7 +499,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	id_access_list = list(ACCESS_AWAY_GENERIC3, ACCESS_RESEARCH)
 	instant = TRUE
 	id = /obj/item/card/id/silver
-	uniform = /obj/item/clothing/under/rank/rnd/research_director
+	uniform = /obj/item/clothing/under/rank/rnd/research_director/doctor_hilbert
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	back = /obj/item/storage/backpack/satchel/leather
 	suit = /obj/item/clothing/suit/toggle/labcoat


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Doctor Hilbert has an RD jumpsuit. This jumpsuit is suit sensors compatible.
Doctor Hilbert spawns in a Hilbert's Hotel room that can cause him to be stored in nullspace.
When he gets stored in nullspace, crew monitor code runtimes when attempting to check his z-level, as he has no `pos`.
This breaks crew monitors for as long as Doctor Hilbert's Deathbed is an unloaded Hilbert's Hotel room.

I have given Doctor Hilbert a new, sensorless jumpsuit subtype to alleviate this.

The crew monitor datum has much more robust error handling and will now spit out stack_traces to the runtime logs while continuing to operate as normal instead of breaking all functionality. The reason for this is that while certain errors are unexpected, they are also not critical errors that should prevent the operation of the entire crew monitor.

I've also done numerous logic/code improvement tweaks to allow for additional error-state tracking and more sane logic flow.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The Crew Monitor should no longer stop functioning when Doctor Hilbert hangs out in nullspace, and should continue to work despite any similar errors in the future.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
