### PR TITLE
Fixes attacks doing 0 damage when dismemberment wound fails

### DIFF
--- a/code/datums/wounds/loss.dm
+++ b/code/datums/wounds/loss.dm
@@ -51,3 +51,4 @@
 	log_wound(victim, src)
 	dismembered_part.dismember(wounding_type == WOUND_BURN ? BURN : BRUTE)
 	qdel(src)
+	return TRUE

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -191,8 +191,7 @@
 
 	if(prob(base_chance))
 		var/datum/wound/loss/dismembering = new
-		dismembering.apply_dismember(src, wounding_type)
-		return TRUE
+		return dismembering.apply_dismember(src, wounding_type)
 
 //when a limb is dropped, the internal organs are removed from the mob and put into the limb
 /obj/item/organ/proc/transfer_to_limb(obj/item/bodypart/LB, mob/living/carbon/C)


### PR DESCRIPTION
`apply_dismember` can fail if the limb is not dismember-able (heads are not dismember-able when not in crit), however `try_dismember` returned `TRUE` even if `apply_dismember` failed which prevented damage from being applied.
https://github.com/tgstation/tgstation/blob/a69ee4d35082b9a1ebe440fa42f2a0226b62a140/code/datums/wounds/loss.dm#L15-L18
Fixes #56514