### PR TITLE
fix modular id console telekinesis+ai

### DIFF
--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -160,7 +160,7 @@
 			else
 				var/obj/item/I = user.get_active_held_item()
 				if(istype(I, /obj/item/card/id))
-					return card_slot2.try_insert(I)
+					return card_slot2.try_insert(I, user)
 			return FALSE
 		if("PRG_terminate")
 			if(!computer || !authenticated)

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -47,6 +47,11 @@
 
 	if(stored_card)
 		return FALSE
+
+	// item instead of player is checked so telekinesis will still work if the item itself is close
+	if(!in_range(src, I))
+		return FALSE
+
 	if(user)
 		if(!user.transferItemToLoc(I, src))
 			return FALSE
@@ -68,7 +73,7 @@
 		to_chat(user, "<span class='warning'>There are no cards in \the [src].</span>")
 		return FALSE
 
-	if(user)
+	if(user && !issilicon(user) && in_range(src, user))
 		user.put_in_hands(stored_card)
 	else
 		stored_card.forceMove(drop_location())


### PR DESCRIPTION
resolves: #56777 

## Changelog
:cl:
fix: Modular ID console will no longer insert/eject ID card for AI or to telekinesis players.
/:cl:
