### PR TITLE
Flash immune cyborgs are now immune to flash.

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -230,21 +230,23 @@
 /obj/item/assembly/flash/attack(mob/living/M, mob/user)
 	if(!try_use_flash(user))
 		return FALSE
+
+	. = TRUE
 	if(iscarbon(M))
-		flash_carbon(M, user, 5, 1)
-		return TRUE
+		flash_carbon(M, user, 5, TRUE)
+		return
 	if(issilicon(M))
-		var/mob/living/silicon/robot/R = M
-		log_combat(user, R, "flashed", src)
+		var/mob/living/silicon/robot/flashed_borgo = M
+		log_combat(user, flashed_borgo, "flashed", src)
 		update_icon(TRUE)
-		if(!R.flash_act(affect_silicon = TRUE))
-			user.visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>", "<span class='warning'>You fail to blind [M] with the flash!</span>")
-			return TRUE
-		R.Paralyze(rand(80,120))
+		if(!flashed_borgo.flash_act(affect_silicon = TRUE))
+			user.visible_message("<span class='warning'>[user] fails to blind [flashed_borgo] with the flash!</span>", "<span class='warning'>You fail to blind [flashed_borgo] with the flash!</span>")
+			return
+		flashed_borgo.Paralyze(rand(80,120))
 		var/diff = 5 * CONFUSION_STACK_MAX_MULTIPLIER - M.get_confusion()
-		R.add_confusion(min(5, diff))
-		user.visible_message("<span class='warning'>[user] overloads [R]'s sensors with the flash!</span>", "<span class='danger'>You overload [R]'s sensors with the flash!</span>")
-		return TRUE
+		flashed_borgo.add_confusion(min(5, diff))
+		user.visible_message("<span class='warning'>[user] overloads [flashed_borgo]'s sensors with the flash!</span>", "<span class='danger'>You overload [flashed_borgo]'s sensors with the flash!</span>")
+		return
 
 	user.visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>", "<span class='warning'>You fail to blind [M] with the flash!</span>")
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -233,14 +233,16 @@
 	if(iscarbon(M))
 		flash_carbon(M, user, 5, 1)
 		return TRUE
-	else if(issilicon(M))
+	if(issilicon(M))
 		var/mob/living/silicon/robot/R = M
 		log_combat(user, R, "flashed", src)
-		update_icon(1)
+		update_icon(TRUE)
+		if(!R.flash_act(affect_silicon = TRUE))
+			user.visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>", "<span class='warning'>You fail to blind [M] with the flash!</span>")
+			return TRUE
 		R.Paralyze(rand(80,120))
 		var/diff = 5 * CONFUSION_STACK_MAX_MULTIPLIER - M.get_confusion()
 		R.add_confusion(min(5, diff))
-		R.flash_act(affect_silicon = 1)
 		user.visible_message("<span class='warning'>[user] overloads [R]'s sensors with the flash!</span>", "<span class='danger'>You overload [R]'s sensors with the flash!</span>")
 		return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A cyborg with TRAIT_NOFLASH is not actually immune to flashes, as the cyborg effects are hardcoded and the return result of flash_act() is ignored.

Moved flash_act() earlier and early return if it fails.

Should be no gameplay impact as the only way to make cyborgs flash immune is by adding the trait via admin abuse.

Minor code cleanup as well, with better var names and TRUE/FALSE defines used.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: When an admin makes a cyborg flash immune by giving it TRAIT_NOFLASH, that cyborg is now actually immune to flash.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
