### PR TITLE
Add missing newline in circuit board definitions

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -991,6 +991,7 @@
 	build_path = /obj/machinery/deepfryer
 	req_components = list(/obj/item/stock_parts/micro_laser = 1)
 	needs_anchored = FALSE
+
 /obj/item/circuitboard/machine/griddle
 	name = "circuit board (Griddle)"
 	icon_state = "service"


### PR DESCRIPTION
Two of the type definitions did not have a newline separating them.