### PR TITLE
makes movement reset tolerance less harsh on jousting component, adds keycheck to mob riding

### DIFF
--- a/code/datums/components/jousting.dm
+++ b/code/datums/components/jousting.dm
@@ -12,7 +12,6 @@
 	var/mounted_knockdown_time = 20
 	var/requires_mob_riding = TRUE			//whether this only works if the attacker is riding a mob, rather than anything they can buckle to.
 	var/requires_mount = TRUE				//kinda defeats the point of jousting if you're not mounted but whatever.
-	var/active = TRUE
 	var/mob/current_holder
 	var/current_timerid
 

--- a/code/datums/components/jousting.dm
+++ b/code/datums/components/jousting.dm
@@ -22,7 +22,6 @@
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/on_drop)
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK, .proc/on_attack)
-	RegisterSignal(parent, COMSIG_MELEE_TRANSFORM, .proc/on_transform)
 
 /datum/component/jousting/proc/on_equip(datum/source, mob/user, slot)
 	SIGNAL_HANDLER

--- a/code/datums/components/jousting.dm
+++ b/code/datums/components/jousting.dm
@@ -3,7 +3,7 @@
 	var/max_tile_charge = 5
 	var/min_tile_charge = 2				//tiles before this code gets into effect.
 	var/current_tile_charge = 0
-	var/movement_reset_tolerance = 2			//deciseconds
+	var/movement_reset_tolerance = 3			//deciseconds
 	var/unmounted_damage_boost_per_tile = 0
 	var/unmounted_knockdown_chance_per_tile = 0
 	var/unmounted_knockdown_time = 0
@@ -12,6 +12,7 @@
 	var/mounted_knockdown_time = 20
 	var/requires_mob_riding = TRUE			//whether this only works if the attacker is riding a mob, rather than anything they can buckle to.
 	var/requires_mount = TRUE				//kinda defeats the point of jousting if you're not mounted but whatever.
+	var/active = TRUE
 	var/mob/current_holder
 	var/current_timerid
 
@@ -21,6 +22,7 @@
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/on_drop)
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK, .proc/on_attack)
+	RegisterSignal(parent, COMSIG_MELEE_TRANSFORM, .proc/on_transform)
 
 /datum/component/jousting/proc/on_equip(datum/source, mob/user, slot)
 	SIGNAL_HANDLER

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -79,7 +79,9 @@
 	if(!COOLDOWN_FINISHED(src, vehicle_move_cooldown))
 		return COMPONENT_DRIVER_BLOCK_MOVE
 	if(!keycheck(user))
-		to_chat(user, "<span class='warning'>You need a [initial(keytype.name)] to ride [movable_parent]!</span>")
+		if(ispath(keytype, /obj/item))
+			var/obj/item/key = keytype
+			to_chat(user, "<span class='warning'>You need a [initial(key.name)] to ride [movable_parent]!</span>")
 		return COMPONENT_DRIVER_BLOCK_MOVE
 	var/mob/living/living_parent = parent
 	var/turf/next = get_step(living_parent, direction)

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -78,7 +78,9 @@
 /datum/component/riding/creature/driver_move(atom/movable/movable_parent, mob/living/user, direction)
 	if(!COOLDOWN_FINISHED(src, vehicle_move_cooldown))
 		return COMPONENT_DRIVER_BLOCK_MOVE
-
+	if(!keycheck(user))
+		to_chat(user, "<span class='warning'>You need a [initial(keytype.name)] to ride [movable_parent]!</span>")
+		return COMPONENT_DRIVER_BLOCK_MOVE
 	var/mob/living/living_parent = parent
 	var/turf/next = get_step(living_parent, direction)
 	step(living_parent, direction)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -232,7 +232,9 @@
 /mob/living/simple_animal/attackby(obj/item/O, mob/user, params)
 	if(!is_type_in_list(O, food_type))
 		return ..()
-
+	if(stat == DEAD)
+		to_chat(user, "<span class='warning'>[capitalize(src)] is dead!</span>")
+		return
 	user.visible_message("<span class='notice'>[user] hand-feeds [O] to [src].</span>", "<span class='notice'>You hand-feed [O] to [src].</span>")
 	qdel(O)
 	if(tame)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
the current tolerance on jousting is 2 deciseconds not enough to do fun stuff with any of the mobs you can ride on station like cows or goliaths, this is now 3
mob riding never had a keycheck so u could ride goliaths without a lasso and stuff like that

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
fun and fix

## Changelog
:cl:
tweak: you can now joust with friends on ridden animals, not just borgs anymore! to joust have a spear in one of your hands, ride a mob of some kind and you can knock other people off the mobs they are riding!
fix: you can no longer ride goliaths without a lasso
fix: you can no longer feed dead mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
