### PR TITLE
amputation shears now check for incapatation instead of specifically the stunned status effect

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -397,9 +397,9 @@
 	if(patient.stat >= UNCONSCIOUS || patient.IsImmobilized()) //if you can't move (due to paralysis, a stun, being in staminacrit, etc.), it's much easier to properly "snip" you
 		amputation_speed_mod *= 0.5
 	if(patient.jitteriness >= 1) //jittering will make it harder to secure the shears, even if you can't otherwise move
-		amputation_speed_mod *= 1.5 //15*0.5*1.5, so staminacritting someone who's jittering (from, say, a stun baton) won't give you enough time to snip their head off, but staminacritting someone who isn't jittering will
+		amputation_speed_mod *= 1.5 //15*0.5*1.5=11.25, so staminacritting someone who's jittering (from, say, a stun baton) won't give you enough time to snip their head off, but staminacritting someone who isn't jittering will
 
-	if(do_after(user,  toolspeed * 150 * amputation_speed_mod, target = patient))
+	if(do_after(user,  toolspeed * 15 SECONDS * amputation_speed_mod, target = patient))
 		playsound(get_turf(patient), 'sound/weapons/bladeslice.ogg', 250, TRUE)
 		if(user.zone_selected == BODY_ZONE_PRECISE_GROIN) //OwO
 			tail_snip_candidate.Remove(patient)

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -396,7 +396,7 @@
 	playsound(get_turf(patient), 'sound/items/ratchet.ogg', 20, TRUE)
 	if(patient.stat >= UNCONSCIOUS || patient.IsImmobilized()) //if you can't move (due to paralysis, a stun, being in staminacrit, etc.), it's much easier to properly "snip" you
 		amputation_speed_mod *= 0.5
-	if(patient.jitteriness >= 1) //jittering will make it harder to secure the shears, even if you can't otherwise move
+	if(patient.jitteriness) //jittering will make it harder to secure the shears, even if you can't otherwise move
 		amputation_speed_mod *= 1.5 //15*0.5*1.5=11.25, so staminacritting someone who's jittering (from, say, a stun baton) won't give you enough time to snip their head off, but staminacritting someone who isn't jittering will
 
 	if(do_after(user,  toolspeed * 15 SECONDS * amputation_speed_mod, target = patient))

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -394,7 +394,7 @@
 
 	patient.visible_message("<span class='danger'>[user] begins to secure [src] around [patient]'s [candidate_name].</span>", "<span class='userdanger'>[user] begins to secure [src] around your [candidate_name]!</span>")
 	playsound(get_turf(patient), 'sound/items/ratchet.ogg', 20, TRUE)
-	if(patient.stat >= UNCONSCIOUS || patient.IsImmobilized()) //if you can't move (due to paralysis, a stun, being in staminacrit, etc.), it's much easier to properly "snip" you
+	if(patient.stat >= UNCONSCIOUS || HAS_TRAIT(patient, TRAIT_INCAPACITATED)) //if you're incapacitated (due to paralysis, a stun, being in staminacrit, etc.), critted, unconscious, or dead, it's much easier to properly line up a snip
 		amputation_speed_mod *= 0.5
 	if(patient.stat != DEAD && patient.jitteriness) //jittering will make it harder to secure the shears, even if you can't otherwise move
 		amputation_speed_mod *= 1.5 //15*0.5*1.5=11.25, so staminacritting someone who's jittering (from, say, a stun baton) won't give you enough time to snip their head off, but staminacritting someone who isn't jittering will

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -394,7 +394,7 @@
 
 	patient.visible_message("<span class='danger'>[user] begins to secure [src] around [patient]'s [candidate_name].</span>", "<span class='userdanger'>[user] begins to secure [src] around your [candidate_name]!</span>")
 	playsound(get_turf(patient), 'sound/items/ratchet.ogg', 20, TRUE)
-	if(patient.stat >= UNCONSCIOUS || patient.IsImmobilized()) //if you can't move (from paralysis, staminacrit, a stun, etc.), it's much easier to properly "snip" you
+	if(patient.stat >= UNCONSCIOUS || patient.IsImmobilized()) //if you can't move (due to paralysis, a stun, being in staminacrit, etc.), it's much easier to properly "snip" you
 		amputation_speed_mod *= 0.5
 	if(patient.jitteriness >= 1) //jittering will make it harder to secure the shears, even if you can't otherwise move
 		amputation_speed_mod *= 1.5 //15*0.5*1.5, so staminacritting someone who's jittering (from, say, a stun baton) won't give you enough time to snip their head off, but staminacritting someone who isn't jittering will

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -390,16 +390,14 @@
 			return
 		candidate_name = limb_snip_candidate.name
 
-	var/amputation_speed_mod
+	var/amputation_speed_mod = 1
 
 	patient.visible_message("<span class='danger'>[user] begins to secure [src] around [patient]'s [candidate_name].</span>", "<span class='userdanger'>[user] begins to secure [src] around your [candidate_name]!</span>")
 	playsound(get_turf(patient), 'sound/items/ratchet.ogg', 20, TRUE)
-	if(patient.stat >= UNCONSCIOUS || patient.IsStun()) //Stun is used by paralytics like curare it should not be confused with the more common paralyze.
-		amputation_speed_mod = 0.5
-	else if(patient.jitteriness >= 1)
-		amputation_speed_mod = 1.5
-	else
-		amputation_speed_mod = 1
+	if(patient.stat >= UNCONSCIOUS || patient.IsImmobilized()) //if you can't move (from paralysis, staminacrit, a stun, etc.), it's much easier to properly "snip" you
+		amputation_speed_mod *= 0.5
+	if(patient.jitteriness >= 1) //jittering will make it harder to secure the shears, even if you can't otherwise move
+		amputation_speed_mod *= 1.5 //15*0.5*1.5, so staminacritting someone who's jittering (from, say, a stun baton) won't give you enough time to snip their head off, but staminacritting someone who isn't jittering will
 
 	if(do_after(user,  toolspeed * 150 * amputation_speed_mod, target = patient))
 		playsound(get_turf(patient), 'sound/weapons/bladeslice.ogg', 250, TRUE)

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -396,7 +396,7 @@
 	playsound(get_turf(patient), 'sound/items/ratchet.ogg', 20, TRUE)
 	if(patient.stat >= UNCONSCIOUS || patient.IsImmobilized()) //if you can't move (due to paralysis, a stun, being in staminacrit, etc.), it's much easier to properly "snip" you
 		amputation_speed_mod *= 0.5
-	if(patient.jitteriness) //jittering will make it harder to secure the shears, even if you can't otherwise move
+	if(patient.stat != DEAD && patient.jitteriness) //jittering will make it harder to secure the shears, even if you can't otherwise move
 		amputation_speed_mod *= 1.5 //15*0.5*1.5=11.25, so staminacritting someone who's jittering (from, say, a stun baton) won't give you enough time to snip their head off, but staminacritting someone who isn't jittering will
 
 	if(do_after(user,  toolspeed * 15 SECONDS * amputation_speed_mod, target = patient))


### PR DESCRIPTION
## About The Pull Request

Amputation shears now check for incapacitation instead of specifically the stunned status effect to determine if you can get a 0.5x multiplier for the time required to cut off a patient's limb despite the patient not being unconscious, critted, or dead. This means that staminacritting and paralysis can now count for this check.

In addition, the 1.5x time multiplier for the patient/victim being jittery is now no longer mutually exclusive with the above 0.5x multiplier (previously, the 0.5x multiplier would take priority). Note that this penalty does not apply if the patient is dead, as having a nonzero jitteriness variable only causes a jittering animation if you're not dead.

Together, this means that if you stun baton someone into staminacrit, the amount of time it should take to cut off their head with amputation shears should be 11.25 seconds, which means that the person you're trying to decapitate should recover from their staminacritting before you can finish cutting off their head (unless they receive more stamina damage partway through the procedure). If you telebaton, disabler, riot dart, bone hurting juice, etc. someone into staminacrit, however, the amount of time it should take to cut off their head with amputation shears should be 7.5 seconds, which should be short enough to decapitate someone before they recover from staminacrit, but not so short that you could get it cheaply with a shovestun or the like.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/42606352/107015982-01874e80-6763-11eb-93d0-08d2da22b80a.png)

As we move gradually move from a stun-based combat system into a stamina-based one, we should adapt things that require specific kinds of stuns to also work with staminacritting. Also, I always found it weird that amputation shears become more effective when used on someone who's been stunned by a goliath, but not when used on someone who's been completely paralyzed.

I do not believe that this PR will cause balance concerns, as trying to get a head snip off mid-combat requires you to stand still next to a stunned (but not jittering, so nuka cola, atropine, etc. can easily counter this gimmick) target for 7.5 straight seconds without being moved or otherwise interrupted. It also requires you to have a box-sized, expensive, very specialized tool on your person. If you're in that situation, the person you're trying to snip is basically already dead (or very easily handcuffable, unless they have only one arm or something, in which case you can just beat them into crit). In other words, it's basically a (badass) gimmick.

Finally, I'd like to point out that heads aren't the only things that can be removed by amputation shears. They can remove felinid and lizard tails, as well as the remaining arm of a powergamer who's intentionally had one of their arms removed so that they can become uncuffable. You can also nugget people if you're a sadist or if you want to set up a horror movie gimmick/reference.

## Changelog
:cl:
balance: Using amputation shears on incapacitated, critted, dead, unconscious, paralyzed, staminacritted, etc. targets is now much faster. Jittering still penalizes the speed at which you can cut someone's limbs off with amputation shears, and that penalty now applies even if the target is stunned or in critical condition.
/:cl: