### PR TITLE
fixes 2 runtimes caused by holding people up with a gun

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -109,13 +109,13 @@
 
 #define STATUS_EFFECT_BOUNTY /datum/status_effect/bounty //rewards the person who added this to the target with refreshed spells and a fair heal
 
-#define STATUS_EFFECT_HELDUP /datum/status_effect/heldup // someone is currently pointing a gun at you
+#define STATUS_EFFECT_HELDUP /datum/status_effect/grouped/heldup // someone is currently pointing a gun at you
 
 #define STATUS_EFFECT_HOLDUP /datum/status_effect/holdup // you are currently pointing a gun at someone
 
 #define STATUS_EFFECT_HIGHFIVE /datum/status_effect/high_fiving // you are angling for a high five
 
-#define STATUS_EFFECT_SURRENDER /datum/status_effect/surrender // gives an alert to quickly surrender
+#define STATUS_EFFECT_SURRENDER /datum/status_effect/grouped/surrender // gives an alert to quickly surrender
 /////////////
 //  SLIME  //
 /////////////

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -21,7 +21,7 @@
 	if(alerts[category])
 		thealert = alerts[category]
 		if(thealert.override_alerts)
-			return 0
+			return thealert
 		if(new_master && new_master != thealert.master)
 			WARNING("[src] threw alert [category] with new_master [new_master] while already having that alert with master [thealert.master]")
 
@@ -35,7 +35,7 @@
 				clear_alert(category)
 				return .()
 			else //no need to update
-				return 0
+				return thealert
 	else
 		thealert = new type()
 		thealert.override_alerts = override

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -111,7 +111,7 @@
 		rewarded.adjustCloneLoss(-25)
 
 // heldup is for the person being aimed at
-/datum/status_effect/heldup
+/datum/status_effect/grouped/heldup
 	id = "heldup"
 	duration = -1
 	tick_interval = -1
@@ -123,11 +123,11 @@
 	desc = "Making any sudden moves would probably be a bad idea!"
 	icon_state = "aimed"
 
-/datum/status_effect/heldup/on_apply()
+/datum/status_effect/grouped/heldup/on_apply()
 	owner.apply_status_effect(STATUS_EFFECT_SURRENDER)
 	return ..()
 
-/datum/status_effect/heldup/on_remove()
+/datum/status_effect/grouped/heldup/on_remove()
 	owner.remove_status_effect(STATUS_EFFECT_SURRENDER)
 	return ..()
 
@@ -302,7 +302,7 @@
 	slap_item = null
 
 //this effect gives the user an alert they can use to surrender quickly
-/datum/status_effect/surrender
+/datum/status_effect/grouped/surrender
 	id = "surrender"
 	duration = -1
 	tick_interval = -1

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -197,6 +197,9 @@
 	if (user.GetComponent(/datum/component/gunpoint))
 		to_chat(user, "<span class='warning'>You are already holding someone up!</span>")
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	if (user == victim)
+		to_chat(user,"<span class='warning'>You can't hold yourself up!</span>")
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	user.AddComponent(/datum/component/gunpoint, victim, src)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes two runtimes, one caused by status effects always expecting a return from throw_alert, and another caused by holding yourself up (which you shouldn't even be able to do). Also fixes an issue caused by multiple people holding up the same person, when one of the perpetrators stopped holding up the victim, all of the victim's related alerts disappeared. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtimes are not good. Fixes #56709 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can no longer hold yourself up with a gun
fix: Holding someone up with a gun will no longer cause a runtime when two people hold up the same person.
fix: Having multiple people hold up the same person will no longer cause the victim's alerts to disappear when just one of the perpetrators stops holding them up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
