### PR TITLE
Makes mulebots not run people over unless hacked

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -727,7 +727,7 @@
 // when mulebot is in the same loc
 /mob/living/simple_animal/bot/mulebot/proc/RunOver(mob/living/carbon/human/H)
 	if(!wires.is_cut(WIRE_AVOIDANCE))
-		return ..()
+		return
 	log_combat(src, H, "run over", null, "(DAMTYPE: [uppertext(BRUTE)])")
 	H.visible_message("<span class='danger'>[src] drives over [H]!</span>", \
 					"<span class='userdanger'>[src] drives over you!</span>")

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -726,25 +726,26 @@
 // called from mob/living/carbon/human/Crossed()
 // when mulebot is in the same loc
 /mob/living/simple_animal/bot/mulebot/proc/RunOver(mob/living/carbon/human/H)
-	log_combat(src, H, "run over", null, "(DAMTYPE: [uppertext(BRUTE)])")
-	H.visible_message("<span class='danger'>[src] drives over [H]!</span>", \
-					"<span class='userdanger'>[src] drives over you!</span>")
-	playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
+	if(wires.is_cut(WIRE_AVOIDANCE))
+		log_combat(src, H, "run over", null, "(DAMTYPE: [uppertext(BRUTE)])")
+		H.visible_message("<span class='danger'>[src] drives over [H]!</span>", \
+						"<span class='userdanger'>[src] drives over you!</span>")
+		playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
 
-	var/damage = rand(5,15)
-	H.apply_damage(2*damage, BRUTE, BODY_ZONE_HEAD, run_armor_check(BODY_ZONE_HEAD, MELEE))
-	H.apply_damage(2*damage, BRUTE, BODY_ZONE_CHEST, run_armor_check(BODY_ZONE_CHEST, MELEE))
-	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_L_LEG, run_armor_check(BODY_ZONE_L_LEG, MELEE))
-	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_R_LEG, run_armor_check(BODY_ZONE_R_LEG, MELEE))
-	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_L_ARM, run_armor_check(BODY_ZONE_L_ARM, MELEE))
-	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_R_ARM, run_armor_check(BODY_ZONE_R_ARM, MELEE))
+		var/damage = rand(5,15)
+		H.apply_damage(2*damage, BRUTE, BODY_ZONE_HEAD, run_armor_check(BODY_ZONE_HEAD, MELEE))
+		H.apply_damage(2*damage, BRUTE, BODY_ZONE_CHEST, run_armor_check(BODY_ZONE_CHEST, MELEE))
+		H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_L_LEG, run_armor_check(BODY_ZONE_L_LEG, MELEE))
+		H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_R_LEG, run_armor_check(BODY_ZONE_R_LEG, MELEE))
+		H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_L_ARM, run_armor_check(BODY_ZONE_L_ARM, MELEE))
+		H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_R_ARM, run_armor_check(BODY_ZONE_R_ARM, MELEE))
 
-	var/turf/T = get_turf(src)
-	T.add_mob_blood(H)
+		var/turf/T = get_turf(src)
+		T.add_mob_blood(H)
 
-	var/list/blood_dna = H.get_blood_dna_list()
-	add_blood_DNA(blood_dna)
-	bloodiness += 4
+		var/list/blood_dna = H.get_blood_dna_list()
+		add_blood_DNA(blood_dna)
+		bloodiness += 4
 
 // player on mulebot attempted to move
 /mob/living/simple_animal/bot/mulebot/relaymove(mob/living/user, direction)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -726,26 +726,27 @@
 // called from mob/living/carbon/human/Crossed()
 // when mulebot is in the same loc
 /mob/living/simple_animal/bot/mulebot/proc/RunOver(mob/living/carbon/human/H)
-	if(wires.is_cut(WIRE_AVOIDANCE))
-		log_combat(src, H, "run over", null, "(DAMTYPE: [uppertext(BRUTE)])")
-		H.visible_message("<span class='danger'>[src] drives over [H]!</span>", \
-						"<span class='userdanger'>[src] drives over you!</span>")
-		playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
+	if(!wires.is_cut(WIRE_AVOIDANCE))
+		return ..()
+	log_combat(src, H, "run over", null, "(DAMTYPE: [uppertext(BRUTE)])")
+	H.visible_message("<span class='danger'>[src] drives over [H]!</span>", \
+					"<span class='userdanger'>[src] drives over you!</span>")
+	playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
 
-		var/damage = rand(5,15)
-		H.apply_damage(2*damage, BRUTE, BODY_ZONE_HEAD, run_armor_check(BODY_ZONE_HEAD, MELEE))
-		H.apply_damage(2*damage, BRUTE, BODY_ZONE_CHEST, run_armor_check(BODY_ZONE_CHEST, MELEE))
-		H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_L_LEG, run_armor_check(BODY_ZONE_L_LEG, MELEE))
-		H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_R_LEG, run_armor_check(BODY_ZONE_R_LEG, MELEE))
-		H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_L_ARM, run_armor_check(BODY_ZONE_L_ARM, MELEE))
-		H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_R_ARM, run_armor_check(BODY_ZONE_R_ARM, MELEE))
+	var/damage = rand(5,15)
+	H.apply_damage(2*damage, BRUTE, BODY_ZONE_HEAD, run_armor_check(BODY_ZONE_HEAD, MELEE))
+	H.apply_damage(2*damage, BRUTE, BODY_ZONE_CHEST, run_armor_check(BODY_ZONE_CHEST, MELEE))
+	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_L_LEG, run_armor_check(BODY_ZONE_L_LEG, MELEE))
+	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_R_LEG, run_armor_check(BODY_ZONE_R_LEG, MELEE))
+	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_L_ARM, run_armor_check(BODY_ZONE_L_ARM, MELEE))
+	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_R_ARM, run_armor_check(BODY_ZONE_R_ARM, MELEE))
 
-		var/turf/T = get_turf(src)
-		T.add_mob_blood(H)
+	var/turf/T = get_turf(src)
+	T.add_mob_blood(H)
 
-		var/list/blood_dna = H.get_blood_dna_list()
-		add_blood_DNA(blood_dna)
-		bloodiness += 4
+	var/list/blood_dna = H.get_blood_dna_list()
+	add_blood_DNA(blood_dna)
+	bloodiness += 4
 
 // player on mulebot attempted to move
 /mob/living/simple_animal/bot/mulebot/relaymove(mob/living/user, direction)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Contrary to popular belief, the only thing preventing people from getting run over by unhacked mulebots is their pathing, which stops them before they move onto the same space as a person. This usually works fine, but it doesn't account for the mulebot being pAI controlled, which overrides pathing.

This pr simply adds a `if(wires.is_cut(WIRE_AVOIDANCE))` before the damage is calculated and added, preventing the mulebot from running people over unless it has had it's safeties wire cut.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
PAI controlled mulebots can now wander through the station without accidentally running over people who are laying down (be it from security stunning, clown slipping, assistant pushing, etc).
People now see flashing lights on the mulebots if it is capable of running them over, so pAI controlled mulebots can't surprise em.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Mulebots will now need their safeties manually disabled to run over people. That's one less space OSHA violation!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
