### PR TITLE
Fix certain station traits blocking reports and code blue on dynamic

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -269,7 +269,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		for(var/i in SSstation.station_traits)
 			var/datum/station_trait/station_trait_iterator = i
 			if(!station_trait_iterator.show_in_report)
-				return
+				continue
 			. += "[station_trait_iterator.get_report()]<BR>"
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The station traits that have `show_in_report = FALSE` (read: most of them) would completely block the report.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Station traits will no longer completely block the Central Command report or the automatic code blue on Dynamic.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
