### PR TITLE
Adds a shift to z level stacking

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -280,8 +280,10 @@
 
 // /turf signals
 
-///from base of turf/ChangeTurf(): (path, list/new_baseturfs, flags, list/transferring_comps)
+///from base of turf/ChangeTurf(): (turf/source, path, list/new_baseturfs, flags, list/transferring_comps)
 #define COMSIG_TURF_CHANGE "turf_change"
+///from base of turf/ChangeTurf(): (turf/new_turf)
+#define COMSIG_TURF_CHANGED "turf_changed"
 ///from base of atom/has_gravity(): (atom/asker, list/forced_gravities)
 #define COMSIG_TURF_HAS_GRAVITY "turf_has_gravity"
 ///from base of turf/multiz_turf_del(): (turf/source, direction)

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -312,8 +312,8 @@
 	src.typep = typep
 
 /**
-  * Send the signal with given arguments.
-  */
+ * Send the signal with given arguments.
+ */
 /datum/signal_sender/proc/send(list/arguments)
 	if(!target)
 		return NONE
@@ -332,11 +332,11 @@
 		. |= CallAsync(C, proctype, arguments)
 
 /**
-  * Unregisters all the signal handlers that match,
-  * and returns a /datum/signal_sender which can be used to send the signal once again.
-  *
-  * Useful for sending signals after deleting.
-  */
+ * Unregisters all the signal handlers that match,
+ * and returns a /datum/signal_sender which can be used to send the signal once again.
+ *
+ * Useful for sending signals after deleting.
+ */
 /datum/proc/TakeSignalSender(sigtype)
 	if(!comp_lookup || !comp_lookup[sigtype])
 		return null

--- a/code/datums/elements/turf_transparency.dm
+++ b/code/datums/elements/turf_transparency.dm
@@ -1,75 +1,114 @@
-/datum/element/turf_z_transparency
-	var/show_bottom_level = FALSE
+#define MULTIZ_SHIFT 8
 
-///This proc sets up the signals to handle updating viscontents when turfs above/below update. Handle plane and layer here too so that they don't cover other obs/turfs in Dream Maker
+/turf
+	var/atom/movable/visual/below/below = null /// used by show_below_turf
+
+///Show the turf on the z-level below this one.
+/turf/proc/show_below_turf(show_bottom_level = TRUE)
+	below = new(null, src, show_bottom_level)
+	vis_contents += below
+
+///Hide the turf on the z-level below this one.
+/turf/proc/hide_below_turf()
+	vis_contents -= below
+	qdel(below)
+
+///Appearance of a below turf
+/atom/movable/visual/below
+	pixel_y = -MULTIZ_SHIFT
+	vis_flags = VIS_INHERIT_ID
+	plane = OPENSPACE_PLANE
+	layer = OPENSPACE_LAYER
+	var/show_bottom_level
+	var/turf/source
+
+/atom/movable/visual/below/Initialize(mapload, turf/our_turf, show_bottom_level)
+	. = ..()
+	RegisterSignal(our_turf, COMSIG_TURF_MULTIZ_DEL, .proc/update_icon)
+	RegisterSignal(our_turf, COMSIG_TURF_MULTIZ_NEW, .proc/update_icon)
+	src.show_bottom_level = show_bottom_level
+	source = our_turf
+	update_icon()
+
+/atom/movable/visual/below/Destroy()
+	. = ..()
+	UnregisterSignal(source, COMSIG_TURF_MULTIZ_DEL)
+	UnregisterSignal(source, COMSIG_TURF_MULTIZ_NEW)
+	source = null
+	vis_contents.len = 0
+
+/atom/movable/visual/below/update_icon()
+	. = ..()
+
+	var/turf/below = source.below()
+
+	vis_contents.len = 0
+
+	if(below)
+		vis_contents += below
+	else if(show_bottom_level)
+		var/turf/path = SSmapping.level_trait(source.z, ZTRAIT_BASETURF) || /turf/open/space
+		if(!ispath(path))
+			path = text2path(path)
+			if(!ispath(path))
+				warning("Z-level [source.z] has invalid baseturf '[SSmapping.level_trait(source.z, ZTRAIT_BASETURF)]'")
+				path = /turf/open/space
+		var/mutable_appearance/underlay_appearance = mutable_appearance(initial(path.icon), initial(path.icon_state), layer = TURF_LAYER-0.02, plane = PLANE_SPACE)
+		underlay_appearance.appearance_flags = RESET_ALPHA | RESET_COLOR
+		underlays += underlay_appearance
+
+	if(isclosedturf(source)) //Show girders below closed turfs
+		var/mutable_appearance/girder_underlay = mutable_appearance('icons/obj/structures.dmi', "girder", layer = TURF_LAYER-0.01)
+		girder_underlay.appearance_flags = RESET_ALPHA | RESET_COLOR
+		underlays += girder_underlay
+		var/mutable_appearance/plating_underlay = mutable_appearance('icons/turf/floors.dmi', "plating", layer = TURF_LAYER-0.02)
+		plating_underlay = RESET_ALPHA | RESET_COLOR
+		underlays += plating_underlay
+
+/datum/element/turf_z_transparency
+	var/show_bottom_level
+
 /datum/element/turf_z_transparency/Attach(datum/target, show_bottom_level = TRUE)
 	. = ..()
 	if(!isturf(target))
 		return ELEMENT_INCOMPATIBLE
 
 	var/turf/our_turf = target
+	if(!show_bottom_level && !our_turf.below())
+		our_turf.ChangeTurf(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+		return
 
 	src.show_bottom_level = show_bottom_level
 
-	our_turf.plane = OPENSPACE_PLANE
-	our_turf.layer = OPENSPACE_LAYER
-
-	RegisterSignal(target, COMSIG_TURF_MULTIZ_DEL, .proc/on_multiz_turf_del)
-	RegisterSignal(target, COMSIG_TURF_MULTIZ_NEW, .proc/on_multiz_turf_new)
-
+	our_turf.show_below_turf(show_bottom_level)
 	ADD_TRAIT(our_turf, TURF_Z_TRANSPARENT_TRAIT, TURF_TRAIT)
 
-
-	update_multiz(our_turf, TRUE, TRUE)
+	change_north(null, get_step(our_turf, NORTH))
 
 /datum/element/turf_z_transparency/Detach(datum/source, force)
 	. = ..()
+
 	var/turf/our_turf = source
-	our_turf.vis_contents.len = 0
 	REMOVE_TRAIT(our_turf, TURF_Z_TRANSPARENT_TRAIT, TURF_TRAIT)
+	our_turf.hide_below_turf()
 
-///Updates the viscontents or underlays below this tile.
-/datum/element/turf_z_transparency/proc/update_multiz(turf/our_turf, prune_on_fail = FALSE, init = FALSE)
-	var/turf/below_turf = our_turf.below()
-	if(!below_turf)
-		our_turf.vis_contents.len = 0
-		if(!show_bottom_level(our_turf) && prune_on_fail) //If we cant show whats below, and we prune on fail, change the turf to plating as a fallback
-			our_turf.ChangeTurf(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
-			return FALSE
-	if(init)
-		our_turf.vis_contents += below_turf
-	if(isclosedturf(our_turf)) //Show girders below closed turfs
-		var/mutable_appearance/girder_underlay = mutable_appearance('icons/obj/structures.dmi', "girder", layer = TURF_LAYER-0.01)
-		girder_underlay.appearance_flags = RESET_ALPHA | RESET_COLOR
-		our_turf.underlays += girder_underlay
-		var/mutable_appearance/plating_underlay = mutable_appearance('icons/turf/floors.dmi', "plating", layer = TURF_LAYER-0.02)
-		plating_underlay = RESET_ALPHA | RESET_COLOR
-		our_turf.underlays += plating_underlay
-	return TRUE
+	var/turf/north = get_step(our_turf, NORTH)
+	if(north && !istransparentturf(north))
+		north.hide_below_turf()
 
-/datum/element/turf_z_transparency/proc/on_multiz_turf_del(turf/our_turf, turf/T, dir)
+/datum/element/turf_z_transparency/proc/change_north_before(turf/source)
 	SIGNAL_HANDLER
-	if(dir != DOWN)
-		return
-	update_multiz(our_turf)
 
-/datum/element/turf_z_transparency/proc/on_multiz_turf_new(turf/our_turf, turf/T, dir)
+	if(source && !istransparentturf(source))
+		source.hide_below_turf()
+
+
+/datum/element/turf_z_transparency/proc/change_north(turf/north)
 	SIGNAL_HANDLER
-	if(dir != DOWN)
-		return
-	update_multiz(our_turf)
 
-///Called when there is no real turf below this turf
-/datum/element/turf_z_transparency/proc/show_bottom_level(turf/our_turf)
-	if(!show_bottom_level)
-		return FALSE
-	var/turf/path = SSmapping.level_trait(our_turf.z, ZTRAIT_BASETURF) || /turf/open/space
-	if(!ispath(path))
-		path = text2path(path)
-		if(!ispath(path))
-			warning("Z-level [our_turf.z] has invalid baseturf '[SSmapping.level_trait(our_turf.z, ZTRAIT_BASETURF)]'")
-			path = /turf/open/space
-	var/mutable_appearance/underlay_appearance = mutable_appearance(initial(path.icon), initial(path.icon_state), layer = TURF_LAYER-0.02, plane = PLANE_SPACE)
-	underlay_appearance.appearance_flags = RESET_ALPHA | RESET_COLOR
-	our_turf.underlays += underlay_appearance
-	return TRUE
+	if(!north)
+		return
+	if(!istransparentturf(north))
+		north.show_below_turf()
+	RegisterSignal(north, COMSIG_TURF_CHANGE, .proc/change_north_before)
+	RegisterSignal(north, COMSIG_TURF_CHANGED, .proc/change_north)

--- a/code/datums/elements/turf_transparency.dm
+++ b/code/datums/elements/turf_transparency.dm
@@ -83,7 +83,7 @@
 	our_turf.show_below_turf(show_bottom_level)
 	ADD_TRAIT(our_turf, TURF_Z_TRANSPARENT_TRAIT, TURF_TRAIT)
 
-	change_north(null, get_step(our_turf, NORTH))
+	change_north(get_step(our_turf, NORTH))
 
 /datum/element/turf_z_transparency/Detach(datum/source, force)
 	. = ..()

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -91,10 +91,13 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	var/old_type = type
 
 	var/list/transferring_comps = list()
-	SEND_SIGNAL(src, COMSIG_TURF_CHANGE, path, new_baseturfs, flags, transferring_comps)
+	SEND_SIGNAL(src, COMSIG_TURF_CHANGE, src, path, new_baseturfs, flags, transferring_comps)
 	for(var/i in transferring_comps)
 		var/datum/component/comp = i
 		comp.RemoveComponent()
+
+	//sending the signal after `qdel(src)` means we have to remove the signal beforehand
+	var/datum/signal_sender/changed = TakeSignalSender(COMSIG_TURF_CHANGED)
 
 	changing_turf = TRUE
 	qdel(src)	//Just get the side effects and call Destroy
@@ -134,6 +137,8 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 
 	QUEUE_SMOOTH_NEIGHBORS(src)
 	QUEUE_SMOOTH(src)
+
+	changed.send(list(W))
 
 	return W
 


### PR DESCRIPTION

## About The Pull Request

This adds a y axis shift to the z level shown using open space.

https://user-images.githubusercontent.com/20824501/107124182-08a47e80-6881-11eb-8343-90e1425c8678.mp4

## Why It's Good For The Game

This will be necessary when the new walls are done. I'm pushing this now so that the code can be reviewed, as there may be a better way to do what I want here.

Currently, the method makes use of an extra atom for each open space.
