### PR TITLE
Ability to select the logic for Nanite rules (AND, OR)

### DIFF
--- a/code/modules/research/nanites/nanite_cloud_controller.dm
+++ b/code/modules/research/nanites/nanite_cloud_controller.dm
@@ -144,6 +144,7 @@
 				cloud_program["rules"] = rules
 				if(LAZYLEN(rules))
 					cloud_program["has_rules"] = TRUE
+				cloud_program["all_rules_required"] = P.all_rules_required
 
 				var/list/extra_settings = P.get_extra_settings_frontend()
 				cloud_program["extra_settings"] = extra_settings
@@ -233,6 +234,15 @@
 
 				investigate_log("[key_name(usr)] removed rule [rule.display()] from program [P.name] in cloud #[current_view]", INVESTIGATE_NANITES)
 			. = TRUE
+		if("toggle_rule_logic")
+			var/datum/nanite_cloud_backup/backup = get_backup(current_view)
+			if(backup)
+				playsound(src, 'sound/machines/terminal_prompt.ogg', 50, FALSE)
+				var/datum/component/nanites/nanites = backup.nanites
+				var/datum/nanite_program/P = nanites.programs[text2num(params["program_id"])]
+				P.all_rules_required = !P.all_rules_required
+				investigate_log("[key_name(usr)] edited rule logic for program [P.name] into [P.all_rules_required ? "All" : "Any"] in cloud #[current_view]", INVESTIGATE_NANITES)
+				. = TRUE
 
 /datum/nanite_cloud_backup
 	var/cloud_id = 0

--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -53,6 +53,7 @@
 	//Rules
 	//Rules that automatically manage if the program's active without requiring separate sensor programs
 	var/list/datum/nanite_rule/rules = list()
+	var/all_rules_required = TRUE			//Whether all rules are required for positive condition or any of specified
 
 /datum/nanite_program/New()
 	. = ..()
@@ -92,6 +93,7 @@
 	for(var/R in rules)
 		var/datum/nanite_rule/rule = R
 		rule.copy_to(target)
+	target.all_rules_required = all_rules_required
 
 	if(istype(target,src))
 		copy_extra_settings_to(target)
@@ -194,11 +196,18 @@
 //If false, disables active and passive effects, but doesn't consume nanites
 //Can be used to avoid consuming nanites for nothing
 /datum/nanite_program/proc/check_conditions()
-	for(var/R in rules)
-		var/datum/nanite_rule/rule = R
-		if(!rule.check_rule())
-			return FALSE
-	return TRUE
+	if (rules.len > 1 && !all_rules_required)
+		for(var/R in rules)
+			var/datum/nanite_rule/rule = R
+			if(rule.check_rule())
+				return TRUE
+		return FALSE
+	else
+		for(var/R in rules)
+			var/datum/nanite_rule/rule = R
+			if(!rule.check_rule())
+				return FALSE
+		return TRUE
 
 //Constantly procs as long as the program is active
 /datum/nanite_program/proc/active_effect()

--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -196,7 +196,7 @@
 //If false, disables active and passive effects, but doesn't consume nanites
 //Can be used to avoid consuming nanites for nothing
 /datum/nanite_program/proc/check_conditions()
-	if (rules.len == 0)
+	if (!LAZYLEN(rules))
 		return TRUE
 	for(var/R in rules)
 		var/datum/nanite_rule/rule = R

--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -196,18 +196,15 @@
 //If false, disables active and passive effects, but doesn't consume nanites
 //Can be used to avoid consuming nanites for nothing
 /datum/nanite_program/proc/check_conditions()
-	if (rules.len > 1 && !all_rules_required)
-		for(var/R in rules)
-			var/datum/nanite_rule/rule = R
-			if(rule.check_rule())
-				return TRUE
-		return FALSE
-	else
-		for(var/R in rules)
-			var/datum/nanite_rule/rule = R
-			if(!rule.check_rule())
-				return FALSE
+	if (rules.len == 0)
 		return TRUE
+	for(var/R in rules)
+		var/datum/nanite_rule/rule = R
+		if(!all_rules_required && rule.check_rule())
+			return TRUE
+		if(all_rules_required && !rule.check_rule())
+			return FALSE
+	return all_rules_required ? TRUE : FALSE
 
 //Constantly procs as long as the program is active
 /datum/nanite_program/proc/active_effect()

--- a/tgui/packages/tgui/interfaces/NaniteCloudControl.js
+++ b/tgui/packages/tgui/interfaces/NaniteCloudControl.js
@@ -224,7 +224,8 @@ export const NaniteCloudBackupDetails = (props, context) => {
                   title="Rules"
                   level={2}
                   buttons={(!!can_rule
-                    && <>
+                    && (
+                    <>
                       <Button
                         icon={program.all_rules_required ? 'check-double' : 'check'}
                         content={program.all_rules_required ? 'Meet all' : 'Meet any'}
@@ -239,7 +240,7 @@ export const NaniteCloudBackupDetails = (props, context) => {
                           program_id: program.id,
                         })} />
                     </>
-                  )}>
+                  ))}>
                   {program.has_rules ? (
                     rules.map(rule => (
                       <Box key={rule.display}>

--- a/tgui/packages/tgui/interfaces/NaniteCloudControl.js
+++ b/tgui/packages/tgui/interfaces/NaniteCloudControl.js
@@ -225,14 +225,15 @@ export const NaniteCloudBackupDetails = (props, context) => {
                   level={2}
                   buttons={(
                     <>
-                      {!!can_rule
-                        && <Button
+                      {!!can_rule && (
+                        <Button
                           icon="plus"
                           content="Add Rule from Disk"
                           color="good"
                           onClick={() => act('add_rule', {
                             program_id: program.id,
-                          })} />}
+                          })} />
+                      )}
                       <Button
                         icon={program.all_rules_required ? 'check-double' : 'check'}
                         content={program.all_rules_required ? 'Meet all' : 'Meet any'}

--- a/tgui/packages/tgui/interfaces/NaniteCloudControl.js
+++ b/tgui/packages/tgui/interfaces/NaniteCloudControl.js
@@ -232,8 +232,7 @@ export const NaniteCloudBackupDetails = (props, context) => {
                           color="good"
                           onClick={() => act('add_rule', {
                             program_id: program.id,
-                          })} />
-                      }
+                          })} />}
                       <Button
                         icon={program.all_rules_required ? 'check-double' : 'check'}
                         content={program.all_rules_required ? 'Meet all' : 'Meet any'}

--- a/tgui/packages/tgui/interfaces/NaniteCloudControl.js
+++ b/tgui/packages/tgui/interfaces/NaniteCloudControl.js
@@ -197,7 +197,7 @@ export const NaniteCloudBackupDetails = (props, context) => {
         !!has_program && (
           <Button
             icon="upload"
-            content="Upload From Disk"
+            content="Upload Program from Disk"
             color="good"
             onClick={() => act('upload_program')} />
         )
@@ -223,24 +223,25 @@ export const NaniteCloudBackupDetails = (props, context) => {
                   mt={-2}
                   title="Rules"
                   level={2}
-                  buttons={(!!can_rule
-                    && (
+                  buttons={(
                     <>
+                      {!!can_rule
+                        && <Button
+                          icon="plus"
+                          content="Add Rule from Disk"
+                          color="good"
+                          onClick={() => act('add_rule', {
+                            program_id: program.id,
+                          })} />
+                      }
                       <Button
                         icon={program.all_rules_required ? 'check-double' : 'check'}
                         content={program.all_rules_required ? 'Meet all' : 'Meet any'}
                         onClick={() => act('toggle_rule_logic', {
                           program_id: program.id,
                         })} />
-                      <Button
-                        icon="plus"
-                        content="Add Rule from Disk"
-                        color="good"
-                        onClick={() => act('add_rule', {
-                          program_id: program.id,
-                        })} />
                     </>
-                  ))}>
+                  )}>
                   {program.has_rules ? (
                     rules.map(rule => (
                       <Box key={rule.display}>

--- a/tgui/packages/tgui/interfaces/NaniteCloudControl.js
+++ b/tgui/packages/tgui/interfaces/NaniteCloudControl.js
@@ -223,14 +223,22 @@ export const NaniteCloudBackupDetails = (props, context) => {
                   mt={-2}
                   title="Rules"
                   level={2}
-                  buttons={(!!can_rule
-                    && <Button
-                      icon="plus"
-                      content="Add Rule from Disk"
-                      color="good"
-                      onClick={() => act('add_rule', {
-                        program_id: program.id,
-                      })} />
+                  buttons={(!!can_rule &&
+                    <>
+                      <Button
+                        icon={program.all_rules_required ? 'check-double' : 'check'}
+                        content={program.all_rules_required ? 'Meet all' : 'Meet any'}
+                        onClick={() => act('toggle_rule_logic', {
+                          program_id: program.id,
+                        })} />
+                      <Button
+                        icon="plus"
+                        content="Add Rule from Disk"
+                        color="good"
+                        onClick={() => act('add_rule', {
+                          program_id: program.id,
+                        })} />
+                    </>
                   )}>
                   {program.has_rules ? (
                     rules.map(rule => (

--- a/tgui/packages/tgui/interfaces/NaniteCloudControl.js
+++ b/tgui/packages/tgui/interfaces/NaniteCloudControl.js
@@ -223,8 +223,8 @@ export const NaniteCloudBackupDetails = (props, context) => {
                   mt={-2}
                   title="Rules"
                   level={2}
-                  buttons={(!!can_rule &&
-                    <>
+                  buttons={(!!can_rule
+                    && <>
                       <Button
                         icon={program.all_rules_required ? 'check-double' : 'check'}
                         content={program.all_rules_required ? 'Meet all' : 'Meet any'}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added a button to the Nanite Cloud Controller Rules UI with two states:

- Meet all (default) - all rules must be met to run the program
- Meet any - any of the rules must be met to run the program

<img alt="rules" src="https://user-images.githubusercontent.com/3625094/106390629-59882300-63fa-11eb-8e3f-8a7d21833587.png">

## Why It's Good For The Game

This change doesn't impact the default rule behavior, but gives an ability to create more flexible rule setups when needed.

## Changelog
:cl:
add: Added a button to select how multiple rules applied in a single Nanite program (AND, OR logic)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
