### PR TITLE
Changes fireman carrying from a trait on gloves to a skillchip

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -539,3 +539,11 @@ GLOBAL_LIST_INIT(pda_styles, sortList(list(MONO, VT, ORBITRON, SHARE)))
 #define IGNORE_TARGET_LOC_CHANGE (1<<1)
 #define IGNORE_HELD_ITEM (1<<2)
 #define IGNORE_INCAPACITATED (1<<3)
+
+// Skillchip categories
+//Various skillchip categories. Use these when setting which categories a skillchip restricts being paired with
+//while using the SKILLCHIP_RESTRICTED_CATEGORIES flag
+#define SKILLCHIP_CATEGORY_GENERAL "general"
+#define SKILLCHIP_CATEGORY_JOB "job"
+#define SKILLCHIP_CATEGORY_FIREMAN_CARRYING "fireman carrying"
+#define SKILLCHIP_CATEGORY_SYNDICATE "syndicate"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -205,8 +205,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define	TRAIT_MAGIC_CHOKE		"magic_choke"
 #define TRAIT_SOOTHED_THROAT    "soothed-throat"
 #define TRAIT_BOOZE_SLIDER      "booze-slider"
-#define TRAIT_QUICK_CARRY		"quick-carry"
-#define TRAIT_QUICKER_CARRY		"quicker-carry"
+#define TRAIT_QUICK_CARRY		"quick-carry" //We place people into a fireman carry quicker than standard
+#define TRAIT_QUICKER_CARRY		"quicker-carry" //We place people into a fireman carry especially quickly compared to quick_carry
 #define TRAIT_QUICK_BUILD		"quick-build"
 #define TRAIT_UNINTELLIGIBLE_SPEECH "unintelligible-speech"
 #define TRAIT_UNSTABLE			"unstable"

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1249,6 +1249,29 @@
 	new/obj/item/skillchip/job/engineer(src)
 	new/obj/item/skillchip/job/engineer(src)
 
+/obj/item/storage/box/skillchips/quick
+	name = "box of Ant Hauler skill chips"
+	desc = "Contains Ant Hauler skill chips."
+
+/obj/item/storage/box/skillchips/quick/PopulateContents()
+	new/obj/item/skillchip/quickcarry(src)
+	new/obj/item/skillchip/quickcarry(src)
+	new/obj/item/skillchip/quickcarry(src)
+	new/obj/item/skillchip/quickcarry(src)
+	new/obj/item/skillchip/quickcarry(src)
+	new/obj/item/skillchip/quickcarry(src)
+	new/obj/item/skillchip/quickcarry(src)
+
+/obj/item/storage/box/skillchips/quicker
+	name = "box of RES-Q skill chips"
+	desc = "Contains RES-Q skill chips."
+
+/obj/item/storage/box/skillchips/quicker/PopulateContents()
+	new/obj/item/skillchip/quickercarry(src)
+	new/obj/item/skillchip/quickercarry(src)
+	new/obj/item/skillchip/quickercarry(src)
+	new/obj/item/skillchip/quickercarry(src)
+
 /obj/item/storage/box/swab
 	name = "box of microbiological swabs"
 	desc = "Contains a number of sterile swabs for collecting microbiological samples."

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -42,6 +42,7 @@
 	new /obj/item/clothing/gloves/color/latex/nitrile(src)
 	new /obj/item/storage/belt/medical(src)
 	new /obj/item/clothing/glasses/hud/health(src)
+	new /obj/item/storage/box/skillchips/quick(src)
 	return
 
 /obj/structure/closet/secure_closet/psychology
@@ -95,6 +96,7 @@
 	new /obj/item/wallframe/defib_mount(src)
 	new /obj/item/circuitboard/machine/techfab/department/medical(src)
 	new /obj/item/storage/photo_album/cmo(src)
+	new /obj/item/storage/box/skillchips/quicker(src)
 
 /obj/structure/closet/secure_closet/animal
 	name = "animal control"

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -187,7 +187,6 @@
 	inhand_icon_state = "latex"
 	siemens_coefficient = 0.3
 	permeability_coefficient = 0.01
-	clothing_traits = list(TRAIT_QUICK_CARRY)
 	transfer_prints = TRUE
 	resistance_flags = NONE
 
@@ -196,7 +195,6 @@
 	desc = "Pricy sterile gloves that are thicker than latex. Transfers intimate paramedic knowledge into the user via nanochips."
 	icon_state = "nitrile"
 	inhand_icon_state = "nitrilegloves"
-	clothing_traits = list(TRAIT_QUICKER_CARRY)
 	transfer_prints = FALSE
 
 /obj/item/clothing/gloves/color/latex/nitrile/infiltrator

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -45,7 +45,7 @@
 	suit_store = /obj/item/flashlight/pen/paramedic
 	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1, /obj/item/modular_computer/tablet/preset/advanced/command=1)
 
-	skillchips = list(/obj/item/skillchip/entrails_reader)
+	skillchips = list(/obj/item/skillchip/entrails_reader, /obj/item/skillchip/quickercarry)
 
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -36,6 +36,6 @@
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival/medical
 
-	skillchips = list(/obj/item/skillchip/entrails_reader)
+	skillchips = list(/obj/item/skillchip/entrails_reader, /obj/item/skillchip/quickcarry)
 
 	chameleon_extras = /obj/item/gun/syringe

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -38,6 +38,8 @@
 	backpack_contents = list(/obj/item/roller=1)
 	pda_slot = ITEM_SLOT_LPOCKET
 
+	skillchips = list(/obj/item/skillchip/quickercarry)
+
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med

--- a/code/modules/library/skill_learning/job_skillchips/_job.dm
+++ b/code/modules/library/skill_learning/job_skillchips/_job.dm
@@ -1,6 +1,6 @@
 /obj/item/skillchip/job
 	skillchip_flags = SKILLCHIP_RESTRICTED_CATEGORIES
-	chip_category = "job"
-	incompatibility_list = list("job")
+	chip_category = SKILLCHIP_CATEGORY_JOB
+	incompatibility_list = list(SKILLCHIP_CATEGORY_JOB)
 	abstract_parent_type = /obj/item/skillchip/job
 	slot_use = 2

--- a/code/modules/library/skill_learning/skillchip.dm
+++ b/code/modules/library/skill_learning/skillchip.dm
@@ -14,7 +14,7 @@
 	/// Skill description shown on UI
 	var/skill_description
 	/// Category string. Used alongside SKILLCHIP_RESTRICTED_CATEGORIES flag to make a chip incompatible with chips from another category.
-	var/chip_category = "general"
+	var/chip_category = SKILLCHIP_CATEGORY_GENERAL
 	/// List of any incompatible categories.
 	var/list/incompatibility_list
 	/// Fontawesome icon show on UI, list of possible icons https://fontawesome.com/icons?d=gallery&m=free
@@ -438,9 +438,9 @@
 	name = "Ant Hauler skillchip"
 	auto_traits = list(TRAIT_QUICK_CARRY)
 	skill_name = "Ant Hauler"
-	chip_category = "bodycarrying"
+	chip_category = SKILLCHIP_CATEGORY_FIREMAN_CARRYING
 	skillchip_flags = SKILLCHIP_RESTRICTED_CATEGORIES
-	incompatibility_list = list("bodycarrying")
+	incompatibility_list = list(SKILLCHIP_CATEGORY_FIREMAN_CARRYING)
 	skill_description = "Discover various lifting techniques to more accurately and quickly lift someone up into a fireman carry."
 	skill_icon = "hand-holding"
 	activate_message = "<span class='notice'>You feel like you can easily lift and carry people around.</span>"
@@ -450,9 +450,9 @@
 	name = "RES-Q skillchip"
 	auto_traits = list(TRAIT_QUICKER_CARRY)
 	skill_name = "RES-Q"
-	chip_category = "bodycarrying"
+	chip_category = SKILLCHIP_CATEGORY_FIREMAN_CARRYING
 	skillchip_flags = SKILLCHIP_RESTRICTED_CATEGORIES
-	incompatibility_list = list("bodycarrying")
+	incompatibility_list = list(SKILLCHIP_CATEGORY_FIREMAN_CARRYING)
 	skill_description = "Learn how to fireman carry like a professional, and haul the injured, sick or dying with speed!"
 	skill_icon = "hand-holding"
 	activate_message = "<span class='notice'>Carrying people across your back feels like second nature to you.</span>"

--- a/code/modules/library/skill_learning/skillchip.dm
+++ b/code/modules/library/skill_learning/skillchip.dm
@@ -433,3 +433,27 @@
 	skill_icon = "lungs"
 	activate_message = "<span class='notice'>You feel that you know a lot about interpreting organs.</span>"
 	deactivate_message = "<span class='notice'>Knowledge of liver damage, heart strain and lung scars fades from your mind.</span>"
+
+/obj/item/skillchip/quickcarry
+	name = "Ant Hauler skillchip"
+	auto_traits = list(TRAIT_QUICK_CARRY)
+	skill_name = "Ant Hauler"
+	chip_category = "bodycarrying"
+	skillchip_flags = SKILLCHIP_RESTRICTED_CATEGORIES
+	incompatibility_list = list("bodycarrying")
+	skill_description = "Discover various lifting techniques to more accurately and quickly lift someone up into a fireman carry."
+	skill_icon = "hand-holding"
+	activate_message = "<span class='notice'>You feel like you can easily lift and carry people around.</span>"
+	deactivate_message = "<span class='notice'>Your skill at lifting people into a fireman carry fades from your mind.</span>"
+
+/obj/item/skillchip/quickercarry
+	name = "RES-Q skillchip"
+	auto_traits = list(TRAIT_QUICKER_CARRY)
+	skill_name = "RES-Q"
+	chip_category = "bodycarrying"
+	skillchip_flags = SKILLCHIP_RESTRICTED_CATEGORIES
+	incompatibility_list = list("bodycarrying")
+	skill_description = "Learn how to fireman carry like a professional, and haul the injured, sick or dying with speed!"
+	skill_icon = "hand-holding"
+	activate_message = "<span class='notice'>Carrying people across your back feels like second nature to you.</span>"
+	deactivate_message = "<span class='notice'>Your expert knowledge in fireman carrying fades from your mind.</span>"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1061,7 +1061,7 @@
 		to_chat(src, "<span class='warning'>You can't fireman carry [target] while [target.p_they()] [target.p_are()] standing!</span>")
 		return
 
-	var/carrydelay = 5 SECONDS //if you have latex you are faster at grabbing
+	var/carrydelay = 5 SECONDS //This is augmented by traits from your skillchip
 	var/skills_space = "" //cobby told me to do this
 	if(HAS_TRAIT(src, TRAIT_QUICKER_CARRY))
 		carrydelay = 3 SECONDS
@@ -1072,8 +1072,8 @@
 
 	visible_message("<span class='notice'>[src] starts[skills_space] lifting [target] onto [p_their()] back..</span>",
 	//Joe Medic starts quickly/expertly lifting Grey Tider onto their back..
-	"<span class='notice'>[carrydelay < 3.5 SECONDS ? "Using your gloves' nanochips, you" : "You"][skills_space] start to lift [target] onto your back[carrydelay == 4 SECONDS ? ", while assisted by the nanochips in your gloves.." : "..."]</span>")
-	//(Using your gloves' nanochips, you/You) ( /quickly/expertly) start to lift Grey Tider onto your back(, while assisted by the nanochips in your gloves../...)
+	"<span class='notice'>[carrydelay < 3.5 SECONDS ? "Using your fireman carrying training, you" : "You"][skills_space] start to lift [target] onto your back[carrydelay == 4 SECONDS ? ", with ease thanks to your advanced knowledge.." : "..."]</span>")
+	//(Using your fireman carrying training, you/You) ( /quickly/expertly) start to lift Grey Tider onto your back(, with ease thanks to your advanced knowledge../...)
 	if(!do_after(src, carrydelay, target))
 		visible_message("<span class='warning'>[src] fails to fireman carry [target]!</span>")
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin. 

Latex gloves were readily available in significant numbers. So I put a box of them in the medical lockers. Latex gloves are cheap and plentiful, so the skillchips here should be as well. Every medical doctor starts with this chip implanted.

However, nitrile gloves are special. There aren't as many available in a round, with one in each medical locker, one in the CMO's, and spawned with paramedics. Therefore, the CMO gets a box of the skillchips in their locker. They and paramedics also start with one implanted.

## Why It's Good For The Game

This fits a skillchip way more than a glove trait, since it is literally a skill imparted by the gloves.

## Changelog
:cl:
balance: Changes the carrying traits on Latex/Nitrile gloves into a skillchip.
balance: Medical doctors start the round with a quick carry skillchip (was the latex glove trait).
balance: Paramedics and the CMO start the round with a quicker carry skillchip (was the nitrile glove trait).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
