### PR TITLE
Fixes Unstable Mutagen not mutating on exposure

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -40,7 +40,7 @@
 
 /datum/reagent/toxin/mutagen/expose_mob(mob/living/carbon/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
-	if(!. || !exposed_mob.has_dna() || HAS_TRAIT(exposed_mob, TRAIT_GENELESS) || HAS_TRAIT(exposed_mob, TRAIT_BADDNA))
+	if(!exposed_mob.has_dna() || HAS_TRAIT(exposed_mob, TRAIT_GENELESS) || HAS_TRAIT(exposed_mob, TRAIT_BADDNA))
 		return  //No robots, AIs, aliens, Ians or other mobs should be affected by this.
 	if(((methods & VAPOR) && prob(min(33, reac_volume))) || (methods & (INGEST|PATCH|INJECT)))
 		exposed_mob.randmuti()


### PR DESCRIPTION
## About The Pull Request

Unstable Mutagen, on mob exposure, would check its parent proc's return value to determine whether to actually continue the exposure proc. In the past, this would always return TRUE, so it didn't matter.

5 months ago the exposure proc was changed to not return TRUE or FALSE - but this check was never removed, so it always fails.

(the parent of `expose_mob` returns `. = SEND_SIGNAL(src, COMSIG_REAGENT_EXPOSE_MOB, exposed_mob, methods, reac_volume, show_message, touch_protection)`, which fails the `if(!.)` check.)

This fixes unstable mutagen by removing the check for the parent's return value, since it was never necessary in the first place.

## Why It's Good For The Game

Mutagen is supposed to do the funny mutations.

## Changelog
:cl: Melbert
fix: Unstable Mutagen now mutates again.
/:cl:
