### PR TITLE
Fixes Traitor Uplinks Being Set to Existing Radio Channels

### DIFF
--- a/code/__HELPERS/radio.dm
+++ b/code/__HELPERS/radio.dm
@@ -27,7 +27,6 @@
 	freq_to_check += !(freq_to_check % 2) //make sure freq_to_check is odd
 	while(TRUE)
 		if("[freq_to_check]" in GLOB.reverseradiochannels)
-			message_admins("it worked!")
 			freq_to_check = rand(start, end)
 			freq_to_check += !(freq_to_check % 2)
 		else

--- a/code/__HELPERS/radio.dm
+++ b/code/__HELPERS/radio.dm
@@ -1,4 +1,4 @@
-// Ensure the frequency is within bounds of what it should be sending/receiving at
+/// Ensure the frequency is within bounds of what it should be sending/receiving at
 /proc/sanitize_frequency(frequency, free = FALSE)
 	frequency = round(frequency)
 	if(free)
@@ -8,12 +8,27 @@
 	if(!(. % 2)) // Ensure the last digit is an odd number
 		. += 1
 
-// Format frequency by moving the decimal.
+/// Format frequency by moving the decimal.
 /proc/format_frequency(frequency)
 	frequency = text2num(frequency)
 	return "[round(frequency / 10)].[frequency % 10]"
 
-//Opposite of format, returns as a number
+///Opposite of format, returns as a number
 /proc/unformat_frequency(frequency)
 	frequency = text2num(frequency)
 	return frequency * 10
+
+///returns a random unused frequency between MIN_FREE_FREQ & MAX_FREE_FREQ if free = TRUE, and MIN_FREQ & MAX_FREQ if FALSE
+/proc/return_unused_frequency(free = FALSE)
+	var/start = free ? MIN_FREE_FREQ : MIN_FREQ
+	var/end = free ? MAX_FREE_FREQ : MAX_FREQ
+
+	var/freq_to_check = rand(start, end)
+	freq_to_check += !(freq_to_check % 2) //make sure freq_to_check is odd
+	while(TRUE)
+		if("[freq_to_check]" in GLOB.reverseradiochannels)
+			message_admins("it worked!")
+			freq_to_check = rand(start, end)
+			freq_to_check += !(freq_to_check % 2)
+		else
+			return freq_to_check

--- a/code/__HELPERS/radio.dm
+++ b/code/__HELPERS/radio.dm
@@ -20,14 +20,14 @@
 
 ///returns a random unused frequency between MIN_FREE_FREQ & MAX_FREE_FREQ if free = TRUE, and MIN_FREQ & MAX_FREQ if FALSE
 /proc/return_unused_frequency(free = FALSE)
-	var/start = free ? MIN_FREE_FREQ : MIN_FREQ
-	var/end = free ? MAX_FREE_FREQ : MAX_FREQ
+	var/start = free ? MIN_FREE_FREQ : 1459//MIN_FREQ
+	var/end = free ? MAX_FREE_FREQ : 1460//MAX_FREQ
 
-	var/freq_to_check = rand(start, end)
-	freq_to_check += !(freq_to_check % 2) //make sure freq_to_check is odd
-	while(TRUE)
-		if("[freq_to_check]" in GLOB.reverseradiochannels)
-			freq_to_check = rand(start, end)
-			freq_to_check += !(freq_to_check % 2)
-		else
-			return freq_to_check
+	var/freq_to_check = 0
+	do
+		freq_to_check = rand(start, end)
+		if(!(freq_to_check % 2)) // Ensure the last digit is an odd number
+			freq_to_check++
+	while((freq_to_check == 0) || ("[freq_to_check]" in GLOB.reverseradiochannels))
+
+	return freq_to_check

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -331,7 +331,7 @@
 	if(istype(parent,/obj/item/pda))
 		return "[rand(100,999)] [pick(GLOB.phonetic_alphabet)]"
 	else if(istype(parent,/obj/item/radio))
-		return sanitize_frequency(rand(MIN_FREQ, MAX_FREQ))
+		return return_unused_frequency()
 	else if(istype(parent,/obj/item/pen))
 		var/list/L = list()
 		for(var/i in 1 to PEN_ROTATIONS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #56526 
creates a new proc that returns a random unused radio frequency, tested to confirm that it does not return a used frequency
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: radio uplinks can no longer become unusable due to the code frequency
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
