### PR TITLE
Makes cryo handle reagent transfer better.

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -90,7 +90,6 @@
 	var/conduction_coefficient = 0.3
 
 	var/obj/item/reagent_containers/glass/beaker = null
-	var/reagent_transfer = 0
 	var/consume_gas = FALSE
 
 	var/obj/item/radio/radio
@@ -268,14 +267,9 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 			mob_occupant.Sleeping((mob_occupant.bodytemperature * sleep_factor) * 1000 * delta_time)
 			mob_occupant.Unconscious((mob_occupant.bodytemperature * unconscious_factor) * 1000 * delta_time)
 		if(beaker)
-			if(reagent_transfer == 0) // Magically transfer reagents. Because cryo magic.
-				beaker.reagents.trans_to(occupant, CRYO_TX_QTY * delta_time, efficiency * CRYO_MULTIPLY_FACTOR, methods = VAPOR) // Transfer reagents.
-				consume_gas = TRUE
-			reagent_transfer += 1
-			if(reagent_transfer >= CRYO_THROTTLE_CTR_MAX * efficiency) // Throttle reagent transfer (higher efficiency will transfer the same amount but consume less from the beaker).
-				reagent_transfer = 0
-
-	return 1
+			beaker.reagents.trans_to(occupant, (CRYO_TX_QTY / (efficiency * CRYO_MULTIPLY_FACTOR)) * delta_time, efficiency * CRYO_MULTIPLY_FACTOR, methods = VAPOR) // Transfer reagents.
+			consume_gas = TRUE
+	return TRUE
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/process_atmos(delta_time)
 	..()
@@ -337,7 +331,6 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 		M.forceMove(get_turf(src))
 	set_occupant(null)
 	flick("pod-open-anim", src)
-	reagent_transfer = efficiency * CRYO_THROTTLE_CTR_MAX * 0.5 // wait before injecting the next occupant
 	..()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/close_machine(mob/living/carbon/user)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -6,7 +6,6 @@
 // These three defines control how fast and efficient cryo is
 #define CRYO_MULTIPLY_FACTOR 25
 #define CRYO_TX_QTY 0.5
-#define CRYO_THROTTLE_CTR_MAX 10
 // The minimum O2 moles in the cryotube before it switches off.
 #define CRYO_MIN_GAS_MOLES 5
 #define CRYO_BREAKOUT_TIME 30 SECONDS
@@ -540,6 +539,5 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 #undef MAX_TEMPERATURE
 #undef CRYO_MULTIPLY_FACTOR
 #undef CRYO_TX_QTY
-#undef CRYO_THROTTLE_CTR_MAX
 #undef CRYO_MIN_GAS_MOLES
 #undef CRYO_BREAKOUT_TIME


### PR DESCRIPTION
## About The Pull Request
Cryogenics has a `reagent_transfer` variable that is set to throttle the reagent injection. Upgrading bins increase efficiency and transfer amount, thus making the `reagent_transfer` threshold larger, making it take longer between each injections. However, this variable is stored in the object itself and not on the process proc, presumably to prevent exploits such as rapidly turning the machine on and off. This has a really bad consequence that makes cryo really clunky to use, since you may need to wait for the `reagent_transfer` variable to hit threshold and then reset again for a new patient before any cryoxadone can be injected. Not to mention how upgrading the bins somehow timegaps it even further.
This PR seeks to change the whole system to transfer reagents in a smaller and more continuous manner. If i did my coding right, the machine should inject the same amount of reagents per delta time for each upgrades, while also keeping the old multiplier value intact.

## Why It's Good For The Game
The old system was quite questionable, and it also has some flaws that i mentioned in the above section. Moving over to a more periodic tick based injection would make cryo feel more responsive and better to use.

## Addendums
Cryoxadone overflow (injecting more cryoxadone than metabolized) is still a thing however, which I wont mind removing if people think it is a good thing to remove.
Glancing at the code, i would also assume that sleeping and unconscious timers are longer on upgraded cryo cells than unupgraded ones, which might be intentional?

## Changelog
:cl:
tweak: cryo now inject reagents more consistently i.e. more often and in smaller amounts.
/:cl: