### PR TITLE
You can now remove embedded objects directly with a hemostat

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -150,29 +150,29 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 
 //Embedded objects
 ///Chance for embedded objects to cause pain (damage user)
-#define EMBEDDED_PAIN_CHANCE 					15
+#define EMBEDDED_PAIN_CHANCE 15
 ///Chance for embedded object to fall out (causing pain but removing the object)
-#define EMBEDDED_ITEM_FALLOUT 					5
+#define EMBEDDED_ITEM_FALLOUT 5
 ///Chance for an object to embed into somebody when thrown
-#define EMBED_CHANCE							45
+#define EMBED_CHANCE 45
 ///Coefficient of multiplication for the damage the item does while embedded (this*item.w_class)
-#define EMBEDDED_PAIN_MULTIPLIER				2
+#define EMBEDDED_PAIN_MULTIPLIER 2
 ///Coefficient of multiplication for the damage the item does when it first embeds (this*item.w_class)
-#define EMBEDDED_IMPACT_PAIN_MULTIPLIER			4
+#define EMBEDDED_IMPACT_PAIN_MULTIPLIER 4
 ///The minimum value of an item's throw_speed for it to embed (Unless it has embedded_ignore_throwspeed_threshold set to 1)
-#define EMBED_THROWSPEED_THRESHOLD				4
+#define EMBED_THROWSPEED_THRESHOLD 4
 ///Coefficient of multiplication for the damage the item does when it falls out or is removed without a surgery (this*item.w_class)
 #define EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER 6
 ///A Time in ticks, total removal time = (this*item.w_class)
-#define EMBEDDED_UNSAFE_REMOVAL_TIME			30
+#define EMBEDDED_UNSAFE_REMOVAL_TIME 30
 ///Chance for embedded objects to cause pain every time they move (jostle)
-#define EMBEDDED_JOSTLE_CHANCE					5
+#define EMBEDDED_JOSTLE_CHANCE 5
 ///Coefficient of multiplication for the damage the item does while
-#define EMBEDDED_JOSTLE_PAIN_MULTIPLIER			1
+#define EMBEDDED_JOSTLE_PAIN_MULTIPLIER 1
 ///This percentage of all pain will be dealt as stam damage rather than brute (0-1)
-#define EMBEDDED_PAIN_STAM_PCT					0.0
+#define EMBEDDED_PAIN_STAM_PCT 0.0
 ///For thrown weapons, every extra speed it's thrown at above its normal throwspeed will add this to the embed chance
-#define EMBED_CHANCE_SPEED_BONUS				10
+#define EMBED_CHANCE_SPEED_BONUS 10
 
 #define EMBED_HARMLESS list("pain_mult" = 0, "jostle_pain_mult" = 0, "ignore_throwspeed_threshold" = TRUE)
 #define EMBED_HARMLESS_SUPERIOR list("pain_mult" = 0, "jostle_pain_mult" = 0, "ignore_throwspeed_threshold" = TRUE, "embed_chance" = 100, "fall_chance" = 0.1)

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -171,6 +171,8 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define EMBEDDED_JOSTLE_PAIN_MULTIPLIER			1
 ///This percentage of all pain will be dealt as stam damage rather than brute (0-1)
 #define EMBEDDED_PAIN_STAM_PCT					0.0
+///For thrown weapons, every extra speed it's thrown at above its normal throwspeed will add this to the embed chance
+#define EMBED_CHANCE_SPEED_BONUS				10
 
 #define EMBED_HARMLESS list("pain_mult" = 0, "jostle_pain_mult" = 0, "ignore_throwspeed_threshold" = TRUE)
 #define EMBED_HARMLESS_SUPERIOR list("pain_mult" = 0, "jostle_pain_mult" = 0, "ignore_throwspeed_threshold" = TRUE, "embed_chance" = 100, "fall_chance" = 0.1)

--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -262,7 +262,7 @@
 			vision_distance=COMBAT_MESSAGE_RANGE, ignored_mobs=victim)
 		to_chat(victim, "<span class='userdanger'>[user] begins plucking [weapon] from your [limb.name]...</span>")
 
-	var/pluck_time = 2.5 SECONDS * weapon.w_class * (self_pluck ? 1.5 : 1)
+	var/pluck_time = 2.5 SECONDS * weapon.w_class * (self_pluck ? 2 : 1)
 	if(!do_after(user, pluck_time, victim))
 		if(self_pluck)
 			to_chat(user, "<span class='danger'>You fail to pluck [weapon] from your [limb.name].</span>")

--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -245,6 +245,11 @@
 	if(weapon != limb.embedded_objects[1]) // just pluck the first one, since we can't easily coordinate with other embedded components affecting this limb who is highest priority
 		return
 
+	if(ishuman(victim)) // check to see if the limb is actually exposed
+		var/mob/living/carbon/human/victim_human = victim
+		if(!victim_human.can_inject(user, TRUE, limb.body_zone, ignore_species = TRUE))
+			return TRUE
+
 	INVOKE_ASYNC(src, .proc/tweezePluck, possible_tweezers, user)
 	return COMPONENT_NO_AFTERATTACK
 

--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -116,9 +116,10 @@
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/jostleCheck)
 	RegisterSignal(parent, COMSIG_CARBON_EMBED_RIP, .proc/ripOut)
 	RegisterSignal(parent, COMSIG_CARBON_EMBED_REMOVAL, .proc/safeRemove)
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/checkTweeze)
 
 /datum/component/embedded/UnregisterFromParent()
-	UnregisterSignal(parent, list(COMSIG_MOVABLE_MOVED, COMSIG_CARBON_EMBED_RIP, COMSIG_CARBON_EMBED_REMOVAL))
+	UnregisterSignal(parent, list(COMSIG_MOVABLE_MOVED, COMSIG_CARBON_EMBED_RIP, COMSIG_CARBON_EMBED_REMOVAL, COMSIG_PARENT_ATTACKBY))
 
 /datum/component/embedded/process(delta_time)
 	var/mob/living/carbon/victim = parent
@@ -202,11 +203,11 @@
 		victim.emote("scream")
 
 	victim.visible_message("<span class='notice'>[victim] successfully rips [weapon] [harmful ? "out" : "off"] of [victim.p_their()] [limb.name]!</span>", "<span class='notice'>You successfully remove [weapon] from your [limb.name].</span>")
-	safeRemove(TRUE)
+	safeRemove(victim)
 
 /// This proc handles the final step and actual removal of an embedded/stuck item from a carbon, whether or not it was actually removed safely.
-/// Pass TRUE for to_hands if we want it to go to the victim's hands when they pull it out
-/datum/component/embedded/proc/safeRemove(to_hands)
+/// If you want the thing to go into someone's hands rather than the floor, pass them in to_hands
+/datum/component/embedded/proc/safeRemove(mob/to_hands)
 	SIGNAL_HANDLER
 
 	var/mob/living/carbon/victim = parent
@@ -216,7 +217,7 @@
 	if(!weapon.unembedded()) // if it hasn't deleted itself due to drop del
 		UnregisterSignal(weapon, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
 		if(to_hands)
-			INVOKE_ASYNC(victim, /mob.proc/put_in_hands, weapon)
+			INVOKE_ASYNC(to_hands, /mob.proc/put_in_hands, weapon)
 		else
 			weapon.forceMove(get_turf(victim))
 
@@ -233,3 +234,43 @@
 		to_chat(victim, "<span class='userdanger'>\The [weapon] that was embedded in your [limb.name] disappears!</span>")
 
 	qdel(src)
+
+/// The signal for listening to see if someone is using a hemostat on us to pluck out this object
+/datum/component/embedded/proc/checkTweeze(mob/living/carbon/victim, obj/item/possible_tweezers, mob/user)
+	SIGNAL_HANDLER
+
+	if(!istype(victim) || possible_tweezers.tool_behaviour != TOOL_HEMOSTAT || user.zone_selected != limb.body_zone)
+		return
+
+	if(weapon != limb.embedded_objects[1]) // just pluck the first one, since we can't easily coordinate with other embedded components affecting this limb who is highest priority
+		return
+
+	INVOKE_ASYNC(src, .proc/tweezePluck, possible_tweezers, user)
+	return COMPONENT_NO_AFTERATTACK
+
+/// The actual action for pulling out an embedded object with a hemostat
+/datum/component/embedded/proc/tweezePluck(obj/item/possible_tweezers, mob/user)
+	var/mob/living/carbon/victim = parent
+
+	var/self_pluck = (user == victim)
+
+	if(self_pluck)
+		user.visible_message("<span class='danger'>[user] begins plucking [weapon] from [user.p_their()] [limb.name]</span>", "<span class='notice'>You start plucking [weapon] from your [limb.name]...</span>",\
+			vision_distance=COMBAT_MESSAGE_RANGE, ignored_mobs=victim)
+	else
+		user.visible_message("<span class='danger'>[user] begins plucking [weapon] from [victim]'s [limb.name]</span>","<span class='notice'>You start plucking [weapon] from [victim]'s [limb.name]...</span>", \
+			vision_distance=COMBAT_MESSAGE_RANGE, ignored_mobs=victim)
+		to_chat(victim, "<span class='userdanger'>[user] begins plucking [weapon] from your [limb.name]...</span>")
+
+	var/pluck_time = 2.5 SECONDS * weapon.w_class * (self_pluck ? 1.5 : 1)
+	if(!do_after(user, pluck_time, victim))
+		if(self_pluck)
+			to_chat(user, "<span class='danger'>You fail to pluck [weapon] from your [limb.name].</span>")
+		else
+			to_chat(user, "<span class='danger'>You fail to pluck [weapon] from [victim]'s [limb.name].</span>")
+			to_chat(victim, "<span class='danger'>[user] fails to pluck [weapon] from your [limb.name].</span>")
+		return
+
+	to_chat(user, "<span class='notice'>You successfully pluck [weapon] from [victim]'s [limb.name].</span>")
+	to_chat(victim, "<span class='notice'>[user] plucks [weapon] from your [limb.name].</span>")
+	safeRemove(user)

--- a/code/datums/elements/embed.dm
+++ b/code/datums/elements/embed.dm
@@ -75,6 +75,9 @@
 
 	var/actual_chance = embed_chance
 
+	if(throwingdatum?.speed > weapon.throw_speed)
+		actual_chance += (throwingdatum.speed - weapon.throw_speed) * EMBED_CHANCE_SPEED_BONUS
+
 	if(!weapon.isEmbedHarmless()) // all the armor in the world won't save you from a kick me sign
 		var/armor = max(victim.run_armor_check(hit_zone, BULLET, silent=TRUE), victim.run_armor_check(hit_zone, BOMB, silent=TRUE)) * 0.5 // we'll be nice and take the better of bullet and bomb armor, halved
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -9,9 +9,9 @@
 	sharpness = SHARP_POINTY
 	impact_effect_type = /obj/effect/temp_visual/impact_effect
 	shrapnel_type = /obj/item/shrapnel/bullet
-	embedding = list(embed_chance=15, fall_chance=2, jostle_chance=0, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.5, pain_mult=3, rip_time=10)
+	embedding = list(embed_chance=20, fall_chance=2, jostle_chance=0, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.5, pain_mult=3, rip_time=10)
 	wound_falloff_tile = -5
-	embed_falloff_tile = -5
+	embed_falloff_tile = -3
 
 /obj/projectile/bullet/smite
 	name = "divine retribution"

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -21,7 +21,8 @@
 	ricochet_auto_aim_range = 3
 	wound_bonus = -20
 	bare_wound_bonus = 10
-	embedding = list(embed_chance=15, fall_chance=2, jostle_chance=2, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=3, jostle_pain_mult=5, rip_time=10)
+	embedding = list(embed_chance=25, fall_chance=2, jostle_chance=2, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=3, jostle_pain_mult=5, rip_time=1 SECONDS)
+	embed_falloff_tile = -4
 
 /obj/projectile/bullet/c38/match
 	name = ".38 Match bullet"
@@ -55,7 +56,7 @@
 	sharpness = SHARP_EDGED
 	wound_bonus = 20
 	bare_wound_bonus = 20
-	embedding = list(embed_chance=75, fall_chance=3, jostle_chance=4, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=10)
+	embedding = list(embed_chance=75, fall_chance=3, jostle_chance=4, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=1 SECONDS)
 	wound_falloff_tile = -5
 	embed_falloff_tile = -15
 

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -107,7 +107,7 @@
 /obj/projectile/bullet/a357
 	name = ".357 bullet"
 	damage = 60
-	wound_bonus = -20
+	wound_bonus = -30
 
 // admin only really, for ocelot memes
 /obj/projectile/bullet/a357/match

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -107,7 +107,7 @@
 /obj/projectile/bullet/a357
 	name = ".357 bullet"
 	damage = 60
-	wound_bonus = -70
+	wound_bonus = -20
 
 // admin only really, for ocelot memes
 /obj/projectile/bullet/a357/match

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -55,6 +55,7 @@ As a Medical Doctor, Critical Slash wounds are one of the most dangerous conditi
 As a Medical Doctor, Saline-Glucose not only acts as a temporary boost to a patient's blood level, it also speeds blood regeneration! Perfect for drained patients!
 As a Medical Doctor, almost every type of wound can be treated at least temporarily with gauze. When in doubt, wrap it up!
 As a Paramedic, your UV penlight can be used to stem infections in burn wounds! Just target the infected limb and use it on the patient.
+As a Paramedic, embedded objects in a patient can be safely extracted by targeting the affected limb and using a hemostat on the patient.
 As a Chemist, there are dozens of chemicals that can heal, and even more that can cause harm. Experiment!
 As a Chemist, some chemicals can only be synthesized by heating up the contents with a chemical heater or manually with lighters and similar tools.
 As a Chemist, you will be expected to supply crew with certain chemicals. For example, clonexadone and mannitol for the cryo tubes, unstable mutagen and saltpetre for botany as well as healing pills and patches for the front desk.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3167,7 +3167,6 @@
 #include "code\modules\surgery\organic_steps.dm"
 #include "code\modules\surgery\plastic_surgery.dm"
 #include "code\modules\surgery\prosthetic_replacement.dm"
-#include "code\modules\surgery\remove_embedded_object.dm"
 #include "code\modules\surgery\repair_puncture.dm"
 #include "code\modules\surgery\revival.dm"
 #include "code\modules\surgery\stomachpump.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Getting someone with a bullet or a throwing star lodged in their skull to lay down and let you do the remove embedded object surgery on them (possibly several times if they have shrapnel in multiple limbs) is a lot to ask for in hectic situations, and I doubt people ever really bothered since the object would probably fall out on its own (throwing stars notwithstanding) by the time you could actually finish the surgery.

So, now you just target the affected limb and use a hemostat on the patient to pry shrapnel out, ez pz. It takes a few seconds that scales with the size of the object, and you can do it to yourself if you're fine with taking twice as long (and happen to be carrying around a hemostat, you weirdo). This process causes no harm to the patient.

This PR also makes a few other tiny tweaks to embedding I've been meaning to get around to. Here's the breakdown:

- Objects thrown extra fast (higher than their normal throw_speed, like thrown by a hulk or an amped up disposal outlet) gain +10 to their embedding chance for each extra speed.
- Most bullets are now slightly more likely to embed, especially at point blank
- .357 bullets are somewhat more likely to cause piercing wounds

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes removing embedded objects from other people less obnoxious. The other changes just make embedding and bullets more consistent
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
add: You can now remove embedded objects in a patient by using a hemostat on the patient's affected limb, no surgery necessary!
del: Removed the now obsolete "remove embedded objects" surgery
balance: Objects thrown at high speed (like by a hulk or amped up disposal outlet) are now more likely to embed, scaling with the speed they're flung into you at
balance: Most bullets are now slightly more likely to embed
balance: .357 bullets are now somewhat more likely to cause piercing wounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
