### PR TITLE
Nanite programs with triggers won't ignore rules

### DIFF
--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -223,6 +223,8 @@
 		return
 	if(world.time < next_trigger)
 		return
+	if(check_conditions())
+		return
 	if(!consume_nanites(trigger_cost))
 		return
 	next_trigger = world.time + trigger_cooldown

--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -223,7 +223,7 @@
 		return
 	if(world.time < next_trigger)
 		return
-	if(check_conditions())
+	if(!check_conditions())
 		return
 	if(!consume_nanites(trigger_cost))
 		return

--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -191,7 +191,7 @@
 		if(passive_enabled)
 			disable_passive_effect()
 
-//If false, disables active and passive effects, but doesn't consume nanites
+//If false, disables active, passive effects, and triggers without consuming nanites
 //Can be used to avoid consuming nanites for nothing
 /datum/nanite_program/proc/check_conditions()
 	for(var/R in rules)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The PR adds rule check to the Nanite program trigger function, which allows to forbid triggering when rules are assigned.

## Why It's Good For The Game

Trigger based programs, like Defibrillation ignore rules, even though you can add them, which is misleading. 
Now you can, for instance, make Defibrilation trigger only when you are dead by adding Death rule to Defibrilation program.


## Changelog
:cl:
fix: Nanite programs based on triggers don't ignore rules now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
