### PR TITLE
fixes to holy explosion and the spawned nades

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -574,11 +574,11 @@
 
 /obj/item/grenade/chem_grenade/holy/Initialize()
 	. = ..()
-	var/obj/item/reagent_containers/glass/beaker/large/B1 = new(src)
-	var/obj/item/reagent_containers/glass/beaker/large/B2 = new(src)
+	var/obj/item/reagent_containers/glass/beaker/meta/B1 = new(src)
+	var/obj/item/reagent_containers/glass/beaker/meta/B2 = new(src)
 
-	B1.reagents.add_reagent(/datum/reagent/potassium, 100)
-	B2.reagents.add_reagent(/datum/reagent/water/holywater, 100)
+	B1.reagents.add_reagent(/datum/reagent/potassium, 150)
+	B2.reagents.add_reagent(/datum/reagent/water/holywater, 150)
 
 	beakers += B1
 	beakers += B2

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -142,7 +142,7 @@
 		var/turf/T = get_turf(holder.my_atom)
 		///special size for anti cult effect
 		var/effective_size = round(created_volume/48)
-		playsound(get_turf(holder.my_atom), 'sound/effects/pray.ogg', 80, FALSE, effective_size)
+		playsound(T, 'sound/effects/pray.ogg', 80, FALSE, effective_size)
 		for(var/mob/living/simple_animal/revenant/R in get_hearers_in_view(7,T))
 			var/deity
 			if(GLOB.deity)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -131,14 +131,17 @@
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/potassium = 1)
 	strengthdiv = 20
 
-/datum/chemical_reaction/reagent_explosion/potassium_explosion/holyboom
+/datum/chemical_reaction/reagent_explosion/holyboom
 	required_reagents = list(/datum/reagent/water/holywater = 1, /datum/reagent/potassium = 1)
+	strengthdiv = 20
 
-/datum/chemical_reaction/reagent_explosion/potassium_explosion/holyboom/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/reagent_explosion/holyboom/on_reaction(datum/reagents/holder, created_volume)
 	if(created_volume >= 150)
-		playsound(get_turf(holder.my_atom), 'sound/effects/pray.ogg', 80, FALSE, round(created_volume/48))
 		strengthdiv = 8
-		for(var/mob/living/simple_animal/revenant/R in get_hearers_in_view(7,get_turf(holder.my_atom)))
+		var/turf/T = get_turf(holder.my_atom)
+		var/effective_size = round(created_volume/48)
+		playsound(get_turf(holder.my_atom), 'sound/effects/pray.ogg', 80, FALSE, effective_size)
+		for(var/mob/living/simple_animal/revenant/R in get_hearers_in_view(7,T))
 			var/deity
 			if(GLOB.deity)
 				deity = GLOB.deity
@@ -148,16 +151,13 @@
 			R.stun(20)
 			R.reveal(100)
 			R.adjustHealth(50)
-		addtimer(CALLBACK(src, .proc/divine_explosion, round(created_volume/48,1),get_turf(holder.my_atom)), 2 SECONDS)
+		for(var/mob/living/carbon/C in get_hearers_in_view(effective_size,T))
+			if(iscultist(C))
+				to_chat(C, "<span class='userdanger'>The divine explosion sears you!</span>")
+				C.Paralyze(40)
+				C.adjust_fire_stacks(5)
+				C.IgniteMob()
 	..()
-
-/datum/chemical_reaction/reagent_explosion/potassium_explosion/holyboom/proc/divine_explosion(size, turf/T)
-	for(var/mob/living/carbon/C in get_hearers_in_view(size,T))
-		if(iscultist(C))
-			to_chat(C, "<span class='userdanger'>The divine explosion sears you!</span>")
-			C.Paralyze(40)
-			C.adjust_fire_stacks(5)
-			C.IgniteMob()
 
 /datum/chemical_reaction/gunpowder
 	results = list(/datum/reagent/gunpowder = 3)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -138,7 +138,9 @@
 /datum/chemical_reaction/reagent_explosion/holyboom/on_reaction(datum/reagents/holder, created_volume)
 	if(created_volume >= 150)
 		strengthdiv = 8
+		///turf where to play sound
 		var/turf/T = get_turf(holder.my_atom)
+		///special size for anti cult effect
 		var/effective_size = round(created_volume/48)
 		playsound(get_turf(holder.my_atom), 'sound/effects/pray.ogg', 80, FALSE, effective_size)
 		for(var/mob/living/simple_animal/revenant/R in get_hearers_in_view(7,T))


### PR DESCRIPTION
:cl:
fix: admin spawned holy nades work
fix: holy explosion is more efficient at doing whats supposed to do
/:cl:

the proc to ignite cultists happens after the explosion which throws people out of is small range of chems_created/48(3 when used with 150u 150u metabeakers) thanks to the new explosion subsystem , which made it never work right
