### PR TITLE
Changes advanced medkit contents

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -262,9 +262,9 @@
 	if(empty)
 		return
 	var/static/items_inside = list(
-		/obj/item/reagent_containers/pill/patch/synthflesh = 3,
+		/obj/item/stack/medical/suture/medicated = 2,
+		/obj/item/stack/medical/mesh/advanced = 2,
 		/obj/item/reagent_containers/hypospray/medipen/atropine = 2,
-		/obj/item/stack/medical/gauze = 1,
 		/obj/item/storage/pill_bottle/penacid = 1)
 	generate_items_inside(items_inside,src)
 


### PR DESCRIPTION
## About The Pull Request

Buffs the advanced medkit a bit. The synthflesh patches and gauze have been replaced with medicated sutures and advanced burn mesh.

## Why It's Good For The Game

The advanced medkit is a little underwhelming right now. You can already get synthflesh from the nanochem and pent acid from the toxin kits, leaving the atropine pens as the only unique thing inside. The advanced healing stack items aren't too commonly seen and I think they'd make the advanced medkit more unique without making it too powerful.

## Changelog
:cl: Bumtickley00
balance: Changed the contents of the advanced medkit
/:cl:
