### PR TITLE
Makes borg organ bags into an apparatus

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -958,15 +958,19 @@
 
 /obj/item/borg/apparatus/organ_storage/update_overlays()
 	. = ..()
-	var/mutable_appearance/bag = mutable_appearance(icon, icon_state = "evidence")
+	icon_state = null // hides the original icon (otherwise it's drawn underneath)
+	var/mutable_appearance/bag
 	if(stored)
 		COMPILE_OVERLAYS(stored)
-		stored.pixel_x = 0
-		stored.pixel_y = 0
-		var/mutable_appearance/stored_copy = new /mutable_appearance(stored)
-		stored_copy.layer = FLOAT_LAYER
-		stored_copy.plane = FLOAT_PLANE
-		. += stored_copy
+		var/mutable_appearance/stored_organ = new /mutable_appearance(stored)
+		stored_organ.layer = FLOAT_LAYER
+		stored_organ.plane = FLOAT_PLANE
+		stored_organ.pixel_x = 0
+		stored_organ.pixel_y = 0
+		. += stored_organ
+		bag = mutable_appearance(icon, icon_state = "evidence") // full bag
+	else
+		bag = mutable_appearance(icon, icon_state = "evidenceobj") // empty bag
 	. += bag
 
 /obj/item/borg/apparatus/organ_storage/attack_self(mob/user)
@@ -975,7 +979,6 @@
 		user.visible_message("<span class='notice'>[user] dumps [organ] from [src].</span>", "<span class='notice'>You dump [organ] from [src].</span>")
 		cut_overlays()
 		organ.forceMove(get_turf(src))
-		icon_state = "evidenceobj"
 	else
 		to_chat(user, "<span class='notice'>[src] is empty.</span>")
 	return

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -925,7 +925,7 @@
 	name = "beverage storage apparatus"
 	desc = "A special apparatus for carrying drinks without spilling the contents. Alt-Z or right-click to drop the beaker."
 	icon_state = "borg_beaker_apparatus"
-	storable = list(/obj/item/reagent_containers/food/drinks/,
+	storable = list(/obj/item/reagent_containers/food/drinks,
 					/obj/item/reagent_containers/food/condiment)
 
 /obj/item/borg/apparatus/beaker/service/Initialize()

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -794,7 +794,7 @@
 
 /obj/item/borg/apparatus/Initialize()
 	. = ..()
-	RegisterSignal(loc.loc, COMSIG_BORG_SAFE_DECONSTRUCT, .proc/safe_decon)
+	RegisterSignal(loc.loc, COMSIG_BORG_SAFE_DECONSTRUCT, .proc/safedecon)
 
 /obj/item/borg/apparatus/Destroy()
 	if(stored)
@@ -802,7 +802,7 @@
 	. = ..()
 
 ///If we're safely deconstructed, we put the item neatly onto the ground, rather than deleting it.
-/obj/item/borg/apparatus/proc/safe_decon()
+/obj/item/borg/apparatus/proc/safedecon()
 	if(stored)
 		stored.forceMove(get_turf(src))
 		stored = null

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -947,41 +947,35 @@
 	storable = list(/obj/item/organ,
 					/obj/item/bodypart)
 
-/obj/item/borg/apparatus/organ_storage/afterattack(obj/item/I, mob/user, proximity)
+/obj/item/borg/apparatus/organ_storage/examine()
 	. = ..()
-	if(!proximity)
-		return
-	if(contents.len)
-		to_chat(user, "<span class='warning'>[src] already has something inside it!</span>")
-		return
-	if(!isorgan(I) && !isbodypart(I))
-		to_chat(user, "<span class='warning'>[src] can only hold body parts!</span>")
-		return
+	. += "The organ bag currently contains:"
+	if(stored)
+		var/obj/item/organ = stored
+		. += organ.name
+	else
+		. += "Nothing."
 
-	user.visible_message("<span class='notice'>[user] puts [I] into [src].</span>", "<span class='notice'>You put [I] inside [src].</span>")
-	icon_state = "evidence"
-	var/xx = I.pixel_x
-	var/yy = I.pixel_y
-	I.pixel_x = 0
-	I.pixel_y = 0
-	var/image/img = image("icon"=I, "layer"=FLOAT_LAYER)
-	img.plane = FLOAT_PLANE
-	I.pixel_x = xx
-	I.pixel_y = yy
-	add_overlay(img)
-	add_overlay("evidence")
-	desc = "An organ storage container holding [I]."
-	I.forceMove(src)
-	w_class = I.w_class
+/obj/item/borg/apparatus/organ_storage/update_overlays()
+	. = ..()
+	var/mutable_appearance/bag = mutable_appearance(icon, icon_state = "evidence")
+	if(stored)
+		COMPILE_OVERLAYS(stored)
+		stored.pixel_x = 0
+		stored.pixel_y = 0
+		var/mutable_appearance/stored_copy = new /mutable_appearance(stored)
+		stored_copy.layer = FLOAT_LAYER
+		stored_copy.plane = FLOAT_PLANE
+		. += stored_copy
+	. += bag
 
 /obj/item/borg/apparatus/organ_storage/attack_self(mob/user)
-	if(contents.len)
-		var/obj/item/I = contents[1]
-		user.visible_message("<span class='notice'>[user] dumps [I] from [src].</span>", "<span class='notice'>You dump [I] from [src].</span>")
+	if(stored)
+		var/obj/item/organ = stored
+		user.visible_message("<span class='notice'>[user] dumps [organ] from [src].</span>", "<span class='notice'>You dump [organ] from [src].</span>")
 		cut_overlays()
-		I.forceMove(get_turf(src))
+		organ.forceMove(get_turf(src))
 		icon_state = "evidenceobj"
-		desc = "A container for holding body parts."
 	else
 		to_chat(user, "<span class='notice'>[src] is empty.</span>")
 	return

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -110,7 +110,7 @@
 /obj/item/organ/brain/attackby(obj/item/O, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)
 
-	if(istype(O, /obj/item/organ_storage))
+	if(istype(O, /obj/item/borg/apparatus/organ_storage))
 		return //Borg organ bags shouldn't be killing brains
 
 	if((organ_flags & ORGAN_FAILING) && O.is_drainable() && O.reagents.has_reagent(/datum/reagent/medicine/mannitol)) //attempt to heal the brain

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -197,7 +197,6 @@
 		return FALSE
 	return TRUE
 
-
 // ------------------------------------------ Setting base model modules
 // --------------------- Clown
 /obj/item/robot_model/clown
@@ -333,7 +332,7 @@
 		/obj/item/borg/cyborghug/medical,
 		/obj/item/stack/medical/gauze,
 		/obj/item/stack/medical/bone_gel,
-		/obj/item/organ_storage,
+		/obj/item/borg/apparatus/organ_storage,
 		/obj/item/borg/lollipop)
 	radio_channels = list(RADIO_CHANNEL_MEDICAL)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/hacked)
@@ -436,7 +435,7 @@
 
 /obj/item/robot_model/security/do_transform_animation()
 	..()
-	to_chat(loc, "<span class='userdanger'>While you have picked the security configuration, you still have to follow your laws, NOT Space Law. \
+	to_chat(loc, "<span class='userdanger'>While you have picked the security model, you still have to follow your laws, NOT Space Law. \
 	For Asimov, this means you must follow criminals' orders unless there is a law 1 reason not to.</span>")
 
 /obj/item/robot_model/security/respawn_consumable(mob/living/silicon/robot/R, coeff = 1)
@@ -564,7 +563,7 @@
 		/obj/item/pinpointer/syndicate_cyborg,
 		/obj/item/stack/medical/gauze,
 		/obj/item/gun/medbeam,
-		/obj/item/organ_storage)
+		/obj/item/borg/apparatus/organ_storage)
 
 	cyborg_base_icon = "synd_medical"
 	model_select_icon = "malf"

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -6,7 +6,7 @@
 
 /datum/surgery_step/replace_limb
 	name = "replace limb"
-	implements = list(/obj/item/bodypart = 100, /obj/item/organ_storage = 100)
+	implements = list(/obj/item/bodypart = 100, /obj/item/borg/apparatus/organ_storage = 100)
 	time = 32
 	var/obj/item/bodypart/L = null // L because "limb"
 
@@ -15,7 +15,7 @@
 	if(NOAUGMENTS in target.dna.species.species_traits)
 		to_chat(user, "<span class='warning'>[target] cannot be augmented!</span>")
 		return -1
-	if(istype(tool, /obj/item/organ_storage) && istype(tool.contents[1], /obj/item/bodypart))
+	if(istype(tool, /obj/item/borg/apparatus/organ_storage) && istype(tool.contents[1], /obj/item/bodypart))
 		tool = tool.contents[1]
 	var/obj/item/bodypart/aug = tool
 	if(aug.status != BODYPART_ROBOTIC)
@@ -46,7 +46,7 @@
 
 /datum/surgery_step/replace_limb/success(mob/user, mob/living/carbon/target, target_zone, obj/item/bodypart/tool, datum/surgery/surgery, default_display_results = FALSE)
 	if(L)
-		if(istype(tool, /obj/item/organ_storage))
+		if(istype(tool, /obj/item/borg/apparatus/organ_storage))
 			tool.icon_state = initial(tool.icon_state)
 			tool.desc = initial(tool.desc)
 			tool.cut_overlays()

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -68,7 +68,7 @@
 	time = 64
 	name = "manipulate organs"
 	repeatable = TRUE
-	implements = list(/obj/item/organ = 100, /obj/item/organ_storage = 100)
+	implements = list(/obj/item/organ = 100, /obj/item/borg/apparatus/organ_storage = 100)
 	var/implements_extract = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 55, /obj/item/kitchen/fork = 35)
 	var/current_type
 	var/obj/item/organ/I = null
@@ -79,7 +79,7 @@
 
 /datum/surgery_step/manipulate_organs/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	I = null
-	if(istype(tool, /obj/item/organ_storage))
+	if(istype(tool, /obj/item/borg/apparatus/organ_storage))
 		if(!tool.contents.len)
 			to_chat(user, "<span class='warning'>There is nothing inside [tool]!</span>")
 			return -1
@@ -131,7 +131,7 @@
 
 /datum/surgery_step/manipulate_organs/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results)
 	if(current_type == "insert")
-		if(istype(tool, /obj/item/organ_storage))
+		if(istype(tool, /obj/item/borg/apparatus/organ_storage))
 			I = tool.contents[1]
 			tool.icon_state = initial(tool.icon_state)
 			tool.desc = initial(tool.desc)

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -18,12 +18,12 @@
 
 /datum/surgery_step/add_prosthetic
 	name = "add prosthetic"
-	implements = list(/obj/item/bodypart = 100, /obj/item/organ_storage = 100, /obj/item/chainsaw = 100, /obj/item/melee/synthetic_arm_blade = 100)
+	implements = list(/obj/item/bodypart = 100, /obj/item/borg/apparatus/organ_storage = 100, /obj/item/chainsaw = 100, /obj/item/melee/synthetic_arm_blade = 100)
 	time = 32
 	var/organ_rejection_dam = 0
 
 /datum/surgery_step/add_prosthetic/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(istype(tool, /obj/item/organ_storage))
+	if(istype(tool, /obj/item/borg/apparatus/organ_storage))
 		if(!tool.contents.len)
 			to_chat(user, "<span class='warning'>There is nothing inside [tool]!</span>")
 			return -1
@@ -65,7 +65,7 @@
 
 /datum/surgery_step/add_prosthetic/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	. = ..()
-	if(istype(tool, /obj/item/organ_storage))
+	if(istype(tool, /obj/item/borg/apparatus/organ_storage))
 		tool.icon_state = initial(tool.icon_state)
 		tool.desc = initial(tool.desc)
 		tool.cut_overlays()

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -192,7 +192,7 @@
 
 /obj/item/circular_saw/augment
 	desc = "A small but very fast spinning saw. It rips and tears until it is done."
-	w_class = WEIGHT_CLASS_SMALL	
+	w_class = WEIGHT_CLASS_SMALL
 	toolspeed = 0.5
 
 
@@ -212,52 +212,6 @@
 	. = ..()
 	AddComponent(/datum/component/surgery_initiator, null)
 
-
-/obj/item/organ_storage //allows medical cyborgs to manipulate organs without hands
-	name = "organ storage bag"
-	desc = "A container for holding body parts."
-	icon = 'icons/obj/storage.dmi'
-	icon_state = "evidenceobj"
-	item_flags = SURGICAL_TOOL
-
-/obj/item/organ_storage/afterattack(obj/item/I, mob/user, proximity)
-	. = ..()
-	if(!proximity)
-		return
-	if(contents.len)
-		to_chat(user, "<span class='warning'>[src] already has something inside it!</span>")
-		return
-	if(!isorgan(I) && !isbodypart(I))
-		to_chat(user, "<span class='warning'>[src] can only hold body parts!</span>")
-		return
-
-	user.visible_message("<span class='notice'>[user] puts [I] into [src].</span>", "<span class='notice'>You put [I] inside [src].</span>")
-	icon_state = "evidence"
-	var/xx = I.pixel_x
-	var/yy = I.pixel_y
-	I.pixel_x = 0
-	I.pixel_y = 0
-	var/image/img = image("icon"=I, "layer"=FLOAT_LAYER)
-	img.plane = FLOAT_PLANE
-	I.pixel_x = xx
-	I.pixel_y = yy
-	add_overlay(img)
-	add_overlay("evidence")
-	desc = "An organ storage container holding [I]."
-	I.forceMove(src)
-	w_class = I.w_class
-
-/obj/item/organ_storage/attack_self(mob/user)
-	if(contents.len)
-		var/obj/item/I = contents[1]
-		user.visible_message("<span class='notice'>[user] dumps [I] from [src].</span>", "<span class='notice'>You dump [I] from [src].</span>")
-		cut_overlays()
-		I.forceMove(get_turf(src))
-		icon_state = "evidenceobj"
-		desc = "A container for holding body parts."
-	else
-		to_chat(user, "<span class='notice'>[src] is empty.</span>")
-	return
 
 /obj/item/surgical_processor //allows medical cyborgs to scan and initiate advanced surgeries
 	name = "\improper Surgical Processor"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Despite behaving exactly like a borg apparatus, this was a tool. Now it is an apparatus, and appropriately dumps organs on decon. 

I'm not sure that setting the icon_state to null is the ideal way to handle the organ bag being drawn twice (once underneath and once above as an overlay), so if there's a better way please let me know.

(Also changes one leftover reference to configurations from my previous PR to model) 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #53248
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: borg organ bags are now an apparatus and drop held organs on deconstruction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
