### PR TITLE
Adds Extrovert and Introvert Quirks

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -347,6 +347,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_SNOB				"snob"
 #define TRAIT_BALD				"bald"
 #define TRAIT_BADTOUCH			"bad_touch"
+#define TRAIT_EXTROVERT			"extrovert"
+#define TRAIT_INTROVERT			"introvert"
 ///Trait for dryable items
 #define TRAIT_DRYABLE "trait_dryable"
 ///Trait for dried items

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -26,7 +26,8 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 							list("Ananas Affinity","Ananas Aversion"), \
 							list("Alcohol Tolerance","Light Drinker"), \
 							list("Clown Fan","Mime Fan"), \
-							list("Bad Touch", "Friendly"))
+							list("Bad Touch", "Friendly"), \
+							list("Extrovert", "Introvert"))
 	return ..()
 
 /datum/controller/subsystem/processing/quirks/proc/SetupQuirks()

--- a/code/datums/quirks/good.dm
+++ b/code/datums/quirks/good.dm
@@ -59,15 +59,6 @@
 	lose_text = "<span class='danger'>You feel isolated from others.</span>"
 	medical_record_text = "Patient is highly perceptive of and sensitive to social cues, or may possibly have ESP. Further testing needed."
 
-/datum/quirk/extrovert
-	name = "Extrovert"
-	desc = "You are energized by talking to others, and enjoy spending your free time in the bar."
-	value = 1
-	mob_trait = TRAIT_EXTROVERT
-	gain_text = "<span class='notice'>You feel like hanging out with other people.</span>"
-	lose_text = "<span class='danger'>You feel like you're over the bar scene.</span>"
-	medical_record_text = "Patient will not shut the hell up."
-
 /datum/quirk/fan_clown
 	name = "Clown Fan"
 	desc = "You enjoy clown antics and get a mood boost from wearing your clown pin."
@@ -126,15 +117,6 @@
 	lose_text = "<span class='danger'>You no longer feel compelled to hug others.</span>"
 	mood_quirk = TRUE
 	medical_record_text = "Patient demonstrates low-inhibitions for physical contact and well-developed arms. Requesting another doctor take over this case."
-
-/datum/quirk/introvert
-	name = "Introvert"
-	desc = "You are energized by having time to yourself, and enjoy spending your free time in the library."
-	value = 1
-	mob_trait = TRAIT_INTROVERT
-	gain_text = "<span class='notice'>You feel like reading a good book quietly.</span>"
-	lose_text = "<span class='danger'>You feel like libraries are boring.</span>"
-	medical_record_text = "Patient doesn't seem to say much."
 
 /datum/quirk/jolly
 	name = "Jolly"

--- a/code/datums/quirks/good.dm
+++ b/code/datums/quirks/good.dm
@@ -59,6 +59,15 @@
 	lose_text = "<span class='danger'>You feel isolated from others.</span>"
 	medical_record_text = "Patient is highly perceptive of and sensitive to social cues, or may possibly have ESP. Further testing needed."
 
+/datum/quirk/extrovert
+	name = "Extrovert"
+	desc = "You are energized by talking to others, and enjoy spending your free time in the bar."
+	value = 1
+	mob_trait = TRAIT_EXTROVERT
+	gain_text = "<span class='notice'>You feel like hanging out with other people.</span>"
+	lose_text = "<span class='danger'>You feel like you're over the bar scene.</span>"
+	medical_record_text = "Patient will not shut the hell up."
+
 /datum/quirk/fan_clown
 	name = "Clown Fan"
 	desc = "You enjoy clown antics and get a mood boost from wearing your clown pin."
@@ -117,6 +126,15 @@
 	lose_text = "<span class='danger'>You no longer feel compelled to hug others.</span>"
 	mood_quirk = TRUE
 	medical_record_text = "Patient demonstrates low-inhibitions for physical contact and well-developed arms. Requesting another doctor take over this case."
+
+/datum/quirk/introvert
+	name = "Introvert"
+	desc = "You are energized by having time to yourself, and enjoy spending your free time in the library."
+	value = 1
+	mob_trait = TRAIT_INTROVERT
+	gain_text = "<span class='notice'>You feel like reading a good book quietly.</span>"
+	lose_text = "<span class='danger'>You feel like libraries are boring.</span>"
+	medical_record_text = "Patient doesn't seem to say much."
 
 /datum/quirk/jolly
 	name = "Jolly"

--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -1,6 +1,24 @@
 //traits with no real impact that can be taken freely
 //MAKE SURE THESE DO NOT MAJORLY IMPACT GAMEPLAY. those should be positive or negative traits.
 
+/datum/quirk/extrovert
+	name = "Extrovert"
+	desc = "You are energized by talking to others, and enjoy spending your free time in the bar."
+	value = 0
+	mob_trait = TRAIT_EXTROVERT
+	gain_text = "<span class='notice'>You feel like hanging out with other people.</span>"
+	lose_text = "<span class='danger'>You feel like you're over the bar scene.</span>"
+	medical_record_text = "Patient will not shut the hell up."
+
+/datum/quirk/introvert
+	name = "Introvert"
+	desc = "You are energized by having time to yourself, and enjoy spending your free time in the library."
+	value = 0
+	mob_trait = TRAIT_INTROVERT
+	gain_text = "<span class='notice'>You feel like reading a good book quietly.</span>"
+	lose_text = "<span class='danger'>You feel like libraries are boring.</span>"
+	medical_record_text = "Patient doesn't seem to say much."
+
 /datum/quirk/no_taste
 	name = "Ageusia"
 	desc = "You can't taste anything! Toxic food will still poison you."

--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -472,6 +472,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "bar"
 	mood_bonus = 5
 	mood_message = "<span class='nicegreen'>I love being in the bar!\n</span>"
+	mood_trait = TRAIT_EXTROVERT
 	airlock_wires = /datum/wires/airlock/service
 	sound_environment = SOUND_AREA_WOODFLOOR
 
@@ -503,6 +504,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/library
 	name = "Library"
 	icon_state = "library"
+	mood_bonus = 5
+	mood_message = "I love being in the library!"
+	mood_trait = TRAIT_INTROVERT
 	flags_1 = CULT_PERMITTED_1
 	sound_environment = SOUND_AREA_LARGE_SOFTFLOOR
 

--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -505,7 +505,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Library"
 	icon_state = "library"
 	mood_bonus = 5
-	mood_message = "I love being in the library!"
+	mood_message = "<span class='nicegreen'>I love being in the library!</span>\n"
 	mood_trait = TRAIT_INTROVERT
 	flags_1 = CULT_PERMITTED_1
 	sound_environment = SOUND_AREA_LARGE_SOFTFLOOR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Extrovert and Introvert quirks. Removes the free bar moodlet, gives it to extroverts, makes a corresponding library moodlet for introverts. _Introvert and Extrovert are blacklisted and therefore mutually exclusive._

**Seems a bit thin, could we do `x`?**
Yeah sure, and I'd appreciate feedback on where you'd like to see these quirks go. I want to start basic with "where do they spend their free time?" Rather than trying to do something big like moodlets for speaking a lot/little, especially because that seems a *bit* unbalanced and we already have a quirk that penalizes speech. I'm also looking to avoid unrealistic stereotypes, speech penalties to introverts are kind of unreasonable, introverts aren't inherently bad at talking, they just like alone time.

**Why make it free?**
I'm taking away a pre-existing moodlet that was free for everyone, _also_ positive quirks are capped at 6 and I see this quirk as being essential to character building so I would prefer not to make someone pick between giving any sort of depth to their character and their powergaming loadout.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having players define their character as introverted or extroverted and reinforcing the decision through gameplay mechanics is a great way to get them thinking about their character beyond an avatar to make other spacemen horizontal with. I'd argue that it is as foundational as decisions like gender, species, and age. 
This opens up the library as a social space, as the two people who take introvert might occasionally run into each other when they are recovering mood and sanity there.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Extrovert and Introvert quirks, they add mood bonuses to the bar and library, respectively.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
