### PR TITLE
Fixes Icebox backstage from service hall access inconsistency.

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -8705,7 +8705,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Service Hall Maintenance";
-	req_access_txt = "22;25;26;28;35;37;38;46;70"
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/service)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -8697,15 +8697,15 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Service Hall";
-	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Service Hall Maintenance";
+	req_access_txt = "22;25;26;28;35;37;38;46;70"
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
@@ -31645,10 +31645,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock{
-	name = "Service Hall";
-	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -31656,6 +31652,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/door/airlock{
+	name = "Theater Backstage Service Hall";
+	req_access_txt = "46"
+	},
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "giT" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #56458 
On IceboxStation, the airlock leading from the Service Hall to Theater Backstage seemed to be a copy of the Service Hall airlocks that any other service member could access, which isn't consistent with any other map.
I also changed the airlock leading into maint from Service Hall from a generic green striped airlock to an actual maint airlock, since I happened to notice this as well.

## Why It's Good For The Game

Consistency, and the poor clown/mime has to have _somewhere_ to keep their ~~bodies~~ spare costumes!

## Changelog
:cl: Potato Masher
fix: The entire service department can no longer access the Theater Backstage from the Service Hall. Can't a clown get some privacy?
/:cl: