### PR TITLE
Enables 514 testing on master, Removes all reliance on extools outside of maptick

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -7,3 +7,6 @@ disallow_relative_proc_definitions = true
 
 [dmdoc]
 use_typepath_names = true
+
+[debugger]
+engine = "auxtools"

--- a/code/__DEFINES/_tick.dm
+++ b/code/__DEFINES/_tick.dm
@@ -1,7 +1,11 @@
 /// Percentage of tick to leave for master controller to run
 #define MAPTICK_MC_MIN_RESERVE 70
 /// internal_tick_usage is updated every tick by extools
+#ifdef USE_EXTOOLS
 #define MAPTICK_LAST_INTERNAL_TICK_USAGE ((GLOB.internal_tick_usage / world.tick_lag) * 100)
+#else
+#define MAPTICK_LAST_INTERNAL_TICK_USAGE (world.map_cpu)
+#endif
 /// Tick limit while running normally
 #define TICK_BYOND_RESERVE 2
 #define TICK_LIMIT_RUNNING (max(100 - TICK_BYOND_RESERVE - MAPTICK_LAST_INTERNAL_TICK_USAGE, MAPTICK_MC_MIN_RESERVE))

--- a/code/__DEFINES/qdel.dm
+++ b/code/__DEFINES/qdel.dm
@@ -15,8 +15,8 @@
 
 //! Defines for the [gc_destroyed][/datum/var/gc_destroyed] var.
 
-#ifdef LEGACY_REFERENCE_TRACKING
-/** If LEGACY_REFERENCE_TRACKING is enabled, qdel will call this object's find_references() verb.
+#ifdef REFERENCE_TRACKING
+/** If REFERENCE_TRACKING is enabled, qdel will call this object's find_references() verb.
  *
  * Functionally identical to [QDEL_HINT_QUEUE] if [GC_FAILURE_HARD_LOOKUP] is not enabled in _compiler_options.dm.
 */

--- a/code/__DEFINES/spaceman_dmm.dm
+++ b/code/__DEFINES/spaceman_dmm.dm
@@ -28,7 +28,20 @@
 	#define VAR_PROTECTED var
 #endif
 
+/proc/auxtools_stack_trace(msg)
+	CRASH(msg)
+
+/proc/enable_debugging(mode, port)
+	CRASH("auxtools not loaded")
+
 /world/proc/enable_debugger()
-	var/dll = world.GetConfig("env", "EXTOOLS_DLL")
+	var/dll = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
 	if (dll)
-		call(dll, "debug_initialize")()
+		call(dll, "auxtools_init")()
+		enable_debugging()
+
+/world/Del()
+	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
+	if (debug_server)
+		call(debug_server, "auxtools_shutdown")()
+	. = ..()

--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -75,7 +75,6 @@
 #define VV_HK_MARK "mark"
 #define VV_HK_ADDCOMPONENT "addcomponent"
 #define VV_HK_MODIFY_TRAITS "modtraits"
-#define VV_HK_VIEW_REFERENCES "viewreferences"
 
 // /atom
 #define VV_HK_MODIFY_TRANSFORM "atom_transform"

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -54,6 +54,10 @@
 #error You need version 513.1514 or higher
 #endif
 
+#if 514 > DM_VERSION
+#define USE_EXTOOLS
+#endif
+
 //Additional code for the above flags.
 #ifdef TESTING
 #warn compiling in TESTING mode. testing() debug messages will be visible.

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -11,24 +11,17 @@
 #ifdef TESTING
 #define DATUMVAR_DEBUGGING_MODE
 
-/*
-* Enables extools-powered reference tracking system, letting you see what is referencing objects that refuse to hard delete.
-*
-* * Requires TESTING to be defined to work.
-*/
+///Used to find the sources of harddels, quite laggy, don't be surpised if it freezes your client for a good while
 //#define REFERENCE_TRACKING
+#ifdef REFERENCE_TRACKING
 
-///Method of tracking references without using extools. Slower, kept to avoid over-reliance on extools.
-//#define LEGACY_REFERENCE_TRACKING
-#ifdef LEGACY_REFERENCE_TRACKING
-
-///Use the legacy reference on things hard deleting by default.
+///Run a lookup on things hard deleting by default.
 //#define GC_FAILURE_HARD_LOOKUP
 #ifdef GC_FAILURE_HARD_LOOKUP
 #define FIND_REF_NO_CHECK_TICK
 #endif //ifdef GC_FAILURE_HARD_LOOKUP
 
-#endif //ifdef LEGACY_REFERENCE_TRACKING
+#endif //ifdef REFERENCE_TRACKING
 
 #define VISUALIZE_ACTIVE_TURFS	//Highlights atmos active turfs in green
 #define TRACK_MAX_SHARE	//Allows max share tracking, for use in the atmos debugging ui
@@ -54,7 +47,8 @@
 #error You need version 513.1514 or higher
 #endif
 
-#if 514 > DM_VERSION
+//Don't load extools on 514
+#if DM_VERSION < 514
 #define USE_EXTOOLS
 #endif
 

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -47,7 +47,7 @@ SUBSYSTEM_DEF(garbage)
 
 	//Queue
 	var/list/queues
-	#ifdef LEGACY_REFERENCE_TRACKING
+	#ifdef REFERENCE_TRACKING
 	var/list/reference_find_on_fail = list()
 	#endif
 
@@ -161,7 +161,7 @@ SUBSYSTEM_DEF(garbage)
 			++gcedlasttick
 			++totalgcs
 			pass_counts[level]++
-			#ifdef LEGACY_REFERENCE_TRACKING
+			#ifdef REFERENCE_TRACKING
 			reference_find_on_fail -= refID	//It's deleted we don't care anymore.
 			#endif
 			if (MC_TICK_CHECK)
@@ -173,13 +173,11 @@ SUBSYSTEM_DEF(garbage)
 		switch (level)
 			if (GC_QUEUE_CHECK)
 				#ifdef REFERENCE_TRACKING
-				D.find_references()
-				#elif defined(LEGACY_REFERENCE_TRACKING)
 				if(reference_find_on_fail[refID])
-					D.find_references_legacy()
+					D.find_references()
 				#ifdef GC_FAILURE_HARD_LOOKUP
 				else
-					D.find_references_legacy()
+					D.find_references()
 				#endif
 				reference_find_on_fail -= refID
 				#endif
@@ -193,10 +191,6 @@ SUBSYSTEM_DEF(garbage)
 						continue
 					to_chat(admin, "## TESTING: GC: -- [ADMIN_VV(D)] | [type] was unable to be GC'd --")
 				testing("GC: -- \ref[src] | [type] was unable to be GC'd --")
-				#endif
-				#ifdef REFERENCE_TRACKING
-				GLOB.deletion_failures += D //It should no longer be bothered by the GC, manual deletion only.
-				continue
 				#endif
 				I.failures++
 			if (GC_QUEUE_HARDDELETE)
@@ -334,10 +328,10 @@ SUBSYSTEM_DEF(garbage)
 				SSgarbage.Queue(D, GC_QUEUE_HARDDELETE)
 			if (QDEL_HINT_HARDDEL_NOW)	//qdel should assume this object won't gc, and hard del it post haste.
 				SSgarbage.HardDelete(D)
-			#ifdef LEGACY_REFERENCE_TRACKING
-			if (QDEL_HINT_FINDREFERENCE) //qdel will, if LEGACY_REFERENCE_TRACKING is enabled, display all references to this object, then queue the object for deletion.
+			#ifdef REFERENCE_TRACKING
+			if (QDEL_HINT_FINDREFERENCE) //qdel will, if REFERENCE_TRACKING is enabled, display all references to this object, then queue the object for deletion.
 				SSgarbage.Queue(D)
-				D.find_references_legacy()
+				D.find_references()
 			if (QDEL_HINT_IFFAIL_FINDREFERENCE)
 				SSgarbage.Queue(D)
 				SSgarbage.reference_find_on_fail[REF(D)] = TRUE

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -31,7 +31,6 @@
 	VV_DROPDOWN_OPTION(VV_HK_EXPOSE, "Show VV To Player")
 	VV_DROPDOWN_OPTION(VV_HK_ADDCOMPONENT, "Add Component/Element")
 	VV_DROPDOWN_OPTION(VV_HK_MODIFY_TRAITS, "Modify Traits")
-	VV_DROPDOWN_OPTION(VV_HK_VIEW_REFERENCES, "View References")
 
 //This proc is only called if everything topic-wise is verified. The only verifications that should happen here is things like permission checks!
 //href_list is a reference, modifying it in these procs WILL change the rest of the proc in topic.dm of admin/view_variables!

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -29,9 +29,11 @@ GLOBAL_VAR(restart_counter)
  *			All atoms in both compiled and uncompiled maps are initialized()
  */
 /world/New()
+#ifdef USE_EXTOOLS
 	var/extools = world.GetConfig("env", "EXTOOLS_DLL") || (world.system_type == MS_WINDOWS ? "./byond-extools.dll" : "./libbyond-extools.so")
 	if (fexists(extools))
 		call(extools, "maptick_initialize")()
+#endif
 	enable_debugger()
 #ifdef REFERENCE_TRACKING
 	enable_reference_tracking()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -35,9 +35,6 @@ GLOBAL_VAR(restart_counter)
 		call(extools, "maptick_initialize")()
 #endif
 	enable_debugger()
-#ifdef REFERENCE_TRACKING
-	enable_reference_tracking()
-#endif
 
 	log_world("World loaded at [time_stamp()]!")
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -181,10 +181,6 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/run_dynamic_simulations,
 	#endif
 	/datum/admins/proc/create_or_modify_area,
-#ifdef REFERENCE_TRACKING
-	/datum/admins/proc/view_refs,
-	/datum/admins/proc/view_del_failures,
-#endif
 	/client/proc/check_timer_sources,
 	/client/proc/toggle_cdn
 	)

--- a/code/modules/admin/view_variables/reference_tracking.dm
+++ b/code/modules/admin/view_variables/reference_tracking.dm
@@ -1,119 +1,14 @@
 #ifdef REFERENCE_TRACKING
 
-GLOBAL_LIST_EMPTY(deletion_failures)
-
-/world/proc/enable_reference_tracking()
-	var/extools = world.GetConfig("env", "EXTOOLS_DLL") || (world.system_type == MS_WINDOWS ? "./byond-extools.dll" : "./libbyond-extools.so")
-	if (fexists(extools))
-		call(extools, "ref_tracking_initialize")()
-
-/proc/get_back_references(datum/D)
-	CRASH("/proc/get_back_references not hooked by extools, reference tracking will not function!")
-
-/proc/get_forward_references(datum/D)
-	CRASH("/proc/get_forward_references not hooked by extools, reference tracking will not function!")
-
-/proc/clear_references(datum/D)
-	return
-
-/datum/admins/proc/view_refs(atom/D in world) //it actually supports datums as well but byond no likey
-	set category = "Debug"
-	set name = "View References"
-
-	if(!check_rights(R_DEBUG) || !D)
-		return
-
-	var/list/backrefs = get_back_references(D)
-	if(isnull(backrefs))
-		var/datum/browser/popup = new(usr, "ref_view", "<div align='center'>Error</div>")
-		popup.set_content("Reference tracking not enabled")
-		popup.open(FALSE)
-		return
-
-	var/list/frontrefs = get_forward_references(D)
-	var/list/dat = list()
-	dat += "<h1>References of \ref[D] - [D]</h1><br><a href='?_src_=vars;[HrefToken()];[VV_HK_VIEW_REFERENCES]=TRUE;[VV_HK_TARGET]=[REF(D)]'>\[Refresh\]</a><hr>"
-	dat += "<h3>Back references - these things hold references to this object.</h3>"
-	dat += "<table>"
-	dat += "<tr><th>Ref</th><th>Type</th><th>Variable Name</th><th>Follow</th>"
-	for(var/ref in backrefs)
-		var/datum/backreference = ref
-		if(isnull(backreference))
-			dat += "<tr><td>GC'd Reference</td></tr>"
-		if(istype(backreference))
-			dat += "<tr><td><a href='?_src_=vars;[HrefToken()];Vars=[REF(backreference)]'>[REF(backreference)]</td><td>[backreference.type]</td><td>[backrefs[backreference]]</td><td><a href='?_src_=vars;[HrefToken()];[VV_HK_VIEW_REFERENCES]=TRUE;[VV_HK_TARGET]=[REF(backreference)]'>\[Follow\]</a></td></tr>"
-		else if(islist(backreference))
-			dat += "<tr><td><a href='?_src_=vars;[HrefToken()];Vars=[REF(backreference)]'>[REF(backreference)]</td><td>list</td><td>[backrefs[backreference]]</td><td><a href='?_src_=vars;[HrefToken()];[VV_HK_VIEW_REFERENCES]=TRUE;[VV_HK_TARGET]=[REF(backreference)]'>\[Follow\]</a></td></tr>"
-		else
-			dat += "<tr><td>Weird reference type. Add more debugging checks.</td></tr>"
-	dat += "</table><hr>"
-	dat += "<h3>Forward references - this object is referencing those things.</h3>"
-	dat += "<table>"
-	dat += "<tr><th>Variable name</th><th>Ref</th><th>Type</th><th>Follow</th>"
-	for(var/ref in frontrefs)
-		var/datum/backreference = frontrefs[ref]
-		dat += "<tr><td>[ref]</td><td><a href='?_src_=vars;[HrefToken()];Vars=[REF(backreference)]'>[REF(backreference)]</a></td><td>[backreference.type]</td><td><a href='?_src_=vars;[HrefToken()];[VV_HK_VIEW_REFERENCES]=TRUE;[VV_HK_TARGET]=[REF(backreference)]'>\[Follow\]</a></td></tr>"
-	dat += "</table><hr>"
-	dat = dat.Join()
-
-	var/datum/browser/popup = new(usr, "ref_view", "<div align='center'>References of \ref[D]</div>")
-	popup.set_content(dat)
-	popup.open(FALSE)
-
-
-/datum/admins/proc/view_del_failures()
-	set category = "Debug"
-	set name = "View Deletion Failures"
-
-	if(!check_rights(R_DEBUG))
-		return
-
-	var/list/dat = list("<table>")
-	for(var/t in GLOB.deletion_failures)
-		if(isnull(t))
-			dat += "<tr><td>GC'd Reference | <a href='byond://?src=[REF(src)];[HrefToken(TRUE)];delfail_clearnulls=TRUE'>Clear Nulls</a></td></tr>"
-			continue
-		var/datum/thing = t
-		dat += "<tr><td>\ref[thing] | [thing.type][thing.gc_destroyed ? " (destroyed)" : ""] [ADMIN_VV(thing)]</td></tr>"
-	dat += "</table><hr>"
-	dat = dat.Join()
-
-	var/datum/browser/popup = new(usr, "del_failures", "<div align='center'>Deletion Failures</div>")
-	popup.set_content(dat)
-	popup.open(FALSE)
-
-
-/datum/proc/find_references()
-	testing("Beginning search for references to a [type].")
-	var/list/backrefs = get_back_references(src)
-	for(var/ref in backrefs)
-		if(isnull(ref))
-			log_world("## TESTING: Datum reference found, but gone now.")
-			continue
-		if(islist(ref))
-			log_world("## TESTING: Found [type] \ref[src] in list.")
-			continue
-		var/datum/datum_ref = ref
-		if(!istype(datum_ref))
-			log_world("## TESTING: Found [type] \ref[src] in unknown type reference: [datum_ref].")
-			return
-		log_world("## TESTING: Found [type] \ref[src] in [datum_ref.type][datum_ref.gc_destroyed ? " (destroyed)" : ""]")
-		message_admins("Found [type] \ref[src] [ADMIN_VV(src)] in [datum_ref.type][datum_ref.gc_destroyed ? " (destroyed)" : ""] [ADMIN_VV(datum_ref)]")
-	testing("Completed search for references to a [type].")
-
-#endif
-
-#ifdef LEGACY_REFERENCE_TRACKING
-
-/datum/verb/legacy_find_refs()
+/datum/verb/find_refs()
 	set category = "Debug"
 	set name = "Find References"
 	set src in world
 
-	find_references_legacy(FALSE)
+	find_references(FALSE)
 
 
-/datum/proc/find_references_legacy(skip_alert)
+/datum/proc/find_references(skip_alert)
 	running_find_references = type
 	if(usr?.client)
 		if(usr.client.running_find_references)
@@ -165,7 +60,7 @@ GLOBAL_LIST_EMPTY(deletion_failures)
 
 	qdel(src, TRUE) //force a qdel
 	if(!running_find_references)
-		find_references_legacy(TRUE)
+		find_references(TRUE)
 
 
 /datum/verb/qdel_then_if_fail_find_references()

--- a/code/modules/admin/view_variables/topic_basic.dm
+++ b/code/modules/admin/view_variables/topic_basic.dm
@@ -47,16 +47,6 @@
 				usr.client.debug_variables(src)
 				return
 
-		#ifdef REFERENCE_TRACKING
-		if(href_list[VV_HK_VIEW_REFERENCES])
-			var/datum/D = locate(href_list[VV_HK_TARGET])
-			if(!D)
-				to_chat(usr, "<span class='warning'>Unable to locate item.</span>")
-				return
-			usr.client.holder.view_refs(target)
-			return
-		#endif
-
 	if(href_list[VV_HK_MARK])
 		usr.client.mark_datum(target)
 	if(href_list[VV_HK_ADDCOMPONENT])

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -62,7 +62,6 @@
 			"Set len" = VV_HREF_TARGETREF_INTERNAL(refid, VV_HK_LIST_SET_LENGTH),
 			"Shuffle" = VV_HREF_TARGETREF_INTERNAL(refid, VV_HK_LIST_SHUFFLE),
 			"Show VV To Player" = VV_HREF_TARGETREF_INTERNAL(refid, VV_HK_EXPOSE),
-			"View References" = VV_HREF_TARGETREF_INTERNAL(refid, VV_HK_VIEW_REFERENCES),
 			"---"
 			)
 		for(var/i in 1 to length(dropdownoptions))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Enables 514 testing on master, and replaces our extools maptick implementation with map_cpu on proper versions.
Replaces the extools debugging with auxtools debugging, this is supports the most recent byond beta, and our current version.
Nukes extools ref-tracking and its associated code. It doesn't work currently, and there don't appear to be any plans to replace it.

## Why It's Good For The Game
514 is by no means stable or ready for production, but this way we're at least able to test it without needing to fuck with defines and comment out code locally.

At this point we are only reliant on extools for maptick, so any transitions in future would be as easy as removing my version checks, and nuking some #ifdefs