### PR TITLE
Simplifies bullet calibers

### DIFF
--- a/code/__DEFINES/projectiles.dm
+++ b/code/__DEFINES/projectiles.dm
@@ -7,3 +7,53 @@
 #define PROJECTILE_PIERCE_PHASE		2
 // Delete self without hitting
 #define PROJECTILE_DELETE_WITHOUT_HITTING		3
+
+// Caliber defines: (current count stands at 24)
+/// The caliber used by the [L6 SAW][/obj/item/gun/ballistic/automatic/l6_saw].
+#define CALIBER_712X82MM	"mm71282"
+/// The caliber used by the [security auto-rifle][/obj/item/gun/ballistic/automatic/wt550].
+#define CALIBER_46X30MM		"4.6x30mm"
+/// The caliber used by the [plastikov SMG][/obj/item/gun/ballistic/automatic/plastikov].
+#define CALIBER_9X19MM		"9x19mm"
+/// The caliber used by the Nanotrasen Saber SMG, and Type U3 Uzi. Also used as the default caliber for pistols but only the stechkin APS machine pistol doesn't override it.
+#define CALIBER_9MM			"9mm"
+/// The caliber used as the default for ballistic guns. Only not overridden for the [surplus rifle][/obj/item/gun/ballistic/automatic/surplus].
+#define CALIBER_10MM		"10mm"
+/// The caliber used by most revolver variants.
+#define CALIBER_357			".357"
+/// The caliber used by the detective's revolver.
+#define CALIBER_38			".38"
+/// The caliber used by the C-20r SMG, the tommygun, and the M1911 pistol.
+#define CALIBER_45			".45"
+/// The caliber used by sniper rifles and the desert eagle.
+#define CALIBER_50			".50"
+/// The caliber used by the gyrojet pistol.
+#define CALIBER_75			".75"
+/// The caliber used by [one revolver variant][/obj/item/gun/ballistic/revolver/nagant].
+#define CALIBER_N762		"n762"
+/// The caliber used by the the M-90gl Carbine, and NT-ARG 'Boarder'.
+#define CALIBER_A556		"a556"
+/// The caliber used by bolt action rifles.
+#define CALIBER_A762		"a762"
+/// The caliber used by shotguns.
+#define CALIBER_SHOTGUN		"shotgun"
+/// The caliber used by grenade launchers.
+#define CALIBER_40MM		"40mm"
+/// The caliber used by rocket launchers.
+#define CALIBER_84MM		"84mm"
+/// The caliber used by laser guns.
+#define CALIBER_LASER		"laser"
+/// The caliber used by most energy guns.
+#define CALIBER_ENERGY		"energy"
+/// The caliber used by the laser minigun.
+#define CALIBER_GATLING		"gatling"
+/// The acliber used by foam force and donksoft toy guns.
+#define CALIBER_FOAM		"foam_force"
+/// The caliber used by the bow and arrow.
+#define CALIBER_ARROW		"arrow"
+/// The caliber used by the harpoon gun.
+#define CALIBER_HARPOON		"harpoon"
+/// The caliber used by the meat hook.
+#define CALIBER_HOOK		"hook"
+/// The caliber used by the changeling tentacle mutation.
+#define CALIBER_TENTACLE	"tentacle"

--- a/code/__DEFINES/projectiles.dm
+++ b/code/__DEFINES/projectiles.dm
@@ -8,52 +8,30 @@
 // Delete self without hitting
 #define PROJECTILE_DELETE_WITHOUT_HITTING		3
 
-// Caliber defines: (current count stands at 24)
-/// The caliber used by the [L6 SAW][/obj/item/gun/ballistic/automatic/l6_saw].
-#define CALIBER_712X82MM	"mm71282"
-/// The caliber used by the [security auto-rifle][/obj/item/gun/ballistic/automatic/wt550].
-#define CALIBER_46X30MM		"4.6x30mm"
-/// The caliber used by the [plastikov SMG][/obj/item/gun/ballistic/automatic/plastikov].
-#define CALIBER_9X19MM		"9x19mm"
-/// The caliber used by the Nanotrasen Saber SMG, and Type U3 Uzi. Also used as the default caliber for pistols but only the stechkin APS machine pistol doesn't override it.
-#define CALIBER_9MM			"9mm"
-/// The caliber used as the default for ballistic guns. Only not overridden for the [surplus rifle][/obj/item/gun/ballistic/automatic/surplus].
-#define CALIBER_10MM		"10mm"
-/// The caliber used by most revolver variants.
-#define CALIBER_357			".357"
-/// The caliber used by the detective's revolver.
-#define CALIBER_38			".38"
-/// The caliber used by the C-20r SMG, the tommygun, and the M1911 pistol.
-#define CALIBER_45			".45"
-/// The caliber used by sniper rifles and the desert eagle.
-#define CALIBER_50			".50"
-/// The caliber used by the gyrojet pistol.
-#define CALIBER_75			".75"
-/// The caliber used by [one revolver variant][/obj/item/gun/ballistic/revolver/nagant].
-#define CALIBER_N762		"n762"
-/// The caliber used by the the M-90gl Carbine, and NT-ARG 'Boarder'.
-#define CALIBER_A556		"a556"
-/// The caliber used by bolt action rifles.
-#define CALIBER_A762		"a762"
-/// The caliber used by shotguns.
-#define CALIBER_SHOTGUN		"shotgun"
-/// The caliber used by grenade launchers.
-#define CALIBER_40MM		"40mm"
-/// The caliber used by rocket launchers.
-#define CALIBER_84MM		"84mm"
-/// The caliber used by laser guns.
-#define CALIBER_LASER		"laser"
-/// The caliber used by most energy guns.
-#define CALIBER_ENERGY		"energy"
-/// The caliber used by the laser minigun.
-#define CALIBER_GATLING		"gatling"
-/// The acliber used by foam force and donksoft toy guns.
+// Caliber defines: (Current count stands at 13)
+/// Small bullets used by most automatic pistols and SMGs.
+#define CALIBER_BALLISTIC_LIGHT		"ballistic-light"
+/// Mid size bullets used by automatic rifles and revolvers.
+#define CALIBER_BALLISTIC_MEDIUM	"ballistic-medium"
+/// Large bullets used by the deagle and sniper rifles.
+#define CALIBER_BALLISTIC_HEAVY		"ballistic-heavy"
+/// Shotgun shells used by shotguns.
+#define CALIBER_SHOTGUN				"shotgun"
+/// Grenades and gyrojet rounds used by grenade launchers and the gyrojet pistol.
+#define CALIBER_GRENADE				"grenade"
+/// Rockets used by the rocket launcher.
+#define CALIBER_ROCKET				"rocket"
+/// Foam darts used by donksoft and foam force guns.
 #define CALIBER_FOAM		"foam_force"
-/// The caliber used by the bow and arrow.
+/// Disposable laser cartriges used by laser guns.
+#define CALIBER_LASER		"laser"
+/// Some form of lens or emitter used by energy guns.
+#define CALIBER_ENERGY		"energy"
+/// Arrows used by the bow.
 #define CALIBER_ARROW		"arrow"
-/// The caliber used by the harpoon gun.
+/// Harpoons used by the harpoon gun.
 #define CALIBER_HARPOON		"harpoon"
-/// The caliber used by the meat hook.
+/// The meat hook used... by the meat hook.
 #define CALIBER_HOOK		"hook"
-/// The caliber used by the changeling tentacle mutation.
+/// The tentacle used by the tentacle mutation.
 #define CALIBER_TENTACLE	"tentacle"

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -280,7 +280,7 @@
 	name = "tentacle"
 	desc = "A tentacle."
 	projectile_type = /obj/projectile/tentacle
-	caliber = "tentacle"
+	caliber = CALIBER_TENTACLE
 	icon_state = "tentacle_end"
 	firing_effect_type = null
 	var/obj/item/gun/magic/tentacle/gun //the item that shot it

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -416,7 +416,7 @@
 	name = "hook"
 	desc = "A hook."
 	projectile_type = /obj/projectile/hook
-	caliber = "hook"
+	caliber = CALIBER_HOOK
 	icon_state = "hook"
 
 /obj/projectile/hook

--- a/code/modules/projectiles/ammunition/ballistic/lmg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/lmg.dm
@@ -4,7 +4,7 @@
 	name = "7.12x82mm bullet casing"
 	desc = "A 7.12x82mm bullet casing."
 	icon_state = "762-casing"
-	caliber = "mm71282"
+	caliber = CALIBER_712X82MM
 	projectile_type = /obj/projectile/bullet/mm712x82
 
 /obj/item/ammo_casing/mm712x82/ap

--- a/code/modules/projectiles/ammunition/ballistic/lmg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/lmg.dm
@@ -4,7 +4,7 @@
 	name = "7.12x82mm bullet casing"
 	desc = "A 7.12x82mm bullet casing."
 	icon_state = "762-casing"
-	caliber = CALIBER_712X82MM
+	caliber = CALIBER_BALLISTIC_LIGHT
 	projectile_type = /obj/projectile/bullet/mm712x82
 
 /obj/item/ammo_casing/mm712x82/ap

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -3,7 +3,7 @@
 /obj/item/ammo_casing/c10mm
 	name = "10mm bullet casing"
 	desc = "A 10mm bullet casing."
-	caliber = "10mm"
+	caliber = CALIBER_10MM
 	projectile_type = /obj/projectile/bullet/c10mm
 
 /obj/item/ammo_casing/c10mm/ap
@@ -26,14 +26,14 @@
 /obj/item/ammo_casing/c9mm
 	name = "9mm bullet casing"
 	desc = "A 9mm bullet casing."
-	caliber = "9mm"
+	caliber = CALIBER_9MM
 	projectile_type = /obj/projectile/bullet/c9mm
 
 /obj/item/ammo_casing/c9mm/ap
 	name = "9mm armor-piercing bullet casing"
 	desc = "A 9mm armor-piercing bullet casing."
 	projectile_type =/obj/projectile/bullet/c9mm_ap
-	
+
 /obj/item/ammo_casing/c9mm/hp
 	name = "9mm hollow-point bullet casing"
 	desc = "A 10mm hollow-point bullet casing."
@@ -50,5 +50,5 @@
 /obj/item/ammo_casing/a50ae
 	name = ".50AE bullet casing"
 	desc = "A .50AE bullet casing."
-	caliber = ".50"
+	caliber = CALIBER_50
 	projectile_type = /obj/projectile/bullet/a50ae

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -3,7 +3,7 @@
 /obj/item/ammo_casing/c10mm
 	name = "10mm bullet casing"
 	desc = "A 10mm bullet casing."
-	caliber = CALIBER_10MM
+	caliber = CALIBER_BALLISTIC_LIGHT
 	projectile_type = /obj/projectile/bullet/c10mm
 
 /obj/item/ammo_casing/c10mm/ap
@@ -26,7 +26,7 @@
 /obj/item/ammo_casing/c9mm
 	name = "9mm bullet casing"
 	desc = "A 9mm bullet casing."
-	caliber = CALIBER_9MM
+	caliber = CALIBER_BALLISTIC_LIGHT
 	projectile_type = /obj/projectile/bullet/c9mm
 
 /obj/item/ammo_casing/c9mm/ap
@@ -50,5 +50,5 @@
 /obj/item/ammo_casing/a50ae
 	name = ".50AE bullet casing"
 	desc = "A .50AE bullet casing."
-	caliber = CALIBER_50
+	caliber = CALIBER_BALLISTIC_HEAVY
 	projectile_type = /obj/projectile/bullet/a50ae

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -3,13 +3,12 @@
 /obj/item/ammo_casing/a357
 	name = ".357 bullet casing"
 	desc = "A .357 bullet casing."
-	caliber = "357"
+	caliber = CALIBER_357
 	projectile_type = /obj/projectile/bullet/a357
 
 /obj/item/ammo_casing/a357/match
 	name = ".357 match bullet casing"
 	desc = "A .357 bullet casing, manufactured to exceedingly high standards."
-	caliber = "357"
 	projectile_type = /obj/projectile/bullet/a357/match
 
 // 7.62x38mmR (Nagant Revolver)
@@ -17,7 +16,7 @@
 /obj/item/ammo_casing/n762
 	name = "7.62x38mmR bullet casing"
 	desc = "A 7.62x38mmR bullet casing."
-	caliber = "n762"
+	caliber = CALIBER_N762
 	projectile_type = /obj/projectile/bullet/n762
 
 // .38 (Detective's Gun)
@@ -25,7 +24,7 @@
 /obj/item/ammo_casing/c38
 	name = ".38 bullet casing"
 	desc = "A .38 bullet casing."
-	caliber = "38"
+	caliber = CALIBER_38
 	projectile_type = /obj/projectile/bullet/c38
 
 /obj/item/ammo_casing/c38/trac
@@ -51,11 +50,9 @@
 /obj/item/ammo_casing/c38/hotshot
 	name = ".38 Hot Shot bullet casing"
 	desc = "A .38 Hot Shot bullet casing."
-	caliber = "38"
 	projectile_type = /obj/projectile/bullet/c38/hotshot
 
 /obj/item/ammo_casing/c38/iceblox
 	name = ".38 Iceblox bullet casing"
 	desc = "A .38 Iceblox bullet casing."
-	caliber = "38"
 	projectile_type = /obj/projectile/bullet/c38/iceblox

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -3,7 +3,7 @@
 /obj/item/ammo_casing/a357
 	name = ".357 bullet casing"
 	desc = "A .357 bullet casing."
-	caliber = CALIBER_357
+	caliber = CALIBER_BALLISTIC_MEDIUM
 	projectile_type = /obj/projectile/bullet/a357
 
 /obj/item/ammo_casing/a357/match
@@ -16,7 +16,7 @@
 /obj/item/ammo_casing/n762
 	name = "7.62x38mmR bullet casing"
 	desc = "A 7.62x38mmR bullet casing."
-	caliber = CALIBER_N762
+	caliber = CALIBER_BALLISTIC_LIGHT
 	projectile_type = /obj/projectile/bullet/n762
 
 // .38 (Detective's Gun)
@@ -24,7 +24,7 @@
 /obj/item/ammo_casing/c38
 	name = ".38 bullet casing"
 	desc = "A .38 bullet casing."
-	caliber = CALIBER_38
+	caliber = CALIBER_BALLISTIC_LIGHT
 	projectile_type = /obj/projectile/bullet/c38
 
 /obj/item/ammo_casing/c38/trac

--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -4,7 +4,7 @@
 	name = "7.62 bullet casing"
 	desc = "A 7.62 bullet casing."
 	icon_state = "762-casing"
-	caliber = "a762"
+	caliber = CALIBER_A762
 	projectile_type = /obj/projectile/bullet/a762
 
 /obj/item/ammo_casing/a762/enchanted
@@ -15,7 +15,7 @@
 /obj/item/ammo_casing/a556
 	name = "5.56mm bullet casing"
 	desc = "A 5.56mm bullet casing."
-	caliber = "a556"
+	caliber = CALIBER_A556
 	projectile_type = /obj/projectile/bullet/a556
 
 /obj/item/ammo_casing/a556/phasic
@@ -28,6 +28,6 @@
 /obj/item/ammo_casing/a40mm
 	name = "40mm HE shell"
 	desc = "A cased high explosive grenade that can only be activated once fired out of a grenade launcher."
-	caliber = "40mm"
+	caliber = CALIBER_40MM
 	icon_state = "40mmHE"
 	projectile_type = /obj/projectile/bullet/a40mm

--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -4,7 +4,7 @@
 	name = "7.62 bullet casing"
 	desc = "A 7.62 bullet casing."
 	icon_state = "762-casing"
-	caliber = CALIBER_A762
+	caliber = CALIBER_BALLISTIC_MEDIUM
 	projectile_type = /obj/projectile/bullet/a762
 
 /obj/item/ammo_casing/a762/enchanted
@@ -15,7 +15,7 @@
 /obj/item/ammo_casing/a556
 	name = "5.56mm bullet casing"
 	desc = "A 5.56mm bullet casing."
-	caliber = CALIBER_A556
+	caliber = CALIBER_BALLISTIC_MEDIUM
 	projectile_type = /obj/projectile/bullet/a556
 
 /obj/item/ammo_casing/a556/phasic
@@ -28,6 +28,6 @@
 /obj/item/ammo_casing/a40mm
 	name = "40mm HE shell"
 	desc = "A cased high explosive grenade that can only be activated once fired out of a grenade launcher."
-	caliber = CALIBER_40MM
+	caliber = CALIBER_GRENADE
 	icon_state = "40mmHE"
 	projectile_type = /obj/projectile/bullet/a40mm

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -5,7 +5,7 @@
 	desc = "A 12 gauge lead slug."
 	icon_state = "blshell"
 	worn_icon_state = "shell"
-	caliber = "shotgun"
+	caliber = CALIBER_SHOTGUN
 	custom_materials = list(/datum/material/iron=4000)
 	projectile_type = /obj/projectile/bullet/shotgun_slug
 

--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -3,7 +3,7 @@
 /obj/item/ammo_casing/c46x30mm
 	name = "4.6x30mm bullet casing"
 	desc = "A 4.6x30mm bullet casing."
-	caliber = "4.6x30mm"
+	caliber = CALIBER_46X30MM
 	projectile_type = /obj/projectile/bullet/c46x30mm
 
 /obj/item/ammo_casing/c46x30mm/ap
@@ -21,19 +21,17 @@
 /obj/item/ammo_casing/c45
 	name = ".45 bullet casing"
 	desc = "A .45 bullet casing."
-	caliber = ".45"
+	caliber = CALIBER_45
 	projectile_type = /obj/projectile/bullet/c45
 
 /obj/item/ammo_casing/c45/ap
 	name = ".45 armor-piercing bullet casing"
 	desc = "A .45 bullet casing."
-	caliber = ".45"
 	projectile_type = /obj/projectile/bullet/c45_ap
 
 /obj/item/ammo_casing/c45/inc
-	name = ".45 armor-piercing bullet casing"
+	name = ".45 incendiary bullet casing"
 	desc = "A .45 bullet casing."
-	caliber = ".45"
 	projectile_type = /obj/projectile/bullet/incendiary/c45
 
 // 9x19mm (PP-95)
@@ -41,5 +39,5 @@
 /obj/item/ammo_casing/c9x19mm
 	name = "9x19mm bullet casing"
 	desc = "A 9.19mm bullet casing."
-	caliber = "9x19mm"
+	caliber = CALIBER_9X19MM
 	projectile_type = /obj/projectile/bullet/c9x19mm

--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -3,7 +3,7 @@
 /obj/item/ammo_casing/c46x30mm
 	name = "4.6x30mm bullet casing"
 	desc = "A 4.6x30mm bullet casing."
-	caliber = CALIBER_46X30MM
+	caliber = CALIBER_BALLISTIC_LIGHT
 	projectile_type = /obj/projectile/bullet/c46x30mm
 
 /obj/item/ammo_casing/c46x30mm/ap
@@ -21,7 +21,7 @@
 /obj/item/ammo_casing/c45
 	name = ".45 bullet casing"
 	desc = "A .45 bullet casing."
-	caliber = CALIBER_45
+	caliber = CALIBER_BALLISTIC_MEDIUM
 	projectile_type = /obj/projectile/bullet/c45
 
 /obj/item/ammo_casing/c45/ap
@@ -39,5 +39,5 @@
 /obj/item/ammo_casing/c9x19mm
 	name = "9x19mm bullet casing"
 	desc = "A 9.19mm bullet casing."
-	caliber = CALIBER_9X19MM
+	caliber = CALIBER_BALLISTIC_LIGHT
 	projectile_type = /obj/projectile/bullet/c9x19mm

--- a/code/modules/projectiles/ammunition/ballistic/sniper.dm
+++ b/code/modules/projectiles/ammunition/ballistic/sniper.dm
@@ -3,7 +3,7 @@
 /obj/item/ammo_casing/p50
 	name = ".50 bullet casing"
 	desc = "A .50 bullet casing."
-	caliber = ".50"
+	caliber = CALIBER_50
 	projectile_type = /obj/projectile/bullet/p50
 	icon_state = ".50"
 

--- a/code/modules/projectiles/ammunition/ballistic/sniper.dm
+++ b/code/modules/projectiles/ammunition/ballistic/sniper.dm
@@ -3,7 +3,7 @@
 /obj/item/ammo_casing/p50
 	name = ".50 bullet casing"
 	desc = "A .50 bullet casing."
-	caliber = CALIBER_50
+	caliber = CALIBER_BALLISTIC_HEAVY
 	projectile_type = /obj/projectile/bullet/p50
 	icon_state = ".50"
 

--- a/code/modules/projectiles/ammunition/caseless/foam.dm
+++ b/code/modules/projectiles/ammunition/caseless/foam.dm
@@ -2,7 +2,7 @@
 	name = "foam dart"
 	desc = "It's Donk or Don't! Ages 8 and up."
 	projectile_type = /obj/projectile/bullet/reusable/foam_dart
-	caliber = "foam_force"
+	caliber = CALIBER_FOAM
 	icon = 'icons/obj/guns/toy.dmi'
 	icon_state = "foamdart"
 	custom_materials = list(/datum/material/iron = 11.25)

--- a/code/modules/projectiles/ammunition/caseless/misc.dm
+++ b/code/modules/projectiles/ammunition/caseless/misc.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/caseless/laser
 	name = "laser casing"
 	desc = "You shouldn't be seeing this."
-	caliber = "laser"
+	caliber = CALIBER_LASER
 	icon_state = "s-casing-live"
 	slot_flags = null
 	projectile_type = /obj/projectile/beam
@@ -17,6 +17,6 @@
 
 /obj/item/ammo_casing/caseless/harpoon
 	name = "harpoon"
-	caliber = "harpoon"
+	caliber = CALIBER_HARPOON
 	icon_state = "magspear"
 	projectile_type = /obj/projectile/bullet/harpoon

--- a/code/modules/projectiles/ammunition/caseless/misc.dm
+++ b/code/modules/projectiles/ammunition/caseless/misc.dm
@@ -8,13 +8,13 @@
 	fire_sound = 'sound/weapons/laser.ogg'
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/energy
 
+// Laser gatling gun
 /obj/item/ammo_casing/caseless/laser/gatling
 	projectile_type = /obj/projectile/beam/weak/penetrator
 	variance = 0.8
 	click_cooldown_override = 1
 
-	// Harpoons (Ballistic Harpoon Gun)
-
+// Harpoons (Ballistic Harpoon Gun)
 /obj/item/ammo_casing/caseless/harpoon
 	name = "harpoon"
 	caliber = CALIBER_HARPOON

--- a/code/modules/projectiles/ammunition/caseless/rocket.dm
+++ b/code/modules/projectiles/ammunition/caseless/rocket.dm
@@ -1,14 +1,13 @@
 /obj/item/ammo_casing/caseless/rocket
 	name = "\improper PM-9HE"
 	desc = "An 84mm High Explosive rocket. Fire at people and pray."
-	caliber = "84mm"
+	caliber = CALIBER_84MM
 	icon_state = "srm-8"
 	projectile_type = /obj/projectile/bullet/a84mm_he
 
 /obj/item/ammo_casing/caseless/rocket/hedp
 	name = "\improper PM-9HEDP"
 	desc = "An 84mm High Explosive Dual Purpose rocket. Pointy end toward mechs."
-	caliber = "84mm"
 	icon_state = "84mm-hedp"
 	projectile_type = /obj/projectile/bullet/a84mm
 
@@ -19,6 +18,6 @@
 
 /obj/item/ammo_casing/caseless/a75
 	desc = "A .75 bullet casing."
-	caliber = "75"
+	caliber = CALIBER_75
 	icon_state = "s-casing-live"
 	projectile_type = /obj/projectile/bullet/gyro

--- a/code/modules/projectiles/ammunition/caseless/rocket.dm
+++ b/code/modules/projectiles/ammunition/caseless/rocket.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/caseless/rocket
 	name = "\improper PM-9HE"
 	desc = "An 84mm High Explosive rocket. Fire at people and pray."
-	caliber = CALIBER_84MM
+	caliber = CALIBER_ROCKET
 	icon_state = "srm-8"
 	projectile_type = /obj/projectile/bullet/a84mm_he
 
@@ -18,6 +18,6 @@
 
 /obj/item/ammo_casing/caseless/a75
 	desc = "A .75 bullet casing."
-	caliber = CALIBER_75
+	caliber = CALIBER_GRENADE
 	icon_state = "s-casing-live"
 	projectile_type = /obj/projectile/bullet/gyro

--- a/code/modules/projectiles/ammunition/energy/_energy.dm
+++ b/code/modules/projectiles/ammunition/energy/_energy.dm
@@ -5,7 +5,7 @@
 	projectile_type = /obj/projectile/energy
 	slot_flags = null
 	var/e_cost = 100 //The amount of energy a cell needs to expend to create this shot.
-	var/select_name = ENERGY
+	var/select_name = CALIBER_ENERGY
 	fire_sound = 'sound/weapons/laser.ogg'
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/energy
 	heavy_metal = FALSE

--- a/code/modules/projectiles/ammunition/energy/_energy.dm
+++ b/code/modules/projectiles/ammunition/energy/_energy.dm
@@ -1,11 +1,11 @@
 /obj/item/ammo_casing/energy
 	name = "energy weapon lens"
 	desc = "The part of the gun that makes the laser go pew."
-	caliber = ENERGY
+	caliber = CALIBER_ENERGY
 	projectile_type = /obj/projectile/energy
 	slot_flags = null
 	var/e_cost = 100 //The amount of energy a cell needs to expend to create this shot.
-	var/select_name = CALIBER_ENERGY
+	var/select_name = "energy"
 	fire_sound = 'sound/weapons/laser.ogg'
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/energy
 	heavy_metal = FALSE

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -54,7 +54,7 @@
 		load_type = ammo_type
 
 	var/obj/item/ammo_casing/round_check = load_type
-	if(!starting && (caliber && initial(round_check.caliber) != caliber) || (!caliber && load_type != ammo_type))
+	if(!starting && !(caliber ? (caliber == initial(round_check.caliber)) : (ammo_type == load_type)))
 		stack_trace("Tried loading unsupported ammocasing type [load_type] into ammo box [type].")
 		return
 
@@ -76,7 +76,7 @@
 ///puts a round into the magazine
 /obj/item/ammo_box/proc/give_round(obj/item/ammo_casing/R, replace_spent = 0)
 	// Boxes don't have a caliber type, magazines do. Not sure if it's intended or not, but if we fail to find a caliber, then we fall back to ammo_type.
-	if(!R || (caliber && R.caliber != caliber) || (!caliber && R.type != ammo_type))
+	if(!R || !(caliber ? (caliber == R.caliber) : (ammo_type == R.type)))
 		return FALSE
 
 	if (stored_ammo.len < max_ammo)

--- a/code/modules/projectiles/boxes_magazines/external/grenade.dm
+++ b/code/modules/projectiles/boxes_magazines/external/grenade.dm
@@ -2,7 +2,7 @@
 	name = "specialized magazine (.75)"
 	icon_state = "75"
 	ammo_type = /obj/item/ammo_casing/caseless/a75
-	caliber = "75"
+	caliber = CALIBER_75
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 	max_ammo = 8
 

--- a/code/modules/projectiles/boxes_magazines/external/grenade.dm
+++ b/code/modules/projectiles/boxes_magazines/external/grenade.dm
@@ -2,7 +2,7 @@
 	name = "specialized magazine (.75)"
 	icon_state = "75"
 	ammo_type = /obj/item/ammo_casing/caseless/a75
-	caliber = CALIBER_75
+	caliber = CALIBER_GRENADE
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 	max_ammo = 8
 

--- a/code/modules/projectiles/boxes_magazines/external/lmg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/lmg.dm
@@ -2,7 +2,7 @@
 	name = "box magazine (7.12x82mm)"
 	icon_state = "a762-50"
 	ammo_type = /obj/item/ammo_casing/mm712x82
-	caliber = "mm71282"
+	caliber = CALIBER_712X82MM
 	max_ammo = 50
 
 /obj/item/ammo_box/magazine/mm712x82/hollow

--- a/code/modules/projectiles/boxes_magazines/external/lmg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/lmg.dm
@@ -2,7 +2,7 @@
 	name = "box magazine (7.12x82mm)"
 	icon_state = "a762-50"
 	ammo_type = /obj/item/ammo_casing/mm712x82
-	caliber = CALIBER_712X82MM
+	caliber = CALIBER_BALLISTIC_LIGHT
 	max_ammo = 50
 
 /obj/item/ammo_box/magazine/mm712x82/hollow

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -3,7 +3,7 @@
 	desc = "A gun magazine."
 	icon_state = "9x19p"
 	ammo_type = /obj/item/ammo_casing/c10mm
-	caliber = "10mm"
+	caliber = CALIBER_10MM
 	max_ammo = 8
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
@@ -11,7 +11,7 @@
 	name = "handgun magazine (.45)"
 	icon_state = "45-8"
 	ammo_type = /obj/item/ammo_casing/c45
-	caliber = ".45"
+	caliber = CALIBER_45
 	max_ammo = 8
 
 /obj/item/ammo_box/magazine/m45/update_icon()
@@ -25,7 +25,7 @@
 	name = "pistol magazine (9mm)"
 	icon_state = "9x19p-8"
 	ammo_type = /obj/item/ammo_casing/c9mm
-	caliber = "9mm"
+	caliber = CALIBER_9MM
 	max_ammo = 8
 
 /obj/item/ammo_box/magazine/m9mm/update_icon()
@@ -54,7 +54,7 @@
 	name = "stechkin pistol magazine (9mm)"
 	icon_state = "9mmaps-15"
 	ammo_type = /obj/item/ammo_casing/c9mm
-	caliber = "9mm"
+	caliber = CALIBER_9MM
 	max_ammo = 15
 
 /obj/item/ammo_box/magazine/m9mm_aps/update_icon()
@@ -80,6 +80,6 @@
 	name = "handgun magazine (.50ae)"
 	icon_state = "50ae"
 	ammo_type = /obj/item/ammo_casing/a50ae
-	caliber = ".50"
+	caliber = CALIBER_50
 	max_ammo = 7
 	multiple_sprites = AMMO_BOX_PER_BULLET

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -3,7 +3,7 @@
 	desc = "A gun magazine."
 	icon_state = "9x19p"
 	ammo_type = /obj/item/ammo_casing/c10mm
-	caliber = CALIBER_10MM
+	caliber = CALIBER_BALLISTIC_LIGHT
 	max_ammo = 8
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
@@ -11,7 +11,7 @@
 	name = "handgun magazine (.45)"
 	icon_state = "45-8"
 	ammo_type = /obj/item/ammo_casing/c45
-	caliber = CALIBER_45
+	caliber = CALIBER_BALLISTIC_MEDIUM
 	max_ammo = 8
 
 /obj/item/ammo_box/magazine/m45/update_icon()
@@ -25,7 +25,7 @@
 	name = "pistol magazine (9mm)"
 	icon_state = "9x19p-8"
 	ammo_type = /obj/item/ammo_casing/c9mm
-	caliber = CALIBER_9MM
+	caliber = CALIBER_BALLISTIC_LIGHT
 	max_ammo = 8
 
 /obj/item/ammo_box/magazine/m9mm/update_icon()
@@ -54,7 +54,7 @@
 	name = "stechkin pistol magazine (9mm)"
 	icon_state = "9mmaps-15"
 	ammo_type = /obj/item/ammo_casing/c9mm
-	caliber = CALIBER_9MM
+	caliber = CALIBER_BALLISTIC_LIGHT
 	max_ammo = 15
 
 /obj/item/ammo_box/magazine/m9mm_aps/update_icon()
@@ -80,6 +80,6 @@
 	name = "handgun magazine (.50ae)"
 	icon_state = "50ae"
 	ammo_type = /obj/item/ammo_casing/a50ae
-	caliber = CALIBER_50
+	caliber = CALIBER_BALLISTIC_HEAVY
 	max_ammo = 7
 	multiple_sprites = AMMO_BOX_PER_BULLET

--- a/code/modules/projectiles/boxes_magazines/external/rechargable.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rechargable.dm
@@ -3,7 +3,7 @@
 	desc = "A rechargeable, detachable battery that serves as a magazine for laser rifles."
 	icon_state = "oldrifle-20"
 	ammo_type = /obj/item/ammo_casing/caseless/laser
-	caliber = "laser"
+	caliber = CALIBER_LASER
 	max_ammo = 20
 
 /obj/item/ammo_box/magazine/recharge/update_icon()

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -3,7 +3,6 @@
 	desc = "A well-worn magazine fitted for the surplus rifle."
 	icon_state = "75-8"
 	ammo_type = /obj/item/ammo_casing/c10mm
-	caliber = "10mm"
 	max_ammo = 10
 
 /obj/item/ammo_box/magazine/m10mm/rifle/update_icon()
@@ -17,7 +16,7 @@
 	name = "toploader magazine (5.56mm)"
 	icon_state = "5.56m"
 	ammo_type = /obj/item/ammo_casing/a556
-	caliber = "a556"
+	caliber = CALIBER_A556
 	max_ammo = 30
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -16,7 +16,7 @@
 	name = "toploader magazine (5.56mm)"
 	icon_state = "5.56m"
 	ammo_type = /obj/item/ammo_casing/a556
-	caliber = CALIBER_A556
+	caliber = CALIBER_BALLISTIC_MEDIUM
 	max_ammo = 30
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 

--- a/code/modules/projectiles/boxes_magazines/external/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/external/shotgun.dm
@@ -3,7 +3,7 @@
 	desc = "A drum magazine."
 	icon_state = "m12gb"
 	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
-	caliber = "shotgun"
+	caliber = CALIBER_SHOTGUN
 	max_ammo = 8
 
 /obj/item/ammo_box/magazine/m12g/update_icon()

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -2,7 +2,7 @@
 	name = "wt550 magazine (4.6x30mm)"
 	icon_state = "46x30mmt-20"
 	ammo_type = /obj/item/ammo_casing/c46x30mm
-	caliber = "4.6x30mm"
+	caliber = CALIBER_46X30MM
 	max_ammo = 20
 
 /obj/item/ammo_box/magazine/wt550m9/update_icon()
@@ -29,9 +29,9 @@
 
 /obj/item/ammo_box/magazine/plastikov9mm
 	name = "PP-95 magazine (9x19mm)"
-	icon_state = "9x19-50"
+	icon_state = CALIBER_9X19MM
 	ammo_type = /obj/item/ammo_casing/c9x19mm
-	caliber = "9x19mm"
+	caliber = CALIBER_9X19MM
 	max_ammo = 50
 
 /obj/item/ammo_box/magazine/plastikov9mm/update_icon()
@@ -45,7 +45,7 @@
 	name = "uzi magazine (9mm)"
 	icon_state = "uzi9mm-32"
 	ammo_type = /obj/item/ammo_casing/c9mm
-	caliber = "9mm"
+	caliber = CALIBER_9MM
 	max_ammo = 32
 
 /obj/item/ammo_box/magazine/uzim9mm/update_icon()
@@ -56,7 +56,7 @@
 	name = "SMG magazine (9mm)"
 	icon_state = "smg9mm-42"
 	ammo_type = /obj/item/ammo_casing/c9mm
-	caliber = "9mm"
+	caliber = CALIBER_9MM
 	max_ammo = 21
 
 /obj/item/ammo_box/magazine/smgm9mm/update_icon()
@@ -75,7 +75,7 @@
 	name = "SMG magazine (.45)"
 	icon_state = "c20r45-24"
 	ammo_type = /obj/item/ammo_casing/c45
-	caliber = ".45"
+	caliber = CALIBER_45
 	max_ammo = 24
 
 /obj/item/ammo_box/magazine/smgm45/update_icon()
@@ -94,5 +94,5 @@
 	name = "drum magazine (.45)"
 	icon_state = "drum45"
 	ammo_type = /obj/item/ammo_casing/c45
-	caliber = ".45"
+	caliber = CALIBER_45
 	max_ammo = 50

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -2,7 +2,7 @@
 	name = "wt550 magazine (4.6x30mm)"
 	icon_state = "46x30mmt-20"
 	ammo_type = /obj/item/ammo_casing/c46x30mm
-	caliber = CALIBER_46X30MM
+	caliber = CALIBER_BALLISTIC_LIGHT
 	max_ammo = 20
 
 /obj/item/ammo_box/magazine/wt550m9/update_icon()
@@ -29,9 +29,9 @@
 
 /obj/item/ammo_box/magazine/plastikov9mm
 	name = "PP-95 magazine (9x19mm)"
-	icon_state = CALIBER_9X19MM
+	icon_state = CALIBER_BALLISTIC_LIGHT
 	ammo_type = /obj/item/ammo_casing/c9x19mm
-	caliber = CALIBER_9X19MM
+	caliber = CALIBER_BALLISTIC_LIGHT
 	max_ammo = 50
 
 /obj/item/ammo_box/magazine/plastikov9mm/update_icon()
@@ -45,7 +45,7 @@
 	name = "uzi magazine (9mm)"
 	icon_state = "uzi9mm-32"
 	ammo_type = /obj/item/ammo_casing/c9mm
-	caliber = CALIBER_9MM
+	caliber = CALIBER_BALLISTIC_LIGHT
 	max_ammo = 32
 
 /obj/item/ammo_box/magazine/uzim9mm/update_icon()
@@ -56,7 +56,7 @@
 	name = "SMG magazine (9mm)"
 	icon_state = "smg9mm-42"
 	ammo_type = /obj/item/ammo_casing/c9mm
-	caliber = CALIBER_9MM
+	caliber = CALIBER_BALLISTIC_LIGHT
 	max_ammo = 21
 
 /obj/item/ammo_box/magazine/smgm9mm/update_icon()
@@ -75,7 +75,7 @@
 	name = "SMG magazine (.45)"
 	icon_state = "c20r45-24"
 	ammo_type = /obj/item/ammo_casing/c45
-	caliber = CALIBER_45
+	caliber = CALIBER_BALLISTIC_MEDIUM
 	max_ammo = 24
 
 /obj/item/ammo_box/magazine/smgm45/update_icon()
@@ -94,5 +94,5 @@
 	name = "drum magazine (.45)"
 	icon_state = "drum45"
 	ammo_type = /obj/item/ammo_casing/c45
-	caliber = CALIBER_45
+	caliber = CALIBER_BALLISTIC_MEDIUM
 	max_ammo = 50

--- a/code/modules/projectiles/boxes_magazines/external/sniper.dm
+++ b/code/modules/projectiles/boxes_magazines/external/sniper.dm
@@ -3,7 +3,7 @@
 	icon_state = ".50mag"
 	ammo_type = /obj/item/ammo_casing/p50
 	max_ammo = 6
-	caliber = ".50"
+	caliber = CALIBER_50
 
 /obj/item/ammo_box/magazine/sniper_rounds/update_icon()
 	..()
@@ -18,7 +18,7 @@
 	icon_state = "soporific"
 	ammo_type = /obj/item/ammo_casing/p50/soporific
 	max_ammo = 3
-	caliber = ".50"
+	caliber = CALIBER_50
 
 /obj/item/ammo_box/magazine/sniper_rounds/penetrator
 	name = "sniper rounds (penetrator)"

--- a/code/modules/projectiles/boxes_magazines/external/sniper.dm
+++ b/code/modules/projectiles/boxes_magazines/external/sniper.dm
@@ -3,7 +3,7 @@
 	icon_state = ".50mag"
 	ammo_type = /obj/item/ammo_casing/p50
 	max_ammo = 6
-	caliber = CALIBER_50
+	caliber = CALIBER_BALLISTIC_HEAVY
 
 /obj/item/ammo_box/magazine/sniper_rounds/update_icon()
 	..()
@@ -18,7 +18,6 @@
 	icon_state = "soporific"
 	ammo_type = /obj/item/ammo_casing/p50/soporific
 	max_ammo = 3
-	caliber = CALIBER_50
 
 /obj/item/ammo_box/magazine/sniper_rounds/penetrator
 	name = "sniper rounds (penetrator)"

--- a/code/modules/projectiles/boxes_magazines/external/toy.dm
+++ b/code/modules/projectiles/boxes_magazines/external/toy.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_box/magazine/toy
 	name = "foam force META magazine"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
-	caliber = "foam_force"
+	caliber = CALIBER_FOAM
 
 /obj/item/ammo_box/magazine/toy/smg
 	name = "foam force SMG magazine"
@@ -31,7 +31,7 @@
 /obj/item/ammo_box/magazine/toy/smgm45
 	name = "donksoft SMG magazine"
 	icon_state = "c20r45-toy"
-	caliber = "foam_force"
+	caliber = CALIBER_FOAM
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
 	max_ammo = 20
 
@@ -46,7 +46,6 @@
 /obj/item/ammo_box/magazine/toy/m762
 	name = "donksoft box magazine"
 	icon_state = "a762-toy"
-	caliber = "foam_force"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
 	max_ammo = 50
 

--- a/code/modules/projectiles/boxes_magazines/external/toy.dm
+++ b/code/modules/projectiles/boxes_magazines/external/toy.dm
@@ -31,7 +31,6 @@
 /obj/item/ammo_box/magazine/toy/smgm45
 	name = "donksoft SMG magazine"
 	icon_state = "c20r45-toy"
-	caliber = CALIBER_FOAM
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
 	max_ammo = 20
 

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_box/magazine/internal/cylinder
 	name = "revolver cylinder"
 	ammo_type = /obj/item/ammo_casing/a357
-	caliber = "357"
+	caliber = CALIBER_357
 	max_ammo = 7
 
 /obj/item/ammo_box/magazine/internal/cylinder/get_round(keep = 0)
@@ -33,7 +33,7 @@
 	return L
 
 /obj/item/ammo_box/magazine/internal/cylinder/give_round(obj/item/ammo_casing/R, replace_spent = 0)
-	if(!R || (caliber && R.caliber != caliber) || (!caliber && R.type != ammo_type))
+	if(!R || !(caliber ? (caliber == R.caliber) : (ammo_type == R.type)))
 		return FALSE
 
 	for(var/i in 1 to stored_ammo.len)

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_box/magazine/internal/cylinder
 	name = "revolver cylinder"
 	ammo_type = /obj/item/ammo_casing/a357
-	caliber = CALIBER_357
+	caliber = CALIBER_BALLISTIC_MEDIUM
 	max_ammo = 7
 
 /obj/item/ammo_box/magazine/internal/cylinder/get_round(keep = 0)

--- a/code/modules/projectiles/boxes_magazines/internal/grenade.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/grenade.dm
@@ -1,17 +1,17 @@
 /obj/item/ammo_box/magazine/internal/cylinder/grenademulti
 	name = "grenade launcher internal magazine"
 	ammo_type = /obj/item/ammo_casing/a40mm
-	caliber = "40mm"
+	caliber = CALIBER_40MM
 	max_ammo = 6
 
 /obj/item/ammo_box/magazine/internal/grenadelauncher
 	name = "grenade launcher internal magazine"
 	ammo_type = /obj/item/ammo_casing/a40mm
-	caliber = "40mm"
+	caliber = CALIBER_40MM
 	max_ammo = 1
 
 /obj/item/ammo_box/magazine/internal/rocketlauncher
 	name = "rocket launcher internal magazine"
 	ammo_type = /obj/item/ammo_casing/caseless/rocket
-	caliber = "84mm"
+	caliber = CALIBER_84MM
 	max_ammo = 1

--- a/code/modules/projectiles/boxes_magazines/internal/grenade.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/grenade.dm
@@ -1,17 +1,17 @@
 /obj/item/ammo_box/magazine/internal/cylinder/grenademulti
 	name = "grenade launcher internal magazine"
 	ammo_type = /obj/item/ammo_casing/a40mm
-	caliber = CALIBER_40MM
+	caliber = CALIBER_GRENADE
 	max_ammo = 6
 
 /obj/item/ammo_box/magazine/internal/grenadelauncher
 	name = "grenade launcher internal magazine"
 	ammo_type = /obj/item/ammo_casing/a40mm
-	caliber = CALIBER_40MM
+	caliber = CALIBER_GRENADE
 	max_ammo = 1
 
 /obj/item/ammo_box/magazine/internal/rocketlauncher
 	name = "rocket launcher internal magazine"
 	ammo_type = /obj/item/ammo_casing/caseless/rocket
-	caliber = CALIBER_84MM
+	caliber = CALIBER_ROCKET
 	max_ammo = 1

--- a/code/modules/projectiles/boxes_magazines/internal/misc.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/misc.dm
@@ -1,11 +1,11 @@
 /obj/item/ammo_box/magazine/internal/minigun
 	name = "gatling gun fusion core"
 	ammo_type = /obj/item/ammo_casing/caseless/laser/gatling
-	caliber = "gatling"
+	caliber = CALIBER_GATLING
 	max_ammo = 5000
 
 /obj/item/ammo_box/magazine/internal/hook
 	name = "hook internal tube"
 	ammo_type = /obj/item/ammo_casing/magic/hook
-	caliber = "hook"
+	caliber = CALIBER_HOOK
 	max_ammo = 1

--- a/code/modules/projectiles/boxes_magazines/internal/misc.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/misc.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_box/magazine/internal/minigun
 	name = "gatling gun fusion core"
 	ammo_type = /obj/item/ammo_casing/caseless/laser/gatling
-	caliber = CALIBER_GATLING
+	caliber = CALIBER_LASER
 	max_ammo = 5000
 
 /obj/item/ammo_box/magazine/internal/hook

--- a/code/modules/projectiles/boxes_magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/revolver.dm
@@ -1,19 +1,19 @@
 /obj/item/ammo_box/magazine/internal/cylinder/rev38
 	name = "detective revolver cylinder"
 	ammo_type = /obj/item/ammo_casing/c38
-	caliber = "38"
+	caliber = CALIBER_38
 	max_ammo = 6
 
 /obj/item/ammo_box/magazine/internal/cylinder/rev762
 	name = "\improper Nagant revolver cylinder"
 	ammo_type = /obj/item/ammo_casing/n762
-	caliber = "n762"
+	caliber = CALIBER_N762
 	max_ammo = 7
 
 /obj/item/ammo_box/magazine/internal/cylinder/rus357
 	name = "\improper Russian revolver cylinder"
 	ammo_type = /obj/item/ammo_casing/a357
-	caliber = "357"
+	caliber = CALIBER_357
 	max_ammo = 6
 	multiload = FALSE
 

--- a/code/modules/projectiles/boxes_magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/revolver.dm
@@ -1,19 +1,19 @@
 /obj/item/ammo_box/magazine/internal/cylinder/rev38
 	name = "detective revolver cylinder"
 	ammo_type = /obj/item/ammo_casing/c38
-	caliber = CALIBER_38
+	caliber = CALIBER_BALLISTIC_LIGHT
 	max_ammo = 6
 
 /obj/item/ammo_box/magazine/internal/cylinder/rev762
 	name = "\improper Nagant revolver cylinder"
 	ammo_type = /obj/item/ammo_casing/n762
-	caliber = CALIBER_N762
+	caliber = CALIBER_BALLISTIC_LIGHT
 	max_ammo = 7
 
 /obj/item/ammo_box/magazine/internal/cylinder/rus357
 	name = "\improper Russian revolver cylinder"
 	ammo_type = /obj/item/ammo_casing/a357
-	caliber = CALIBER_357
+	caliber = CALIBER_BALLISTIC_MEDIUM
 	max_ammo = 6
 	multiload = FALSE
 

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -2,7 +2,7 @@
 	name = "bolt action rifle internal magazine"
 	desc = "Oh god, this shouldn't be here"
 	ammo_type = /obj/item/ammo_casing/a762
-	caliber = "a762"
+	caliber = CALIBER_A762
 	max_ammo = 5
 	multiload = TRUE
 
@@ -15,5 +15,5 @@
 
 /obj/item/ammo_box/magazine/internal/boltaction/harpoon
 	max_ammo = 1
-	caliber = "harpoon"
+	caliber = CALIBER_HARPOON
 	ammo_type = /obj/item/ammo_casing/caseless/harpoon

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -2,7 +2,7 @@
 	name = "bolt action rifle internal magazine"
 	desc = "Oh god, this shouldn't be here"
 	ammo_type = /obj/item/ammo_casing/a762
-	caliber = CALIBER_A762
+	caliber = CALIBER_BALLISTIC_MEDIUM
 	max_ammo = 5
 	multiload = TRUE
 

--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_box/magazine/internal/shot
 	name = "shotgun internal magazine"
 	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
-	caliber = "shotgun"
+	caliber = CALIBER_SHOTGUN
 	max_ammo = 4
 	multiload = FALSE
 

--- a/code/modules/projectiles/boxes_magazines/internal/toy.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/toy.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_box/magazine/internal/shot/toy
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
-	caliber = "foam_force"
+	caliber = CALIBER_FOAM
 	max_ammo = 4
 
 /obj/item/ammo_box/magazine/internal/shot/toy/crossbow

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -124,16 +124,18 @@
 		if(drop_the_gun_it_actually_fired) //We do it like this instead of directly checking chambered.BB here because process_fire will cycle the chamber.
 			user.dropItemToGround(src)
 		return TRUE
-	if(magazine.caliber == "38")
-		magazine.caliber = "357"
-		fire_sound = 'sound/weapons/gun/revolver/shot_alt.ogg'
-		desc = "A classic, if not outdated, law enforcement firearm. \nIt has been modified to fire .357 rounds."
-		to_chat(user, "<span class='notice'>You loosen the barrel of [src]. Now it will fire .357 rounds.</span>")
-	else
-		magazine.caliber = "38"
-		fire_sound = 'sound/weapons/gun/revolver/shot.ogg'
-		desc = initial(desc)
-		to_chat(user, "<span class='notice'>You tighten the barrel of [src]. Now it will fire .38 rounds.</span>")
+
+	switch(magazine.caliber)
+		if(CALIBER_38)
+			magazine.caliber = CALIBER_357
+			fire_sound = 'sound/weapons/gun/revolver/shot_alt.ogg'
+			desc = "A classic, if not outdated, law enforcement firearm. \nIt has been modified to fire .357 rounds."
+			to_chat(user, "<span class='notice'>You loosen the barrel of [src]. Now it will fire .357 rounds.</span>")
+		else
+			magazine.caliber = CALIBER_38
+			fire_sound = 'sound/weapons/gun/revolver/shot.ogg'
+			desc = initial(desc)
+			to_chat(user, "<span class='notice'>You tighten the barrel of [src]. Now it will fire .38 rounds.</span>")
 
 
 /obj/item/gun/ballistic/revolver/mateba

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -126,13 +126,13 @@
 		return TRUE
 
 	switch(magazine.caliber)
-		if(CALIBER_38)
-			magazine.caliber = CALIBER_357
+		if(CALIBER_BALLISTIC_LIGHT)
+			magazine.caliber = CALIBER_BALLISTIC_MEDIUM
 			fire_sound = 'sound/weapons/gun/revolver/shot_alt.ogg'
 			desc = "A classic, if not outdated, law enforcement firearm. \nIt has been modified to fire .357 rounds."
 			to_chat(user, "<span class='notice'>You loosen the barrel of [src]. Now it will fire .357 rounds.</span>")
 		else
-			magazine.caliber = CALIBER_38
+			magazine.caliber = CALIBER_BALLISTIC_LIGHT
 			fire_sound = 'sound/weapons/gun/revolver/shot.ogg'
 			desc = initial(desc)
 			to_chat(user, "<span class='notice'>You tighten the barrel of [src]. Now it will fire .38 rounds.</span>")

--- a/code/modules/projectiles/guns/misc/bow.dm
+++ b/code/modules/projectiles/guns/misc/bow.dm
@@ -67,7 +67,7 @@
 	ammo_type = /obj/item/ammo_casing/caseless/arrow
 	max_ammo = 1
 	start_empty = TRUE
-	caliber = "arrow"
+	caliber = CALIBER_ARROW
 
 /obj/item/ammo_casing/caseless/arrow
 	name = "arrow"
@@ -77,7 +77,7 @@
 	throwforce = 1
 	projectile_type = /obj/projectile/bullet/reusable/arrow
 	firing_effect_type = null
-	caliber = "arrow"
+	caliber = CALIBER_ARROW
 	heavy_metal = FALSE
 
 /obj/item/ammo_casing/caseless/arrow/despawning/dropped()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pairs down most of the bullet calibers into light, medium, and heavy. There were a lot of them that were only used for one or two guns.

<details>
<summary>Summary of bullet calibers:</summary>

- Light Caliber Ballistic: Small bullets. Used by most automatic pistols and SMGs.
  - 9mm: Used by the Saber SMG, Uzi, stechkin, and the other syndicate pistol.
  - 9x19mm: Exclusive to the plastikov SMG.
  - 10mm: Exclusive to the surplus rifle
  - 7.12x82mm: Exclusive to the L6-SAW
  - 4.6x30mm: Exclusive to the security auto-rifle
  - .38: Used by the detective's revolver.
  - n762: Used by one of the russian revolver variants.
- Medium Caliber Ballistic: Midsized bullets. Used by a variety of guns.
  - .357: Used by the majority of the revolvers.
  - .45: Used by the C20-r SMG, tommygun, and M1911 pistol.
  - a556: Used by the M-90gl carbine and NT-ARG 'boarder'
  - a762: Used by bolt action rifles.
- Heavy Caliber Ballistic: Big bullets. Used by the sniper rifles and desert eagle. Basically a rename of the .50.
- Shotgun: Shotgun shells. Used by shotguns. Unchanged.
- Grenade: Grenades and bulky explosive rounds. Used by grenade launchers and the gyrojet pistol.
  - 40mm: Used by the grenade launchers.
  - .75: Exclusive to the gyrojet pistol.
- Rocket: Used by the rocket launcher. Basically a rename of the 84mm.
- Laser: Disposable laser cartridges. Used by the laser guns and laser minigun.
  - Laser: Used by laser guns.
  - Gatling: Used by the laser minigun. Folded into normal lasers.
- Energy: Energy lenses and emitters. Used by energy guns. Unchanged.
- Foam: Foam darts. Used by foam force and donksoft toy guns.  Unchanged.
- Arrow: Arrows. Exclusive to the bow. Unchanged.
- Harpoon: Harpoons. Exclusive to the harpoon gun. Unchanged.
- Hook: Meat hooks. Exclusive to the meat hook. Unchanged.
- Tentacle: Tentacles. Exclusive to the changeling's tentacle arm mutation. Unchanged
</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

NOTE: _I have zero sense of game balance. Help._

## Why It's Good For The Game
- Crunches 24 calibers (16 ballistic) down to 13 calibers (6 ballistic).
- Ammo can be shared between guns. (Not sure if this is an upside or a downside honestly)
- People have been asking for this for a while.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Bullet calibers have recently been standardized. Some guns are now fully capable of sharing ammunition with other guns.
code: Ballistic bullet calibers have been reduced to `LIGHT`, `MEDIUM`, `HEAVY`, and `SHOTGUN`.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
