### PR TITLE
Captain's gun now shoots hellfire lasers

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -7,6 +7,9 @@
 	e_cost = 130
 	select_name = "maim"
 
+/obj/item/ammo_casing/energy/laser/hellfire/antique
+	e_cost = 100
+
 /obj/item/ammo_casing/energy/lasergun
 	projectile_type = /obj/projectile/beam/laser
 	e_cost = 71

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -45,7 +45,7 @@
 	ammo_x_offset = 3
 	selfcharge = 1
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
-	ammo_type = list(/obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/laser/hellfire)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/hellfire/antique)
 
 /obj/item/gun/energy/laser/captain/scattershot
 	name = "scatter shot laser rifle"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -45,6 +45,7 @@
 	ammo_x_offset = 3
 	selfcharge = 1
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	ammo_type = list(/obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/laser/hellfire)
 
 /obj/item/gun/energy/laser/captain/scattershot
 	name = "scatter shot laser rifle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR changes the Captain's antique laser to fire hellfire lasers instead of normal ones, which for those who don't know, deal much more grievous burn wounds and slightly more damage (25 burn vs 20). Originally this PR let the Cap's gun switch between normal lasers at the normal energy cost and hellfires at 30% more energy cost, but coiax suggested just making it shoot hellfires only so here we are.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This gives the Cap's gun more personality and utility than just being a smaller advanced energy gun without disablers. Hellfire lasers and burn wounds work best against unarmored targets (like, say, a swarm of assistants breaking into your office), so this gives the wielder an extra edge against rowdy crewmembers who need to be brought back into line.

It also works out fluff-wise, since hellguns are supposed to be really old laser guns that were so gruesome that NT limited their power to avoid the bad PR that comes with selling war-crime guns, so an antique from before that change would still have them. Plus I think it's funny that the Captain gets a gun that specializes in maiming and disfiguring people.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
balance: The Captain's antique laser now fires more powerful hellfire lasers rather than normal lasers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
