### PR TITLE
Fixes emote runtime / changes how emotes work for ghosts

### DIFF
--- a/code/datums/components/manual_breathing.dm
+++ b/code/datums/components/manual_breathing.dm
@@ -8,7 +8,7 @@
 	var/check_every = 12 SECONDS
 	var/grace_period = 6 SECONDS
 	var/damage_rate = 1 // organ damage taken per tick
-	var/datum/emote/next_breath_type = /datum/emote/inhale
+	var/datum/emote/next_breath_type = /datum/emote/living/inhale
 
 /datum/component/manual_breathing/Initialize()
 	if(!iscarbon(parent))
@@ -90,10 +90,10 @@
 	SIGNAL_HANDLER
 
 	if(emote.type == next_breath_type)
-		if(next_breath_type == /datum/emote/inhale)
-			next_breath_type = /datum/emote/exhale
+		if(next_breath_type == /datum/emote/living/inhale)
+			next_breath_type = /datum/emote/living/exhale
 		else
-			next_breath_type = /datum/emote/inhale
+			next_breath_type = /datum/emote/living/inhale
 
 		warn_grace = FALSE
 		warn_dying = FALSE

--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -1,5 +1,5 @@
 /mob/dead/observer/check_emote(message, forced)
-	if(message == "*spin" || message == "*flip")
+	if(message[1] == "*")
 		emote(copytext(message, length(message[1]) + 1), intentional = !forced)
 		return TRUE
 

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -32,6 +32,36 @@
 		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
 	return FALSE
 
+/datum/emote/help
+	key = "help"
+	mob_type_ignore_stat_typecache = list(/mob/dead/observer, /mob/living/silicon/ai)
+
+/datum/emote/help/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	var/list/keys = list()
+	var/list/message = list("Available emotes, you can use them with say \"*emote\": ")
+
+	for(var/key in GLOB.emote_list)
+		for(var/datum/emote/P in GLOB.emote_list[key])
+			if(P.key in keys)
+				continue
+			if(P.can_run_emote(user, status_check = FALSE , intentional = TRUE))
+				keys += P.key
+
+	keys = sortList(keys)
+
+	for(var/emote in keys)
+		if(LAZYLEN(message) > 1)
+			message += ", [emote]"
+		else
+			message += "[emote]"
+
+	message += "."
+
+	message = jointext(message, "")
+
+	to_chat(user, message)
+
 /datum/emote/flip
 	key = "flip"
 	key_third_person = "flips"

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -49,17 +49,9 @@
 				keys += P.key
 
 	keys = sortList(keys)
-
-	for(var/emote in keys)
-		if(LAZYLEN(message) > 1)
-			message += ", [emote]"
-		else
-			message += "[emote]"
-
+	message += keys.Join(", ")
 	message += "."
-
-	message = jointext(message, "")
-
+	message = message.Join("")
 	to_chat(user, message)
 
 /datum/emote/flip

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -41,7 +41,7 @@
 	sound = 'sound/misc/knuckles.ogg'
 	cooldown = 6 SECONDS
 
-/datum/emote/living/carbon/crack/can_run_emote(var/mob/living/carbon/user, status_check = TRUE , intentional)
+/datum/emote/living/carbon/crack/can_run_emote(mob/living/carbon/user, status_check = TRUE , intentional)
 	if(!iscarbon(user) || user.usable_hands < 2)
 		return FALSE
 	return ..()

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -41,8 +41,8 @@
 	sound = 'sound/misc/knuckles.ogg'
 	cooldown = 6 SECONDS
 
-/datum/emote/living/carbon/crack/can_run_emote(mob/living/carbon/user, status_check = TRUE , intentional)
-	if(user.usable_hands < 2)
+/datum/emote/living/carbon/crack/can_run_emote(var/mob/living/carbon/user, status_check = TRUE , intentional)
+	if(!iscarbon(user) || user.usable_hands < 2)
 		return FALSE
 	return ..()
 /datum/emote/living/carbon/moan

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -455,35 +455,7 @@
 /datum/emote/living/custom/replace_pronoun(mob/user, message)
 	return message
 
-/datum/emote/living/help
-	key = "help"
-
-/datum/emote/living/help/run_emote(mob/user, params, type_override, intentional)
-	var/list/keys = list()
-	var/list/message = list("Available emotes, you can use them with say \"*emote\": ")
-
-	for(var/key in GLOB.emote_list)
-		for(var/datum/emote/P in GLOB.emote_list[key])
-			if(P.key in keys)
-				continue
-			if(P.can_run_emote(user, status_check = FALSE , intentional = TRUE))
-				keys += P.key
-
-	keys = sortList(keys)
-
-	for(var/emote in keys)
-		if(LAZYLEN(message) > 1)
-			message += ", [emote]"
-		else
-			message += "[emote]"
-
-	message += "."
-
-	message = jointext(message, "")
-
-	to_chat(user, message)
-
-/datum/emote/beep
+/datum/emote/living/beep
 	key = "beep"
 	key_third_person = "beeps"
 	message = "beeps."
@@ -492,13 +464,13 @@
 	mob_type_allowed_typecache = list(/mob/living/brain, /mob/living/silicon)
 	emote_type = EMOTE_AUDIBLE
 
-/datum/emote/inhale
+/datum/emote/living/inhale
 	key = "inhale"
 	key_third_person = "inhales"
 	message = "breathes in."
 	emote_type = EMOTE_AUDIBLE
 
-/datum/emote/exhale
+/datum/emote/living/exhale
 	key = "exhale"
 	key_third_person = "exhales"
 	message = "breathes out."


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This started as a simple fix for this runtime:
![image](https://user-images.githubusercontent.com/33846895/106365117-a7862380-6333-11eb-9954-d31894186cb2.png)
But at the end I ended up fixing / refactoring the following things:

- Crack emote no longer runtimes when used by non carbon
- Ghosts can use the help emote
- Exhale / inhale emote only work/appear for living
- Move beep emote living subtype
- Help emote no longer tells you that you can't use it ("Unusable emote 'help'. Say *help for a list.") while also printing out your usable emotes

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes some bugs / runtimes and also allows ghosts to use emotes like normal living players 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Gamer025
fix: The help emote will no longer tell you that you cant use is
code: Ghosts can now use the help emote and emotes generally behave like they normally would instead of being posted into death chat
fix: Crack emote no longer runtimes when trying to be used by ghosts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
