### PR TITLE
Changed the population scaling coefficients minimal values to 0.

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -71,27 +71,27 @@
 /datum/config_entry/number/traitor_scaling_coeff	//how much does the amount of players get divided by to determine traitors
 	config_entry_value = 6
 	integer = FALSE
-	min_val = 1
+	min_val = 0
 
 /datum/config_entry/number/brother_scaling_coeff	//how many players per brother team
 	config_entry_value = 25
 	integer = FALSE
-	min_val = 1
+	min_val = 0
 
 /datum/config_entry/number/changeling_scaling_coeff	//how much does the amount of players get divided by to determine changelings
 	config_entry_value = 6
 	integer = FALSE
-	min_val = 1
+	min_val = 0
 
 /datum/config_entry/number/ecult_scaling_coeff	//how much does the amount of players get divided by to determine e_cult
 	config_entry_value = 6
 	integer = FALSE
-	min_val = 1
+	min_val = 0
 
 /datum/config_entry/number/security_scaling_coeff	//how much does the amount of players get divided by to determine open security officer positions
 	config_entry_value = 8
 	integer = FALSE
-	min_val = 1
+	min_val = 0
 
 /datum/config_entry/number/traitor_objectives_amount
 	config_entry_value = 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So, there on the downstream we've encountered a problem with the security officer slots jumping to 12 every time the round starts, regardless of what we set them to in the configs.
In the configs it says that you can set the coefficients to 0 to disable scaling, and upon investigation, it seems that all the scaling coefficients suffer from similar problem.
https://github.com/tgstation/tgstation/blob/master/config/game_options.txt#L198
the `min_val` in the config entry datums is 1 on each of them, leading to unexpected behaviour

## Why It's Good For The Game

It fixes certain config values leading to unexpected and unwanted behaviour

## Changelog
:cl:
fix: scaling coefficients for security and antagonists in the game_options.txt will now respect being disabled by being set to 0, instead of having 1 as their minimal possible value
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
