### PR TITLE
Fixes bullying socially anxious dead people by blowing kisses at their corpse

### DIFF
--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -24,7 +24,8 @@
 	colour = "black"
 
 /obj/item/lipstick/black/death
-	name = "Kiss of Death"
+	name = "\improper Kiss of Death"
+	desc = "An incredibly potent cosmetic made from the venom of the dreaded Yellow Spotted Lizard, as deadly as it is chic. Try not to smear it!"
 	lipstick_trait = TRAIT_KISS_OF_DEATH
 
 /obj/item/lipstick/random

--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -25,7 +25,7 @@
 
 /obj/item/lipstick/black/death
 	name = "\improper Kiss of Death"
-	desc = "An incredibly potent cosmetic made from the venom of the dreaded Yellow Spotted Lizard, as deadly as it is chic. Try not to smear it!"
+	desc = "An incredibly potent tube of lipstick made from the venom of the dreaded Yellow Spotted Space Lizard, as deadly as it is chic. Try not to smear it!"
 	lipstick_trait = TRAIT_KISS_OF_DEATH
 
 /obj/item/lipstick/random

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -278,9 +278,9 @@
 	SEND_SIGNAL(target, COMSIG_ADD_MOOD_EVENT, "kiss", /datum/mood_event/kiss, firer)
 	var/mob/living/target_living = target
 
-	// people with the social anxiety quirk have a 50% chance to get flustered when hit with a kiss
-	if(HAS_TRAIT(target_living, TRAIT_ANXIOUS) && (target_living.stat > SOFT_CRIT) && prob(50)))
-		if(HAS_TRAIT(target_living, TRAIT_FEARLESS)) //immune while on meds
+	// people with the social anxiety quirk can get flustered when hit by a kiss
+	if(HAS_TRAIT(target_living, TRAIT_ANXIOUS) && (target_living.stat > SOFT_CRIT))
+		if(prob(50) || HAS_TRAIT(target_living, TRAIT_FEARLESS)) // 50% chance for it to apply, also immune while on meds
 			return
 		var/other_msg
 		var/self_msg

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -277,7 +277,7 @@
 		return
 	SEND_SIGNAL(target, COMSIG_ADD_MOOD_EVENT, "kiss", /datum/mood_event/kiss, firer)
 	var/mob/living/target_living = target
-	if(!(HAS_TRAIT(target_living, TRAIT_ANXIOUS) && prob(30)))
+
 	if((target_living.stat > SOFT_CRIT) || !(HAS_TRAIT(target_living, TRAIT_ANXIOUS) && prob(30)))
 		return
 

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -278,30 +278,28 @@
 	SEND_SIGNAL(target, COMSIG_ADD_MOOD_EVENT, "kiss", /datum/mood_event/kiss, firer)
 	var/mob/living/target_living = target
 
-	if((target_living.stat > SOFT_CRIT) || !(HAS_TRAIT(target_living, TRAIT_ANXIOUS) && prob(30)))
-		return
+	// people with the social anxiety quirk have a 50% chance to get flustered when hit with a kiss
+	if(HAS_TRAIT(target_living, TRAIT_ANXIOUS) && (target_living.stat > SOFT_CRIT) && prob(50)))
+		var/other_msg
+		var/self_msg
+		var/roll = rand(1, 3)
+		switch(roll)
+			if(1)
+				other_msg = "stumbles slightly, turning a bright red!"
+				self_msg = "You lose control of your limbs for a moment as your blood rushes to your face, turning it bright red!"
+				target_living.add_confusion(rand(5, 10))
+			if(2)
+				other_msg = "stammers softly for a moment before choking on something!"
+				self_msg = "You feel your tongue disappear down your throat as you fight to remember how to make words!"
+				addtimer(CALLBACK(target_living, /atom/movable.proc/say, pick("Uhhh...", "O-oh, uhm...", "I- uhhhhh??", "You too!!", "What?")), rand(0.5 SECONDS, 1.5 SECONDS))
+				target_living.stuttering += rand(5, 15)
+			if(3)
+				other_msg = "locks up with a stunned look on [target_living.p_their()] face, staring at [firer ? firer : "the ceiling"]!"
+				self_msg = "Your brain completely fails to process what just happened, leaving you rooted in place staring [firer ? "at [firer]" : "the ceiling"] for what feels like an eternity!"
+				target_living.face_atom(firer)
+				target_living.Stun(rand(3 SECONDS, 8 SECONDS))
 
-	// flustered!!!
-	var/other_msg
-	var/self_msg
-	var/roll = rand(1, 3)
-	switch(roll)
-		if(1)
-			other_msg = "stumbles slightly, turning a bright red!"
-			self_msg = "You lose control of your limbs for a moment as your blood rushes to your face, turning it bright red!"
-			target_living.add_confusion(rand(5, 10))
-		if(2)
-			other_msg = "stammers softly for a moment before choking on something!"
-			self_msg = "You feel your tongue disappear down your throat as you fight to remember how to make words!"
-			addtimer(CALLBACK(target_living, /atom/movable.proc/say, pick("Uhhh...", "O-oh, uhm...", "I- uhhhhh??", "You too!!", "What?")), rand(0.5 SECONDS, 1.5 SECONDS))
-			target_living.stuttering += rand(5, 15)
-		if(3)
-			other_msg = "locks up with a stunned look on [target_living.p_their()] face, staring at [firer ? firer : "the ceiling"]!"
-			self_msg = "Your brain completely fails to process what just happened, leaving you rooted in place staring [firer ? "at [firer]" : "the ceiling"] for what feels like an eternity!"
-			target_living.face_atom(firer)
-			target_living.Stun(rand(3 SECONDS, 8 SECONDS))
-
-	target_living.visible_message("<b>[target_living]</b> [other_msg]", "<span class='userdanger'>Whoa! [self_msg]</span>")
+		target_living.visible_message("<b>[target_living]</b> [other_msg]", "<span class='userdanger'>Whoa! [self_msg]</span>")
 
 /obj/projectile/kiss/death
 	name = "kiss of death"

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -278,6 +278,7 @@
 	SEND_SIGNAL(target, COMSIG_ADD_MOOD_EVENT, "kiss", /datum/mood_event/kiss, firer)
 	var/mob/living/target_living = target
 	if(!(HAS_TRAIT(target_living, TRAIT_ANXIOUS) && prob(30)))
+	if((target_living.stat > SOFT_CRIT) || !(HAS_TRAIT(target_living, TRAIT_ANXIOUS) && prob(30)))
 		return
 
 	// flustered!!!

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -280,6 +280,8 @@
 
 	// people with the social anxiety quirk have a 50% chance to get flustered when hit with a kiss
 	if(HAS_TRAIT(target_living, TRAIT_ANXIOUS) && (target_living.stat > SOFT_CRIT) && prob(50)))
+		if(HAS_TRAIT(target_living, TRAIT_FEARLESS)) //immune while on meds
+			return
 		var/other_msg
 		var/self_msg
 		var/roll = rand(1, 3)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -196,6 +196,7 @@
 /datum/emote/living/kiss
 	key = "kiss"
 	key_third_person = "kisses"
+	cooldown = 3 SECONDS
 
 /datum/emote/living/kiss/run_emote(mob/living/user, params, type_override, intentional)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
At the end of #56698 I added interactions for people with the social anxiety quirk so they sometimes get flustered when hit by a kiss, but I realized precisely 0.2 seconds too late that I didn't actually check if they were alive or conscious before doing so. 

[![dreamseeker_2021-02-07_03-58-35.png](https://i.imgur.com/kt6riMVl.jpg)](https://i.imgur.com/kt6riMV.png)
This PR fixes this so those reactions will only happen if they're conscious or in soft crit. I also changed the description of the kiss of death lipstick, cause I forgot to put one
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Let the dead have their peace. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
