### PR TITLE
Various crew tracking fixes

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -128,7 +128,8 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			stack_trace("Tracked mob has no loc and is likely in nullspace: [tracked_living_mob] ([tracked_living_mob.type])")
 			continue
 
-		if (pos.z != z)
+		// Machinery and the target should be on the same level or different levels of the same station
+		if(pos.z != z && (!is_station_level(pos.z) || !is_station_level(z)))
 			continue
 
 		var/sensor_mode

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -97,16 +97,14 @@
 
 /obj/item/pinpointer/crew/proc/trackable(mob/living/carbon/human/H)
 	var/turf/here = get_turf(src)
-	if((H.z == 0 || H.z == here.z) && istype(H.w_uniform, /obj/item/clothing/under))
-		var/obj/item/clothing/under/U = H.w_uniform
-
-		// Suit sensors must be on maximum.
-		if(!U.has_sensor || (U.sensor_mode < SENSOR_COORDS && !ignore_suit_sensor_level))
-			return FALSE
-
-		var/turf/there = get_turf(H)
-		return (H.z != 0 || (there && there.z == here.z))
-
+	var/turf/there = get_turf(H)
+	if((H.z == 0 || H.z == here.z) && (H.z != 0 || (there && there.z == here.z)))
+		if (H in GLOB.nanite_sensors_list)
+			return TRUE
+		if (istype(H.w_uniform, /obj/item/clothing/under))
+			var/obj/item/clothing/under/U = H.w_uniform
+			if(U.has_sensor && (U.sensor_mode >= SENSOR_COORDS || ignore_suit_sensor_level)) // Suit sensors must be on maximum
+				return TRUE
 	return FALSE
 
 /obj/item/pinpointer/crew/attack_self(mob/living/user)

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -98,12 +98,12 @@
 /obj/item/pinpointer/crew/proc/trackable(mob/living/carbon/human/H)
 	var/turf/here = get_turf(src)
 	var/turf/there = get_turf(H)
-	if((H.z == 0 || H.z == here.z) && (H.z != 0 || (there && there.z == here.z)))
+	if(here && there && (there.z == here.z || (is_station_level(here.z) && is_station_level(there.z))) // Device and target should be on the same level (or different layers of the same station)
 		if (H in GLOB.nanite_sensors_list)
 			return TRUE
 		if (istype(H.w_uniform, /obj/item/clothing/under))
 			var/obj/item/clothing/under/U = H.w_uniform
-			if(U.has_sensor && (U.sensor_mode >= SENSOR_COORDS || ignore_suit_sensor_level)) // Suit sensors must be on maximum
+			if(U.has_sensor && (U.sensor_mode >= SENSOR_COORDS || ignore_suit_sensor_level)) // Suit sensors must be on maximum or a contractor pinpointer
 				return TRUE
 	return FALSE
 

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -98,7 +98,7 @@
 /obj/item/pinpointer/crew/proc/trackable(mob/living/carbon/human/H)
 	var/turf/here = get_turf(src)
 	var/turf/there = get_turf(H)
-	if(here && there && (there.z == here.z || (is_station_level(here.z) && is_station_level(there.z))) // Device and target should be on the same level (or different layers of the same station)
+	if(here && there && (there.z == here.z || (is_station_level(here.z) && is_station_level(there.z)))) // Device and target should be on the same level or different levels of the same station
 		if (H in GLOB.nanite_sensors_list)
 			return TRUE
 		if (istype(H.w_uniform, /obj/item/clothing/under))

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -241,13 +241,14 @@
 /datum/computer_file/program/radar/lifeline/trackable(mob/living/carbon/human/humanoid)
 	if(!humanoid || !istype(humanoid))
 		return FALSE
-	if(..() && istype(humanoid.w_uniform, /obj/item/clothing/under))
-
-		var/obj/item/clothing/under/uniform = humanoid.w_uniform
-		if(!uniform.has_sensor || (uniform.sensor_mode < SENSOR_COORDS)) // Suit sensors must be on maximum.
-			return FALSE
-
-		return TRUE
+	if(..())
+		if (humanoid in GLOB.nanite_sensors_list)
+			return TRUE
+		if (istype(humanoid.w_uniform, /obj/item/clothing/under))
+			var/obj/item/clothing/under/uniform = humanoid.w_uniform
+			if(uniform.has_sensor && uniform.sensor_mode >= SENSOR_COORDS) // Suit sensors must be on maximum
+				return TRUE
+	return FALSE
 
 ////////////////////////
 //Nuke Disk Finder App//


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

> Monitoring: The nanites monitor the host's vitals and location, sending them to the suit sensor network.

Nanite Monitoring program now makes people trackable as if they have enabled their suit sensors, as stated in the program description.

Now you can track people with Nanites Monitoring program using following devices:

- Crew pinpointer (arrow)
- Crew pinpointer - contractor version (arrow)
- Crew pinpointer (proximity)
- Lifeline radar (modular computers software)

Also fixed multi-Z tracking for the first three devices. When the target is on different Z of the same station, it shows "?" icon.

Also, the stationary crew monitor will now work properly on multi-Z stations.

<img width="326" alt="nanite" src="https://user-images.githubusercontent.com/3625094/106603744-c2dd7280-656f-11eb-8de9-8dd0a571a067.png">

## Why It's Good For The Game

Fixes #51495
Fixes #40541
Fixes #47064

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Nanite Monitoring now works with pinpointers and Lifeline
fix: Pinpointers now track properly on multi-z stations 
fix: Stationary crew monitor now shows data from all levels of multi-z station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
