### PR TITLE
Pyro anomalies no longer make their own oxygen

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -290,7 +290,7 @@
 		ticks -= releasedelay
 	var/turf/open/T = get_turf(src)
 	if(istype(T))
-		T.atmos_spawn_air("o2=5;plasma=5;TEMP=1000")
+		T.atmos_spawn_air("plasma=6;TEMP=1000")
 
 /obj/effect/anomaly/pyro/detonate()
 	INVOKE_ASYNC(src, .proc/makepyroslime)
@@ -298,7 +298,7 @@
 /obj/effect/anomaly/pyro/proc/makepyroslime()
 	var/turf/open/T = get_turf(src)
 	if(istype(T))
-		T.atmos_spawn_air("o2=500;plasma=500;TEMP=1000") //Make it hot and burny for the new slime
+		T.atmos_spawn_air("plasma=550;TEMP=1000") //Make it hot and burny for the new slime
 	var/new_colour = pick("red", "orange")
 	var/mob/living/simple_animal/slime/S = new(T, new_colour)
 	S.rabid = TRUE


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I've removed the o2 generation from pyro anomalies, they only make plasma now. It doesn't really effect the usual spawn, but it allows for some level of counterplay.

Oh and I balanced out the energy produced, in case you care about that sort of thing.

## Why It's Good For The Game

 This allows for less restrictive high energy supermatter setups, so you don't need to be a borg or the ce to work in the engine room. Mostly. The gas it spits out will still be hot, but it won't always cause a plasma fire.

## Changelog
:cl:
add: Pyro anomalies no longer make their own oxygen, get to venting!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
