### PR TITLE
Refactor radiation emitted by uranium walls, floors

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -1006,3 +1006,6 @@
 #define COMSIG_AQUARIUM_BEFORE_INSERT_CHECK "aquarium_about_to_be_inserted"
 #define COMSIG_AQUARIUM_SURFACE_CHANGED "aquarium_surface_changed"
 #define COMSIG_AQUARIUM_FLUID_CHANGED "aquarium_fluid_changed"
+
+// Signals used by radiation ripple component, to trigger adjacent turfs.
+#define COMSIG_RADIATION_RIPPLE_TRIGGER "radiation_ripple_trigger"

--- a/code/datums/components/radiation_ripple.dm
+++ b/code/datums/components/radiation_ripple.dm
@@ -1,0 +1,37 @@
+/* Various forms of radioactive structures, like uranium walls and floors
+ * do not actively emit radiation, unless interacted with. In which case
+ * they then trigger a radiation pulse which then ripples across all
+ * adjacent turfs, which may then activate THOSE to pulse and so on.
+ */
+#define RADIATION_EVENT_COOLDOWN 1.5 SECONDS
+
+/datum/component/radiation_ripple
+	/// Strength of radiation pulse when triggered
+	var/strength
+
+	COOLDOWN_DECLARE(last_event)
+	var/active = FALSE
+
+/datum/component/radiation_ripple/Initialize(signal_or_siglist, strength = 150)
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	src.strength = strength
+
+	RegisterSignal(parent, signal_or_siglist, .proc/trigger)
+	RegisterSignal(parent, COMSIG_RADIATION_RIPPLE_TRIGGER, .proc/trigger)
+
+/datum/component/radiation_ripple/proc/trigger()
+	if(active || !COOLDOWN_FINISHED(src, last_event))
+		return
+
+	active = TRUE
+	radiation_pulse(parent, strength)
+
+	for(var/atom/A in orange(1, parent))
+		SEND_SIGNAL(A, COMSIG_RADIATION_RIPPLE_TRIGGER)
+
+	COOLDOWN_START(src, last_event, RADIATION_EVENT_COOLDOWN)
+	active = FALSE
+
+#undef RADIATION_EVENT_COOLDOWN

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -164,28 +164,11 @@
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_WALLS, SMOOTH_GROUP_URANIUM_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_URANIUM_WALLS)
-	var/active = null
-	var/last_event = 0
 
-/obj/structure/falsewall/uranium/attackby(obj/item/W, mob/user, params)
-	radiate()
-	return ..()
-
-/obj/structure/falsewall/uranium/attack_hand(mob/user)
-	radiate()
+/obj/structure/falsewall/uranium/Initialize()
 	. = ..()
+	AddComponent(/datum/component/radiation_ripple, list(COMSIG_PARENT_ATTACKBY, COMSIG_MOB_ATTACK_HAND), strength = 150)
 
-/obj/structure/falsewall/uranium/proc/radiate()
-	if(!active)
-		if(world.time > last_event+15)
-			active = 1
-			radiation_pulse(src, 150)
-			for(var/turf/closed/wall/mineral/uranium/T in orange(1,src))
-				T.radiate()
-			last_event = world.time
-			active = null
-			return
-	return
 /*
  * Other misc falsewall types
  */

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -80,29 +80,9 @@
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_URANIUM_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_URANIUM_WALLS)
 
-/turf/closed/wall/mineral/uranium/proc/radiate()
-	if(!active)
-		if(world.time > last_event+15)
-			active = 1
-			radiation_pulse(src, 40)
-			for(var/turf/closed/wall/mineral/uranium/T in orange(1,src))
-				T.radiate()
-			last_event = world.time
-			active = null
-			return
-	return
-
-/turf/closed/wall/mineral/uranium/attack_hand(mob/user)
-	radiate()
+/turf/closed/wall/mineral/uranium/Initialize()
 	. = ..()
-
-/turf/closed/wall/mineral/uranium/attackby(obj/item/W, mob/user, params)
-	radiate()
-	..()
-
-/turf/closed/wall/mineral/uranium/Bumped(atom/movable/AM)
-	radiate()
-	..()
+	AddComponent(/datum/component/radiation_ripple, list(COMSIG_MOB_ATTACK_HAND, COMSIG_PARENT_ATTACKBY, COMSIG_ATOM_BUMPED), strength = 40)
 
 /turf/closed/wall/mineral/uranium/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman, damage = 41)
 	return ..()

--- a/code/game/turfs/open/floor/mineral_floor.dm
+++ b/code/game/turfs/open/floor/mineral_floor.dm
@@ -251,37 +251,10 @@
 	var/last_event = 0
 	var/active = null
 
-/turf/open/floor/mineral/uranium/Entered(atom/movable/AM)
-	.=..()
-	if(!.)
-		if(ismob(AM))
-			radiate()
+/turf/open/floor/mineral/uranium/Initialize()
+	. = ..()
+	AddComponent(/datum/component/radiation_ripple, list(COMSIG_ATOM_ENTERED, COMSIG_PARENT_ATTACKBY, COMSIG_MOB_ATTACK_HAND, COMSIG_ATOM_ATTACK_PAW), strength = 10)
 
-/turf/open/floor/mineral/uranium/attackby(obj/item/W, mob/user, params)
-	.=..()
-	if(!.)
-		radiate()
-
-/turf/open/floor/mineral/uranium/attack_hand(mob/user)
-	.=..()
-	if(!.)
-		radiate()
-
-/turf/open/floor/mineral/uranium/attack_paw(mob/user)
-	.=..()
-	if(!.)
-		radiate()
-
-/turf/open/floor/mineral/uranium/proc/radiate()
-	if(!active)
-		if(world.time > last_event+15)
-			active = TRUE
-			radiation_pulse(src, 10)
-			for(var/turf/open/floor/mineral/uranium/T in orange(1,src))
-				T.radiate()
-			last_event = world.time
-			active = FALSE
-			return
 
 // ALIEN ALLOY
 /turf/open/floor/mineral/abductor

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -472,6 +472,7 @@
 #include "code\datums\components\pricetag.dm"
 #include "code\datums\components\projectile_shooter.dm"
 #include "code\datums\components\punchcooldown.dm"
+#include "code\datums\components\radiation_ripple.dm"
 #include "code\datums\components\radioactive.dm"
 #include "code\datums\components\religious_tool.dm"
 #include "code\datums\components\remote_materials.dm"


### PR DESCRIPTION
Radiation "ripples/pulses" emitted by floors and walls will now trigger
ripples/pulses in adjacent walls/floors, rather than just ones of the
same type.

Most of the triggering for the ripple is done with signals.