### PR TITLE
removes some unnecessary code from Oztek boomerangs

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -320,13 +320,6 @@
 	convertible = FALSE
 	custom_materials = list(/datum/material/iron = 10000, /datum/material/glass = 4000, /datum/material/silver = 10000, /datum/material/gold = 2000)
 
-/obj/item/melee/baton/boomerang/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, gentle = FALSE, quickstart = TRUE)
-	if(turned_on)
-		if(ishuman(thrower))
-			var/mob/living/carbon/human/H = thrower
-			H.throw_mode_off() //so they can catch it on the return.
-	return ..()
-
 /obj/item/melee/baton/boomerang/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(turned_on)
 		var/caught = hit_atom.hitby(src, FALSE, FALSE, throwingdatum=throwingdatum)


### PR DESCRIPTION
## About The Pull Request

Removes a section of code from Oztek boomerangs that is supposed to turn your throw mode off after you throw them.

## Why It's Good For The Game

Throw mode already toggles itself off after you throw something.

## Changelog
:cl: ATHATH
del: Some redundant code from Oztek boomerangs has been removed. This should have pretty much no gameplay effect.
/:cl: