### PR TITLE
Renames the _alt attacks to _secondary for clarity

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -279,8 +279,8 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 /// If a carbon is thrown at a speed faster than normal and impacts something solid, they take extra damage for every extra speed up to this number (see [/mob/living/carbon/proc/throw_impact])
 #define CARBON_MAX_IMPACT_SPEED_BONUS	5
 
-/// Alternate attack defines. Return these at the end of procs like afterattack_alt.
-/// Calls the normal attack proc. For example, if returned in afterattack_alt, will call afterattack.
+/// Alternate attack defines. Return these at the end of procs like afterattack_secondary.
+/// Calls the normal attack proc. For example, if returned in afterattack_secondary, will call afterattack.
 /// Will continue the chain depending on the return value of the non-alternate proc, like with normal attacks.
 #define ALT_ATTACK_CALL_NORMAL 1
 

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -282,10 +282,10 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 /// Alternate attack defines. Return these at the end of procs like afterattack_secondary.
 /// Calls the normal attack proc. For example, if returned in afterattack_secondary, will call afterattack.
 /// Will continue the chain depending on the return value of the non-alternate proc, like with normal attacks.
-#define ALT_ATTACK_CALL_NORMAL 1
+#define SECONDARY_ATTACK_CALL_NORMAL 1
 
 /// Cancels the attack chain entirely.
-#define ALT_ATTACK_CANCEL_ATTACK_CHAIN 2
+#define SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN 2
 
 /// Proceed with the attack chain, but don't call the normal methods.
-#define ALT_ATTACK_CONTINUE_CHAIN 3
+#define SECONDARY_ATTACK_CONTINUE_CHAIN 3

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -20,12 +20,12 @@
 
 	if (is_right_clicking)
 		switch (target.attackby_secondary(src, user, params))
-			if (ALT_ATTACK_CALL_NORMAL)
+			if (SECONDARY_ATTACK_CALL_NORMAL)
 				attackby_result = target.attackby(src, user, params)
-			if (ALT_ATTACK_CANCEL_ATTACK_CHAIN)
+			if (SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
 				return TRUE
 			if (null)
-				CRASH("attackby_secondary must return an ALT_ATTACK_* define, please consult code/__DEFINES/combat.dm")
+				CRASH("attackby_secondary must return an SECONDARY_ATTACK_* define, please consult code/__DEFINES/combat.dm")
 	else
 		attackby_result = target.attackby(src, user, params)
 
@@ -40,7 +40,7 @@
 		var/after_attack_secondary_result = afterattack_secondary(target, user, TRUE, params)
 
 		// There's no chain left to continue at this point, so CANCEL_ATTACK_CHAIN and CONTINUE_CHAIN are functionally the same.
-		if (after_attack_secondary_result == ALT_ATTACK_CANCEL_ATTACK_CHAIN || after_attack_secondary_result == ALT_ATTACK_CONTINUE_CHAIN)
+		if (after_attack_secondary_result == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN || after_attack_secondary_result == SECONDARY_ATTACK_CONTINUE_CHAIN)
 			return TRUE
 
 	return afterattack(target, user, TRUE, params)
@@ -92,7 +92,7 @@
  * See: [/obj/item/proc/melee_attack_chain]
  */
 /atom/proc/attackby_secondary(obj/item/weapon, mob/user, params)
-	return ALT_ATTACK_CALL_NORMAL
+	return SECONDARY_ATTACK_CALL_NORMAL
 
 /obj/attackby(obj/item/I, mob/living/user, params)
 	return ..() || ((obj_flags & CAN_BE_HIT) && I.attack_obj(src, user))
@@ -107,7 +107,7 @@
 	var/result = weapon.attack_secondary(src, user, params)
 
 	// Normal attackby updates click cooldown, so we have to make up for it
-	if (result != ALT_ATTACK_CALL_NORMAL)
+	if (result != SECONDARY_ATTACK_CALL_NORMAL)
 		user.changeNext_move(CLICK_CD_MELEE)
 
 	return result
@@ -160,7 +160,7 @@
 
 /// The equivalent of [/obj/item/proc/attack] but for alternate attacks, AKA right clicking
 /obj/item/proc/attack_secondary(mob/living/victim, mob/living/user, params)
-	return ALT_ATTACK_CALL_NORMAL
+	return SECONDARY_ATTACK_CALL_NORMAL
 
 /// The equivalent of the standard version of [/obj/item/proc/attack] but for object targets.
 /obj/item/proc/attack_obj(obj/O, mob/living/user)
@@ -226,7 +226,7 @@
  * * click_parameters - is the params string from byond [/atom/proc/Click] code, see that documentation.
  */
 /obj/item/proc/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
-	return ALT_ATTACK_CALL_NORMAL
+	return SECONDARY_ATTACK_CALL_NORMAL
 
 /// Called if the target gets deleted by our attack
 /obj/item/proc/attack_qdeleted(atom/target, mob/user, proximity_flag, click_parameters)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -19,13 +19,13 @@
 	var/attackby_result
 
 	if (is_right_clicking)
-		switch (target.attackby_alt(src, user, params))
+		switch (target.attackby_secondary(src, user, params))
 			if (ALT_ATTACK_CALL_NORMAL)
 				attackby_result = target.attackby(src, user, params)
 			if (ALT_ATTACK_CANCEL_ATTACK_CHAIN)
 				return TRUE
 			if (null)
-				CRASH("attackby_alt must return an ALT_ATTACK_* define, please consult code/__DEFINES/combat.dm")
+				CRASH("attackby_secondary must return an ALT_ATTACK_* define, please consult code/__DEFINES/combat.dm")
 	else
 		attackby_result = target.attackby(src, user, params)
 
@@ -37,10 +37,10 @@
 		return TRUE
 
 	if (is_right_clicking)
-		var/after_attack_alt_result = afterattack_alt(target, user, TRUE, params)
+		var/after_attack_secondary_result = afterattack_secondary(target, user, TRUE, params)
 
 		// There's no chain left to continue at this point, so CANCEL_ATTACK_CHAIN and CONTINUE_CHAIN are functionally the same.
-		if (after_attack_alt_result == ALT_ATTACK_CANCEL_ATTACK_CHAIN || after_attack_alt_result == ALT_ATTACK_CONTINUE_CHAIN)
+		if (after_attack_secondary_result == ALT_ATTACK_CANCEL_ATTACK_CHAIN || after_attack_secondary_result == ALT_ATTACK_CONTINUE_CHAIN)
 			return TRUE
 
 	return afterattack(target, user, TRUE, params)
@@ -91,7 +91,7 @@
  *
  * See: [/obj/item/proc/melee_attack_chain]
  */
-/atom/proc/attackby_alt(obj/item/weapon, mob/user, params)
+/atom/proc/attackby_secondary(obj/item/weapon, mob/user, params)
 	return ALT_ATTACK_CALL_NORMAL
 
 /obj/attackby(obj/item/I, mob/living/user, params)
@@ -103,8 +103,8 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	return I.attack(src, user, params)
 
-/mob/living/attackby_alt(obj/item/weapon, mob/living/user, params)
-	var/result = weapon.attack_alt(src, user, params)
+/mob/living/attackby_secondary(obj/item/weapon, mob/living/user, params)
+	var/result = weapon.attack_secondary(src, user, params)
 
 	// Normal attackby updates click cooldown, so we have to make up for it
 	if (result != ALT_ATTACK_CALL_NORMAL)
@@ -159,7 +159,7 @@
 	add_fingerprint(user)
 
 /// The equivalent of [/obj/item/proc/attack] but for alternate attacks, AKA right clicking
-/obj/item/proc/attack_alt(mob/living/victim, mob/living/user, params)
+/obj/item/proc/attack_secondary(mob/living/victim, mob/living/user, params)
 	return ALT_ATTACK_CALL_NORMAL
 
 /// The equivalent of the standard version of [/obj/item/proc/attack] but for object targets.
@@ -225,7 +225,7 @@
  * * proximity_flag - is 1 if this afterattack was called on something adjacent, in your square, or on your person.
  * * click_parameters - is the params string from byond [/atom/proc/Click] code, see that documentation.
  */
-/obj/item/proc/afterattack_alt(atom/target, mob/user, proximity_flag, click_parameters)
+/obj/item/proc/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
 	return ALT_ATTACK_CALL_NORMAL
 
 /// Called if the target gets deleted by our attack

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -42,7 +42,7 @@
 	if(!attach_accessory(I, user))
 		return ..()
 
-/obj/item/clothing/under/attackby_alt(obj/item/weapon, mob/user, params)
+/obj/item/clothing/under/attackby_secondary(obj/item/weapon, mob/user, params)
 	toggle()
 	return ALT_ATTACK_CANCEL_ATTACK_CHAIN
 

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -44,7 +44,7 @@
 
 /obj/item/clothing/under/attackby_secondary(obj/item/weapon, mob/user, params)
 	toggle()
-	return ALT_ATTACK_CANCEL_ATTACK_CHAIN
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/clothing/under/update_clothes_damaged_state(damaged_state = CLOTHING_DAMAGED)
 	..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -193,7 +193,7 @@
 		for(var/obj/O in contents)
 			O.emp_act(severity)
 
-/obj/item/gun/attack_alt(mob/living/victim, mob/living/user, params)
+/obj/item/gun/attack_secondary(mob/living/victim, mob/living/user, params)
 	if (user.GetComponent(/datum/component/gunpoint))
 		to_chat(user, "<span class='warning'>You are already holding someone up!</span>")
 		return ALT_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -196,10 +196,10 @@
 /obj/item/gun/attack_secondary(mob/living/victim, mob/living/user, params)
 	if (user.GetComponent(/datum/component/gunpoint))
 		to_chat(user, "<span class='warning'>You are already holding someone up!</span>")
-		return ALT_ATTACK_CANCEL_ATTACK_CHAIN
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	user.AddComponent(/datum/component/gunpoint, victim, src)
-	return ALT_ATTACK_CANCEL_ATTACK_CHAIN
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/gun/afterattack(atom/target, mob/living/user, flag, params)
 	. = ..()


### PR DESCRIPTION
It's unclear at first sight whether an alt-attack means something involving the alt key or something else.
Since this actually means a secondary/alternative attack performed by right-clicking I decided to rename it to improve clarity.

Asked @Qustinnus , who introduced this, and they're fine with the change.

Also related to #56700