### PR TITLE
disabled DLC only content on arena shuttle

### DIFF
--- a/_maps/shuttles/emergency_arena.dmm
+++ b/_maps/shuttles/emergency_arena.dmm
@@ -46,6 +46,7 @@
 /area/shuttle/escape/arena)
 "p" = (
 /obj/structure/healingfountain,
+/obj/item/skeleton_key,
 /turf/open/indestructible/necropolis/air,
 /area/shuttle/escape/arena)
 "z" = (
@@ -59,6 +60,12 @@
 /turf/open/indestructible{
 	icon_state = "cult"
 	},
+/area/shuttle/escape/arena)
+"V" = (
+/obj/structure/healingfountain,
+/obj/item/skeleton_key,
+/obj/item/skeleton_key,
+/turf/open/indestructible/necropolis/air,
 /area/shuttle/escape/arena)
 
 (1,1,1) = {"
@@ -154,7 +161,7 @@ j
 m
 j
 j
-p
+V
 g
 "}
 (5,1,1) = {"
@@ -250,7 +257,7 @@ j
 j
 j
 j
-p
+V
 g
 "}
 (9,1,1) = {"

--- a/_maps/shuttles/emergency_arena.dmm
+++ b/_maps/shuttles/emergency_arena.dmm
@@ -44,11 +44,6 @@
 	},
 /turf/open/indestructible/necropolis/air,
 /area/shuttle/escape/arena)
-"p" = (
-/obj/structure/healingfountain,
-/obj/item/skeleton_key,
-/turf/open/indestructible/necropolis/air,
-/area/shuttle/escape/arena)
 "z" = (
 /obj/effect/landmark/shuttle_arena_safe,
 /turf/open/indestructible/necropolis/air,
@@ -63,8 +58,6 @@
 /area/shuttle/escape/arena)
 "V" = (
 /obj/structure/healingfountain,
-/obj/item/skeleton_key,
-/obj/item/skeleton_key,
 /turf/open/indestructible/necropolis/air,
 /area/shuttle/escape/arena)
 
@@ -137,7 +130,7 @@ j
 j
 j
 h
-p
+V
 g
 "}
 (4,1,1) = {"
@@ -185,7 +178,7 @@ j
 j
 j
 j
-p
+V
 g
 "}
 (6,1,1) = {"
@@ -233,7 +226,7 @@ j
 j
 j
 j
-p
+V
 g
 "}
 (8,1,1) = {"
@@ -281,7 +274,7 @@ j
 m
 j
 j
-p
+V
 g
 "}
 (10,1,1) = {"

--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -129,6 +129,8 @@
 		to_chat(L, "<span class='reallybig redtext'>The battle is won. Your bloodlust subsides.</span>", confidential = TRUE)
 		for(var/obj/item/chainsaw/doomslayer/chainsaw in L)
 			qdel(chainsaw)
+		var/obj/item/skeleton_key/key = new(L)
+		L.put_in_hands(key)
 	else
 		to_chat(L, "<span class='warning'>You are not yet worthy of passing. Drag a severed head to the barrier to be allowed entry to the hall of champions.</span>", confidential = TRUE)
 


### PR DESCRIPTION
🆑 
fix: arena shuttle has keys to open the crates
/:cl:
forgot about the only place that spawns tendril crates outside of tendrils, now it has keys to open the boxes
used strongdmm to edit map, not sure if it worked right