### PR TITLE
Removes Holodeck Access Flags Feature That Shouldnt Have Been in My Previous Refactor

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -1,9 +1,7 @@
 /*
 Map Template Holodeck
 
-Holodeck finds the location of mapped_start_area and loads offline_program in it on LateInitialize. It then loads the programs that have the
-same holodeck_access flag as it (e.g. the station holodeck has the holodeck_access flag STATION_HOLODECK, and it loads all programs with this
-flag). These program templates are then given to Holodeck.js in the form of program_cache and emag_programs. when a user selects a program the
+Holodeck finds the location of mapped_start_area and loads offline_program in it on LateInitialize. It then passes its program templates to Holodeck.js in the form of program_cache and emag_programs. when a user selects a program the
 ui calls load_program() with the id of the selected program.
 load_program() -> map_template/load() on map_template/holodeck.
 
@@ -36,9 +34,6 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 	active_power_usage = 50
 
 	//new vars
-	///what access type this holodeck has, used to specify programs for another holodeck that others cant load.
-	var/holodeck_access = STATION_HOLODECK
-
 	///what area type this holodeck loads into. linked turns into the nearest instance of this area
 	var/area/mapped_start_area = /area/holodeck/rec_center
 
@@ -121,9 +116,9 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 	for(var/typekey in subtypesof(program_type))
 		var/datum/map_template/holodeck/program = typekey
 		var/list/info_this = list("id" = initial(program.template_id), "name" = initial(program.name))
-		if(initial(program.restricted) && (initial(program.access_flags) & holodeck_access))
+		if(initial(program.restricted))
 			LAZYADD(emag_programs, list(info_this))
-		else if (initial(program.access_flags) & holodeck_access)
+		else
 			LAZYADD(program_cache, list(info_this))
 
 /obj/machinery/computer/holodeck/ui_interact(mob/user, datum/tgui/ui)
@@ -401,13 +396,6 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 /obj/machinery/computer/holodeck/blob_act(obj/structure/blob/B)
 	emergency_shutdown()
 	return ..()
-
-/obj/machinery/computer/holodeck/offstation //second holodeck if you want to add one to a ruin :flushed:
-	name = "holodeck control console"
-	desc = "A computer used to control a nearby holodeck."
-	offline_program = "holodeck_offline"
-	holodeck_access = HOLODECK_DEBUG | STATION_HOLODECK
-	mapped_start_area = /area/holodeck/rec_center/offstation_one
 
 #undef HOLODECK_CD
 #undef HOLODECK_DMG_CD

--- a/code/modules/holodeck/holodeck_map_templates.dm
+++ b/code/modules/holodeck/holodeck_map_templates.dm
@@ -1,13 +1,7 @@
 
-#define STATION_HOLODECK		(1<<0)
-#define CUSTOM_HOLODECK_ONE		(1<<1)
-#define CUSTOM_HOLODECK_TWO		(1<<2)
-#define HOLODECK_DEBUG			(1<<3)//you should never see this
-
 /datum/map_template/holodeck
 	var/template_id
 	var/description
-	var/access_flags //bitflags representing what holodeck is allowed to access them
 	var/restricted = FALSE
 	var/datum/parsed_map/lastparsed
 
@@ -22,119 +16,102 @@
 	template_id = "holodeck_offline"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_offline.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/emptycourt
 	name = "Holodeck - Empty Court"
 	template_id = "holodeck_emptycourt"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_emptycourt.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/dodgeball
 	name = "Holodeck - Dodgeball Court"
 	template_id = "holodeck_dodgeball"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_dodgeball.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/basketball
 	name = "Holodeck - Basketball Court"
 	template_id = "holodeck_basketball"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_basketball.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/thunderdome
 	name = "Holodeck - Thunderdome Arena"
 	template_id = "holodeck_thunderdome"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_thunderdome.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/beach
 	name = "Holodeck - Beach"
 	template_id = "holodeck_beach"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_beach.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/lounge
 	name = "Holodeck - Lounge"
 	template_id = "holodeck_lounge"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_lounge.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/petpark
 	name = "Holodeck - Pet Park"
 	template_id = "holodeck_petpark"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_petpark.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/firingrange
 	name = "Holodeck - Firing Range"
 	template_id = "holodeck_firingrange"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_firingrange.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/anime_school
 	name = "Holodeck - Anime School"
 	template_id = "holodeck_animeschool"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_animeschool.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/chapelcourt
 	name = "Holodeck - Chapel Courtroom"
 	template_id = "holodeck_chapelcourt"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_chapelcourt.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/spacechess
 	name = "Holodeck - Space Chess"
 	template_id = "holodeck_spacechess"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_spacechess.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/spacecheckers
 	name = "Holodeck - Space Checkers"
 	template_id = "holodeck_spacecheckers"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_spacecheckers.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/kobayashi
 	name = "Holodeck - Kobayashi Maru"
 	template_id = "holodeck_kobayashi"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_kobayashi.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/winterwonderland
 	name = "Holodeck - Winter Wonderland"
 	template_id = "holodeck_winterwonderland"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_winterwonderland.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/photobooth
 	name = "Holodeck - Photobooth"
 	template_id = "holodeck_photobooth"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_photobooth.dmm"
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/skatepark
 	name = "Holodeck - Skatepark"
 	template_id = "holodeck_skatepark"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_skatepark.dmm"
-	access_flags = STATION_HOLODECK
 
 //bad evil no good programs
 
@@ -144,7 +121,6 @@
 	description = "benis"
 	mappath = "_maps/templates/holodeck_medicalsim.dmm"
 	restricted = TRUE
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/thunderdome1218
 	name = "Holodeck - 1218 AD"
@@ -152,7 +128,6 @@
 	description = "benis"
 	mappath = "_maps/templates/holodeck_thunderdome1218.dmm"
 	restricted = TRUE
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/burntest
 	name = "Holodeck - Atmospheric Burn Test"
@@ -160,7 +135,6 @@
 	description = "benis"
 	mappath = "_maps/templates/holodeck_burntest.dmm"
 	restricted = TRUE
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/wildlifesim
 	name = "Holodeck - Wildlife Simulation"
@@ -168,7 +142,6 @@
 	description = "benis"
 	mappath = "_maps/templates/holodeck_wildlifesim.dmm"
 	restricted = TRUE
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/holdoutbunker
 	name = "Holodeck - Holdout Bunker"
@@ -176,7 +149,6 @@
 	description = "benis"
 	mappath = "_maps/templates/holodeck_holdoutbunker.dmm"
 	restricted = TRUE
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/anthophillia
 	name = "Holodeck - Anthophillia"
@@ -184,7 +156,6 @@
 	description = "benis"
 	mappath = "_maps/templates/holodeck_anthophillia.dmm"
 	restricted = TRUE
-	access_flags = STATION_HOLODECK
 
 /datum/map_template/holodeck/refuelingstation
 	name = "Holodeck - Refueling Station"
@@ -192,13 +163,3 @@
 	description = "benis"
 	mappath = "_maps/templates/holodeck_refuelingstation.dmm"
 	restricted = TRUE
-	access_flags = STATION_HOLODECK
-
-//flag debug holodeck
-
-/datum/map_template/holodeck/gamer
-	name = "Holodeck - Gamer"
-	template_id = "holodeck_gamer"
-	description = "benis"
-	mappath = "_maps/templates/holodeck_gamer.dmm"
-	access_flags = HOLODECK_DEBUG


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The holodeck access flags that i added in my previous holodeck refactor added nothing of value, have caused issues (only because of the .dme file ordering but still), and was a feature in a refactor. They were added as a way to eventually have two separate holodecks with their own separate programs loadable but that is not going to be used for quite a while until the offstation ban lifts. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
removes feature that shouldnt have been added and has caused problems
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: holodeck access flags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
