### PR TITLE
makes blast cannons not seem like an innocent item before a bomb is loaded

### DIFF
--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/gun/blastcannon
 	name = "blast cannon"
-	desc = "A pipe welded onto a gun stock, with a mechanical trigger. The pipe has an opening near the top, and there seems to be a spring loaded wheel in the hole. Small enough to stow in a bag."
+	desc = "A makeshift device used to concentrate a bomb's blast energy to a narrow wave. Small enough to stow in a bag."
 	icon_state = "empty_blastcannon"
 	inhand_icon_state = "blastcannon_empty"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -39,6 +39,11 @@
 	debug_power = 80
 	bombcheck = FALSE
 
+/obj/item/gun/blastcannon/examine(mob/user)
+	. = ..()
+	if(bomb)
+		. += "<span class='notice'>A bomb is loaded inside.</span>"
+
 /obj/item/gun/blastcannon/Initialize()
 	. = ..()
 	if(!pin)
@@ -55,8 +60,6 @@
 		user.put_in_hands(bomb)
 		user.visible_message("<span class='warning'>[user] detaches [bomb] from [src].</span>")
 		bomb = null
-		name = initial(name)
-		desc = initial(desc)
 	update_icon()
 	return ..()
 
@@ -77,8 +80,6 @@
 
 	user.visible_message("<span class='warning'>[user] attaches [bomb_to_attach] to [src]!</span>")
 	bomb = bomb_to_attach
-	name = "blast cannon"
-	desc = "A makeshift device used to concentrate a bomb's blast energy to a narrow wave."
 	update_icon()
 	return TRUE
 

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -4,7 +4,7 @@
  * It's basically an immovable rod launcher.
  */
 /obj/item/gun/blastcannon
-	name = "pipe gun"
+	name = "blast cannon"
 	desc = "A pipe welded onto a gun stock, with a mechanical trigger. The pipe has an opening near the top, and there seems to be a spring loaded wheel in the hole. Small enough to stow in a bag."
 	icon_state = "empty_blastcannon"
 	inhand_icon_state = "blastcannon_empty"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
changes name and desc to stay consistent on blast cannon

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
there is no other item sharing the sprite of this gun so anyone experienced will know its a traitor item that does baboom, no reason to hide it under a name and desc

## Changelog
:cl:
spellcheck: makes blast cannons not seem like an innocent item before a bomb is loaded
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
