### PR TITLE
Admin verb 'Toggle Dead Chat'

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -8,6 +8,7 @@ GLOBAL_VAR_INIT(game_version, "/tg/Station 13")
 GLOBAL_VAR_INIT(changelog_hash, "")
 GLOBAL_VAR_INIT(hub_visibility, FALSE)
 
+GLOBAL_VAR_INIT(dchat_allowed, TRUE)
 GLOBAL_VAR_INIT(ooc_allowed, TRUE)	// used with admin verbs to disable ooc - not a config option apparently
 GLOBAL_VAR_INIT(dooc_allowed, TRUE)
 GLOBAL_VAR_INIT(enter_allowed, TRUE)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -548,6 +548,16 @@
 	GLOB.admin_notice = new_admin_notice
 	return
 
+/datum/admins/proc/toggledeadchat()
+	set category = "Server"
+	set desc="Toggle Dead Chat"
+	set name="Toggle Dead Chat"
+	GLOB.dchat_allowed = !GLOB.dchat_allowed
+	deadchat_broadcast(" has toggled Dead Chat.", "<span class='name'>An admin</span>", message_type=DEADCHAT_ANNOUNCEMENT)
+	log_admin("[key_name(usr)] toggled Dead Chat.")
+	message_admins("[key_name_admin(usr)] toggled Dead Chat.")
+	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Dead Chat", "[GLOB.dchat_allowed ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /datum/admins/proc/toggleooc()
 	set category = "Server"
 	set desc="Toggle dis bitch"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -32,6 +32,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/client/proc/game_panel,			/*game panel, allows to change game-mode etc*/
 	/client/proc/check_ai_laws,			/*shows AI and borg laws*/
 	/client/proc/ghost_pool_protection,	/*opens a menu for toggling ghost roles*/
+	/datum/admins/proc/toggledeadchat, 	/*toggles the ability for observers to speak*/
 	/datum/admins/proc/toggleooc,		/*toggles ooc on/off for everyone*/
 	/datum/admins/proc/toggleoocdead,	/*toggles ooc on/off for everyone who is dead*/
 	/datum/admins/proc/toggleenter,		/*toggles whether people can join the current game*/

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -45,6 +45,10 @@
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
 
+	if(!GLOB.dchat_allowed)
+		to_chat(usr, "<span class='danger'>Dead Chat is currently admin-disabled.</span>")
+		return
+
 	var/jb = is_banned_from(ckey, "Deadchat")
 	if(QDELETED(src))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds an admin verb that toggles the ability for ghosts to speak in deadchat. The 'dsay' verb and automated announcements still bypass this.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows admins to smack dchat with a mute when things get too salty sometimes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Admins now have a Toggle Dead Chat verb under 'Server'.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
