### PR TITLE
Vend-A-Trays can be moved onto tables.

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -389,6 +389,7 @@
 	req_access = null
 	alert = FALSE //No, we're not calling the fire department because someone stole your cookie.
 	glass_fix = FALSE //Fixable with tools instead.
+	pass_flags = PASSTABLE ///Can be placed and moved onto a table.
 	///The price of the item being sold. Altered by grab intent ID use.
 	var/sale_price = 20
 	///The Account which will receive payment for purchases. Set by the first ID to swipe the tray.


### PR DESCRIPTION

## About The Pull Request

Vend a trays are mapped onto kitchen tables and bar counters. They can't be moved back onto the table with deconstructing the table. This gives them the table passflag, allowing them to be just moved back onto the tabletop.

## Why It's Good For The Game

Illegal mapping positions are bad, legal can_pass adjustment is a quick and easy fix.

## Changelog
:cl:
fix: Vend A Trays can now be moved onto and off of tables.
/:cl:
