### PR TITLE
Re-adds the admin button to let them exempt players from job exp requirements.

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -47,16 +47,6 @@
 			to_chat(usr, "<span class='danger'>ERROR: Mob not found.</span>", confidential = TRUE)
 			return
 		cmd_show_exp_panel(M.client)
-
-	else if(href_list["toggleexempt"])
-		if(!check_rights(R_ADMIN))
-			return
-		var/client/C = locate(href_list["toggleexempt"]) in GLOB.clients
-		if(!C)
-			to_chat(usr, "<span class='danger'>ERROR: Client not found.</span>", confidential = TRUE)
-			return
-		toggle_exempt_status(C)
-
 	else if(href_list["makeAntag"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/tgui/packages/tgui/interfaces/TrackedPlaytime.js
+++ b/tgui/packages/tgui/interfaces/TrackedPlaytime.js
@@ -1,6 +1,6 @@
 import { sortBy } from "common/collections";
 import { useBackend } from "../backend";
-import { Box, Flex, ProgressBar, Section, Table } from "../components";
+import { Box, Flex, ProgressBar, Section, Table, Button } from "../components";
 import { Window } from "../layouts";
 
 const JOB_REPORT_MENU_FAIL_REASON_TRACKING_DISABLED = 1;
@@ -46,11 +46,13 @@ const PlaytimeSection = props => {
 };
 
 export const TrackedPlaytime = (props, context) => {
-  const { data } = useBackend(context);
+  const { act, data } = useBackend(context);
   const {
     failReason,
     jobPlaytimes,
     specialPlaytimes,
+    exemptStatus,
+    isAdmin,
     livingTime,
     ghostTime,
   } = data;
@@ -75,8 +77,18 @@ export const TrackedPlaytime = (props, context) => {
                 }}
               />
             </Section>
-            <Section title="Jobs">
-              <PlaytimeSection playtimes={jobPlaytimes} />
+            <Section
+              title="Jobs"
+              buttons={!!isAdmin && (
+                <Button.Checkbox
+                  checked={!!exemptStatus}
+                  onClick={() => act("toggle_exempt")}>
+                  Job Playtime Exempt
+                </Button.Checkbox>
+              )}>
+              <PlaytimeSection
+                playtimes={jobPlaytimes}
+              />
             </Section>
             <Section title="Special">
               <PlaytimeSection playtimes={specialPlaytimes} />

--- a/tgui/packages/tgui/interfaces/TrackedPlaytime.js
+++ b/tgui/packages/tgui/interfaces/TrackedPlaytime.js
@@ -1,6 +1,6 @@
 import { sortBy } from "common/collections";
 import { useBackend } from "../backend";
-import { Box, Flex, ProgressBar, Section, Table, Button } from "../components";
+import { Box, Button, Flex, ProgressBar, Section, Table } from "../components";
 import { Window } from "../layouts";
 
 const JOB_REPORT_MENU_FAIL_REASON_TRACKING_DISABLED = 1;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![xbMre1uukl](https://user-images.githubusercontent.com/24975989/107446571-a7a5d080-6b36-11eb-8cfb-e97908ffa9b9.gif)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Re-added the button to the player playtime panel that lets admins toggle a player's job playtime exemption status.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
