### PR TITLE
All Holodeck Bugs Must Die The Same Day Theyre Born or Your Money Back

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -195,6 +195,7 @@ DEFINE_BITFIELD(turret_flags, list(
 
 ///destroys reference to stored_gun to prevent hard deletions
 /obj/machinery/porta_turret/proc/null_gun()
+	SIGNAL_HANDLER
 	stored_gun = null
 
 /obj/machinery/porta_turret/Destroy()
@@ -413,7 +414,13 @@ DEFINE_BITFIELD(turret_flags, list(
 				cover = new /obj/machinery/porta_turret_cover(loc)	//if the turret has no cover and is anchored, give it a cover
 				cover.parent_turret = src	//assign the cover its parent_turret, which would be this (src)
 
-	if(!on || (machine_stat & (NOPOWER|BROKEN)) || manual_control || (!stored_gun && uses_stored))
+	if(!on || (machine_stat & (NOPOWER|BROKEN)))
+		return PROCESS_KILL
+
+	if(manual_control)
+		return PROCESS_KILL
+
+	if(uses_stored && !stored_gun)
 		return PROCESS_KILL
 
 	var/list/targets = list()

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -41,6 +41,9 @@ DEFINE_BITFIELD(turret_flags, list(
 	integrity_failure = 0.5
 	armor = list(MELEE = 50, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 30, BIO = 0, RAD = 0, FIRE = 90, ACID = 90)
 	base_icon_state = "standard"
+
+	///if TRUE this will cause the turret to stop working if the stored_gun var is null in process()
+	var/uses_stored = TRUE
 	/// Scan range of the turret for locating targets
 	var/scan_range = 7
 	/// For turrets inside other objects
@@ -168,8 +171,10 @@ DEFINE_BITFIELD(turret_flags, list(
 	if(installation && !turret_gun)
 		stored_gun = new installation(src)
 	else if (turret_gun)
+		turret_gun.forceMove(src)
 		stored_gun = turret_gun
 
+	RegisterSignal(stored_gun, COMSIG_PARENT_PREQDELETED, .proc/null_gun)
 	var/list/gun_properties = stored_gun.get_turret_properties()
 
 	//required properties
@@ -187,6 +192,10 @@ DEFINE_BITFIELD(turret_flags, list(
 
 	update_icon()
 	return gun_properties
+
+///destroys reference to stored_gun to prevent hard deletions
+/obj/machinery/porta_turret/proc/null_gun()
+	stored_gun = null
 
 /obj/machinery/porta_turret/Destroy()
 	//deletes its own cover with it
@@ -404,7 +413,7 @@ DEFINE_BITFIELD(turret_flags, list(
 				cover = new /obj/machinery/porta_turret_cover(loc)	//if the turret has no cover and is anchored, give it a cover
 				cover.parent_turret = src	//assign the cover its parent_turret, which would be this (src)
 
-	if(!on || (machine_stat & (NOPOWER|BROKEN)) || manual_control)
+	if(!on || (machine_stat & (NOPOWER|BROKEN)) || manual_control || (!stored_gun && uses_stored))
 		return PROCESS_KILL
 
 	var/list/targets = list()
@@ -691,11 +700,12 @@ DEFINE_BITFIELD(turret_flags, list(
 
 /obj/machinery/porta_turret/syndicate
 	installation = null
-	always_up = 1
+	always_up = TRUE
 	use_power = NO_POWER_USE
-	has_cover = 0
+	has_cover = TRUE
 	scan_range = 9
 	req_access = list(ACCESS_SYNDICATE)
+	uses_stored = FALSE
 	mode = TURRET_LETHAL
 	stun_projectile = /obj/projectile/bullet
 	lethal_projectile = /obj/projectile/bullet
@@ -799,7 +809,7 @@ DEFINE_BITFIELD(turret_flags, list(
 /obj/machinery/porta_turret/centcom_shuttle
 	installation = null
 	max_integrity = 260
-	always_up = 1
+	always_up = TRUE
 	use_power = NO_POWER_USE
 	has_cover = 0
 	scan_range = 9

--- a/code/game/machinery/porta_turret/portable_turret_construct.dm
+++ b/code/game/machinery/porta_turret/portable_turret_construct.dm
@@ -188,9 +188,3 @@
 
 /obj/machinery/porta_turret_construct/attack_ai()
 	return
-
-/obj/machinery/porta_turret_construct/Destroy()
-	if(installed_gun)
-		qdel(installed_gun)
-		installed_gun = null
-	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #56635 
theres a good chance i should have just bit the bullet and forced yet another snowflakey if(flags_1 & HOLOGRAM_1) check that rejects laser guns being put into turrets if theyre a hologram but in my opinion the turrets should be makeable with it assuming they properly derez<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
athath put the eyes reaction on the bug report, making this so he cant farm laser guns via the 70% turret drop rate strategy hes no doubt already made.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: turrets made via the holodeck laser guns now stop working when the guns get deleted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
