### PR TITLE
Fixes borg logs missing from Robotact

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosRobotact.js
+++ b/tgui/packages/tgui/interfaces/NtosRobotact.js
@@ -289,11 +289,12 @@ export const NtosRobotactContent = (props, context) => {
         </>
       )}
       {tab_main === 2 && (
-        <Flex.Item>
+        <Flex.Item
+        height={40}>
           <Section
-            backgroundColor="black"
-            height={40}>
-            <NtosWindow.Content scrollable>
+            fill
+            scrollable
+            backgroundColor="black">
               {borgLog.map(log => (
                 <Box
                   mb={1}
@@ -301,7 +302,6 @@ export const NtosRobotactContent = (props, context) => {
                   <font color="green">{log}</font>
                 </Box>
               ))}
-            </NtosWindow.Content>
           </Section>
         </Flex.Item>
       )}

--- a/tgui/packages/tgui/interfaces/NtosRobotact.js
+++ b/tgui/packages/tgui/interfaces/NtosRobotact.js
@@ -290,18 +290,18 @@ export const NtosRobotactContent = (props, context) => {
       )}
       {tab_main === 2 && (
         <Flex.Item
-        height={40}>
+          height={40}>
           <Section
             fill
             scrollable
             backgroundColor="black">
-              {borgLog.map(log => (
-                <Box
-                  mb={1}
-                  key={log}>
-                  <font color="green">{log}</font>
-                </Box>
-              ))}
+            {borgLog.map(log => (
+              <Box
+                mb={1}
+                key={log}>
+                <font color="green">{log}</font>
+              </Box>
+            ))}
           </Section>
         </Flex.Item>
       )}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Apparently using `<NtosWindow.Content scrollable>` inside a section doesn't work anymore. This PR removes these tags from RoboTact and changes the `<Section>` tag to handle the scrolling instead, with the `<Flex.Item>` tag now handling the size of the area, allowing RoboTact to display logs once again.

Closes #56494
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: RoboTact will now show borgs their logs again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
