### PR TITLE
felinids with the family heirloom quirk can now roll toy mice as their family heirlooms

### DIFF
--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -138,6 +138,8 @@
 
 	if(ismoth(H) && prob(50))
 		heirloom_type = /obj/item/flashlight/lantern/heirloom_moth
+	else if(isfelinid(H) && prob(50))
+		heirloom_type = /obj/item/toy/cattoy
 	else
 		switch(quirk_holder.mind.assigned_role)
 			//Service jobs


### PR DESCRIPTION
## About The Pull Request

Similarly to how moth characters with the family heirloom quirk have a 50% chance to receive an old lantern as their family heirloom instead of one of their job's normal family heirloom items, felinids with the family heirloom quirk now have a 50% chance to receive a toy mouse as their family heirloom.

## Why It's Good For The Game

funny

maintainer approval:
![image](https://user-images.githubusercontent.com/42606352/107424354-27a24b00-6ae3-11eb-8e97-e84f4783d139.png)

## Changelog
:cl: ATHATH
tweak: Similarly to how moth characters with the family heirloom quirk have a 50% chance to receive an old lantern as their family heirloom instead of one of their job's normal family heirloom items, felinids with the family heirloom quirk now have a 50% chance to receive a toy mouse as their family heirloom.
/:cl: