### PR TITLE
Fix reconnect issue during roundrestart

### DIFF
--- a/tgui/packages/tgui-panel/ping/middleware.js
+++ b/tgui/packages/tgui-panel/ping/middleware.js
@@ -11,6 +11,7 @@ import { PING_INTERVAL, PING_QUEUE_SIZE, PING_TIMEOUT } from './constants';
 export const pingMiddleware = store => {
   let initialized = false;
   let index = 0;
+  let interval;
   const pings = [];
   const sendPing = () => {
     for (let i = 0; i < PING_QUEUE_SIZE; i++) {
@@ -32,8 +33,14 @@ export const pingMiddleware = store => {
     const { type, payload } = action;
     if (!initialized) {
       initialized = true;
-      setInterval(sendPing, PING_INTERVAL);
+      interval = setInterval(sendPing, PING_INTERVAL);
       sendPing();
+    }
+    if (type === 'roundrestart') {
+      // Stop pinging because dreamseeker is currently reconnecting.
+      // Topic calls in the middle of reconnect will crash the connection.
+      clearInterval(interval);
+      return next(action);
     }
     if (type === 'pingReply') {
       const { index } = payload;


### PR DESCRIPTION
## About The Pull Request

> Fixes #54131
> Fixes #53213
> Fixes #55301 (unless it's something different, then reopen)

I have confirmed that this was a BYOND issue.

TGchat makes topic calls to calculate ping, and if ping is issued in the middle of reconnect, it confuses Dreamseeker and it causes the connection to crash.

![image](https://user-images.githubusercontent.com/1516236/107128143-f26be200-68c3-11eb-8a2e-7be5d2282098.png)

The reason why reconnect worked **sometimes** is exactly because of the pings, because they were sent every second, and it was totally possible to reconnect in between those pings.

**This does not fix manually initiated reconnects**.

This also fixes `You are either AFK, experiencing lag or the connection has closed.` message during roundrestart.

## Changelog
:cl:
fix: IMPORTANT FIX: Game client will now properly reconnect on roundrestart!!!
/:cl:
