### PR TITLE
Added stamina and brain damage types to Nanite damage sensor

### DIFF
--- a/code/modules/research/nanites/nanite_programs/sensor.dm
+++ b/code/modules/research/nanites/nanite_programs/sensor.dm
@@ -184,7 +184,7 @@
 
 /datum/nanite_program/sensor/damage/register_extra_settings()
 	. = ..()
-	extra_settings[NES_DAMAGE_TYPE] = new /datum/nanite_extra_setting/type(BRUTE, list(BRUTE, BURN, TOX, OXY, CLONE))
+	extra_settings[NES_DAMAGE_TYPE] = new /datum/nanite_extra_setting/type(BRUTE, list(BRUTE, BURN, TOX, OXY, CLONE, STAMINA, BRAIN))
 	extra_settings[NES_DAMAGE] = new /datum/nanite_extra_setting/number(50, 0, 500)
 	extra_settings[NES_DIRECTION] = new /datum/nanite_extra_setting/boolean(TRUE, "Above", "Below")
 
@@ -206,6 +206,10 @@
 			damage_amt = host_mob.getOxyLoss()
 		if(CLONE)
 			damage_amt = host_mob.getCloneLoss()
+		if(STAMINA)
+			damage_amt = host_mob.getStaminaLoss()
+		if(BRAIN)
+			damage_amt = host_mob.getOrganLoss(ORGAN_SLOT_BRAIN)
 
 	if(check_above)
 		if(damage_amt >= damage.get_value())

--- a/code/modules/research/nanites/rules.dm
+++ b/code/modules/research/nanites/rules.dm
@@ -131,6 +131,10 @@
 			damage_amt = program.host_mob.getOxyLoss()
 		if(CLONE)
 			damage_amt = program.host_mob.getCloneLoss()
+		if(STAMINA)
+			damage_amt = program.host_mob.getStaminaLoss()
+		if(BRAIN)
+			damage_amt = program.host_mob.getOrganLoss(ORGAN_SLOT_BRAIN)
 
 	if(above)
 		if(damage_amt >= threshold)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added missing Stamina and Brain damage options to the Damage sensor Nanite program.

## Why It's Good For The Game

There are programs that heal Brain damage, but there was no way to detect that brain is damaged with Nanites. This is important, because there are cases when you don't want to bother with brain damage unless it leads to severe wounds (brain damage > 100)

Stamina damage sensor is useful to detect that the host is under attack with stamina damaging weapons. The Nerve Support program (Stun duration reduction) doesn't seem that useful without this sensor, as you usually don't want it to just run on the background.

## Changelog
:cl:
add: Extended Nanite damage sensor program with stamina and brain damage types
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
