### PR TITLE
Fix the Chief Engineer's envirogloves not being Insulated like other Plasmaman engineering gloves.

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -162,6 +162,7 @@
 	name = "chief engineer's envirogloves"
 	icon_state = "ceplasma"
 	inhand_icon_state = "ceplasma"
+	siemens_coefficient = 0
 
 /obj/item/clothing/gloves/color/plasmaman/chief_medical_officer
 	name = "chief medical officer's envirogloves"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simple fix for the Chief Engineer's envirogloves. Both the Engineer and Atmos gloves are insulated but the CE one isn't and that was an oversight on my part.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency, the CE gloves shouldn't be worse than a Station Engineer one...
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Guillaume Prata
fix: Chief Engineer's envirogloves (Plasmaman) are insulated like the others from Engineering now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
