### PR TITLE
simple animals no longer reset their icon file on death

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -520,7 +520,6 @@
 	. = ..()
 	if(!.)
 		return
-	icon = initial(icon)
 	icon_state = icon_living
 	density = initial(density)
 	if(is_flying_animal)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
what the title says

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
its really annoying when you revive a mob you var edited and it becomes invisible for no reason, this is probably ancient code anyway, and why would you not have your mob's death sprite in the same icon file as the mob

## Changelog
:cl:
code: simple animals no longer reset their icon file on death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
