### PR TITLE
Fixes minor logging issue with hydroponics trays

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -510,8 +510,8 @@
  */
 /obj/machinery/hydroponics/proc/mutatepest(mob/user)
 	if(pestlevel > 5)
-		message_admins("[ADMIN_LOOKUPFLW(user)] last altered a hydro tray's contents which spawned spiderlings")
-		log_game("[key_name(user)] last altered a hydro tray, which spiderlings spawned from.")
+		message_admins("[ADMIN_LOOKUPFLW(lastuser)] last altered a hydro tray's contents which spawned spiderlings")
+		log_game("[key_name(lastuser)] last altered a hydro tray, which spiderlings spawned from.")
 		visible_message("<span class='warning'>The pests seem to behave oddly...</span>")
 		spawn_atom_to_turf(/obj/structure/spider/spiderling/hunter, src, 3, FALSE)
 	else if(myseed)
@@ -567,9 +567,9 @@
 				H.adjustWater(round(water_amt))
 				reagent_source.reagents.remove_reagent(/datum/reagent/water, water_amt)
 			reagent_source.reagents.trans_to(H.reagents, transfer_amount, transfered_by = user)
+			lastuser = user
 			if(IS_EDIBLE(reagent_source) || istype(reagent_source, /obj/item/reagent_containers/pill))
 				qdel(reagent_source)
-				lastuser = user
 				H.update_icon()
 				return 1
 			H.update_icon()

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -49,7 +49,7 @@
 	///Have we been visited by a bee recently, so bees dont overpollinate one plant
 	var/recent_bee_visit = FALSE
 	///The last user to add a reagent to the tray, mostly for logging purposes.
-	var/mob/lastuser
+	var/datum/weakref/lastuser
 	///If the tray generates nutrients and water on its own
 	var/self_sustaining = FALSE
 
@@ -153,7 +153,7 @@
 
 //Nutrients//////////////////////////////////////////////////////////////
 			// Nutrients deplete at a constant rate, since new nutrients can boost stats far easier.
-			apply_chemicals(lastuser)
+			apply_chemicals(lastuser?.resolve())
 			if(self_sustaining)
 				reagents.remove_any(min(0.5, nutridrain))
 			else
@@ -510,8 +510,8 @@
  */
 /obj/machinery/hydroponics/proc/mutatepest(mob/user)
 	if(pestlevel > 5)
-		message_admins("[ADMIN_LOOKUPFLW(lastuser)] last altered a hydro tray's contents which spawned spiderlings")
-		log_game("[key_name(lastuser)] last altered a hydro tray, which spiderlings spawned from.")
+		message_admins("[ADMIN_LOOKUPFLW(lastuser?.resolve())] last altered a hydro tray's contents which spawned spiderlings")
+		log_game("[key_name(lastuser?.resolve())] last altered a hydro tray, which spiderlings spawned from.")
 		visible_message("<span class='warning'>The pests seem to behave oddly...</span>")
 		spawn_atom_to_turf(/obj/structure/spider/spiderling/hunter, src, 3, FALSE)
 	else if(myseed)
@@ -567,7 +567,7 @@
 				H.adjustWater(round(water_amt))
 				reagent_source.reagents.remove_reagent(/datum/reagent/water, water_amt)
 			reagent_source.reagents.trans_to(H.reagents, transfer_amount, transfered_by = user)
-			lastuser = user
+			lastuser = WEAKREF(user)
 			if(IS_EDIBLE(reagent_source) || istype(reagent_source, /obj/item/reagent_containers/pill))
 				qdel(reagent_source)
 				H.update_icon()

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -510,8 +510,8 @@
  */
 /obj/machinery/hydroponics/proc/mutatepest(mob/user)
 	if(pestlevel > 5)
-		message_admins("[ADMIN_LOOKUPFLW(lastuser?.resolve())] last altered a hydro tray's contents which spawned spiderlings")
-		log_game("[key_name(lastuser?.resolve())] last altered a hydro tray, which spiderlings spawned from.")
+		message_admins("[ADMIN_LOOKUPFLW(user)] last altered a hydro tray's contents which spawned spiderlings")
+		log_game("[key_name(user)] last altered a hydro tray, which spiderlings spawned from.")
 		visible_message("<span class='warning'>The pests seem to behave oddly...</span>")
 		spawn_atom_to_turf(/obj/structure/spider/spiderling/hunter, src, 3, FALSE)
 	else if(myseed)


### PR DESCRIPTION
## About The Pull Request

Hydroponics trays have a var, `lastuser`, that it's supposed to use in logging as the last person who modified a tray's reagents
this variable was only set if you transferred reagents to the tray via composting, so it was null 99% of the time.

The var is now set when any reagents are transferred and the logging for spawning spiders now uses this var.

The var is now a weakref, to prevent hydroponics trays from harddels.

## Why It's Good For The Game

"`null` last modified a tray's contents that spawned spiderlings." Not very helpful to admins, is it.

## Changelog
:cl: Melbert
fix: Fixes a logging issue with hydroponics trays spawning spiderlings
/:cl:
