### PR TITLE
Simplified Node Bootstrap mk. II

### DIFF
--- a/tools/bootstrap/node.bat
+++ b/tools/bootstrap/node.bat
@@ -1,1 +1,9 @@
-@call powershell.exe -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" %*
+@echo off
+where node.exe >nul 2>nul
+if errorlevel 0 (
+	echo | set /p printed_str="Using system-wide Node "
+	call node.exe --version
+	call node.exe %*
+) else (
+	call powershell.exe -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" %*
+)

--- a/tools/bootstrap/node.bat
+++ b/tools/bootstrap/node.bat
@@ -1,6 +1,6 @@
 @echo off
 where node.exe >nul 2>nul
-if errorlevel 0 (
+if %errorlevel% == 0 (
 	echo | set /p printed_str="Using system-wide Node "
 	call node.exe --version
 	call node.exe %*

--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -1,19 +1,19 @@
+## bootstrap/node_.ps1
+##
+## Node bootstrapping script for Windows.
+##
+## Automatically downloads a Node version to a cache directory and invokes it.
+##
+## The underscore in the name is so that typing `bootstrap/node` into
+## PowerShell finds the `.bat` file first, which ensures this script executes
+## regardless of ExecutionPolicy.
+
 #Requires -Version 4.0
 
-# bootstrap/node_.ps1
-#
-# Node bootstrapping script for Windows.
-#
-# Automatically downloads a Node version to a cache directory and invokes it.
-#
-# The underscore in the name is so that typing `bootstrap/node` into
-# PowerShell finds the `.bat` file first, which ensures this script executes
-# regardless of ExecutionPolicy.
-$host.ui.RawUI.WindowTitle = "starting :: node $args"
+$Host.ui.RawUI.WindowTitle = "starting :: node $Args"
 $ErrorActionPreference = "Stop"
-Add-Type -AssemblyName System.IO.Compression.FileSystem
 
-# This forces UTF-8 encoding across all powershell built-ins
+## This forces UTF-8 encoding across all powershell built-ins
 $OutputEncoding = [System.Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $PSDefaultParameterValues['*:Encoding'] = 'utf8'
 
@@ -27,47 +27,31 @@ function ExtractVersion {
 	throw "Couldn't find value for $Key in $Path"
 }
 
-# Convenience variables
-$Bootstrap = Split-Path $script:MyInvocation.MyCommand.Path
-$Cache = "$Bootstrap/.cache"
+## Convenience variables
+$BaseDir = Split-Path $script:MyInvocation.MyCommand.Path
+$Cache = "$BaseDir/.cache"
 if ($Env:TG_BOOTSTRAP_CACHE) {
 	$Cache = $Env:TG_BOOTSTRAP_CACHE
 }
-$NodeVersion = ExtractVersion -Path "$Bootstrap/../../dependencies.sh" -Key "NODE_VERSION_PRECISE"
-$NodeFullVersion = "node-v$NodeVersion-win-x64"
-$NodeDir = "$Cache/$NodeFullVersion"
+$NodeVersion = ExtractVersion -Path "$BaseDir/../../dependencies.sh" -Key "NODE_VERSION_PRECISE"
+$NodeDir = "$Cache/node-v$NodeVersion"
 $NodeExe = "$NodeDir/node.exe"
-$Log = "$Cache/last-command.log"
 
-# Download and unzip Node
+## Download and unzip Node
 if (!(Test-Path $NodeExe -PathType Leaf)) {
-	$host.ui.RawUI.WindowTitle = "Downloading Node $NodeVersion..."
-	New-Item $Cache -ItemType Directory -ErrorAction silentlyContinue | Out-Null
-
-	$Archive = "$Cache/node-v$NodeVersion.zip"
+	$Host.ui.RawUI.WindowTitle = "Downloading Node $NodeVersion..."
+	New-Item $NodeDir -ItemType Directory -ErrorAction silentlyContinue | Out-Null
 	Invoke-WebRequest `
-		"https://nodejs.org/download/release/v$NodeVersion/$NodeFullVersion.zip" `
-		-OutFile $Archive `
+		"https://nodejs.org/download/release/v$NodeVersion/win-x86/node.exe" `
+		-OutFile $NodeExe `
 		-ErrorAction Stop
-	$tmp = "$Cache/tmp"
-	if (Test-Path $tmp) {
-		Remove-Item $tmp -Recurse
-	}
-	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $tmp)
-	Move-Item $tmp/node-* $Cache
-	Remove-Item $tmp
-	Remove-Item $Archive
 }
 
-# Invoke Node with all command-line arguments
-Write-Output $NodeExe | Out-File -Encoding utf8 $Log
-[System.String]::Join([System.Environment]::NewLine, $args) | Out-File -Encoding utf8 -Append $Log
-Write-Output "---" | Out-File -Encoding utf8 -Append $Log
-$Env:PATH = "$NodeDir;$ENV:Path"  # Set PATH so that recursive calls find it
-$host.ui.RawUI.WindowTitle = "node $args"
+## Set PATH so that recursive calls find it
+$Env:PATH = "$NodeDir;$ENV:Path"
+
+## Invoke Node with all command-line arguments
+$Host.ui.RawUI.WindowTitle = "node $Args"
 $ErrorActionPreference = "Continue"
-& $NodeExe $args 2>&1 | ForEach-Object {
-	"$_" | Out-File -Encoding utf8 -Append $Log
-	"$_" | Out-Host
-}
+& "$NodeExe" @Args
 exit $LastExitCode

--- a/tools/build/cbt/task.js
+++ b/tools/build/cbt/task.js
@@ -69,7 +69,7 @@ class Task {
     if (!this.script) {
       return;
     }
-    console.warn(` => Starting '${this.name}': ${needsRebuild}`);
+    console.warn(` => Starting '${this.name}'`);
     const startedAt = Date.now();
     // Run the script
     await this.script();


### PR DESCRIPTION
## About This Pull Request

This attempt adds a tiny fix to the `%errorlevel%` check in the batch file.

Can't stop me now.

https://cdn.discordapp.com/attachments/326831214667235328/808832957912449041/output.webm

---

> Fixes #56676

- Script `tools/bootstrap/node_.ps1` will now only download a single `node.exe` file (32-bit variant) and nothing more.
- Since we don't need to unzip, we removed a dependency on a .NET component.
- Removed logging, because TGS4 already logs stdout/err, while all this fancy output redirection breaks on older PowerShell versions.
- `node.bat` uses a system-wide node exe if available
- CBT will not mislead users by printing things like "missing tgstation.dmb"
