### PR TITLE
Fix 2 wendigo runtimes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
@@ -183,7 +183,7 @@ Difficulty: Hard
 	animate(pixel_z = 0, time = 1)
 	for(var/mob/living/L in get_hearers_in_view(7, src) - src)
 		L.Dizzy(6)
-		to_chat(L, "<span class='danger'>[capitalize(src)] screams loudly!</span>")
+		to_chat(L, "<span class='danger'>[capitalize(src.name)] screams loudly!</span>")
 	SetRecoveryTime(30, 0)
 	SLEEP_CHECK_DEATH(12)
 	can_move = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
@@ -170,9 +170,10 @@ Difficulty: Hard
 		if(isclosedturf(T))
 			continue
 		possible_ends |= T
-	var/turf/end = pick(possible_ends)
-	do_teleport(src, end, 0,  channel=TELEPORT_CHANNEL_BLUESPACE, forced = TRUE)
-	SetRecoveryTime(20, 0)
+	if (LAZYLEN(possible_ends))
+		var/turf/end = pick(possible_ends)
+		do_teleport(src, end, 0,  channel=TELEPORT_CHANNEL_BLUESPACE, forced = TRUE)
+		SetRecoveryTime(20, 0)
 
 /// Applies dizziness to all nearby enemies that can hear the scream and animates the wendigo shaking up and down
 /mob/living/simple_animal/hostile/megafauna/wendigo/proc/disorienting_scream()
@@ -183,7 +184,7 @@ Difficulty: Hard
 	animate(pixel_z = 0, time = 1)
 	for(var/mob/living/L in get_hearers_in_view(7, src) - src)
 		L.Dizzy(6)
-		to_chat(L, "<span class='danger'>[capitalize(src.name)] screams loudly!</span>")
+		to_chat(L, "<span class='danger'>[src] screams loudly!</span>")
 	SetRecoveryTime(30, 0)
 	SLEEP_CHECK_DEATH(12)
 	can_move = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes 2 wendigo runtimes:

- When the wendigo tries to teleport to you but there is no location to teleport it would runtimes because the code tried to pick from a empty list
- The wendigo scream message used capitalize which is not needed and also runtimed, since capitalize expects a string not some object

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes runtimes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Gamer025
fix: Wendigo will no longer runtimes when screaming
fix: Wendigo will no longer runtime when it tries to teleport but has no location to teleport to
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
