### PR TITLE
Turbo fix for holodecks not clearing previous programs under live server lag

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -43,7 +43,9 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 	///bottom left corner of the loading room, used for placing
 	var/turf/bottom_left
 
+	///if TRUE the holodeck is busy spawning another simulation and should immediately stop loading the newest one
 	var/spawning_simulation = FALSE
+
 	//old vars
 
 	///the area that this holodeck loads templates into, used for power and deleting holo objects that leave it
@@ -187,7 +189,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 		map_id = offline_program
 		force = TRUE
 
-	if ((!COOLDOWN_FINISHED(src, holodeck_cooldown) || spawning_simulation) && !force)
+	if ((!COOLDOWN_FINISHED(src, holodeck_cooldown) && !force) || spawning_simulation)
 		say("ERROR. Recalibrating projection apparatus.")
 		return
 

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -43,6 +43,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 	///bottom left corner of the loading room, used for placing
 	var/turf/bottom_left
 
+	var/spawning_simulation = FALSE
 	//old vars
 
 	///the area that this holodeck loads templates into, used for power and deleting holo objects that leave it
@@ -186,7 +187,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 		map_id = offline_program
 		force = TRUE
 
-	if (!COOLDOWN_FINISHED(src, holodeck_cooldown) && !force)
+	if ((!COOLDOWN_FINISHED(src, holodeck_cooldown) || spawning_simulation) && !force)
 		say("ERROR. Recalibrating projection apparatus.")
 		return
 
@@ -195,6 +196,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 		if (damaged && floorcheck())
 			damaged = FALSE
 
+	spawning_simulation = TRUE
 	active = (map_id != offline_program)
 	use_power = active + IDLE_POWER_USE
 	program = map_id
@@ -270,6 +272,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 				if(istype(machines, /obj/machinery/button))
 					var/obj/machinery/button/buttons = machines
 					buttons.setup_device()
+	spawning_simulation = FALSE
 
 ///this qdels holoitems that should no longer exist for whatever reason
 /obj/machinery/computer/holodeck/proc/derez(obj/object, silent = TRUE, forced = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #56561 
the holodeck control console now returns if the previous program still has not finished loading in, so it should now be impossible to have two concurrent load_program() processes running at the same time and thus programs should not overlap under lag. tested locally with around 80% time dilation and 0 holodeck cooldown while spamming the fuck out of loading simulations
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
holodeck doesnt duplicate materials en masse anymore!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: holodeck doesnt absentmindedly forget to clear previous programs anymore when hit with the free lag hammer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
