### PR TITLE
Fix #56371 - Some machines do not deconstruct into frames

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -512,7 +512,7 @@
 	if(isturf(loc))
 		var/turf/machine_turf = loc
 		// We're spawning a frame before this machine is qdeleted, so we want to ignore it. We've also just spawned a new frame, so ignore that too.
-		if(machine_turf.is_blocked_turf(TRUE, source_atom = src, ignore_atoms = list(new_frame)))
+		if(machine_turf.is_blocked_turf(TRUE, source_atom = new_frame, ignore_atoms = list(src)))
 			new_frame.deconstruct(disassembled)
 			return
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -511,7 +511,8 @@
 	// If the new frame shouldn't be able to fit here due to the turf being blocked, spawn the frame deconstructed.
 	if(isturf(loc))
 		var/turf/machine_turf = loc
-		if(machine_turf.is_blocked_turf(TRUE, source_atom = new_frame))
+		// We're spawning a frame before this machine is qdeleted, so we want to ignore it. We've also just spawned a new frame, so ignore that too.
+		if(machine_turf.is_blocked_turf(TRUE, source_atom = src, ignore_atoms = list(new_frame)))
 			new_frame.deconstruct(disassembled)
 			return
 
@@ -594,7 +595,7 @@
 		var/prev_anchored = anchored
 		//as long as we're the same anchored state and we're either on a floor or are anchored, toggle our anchored state
 		if(I.use_tool(src, user, time, extra_checks = CALLBACK(src, .proc/unfasten_wrench_check, prev_anchored, user)))
-			if(!anchored && ground.is_blocked_turf(exclude_mobs = TRUE, source_atom = src))//i know what you tryin to sneak in
+			if(!anchored && ground.is_blocked_turf(exclude_mobs = TRUE, source_atom = src))
 				to_chat(user, "<span class='notice'>You fail to secure [src].</span>")
 				return CANT_UNFASTEN
 			to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [src].</span>")

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -167,24 +167,31 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	SEND_SIGNAL(src, COMSIG_TURF_MULTIZ_NEW, T, dir)
 
 /**
- * Check whether the specified turf is blocked by something dense inside it.
+ * Check whether the specified turf is blocked by something dense inside it with respect to a specific atom.
  *
- * Returns TRUE if the turf is blocked, FALSE otherwise.
+ * Returns truthy value TURF_BLOCKED_TURF_DENSE if the turf is blocked because the turf itself is dense.
+ * Returns truthy value TURF_BLOCKED_CONTENT_DENSE if one of the turf's contents is dense and would block
+ * a source atom's movement.
+ * Returns falsey value TURF_NOT_BLOCKED if the turf is not blocked.
  *
  * Arguments:
  * * exclude_mobs - If TRUE, ignores dense mobs on the turf.
- * * source_atom - If you're checking if the turf an atom is on is blocked, this will let you exclude the atom from this check so it doesn't block itself with its own density.
+ * * source_atom - If this is not null, will check whether any contents on the turf can block this atom specifically. Also ignores itself on the turf.
+ * * ignore_atoms - Check will ignore any atoms in this list. Useful to prevent an atom from blocking itself on the turf.
  */
-/turf/proc/is_blocked_turf(exclude_mobs, source_atom)
+/turf/proc/is_blocked_turf(exclude_mobs = FALSE, source_atom = null, list/ignore_atoms)
 	if(density)
 		return TRUE
-	for(var/i in contents)
-		var/atom/movable/thing = i
-		if(thing == source_atom)
+
+	for(var/content in contents)
+		// We don't want to block ourselves or consider any ignored atoms.
+		if((content == source_atom) || (content in ignore_atoms))
 			continue
+
+		var/atom/atom_content = content
 		// If the thing is dense AND we're including mobs or the thing isn't a mob AND if there's a source atom and
 		// it cannot pass through the thing on the turf, we consider the turf blocked.
-		if(thing.density && (!exclude_mobs || !ismob(thing)) && (source_atom && !thing.CanPass(source_atom, src)))
+		if(atom_content.density && (!exclude_mobs || !ismob(atom_content)) && (source_atom && !atom_content.CanPass(source_atom, src)))
 			return TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #56371

When fixing another stacked machine frame exploit, I included a check on the turf when deconstructing machines - If the turf wasn't blocked, it would pop out a machine frame nice and happy-like. If it was, it'd deconstruct the frame as well leaving behind the metal and wires ontop of everything else.

The exploit was stacking non-dense machines like rechargers and deconstructing them to stack frames. I tested the fix on non-dense machines, but didn't check dense machines. Dense machines block their own frames from spawning because the frame is spawned before the machine itself is deleted.

I considered two options - The first was just making the machine non-dense before it tries to spawn a frame, as it's just being deconstructed anyway and will end up deleted. While incredibly simple, it felt like an uber code-hack.

So I went back and just buffed up the `is_blocked_turf` proc to accept an optional list of ignore atoms alongside the optional source atom. This lets the proc either check if the turf is blocked in general or check if the turf is blocked to a specific atom, while considering there are some atoms we just don't care about on the turf that could be safely ignored.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Dense machines now deconstruct into frames?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Dense machines once again deconstuct into frames instead of all their raw component parts. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
