### PR TITLE
Heretic void cloak no longer deletes itself when you unequip it.

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -214,21 +214,24 @@
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/void_cloak
 	alternative_mode = TRUE
 
-/obj/item/clothing/suit/hooded/cultrobes/void/ToggleHood()
+/obj/item/clothing/suit/hooded/cultrobes/void/RemoveHood()
+	var/mob/living/carbon/carbon_user = loc
+	to_chat(carbon_user,"<span class='notice'>The kaleidoscope of colours collapses around you, as the cloak shifts to visibility!</span>")
+	item_flags &= ~EXAMINE_SKIP
+	return ..()
+
+/obj/item/clothing/suit/hooded/cultrobes/void/MakeHood()
 	if(!iscarbon(loc))
-		return
+		CRASH("[src] attempted to make a hood on a non-carbon thing: [loc]")
+
 	var/mob/living/carbon/carbon_user = loc
 	if(IS_HERETIC(carbon_user) || IS_HERETIC_MONSTER(carbon_user))
 		. = ..()
-		//We need to account for the hood shenanigans, and that way we can make sure items always fit, even if one of the slots is used by the fucking hood.
-		if(suittoggled)
-			to_chat(carbon_user,"<span class='notice'>The light shifts around you making the cloak invisible!</span>")
-		else
-			to_chat(carbon_user,"<span class='notice'>The kaleidoscope of colours collapses around you, as the cloak shifts to visibility!</span>")
-		item_flags = suittoggled ? EXAMINE_SKIP : ~EXAMINE_SKIP
-	else
-		to_chat(carbon_user,"<span class='danger'>You can't force the hood onto your head!</span>")
+		to_chat(carbon_user,"<span class='notice'>The light shifts around you making the cloak invisible!</span>")
+		item_flags |= EXAMINE_SKIP
+		return
 
+	to_chat(carbon_user,"<span class='danger'>You can't force the hood onto your head!</span>")
 
 /obj/item/clothing/mask/void_mask
 	name = "Abyssal Mask"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/106791839-5df84a00-664d-11eb-9814-838a0a5f3696.png)
![image](https://user-images.githubusercontent.com/24975989/106791848-60f33a80-664d-11eb-88d6-8a814838fb6e.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No longer drives me into alcohol's sweet embrace.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Heretic's void cloak no longer deletes itself when you take it off after removing the hood using the action button.
fix: Heretic's void cloak is once again visible on examining a player when they have unequipped the hood direct from the equipment menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
