### PR TITLE
Makes reinforced plasma windows block heatspreading

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -511,6 +511,8 @@
 	explosion_block = 2
 	glass_type = /obj/item/stack/sheet/plasmarglass
 
+/obj/structure/window/plasma/reinforced/BlockSuperconductivity()
+	return TRUE
 //entirely copypasted code
 //take this out when construction is made a component or otherwise modularized in some way
 /obj/structure/window/plasma/reinforced/attackby(obj/item/I, mob/living/user, params)

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -41,7 +41,7 @@
 
 	return !R
 
-/atom/movable/proc/BlockSuperconductivity() // objects that block air and don't let superconductivity act. Only firelocks atm.
+/atom/movable/proc/BlockSuperconductivity() // objects that block air and don't let superconductivity act
 	return FALSE
 
 /turf/proc/ImmediateCalculateAdjacentTurfs()


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
We do this mostly so the sm delams properly, and partially so mappers have a tool for this sort of thing
## Why It's Good For The Game

See above

## Changelog
:cl:
add: Reinforced plasma windows now fully block superconduction, or heat movement
add: Heat from a delaminating supermatter won't leak out of the chamber on its own now, things will be a bit more spicy now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
