### PR TITLE
Makes fake moustaches tiny

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -38,6 +38,7 @@
 	name = "fake moustache"
 	desc = "Warning: moustache is fake."
 	icon_state = "fake-moustache"
+	w_class = WEIGHT_CLASS_TINY
 	flags_inv = HIDEFACE
 	species_exception = list(/datum/species/golem)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fake moustaches don't have a defined size, the one they inherit is inappropriate.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I can't put my chef moustache in my internals box round start ARE YOU KIDDING ME RIGHT NOW?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Fake moustaches are tiny and can fit in boxes
/:cl:

tbh this _should_ be a fix but it's also a small change so it deserves to be punished with the tweak label
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
