### PR TITLE
Removed antiquated intent cycle hotkey for borgs

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -74,7 +74,6 @@
 #define COMSIG_KB_SILICON_TOGGLEMODULEONE_DOWN "keybinding_silicon_togglemoduleone_down"
 #define COMSIG_KB_SILICON_TOGGLEMODULETWO_DOWN "keybinding_silicon_togglemoduletwo_down"
 #define COMSIG_KB_SILICON_TOGGLEMODULETHREE_DOWN "keybinding_silicon_togglemodulethree_down"
-#define COMSIG_KB_SILICON_CYCLEINTENT_DOWN "keybinding_silicon_cycleintent_down"
 #define COMSIG_KB_SILICON_UNEQUIPMODULE_DOWN "keybinding_silicon_unequipmodule_down"
 
 //Movement

--- a/code/datums/keybinding/robot.dm
+++ b/code/datums/keybinding/robot.dm
@@ -50,21 +50,6 @@
 	R.toggle_module(3)
 	return TRUE
 
-/datum/keybinding/robot/intent_cycle
-	hotkey_keys = list("4")
-	name = "cycle_intent"
-	full_name = "Cycle intent left"
-	description = "Cycles the intent left"
-	keybind_signal = COMSIG_KB_SILICON_CYCLEINTENT_DOWN
-
-/datum/keybinding/robot/intent_cycle/down(client/user)
-	. = ..()
-	if(.)
-		return
-	var/mob/living/silicon/robot/R = user.mob
-	R.set_combat_mode(!R.combat_mode)
-	return TRUE
-
 /datum/keybinding/robot/unequip_module
 	hotkey_keys = list("Q")
 	name = "unequip_module"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The `intent_cycle` hotkey for borgs was left behind during the combat mode switch. It does nothing on its own, but existing as a default hotkey blocks the actual combat mode hotkey unless unbound manually.

Closes #56668
Related to #56601
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes old hotkey, fixes hotkey conflict.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed a hotkey conflict that by default prevents borgs from toggling combat mode using '4'.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
