### PR TITLE
The immovable rod is now crazy fast, is overpowered broken and doesn't afraid of anything.

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -16,7 +16,7 @@
 		/obj/effect/dummy/chameleon,
 		/obj/effect/wisp,
 		/obj/effect/mob_spawn,
-		/obj/effect/immovablerod
+		/obj/effect/immovablerod,
 		))
 	if(delete_atoms[teleatom.type])
 		qdel(teleatom)

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -16,6 +16,7 @@
 		/obj/effect/dummy/chameleon,
 		/obj/effect/wisp,
 		/obj/effect/mob_spawn,
+		/obj/effect/immovablerod
 		))
 	if(delete_atoms[teleatom.type])
 		qdel(teleatom)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -67,6 +67,8 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/num_sentient_mobs_hit = 0
 	///How many people we've hit with clients
 	var/num_sentient_people_hit = 0
+	/// The rod levels up with each kill, increasing in size and auto-renaming itself.
+	var/dnd = TRUE
 
 /obj/effect/immovablerod/New(atom/start, atom/end, aimed_at)
 	. = ..()
@@ -224,6 +226,9 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 			num_sentient_mobs_hit++
 			if(iscarbon(smeared_mob))
 				num_sentient_people_hit++
+			if(dnd)
+				transform = transform.Scale(1.005, 1.005)
+				name = "[initial(name)] of sentient slaying +[num_sentient_mobs_hit]"
 
 	if(iscarbon(smeared_mob))
 		var/mob/living/carbon/smeared_carbon = smeared_mob

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -68,7 +68,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	///How many people we've hit with clients
 	var/num_sentient_people_hit = 0
 	/// The rod levels up with each kill, increasing in size and auto-renaming itself.
-	var/dnd = TRUE
+	var/dnd_style_level_up = TRUE
 
 /obj/effect/immovablerod/New(atom/start, atom/end, aimed_at)
 	. = ..()
@@ -229,7 +229,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 			num_sentient_mobs_hit++
 			if(iscarbon(smeared_mob))
 				num_sentient_people_hit++
-			if(dnd)
+			if(dnd_style_level_up)
 				transform = transform.Scale(1.005, 1.005)
 				name = "[initial(name)] of sentient slaying +[num_sentient_mobs_hit]"
 

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -147,7 +147,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	if(destination)
 		var/turf/target_turf = get_turf(destination)
 
-		// Did an oopsie happen? Let's just get a new turf to head towards.
+		// Did we slip off the old z-level? Let's pick a new destination on the new z-level! Loops for days!
 		if(target_turf.z != z)
 			complete_trajectory()
 			return ..()

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -149,10 +149,12 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	if(destination)
 		var/turf/target_turf = get_turf(destination)
 
-		// Did we slip off the old z-level? Let's pick a new destination on the new z-level! Loops for days!
+		// Note: There is no way to detect if this is because it spawned off the primary station
+		// z-level with a destination on the primary station z-level. As a result, maps with
+		// multiple station z-levels may find their immovable rods immediately deleting themselves.
 		if(target_turf.z != z)
-			complete_trajectory()
-			return ..()
+			qdel(src)
+			return
 
 		// Did we reach our destination? We're probably on Icebox. Let's get rid of ourselves.
 		// Ordinarily this won't happen as the average destination is the edge of the map and
@@ -192,8 +194,9 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		smoke.start()
 		var/obj/singularity/bad_luck = new(get_turf(src))
 		bad_luck.energy = 800
-		qdel(src)
 		qdel(clong)
+		qdel(src)
+		return
 
 	// If we Bump into a turf, turf go boom.
 	if(isturf(clong))

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -34,9 +34,8 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /datum/round_event/immovable_rod/start()
 	var/datum/round_event_control/immovable_rod/C = control
 	var/startside = pick(GLOB.cardinals)
-	var/z = pick(SSmapping.levels_by_trait(ZTRAIT_STATION))
-	var/turf/startT = spaceDebrisStartLoc(startside, z)
 	var/turf/endT = get_edge_target_turf(get_random_station_turf(), turn(startside, 180))
+	var/turf/startT = spaceDebrisStartLoc(startside, endT.z)
 	var/atom/rod = new /obj/effect/immovablerod(startT, endT, C.special_target)
 	C.special_target = null //Cleanup for future event rolls.
 	announce_to_ghosts(rod)

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -34,6 +34,7 @@
 	var/damage_bonus = 0
 	var/turf/start_turf
 	notify = FALSE
+	dnd_style_level_up = FALSE
 
 /obj/effect/immovablerod/wizard/Move()
 	if(get_dist(start_turf, get_turf(src)) >= max_distance)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #51506 - Immovable rods no longer prob(25) deal different damage to things depending on how many things are on the the turf

Reworks the immovable rod code-wise. It's now fast. Hella fucking fast. And it does not afraid of anything.

The rod is now a flying, phasing, abstract entity that wrecks every /mob/living and dense object on every turf it enters, instantly.

https://cdn.discordapp.com/attachments/326831214667235328/808819408775938088/ROU4ouNhWL.gif

~~It cares not for your z-level transitions and will loop across z-levels at every available opportunity.~~

~~Similarly, it actually works properly on Icebox. It no longer stalls when it spawns on a lower z-level. It qdels itself when it reaches the edge of the map.~~

~~The rod will now just qdel itself instead of stalling when it spawns on one station z-level with a destination turf on a different station z-level. This can be seen on Icebox, but could happen on any multi-z station  with multiple station z-levels in the future.~~

The RNG event rod now always spawns on the same z-level as its target. Except when it doesn't. But it should.

Also targetted rods are very, very homing. They can now chase their targets across z-levels and will teleport through space and time to try and accomplish this task.

You think you can avoid this thing by lying down? Think again. Immovable rods are now grass cutters and will **penetrate** you whether you're standing, sitting, flying or lying, living or dead, sentient or otherwise.

https://cdn.discordapp.com/attachments/326831214667235328/808826058873897000/VPKuDCFxte.gif

Oh. Right. And when two rods collide? Singulo. Including wizard rods. Talk about a bit of FUUUU-SION-HA!

https://cdn.discordapp.com/attachments/326831214667235328/808826436764958730/IuipZCzJMR.gif

[New Addition!] - The rod also has a new bool. When TRUE, the rod will grow in size (visual only, doesn't increase its range or radius) and stature every time it hits a sentient, becoming an immovable rod of sentient slaying +x.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It probably isn't. I originally just wanted to make rods qdel themselves properly on Icebox. I did not stop. Send help.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The wizard's immovable rod form no longer deals variable damage depending on the number of objects on the turfs it's passing through. It instead deals full damage to everything it hits and hits everything on the turf at the same time.
balance: The wizard's immovable rod from can now impact with any other immovable rod to create a singularity. This probably kills the wizard. This definitely kills the rod.
balance: The wizard's immovable rod from can now hit mobs that are lying on the floor.
balance: The wizard's immovable rod form is now incorporeal and flying.
balance: The wizard's immovable rod form is now much, must faster - Especially when hitting multiple targets.
balance: The wizard's immovable rod form deals a LOT more damage to non-mobs that it passes through.
fix: The immovable rod no longer deals variable damage depending on the number of objects on the turfs it's passing through. It instead deals full damage to everything it hits and hits everything on the turf at the same time.
balance: The immovable rod can now impact with any other immovable rod to create a singularity. This definitely kills the rod.
balance: The immovable rod can now hit mobs that are lying on the floor.
balance: The immovable rod is now incorporeal and flying.
balance: The immovable rod is now much, must faster - Especially when hitting multiple targets.
balance: The immovable rod deals a LOT more damage to non-mobs that it passes through.
feature: The immovable rod can now traverse z-level to chase its targets down when used as both a targetted smite and as an option from the admin event menu.
feature: The immovable rod will subtly grow as it consumes the souls of sentients it hits.
fix: The immovable rod no longer stalls on Icebox and will now spawn on the same z-level as its destination.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
