### PR TITLE
Adds locks to Deltastation Toilets

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -68920,9 +68920,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "cGK" = (
 /obj/machinery/door/airlock{
@@ -112119,9 +112117,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "sPv" = (
 /obj/structure/bed,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -10292,7 +10292,8 @@
 /area/janitor)
 "azg" = (
 /obj/machinery/door/airlock{
-	name = "Toilet Unit"
+	id_tag = "AuxToilet1";
+	name = "Toilet Unit 1"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -10658,6 +10659,13 @@
 	},
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/vomit,
+/obj/machinery/button/door{
+	id = "AuxToilet1";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/auxiliary)
 "aAn" = (
@@ -10670,6 +10678,13 @@
 	},
 /obj/machinery/light/small,
 /obj/effect/turf_decal/bot,
+/obj/machinery/button/door{
+	id = "AuxToilet2";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/auxiliary)
 "aAo" = (
@@ -10683,6 +10698,13 @@
 /obj/machinery/light/small,
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/bot,
+/obj/machinery/button/door{
+	id = "AuxToilet3";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/auxiliary)
 "aAp" = (
@@ -68889,7 +68911,8 @@
 "cGJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
-	name = "Toilet Unit"
+	id_tag = "Toilet1";
+	name = "Toilet Unit 1"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -68903,6 +68926,7 @@
 /area/crew_quarters/toilet/restrooms)
 "cGK" = (
 /obj/machinery/door/airlock{
+	id_tag = "Toilet3";
 	name = "Toilet Unit"
 	},
 /turf/open/floor/plating,
@@ -69542,6 +69566,13 @@
 	pixel_x = -32
 	},
 /obj/machinery/light/small,
+/obj/machinery/button/door{
+	id = "Toilet1";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/restrooms)
 "cIb" = (
@@ -69554,6 +69585,13 @@
 	},
 /obj/machinery/light/small,
 /obj/effect/turf_decal/bot,
+/obj/machinery/button/door{
+	id = "Toilet2";
+	name = "Lock control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "cIc" = (
@@ -69567,6 +69605,13 @@
 /obj/machinery/light/small,
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/bot,
+/obj/machinery/button/door{
+	id = "Toilet3";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "cId" = (
@@ -107924,6 +107969,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"kob" = (
+/obj/machinery/door/airlock{
+	id_tag = "AuxToilet3";
+	name = "Toilet Unit 3"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/toilet/auxiliary)
 "kpy" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Sanitarium";
@@ -108649,6 +108705,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"lEu" = (
+/obj/machinery/door/airlock{
+	id_tag = "AuxToilet2";
+	name = "Toilet Unit 2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/toilet/auxiliary)
 "lFl" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -112040,6 +112107,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"sOQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock{
+	id_tag = "Toilet2";
+	name = "Toilet Unit 2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
+/area/crew_quarters/toilet/restrooms)
 "sPv" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -151732,7 +151815,7 @@ auj
 avI
 awK
 ayc
-azg
+lEu
 aAn
 auj
 aIK
@@ -152246,7 +152329,7 @@ auj
 auj
 awM
 aye
-azg
+kob
 aAo
 auj
 aCJ
@@ -161310,7 +161393,7 @@ cAm
 cBP
 cDw
 cFk
-cGJ
+sOQ
 cIb
 cAm
 cZX


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds locks to the toilets and auxiliary toilets on Deltastation. 

Also removes a small weird heat-resistance increase on one of the floor tiles underneath a toilet airlock.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More player storage, and also it's jank as all heck to not be able to lock the toilet while you're in it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Rejoice Crew! NT has finally added locks to Deltastation's toilets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
