### PR TITLE
Allows you to use both soy and regular milk for the chocolate bar recipe

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -46,6 +46,15 @@
 		new /obj/item/food/chocolatebar(location)
 	return
 
+/datum/chemical_reaction/chocolate_bar3
+	required_reagents = list(/datum/reagent/consumable/milk = 2, /datum/reagent/consumable/coco = 2, /datum/reagent/consumable/sugar = 2)
+
+/datum/chemical_reaction/chocolate_bar3/on_reaction(datum/reagents/holder, created_volume)
+	var/location = get_turf(holder.my_atom)
+	for(var/i = 1, i <= created_volume, i++)
+		new /obj/item/food/chocolatebar(location)
+	return
+
 /datum/chemical_reaction/soysauce
 	results = list(/datum/reagent/consumable/soysauce = 5)
 	required_reagents = list(/datum/reagent/consumable/soymilk = 4, /datum/reagent/toxin/acid = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The wiki states that both soy and regular milk can be used to make chocolate bars, currently only soy milk works.
In PR #21206 the recipe for chocolate milk was made to be 1 unit coco powder and 1 unit milk keeping this recipe functional but adding an additional step. However as of PR #55606 the recipe for chocolate milk was changed to use hot cocoa. This PR restores to original method of making chocolate bars.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Chocolate bars are made from milk, coco powder and sugar, you shouldn't need to mix in hot cocoa to make a chocolate bar.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Chocolate bars can be made using regular milk again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
