### PR TITLE
Duffelbag Curse: Sane Edition

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -235,6 +235,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_SIGN_LANG				"sign_language" //Galactic Common Sign Language
 #define TRAIT_NANITE_MONITORING	"nanite_monitoring" //The mob's nanites are sending a monitoring signal visible on diag HUD
 #define TRAIT_MARTIAL_ARTS_IMMUNE "martial_arts_immune" // nobody can use martial arts on this mob
+#define TRAIT_DUFFEL_CURSED "duffel_cursed" //You've been cursed with a living duffelbag, and can't have more added
 /// Prevents mob from riding mobs when buckled onto something
 #define TRAIT_CANT_RIDE			"cant_ride"
 #define TRAIT_BLOODY_MESS		"bloody_mess" //from heparin, makes open bleeding wounds rapidly spill more blood

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -355,7 +355,7 @@
 	desc = "A cursed clown duffel bag that hungers for food of any kind. Putting some food for it to eat inside of it should distract it from eating you for a while. A warning label on one of the duffel bag's sides cautions against feeding your \"new pet\" anything poisonous..."
 	icon_state = "duffel-curse"
 	inhand_icon_state = "duffel-curse"
-	slowdown = 1.3
+	slowdown = 2
 	max_integrity = 100
 	///counts time passed since it ate food
 	var/hunger = 0
@@ -363,7 +363,16 @@
 /obj/item/storage/backpack/duffelbag/cursed/Initialize()
 	. = ..()
 	START_PROCESSING(SSobj,src)
-	ADD_TRAIT(src, TRAIT_NODROP, "duffelbag")
+	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
+
+/obj/item/storage/backpack/duffelbag/cursed/equipped(mob/living/carbon/human/user, slot)
+	. = ..()
+	ADD_TRAIT(user, TRAIT_DUFFEL_CURSED, CURSED_ITEM_TRAIT)
+
+/obj/item/storage/backpack/duffelbag/cursed/dropped(mob/living/carbon/human/user)
+	REMOVE_TRAIT(user, TRAIT_DUFFEL_CURSED, CURSED_ITEM_TRAIT)
+	qdel(src)
+	return ..()
 
 /obj/item/storage/backpack/duffelbag/cursed/process()
 	///don't process if it's somehow on the floor
@@ -378,7 +387,6 @@
 		var/turf/T = get_turf(user)
 		playsound(T, 'sound/effects/splat.ogg', 50, TRUE)
 		new /obj/effect/decal/cleanable/vomit(T)
-		qdel(src)
 	hunger++
 	///check hunger
 	if((hunger > 50) && prob(20))
@@ -390,7 +398,7 @@
 				///poisoned food damages it
 				if(F.reagents.has_reagent(/datum/reagent/toxin))
 					to_chat(user, "<span class='warning'>The [name] grumbles!</span>")
-					obj_integrity -= 20
+					obj_integrity -= 50
 				else
 					to_chat(user, "<span class='notice'>The [name] eats your [F]!</span>")
 				qdel(F)
@@ -398,11 +406,11 @@
 				return
 		///no food found: it bites you and loses some hp
 		var/affecting = user.get_bodypart(BODY_ZONE_CHEST)
-		user.apply_damage(40, BRUTE, affecting)
-		hunger = 5
+		user.apply_damage(60, BRUTE, affecting)
+		hunger = initial(hunger)
 		playsound(src, 'sound/items/eatfood.ogg', 20, TRUE)
 		to_chat(user, "<span class='warning'>The [name] eats your back!</span>")
-		obj_integrity -= 15
+		obj_integrity -= 20
 
 /obj/item/storage/backpack/duffelbag/cursed/Destroy()
 	. = ..()

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -356,22 +356,21 @@
 	icon_state = "duffel-curse"
 	inhand_icon_state = "duffel-curse"
 	slowdown = 2
+	item_flags = DROPDEL
 	max_integrity = 100
 	///counts time passed since it ate food
 	var/hunger = 0
 
-/obj/item/storage/backpack/duffelbag/cursed/Initialize()
+/obj/item/storage/backpack/duffelbag/cursed/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	START_PROCESSING(SSobj,src)
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
-
-/obj/item/storage/backpack/duffelbag/cursed/equipped(mob/living/carbon/human/user, slot)
-	. = ..()
 	ADD_TRAIT(user, TRAIT_DUFFEL_CURSED, CURSED_ITEM_TRAIT)
 
 /obj/item/storage/backpack/duffelbag/cursed/dropped(mob/living/carbon/human/user)
 	REMOVE_TRAIT(user, TRAIT_DUFFEL_CURSED, CURSED_ITEM_TRAIT)
-	qdel(src)
+	
+	STOP_PROCESSING(SSobj,src)
 	return ..()
 
 /obj/item/storage/backpack/duffelbag/cursed/process()
@@ -410,11 +409,7 @@
 		hunger = initial(hunger)
 		playsound(src, 'sound/items/eatfood.ogg', 20, TRUE)
 		to_chat(user, "<span class='warning'>The [name] eats your back!</span>")
-		obj_integrity -= 20
-
-/obj/item/storage/backpack/duffelbag/cursed/Destroy()
-	. = ..()
-	STOP_PROCESSING(SSobj,src)
+		obj_integrity -= 25
 
 /obj/item/storage/backpack/duffelbag/captain
 	name = "captain's duffel bag"

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -473,7 +473,7 @@
 	desc = "A curse that firmly attaches a demonic duffel bag to the target's back. The duffel bag will make the person it's attached to take periodical damage if it is not fed regularly, and regardless of whether or not it's been fed, it will slow the person wearing it down significantly."
 	spell_type = /obj/effect/proc_holder/spell/pointed/duffelbagcurse
 	category = "Assistance"
-	cost = 1
+	cost = 2
 
 /datum/spellbook_entry/summon
 	name = "Summon Stuff"

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -473,7 +473,7 @@
 	desc = "A curse that firmly attaches a demonic duffel bag to the target's back. The duffel bag will make the person it's attached to take periodical damage if it is not fed regularly, and regardless of whether or not it's been fed, it will slow the person wearing it down significantly."
 	spell_type = /obj/effect/proc_holder/spell/pointed/duffelbagcurse
 	category = "Assistance"
-	cost = 2
+	cost = 1
 
 /datum/spellbook_entry/summon
 	name = "Summon Stuff"

--- a/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
+++ b/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
@@ -3,7 +3,7 @@
 	desc = "A spell that summons a duffel bag demon on the target, slowing them down and slowly eating them."
 	school = "transmutation"
 	charge_type = "recharge"
-	charge_max	= 200
+	charge_max	= 300
 	charge_counter = 0
 	clothes_req = FALSE
 	stat_allowed = FALSE

--- a/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
+++ b/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
@@ -8,7 +8,7 @@
 	clothes_req = FALSE
 	stat_allowed = FALSE
 	invocation = "BA'R A'RP!"
-	invocation_type = INVOCATION_SHOUT
+	invocation_type = INVOCATION_WHISPER
 	range = 7
 	cooldown_min = 50
 	ranged_mousepointer = 'icons/effects/mouse_pointers/mecha_mouse.dmi'

--- a/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
+++ b/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
@@ -3,7 +3,7 @@
 	desc = "A spell that summons a duffel bag demon on the target, slowing them down and slowly eating them."
 	school = "transmutation"
 	charge_type = "recharge"
-	charge_max	= 150
+	charge_max	= 200
 	charge_counter = 0
 	clothes_req = FALSE
 	stat_allowed = FALSE
@@ -24,8 +24,12 @@
 		return FALSE
 	if(!can_target(targets[1], user))
 		return FALSE
-
+	
 	var/mob/living/carbon/target = targets[1]
+	if(HAS_TRAIT(target, TRAIT_DUFFEL_CURSED))
+		to_chat(user, "<span class='warning'>That person is already cursed!</span>")
+		return FALSE
+
 	if(target.anti_magic_check())
 		to_chat(user, "<span class='warning'>The spell had no effect!</span>")
 		target.visible_message("<span class='danger'>[target] was unaffected by the curse!</span>", \
@@ -45,6 +49,7 @@
 			if(!target.put_in_hands(C))
 				target.dropItemToGround(target.get_active_held_item())
 				target.put_in_hands(C)
+
 /obj/effect/proc_holder/spell/pointed/duffelbagcurse/can_target(atom/target, mob/user, silent)
 	. = ..()
 	if(!.)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

~~The duffelbag curse is more expensive for a fairly potent effect of a permanent slow until the bag is removed, which is significantly more useful and powerful than similar spells.~~ It's back to being a 1 cost spell.

You also cannot force more than a single duffelbag on people until the previous one is removed. This stops the spell from rendering you incapable of removing the bag under your own efforts or before the bag bites three times in a row from having a duffelbag on your back and in your hands.

The bag takes a full 50 integrity damage from poison instead of the pathetically tiny amount before.

More importantly, the duffelbag curse also has a higher cooldown overall, at 30 seconds, the same as the Blind spell. Since it's a pointed spell, you can fairly reliably drop the spell on people in view. (The spell is also robeless by the way)

The duffelbag however will do quite a bit more damage to you if it does bite into you, and slows you even harder than before.

Since it is robeless, I figured I'd also make it whisper. Because it'd be funny to see a disguised wizard giving people duffelbags.

## Why It's Good For The Game

![hmmm](https://user-images.githubusercontent.com/40847847/105607456-f4796f80-5df2-11eb-85e9-8c8b7e9e9033.png)

This was really funny but holy shit is it massively degenerate. Since wizards get effectively xray out of scrying orb, and duffelcurse is really, really cheap and a pointed spell (meaning you can do it through terrain and thus in maint), he was able to do this combination without running out of points for jaunt to prevent anyone from being able to touch him without also giving them the dreaded duffels.

Also, 5 second cooldown at max power, which he had done without much expense given it only costs 1 point per upgrade, so the moment you're in vision he's probably filled your hands with duffels. Point and click powers are literally that.

These duffels all gain hunger individually, so they will invariably reach bite hunger range before anything like acid will remove them, and you YOURSELF cannot use any equipment to splash acid on you, so usually in a situation like this, where the wizard has likely given everyone ELSE duffelbags, it's a death spiral you can't do much about.

This is the definition of noninteractive bullshit that wizard is infamous for already. And the duffelbag only pushes that further by also being extremely effective for what it does. It doesn't just kill you, it renders the station largely incapable of fixing the thing the wizard is doing to you because [the wizard is slapping everyone with duffelbags.](https://www.youtube.com/watch?v=hHZvUeAdzeI)

## Changelog
:cl:
balance: Sanity checks the duffelbag curse by making it restricted to a single bag per person, but dealing with the bag is a little easier too.
balance: The bag will murder the crap out of you if you don't remove it however. It also slows you to a crawl.
balance: The bag is easier to destroy with poison and loses more integrity if it bites you. (if that matters at all)
balance: The invocation for the duffelbag curse is whispered.
tweak: The spell is equal to the Blind spell for cooldown and cost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
