### PR TITLE
[s] Fixes possible APC control console HREF exploit

### DIFF
--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -153,7 +153,16 @@
 			var/obj/machinery/power/apc/target = locate(ref) in GLOB.apcs_list
 			if(!target)
 				return
-			target.vars[type] = target.setsubsystem(text2num(value))
+
+			value = target.setsubsystem(text2num(value))
+			switch(type) // Sanity check
+				if("equipment", "lighting", "environ")
+					target.vars[type] = value
+				else
+					message_admins("Warning: possible href exploit by [key_name(usr)] - attempted to set [type] on [target] to [value]")
+					log_game("Warning: possible href exploit by [key_name(usr)] - attempted to set [type] on [target] to [value]")
+					return
+
 			target.update_icon()
 			target.update()
 			var/setTo = ""


### PR DESCRIPTION
## About The Pull Request
- Makes the APC control console check what variables it's being asked to set before it sets them.

Also, while this should work I'd like for someone who knows how HREF exploits work to test this. All I know is that they involve handing BYOND fake args and the code running with them. I don't know how that works from the client's side so I can't really test this beyond whether it can still operate normally.

## Why It's Good For The Game
- One less HREF exploit

