### PR TITLE
Remove adrenal implant and associated reagent

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -12,39 +12,6 @@
 				<b>Function:</b> Allows operation of implant-locked weaponry, preventing equipment from falling into enemy hands."}
 	return dat
 
-
-/obj/item/implant/adrenalin
-	name = "adrenal implant"
-	desc = "Removes all stuns."
-	icon_state = "adrenal"
-	uses = 3
-
-/obj/item/implant/adrenalin/get_data()
-	var/dat = {"<b>Implant Specifications:</b><BR>
-				<b>Name:</b> Cybersun Industries Adrenaline Implant<BR>
-				<b>Life:</b> Five days.<BR>
-				<b>Important Notes:</b> <font color='red'>Illegal</font><BR>
-				<HR>
-				<b>Implant Details:</b> Subjects injected with implant can activate an injection of medical cocktails.<BR>
-				<b>Function:</b> Pushes the body past the normal limits, assisting in escape from sticky situations.<BR>
-				<b>Integrity:</b> Implant can only be used three times before reserves are depleted."}
-	return dat
-
-/obj/item/implant/adrenalin/activate()
-	. = ..()
-	uses--
-	to_chat(imp_in, "<span class='notice'>You feel a sudden surge of energy!</span>")
-	imp_in.SetKnockdown(0)
-	imp_in.set_resting(FALSE)
-	imp_in.reagents.add_reagent(/datum/reagent/medicine/badstims, 6)
-	if(!uses)
-		qdel(src)
-
-/obj/item/implanter/adrenalin
-	name = "implanter (adrenalin)"
-	imp_type = /obj/item/implant/adrenalin
-
-
 /obj/item/implant/emp
 	name = "emp implant"
 	desc = "Triggers an EMP."

--- a/code/game/objects/items/implants/implantcase.dm
+++ b/code/game/objects/items/implants/implantcase.dm
@@ -78,8 +78,3 @@
 	name = "implant case - 'Firearms Authentication'"
 	desc = "A glass case containing a firearms authentication implant."
 	imp_type = /obj/item/implant/weapons_auth
-
-/obj/item/implantcase/adrenaline
-	name = "implant case - 'Adrenaline'"
-	desc = "A glass case containing an adrenaline implant."
-	imp_type = /obj/item/implant/adrenalin

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -67,7 +67,6 @@
 			new /obj/item/implanter/freedom(src)
 			new /obj/item/implanter/uplink/precharged(src)
 			new /obj/item/implanter/emp(src)
-			new /obj/item/implanter/adrenalin(src)
 			new /obj/item/implanter/explosive(src)
 			new /obj/item/implanter/storage(src)
 
@@ -134,7 +133,7 @@
 
 		if("ninja")
 			new /obj/item/katana(src) // Unique , hard to tell how much tc this is worth. 8 tc?
-			new /obj/item/implanter/adrenalin(src) // 8 tc
+			new /obj/item/reagent_containers/hypospray/medipen/stimulants(src) // 5 tc
 			for(var/i in 1 to 6)
 				new /obj/item/throwing_star(src) // ~5 tc for all 6
 			new /obj/item/storage/belt/chameleon(src) // Unique but worth at least 2 tc
@@ -356,12 +355,6 @@
 /obj/item/storage/box/syndie_kit/clownpins/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/firing_pin/clown/ultra(src)
-
-/obj/item/storage/box/syndie_kit/imp_adrenal
-	name = "adrenal implant box"
-
-/obj/item/storage/box/syndie_kit/imp_adrenal/PopulateContents()
-	new /obj/item/implanter/adrenalin(src)
 
 /obj/item/storage/box/syndie_kit/imp_storage
 	name = "storage implant box"

--- a/code/modules/movespeed/modifiers/reagent.dm
+++ b/code/modules/movespeed/modifiers/reagent.dm
@@ -10,9 +10,6 @@
 /datum/movespeed_modifier/reagent/pepperspray
 	multiplicative_slowdown = 0.25
 
-/datum/movespeed_modifier/reagent/badstims
-	multiplicative_slowdown = -0.45
-
 /datum/movespeed_modifier/reagent/monkey_energy
 	multiplicative_slowdown = -0.35
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1320,38 +1320,6 @@
 	M.adjustToxLoss(0.2 * REM, 0) //Only really deadly if you eat over 100u
 	..()
 
-/datum/reagent/medicine/badstims  //These are bad for combat on purpose. Used in adrenal implant.
-	name = "Experimental Stimulants"
-	description = "Experimental Stimulants designed to get you away from trouble."
-	reagent_state = LIQUID
-	color = "#F5F5F5"
-
-/datum/reagent/medicine/badstims/on_mob_life(mob/living/carbon/M)
-	..()
-	if(prob(30) && iscarbon(M))
-		var/obj/item/I = M.get_active_held_item()
-		if(I && M.dropItemToGround(I))
-			to_chat(M, "<span class='notice'>Your hands spaz out and you drop what you were holding!</span>")
-	M.adjustStaminaLoss(-10, 0)
-	M.Jitter(10)
-	M.Dizzy(15)
-
-/datum/reagent/medicine/badstims/on_mob_metabolize(mob/living/L)
-	..()
-	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
-	ADD_TRAIT(L, TRAIT_STUNRESISTANCE, type)
-	L.add_movespeed_modifier(/datum/movespeed_modifier/reagent/badstims)
-	L.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
-
-/datum/reagent/medicine/badstims/on_mob_end_metabolize(mob/living/L)
-	..()
-	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
-	REMOVE_TRAIT(L, TRAIT_STUNRESISTANCE, type)
-	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/badstims)
-	L.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
-	L.Dizzy(0)
-	L.Jitter(0)
-
 // helps bleeding wounds clot faster
 /datum/reagent/medicine/coagulant
 	name = "Sanguirite"

--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -244,13 +244,6 @@
 	program_type = /datum/nanite_program/conductive
 	category = list("Augmentation Nanites")
 
-/datum/design/nanites/adrenaline
-	name = "Adrenaline Burst"
-	desc = "The nanites cause a burst of adrenaline when triggered, waking the host from stuns and temporarily increasing their speed."
-	id = "adrenaline_nanites"
-	program_type = /datum/nanite_program/adrenaline
-	category = list("Augmentation Nanites")
-
 /datum/design/nanites/mindshield
 	name = "Mental Barrier"
 	desc = "The nanites form a protective membrane around the host's brain, shielding them from abnormal influences while they're active."

--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -18,19 +18,6 @@
 		var/mob/living/carbon/human/H = host_mob
 		H.physiology.stun_mod *= 2
 
-/datum/nanite_program/adrenaline
-	name = "Adrenaline Burst"
-	desc = "The nanites cause a burst of adrenaline when triggered, allowing the user to push their body past its normal limits."
-	can_trigger = TRUE
-	trigger_cost = 25
-	trigger_cooldown = 1200
-	rogue_types = list(/datum/nanite_program/toxic, /datum/nanite_program/nerve_decay)
-
-/datum/nanite_program/adrenaline/on_trigger()
-	to_chat(host_mob, "<span class='notice'>You feel a sudden surge of energy!</span>")
-	host_mob.set_resting(FALSE)
-	host_mob.reagents.add_reagent(/datum/reagent/medicine/badstims, 3)
-
 /datum/nanite_program/hardening
 	name = "Dermal Hardening"
 	desc = "The nanites form a mesh under the host's skin, protecting them from melee and bullet impacts."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -870,7 +870,7 @@
 	display_name = "Harmonic Nanite Programming"
 	description = "Nanite programs that require seamless integration between nanites and biology. Passively increases nanite regeneration rate for all clouds upon researching."
 	prereq_ids = list("nanite_bio","nanite_smart","nanite_mesh")
-	design_ids = list("fakedeath_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","adrenaline_nanites")
+	design_ids = list("fakedeath_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000, TECHWEB_POINT_TYPE_NANITES = 3000)
 
 /datum/techweb_node/nanite_combat

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1608,14 +1608,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	category = "Implants"
 	surplus = 50
 
-/datum/uplink_item/implants/adrenal
-	name = "Adrenal Implant"
-	desc = "An implant injected into the body, and later activated at the user's will. It will inject a chemical \
-			cocktail which lets you push yourself harder to get out of sticky situations. Avoid large doses if possible."
-	item = /obj/item/storage/box/syndie_kit/imp_adrenal
-	cost = 8
-	player_minimum = 25
-
 /datum/uplink_item/implants/antistun
 	name = "CNS Rebooter Implant"
 	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autosurgeon."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
People are still regularly whinging about the adrenal implant rebalance I did a year and a half ago, and it is high time I correct my mistakes. This PR fully removes the adrenal implant and its associated chemical. Since nanite adrenals rely on the same chemical, those are gone too.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Old adrenals were not in a good state, and ended up being a "must buy" to succeed as a traitor. New adrenals are more acceptable from a balance standpoint but requires a bit of timing and at least two braincells to use effectively. In other words, new adrenals are completely unwanted by our playerbase. I do not believe the existence of adrenals is worth the balance implications of "fixing" them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
del: Removes the adrenal implant and the adrenal nanite program.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
