### PR TITLE
The return of standard cyborgs (sort of)

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -66,8 +66,6 @@
 
 /datum/config_entry/flag/disable_peaceborg		// removes the peacekeeper model from the list of models that cyborgs can turn into.
 
-/datum/config_entry/flag/disable_standardborg	// removes the standard model from the list of models that cyborgs can turn into.
-
 /datum/config_entry/flag/disable_warops
 
 /datum/config_entry/number/traitor_scaling_coeff	//how much does the amount of players get divided by to determine traitors

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -62,9 +62,11 @@
 
 /datum/config_entry/flag/disable_human_mood
 
-/datum/config_entry/flag/disable_secborg	// disallow secborg model to be chosen.
+/datum/config_entry/flag/disable_secborg		// removes the security model from the list of models that cyborgs can turn into.
 
-/datum/config_entry/flag/disable_peaceborg
+/datum/config_entry/flag/disable_peaceborg		// removes the peacekeeper model from the list of models that cyborgs can turn into.
+
+/datum/config_entry/flag/disable_standardborg	// removes the standard model from the list of models that cyborgs can turn into.
 
 /datum/config_entry/flag/disable_warops
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -677,7 +677,7 @@
 	name = "borg model picker (Standard)"
 	desc = "Allows you to to turn a cyborg into a standard cyborg."
 	icon_state = "cyborg_upgrade3"
-	var/obj/item/robot_model/new_model = /obj/item/robot_module/standard
+	var/obj/item/robot_model/new_model = /obj/item/robot_model/standard
 
 /obj/item/borg/upgrade/transform/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -677,7 +677,7 @@
 	name = "borg model picker (Standard)"
 	desc = "Allows you to to turn a cyborg into a standard cyborg."
 	icon_state = "cyborg_upgrade3"
-	var/obj/item/robot_model/new_model = null
+	var/obj/item/robot_model/new_model = /obj/item/robot_module/standard
 
 /obj/item/borg/upgrade/transform/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -65,13 +65,11 @@
 
 /obj/item/pickaxe/cyborg
 	name = "cyborg pickaxe"
-	desc = "An integrated pickaxe."
+	desc = "I used to rule the world..."
 
 /obj/item/pickaxe/cyborg/Initialize()
 	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CYBORG_ITEM_TRAIT)
-	if(CONFIG_GET(flag/disable_standardborg)) //rip
-		desc = "I used to rule the world..."
+	ADD_TRAIT(src, TRAIT_NODROP, CYBORG_ITEM_TRAIT)	
 
 /obj/item/pickaxe/drill
 	name = "mining drill"

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -63,6 +63,16 @@
 	desc = "A pickaxe with a diamond pick head. Extremely robust at cracking rock walls and digging up dirt."
 	force = 19
 
+/obj/item/pickaxe/cyborg
+	name = "cyborg pickaxe"
+	desc = "An integrated pickaxe."
+
+/obj/item/pickaxe/cyborg/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, CYBORG_ITEM_TRAIT)
+	if(CONFIG_GET(flag/disable_standardborg)) //rip
+		desc = "I used to rule the world..."
+
 /obj/item/pickaxe/drill
 	name = "mining drill"
 	icon_state = "handdrill"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -146,6 +146,8 @@
 		model_list["Peacekeeper"] = /obj/item/robot_model/peacekeeper
 	if(!CONFIG_GET(flag/disable_secborg))
 		model_list["Security"] = /obj/item/robot_model/security
+	if(!CONFIG_GET(flag/disable_standardborg))
+		model_list["Standard"] = /obj/item/robot_model/standard
 
 	var/input_model = input("Please, select a model!", "Robot", null, null) as null|anything in sortList(model_list)
 	if(!input_model || model.type != /obj/item/robot_model)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -146,8 +146,6 @@
 		model_list["Peacekeeper"] = /obj/item/robot_model/peacekeeper
 	if(!CONFIG_GET(flag/disable_secborg))
 		model_list["Security"] = /obj/item/robot_model/security
-	if(!CONFIG_GET(flag/disable_standardborg))
-		model_list["Standard"] = /obj/item/robot_model/standard
 
 	var/input_model = input("Please, select a model!", "Robot", null, null) as null|anything in sortList(model_list)
 	if(!input_model || model.type != /obj/item/robot_model)

--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -199,6 +199,11 @@
 	set_model = /obj/item/robot_model/service
 	icon_state = "brobot"
 
+// --------------------- Standard
+/mob/living/silicon/robot/model/standard
+	set_model = /obj/item/robot_model/standard
+	icon_state = "robot" //redundant, but here anyway for clarity
+
 // ------------------------------------------ Syndie borgs
 // --------------------- Syndicate Assault
 /mob/living/silicon/robot/model/syndicate

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -513,6 +513,29 @@
 			return FALSE
 	return ..()
 
+// --------------------- Standard
+/obj/item/robot_model/standard
+	name = "Standard"
+	basic_modules = list(
+		/obj/item/assembly/flash/cyborg,
+		/obj/item/reagent_containers/borghypo/epi,
+		/obj/item/healthanalyzer,
+		/obj/item/weldingtool/largetank/cyborg,
+		/obj/item/wrench/cyborg,
+		/obj/item/crowbar/cyborg,
+		/obj/item/stack/sheet/metal/cyborg,
+		/obj/item/stack/rods/cyborg,
+		/obj/item/stack/tile/plasteel/cyborg,
+		/obj/item/extinguisher,
+		/obj/item/pickaxe/cyborg,
+		/obj/item/t_scanner/adv_mining_scanner,
+		/obj/item/restraints/handcuffs/cable/zipties,
+		/obj/item/soap/nanotrasen,
+		/obj/item/borg/cyborghug)
+	emag_modules = list(/obj/item/melee/transforming/energy/sword/cyborg)
+	moduleselect_icon = "standard"
+	hat_offset = -3
+
 // ------------------------------------------ Syndicate
 // --------------------- Syndicate Assault
 /obj/item/robot_model/syndicate

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -523,9 +523,9 @@
 		/obj/item/weldingtool/largetank/cyborg,
 		/obj/item/wrench/cyborg,
 		/obj/item/crowbar/cyborg,
-		/obj/item/stack/sheet/metal/cyborg,
+		/obj/item/stack/sheet/metal,
 		/obj/item/stack/rods/cyborg,
-		/obj/item/stack/tile/plasteel/cyborg,
+		/obj/item/stack/tile/plasteel,
 		/obj/item/extinguisher,
 		/obj/item/pickaxe/cyborg,
 		/obj/item/t_scanner/adv_mining_scanner,
@@ -533,7 +533,7 @@
 		/obj/item/soap/nanotrasen,
 		/obj/item/borg/cyborghug)
 	emag_modules = list(/obj/item/melee/transforming/energy/sword/cyborg)
-	moduleselect_icon = "standard"
+	model_select_icon = "standard"
 	hat_offset = -3
 
 // ------------------------------------------ Syndicate

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -278,7 +278,7 @@ DISABLE_SECBORG
 
 ## Standard Borg ###
 ## Uncomment to prevent the standard cyborg model from being chosen
-DISABLE_STANDARDBORG
+#DISABLE_STANDARDBORG
 
 ## AWAY MISSIONS ###
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -276,10 +276,6 @@ DISABLE_SECBORG
 ## Uncomment to prevent the peacekeeper cyborg model from being chosen
 #DISABLE_PEACEBORG
 
-## Standard Borg ###
-## Uncomment to prevent the standard cyborg model from being chosen
-DISABLE_STANDARDBORG
-
 ## AWAY MISSIONS ###
 
 ## Uncomment to load the virtual reality hub map

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -270,11 +270,15 @@ ALLOW_AI_MULTICAM
 
 ## Secborg ###
 ## Uncomment to prevent the security cyborg model from being chosen
-#DISABLE_SECBORG
+DISABLE_SECBORG
 
 ## Peacekeeper Borg ###
 ## Uncomment to prevent the peacekeeper cyborg model from being chosen
 #DISABLE_PEACEBORG
+
+## Standard Borg ###
+## Uncomment to prevent the standard cyborg model from being chosen
+DISABLE_STANDARDBORG
 
 ## AWAY MISSIONS ###
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -278,7 +278,7 @@ DISABLE_SECBORG
 
 ## Standard Borg ###
 ## Uncomment to prevent the standard cyborg model from being chosen
-#DISABLE_STANDARDBORG
+DISABLE_STANDARDBORG
 
 ## AWAY MISSIONS ###
 


### PR DESCRIPTION
## About The Pull Request

Reverts https://github.com/tgstation/tgstation/pull/53276, **but makes standard cyborgs admin-only**. The standard model has been updated to fit the current cyborg mechanics.

Changes the default state of the configuration option for disabling the secborg module to uncommented, meaning that **under the default configuration settings, the security model cannot be selected.** This is to reflect the fact that our actual servers have had secborgs disabled for years and that this is the expected state for this configuration option. **If the maintainers or the headmins desire it, I can atomize this into its own PR.**

The pickaxes of standard cyborgs are now a subtype (with a special description) that has TRAIT_NODROP like the drills of mining cyborgs do.

## Why It's Good For The Game

Admins might want to spawn in standard cyborgs in for TC trades, sentimental reasons, jokes, history lessons, etc., like they currently do sometimes with secborgs.

Private server owners who don't know how to code or how to update the standard model to the current cyborg mechanics might wish to readd standard cyborgs to their server(s).

Standard cyborgs do not require much effort to maintain, as their only unique modules are their epinephrine injectors (which are subtypes of the ones used by mediborgs) and their pickaxes (which I've updated in this PR, and which can be replaced by the mining cyborg's drill in the future if necessary).

Standard cyborgs are a piece of our server's history, and I'd rather not see them be swept under the rug.

## Changelog
:cl:
add: Standard cyborgs have been readded to the game, but are now admin-only.
tweak: The default config settings now disable secborgs from being chosen, to better reflect the config settings that our servers have been operating under for years.
tweak: The standard cyborg's pickaxe now has its own description (and its own name) and TRAIT_NODROP.
/:cl: