### PR TITLE
Fixes CTF runtimes / hard del

### DIFF
--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -296,6 +296,7 @@
 	SIGNAL_HANDLER
 
 	recently_dead_ckeys += body.ckey
+	spawned_mobs -= body
 	addtimer(CALLBACK(src, .proc/clear_cooldown, body.ckey), respawn_cooldown, TIMER_UNIQUE)
 
 /obj/machinery/capture_the_flag/proc/clear_cooldown(ckey)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -225,6 +225,8 @@
 	QDEL_LIST(traumas)
 
 	destroy_all_skillchips()
+	if(owner?.mind)	//You aren't allowed to return to brains that don't exist
+		owner.mind.current = null
 	return ..()
 
 /obj/item/organ/brain/on_life()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
CTF has a bug where it tries to dust players over and over again.
![image](https://user-images.githubusercontent.com/33846895/107080157-27f3cb00-67f1-11eb-8b79-d70bf0d2720f.png)

This happens because the CTF players aren't removed from "spawned_mobs" when qdeled
This caused the process proc to constantly try to dust already dusted mobs until the already qdeled mob finally got hardeleted (because the spawned_mobs list still had a ref to the mob )
This removes the mob from the list when being qdeleted which fixes both the runtimes and the harddel
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes runtime / harddel
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Gamer025 & nightred
fix: CTF no longer tries to dust the same mob multiple times which caused a lot of runtimes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
