### PR TITLE
Energy katana now uses right click to teleport instead of toggling

### DIFF
--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -44,7 +44,7 @@
 
 	var/list/params = params2list(click_parameters)
 
-	if(params["right"] && !Adjacent(target) && !target.density)
+	if(params["right"] && !target.density)
 		jaunt.Teleport(user, target)
 
 /obj/item/energy_katana/pickup(mob/living/user)

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -4,14 +4,14 @@
  * The space ninja's katana.
  *
  * The katana that only space ninja spawns with.  Comes with 30 force and throwforce, along with a signature special jaunting system.
- * Upon clicking on a tile with the dash on, the user will teleport to that tile, assuming their target was not dense.
+ * Upon clicking on a tile when right clicking, the user will teleport to that tile, assuming their target was not dense.
  * The katana has 3 dashes stored at maximum, and upon using the dash, it will return 20 seconds after it was used.
  * It also has a special feature where if it is tossed at a space ninja who owns it (determined by the ninja suit), the ninja will catch the katana instead of being hit by it.
  *
  */
 /obj/item/energy_katana
 	name = "energy katana"
-	desc = "A katana infused with strong energy."
+	desc = "A katana infused with strong energy. Right-click to dash."
 	icon_state = "energy_katana"
 	inhand_icon_state = "energy_katana"
 	worn_icon_state = "energy_katana"
@@ -31,7 +31,6 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/datum/effect_system/spark_spread/spark_system
 	var/datum/action/innate/dash/ninja/jaunt
-	var/dash_toggled = TRUE
 
 /obj/item/energy_katana/Initialize()
 	. = ..()
@@ -40,13 +39,12 @@
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 
-/obj/item/energy_katana/attack_self(mob/user)
-	dash_toggled = !dash_toggled
-	to_chat(user, "<span class='notice'>You [dash_toggled ? "enable" : "disable"] the dash function on [src].</span>")
-
 /obj/item/energy_katana/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
-	if(dash_toggled && !Adjacent(target) && !target.density)
+
+	var/list/params = params2list(click_parameters)
+
+	if(params["right"] && !Adjacent(target) && !target.density)
 		jaunt.Teleport(user, target)
 
 /obj/item/energy_katana/pickup(mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Energy katana now uses right click to teleport instead of toggling by activating in hand.

**Right clicking being the new method of minor interactions starts now.**

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Right click is the new standard for minor interactions. This feels much more fluid than switching, and ensures you'll never mess it up.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The ninja's energy katana now uses right click to dash instead of being a toggle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
