### PR TITLE
Fix forcing certain roundstart rulesets dividing by zero

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -421,7 +421,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		if (rule.ready(roundstart_pop_ready, TRUE))
 			var/cost = rule.cost
 			var/scaled_times = 0
-			if (!(rule.flags & LONE_RULESET))
+			if (rule.scaling_cost)
 				scaled_times = round(max(round_start_budget - cost, 0) / rule.scaling_cost)
 				cost += rule.scaling_cost * scaled_times
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It was trying to scale `HIGH_IMPACT_RULESETS`, which are not lone. This generalizes it to checking for a scaling cost.

Fixes #56722

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Forcing roundstart rulesets should now work properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
