### PR TITLE
The Seed Extractor now vends into hands if possible

### DIFF
--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -190,11 +190,18 @@
 		if("select")
 			var/item = params["item"]
 			if(piles[item] && length(piles[item]) > 0)
-				var/datum/weakref/WO = piles[item][1]
-				var/obj/item/seeds/O = WO.resolve()
-				if(O)
-					piles[item] -= WO
-					O.forceMove(drop_location())
+				var/datum/weakref/found_seed_weakref = piles[item][1]
+				var/obj/item/seeds/found_seed = found_seed_weakref.resolve()
+				if(found_seed)
+					piles[item] -= found_seed_weakref
+					if(usr)
+						var/mob/user = usr
+						if(user.put_in_hands(found_seed))
+							to_chat(user, "<span class='notice'>[found_seed] drops into your hand.</span>")
+						else
+							to_chat(user, "<span class='notice'>[found_seed] drops onto the seed extractor.</span>")
+					else
+						found_seed.forceMove(drop_location())
+						visible_message("<span class='notice'>[found_seed] drops onto the floor.</span>", null, "<span class='hear'>You hear a soft clatter.</span>", COMBAT_MESSAGE_RANGE)
 					. = TRUE
-					//to_chat(usr, "<span class='notice'>[src] clanks to life briefly before vending [prize.equipment_name]!</span>")
 

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -192,16 +192,18 @@
 			if(piles[item] && length(piles[item]) > 0)
 				var/datum/weakref/found_seed_weakref = piles[item][1]
 				var/obj/item/seeds/found_seed = found_seed_weakref.resolve()
-				if(found_seed)
-					piles[item] -= found_seed_weakref
-					if(usr)
-						var/mob/user = usr
-						if(user.put_in_hands(found_seed))
-							to_chat(user, "<span class='notice'>You take \the [found_seed] out of the slot.</span>")
-						else
-							to_chat(user, "<span class='notice'>\The [found_seed] falls onto the floor.</span>")
+				if(!found_seed)
+					return
+
+				piles[item] -= found_seed_weakref
+				if(usr)
+					var/mob/user = usr
+					if(user.put_in_hands(found_seed))
+						to_chat(user, "<span class='notice'>You take [found_seed] out of the slot.</span>")
 					else
-						found_seed.forceMove(drop_location())
-						visible_message("<span class='notice'>[found_seed] falls onto the floor.</span>", null, "<span class='hear'>You hear a soft clatter.</span>", COMBAT_MESSAGE_RANGE)
-					. = TRUE
+						to_chat(user, "<span class='notice'>[found_seed] falls onto the floor.</span>")
+				else
+					found_seed.forceMove(drop_location())
+					visible_message("<span class='notice'>[found_seed] falls onto the floor.</span>", null, "<span class='hear'>You hear a soft clatter.</span>", COMBAT_MESSAGE_RANGE)
+				. = TRUE
 

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -197,11 +197,11 @@
 					if(usr)
 						var/mob/user = usr
 						if(user.put_in_hands(found_seed))
-							to_chat(user, "<span class='notice'>[found_seed] drops into your hand.</span>")
+							to_chat(user, "<span class='notice'>You take \the [found_seed] out of the slot.</span>")
 						else
-							to_chat(user, "<span class='notice'>[found_seed] drops onto the seed extractor.</span>")
+							to_chat(user, "<span class='notice'>\The [found_seed] falls onto the floor.</span>")
 					else
 						found_seed.forceMove(drop_location())
-						visible_message("<span class='notice'>[found_seed] drops onto the floor.</span>", null, "<span class='hear'>You hear a soft clatter.</span>", COMBAT_MESSAGE_RANGE)
+						visible_message("<span class='notice'>[found_seed] falls onto the floor.</span>", null, "<span class='hear'>You hear a soft clatter.</span>", COMBAT_MESSAGE_RANGE)
 					. = TRUE
 


### PR DESCRIPTION
## About The Pull Request

When vending seeds from botany's machine seed extractor, it will now try to place the chosen seeds into the user's hand or offhand first, before dropping it onto the ground.

Also removes a weird commented out to_chat message and gives it some more descriptive variables.

To clarify: Extracting seeds from a plant is unchanged. The only thing this adjusts is vending seeds from the machine.

## Why It's Good For The Game

Just like how the seed vendor drops seeds into your hand automatically, so does the seed extractor now, for consistency. 

## Changelog
:cl: Melbert
tweak: The seed extractor will now dispense seeds directly into hands first like vending machines.
/:cl:
