### PR TITLE
Fix opening of tgchat links that contain nested markup

### DIFF
--- a/tgui/packages/tgui/links.js
+++ b/tgui/packages/tgui/links.js
@@ -10,12 +10,21 @@
 export const captureExternalLinks = () => {
   // Subscribe to all document clicks
   document.addEventListener('click', e => {
-    const tagName = String(e.target.tagName).toLowerCase();
-    const hrefAttr = e.target.getAttribute('href') || '';
-    // Must be a link
-    if (tagName !== 'a') {
+    /** @type {HTMLElement} */
+    let target = e.target;
+    // Recurse down the tree to find a valid link
+    while (target && target !== document.body) {
+      const tagName = String(target.tagName).toLowerCase();
+      if (tagName === 'a') {
+        break;
+      }
+      target = target.parentElement;
+    }
+    // Not a link, do nothing.
+    if (!target) {
       return;
     }
+    const hrefAttr = target.getAttribute('href') || '';
     // Leave BYOND links alone
     const isByondLink = hrefAttr.charAt(0) === '?'
       || hrefAttr.startsWith('byond://');


### PR DESCRIPTION
## About The Pull Request

> Fixes #54723

Links were mostly working fine except a few cases, when you had some nested markup in the link, e.g.:

```
<a href="https://example.com">Test<b>Foo</b></a>
```

When clicking on Test, link was opening externally (as it should), but when clicking on Foo, it was opening in the panel instead.

**This is now fixed**.

## Why It's Good For The Game

## Changelog
:cl:
fix: Fixed a few cases where links in tgchat opened directly in the panel instead of the browser.
/:cl:
