### PR TITLE
Changes UI code to use ease-out on transitions

### DIFF
--- a/tgui/packages/tgui-panel/styles/components/Chat.scss
+++ b/tgui/packages/tgui-panel/styles/components/Chat.scss
@@ -26,7 +26,7 @@ $color-bg-section: base.$color-bg-section !default;
   vertical-align: middle;
   background-color: crimson;
   border-radius: 10px;
-  transition: font-size 200ms;
+  transition: font-size 200ms ease-out;
 
   &:before {
     content: 'x';

--- a/tgui/packages/tgui/styles/components/Dropdown.scss
+++ b/tgui/packages/tgui/styles/components/Dropdown.scss
@@ -58,7 +58,7 @@
   font-family: Verdana, sans-serif;
   font-size: base.em(12px);
   line-height: base.em(17px);
-  transition: background-color 100ms;
+  transition: background-color 100ms ease-out;
 
   &:hover {
     background-color: rgba(255, 255, 255, 0.2);

--- a/tgui/packages/tgui/styles/components/Knob.scss
+++ b/tgui/packages/tgui/styles/components/Knob.scss
@@ -117,7 +117,7 @@ $pi: 3.1416;
   stroke-width: 8;
   stroke-linecap: round;
   stroke-dasharray: 100 * $pi;
-  transition: stroke 50ms;
+  transition: stroke 50ms ease-out;
 }
 
 @each $color-name, $color-value in $fg-map {

--- a/tgui/packages/tgui/styles/components/ProgressBar.scss
+++ b/tgui/packages/tgui/styles/components/ProgressBar.scss
@@ -19,7 +19,7 @@ $bg-map: colors.$bg-map !default;
   padding: 0 0.5em;
   border-radius: $border-radius;
   background-color: $background-color;
-  transition: border-color 500ms;
+  transition: border-color 900ms ease-out;
 }
 
 .ProgressBar__fill {
@@ -30,7 +30,7 @@ $bg-map: colors.$bg-map !default;
 }
 
 .ProgressBar__fill--animated {
-  transition: background-color 500ms, width 500ms;
+  transition: background-color 900ms ease-out, width 900ms ease-out;
 }
 
 .ProgressBar__content {

--- a/tgui/packages/tgui/styles/components/RoundGauge.scss
+++ b/tgui/packages/tgui/styles/components/RoundGauge.scss
@@ -33,7 +33,7 @@ $pi: 3.1416;
   stroke: $ring-color;
   stroke-width: 10;
   stroke-dasharray: 100 * $pi;
-  transition: stroke 50ms;
+  transition: stroke 50ms ease-out;
 }
 
 .RoundGauge__needle, .RoundGauge__ringFill {

--- a/tgui/packages/tgui/styles/components/Tooltip.scss
+++ b/tgui/packages/tgui/styles/components/Tooltip.scss
@@ -31,7 +31,7 @@ $border-radius: base.$border-radius !default;
     opacity: 0;
     text-align: left;
     content: attr(data-tooltip);
-    transition: all 150ms;
+    transition: all 150ms ease-out;
     background-color: $background-color;
     color: $color;
     box-shadow: 0.1em 0.1em 1.25em -0.1em rgba(0, 0, 0, 0.5);

--- a/tgui/packages/tgui/styles/interfaces/AlertModal.scss
+++ b/tgui/packages/tgui/styles/interfaces/AlertModal.scss
@@ -22,7 +22,7 @@
 
 .AlertModal__LoaderProgress {
   position: absolute;
-  transition: background-color 500ms, width 500ms;
+  transition: background-color 500ms ease-out, width 500ms ease-out;
   background-color: colors.bg(colors.$primary);
   height: 100%;
 }

--- a/tgui/packages/tgui/styles/interfaces/ListInput.scss
+++ b/tgui/packages/tgui/styles/interfaces/ListInput.scss
@@ -23,7 +23,7 @@
 
  .ListInput__LoaderProgress {
    position: absolute;
-   transition: background-color 500ms, width 500ms;
+   transition: background-color 500ms ease-out, width 500ms ease-out;
    background-color: colors.bg(colors.$primary);
    height: 100%;
  }

--- a/tgui/packages/tgui/styles/layouts/TitleBar.scss
+++ b/tgui/packages/tgui/styles/layouts/TitleBar.scss
@@ -24,7 +24,7 @@ $shadow-color: rgba(0, 0, 0, 0.1) !default;
 .TitleBar__clickable {
   color: color.change($text-color, $alpha: 0.5);
   background-color: $background-color;
-  transition: color 250ms, background-color 250ms;
+  transition: color 250ms ease-out, background-color 250ms ease-out;
 
   &:hover {
     color: rgba(255, 255, 255, 1.0);


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds ease out to most of the uses of transition - this makes the UI widgets appear more smooth.
In some cases 500ms has been changed to 900ms to be in sync with the UI update delta. This makes things appear like they're constantly progressing (like the progress bar).

## Why It's Good For The Game

Hopefully improved user feel.

## Changelog
:cl:
tweak: tweaked transitional ui widgets to appear smoother
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
