### PR TITLE
Fixes space vines dying instantly to gas movement

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -574,15 +574,14 @@
 		qdel(src)
 
 /obj/structure/spacevine/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
-	return TRUE
+	return exposed_temperature > FIRE_MINIMUM_TEMPERATURE_TO_SPREAD //if you're cold you're safe
 
 /obj/structure/spacevine/atmos_expose(datum/gas_mixture/air, exposed_temperature)
 	var/volume = air.return_volume()
-	var/override = 0
 	for(var/datum/spacevine_mutation/SM in mutations)
-		override += SM.process_temperature(src, exposed_temperature, volume)
-	if(!override)
-		qdel(src)
+		if(SM.process_temperature(src, exposed_temperature, volume)) //If it's ever true we're safe
+			return
+	qdel(src)
 
 /obj/structure/spacevine/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I mistakenly copied over space vine code in #55604, and assumed that the default mutation had some sort of cutoff for heat. I was wrong.

Fixes #56552

## Why It's Good For The Game

Spacevines no longer disappear randomly when the turf they're on becomes active
## Changelog
:cl:
fix: Fixes spacevines seemingly randomly dying
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
