### PR TITLE
ICEBOX: Snow plates outside, wiring and camera fixes

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -20111,6 +20111,9 @@
 /area/science/test_area)
 "bIZ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bJc" = (
@@ -29533,11 +29536,11 @@
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "eGj" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
 	},
 /turf/open/floor/plating/snowed/icemoon,
-/area/engineering/atmos)
+/area/icemoon/surface/outdoors)
 "eGU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -38332,6 +38335,12 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"kWf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors)
 "kWH" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -38617,6 +38626,13 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"lni" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors)
 "lnM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -39743,6 +39759,13 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/commons/locker)
+"mbN" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors)
 "mdh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42160,6 +42183,13 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"nIF" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors)
 "nIQ" = (
 /obj/machinery/processor/slime,
 /turf/open/floor/iron,
@@ -49056,6 +49086,12 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
+"sOq" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/engineering/atmos)
 "sOs" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -90570,7 +90606,7 @@ qnI
 nOx
 rpL
 mqM
-bHV
+mbN
 hZh
 xhX
 eeh
@@ -90827,7 +90863,7 @@ rLU
 ivF
 uYt
 vqw
-pjX
+kWf
 riF
 nVN
 mwT
@@ -91084,7 +91120,7 @@ pwx
 dpn
 jZW
 nqb
-buv
+lni
 hZh
 vfP
 eeh
@@ -91341,7 +91377,7 @@ xFV
 ivF
 rLU
 vqw
-pjX
+kWf
 ccm
 ccm
 ccm
@@ -91855,7 +91891,7 @@ pjs
 sWG
 qpg
 vqw
-pjX
+kWf
 riF
 jnK
 uqM
@@ -92369,7 +92405,7 @@ ojf
 ojf
 fsN
 ojf
-pjX
+kWf
 ccm
 ccm
 ccm
@@ -92626,7 +92662,7 @@ bAi
 ckR
 tWV
 ckR
-bAi
+nIF
 bAi
 bAi
 bAi
@@ -92883,7 +92919,7 @@ pjX
 xjx
 nxB
 xjx
-boP
+sOq
 boP
 boP
 boP

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -16,17 +16,13 @@
 "aae" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "aaf" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
-"aah" = (
-/obj/structure/cable,
-/turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors)
 "aai" = (
 /turf/closed/wall/r_wall,
@@ -1671,7 +1667,7 @@
 	name = "Port Auxiliary Solar Array"
 	},
 /obj/structure/cable,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "agh" = (
 /obj/machinery/shower{
@@ -2879,7 +2875,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "ajX" = (
 /obj/machinery/computer/teleporter{
@@ -6108,7 +6104,7 @@
 	name = "Port Solar Array"
 	},
 /obj/structure/cable,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "auc" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -6126,7 +6122,7 @@
 	name = "Starboard Solar Array"
 	},
 /obj/structure/cable,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "aue" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -8819,17 +8815,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
-"aHs" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 1;
-	height = 4;
-	name = "escape pod loader";
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
-	},
-/turf/open/floor/plating/icemoon,
-/area/icemoon/surface/outdoors)
 "aHt" = (
 /turf/open/floor/iron/icemoon{
 	icon_state = "damaged3"
@@ -10886,7 +10871,7 @@
 	roundstart_template = /datum/map_template/shuttle/labour/box;
 	width = 9
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "aVn" = (
 /obj/effect/turf_decal/tile/red{
@@ -11339,7 +11324,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 1
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/engineering/main)
 "aYE" = (
 /obj/machinery/door/firedoor,
@@ -12027,7 +12012,7 @@
 	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
 	width = 3
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bdz" = (
 /obj/structure/disposalpipe/segment{
@@ -12127,7 +12112,7 @@
 	name = "BoxStation emergency evac bay";
 	width = 32
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bdW" = (
 /obj/item/clothing/gloves/color/rainbow,
@@ -12312,7 +12297,7 @@
 	name = "port bay 2";
 	width = 5
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "beE" = (
 /obj/machinery/light,
@@ -12750,7 +12735,7 @@
 	name = "SS13: Auxiliary Dock, Station-Port";
 	width = 35
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bgw" = (
 /obj/structure/disposalpipe/segment{
@@ -14422,7 +14407,7 @@
 /obj/effect/turf_decal/caution{
 	dir = 8
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bmD" = (
 /obj/structure/cable,
@@ -16298,10 +16283,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"btF" = (
-/obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plating/icemoon,
-/area/icemoon/surface/outdoors)
 "btN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -16436,13 +16417,13 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bug" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 10
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "buh" = (
 /obj/structure/disposalpipe/segment{
@@ -16560,7 +16541,7 @@
 /area/science/genetics)
 "buv" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bux" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -16644,7 +16625,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "buK" = (
 /obj/machinery/light{
@@ -16706,7 +16687,7 @@
 /area/science/research)
 "bvb" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/maintenance/port/aft)
 "bvc" = (
 /obj/structure/disposalpipe/segment{
@@ -16820,7 +16801,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bvo" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -16845,7 +16826,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bvr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -16890,7 +16871,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/maintenance/port/aft)
 "bvw" = (
 /obj/docking_port/stationary{
@@ -16901,7 +16882,7 @@
 	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
 	width = 3
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bvx" = (
 /turf/closed/wall/r_wall,
@@ -16981,7 +16962,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/maintenance/port/aft)
 "bvO" = (
 /obj/structure/disposalpipe/segment{
@@ -16991,7 +16972,7 @@
 	dir = 8;
 	name = "Mix to Space"
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/maintenance/port/aft)
 "bvP" = (
 /obj/structure/cable,
@@ -17078,14 +17059,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"bwm" = (
-/obj/structure/marker_beacon/burgundy,
-/obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plating/icemoon,
-/area/icemoon/surface/outdoors)
 "bwo" = (
 /obj/structure/marker_beacon/burgundy,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bwp" = (
 /obj/structure/rack,
@@ -17699,14 +17675,14 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bzn" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bzq" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
@@ -17968,7 +17944,7 @@
 /area/hallway/primary/central)
 "bAi" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bAl" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -18127,7 +18103,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bAG" = (
 /obj/structure/cable,
@@ -18183,7 +18159,7 @@
 /area/maintenance/port/aft)
 "bAN" = (
 /obj/item/weldingtool,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bAO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18402,7 +18378,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bBK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -19498,7 +19474,7 @@
 /obj/item/stack/cable_coil{
 	amount = 5
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bGc" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -19554,7 +19530,7 @@
 /area/maintenance/disposal/incinerator)
 "bGl" = (
 /obj/item/clothing/head/hardhat,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bGo" = (
 /obj/machinery/door/airlock/maintenance{
@@ -19823,7 +19799,7 @@
 /area/maintenance/aft)
 "bHV" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bHW" = (
 /obj/structure/disposalpipe/segment,
@@ -20135,7 +20111,7 @@
 /area/science/test_area)
 "bIZ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bJc" = (
 /obj/structure/grille/broken,
@@ -20291,7 +20267,7 @@
 	name = "Incinerator Output Pump";
 	target_pressure = 4500
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/maintenance/disposal/incinerator)
 "bJN" = (
 /turf/closed/wall,
@@ -20305,7 +20281,7 @@
 /area/science/misc_lab)
 "bJP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/maintenance/disposal/incinerator)
 "bJS" = (
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
@@ -20315,19 +20291,19 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 1
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/maintenance/disposal/incinerator)
 "bJW" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bJX" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bJY" = (
 /obj/item/stack/cable_coil,
@@ -20353,7 +20329,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bKr" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -20617,7 +20593,7 @@
 /obj/structure/transit_tube/curved/flipped{
 	dir = 1
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bLu" = (
 /obj/structure/rack,
@@ -20740,7 +20716,7 @@
 /obj/structure/transit_tube/curved{
 	dir = 4
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bMa" = (
 /obj/structure/table,
@@ -20759,16 +20735,16 @@
 /area/medical/virology)
 "bMb" = (
 /obj/structure/transit_tube/crossing/horizontal,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bMd" = (
 /obj/structure/transit_tube/horizontal,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bMf" = (
 /obj/structure/transit_tube/crossing/horizontal,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "bMi" = (
 /turf/open/floor/iron/white,
@@ -20796,7 +20772,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bMI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29560,7 +29536,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
 	dir = 1
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/engineering/atmos)
 "eGU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
@@ -33656,7 +33632,7 @@
 /area/engineering/break_room)
 "hGN" = (
 /obj/effect/loot_site_spawner,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "hGO" = (
 /obj/effect/turf_decal/tile/brown,
@@ -35630,7 +35606,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/cargo/miningdock)
 "jgM" = (
 /obj/effect/turf_decal/tile/blue{
@@ -38256,7 +38232,7 @@
 /area/cargo/sorting)
 "kRS" = (
 /obj/item/stack/sheet/iron,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "kSP" = (
 /obj/machinery/light,
@@ -44014,6 +43990,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"pjX" = (
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors)
 "pkg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
@@ -52895,7 +52874,7 @@
 /area/service/chapel/main)
 "vsS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plating/icemoon,
+/turf/open/floor/plating/snowed/icemoon,
 /area/engineering/main)
 "vtF" = (
 /turf/closed/wall,
@@ -53185,7 +53164,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/locker)
@@ -64817,7 +64795,7 @@ gQb
 gQb
 gQb
 gQb
-asU
+pjX
 gQb
 gQb
 gQb
@@ -65074,7 +65052,7 @@ gQb
 gQb
 gQb
 gQb
-asU
+pjX
 gQb
 gQb
 gQb
@@ -65331,7 +65309,7 @@ gQb
 gQb
 gQb
 gQb
-asU
+pjX
 gQb
 gQb
 gQb
@@ -65583,16 +65561,16 @@ boP
 boP
 boP
 boP
-asU
+pjX
 boP
 boP
 boP
 boP
-asU
+pjX
 boP
-asU
+pjX
 bdx
-asU
+pjX
 boP
 boP
 boP
@@ -65604,9 +65582,9 @@ boP
 boP
 boP
 boP
-asU
+pjX
 bdx
-asU
+pjX
 boP
 boP
 boP
@@ -65615,7 +65593,7 @@ boP
 boP
 boP
 bwo
-asU
+pjX
 bwo
 boP
 boP
@@ -65839,13 +65817,13 @@ boP
 boP
 boP
 boP
-asU
-asU
-asU
-asU
-asU
+pjX
+pjX
+pjX
+pjX
+pjX
 boP
-asU
+pjX
 arB
 asE
 cyb
@@ -66606,7 +66584,7 @@ gQb
 gQb
 boP
 boP
-asU
+pjX
 apJ
 apN
 apN
@@ -66623,13 +66601,13 @@ ayk
 awW
 aAD
 awW
-asU
+pjX
 boP
 boP
 boP
 boP
 boP
-asU
+pjX
 awW
 awW
 awW
@@ -66647,7 +66625,7 @@ ayk
 awW
 aAD
 awW
-asU
+pjX
 boP
 boP
 boP
@@ -66863,7 +66841,7 @@ gQb
 gQb
 boP
 boP
-asU
+pjX
 apJ
 apN
 apN
@@ -66880,13 +66858,13 @@ ayl
 azy
 auP
 cIh
-asU
+pjX
 boP
 boP
 boP
 boP
 boP
-asU
+pjX
 hFg
 auP
 cIh
@@ -67120,7 +67098,7 @@ gQb
 gQb
 boP
 boP
-asU
+pjX
 apJ
 apN
 apN
@@ -67137,13 +67115,13 @@ ayk
 awW
 awW
 awW
-asU
+pjX
 boP
 boP
 boP
 boP
 boP
-asU
+pjX
 awW
 awW
 awW
@@ -67161,7 +67139,7 @@ ayk
 awW
 awW
 awW
-asU
+pjX
 boP
 boP
 boP
@@ -68148,7 +68126,7 @@ gQb
 gQb
 boP
 boP
-asU
+pjX
 apJ
 apN
 apN
@@ -68422,13 +68400,13 @@ crz
 awW
 awW
 awW
-asU
+pjX
 boP
 boP
 boP
 boP
 boP
-asU
+pjX
 awW
 awW
 awW
@@ -68446,7 +68424,7 @@ ayk
 awW
 awW
 awW
-asU
+pjX
 boP
 boP
 boP
@@ -68679,13 +68657,13 @@ aIK
 azy
 auP
 cIh
-asU
+pjX
 boP
 boP
 boP
 boP
 boP
-asU
+pjX
 azy
 auP
 jly
@@ -68693,9 +68671,9 @@ ayl
 aRY
 awW
 boP
-asU
+pjX
 beC
-asU
+pjX
 boP
 awW
 awZ
@@ -68703,7 +68681,7 @@ ayl
 beL
 auP
 cyu
-asU
+pjX
 boP
 boP
 boP
@@ -68921,7 +68899,7 @@ boP
 boP
 boP
 boP
-asU
+pjX
 apJ
 asH
 atI
@@ -68936,13 +68914,13 @@ crz
 awW
 aAD
 awW
-asU
+pjX
 boP
 boP
 boP
 boP
 boP
-asU
+pjX
 awW
 awW
 awW
@@ -68960,7 +68938,7 @@ ayk
 awW
 aAD
 awW
-asU
+pjX
 boP
 boP
 boP
@@ -69950,9 +69928,9 @@ boP
 boP
 boP
 boP
-asU
-asU
-asU
+pjX
+pjX
+pjX
 hGN
 alU
 atJ
@@ -70208,7 +70186,7 @@ boP
 boP
 boP
 boP
-asU
+pjX
 alU
 alU
 alU
@@ -70465,7 +70443,7 @@ boP
 boP
 boP
 boP
-asU
+pjX
 aqJ
 amC
 gLH
@@ -71234,7 +71212,7 @@ boP
 boP
 boP
 boP
-asU
+pjX
 alU
 alU
 apM
@@ -71830,7 +71808,7 @@ bBM
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
@@ -71988,15 +71966,15 @@ boP
 bBM
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 bBM
@@ -72087,7 +72065,7 @@ boP
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
@@ -72245,15 +72223,15 @@ boP
 bBM
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -72310,7 +72288,7 @@ boP
 boP
 boP
 boP
-btF
+pjX
 boP
 boP
 boP
@@ -72344,7 +72322,7 @@ atY
 atY
 atY
 boP
-asU
+pjX
 boP
 atY
 atY
@@ -72502,15 +72480,15 @@ boP
 bBM
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -72520,8 +72498,8 @@ boP
 boP
 boP
 boP
-asU
-asU
+pjX
+pjX
 ali
 aiR
 aol
@@ -72563,7 +72541,7 @@ bkD
 boP
 boP
 boP
-btF
+pjX
 boP
 boP
 boP
@@ -72595,19 +72573,19 @@ boP
 boP
 bBM
 boP
-aah
-aah
-aah
-aah
-aah
-aah
-asU
-aah
-aah
-aah
-aah
-aah
-aah
+xrV
+xrV
+xrV
+xrV
+xrV
+xrV
+pjX
+xrV
+xrV
+xrV
+xrV
+xrV
+xrV
 boP
 bBM
 boP
@@ -72759,15 +72737,15 @@ boP
 boP
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -72777,8 +72755,8 @@ boP
 boP
 boP
 boP
-asU
-asU
+pjX
+pjX
 ali
 ajw
 aol
@@ -72824,7 +72802,7 @@ bte
 boP
 boP
 boP
-bwm
+bwo
 boP
 boP
 boP
@@ -72858,7 +72836,7 @@ atY
 atY
 atY
 boP
-asU
+pjX
 boP
 atY
 atY
@@ -73016,15 +72994,15 @@ bBM
 boP
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -73077,7 +73055,7 @@ bkF
 boP
 boP
 boP
-btF
+pjX
 boP
 boP
 boP
@@ -73115,7 +73093,7 @@ boP
 boP
 boP
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -73273,15 +73251,15 @@ boP
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
-aah
+xrV
 boP
 bwo
 aCS
@@ -73338,7 +73316,7 @@ boP
 boP
 boP
 boP
-btF
+pjX
 boP
 boP
 boP
@@ -73372,7 +73350,7 @@ atY
 atY
 atY
 boP
-asU
+pjX
 boP
 atY
 atY
@@ -73528,19 +73506,19 @@ bBM
 boP
 glY
 sHm
-aah
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-aah
+xrV
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+xrV
 aEQ
 akB
 alh
@@ -73591,7 +73569,7 @@ bkF
 boP
 boP
 boP
-bwm
+bwo
 boP
 boP
 boP
@@ -73623,19 +73601,19 @@ boP
 boP
 bBM
 boP
-aah
-aah
-aah
-aah
-aah
-aah
-asU
-aah
-aah
-aah
-aah
-aah
-aah
+xrV
+xrV
+xrV
+xrV
+xrV
+xrV
+pjX
+xrV
+xrV
+xrV
+xrV
+xrV
+xrV
 boP
 bBM
 boP
@@ -73787,17 +73765,17 @@ boP
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
-aah
+xrV
 boP
-asU
+pjX
 aCS
 ajV
 ajV
@@ -73852,7 +73830,7 @@ boP
 boP
 boP
 boP
-btF
+pjX
 boP
 boP
 boP
@@ -73886,7 +73864,7 @@ atY
 atY
 atY
 boP
-asU
+pjX
 boP
 atY
 atY
@@ -74044,15 +74022,15 @@ bBM
 boP
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -74143,7 +74121,7 @@ boP
 boP
 boP
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -74301,15 +74279,15 @@ boP
 boP
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -74362,7 +74340,7 @@ bkE
 boP
 boP
 boP
-bwm
+bwo
 boP
 boP
 boP
@@ -74400,7 +74378,7 @@ atY
 atY
 atY
 boP
-asU
+pjX
 boP
 atY
 atY
@@ -74558,15 +74536,15 @@ boP
 bBM
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -74619,11 +74597,11 @@ bkF
 boP
 boP
 boP
-btF
+pjX
 boP
 boP
 bnv
-btF
+pjX
 boP
 boP
 boP
@@ -74651,19 +74629,19 @@ boP
 boP
 bBM
 boP
-aah
-aah
-aah
-aah
-aah
-aah
-asU
-aah
-aah
-aah
-aah
-aah
-aah
+xrV
+xrV
+xrV
+xrV
+xrV
+xrV
+pjX
+xrV
+xrV
+xrV
+xrV
+xrV
+xrV
 boP
 bBM
 boP
@@ -74815,15 +74793,15 @@ boP
 bBM
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -74914,7 +74892,7 @@ atY
 atY
 atY
 boP
-asU
+pjX
 boP
 atY
 atY
@@ -75072,15 +75050,15 @@ boP
 bBM
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 bBM
@@ -75171,7 +75149,7 @@ boP
 boP
 boP
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -75427,9 +75405,9 @@ boP
 boP
 boP
 boP
-asU
-aah
-asU
+pjX
+xrV
+pjX
 boP
 boP
 boP
@@ -76187,9 +76165,9 @@ bLv
 bCq
 bCq
 bvN
-asU
-asU
-asU
+pjX
+pjX
+pjX
 boP
 bCq
 bCq
@@ -76377,7 +76355,7 @@ alU
 amC
 alU
 boP
-asU
+pjX
 alU
 arO
 alU
@@ -76633,7 +76611,7 @@ boP
 ali
 anK
 ali
-asU
+pjX
 boP
 alU
 alU
@@ -76890,10 +76868,10 @@ boP
 alU
 amC
 alU
-asU
+pjX
 boP
 boP
-asU
+pjX
 alU
 ali
 ali
@@ -77149,7 +77127,7 @@ aKY
 ali
 aCV
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -77405,7 +77383,7 @@ ali
 amC
 ali
 aCV
-asU
+pjX
 boP
 boP
 boP
@@ -77663,7 +77641,7 @@ amC
 alU
 alU
 alU
-asU
+pjX
 boP
 boP
 boP
@@ -78004,7 +77982,7 @@ bHE
 bCq
 bCq
 bCq
-asU
+pjX
 boP
 boP
 boP
@@ -78261,7 +78239,7 @@ bHE
 cqH
 dCG
 lWA
-asU
+pjX
 boP
 boP
 boP
@@ -78518,7 +78496,7 @@ bCq
 bCq
 bCq
 bCq
-asU
+pjX
 boP
 boP
 boP
@@ -78770,10 +78748,10 @@ bCq
 bCq
 cgG
 bCq
-asU
-asU
+pjX
+pjX
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -79005,8 +78983,8 @@ dXN
 ufl
 ufX
 oOH
-asU
-asU
+pjX
+pjX
 bCq
 bHE
 bRg
@@ -79208,8 +79186,8 @@ boP
 boP
 boP
 boP
-asU
-asU
+pjX
+pjX
 aqQ
 neA
 ayB
@@ -79790,7 +79768,7 @@ boP
 boP
 aan
 boP
-asU
+pjX
 bGl
 boP
 boP
@@ -80033,8 +80011,8 @@ ukf
 iPp
 oOH
 oOH
-asU
-asU
+pjX
+pjX
 bCq
 bHE
 bHE
@@ -80046,9 +80024,9 @@ boP
 boP
 boP
 boP
-asU
+pjX
 kRS
-asU
+pjX
 boP
 boP
 boP
@@ -80225,10 +80203,10 @@ boP
 boP
 boP
 bwo
-asU
-asU
+pjX
+pjX
 boP
-asU
+pjX
 aVm
 bwo
 boP
@@ -80305,7 +80283,7 @@ boP
 boP
 bAN
 bGa
-asU
+pjX
 boP
 boP
 boP
@@ -80561,7 +80539,7 @@ boP
 boP
 boP
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -80572,7 +80550,7 @@ bLv
 boP
 boP
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -80818,7 +80796,7 @@ boP
 boP
 boP
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -89307,7 +89285,7 @@ rLU
 sfD
 sfD
 ojf
-asU
+pjX
 ccm
 ccm
 ccm
@@ -89323,9 +89301,9 @@ pFQ
 jkP
 wRp
 nrW
-asU
-asU
-asU
+pjX
+pjX
+pjX
 boP
 boP
 boP
@@ -89582,7 +89560,7 @@ seK
 sqc
 boP
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -89821,7 +89799,7 @@ pLy
 nmi
 lAl
 vqw
-asU
+pjX
 riF
 kZi
 jVr
@@ -89839,7 +89817,7 @@ wiL
 fwu
 boP
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -90096,7 +90074,7 @@ fwu
 boP
 boP
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -90353,7 +90331,7 @@ fwu
 boP
 boP
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -90608,9 +90586,9 @@ jfh
 uxt
 kGh
 bLt
-asU
+pjX
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -90849,25 +90827,25 @@ rLU
 ivF
 uYt
 vqw
-asU
+pjX
 riF
 nVN
 mwT
 hsG
 ccm
 fwu
-boP
+pjX
 bvw
-boP
+pjX
 wLf
 hDq
 hDq
 hDq
 fwu
-asU
+pjX
 bLZ
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -91124,7 +91102,7 @@ boP
 boP
 bMb
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -91363,7 +91341,7 @@ xFV
 ivF
 rLU
 vqw
-asU
+pjX
 ccm
 ccm
 ccm
@@ -91381,7 +91359,7 @@ boP
 boP
 bMd
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -91638,7 +91616,7 @@ boP
 boP
 bMd
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -91774,7 +91752,7 @@ gQb
 boP
 boP
 boP
-asU
+pjX
 bPU
 gSh
 gUw
@@ -91877,7 +91855,7 @@ pjs
 sWG
 qpg
 vqw
-asU
+pjX
 riF
 jnK
 uqM
@@ -91895,7 +91873,7 @@ boP
 boP
 bMd
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -92152,7 +92130,7 @@ boP
 boP
 bMb
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -92292,9 +92270,9 @@ boP
 boP
 boP
 vOj
-asU
-aHs
-asU
+pjX
+bvw
+pjX
 vOj
 gQb
 gQb
@@ -92391,7 +92369,7 @@ ojf
 ojf
 fsN
 ojf
-asU
+pjX
 ccm
 ccm
 ccm
@@ -92409,7 +92387,7 @@ boP
 boP
 bMd
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -92627,13 +92605,13 @@ hTU
 hxs
 bzs
 buf
-asU
+pjX
 buf
-asU
+pjX
 buJ
-asU
+pjX
 buf
-asU
+pjX
 buJ
 bzm
 bzn
@@ -92666,7 +92644,7 @@ boP
 boP
 bMd
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -92901,7 +92879,7 @@ frz
 riF
 frz
 ccm
-asU
+pjX
 xjx
 nxB
 xjx
@@ -92923,7 +92901,7 @@ boP
 boP
 bMd
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -93077,9 +93055,9 @@ boP
 boP
 boP
 boP
-asU
-asU
-asU
+pjX
+pjX
+pjX
 boP
 boP
 boP
@@ -93158,13 +93136,13 @@ qHE
 fAQ
 kTm
 ccm
-asU
+pjX
 vqw
 eEf
 xjx
 xjx
 xjx
-asU
+pjX
 boP
 boP
 boP
@@ -93180,7 +93158,7 @@ boP
 boP
 bMb
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -93415,29 +93393,29 @@ tbf
 xzf
 tbf
 ccm
-asU
+pjX
 vqw
 puJ
 pss
 dVz
 epW
 bBE
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
 bMd
-asU
-asU
+pjX
+pjX
 boP
 boP
 boP
@@ -93672,7 +93650,7 @@ tbf
 gOI
 tbf
 ccm
-asU
+pjX
 vqw
 nRn
 xjx
@@ -93694,7 +93672,7 @@ boP
 boP
 bMd
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -93929,12 +93907,12 @@ ccm
 ccm
 ccm
 ccm
-asU
+pjX
 xjx
 nRn
 xjx
 boP
-asU
+pjX
 bug
 buv
 bBE
@@ -93951,7 +93929,7 @@ boP
 boP
 bMd
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -94182,11 +94160,11 @@ buv
 buv
 buv
 bBE
-asU
-asU
-asU
-asU
-asU
+pjX
+pjX
+pjX
+pjX
+pjX
 bxo
 byv
 bzq
@@ -94465,7 +94443,7 @@ boP
 boP
 bMd
 bwo
-asU
+pjX
 bwo
 boP
 boP
@@ -95228,7 +95206,7 @@ cop
 cmd
 cmd
 cqs
-asU
+pjX
 boP
 boP
 boP
@@ -95485,7 +95463,7 @@ bGJ
 bHB
 cpN
 cqt
-asU
+pjX
 boP
 boP
 boP
@@ -95742,7 +95720,7 @@ bGS
 cmd
 cmd
 cqs
-asU
+pjX
 boP
 boP
 boP
@@ -96917,15 +96895,15 @@ gQb
 bBM
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 bBM
@@ -96935,7 +96913,7 @@ boP
 boP
 boP
 boP
-boP
+pjX
 alO
 arp
 alO
@@ -97174,15 +97152,15 @@ gQb
 bBM
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -97192,7 +97170,7 @@ boP
 boP
 boP
 boP
-boP
+pjX
 cxW
 anf
 aqv
@@ -97431,15 +97409,15 @@ gQb
 bBM
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -97449,7 +97427,7 @@ boP
 boP
 boP
 boP
-boP
+pjX
 alO
 arp
 alO
@@ -97688,15 +97666,15 @@ gQb
 boP
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -97945,15 +97923,15 @@ bBM
 boP
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -98202,15 +98180,15 @@ boP
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
@@ -98456,23 +98434,23 @@ gQb
 bBM
 boP
 aae
-aah
-aah
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-aah
-aah
-aah
-aah
+xrV
+xrV
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+xrV
+xrV
+xrV
+xrV
 amv
 ane
 cxN
@@ -98716,20 +98694,20 @@ boP
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
 boP
-asU
+pjX
 amw
 amw
 amw
@@ -98973,15 +98951,15 @@ bBM
 bJY
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -99230,15 +99208,15 @@ gQb
 boP
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -99487,15 +99465,15 @@ gQb
 bBM
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -99744,15 +99722,15 @@ gQb
 bBM
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 boP
@@ -100001,15 +99979,15 @@ gQb
 bBM
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 agg
-aah
+xrV
 agg
 boP
 bBM
@@ -102173,7 +102151,7 @@ jdH
 keQ
 cOe
 cqu
-asU
+pjX
 boP
 boP
 boP
@@ -102430,7 +102408,7 @@ cNW
 cNW
 cqu
 cOT
-asU
+pjX
 boP
 boP
 boP
@@ -105767,15 +105745,15 @@ boP
 bBM
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 bBM
@@ -105938,7 +105916,7 @@ aER
 boP
 boP
 boP
-asU
+pjX
 blq
 blq
 blq
@@ -106024,15 +106002,15 @@ boP
 bJc
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 bBM
@@ -106195,7 +106173,7 @@ aER
 boP
 boP
 boP
-asU
+pjX
 blq
 blq
 blq
@@ -106281,15 +106259,15 @@ boP
 boP
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 bBM
@@ -106448,7 +106426,7 @@ boP
 boP
 boP
 boP
-asU
+pjX
 boP
 boP
 boP
@@ -106538,15 +106516,15 @@ boP
 boP
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 boP
@@ -106795,15 +106773,15 @@ boP
 boP
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 boP
@@ -107047,20 +107025,20 @@ cmw
 cnj
 cnj
 cnj
-asU
+pjX
 boP
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
@@ -107304,23 +107282,23 @@ cks
 cnk
 cks
 cyU
-aah
-aah
-aah
-aah
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-asU
-aah
-aah
+xrV
+xrV
+xrV
+xrV
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+pjX
+xrV
+xrV
 aae
 boP
 bBM
@@ -107566,15 +107544,15 @@ boP
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
-aah
+xrV
 boP
 boP
 boP
@@ -107767,8 +107745,8 @@ aNa
 boP
 boP
 boP
-asU
-asU
+pjX
+pjX
 bky
 vqI
 bon
@@ -107823,15 +107801,15 @@ boP
 boP
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 boP
@@ -108080,15 +108058,15 @@ boP
 boP
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 boP
@@ -108337,15 +108315,15 @@ boP
 boP
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 bBM
@@ -108522,19 +108500,19 @@ boP
 boP
 boP
 boP
-asU
-asU
-asU
+pjX
+pjX
+pjX
 bdV
-asU
+pjX
 boP
 boP
 boP
-asU
-asU
-asU
-asU
-asU
+pjX
+pjX
+pjX
+pjX
+pjX
 boP
 boP
 boP
@@ -108594,15 +108572,15 @@ boP
 boP
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 bBM
@@ -108851,15 +108829,15 @@ boP
 bJc
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 aud
-aah
+xrV
 aud
 boP
 bBM
@@ -109586,7 +109564,7 @@ boP
 boP
 boP
 bwo
-asU
+pjX
 bwo
 boP
 boP
@@ -109605,8 +109583,8 @@ boP
 boP
 boP
 bwo
-asU
-asU
+pjX
+pjX
 boP
 boP
 boP

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -682,7 +682,7 @@
 	},
 /obj/item/clothing/head/beanie/orange,
 /obj/machinery/camera{
-	c_tag = "Atmospherics West";
+	c_tag = "Mining Eva";
 	dir = 8
 	},
 /obj/machinery/light,
@@ -2376,7 +2376,7 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/camera{
-	c_tag = "Mech Bay";
+	c_tag = "Mining Mech Bay";
 	dir = 1;
 	network = list("mine")
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed two cameras having duplicate names in mining outpost.
Fixed double wires in arrivals.
Changed the platting outside to be snow covered, The janitor never shovels the snow that well.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes to cameras and wires.
Better outdoor feel to snow land.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: ICEBOX: fixed Double wiring
fix: ICEBOX: fixed mining mecha bay camera name
fix: ICEBOX: fixed mining eva camera name
fix: ICEBOX: Atmos waste line vent was moved to prevent the melting of atmos
tweak: ICEBOX: plating outside the station is a bit snow covered now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
