### PR TITLE
NTDownloader UI revamp

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -84,6 +84,13 @@
 #define PROGRAM_STATE_KILLED 0
 #define PROGRAM_STATE_BACKGROUND 1
 #define PROGRAM_STATE_ACTIVE 2
+//Program categories
+#define PROGRAM_CATEGORY_MISC "Misc."
+#define PROGRAM_CATEGORY_CREW "Crew"
+#define PROGRAM_CATEGORY_SUPL "Supply"
+#define PROGRAM_CATEGORY_ENGI "Engineering"
+#define PROGRAM_CATEGORY_ROBO "Robotics"
+#define PROGRAM_CATEGORY_SYND "Syndicate"
 
 #define FIREDOOR_OPEN 1
 #define FIREDOOR_CLOSED 2

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -85,7 +85,6 @@
 #define PROGRAM_STATE_BACKGROUND 1
 #define PROGRAM_STATE_ACTIVE 2
 //Program categories
-#define PROGRAM_CATEGORY_ALL "All"
 #define PROGRAM_CATEGORY_CREW "Crew"
 #define PROGRAM_CATEGORY_ENGI "Engineering"
 #define PROGRAM_CATEGORY_ROBO "Robotics"

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -85,12 +85,12 @@
 #define PROGRAM_STATE_BACKGROUND 1
 #define PROGRAM_STATE_ACTIVE 2
 //Program categories
-#define PROGRAM_CATEGORY_MISC "Misc."
+#define PROGRAM_CATEGORY_ALL "All"
 #define PROGRAM_CATEGORY_CREW "Crew"
-#define PROGRAM_CATEGORY_SUPL "Supply"
 #define PROGRAM_CATEGORY_ENGI "Engineering"
 #define PROGRAM_CATEGORY_ROBO "Robotics"
-#define PROGRAM_CATEGORY_SYND "Syndicate"
+#define PROGRAM_CATEGORY_SUPL "Supply"
+#define PROGRAM_CATEGORY_MISC "Other"
 
 #define FIREDOOR_OPEN 1
 #define FIREDOOR_CLOSED 2

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -125,9 +125,6 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 /proc/cmp_pdajob_asc(obj/item/pda/A, obj/item/pda/B)
 	return sorttext(B.ownjob, A.ownjob)
 
-/proc/cmp_program_asc(A, B)
-	return sorttext(B["filedesc"], A["filedesc"])
-
 /proc/cmp_num_string_asc(A, B)
 	return text2num(A) - text2num(B)
 

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -125,6 +125,9 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 /proc/cmp_pdajob_asc(obj/item/pda/A, obj/item/pda/B)
 	return sorttext(B.ownjob, A.ownjob)
 
+/proc/cmp_program_asc(A, B)
+	return sorttext(B["filedesc"], A["filedesc"])
+
 /proc/cmp_num_string_asc(A, B)
 	return text2num(A) - text2num(B)
 

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -15,6 +15,8 @@
 	var/filedesc = "Unknown Program"
 	/// Short description of this program's function.
 	var/extended_desc = "N/A"
+	/// Category in the NTDownloader.
+	var/category = PROGRAM_CATEGORY_MISC
 	/// Program-specific screen icon state
 	var/program_icon_state = null
 	/// Set to 1 for program to require nonstop NTNet connection to run. If NTNet connection is lost program crashes.

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/aidiag
 	filename = "aidiag"
 	filedesc = "NT FRK"
+	category = PROGRAM_CATEGORY_ROBO
 	program_icon_state = "generic"
 	extended_desc = "Firmware Restoration Kit, capable of reconstructing damaged AI systems. Requires direct AI connection via intellicard slot."
 	size = 12

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/alarm_monitor
 	filename = "alarmmonitor"
 	filedesc = "Canary"
+	category = PROGRAM_CATEGORY_ENGI
 	ui_header = "alarm_green.gif"
 	program_icon_state = "alert-green"
 	extended_desc = "This program provides visual interface for a station's alarm system."

--- a/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
@@ -1,7 +1,7 @@
 /datum/computer_file/program/contract_uplink
 	filename = "contractor uplink"
 	filedesc = "Syndicate Contractor Uplink"
-	category = PROGRAM_CATEGORY_SYND
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "assign"
 	extended_desc = "A standard, Syndicate issued system for handling important contracts while on the field."
 	size = 10

--- a/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/contract_uplink
 	filename = "contractor uplink"
 	filedesc = "Syndicate Contractor Uplink"
+	category = PROGRAM_CATEGORY_SYND
 	program_icon_state = "assign"
 	extended_desc = "A standard, Syndicate issued system for handling important contracts while on the field."
 	size = 10

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/ntnet_dos
 	filename = "ntn_dos"
 	filedesc = "DoS Traffic Generator"
+	category = PROGRAM_CATEGORY_SYND
 	program_icon_state = "hostile"
 	extended_desc = "This advanced script can perform denial of service attacks against NTNet quantum relays. The system administrator will probably notice this. Multiple devices can run this program together against same relay for increased effect"
 	size = 20

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -1,7 +1,7 @@
 /datum/computer_file/program/ntnet_dos
 	filename = "ntn_dos"
 	filedesc = "DoS Traffic Generator"
-	category = PROGRAM_CATEGORY_SYND
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "hostile"
 	extended_desc = "This advanced script can perform denial of service attacks against NTNet quantum relays. The system administrator will probably notice this. Multiple devices can run this program together against same relay for increased effect"
 	size = 20

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/revelation
 	filename = "revelation"
 	filedesc = "Revelation"
+	category = PROGRAM_CATEGORY_SYND
 	program_icon_state = "hostile"
 	extended_desc = "This virus can destroy hard drive of system it is executed on. It may be obfuscated to look like another non-malicious program. Once armed, it will destroy the system upon next execution."
 	size = 13

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -1,7 +1,7 @@
 /datum/computer_file/program/revelation
 	filename = "revelation"
 	filedesc = "Revelation"
-	category = PROGRAM_CATEGORY_SYND
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "hostile"
 	extended_desc = "This virus can destroy hard drive of system it is executed on. It may be obfuscated to look like another non-malicious program. Once armed, it will destroy the system upon next execution."
 	size = 13

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/atmosscan
 	filename = "atmosscan"
 	filedesc = "AtmoZphere"
+	category = PROGRAM_CATEGORY_ENGI
 	program_icon_state = "air"
 	extended_desc = "A small built-in sensor reads out the atmospheric conditions around the device."
 	size = 4

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/borg_monitor
 	filename = "siliconnect"
 	filedesc = "SiliConnect"
+	category = PROGRAM_CATEGORY_ROBO
 	ui_header = "borg_mon.gif"
 	program_icon_state = "generic"
 	extended_desc = "This program allows for remote monitoring of station cyborgs."

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -98,6 +98,7 @@
 /datum/computer_file/program/borg_monitor/syndicate
 	filename = "roboverlord"
 	filedesc = "Roboverlord"
+	category = PROGRAM_CATEGORY_ROBO
 	ui_header = "borg_mon.gif"
 	program_icon_state = "generic"
 	extended_desc = "This program allows for remote monitoring of mission-assigned cyborgs."

--- a/code/modules/modular_computers/file_system/programs/bounty_board.dm
+++ b/code/modules/modular_computers/file_system/programs/bounty_board.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/bounty_board
 	filename = "bountyboard"
 	filedesc = "Bounty Board Request Network"
+	category = PROGRAM_CATEGORY_SUPL
 	program_icon_state = "bountyboard"
 	extended_desc = "A multi-platform network for placing requests across the station, with payment across the network being possible.."
 	requires_ntnet = TRUE

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/budgetorders
 	filename = "orderapp"
 	filedesc = "Nanotrasen Internal Requisition Network (NIRN)"
+	category = PROGRAM_CATEGORY_SUPL
 	program_icon_state = "request"
 	extended_desc = "A request network that utilizes the Nanotrasen Ordering network to purchase supplies using a department budget account."
 	requires_ntnet = TRUE

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -1,9 +1,9 @@
 /datum/computer_file/program/budgetorders
 	filename = "orderapp"
-	filedesc = "Nanotrasen Internal Requisition Network (NIRN)"
+	filedesc = "NT IRN"
 	category = PROGRAM_CATEGORY_SUPL
 	program_icon_state = "request"
-	extended_desc = "A request network that utilizes the Nanotrasen Ordering network to purchase supplies using a department budget account."
+	extended_desc = "Nanotrasen Internal Requisition Network interface for supply purchasing using a department budget account."
 	requires_ntnet = TRUE
 	transfer_access = ACCESS_HEADS
 	usage_flags = PROGRAM_LAPTOP | PROGRAM_TABLET

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -9,6 +9,7 @@
 /datum/computer_file/program/card_mod
 	filename = "plexagonidwriter"
 	filedesc = "Plexagon Access Management"
+	category = PROGRAM_CATEGORY_CREW
 	program_icon_state = "id"
 	extended_desc = "Program for programming employee ID cards to access parts of the station."
 	transfer_access = ACCESS_HEADS

--- a/code/modules/modular_computers/file_system/programs/cargoship.dm
+++ b/code/modules/modular_computers/file_system/programs/cargoship.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/shipping
 	filename = "shipping"
 	filedesc = "GrandArk Exporter"
+	category = PROGRAM_CATEGORY_SUPL
 	program_icon_state = "shipping"
 	extended_desc = "A combination printer/scanner app that enables modular computers to print barcodes for easy scanning and shipping."
 	size = 6

--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/crew_manifest
 	filename = "plexagoncrew"
 	filedesc = "Plexagon Crew List"
+	category = PROGRAM_CATEGORY_CREW
 	program_icon_state = "id"
 	extended_desc = "Program for viewing and printing the current crew manifest"
 	transfer_access = ACCESS_HEADS

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/job_management
 	filename = "plexagoncore"
 	filedesc = "Plexagon HR Core"
+	category = PROGRAM_CATEGORY_CREW
 	program_icon_state = "id"
 	extended_desc = "Program for viewing and changing job slot avalibility."
 	transfer_access = ACCESS_HEADS

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -23,7 +23,6 @@
 	var/list/main_repo
 	var/list/antag_repo
 	var/list/show_categories = list(
-		PROGRAM_CATEGORY_ALL,
 		PROGRAM_CATEGORY_CREW,
 		PROGRAM_CATEGORY_ENGI,
 		PROGRAM_CATEGORY_ROBO,
@@ -154,54 +153,23 @@
 	var/obj/item/computer_hardware/hard_drive/hard_drive = my_computer.all_components[MC_HDD]
 	data["disk_size"] = hard_drive.max_capacity
 	data["disk_used"] = hard_drive.used_capacity
-	var/list/programs[0]
-	var/list/programs_incompatible[0]
-	for(var/A in main_repo)
-		var/datum/computer_file/program/P = A
-		if (check_compatibility(P))
-			programs.Add(P)
-		else
-			programs_incompatible.Add(P)
-	if(emagged) // If we are running on emagged computer we have access to some "bonus" software
-		for(var/S in antag_repo)
-			var/datum/computer_file/program/P = S
-			if (check_compatibility(P))
-				programs.Add(P)
-			else
-				programs_incompatible.Add(P)
+	data["emagged"] = emagged
+	data["categories"] = show_categories
 
-	programs = sortList(programs, /proc/cmp_program_asc)
-	programs_incompatible = sortList(programs_incompatible, /proc/cmp_program_asc)
-
-	var/categories = show_categories.Copy()
-	for(var/V in categories)
-		categories[V] = list()
-	for(var/I in programs | programs_incompatible)
+	for(var/I in main_repo | antag_repo)
 		var/datum/computer_file/program/P = I
-		for(var/C in categories)
-			if(C == P.category || C == PROGRAM_CATEGORY_ALL)
-				categories[C] += P
-	for(var/category in categories)
-		if (!LAZYLEN(categories[category]))
-			continue
-		var/list/cat = list(
-			"name" = category,
-			"items" = list())
-		for(var/I in categories[category])
-			var/datum/computer_file/program/P = I
-			cat["items"] += list(list(
-				"icon" = P.program_icon,
-				"filename" = P.filename,
-				"filedesc" = P.filedesc,
-				"fileinfo" = P.extended_desc,
-				"category" = P.category,
-				"installed" = !!hard_drive.find_file_by_name(P.filename),
-				"compatibility" = check_compatibility(P),
-				"size" = P.size,
-				"access" = emagged && P.available_on_syndinet ? TRUE : P.can_run(user,transfer = 1, access = access),
-				"verifiedsource" = P.available_on_ntnet,
-			))
-		data["categories"] += list(cat)
+		data["programs"] += list(list(
+			"icon" = P.program_icon,
+			"filename" = P.filename,
+			"filedesc" = P.filedesc,
+			"fileinfo" = P.extended_desc,
+			"category" = P.category,
+			"installed" = !!hard_drive.find_file_by_name(P.filename),
+			"compatibility" = check_compatibility(P),
+			"size" = P.size,
+			"access" = emagged && P.available_on_syndinet ? TRUE : P.can_run(user,transfer = 1, access = access),
+			"verifiedsource" = P.available_on_ntnet,
+		))
 	return data
 
 /datum/computer_file/program/ntnetdownload/proc/check_compatibility(datum/computer_file/program/P)

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -149,13 +149,11 @@
 	var/list/all_entries[0]
 	for(var/A in main_repo)
 		var/datum/computer_file/program/P = A
-		// Only those programs our user can run will show in the list
-		if(hard_drive.find_file_by_name(P.filename))
-			continue
 		all_entries.Add(list(list(
 			"filename" = P.filename,
 			"filedesc" = P.filedesc,
 			"fileinfo" = P.extended_desc,
+			"installed" = hard_drive.find_file_by_name(P.filename),
 			"compatibility" = check_compatibility(P),
 			"size" = P.size,
 			"access" = P.can_run(user,transfer = 1, access = access)
@@ -165,13 +163,12 @@
 		var/list/hacked_programs[0]
 		for(var/S in antag_repo)
 			var/datum/computer_file/program/P = S
-			if(hard_drive.find_file_by_name(P.filename))
-				continue
 			data["hackedavailable"] = TRUE
 			hacked_programs.Add(list(list(
 				"filename" = P.filename,
 				"filedesc" = P.filedesc,
 				"fileinfo" = P.extended_desc,
+				"installed" = hard_drive.find_file_by_name(P.filename),
 				"compatibility" = check_compatibility(P),
 				"size" = P.size,
 				"access" = TRUE,

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -154,10 +154,14 @@
 	data["disk_size"] = hard_drive.max_capacity
 	data["disk_used"] = hard_drive.used_capacity
 	data["emagged"] = emagged
-	data["categories"] = show_categories
 
-	for(var/I in main_repo | antag_repo)
+	var/list/repo = antag_repo | main_repo
+	var/list/program_categories = list()
+
+	for(var/I in repo)
 		var/datum/computer_file/program/P = I
+		if(!(P.category in program_categories))
+			program_categories.Add(P.category)
 		data["programs"] += list(list(
 			"icon" = P.program_icon,
 			"filename" = P.filename,
@@ -165,11 +169,14 @@
 			"fileinfo" = P.extended_desc,
 			"category" = P.category,
 			"installed" = !!hard_drive.find_file_by_name(P.filename),
-			"compatibility" = check_compatibility(P),
+			"compatible" = check_compatibility(P),
 			"size" = P.size,
 			"access" = emagged && P.available_on_syndinet ? TRUE : P.can_run(user,transfer = 1, access = access),
 			"verifiedsource" = P.available_on_ntnet,
 		))
+
+	data["categories"] = show_categories & program_categories
+
 	return data
 
 /datum/computer_file/program/ntnetdownload/proc/check_compatibility(datum/computer_file/program/P)

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -200,7 +200,7 @@
 				"installed" = !!hard_drive.find_file_by_name(P.filename),
 				"compatibility" = check_compatibility(P),
 				"size" = P.size,
-				"access" = emagged ? TRUE : P.can_run(user,transfer = 1, access = access),
+				"access" = emagged && P.available_on_syndinet ? TRUE : P.can_run(user,transfer = 1, access = access),
 				"verifiedsource" = P.available_on_ntnet,
 			))
 		data["categories"] += list(cat)

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -129,9 +129,6 @@
 				downloaded_file = null
 				downloaderror = ""
 			return TRUE
-		if("select")
-			selected_cat = params["category"]
-			return TRUE
 	return FALSE
 
 /datum/computer_file/program/ntnetdownload/ui_data(mob/user)

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -182,7 +182,7 @@
 			if(C == P.category || C == PROGRAM_CATEGORY_ALL)
 				categories[C] += P
 	for(var/category in categories)
-		if (!categories[category].len)
+		if (!LAZYLEN(categories[category]))
 			continue
 		var/list/cat = list(
 			"name" = category,

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -175,7 +175,7 @@
 			)))
 		data["hacked_programs"] = hacked_programs
 
-	data["downloadable_programs"] = all_entries
+	data["downloadable_programs"] = sortList(all_entries, /proc/cmp_program_asc)
 
 	return data
 

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -169,7 +169,7 @@
 				"filedesc" = P.filedesc,
 				"fileinfo" = P.extended_desc,
 				"installed" = hard_drive.find_file_by_name(P.filename),
-				"compatibility" = check_compatibility(P),
+				"compatible" = check_compatibility(P),
 				"size" = P.size,
 				"access" = TRUE,
 			)))
@@ -183,8 +183,8 @@
 	var/hardflag = computer.hardware_flag
 
 	if(P?.is_supported_by_hardware(hardflag,0))
-		return "Compatible"
-	return "Incompatible!"
+		return TRUE
+	return FALSE
 
 /datum/computer_file/program/ntnetdownload/kill_program(forced)
 	abort_file_download()

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -30,7 +30,6 @@
 		PROGRAM_CATEGORY_SUPL,
 		PROGRAM_CATEGORY_MISC,
 	)
-	var/selected_cat = PROGRAM_CATEGORY_ALL
 
 /datum/computer_file/program/ntnetdownload/run_program()
 	. = ..()
@@ -183,9 +182,11 @@
 			if(C == P.category || C == PROGRAM_CATEGORY_ALL)
 				categories[C] += P
 	for(var/category in categories)
+		if (!categories[category].len)
+			continue
 		var/list/cat = list(
 			"name" = category,
-			"items" = (category == selected_cat ? list() : null))
+			"items" = list())
 		for(var/I in categories[category])
 			var/datum/computer_file/program/P = I
 			cat["items"] += list(list(

--- a/code/modules/modular_computers/file_system/programs/ntmonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmonitor.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/ntnetmonitor
 	filename = "wirecarp"
 	filedesc = "WireCarp"
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "comm_monitor"
 	extended_desc = "This program monitors stationwide NTNet network, provides access to logging systems, and allows for configuration changes"
 	size = 12

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -1,7 +1,7 @@
 /datum/computer_file/program/chatclient
 	filename = "ntnrc_client"
 	filedesc = "Chat Client"
-	category = PROGRAM_CATEGORY_CREW
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "command"
 	extended_desc = "This program allows communication over NTNRC network"
 	size = 8

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/chatclient
 	filename = "ntnrc_client"
 	filedesc = "Chat Client"
+	category = PROGRAM_CATEGORY_CREW
 	program_icon_state = "command"
 	extended_desc = "This program allows communication over NTNRC network"
 	size = 8

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -3,6 +3,7 @@
 /datum/computer_file/program/power_monitor
 	filename = "ampcheck"
 	filedesc = "AmpCheck"
+	category = PROGRAM_CATEGORY_ENGI
 	program_icon_state = "power_monitor"
 	extended_desc = "This program connects to sensors around the station to provide information about electrical systems"
 	ui_header = "power_norm.gif"

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -259,6 +259,7 @@
 /datum/computer_file/program/radar/fission360
 	filename = "fission360"
 	filedesc = "Fission360"
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "radarsyndicate"
 	extended_desc = "This program allows for tracking of nuclear authorization disks and warheads."
 	requires_ntnet = FALSE

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/radar //generic parent that handles most of the process
 	filename = "genericfinder"
 	filedesc = "debug_finder"
+	category = PROGRAM_CATEGORY_CREW
 	ui_header = "borg_mon.gif" //DEBUG -- new icon before PR
 	program_icon_state = "radarntos"
 	requires_ntnet = TRUE

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -2,6 +2,7 @@
 /datum/computer_file/program/robocontrol
 	filename = "botkeeper"
 	filedesc = "BotKeeper"
+	category = PROGRAM_CATEGORY_ROBO
 	program_icon_state = "robot"
 	extended_desc = "A remote controller used for giving basic commands to non-sentient robots."
 	transfer_access = null

--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/robotact
 	filename = "robotact"
 	filedesc = "RoboTact"
+	category = PROGRAM_CATEGORY_ROBO
 	extended_desc = "A built-in app for cyborg self-management and diagnostics."
 	ui_header = "robotact.gif" //DEBUG -- new icon before PR
 	program_icon_state = "command"

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -3,6 +3,7 @@
 /datum/computer_file/program/secureye
 	filename = "secureye"
 	filedesc = "SecurEye"
+	category = PROGRAM_CATEGORY_MISC
 	ui_header = "borg_mon.gif"
 	program_icon_state = "generic"
 	extended_desc = "This program allows access to standard security camera networks."

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/supermatter_monitor
 	filename = "ntcims"
 	filedesc = "NT CIMS"
+	category = PROGRAM_CATEGORY_ENGI
 	ui_header = "smmon_0.gif"
 	program_icon_state = "smmon_0"
 	extended_desc = "Crystal Integrity Monitoring System, connects to specially calibrated supermatter sensors to provide information on the status of supermatter-based engines."

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -8,10 +8,11 @@ export const NtosNetDownloader = (props, context) => {
     PC_device_theme,
     disk_size,
     disk_used,
-    downloadable_programs = [],
+    downloadcompletion,
+    downloading,
+    downloadname,
+    downloadsize,
     error,
-    hacked_programs = [],
-    hackedavailable,
     categories = [],
   } = data;
   const [
@@ -25,8 +26,8 @@ export const NtosNetDownloader = (props, context) => {
   return (
     <NtosWindow
       theme={PC_device_theme}
-      width={512}
-      height={735}
+      width={600}
+      height={600}
       resizable>
       <NtosWindow.Content scrollable>
         {!!error && (
@@ -41,19 +42,31 @@ export const NtosNetDownloader = (props, context) => {
         )}
         <Section>
           <LabeledList>
-            <LabeledList.Item label="Disk usage">
-              <ProgressBar
-                value={disk_used}
-                minValue={0}
-                maxValue={disk_size}>
-                {`${disk_used} GQ / ${disk_size} GQ`}
-              </ProgressBar>
-            </LabeledList.Item>
+            {downloading && (
+              <LabeledList.Item label="Downloading">
+                <ProgressBar
+                  color="green"
+                  minValue={0}
+                  maxValue={downloadsize}
+                  value={downloadcompletion}>
+                  {`File: ${downloadname}, ${downloadcompletion * 10}% complete`}
+                </ProgressBar>
+              </LabeledList.Item>
+            ) || (
+              <LabeledList.Item label="Disk usage">
+                <ProgressBar
+                  value={disk_used}
+                  minValue={0}
+                  maxValue={disk_size}>
+                  {`${disk_used} GQ / ${disk_size} GQ`}
+                </ProgressBar>
+              </LabeledList.Item>
+            )}
           </LabeledList>
         </Section>
         <Flex>
-          <Flex.Item minWidth="110px" shrink={0} basis={0}>
-          <Tabs vertical>
+          <Flex.Item minWidth="105px" shrink={0} basis={0}>
+            <Tabs vertical>
               {categories.map(category => (
                 <Tabs.Tab
                   key={category.name}
@@ -65,28 +78,13 @@ export const NtosNetDownloader = (props, context) => {
             </Tabs>
           </Flex.Item>
           <Flex.Item grow={1} basis={0}>
-            <Section>
-              {items.map(program => (
-                  <Program
-                    key={program.filename}
-                    program={program} />
-                ))}
-            </Section>
+            {items.map(program => (
+                <Program
+                  key={program.filename}
+                  program={program} />
+              ))}
           </Flex.Item>
         </Flex>
-        {!!hackedavailable && (
-          <Section title="UNKNOWN Software Repository">
-            <NoticeBox mb={1}>
-              Please note that Nanotrasen does not recommend download
-              of software from non-official servers.
-            </NoticeBox>
-            {items.map(program => (
-              <Program
-                key={program.filename}
-                program={program} />
-            ))}
-          </Section>
-        )}
       </NtosWindow.Content>
     </NtosWindow>
   );
@@ -105,25 +103,25 @@ const Program = (props, context) => {
   } = data;
   const disk_free = disk_size - disk_used;
   return (
-    <Box mb={3}>
+    <Section>
       <Flex align="baseline">
-        <Flex.Item bold grow={1}>
-          {program.filedesc}
+        <Flex.Item grow={1}>
+          <Icon name={program.icon} /> <Box inline bold>{program.filedesc}</Box>
         </Flex.Item>
         <Flex.Item shrink={0} width="48px" textAlign="right" color="label" nowrap>
           {program.size} GQ
         </Flex.Item>
-        <Flex.Item ml={2} shrink={0} width="128px" textAlign="center">
+        <Flex.Item shrink={0} width="132px" textAlign="right">
           {(downloading && program.filename === downloadname) && (
-            <ProgressBar
-              color="green"
-              minValue={0}
-              maxValue={downloadsize}
-              value={downloadcompletion} />
+            <Button
+              bold
+              color="good"
+              icon="spinner"
+              iconSpin={1}
+              content="Downloading" />
           ) || (
             (!program.installed && program.compatibility && program.access && program.size < disk_free) && (
               <Button
-                fluid
                 bold
                 icon="download"
                 content="Download"
@@ -133,18 +131,22 @@ const Program = (props, context) => {
                 })} />
             ) || (
               <Button
-                fluid
                 bold
                 icon={program.installed ? 'check' : 'times'}
-                color={program.installed ? 'green' : 'red'}
-                content={program.installed ? 'Installed' : !program.compatibility ? 'Incompatible' : !program.access ? 'No Access' : 'Need Space'} />
+                color={program.installed ? 'good' : !program.compatibility ? 'grey' : 'bad'}
+                content={program.installed ? 'Installed' : !program.compatibility ? 'Incompatible' : !program.access ? 'No Access' : 'No Space'} />
             )
           )}
         </Flex.Item>
       </Flex>
-      <Box mt={1} italic color="label" fontSize="12px">
+      <Box mt={1} italic color="label">
         {program.fileinfo}
       </Box>
-    </Box>
+      {!program.verifiedsource && (
+        <NoticeBox mt={3} mb={0} danger fontSize="12px">
+          Unverified source. Please note that Nanotrasen does not recommend download of software from non-official servers.
+        </NoticeBox>
+      )}
+    </Section>
   );
 };

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -155,7 +155,7 @@ const Program = (props, context) => {
       <Box mt={1} italic color="label">
         {program.fileinfo}
       </Box>
-      {(!program.verifiedsource && PC_device_theme == "ntos") && (
+      {(!program.verifiedsource && PC_device_theme === "ntos") && (
         <NoticeBox mt={1} mb={0} danger fontSize="12px">
           Unverified source. Please note that Nanotrasen does not recommend
           download and usage of software from non-official servers.

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -97,45 +97,53 @@ const Program = (props, context) => {
         <Flex.Item color="label" nowrap>
           {program.size} GQ
         </Flex.Item>
-        <Flex.Item ml={2} width="94px" textAlign="center">
-          {program.filename === downloadname && (
+        <Flex.Item ml={2} width="120px" textAlign="center">
+          {program.installed && (
+            <Button
+              fluid
+              icon="check"
+              color="green"
+              content="Installed" />
+          )}
+          {!program.installed && program.compatibility !== 'Compatible' && (
+            <Button
+              fluid
+              icon="times"
+              color="red"
+              content="Incompatible" />
+          )}
+          {(!program.installed && program.compatibility == 'Compatible' && !program.access) && (
+            <Button
+              fluid
+              icon="times"
+              color="red"
+              content="No Access" />
+          )}
+          {(!program.installed && program.compatibility == 'Compatible' && program.access && program.size > disk_free) && (
+            <Button
+              fluid
+              icon="times"
+              color="red"
+              content="No space" />
+          )}
+          {(downloading && program.filename === downloadname) && (
             <ProgressBar
               color="green"
               minValue={0}
               maxValue={downloadsize}
               value={downloadcompletion} />
-          ) || (
+          )}
+          {(!program.installed && program.compatibility == 'Compatible' && program.access && !downloading && program.size < disk_free) && (
             <Button
               fluid
               icon="download"
               content="Download"
-              disabled={
-                downloading || program.size > disk_free || !program.access
-              }
               onClick={() => act('PRG_downloadfile', {
                 filename: program.filename,
               })} />
           )}
         </Flex.Item>
       </Flex>
-      {program.compatibility !== 'Compatible' && (
-        <Box mt={1} italic fontSize="12px" position="relative">
-          <Icon mx={1} color="red" name="times" />
-          Incompatible!
-        </Box>
-      )}
-      {!(program.access) && (
-        <Box mt={1} italic fontSize="12px" position="relative">
-          <Icon mx={1} color="red" name="times" />
-          Invalid credentials loaded!
-        </Box>
-      )}
-      {program.size > disk_free && (
-        <Box mt={1} italic fontSize="12px" position="relative">
-          <Icon mx={1} color="red" name="times" />
-          Not enough disk space!
-        </Box>
-      )}
       <Box mt={1} italic color="label" fontSize="12px">
         {program.fileinfo}
       </Box>

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -1,6 +1,6 @@
 import { scale, toFixed } from 'common/math';
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, Flex, Icon, LabeledList, NoticeBox, ProgressBar, Section, Tabs } from '../components';
+import { Box, Button, Stack, Icon, LabeledList, NoticeBox, ProgressBar, Section, Tabs } from '../components';
 import { NtosWindow } from '../layouts';
 
 export const NtosNetDownloader = (props, context) => {
@@ -68,27 +68,29 @@ export const NtosNetDownloader = (props, context) => {
             )}
           </LabeledList>
         </Section>
-        <Flex>
-          <Flex.Item minWidth="105px" shrink={0} basis={0}>
-            <Tabs vertical>
-              {categories.map(category => (
-                <Tabs.Tab
-                  key={category.name}
-                  selected={category.name === selectedCategory}
-                  onClick={() => setSelectedCategory(category.name)}>
-                  {category.name}
-                </Tabs.Tab>
-              ))}
-            </Tabs>
-          </Flex.Item>
-          <Flex.Item grow={1} basis={0}>
+        <Stack>
+          <Stack.Item minWidth="105px" shrink={0} basis={0}>
+            <Section fill fitted>
+              <Tabs vertical>
+                {categories.map(category => (
+                  <Tabs.Tab
+                    key={category.name}
+                    selected={category.name === selectedCategory}
+                    onClick={() => setSelectedCategory(category.name)}>
+                    {category.name}
+                  </Tabs.Tab>
+                ))}
+              </Tabs>
+            </Section>
+          </Stack.Item>
+          <Stack.Item grow={1} basis={0}>
             {items.map(program => (
               <Program
                 key={program.filename}
                 program={program} />
             ))}
-          </Flex.Item>
-        </Flex>
+          </Stack.Item>
+        </Stack>
       </NtosWindow.Content>
     </NtosWindow>
   );
@@ -107,14 +109,14 @@ const Program = (props, context) => {
   const disk_free = disk_size - disk_used;
   return (
     <Section>
-      <Flex align="baseline">
-        <Flex.Item grow={1}>
-          <Icon name={program.icon} /> <Box inline bold>{program.filedesc}</Box>
-        </Flex.Item>
-        <Flex.Item shrink={0} width="48px" textAlign="right" color="label" nowrap>
+      <Stack align="baseline">
+        <Stack.Item grow={1} blod>
+          <Icon name={program.icon} /> {program.filedesc}
+        </Stack.Item>
+        <Stack.Item shrink={0} width="48px" textAlign="right" color="label" nowrap>
           {program.size} GQ
-        </Flex.Item>
-        <Flex.Item shrink={0} width="134px" textAlign="right">
+        </Stack.Item>
+        <Stack.Item shrink={0} width="134px" textAlign="right">
           {(downloading && program.filename === downloadname) && (
             <Button
               bold
@@ -150,8 +152,8 @@ const Program = (props, context) => {
                 } />
             )
           )}
-        </Flex.Item>
-      </Flex>
+        </Stack.Item>
+      </Stack>
       <Box mt={1} italic color="label">
         {program.fileinfo}
       </Box>

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -49,7 +49,7 @@ export const NtosNetDownloader = (props, context) => {
                   minValue={0}
                   maxValue={downloadsize}
                   value={downloadcompletion}>
-                  {`File: ${downloadname}, ${downloadcompletion * 10}% complete`}
+                  {`File: ${downloadname}, ${toFixed(scale(downloadcompletion, 0, downloadsize) * 100)}% complete`}
                 </ProgressBar>
               </LabeledList.Item>
             ) || (
@@ -111,7 +111,7 @@ const Program = (props, context) => {
         <Flex.Item shrink={0} width="48px" textAlign="right" color="label" nowrap>
           {program.size} GQ
         </Flex.Item>
-        <Flex.Item shrink={0} width="132px" textAlign="right">
+        <Flex.Item shrink={0} width="134px" textAlign="right">
           {(downloading && program.filename === downloadname) && (
             <Button
               bold
@@ -133,7 +133,7 @@ const Program = (props, context) => {
               <Button
                 bold
                 icon={program.installed ? 'check' : 'times'}
-                color={program.installed ? 'good' : !program.compatibility ? 'grey' : 'bad'}
+                color={program.installed ? 'good' : !program.compatibility ? 'bad' : 'grey'}
                 content={program.installed ? 'Installed' : !program.compatibility ? 'Incompatible' : !program.access ? 'No Access' : 'No Space'} />
             )
           )}
@@ -143,8 +143,8 @@ const Program = (props, context) => {
         {program.fileinfo}
       </Box>
       {!program.verifiedsource && (
-        <NoticeBox mt={3} mb={0} danger fontSize="12px">
-          Unverified source. Please note that Nanotrasen does not recommend download of software from non-official servers.
+        <NoticeBox mt={1} mb={0} danger fontSize="12px">
+          Unverified source. Please note that Nanotrasen does not recommend download and usage of software from non-official servers.
         </NoticeBox>
       )}
     </Section>

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -28,7 +28,7 @@ export const NtosNetDownloader = (props, context) => {
     .find(category => category.name === selectedCategory)
     ?.items
     || [];
-  const disk_used_real = !!downloading
+  const disk_used_real = downloading
     ? disk_size - toFixed(disk_used + downloadcompletion)
     : disk_size - disk_used;
   return (
@@ -57,16 +57,18 @@ export const NtosNetDownloader = (props, context) => {
                   icon="spinner"
                   iconSpin={1}
                   tooltipPosition="left"
-                  tooltip={!!downloading && (`Download: ${downloadname}.prg (${downloadpercentage}%)`)}/>
+                  tooltip={!!downloading && (
+                    `Download: ${downloadname}.prg (${downloadpercentage}%)`
+                  )} />
               )}>
-                <ProgressBar
-                  value={!!downloading ? disk_used + downloadcompletion : disk_used}
-                  minValue={0}
-                  maxValue={disk_size}>
-                    <Box textAlign="left">
-                      {`${disk_used_real} GQ free of ${disk_size} GQ`}
-                    </Box>
-                </ProgressBar>
+              <ProgressBar
+                value={downloading ? disk_used + downloadcompletion : disk_used}
+                minValue={0}
+                maxValue={disk_size}>
+                <Box textAlign="left">
+                  {`${disk_used_real} GQ free of ${disk_size} GQ`}
+                </Box>
+              </ProgressBar>
             </LabeledList.Item>
           </LabeledList>
         </Section>
@@ -112,7 +114,7 @@ const Program = (props, context) => {
     <Section>
       <Stack align="baseline">
         <Stack.Item grow={1} blod>
-          <Icon name={program.icon} mr={1}/>
+          <Icon name={program.icon} mr={1} />
           {program.filedesc}
         </Stack.Item>
         <Stack.Item shrink={0} width="48px" textAlign="right" color="label" nowrap>
@@ -125,7 +127,7 @@ const Program = (props, context) => {
               color="good"
               minValue={0}
               maxValue={program.size}
-              value={downloadcompletion}/>
+              value={downloadcompletion} />
           ) || (
             (!program.installed
               && program.compatibility

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -44,14 +44,6 @@ export const NtosNetDownloader = (props, context) => {
         </Section>
         <Section>
           {downloadable_programs
-            .filter(program => program.access)
-            .map(program => (
-              <Program
-                key={program.filename}
-                program={program} />
-            ))}
-          {downloadable_programs
-            .filter(program => !program.access)
             .map(program => (
               <Program
                 key={program.filename}
@@ -94,53 +86,33 @@ const Program = (props, context) => {
         <Flex.Item bold grow={1}>
           {program.filedesc}
         </Flex.Item>
-        <Flex.Item color="label" nowrap>
+        <Flex.Item shrink={0} width="48px" textAlign="right" color="label" nowrap>
           {program.size} GQ
         </Flex.Item>
-        <Flex.Item ml={2} width="120px" textAlign="center">
-          {program.installed && (
-            <Button
-              fluid
-              icon="check"
-              color="green"
-              content="Installed" />
-          )}
-          {!program.installed && program.compatibility !== 'Compatible' && (
-            <Button
-              fluid
-              icon="times"
-              color="red"
-              content="Incompatible" />
-          )}
-          {(!program.installed && program.compatibility == 'Compatible' && !program.access) && (
-            <Button
-              fluid
-              icon="times"
-              color="red"
-              content="No Access" />
-          )}
-          {(!program.installed && program.compatibility == 'Compatible' && program.access && program.size > disk_free) && (
-            <Button
-              fluid
-              icon="times"
-              color="red"
-              content="No space" />
-          )}
+        <Flex.Item ml={2} shrink={0} width="128px" textAlign="center">
           {(downloading && program.filename === downloadname) && (
             <ProgressBar
               color="green"
               minValue={0}
               maxValue={downloadsize}
               value={downloadcompletion} />
-          )}
-          {(!program.installed && program.compatibility == 'Compatible' && program.access && !downloading && program.size < disk_free) && (
-            <Button
-              fluid
-              icon="download"
-              content="Download"
-              onClick={() => act('PRG_downloadfile', {
-                filename: program.filename,
-              })} />
+          ) || (
+            (!program.installed && program.compatibility == 'Compatible' && program.access && program.size < disk_free) && (
+              <Button
+                fluid
+                icon="download"
+                content="Download"
+                disabled={downloading}
+                onClick={() => act('PRG_downloadfile', {
+                  filename: program.filename,
+                })} />
+            ) || (
+              <Button
+                fluid
+                icon={program.installed ? 'check' : 'times'}
+                color={program.installed ? 'green' : 'red'}
+                content={program.installed ? 'Installed' : program.compatibility !== 'Compatible' ? 'Incompatible' : !program.access ? 'No Access' : 'Need Space'} />
+            )
           )}
         </Flex.Item>
       </Flex>

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -97,7 +97,7 @@ const Program = (props, context) => {
               maxValue={downloadsize}
               value={downloadcompletion} />
           ) || (
-            (!program.installed && program.compatibility == 'Compatible' && program.access && program.size < disk_free) && (
+            (!program.installed && program.compatible && program.access && program.size < disk_free) && (
               <Button
                 fluid
                 icon="download"
@@ -111,7 +111,7 @@ const Program = (props, context) => {
                 fluid
                 icon={program.installed ? 'check' : 'times'}
                 color={program.installed ? 'green' : 'red'}
-                content={program.installed ? 'Installed' : program.compatibility !== 'Compatible' ? 'Incompatible' : !program.access ? 'No Access' : 'Need Space'} />
+                content={program.installed ? 'Installed' : !program.compatible ? 'Incompatible' : !program.access ? 'No Access' : 'Need Space'} />
             )
           )}
         </Flex.Item>

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -28,7 +28,7 @@ export const NtosNetDownloader = (props, context) => {
     .find(category => category.name === selectedCategory)
     ?.items
     || [];
-  const disk_used_real = downloading
+  const disk_free_space = downloading
     ? disk_size - toFixed(disk_used + downloadcompletion)
     : disk_size - disk_used;
   return (
@@ -51,7 +51,7 @@ export const NtosNetDownloader = (props, context) => {
         <Section>
           <LabeledList>
             <LabeledList.Item
-              label="Disk usage"
+              label="Hard drive"
               buttons={(!!downloading) && (
                 <Button
                   icon="spinner"
@@ -60,13 +60,19 @@ export const NtosNetDownloader = (props, context) => {
                   tooltip={!!downloading && (
                     `Download: ${downloadname}.prg (${downloadpercentage}%)`
                   )} />
-              )}>
+              ) || (!!downloadname && (
+                <Button
+                  color="good"
+                  icon="download"
+                  tooltipPosition="left"
+                  tooltip={`${downloadname}.prg downloaded`}/>
+              ))}>
               <ProgressBar
                 value={downloading ? disk_used + downloadcompletion : disk_used}
                 minValue={0}
                 maxValue={disk_size}>
                 <Box textAlign="left">
-                  {`${disk_used_real} GQ free of ${disk_size} GQ`}
+                  {`${disk_free_space} GQ free of ${disk_size} GQ`}
                 </Box>
               </ProgressBar>
             </LabeledList.Item>

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -30,11 +30,13 @@ export const NtosNetDownloader = (props, context) => {
   ] = useLocalState(context, 'category', all_categories[0]);
   const items = flow([
     // This filters the list to only contain programs with category
-    selectedCategory !== all_categories[0] && filter(program => program.category === selectedCategory),
+    selectedCategory !== all_categories[0]
+    && filter(program => program.category === selectedCategory),
     // This filters the list to only contain verified programs
-    (!emagged && PC_device_theme === "ntos") && filter(program => program.verifiedsource === 1),
+    (!emagged && PC_device_theme === "ntos")
+    && filter(program => program.verifiedsource === 1),
     // This sorts all programs in the lists by name and compatibility
-    sortBy(program => [-program.compatibility, program.filedesc]),
+    sortBy(program => [-program.compatible, program.filedesc]),
   ])(programs);
   const disk_free_space = downloading
     ? disk_size - toFixed(disk_used + downloadcompletion)
@@ -100,7 +102,7 @@ export const NtosNetDownloader = (props, context) => {
             </Tabs>
           </Stack.Item>
           <Stack.Item grow={1} basis={0}>
-            {items.map(program => (
+            {items?.map(program => (
               <Program
                 key={program.filename}
                 program={program} />
@@ -145,7 +147,7 @@ const Program = (props, context) => {
               value={downloadcompletion} />
           ) || (
             (!program.installed
-              && program.compatibility
+              && program.compatible
               && program.access
               && program.size < disk_free) && (
               <Button
@@ -164,11 +166,11 @@ const Program = (props, context) => {
                 icon={program.installed ? 'check' : 'times'}
                 color={
                   program.installed ? 'good'
-                    : !program.compatibility ? 'bad' : 'grey'
+                    : !program.compatible ? 'bad' : 'grey'
                 }
                 content={
                   program.installed ? 'Installed'
-                    : !program.compatibility ? 'Incompatible'
+                    : !program.compatible ? 'Incompatible'
                       : !program.access ? 'No Access' : 'No Space'
                 } />
             )

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -98,6 +98,7 @@ const Program = (props, context) => {
   const { program } = props;
   const { act, data } = useBackend(context);
   const {
+    PC_device_theme,
     disk_size,
     disk_used,
     downloading,
@@ -154,7 +155,7 @@ const Program = (props, context) => {
       <Box mt={1} italic color="label">
         {program.fileinfo}
       </Box>
-      {!program.verifiedsource && (
+      {(!program.verifiedsource && PC_device_theme == "ntos") && (
         <NoticeBox mt={1} mb={0} danger fontSize="12px">
           Unverified source. Please note that Nanotrasen does not recommend
           download and usage of software from non-official servers.

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -65,7 +65,7 @@ export const NtosNetDownloader = (props, context) => {
                   color="good"
                   icon="download"
                   tooltipPosition="left"
-                  tooltip={`${downloadname}.prg downloaded`}/>
+                  tooltip={`${downloadname}.prg downloaded`} />
               ))}>
               <ProgressBar
                 value={downloading ? disk_used + downloadcompletion : disk_used}

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -1,5 +1,5 @@
-import { useBackend } from '../backend';
-import { Box, Button, Flex, Icon, LabeledList, NoticeBox, ProgressBar, Section } from '../components';
+import { useBackend, useLocalState } from '../backend';
+import { Box, Button, Flex, Icon, LabeledList, NoticeBox, ProgressBar, Section, Tabs } from '../components';
 import { NtosWindow } from '../layouts';
 
 export const NtosNetDownloader = (props, context) => {
@@ -12,11 +12,20 @@ export const NtosNetDownloader = (props, context) => {
     error,
     hacked_programs = [],
     hackedavailable,
+    categories = [],
   } = data;
+  const [
+    selectedCategory,
+    setSelectedCategory,
+  ] = useLocalState(context, 'category', categories[0]?.name);
+  const items = categories
+    .find(category => category.name === selectedCategory)
+    ?.items
+    || [];
   return (
     <NtosWindow
       theme={PC_device_theme}
-      width={480}
+      width={512}
       height={735}
       resizable>
       <NtosWindow.Content scrollable>
@@ -42,21 +51,36 @@ export const NtosNetDownloader = (props, context) => {
             </LabeledList.Item>
           </LabeledList>
         </Section>
-        <Section>
-          {downloadable_programs
-            .map(program => (
-              <Program
-                key={program.filename}
-                program={program} />
-            ))}
-        </Section>
+        <Flex>
+          <Flex.Item minWidth="110px" shrink={0} basis={0}>
+          <Tabs vertical>
+              {categories.map(category => (
+                <Tabs.Tab
+                  key={category.name}
+                  selected={category.name === selectedCategory}
+                  onClick={() => setSelectedCategory(category.name)}>
+                  {category.name}
+                </Tabs.Tab>
+              ))}
+            </Tabs>
+          </Flex.Item>
+          <Flex.Item grow={1} basis={0}>
+            <Section>
+              {items.map(program => (
+                  <Program
+                    key={program.filename}
+                    program={program} />
+                ))}
+            </Section>
+          </Flex.Item>
+        </Flex>
         {!!hackedavailable && (
           <Section title="UNKNOWN Software Repository">
             <NoticeBox mb={1}>
               Please note that Nanotrasen does not recommend download
               of software from non-official servers.
             </NoticeBox>
-            {hacked_programs.map(program => (
+            {items.map(program => (
               <Program
                 key={program.filename}
                 program={program} />
@@ -97,9 +121,10 @@ const Program = (props, context) => {
               maxValue={downloadsize}
               value={downloadcompletion} />
           ) || (
-            (!program.installed && program.compatible && program.access && program.size < disk_free) && (
+            (!program.installed && program.compatibility && program.access && program.size < disk_free) && (
               <Button
                 fluid
+                bold
                 icon="download"
                 content="Download"
                 disabled={downloading}
@@ -109,9 +134,10 @@ const Program = (props, context) => {
             ) || (
               <Button
                 fluid
+                bold
                 icon={program.installed ? 'check' : 'times'}
                 color={program.installed ? 'green' : 'red'}
-                content={program.installed ? 'Installed' : !program.compatible ? 'Incompatible' : !program.access ? 'No Access' : 'Need Space'} />
+                content={program.installed ? 'Installed' : !program.compatibility ? 'Incompatible' : !program.access ? 'No Access' : 'Need Space'} />
             )
           )}
         </Flex.Item>

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -1,3 +1,4 @@
+import { scale, toFixed } from 'common/math';
 import { useBackend, useLocalState } from '../backend';
 import { Box, Button, Flex, Icon, LabeledList, NoticeBox, ProgressBar, Section, Tabs } from '../components';
 import { NtosWindow } from '../layouts';
@@ -15,6 +16,9 @@ export const NtosNetDownloader = (props, context) => {
     error,
     categories = [],
   } = data;
+  const downloadpercentage = toFixed(
+    scale(downloadcompletion, 0, downloadsize) * 100
+  );
   const [
     selectedCategory,
     setSelectedCategory,
@@ -49,7 +53,7 @@ export const NtosNetDownloader = (props, context) => {
                   minValue={0}
                   maxValue={downloadsize}
                   value={downloadcompletion}>
-                  {`File: ${downloadname}, ${toFixed(scale(downloadcompletion, 0, downloadsize) * 100)}% complete`}
+                  {`File: ${downloadname}, ${downloadpercentage}% complete`}
                 </ProgressBar>
               </LabeledList.Item>
             ) || (
@@ -79,10 +83,10 @@ export const NtosNetDownloader = (props, context) => {
           </Flex.Item>
           <Flex.Item grow={1} basis={0}>
             {items.map(program => (
-                <Program
-                  key={program.filename}
-                  program={program} />
-              ))}
+              <Program
+                key={program.filename}
+                program={program} />
+            ))}
           </Flex.Item>
         </Flex>
       </NtosWindow.Content>
@@ -96,10 +100,8 @@ const Program = (props, context) => {
   const {
     disk_size,
     disk_used,
-    downloadcompletion,
     downloading,
     downloadname,
-    downloadsize,
   } = data;
   const disk_free = disk_size - disk_used;
   return (
@@ -120,7 +122,10 @@ const Program = (props, context) => {
               iconSpin={1}
               content="Downloading" />
           ) || (
-            (!program.installed && program.compatibility && program.access && program.size < disk_free) && (
+            (!program.installed
+              && program.compatibility
+              && program.access
+              && program.size < disk_free) && (
               <Button
                 bold
                 icon="download"
@@ -133,8 +138,15 @@ const Program = (props, context) => {
               <Button
                 bold
                 icon={program.installed ? 'check' : 'times'}
-                color={program.installed ? 'good' : !program.compatibility ? 'bad' : 'grey'}
-                content={program.installed ? 'Installed' : !program.compatibility ? 'Incompatible' : !program.access ? 'No Access' : 'No Space'} />
+                color={
+                  program.installed ? 'good'
+                    : !program.compatibility ? 'bad' : 'grey'
+                }
+                content={
+                  program.installed ? 'Installed'
+                    : !program.compatibility ? 'Incompatible'
+                      : !program.access ? 'No Access' : 'No Space'
+                } />
             )
           )}
         </Flex.Item>
@@ -144,7 +156,8 @@ const Program = (props, context) => {
       </Box>
       {!program.verifiedsource && (
         <NoticeBox mt={1} mb={0} danger fontSize="12px">
-          Unverified source. Please note that Nanotrasen does not recommend download and usage of software from non-official servers.
+          Unverified source. Please note that Nanotrasen does not recommend
+          download and usage of software from non-official servers.
         </NoticeBox>
       )}
     </Section>

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -36,7 +36,9 @@ export const NtosNetDownloader = (props, context) => {
     (!emagged && PC_device_theme === "ntos")
     && filter(program => program.verifiedsource === 1),
     // This sorts all programs in the lists by name and compatibility
-    sortBy(program => [-program.compatible, program.filedesc]),
+    sortBy(
+      program => -program.compatible,
+      program => program.filedesc),
   ])(programs);
   const disk_free_space = downloading
     ? disk_size - toFixed(disk_used + downloadcompletion)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Revamp of the software downloader program for modular computers.

Changes:
- Programs are now sorted alphabetically with incompatible ones in the end of the list.
- Installed programs are now displayed in the list.
- Added program icons.
- Moved the error messages in place of the download button.
- Only the most important error message is displayed now. Priority: compatibility, access, free space. 
- Syndicate programs are now displayed in the same list, but have a warning message from NT (There are no warning messages on syndicate OS).
- Added program categories to improve navigation. The default option "All" contains items from all categories.
- Download progress bar moved in place of the Disk usage bar. Disk usage is updated only after the download is complete, so the information was inaccurate during download. And the download bar now always visible regardless of selected category.
- The old download progress bar (next to the corresponding program) is replaced with "Downloading" indicator with a spinner.

### New UI

https://user-images.githubusercontent.com/3625094/107362787-46f0a680-6aea-11eb-9077-7ca6ad9d34a0.mp4


## Why It's Good For The Game

- The old version was hard to navigate because programs were sorted by filename.
- Error messages used vertical space and were sometimes unnecessary (I don't care about disk space or access if the program is incompatible with my device anyway)
- The old version didn't show installed programs, so you had to exit the program to see what you have installed.
- The old version grouped programs by availability. So if you found a program in a list that required access, and you inserted your ID, the list sorting was updating and you had to look for that program once again.
- Categories improve navigation when you need only software from particular category to do your job.

## Changelog
:cl:
refactor: Software Downloader program UI revamp
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
