### PR TITLE
fixes is_blocked_turf from not working

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -187,11 +187,13 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		// We don't want to block ourselves or consider any ignored atoms.
 		if((content == source_atom) || (content in ignore_atoms))
 			continue
-
 		var/atom/atom_content = content
 		// If the thing is dense AND we're including mobs or the thing isn't a mob AND if there's a source atom and
-		// it cannot pass through the thing on the turf, we consider the turf blocked.
-		if(atom_content.density && (!exclude_mobs || !ismob(atom_content)) && (source_atom && !atom_content.CanPass(source_atom, src)))
+		// it cannot pass through the thing on the turf,  we consider the turf blocked.
+		if(atom_content.density && (!exclude_mobs || !ismob(atom_content)))
+			if(source_atom)
+				if(atom_content.CanPass(source_atom, src))
+					return FALSE
 			return TRUE
 	return FALSE
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -191,9 +191,8 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		// If the thing is dense AND we're including mobs or the thing isn't a mob AND if there's a source atom and
 		// it cannot pass through the thing on the turf,  we consider the turf blocked.
 		if(atom_content.density && (!exclude_mobs || !ismob(atom_content)))
-			if(source_atom)
-				if(atom_content.CanPass(source_atom, src))
-					return FALSE
+			if(source_atom && atom_content.CanPass(source_atom, src))
+				continue
 			return TRUE
 	return FALSE
 


### PR DESCRIPTION
:cl:
fix: is_blocked_turf no longer fails to do anything 
/:cl:

before: anything without source atom which is null by default, will return false even if atom on turf are dense
now: it works

fixes: #56370 