### PR TITLE
Fix viruses not working on human subtypes

### DIFF
--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -20,8 +20,7 @@
 	if(!(D.infectable_biotypes & mob_biotypes))
 		return FALSE
 
-
-	if(!(type in D.viable_mobtypes))
+	if(!D.is_viable_mobtype(type))
 		return FALSE
 
 	return TRUE

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -169,13 +169,13 @@
 	affected_mob = null
 
 /**
- * Checks the mob's type against the list of viable mobtypes.
+ * Checks the given typepath against the list of viable mobtypes.
  *
- * Returns TRUE if the mob_type is a type of or subtype of any entry in viable_mobtypes.
+ * Returns TRUE if the mob_type path is derived from of any entry in the viable_mobtypes list.
  * Returns FALSE otherwise.
  *
  * Arguments:
- * * mob_type - Mob or mob type path to check against the viable_mobtypes list.
+ * * mob_type - Type path to check against the viable_mobtypes list.
  */
 /datum/disease/proc/is_viable_mobtype(mob_type)
 	for(var/viable_type in viable_mobtypes)

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -168,6 +168,26 @@
 	affected_mob.med_hud_set_status()
 	affected_mob = null
 
+/**
+ * Checks the mob's type against the list of viable mobtypes.
+ *
+ * Returns TRUE if the mob_type is a type of or subtype of any entry in viable_mobtypes.
+ * Returns FALSE otherwise.
+ *
+ * Arguments:
+ * * mob_type - Mob or mob type path to check against the viable_mobtypes list.
+ */
+/datum/disease/proc/is_viable_mobtype(mob_type)
+	for(var/viable_type in viable_mobtypes)
+		if(ispath(mob_type, viable_type))
+			return TRUE
+
+	// Let's only do this check if it fails. Did some genius coder pass in a non-type argument?
+	if(!ispath(mob_type))
+		stack_trace("Non-path argument passed to mob_type variable: [mob_type]")
+
+	return FALSE
+
 //Use this to compare severities
 /proc/get_disease_severity_value(severity)
 	switch(severity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #56313

Creating something using the species subtypes makes a mob with that subtype as its type path.

Disease code has a list of valid mob types that they can apply to.

Mob code did `if(type in list)` which doesn't work when list contains `/mob/living/carbon/human` and your mob's type is `/mob/living/carbon/human/species/...`

I've added a helper proc to diseases to let the disease itself decide if a mob type should be infected by it. This iterates through the existing list of mob types and does ispath comparison checks.

It also lets mobs created by instantiating a new `.../species/name` subtype get infected with viruses as well. This could allow previously virus immune things (due to not being an exact `/mob/living/carbon/human` type) to become infected by viruses unless they have the appropriate biology flags.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Monke get virus. Also many non-monke get virus. Feex oversight.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Monkeys are once again susceptible to viruses. Some human-derived species that previously were immune to viruses due to an oversight may now be susceptible to viruses too.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
