### PR TITLE
Fixes inconsistent weight classes in chameleon gear

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -661,7 +661,7 @@
 	icon_state = "blacktie"
 	resistance_flags = NONE
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
-	w_class = 2
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/clothing/neck/chameleon
 	var/datum/action/item_action/chameleon/change/chameleon_action

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -466,6 +466,7 @@
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
+	w_class = 2
 
 	var/voice_change = 1 ///This determines if the voice changer is on or off.
 
@@ -660,6 +661,7 @@
 	icon_state = "blacktie"
 	resistance_flags = NONE
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
+	w_class = 2
 
 /obj/item/clothing/neck/chameleon
 	var/datum/action/item_action/chameleon/change/chameleon_action

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -466,7 +466,7 @@
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
-	w_class = 2
+	w_class = WEIGHT_CLASS_SMALL
 
 	var/voice_change = 1 ///This determines if the voice changer is on or off.
 


### PR DESCRIPTION
## About The Pull Request
• Makes chameleon masks w_class 2 (Small)
• Makes chameleon neck w_class 2 (Small)

## Why It's Good For The Game
This seems like an oversight. Almost every mask slot item is small, except for a few outliers like the explorer gas mask.
Same for neck slot items. They're almost always small.
Also, would you really want a breath mask to not fit in a box? This just seems like an accidental oversight.

## Changelog
:cl:
fix: Chameleon masks and neck slot items fit into boxes and pockets, like their counterparts they're camouflaging as almost always do.
/:cl: