### PR TITLE
when you choose a sacrifice as heretic it lists the job other than the name tweak

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -287,7 +287,7 @@
 				var/datum/mind/targeted =  A.find_target()//easy way, i dont feel like copy pasting that entire block of code
 				if(!targeted)
 					break
-				targets[targeted.current.real_name] = targeted.current
+				targets["[targeted.current.real_name] the [targeted.assigned_role]"] = targeted.current
 			LH.target = targets[input(user,"Choose your next target","Target") in targets]
 			qdel(A)
 			if(LH.target)


### PR DESCRIPTION
:cl:
tweak: when u choose a sac target as heretic it ll also tell the job of the sac
/:cl:

qol as you are gonna check the name of the dude anyway with pda  while the input window is open and then missclick into the captain, with this you dont have to 
