### PR TITLE
Fixes mime scream a.k.a. The Silence of the Mimes

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -49,6 +49,7 @@
 	key = "scream"
 	key_third_person = "screams"
 	message = "screams!"
+	message_mime = "acts out a scream!"
 	emote_type = EMOTE_AUDIBLE
 	only_forced_audio = TRUE
 	vary = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hello, Clarice. 
Mime emotes are stored in `living/emote.dm`, including scream, but humans have an override in `human/emote.dm`, so it never happens.
This PR moves that behavior to the override, making sure that mimes cannot scream with their vow active and are only able to act out screams.

~~**Maintainers, should I remove the old entry in `living/emote.dm` or should I leave it?**~~ Lemon told me to keep it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/3204033/105989717-2266ea00-6067-11eb-83d4-da8d56973e87.png)
closes #56464
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Mimes act out screams when their vow is active
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
