### PR TITLE
Anon names post-roundstart now correctly changes IDs as well

### DIFF
--- a/code/modules/admin/verbs/anonymousnames.dm
+++ b/code/modules/admin/verbs/anonymousnames.dm
@@ -59,8 +59,9 @@
 		if(issilicon(player))
 			player.fully_replace_character_name(player.real_name, theme.anonymous_ai_name(isAI(player)))
 		else
+			var/original_name = player.real_name //id will not be changed if you do not do this
 			randomize_human(player) //do this first so the special name can be given
-			player.fully_replace_character_name(player.real_name, theme.anonymous_name(player))
+			player.fully_replace_character_name(original_name, theme.anonymous_name(player))
 
 /* Datum singleton initialized by the client proc to hold the naming generation */
 /datum/anonymous_theme


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/40974010/105641934-768d8680-5e3b-11eb-8bd3-d6c5108272e5.png)

## Why It's Good For The Game

Anon names really loses meaning when everyone's ID shows their old name

## Changelog
:cl:
fix: Anon names post-roundstart now correctly changes IDs as well
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
