### PR TITLE
Windows are now less fussy and will let more things exit a shared turf.

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -118,10 +118,10 @@
 	return TRUE
 
 /obj/structure/window/CheckExit(atom/movable/O, turf/target)
-	if(istype(O) && (O.pass_flags & PASSGLASS))
+	if(istype(O) && (O.pass_flags & pass_flags_self))
 		return TRUE
-	if(get_dir(O.loc, target) == dir)
-		return FALSE
+	if(!fulltile && get_dir(O.loc, target) == dir)
+		return !density
 	return TRUE
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I recently changed it so that windows don't use their direction to decide if they're fulltile or not. I missed a check in CheckExit and as a result, you couldn't exit a fulltile window you were stood on from the South, their default facing direction.

Fulltile windows no longer do this check to block movement off their turf. Directional windows now only block movement off the turf they're on if you're attempting to walk the direction they're facing (i.e. walking through them) and they're not dense.

Finally, windows also check pass_flags_self instead of hardcoded passflags.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Windows are now much less stubborn when you accidentally find yourself inside them (*blushes*) and will let you step off their turf to the South when you were prevented from doing so before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
