### PR TITLE
Fixes a runtime in crate code due to the climbable element

### DIFF
--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -23,7 +23,7 @@
 	RegisterSignal(target, COMSIG_MOUSEDROPPED_ONTO, .proc/mousedrop_receive)
 	RegisterSignal(target, COMSIG_ATOM_BUMPED, .proc/try_speedrun)
 
-/datum/element/climbable/Detach(datum/target)
+/datum/element/climbable/Detach(datum/target, force)
 	UnregisterSignal(target, list(COMSIG_ATOM_ATTACK_HAND, COMSIG_PARENT_EXAMINE, COMSIG_MOUSEDROPPED_ONTO, COMSIG_ATOM_BUMPED))
 	return ..()
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -15,15 +15,17 @@
 	open_sound_volume = 35
 	close_sound_volume = 50
 	drag_slowdown = 0
-	var/climb_time = 20
+	var/crate_climb_time = 20
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 
 /obj/structure/closet/crate/Initialize()
 	. = ..()
 	if(icon_state == "[initial(icon_state)]open")
 		opened = TRUE
+		AddElement(/datum/element/climbable, climb_time = crate_climb_time * 0.5, climb_stun = 0)
+	else
+		AddElement(/datum/element/climbable, climb_time = crate_climb_time, climb_stun = 0)
 	update_icon()
-	AddElement(/datum/element/climbable, climb_time = opened ? climb_time : climb_time * 0.5, climb_stun = 0)
 
 /obj/structure/closet/crate/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
@@ -52,13 +54,13 @@
 
 /obj/structure/closet/crate/after_open(mob/living/user, force)
 	. = ..()
-	RemoveElement(/datum/element/climbable)
-	AddElement(/datum/element/climbable, climb_time = climb_time * 0.5, climb_stun = 0)
+	RemoveElement(/datum/element/climbable, climb_time = crate_climb_time, climb_stun = 0)
+	AddElement(/datum/element/climbable, climb_time = crate_climb_time * 0.5, climb_stun = 0)
 
-/obj/structure/closet/crate/after_close(mob/living/user)
+/obj/structure/closet/crate/after_close(mob/living/user, force)
 	. = ..()
-	RemoveElement(/datum/element/climbable)
-	AddElement(/datum/element/climbable, climb_time = climb_time, climb_stun = 0)
+	RemoveElement(/datum/element/climbable, climb_time = crate_climb_time * 0.5, climb_stun = 0)
+	AddElement(/datum/element/climbable, climb_time = crate_climb_time, climb_stun = 0)
 
 
 /obj/structure/closet/crate/open(mob/living/user, force = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a runtime when the crates open and close due to the element that they're trying to remove not actually being the element that crates initialize with.

## Why It's Good For The Game

ye

## Changelog
:cl:
fix: Fixes a runtime with crates climbable element.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
