### PR TITLE
Adds discrete keybindings for Enabling/Disabling Combat Mode

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -43,6 +43,8 @@
 #define COMSIG_KB_LIVING_LOOKDOWN_DOWN "keybinding_living_lookdown_down"
 #define COMSIG_KB_LIVING_REST_DOWN "keybinding_living_rest_down"
 #define COMSIG_KB_LIVING_TOGGLE_COMBAT_DOWN "keybinding_living_toggle_combat_down"
+#define COMSIG_KB_LIVING_ENABLE_COMBAT_DOWN "keybinding_living_enable_combat_down"
+#define COMSIG_KB_LIVING_DISABLE_COMBAT_DOWN "keybinding_living_disable_combat_down"
 
 //Mob
 #define COMSIG_KB_MOB_FACENORTH_DOWN "keybinding_mob_facenorth_down"

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -94,7 +94,7 @@
 	hotkey_keys = list("Unbound")
 	name = "enable_combat_mode"
 	full_name = "Enable Combat Mode"
-	description = "Enable combat mode. Like Help/Harm but lamer."
+	description = "Enable combat mode."
 	keybind_signal = COMSIG_KB_LIVING_ENABLE_COMBAT_DOWN
 
 /datum/keybinding/living/enable_combat_mode/down(client/user)
@@ -102,13 +102,13 @@
 	if(.)
 		return
 	var/mob/living/user_mob = user.mob
-	user_mob.set_combat_mode(TRUE, FALSE)
+	user_mob.set_combat_mode(TRUE, silent = FALSE)
 
 /datum/keybinding/living/disable_combat_mode
 	hotkey_keys = list("Unbound")
 	name = "disable_combat_mode"
 	full_name = "Disable Combat Mode"
-	description = "Disable combat mode. Like Help/Harm but lamer."
+	description = "Disable combat mode."
 	keybind_signal = COMSIG_KB_LIVING_DISABLE_COMBAT_DOWN
 
 /datum/keybinding/living/disable_combat_mode/down(client/user)
@@ -116,4 +116,4 @@
 	if(.)
 		return
 	var/mob/living/user_mob = user.mob
-	user_mob.set_combat_mode(FALSE, FALSE)
+	user_mob.set_combat_mode(FALSE, silent = FALSE)

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -89,3 +89,31 @@
 		return
 	var/mob/living/user_mob = user.mob
 	user_mob.set_combat_mode(!user_mob.combat_mode, FALSE)
+
+/datum/keybinding/living/enable_combat_mode
+	hotkey_keys = list("Unbound")
+	name = "enable_combat_mode"
+	full_name = "Enable Combat Mode"
+	description = "Enable combat mode. Like Help/Harm but lamer."
+	keybind_signal = COMSIG_KB_LIVING_ENABLE_COMBAT_DOWN
+
+/datum/keybinding/living/enable_combat_mode/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/user_mob = user.mob
+	user_mob.set_combat_mode(TRUE, FALSE)
+
+/datum/keybinding/living/disable_combat_mode
+	hotkey_keys = list("Unbound")
+	name = "disable_combat_mode"
+	full_name = "Disable Combat Mode"
+	description = "Disable combat mode. Like Help/Harm but lamer."
+	keybind_signal = COMSIG_KB_LIVING_DISABLE_COMBAT_DOWN
+
+/datum/keybinding/living/disable_combat_mode/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/user_mob = user.mob
+	user_mob.set_combat_mode(FALSE, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds 2 discrete keybindings for Enabling/Disabling Combat Mode. They are unbound by default.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I find toggle and cycling keybindings to be unreliable, especially considering how laggy and unresponsive the game can become at times. I would much rather have static keybindings that are always guaranteed to do one thing and I imagine I'm not the only one.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Thebleh
add: Added keybindings for enabling and disabling Combat Mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
