### PR TITLE
duffelbagcurse has min cooldown of 8s from 5s and cant be xrayd

### DIFF
--- a/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
+++ b/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
@@ -50,7 +50,8 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(!isInSight(target, user))
+	var/turf/T = get_turf(user)
+	if(!LAZYFIND(dview(8, T),target))
 		return FALSE
 	if(!is_type_in_typecache(target, compatible_mobs_typecache))
 		if(!silent)

--- a/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
+++ b/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
@@ -51,7 +51,8 @@
 	if(!.)
 		return FALSE
 	var/turf/turfie = get_turf(user)
-	if(!LAZYFIND(dview(8, turfie),target))
+	var/list/targets =dview(8, turfie)
+	if(!targets.Find(target))
 		return FALSE
 	if(!is_type_in_typecache(target, compatible_mobs_typecache))
 		if(!silent)

--- a/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
+++ b/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
@@ -9,8 +9,8 @@
 	stat_allowed = FALSE
 	invocation = "BA'R A'RP!"
 	invocation_type = INVOCATION_SHOUT
-	range = 7
-	cooldown_min = 50
+	range = 4
+	cooldown_min = 80
 	ranged_mousepointer = 'icons/effects/mouse_pointers/mecha_mouse.dmi'
 	action_icon_state = "duffelbag_curse"
 	active_msg = "You prepare to curse a target..."

--- a/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
+++ b/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
@@ -50,8 +50,8 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	var/turf/T = get_turf(user)
-	if(!LAZYFIND(dview(8, T),target))
+	var/turf/turf = get_turf(user)
+	if(!LAZYFIND(dview(8, turf),target))
 		return FALSE
 	if(!is_type_in_typecache(target, compatible_mobs_typecache))
 		if(!silent)

--- a/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
+++ b/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
@@ -50,8 +50,8 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	var/turf/turf = get_turf(user)
-	if(!LAZYFIND(dview(8, turf),target))
+	var/turf/turfie = get_turf(user)
+	if(!LAZYFIND(dview(8, turfie),target))
 		return FALSE
 	if(!is_type_in_typecache(target, compatible_mobs_typecache))
 		if(!silent)

--- a/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
+++ b/code/modules/spells/spell_types/pointed/duffelbag_curse.dm
@@ -9,7 +9,7 @@
 	stat_allowed = FALSE
 	invocation = "BA'R A'RP!"
 	invocation_type = INVOCATION_SHOUT
-	range = 4
+	range = 7
 	cooldown_min = 80
 	ranged_mousepointer = 'icons/effects/mouse_pointers/mecha_mouse.dmi'
 	action_icon_state = "duffelbag_curse"
@@ -45,9 +45,12 @@
 			if(!target.put_in_hands(C))
 				target.dropItemToGround(target.get_active_held_item())
 				target.put_in_hands(C)
+
 /obj/effect/proc_holder/spell/pointed/duffelbagcurse/can_target(atom/target, mob/user, silent)
 	. = ..()
 	if(!.)
+		return FALSE
+	if(!isInSight(target, user))
 		return FALSE
 	if(!is_type_in_typecache(target, compatible_mobs_typecache))
 		if(!silent)


### PR DESCRIPTION
:cl:
tweak: duffelbagcurse cant be casted through walls  and min cooldown of 8s from 5s
/:cl:

prevents the wiz from hiding in maint and click away with scrying orb and forces him to be closer to the victim
