### PR TITLE
cyborg disablers and cyborg t*sers are now emp-proof like the other cyborg-mounted energy-based guns are

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -29,6 +29,9 @@
 	can_charge = FALSE
 	use_cyborg_cell = TRUE
 
+/obj/item/gun/energy/e_gun/advtaser/cyborg/emp_act()
+	return
+
 /obj/item/gun/energy/disabler
 	name = "disabler"
 	desc = "A self-defense weapon that exhausts organic targets, weakening them until they collapse."
@@ -45,3 +48,6 @@
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
 	can_charge = FALSE
 	use_cyborg_cell = TRUE
+
+/obj/item/gun/energy/disabler/cyborg/emp_act()
+	return


### PR DESCRIPTION
## About The Pull Request

See the title.

## Why It's Good For The Game

Previously, if a secborg was hit by an EMP, the charge of its disabler's cell would be reduced independently of the secborg's cell. If the charge of the disabler's cell fell below the required amount of energy to fire a single shot, then the secborg would be rendered permanently unable to use its disabler unless it got a module change. Cyborg rechargers would only recharge the secborg's cell, not the cell of the secborg's disabler, and energy weapons with use_cyborg_cell = TRUE still check to see if they have enough charge in their own cell to fire a shot before firing (for some reason).

I considered using EMP_PROTECT_CONTENTS for this, but the other cyborg energy guns (cyborg laser guns and assault cyborg smgs) both just override emp_act(), so I went with the latter option for consistency/safety.

## Changelog
:cl: ATHATH
fix: Repeated EMPs should no longer render a secborg's disabler permanently unusable.
/:cl: