### PR TITLE
Adds training bomb to security offices on Delta and Kilo

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -35878,7 +35878,6 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "bwe" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -35886,6 +35885,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/syndicatebomb/training,
+/obj/structure/table,
+/obj/item/wirecutters,
+/obj/item/screwdriver,
 /turf/open/floor/plasteel,
 /area/security/main)
 "bwf" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -5012,7 +5012,8 @@
 /area/security/main)
 "aiI" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
+/obj/machinery/syndicatebomb/training,
+/obj/item/wirecutters,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "aiJ" = (
@@ -26229,6 +26230,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "aQT" = (


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### KillStation
#### Security office
- Moves donuts beside microwave on same table as donk pockets
- Adds bomb and wirecutters where donuts used to be

### DeltaStation
#### Security office
- Removes one of several pot plants in the S.T.A.R.S. office
- Adds table where plant was because it was in the corner, out of the way
- Adds bomb, wirecutters and screwdriver to table

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Closes #56409
Preparedness saves lives. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
tweak: There are training bombs in KiloStation and DeltaStation security offices now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
