### PR TITLE
Audible Emote Audit

### DIFF
--- a/code/modules/mob/living/carbon/alien/emote.dm
+++ b/code/modules/mob/living/carbon/alien/emote.dm
@@ -11,6 +11,7 @@
 	key_third_person = "hisses"
 	message_alien = "hisses."
 	message_larva = "hisses softly."
+	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/alien/hiss/get_sound(mob/living/user)
 	if(isalienadult(user))

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -37,7 +37,6 @@
 	message = "hugs themself."
 	message_param = "hugs %t."
 	hands_use_check = TRUE
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/carbon/human/mumble
 	key = "mumble"
@@ -217,6 +216,7 @@
 	key = "roar"
 	key_third_person = "roars"
 	message = "roars."
+	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/carbon/human/monkey/tail
 	key = "tail"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -169,7 +169,6 @@
 	key_third_person = "glares"
 	message = "glares."
 	message_param = "glares at %t."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/grin
 	key = "grin"
@@ -181,6 +180,7 @@
 	key_third_person = "groans"
 	message = "groans!"
 	message_mime = "appears to groan!"
+	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/grimace
 	key = "grimace"
@@ -198,7 +198,6 @@
 	key_third_person = "kisses"
 	message = "blows a kiss."
 	message_param = "blows a kiss to %t."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/laugh
 	key = "laugh"
@@ -259,7 +258,6 @@
 	key = "pout"
 	key_third_person = "pouts"
 	message = "pouts."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/scream
 	key = "scream"
@@ -278,19 +276,16 @@
 	key = "scowl"
 	key_third_person = "scowls"
 	message = "scowls."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/shake
 	key = "shake"
 	key_third_person = "shakes"
 	message = "shakes their head."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/shiver
 	key = "shiver"
 	key_third_person = "shiver"
 	message = "shivers."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/sigh
 	key = "sigh"
@@ -390,6 +385,7 @@
 	key_third_person = "whimpers"
 	message = "whimpers."
 	message_mime = "appears hurt."
+	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/wsmile
 	key = "wsmile"
@@ -493,13 +489,16 @@
 	message_param = "beeps at %t."
 	sound = 'sound/machines/twobeep.ogg'
 	mob_type_allowed_typecache = list(/mob/living/brain, /mob/living/silicon)
+	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/inhale
 	key = "inhale"
 	key_third_person = "inhales"
 	message = "breathes in."
+	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/exhale
 	key = "exhale"
 	key_third_person = "exhales"
 	message = "breathes out."
+	emote_type = EMOTE_AUDIBLE

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -12,23 +12,28 @@
 	key_third_person = "buzzes"
 	message = "buzzes."
 	message_param = "buzzes at %t."
+	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/buzz-sigh.ogg'
+
 
 /datum/emote/silicon/buzz2
 	key = "buzz2"
 	message = "buzzes twice."
+	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/buzz-two.ogg'
 
 /datum/emote/silicon/chime
 	key = "chime"
 	key_third_person = "chimes"
 	message = "chimes."
+	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/chime.ogg'
 
 /datum/emote/silicon/honk
 	key = "honk"
 	key_third_person = "honks"
 	message = "honks."
+	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'sound/items/bikehorn.ogg'
 
@@ -37,14 +42,17 @@
 	key_third_person = "pings"
 	message = "pings."
 	message_param = "pings at %t."
+	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/ping.ogg'
 
 /datum/emote/silicon/sad
 	key = "sad"
 	message = "plays a sad trombone..."
+	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/misc/sadtrombone.ogg'
 
 /datum/emote/silicon/warn
 	key = "warn"
 	message = "blares an alarm!"
+	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/warning-buzzer.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/emotes.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/emotes.dm
@@ -7,5 +7,6 @@
 	key_third_person = "oogas"
 	message = "oogas."
 	message_param = "oogas at %t."
+	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/creatures/gorilla.ogg'
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Audits audible emotes. And boy, was there a lot to look at. Let's list 'em!
***Hiss** _audible_
***Hugs** _NOT audible_, and I'm pretty sure blind people get a specific feedback for hugging, the clothes rustling?
***Roars** _audible_
***Glares** _NOT audible_
***Groans** _audible_
***Kiss** _NOT audible_ especially considering that its blowing a kiss and the kiss can be directed
***Pout** _NOT audible_
***Scowl** _NOT audible_
***Shake** _NOT audible_ as in headshake, as in, the visual indicator of "no", the opposite of a nod
***Shiver** _NOT audible_
***Whimper** _audible_
***Beeps** _audible_
***Inhale** _audible_
***Exhale** _audible_
***Buzz** _audible_
***Buzz2** _audible_
***Chime** _audible_
***Honk** _audible_
***Ping** _audible_
***Sad** _audible_ as in, sad trombone
***Warn** _audible_ "blares an alarm!"
***Ooga** _audible_ it's a literal onomatopoeia


_Thanks to @MrMelbert for testing these out in the thunderdome with me._
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency. It's really bizarre when you're blind and people are audibly glaring. Likewise, deaf people shouldn't have to suffer borg noises.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Emotes have been audited for whether they should be seen or heard. No more hearing glares or seeing groans.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
