### PR TITLE
Toggle suit sensors is now bound to right click

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -42,6 +42,10 @@
 	if(!attach_accessory(I, user))
 		return ..()
 
+/obj/item/clothing/under/attackby_alt(obj/item/weapon, mob/user, params)
+	toggle()
+	return ALT_ATTACK_CANCEL_ATTACK_CHAIN
+
 /obj/item/clothing/under/update_clothes_damaged_state(damaged_state = CLOTHING_DAMAGED)
 	..()
 	if(ismob(loc))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Right clicking on a jumpsuit will act as if you pressed the "toggle suit sensors" verb.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is an extremely common action, and is perfect for right click behavior. Also people are stripping in the halls right now, forgetting to shift right click. How embarrassing.

One day verbs will die. This is part of that healing process.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Toggle suit sensors is now bound to right click.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
