### PR TITLE
Rocket boots Rocket boots

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
@@ -68,3 +68,13 @@
 	price_max = 7000
 	stock_max = 1
 	availability_prob = 10
+	
+/datum/blackmarket_item/clothing/rocket_boots
+	name = "Rocket Boots"
+	desc = "We found a pair of jump boots and overclocked the hell out of them. No liability for grevious harm to or with a body."
+	item = /obj/item/clothing/shoes/bhop/rocket
+
+	price_min = 1000
+	price_max = 3000
+	stock_max = 1
+	availability_prob = 40

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -273,6 +273,13 @@
 	else
 		to_chat(user, "<span class='warning'>Something prevents you from dashing forward!</span>")
 
+/obj/item/clothing/shoes/bhop/rocket 
+	name = "rocket boots"
+	desc = "Very special boots with built-in rocket thrusters! SHAZBOT!"
+	var/jumpdistance = 20 //great for throwing yourself into walls and people at high speeds
+	var/jumpspeed = 5
+	var/recharging_rate = 60 //default 6 seconds between each dash
+
 /obj/item/clothing/shoes/singery
 	name = "yellow performer's boots"
 	desc = "These boots were made for dancing."

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -276,9 +276,8 @@
 /obj/item/clothing/shoes/bhop/rocket 
 	name = "rocket boots"
 	desc = "Very special boots with built-in rocket thrusters! SHAZBOT!"
-	var/jumpdistance = 20 //great for throwing yourself into walls and people at high speeds
-	var/jumpspeed = 5
-	var/recharging_rate = 60 //default 6 seconds between each dash
+	jumpdistance = 20 //great for throwing yourself into walls and people at high speeds
+	jumpspeed = 5
 
 /obj/item/clothing/shoes/singery
 	name = "yellow performer's boots"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1607,7 +1607,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Rocket Boots"
 	desc = "A pair of heavily modified jump boots with added rocket thrusters. Great for making quick escapes, although you need a very long, unobstructed space to not slam into anything."
 	item = /obj/item/clothing/shoes/bhop/rocket
-	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	cost = 3 //you have to choose between this or noslips. Personally I'd go with the noslips.
 	illegal_tech = FALSE //It's a bad idea, not an illegal one.
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1602,6 +1602,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	cost = 2
 	illegal_tech = FALSE
+	
+/datum/uplink_item/device_tools/rocketboots
+	name = "Rocket Boots"
+	desc = "A pair of heavily modified jump boots with added rocket thrusters. Great for making quick escapes, although you need a very long, unobstructed space to not slam into anything."
+	item = /obj/item/clothing/shoes/bhop/rocket
+	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+	cost = 3 //you have to choose between this or noslips. Personally I'd go with the noslips.
+	illegal_tech = FALSE //It's a bad idea, not an illegal one.
 
 // Implants
 /datum/uplink_item/implants

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1602,13 +1602,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	cost = 2
 	illegal_tech = FALSE
-	
-/datum/uplink_item/device_tools/rocketboots
-	name = "Rocket Boots"
-	desc = "A pair of heavily modified jump boots with added rocket thrusters. Great for making quick escapes, although you need a very long, unobstructed space to not slam into anything."
-	item = /obj/item/clothing/shoes/bhop/rocket
-	cost = 3 //you have to choose between this or noslips. Personally I'd go with the noslips.
-	illegal_tech = FALSE //It's a bad idea, not an illegal one.
 
 // Implants
 /datum/uplink_item/implants


### PR DESCRIPTION
## About The Pull Request
Adds Rocket Boots, a black market pair of jump boots that makes you slam into walls (or people) up to 20 tiles away

## Why It's Good For The Game
So people can give themselves brain damage in a different way than meth while they avoid the popo.

## Changelog
:cl:
add: Rocket boots, a bad idea from the black market that hurls you 20 tiles in the direction you're facing. Beware of walls and people.
/:cl:

