### PR TITLE
Generalize splashing reagent containers code, put it on right click

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -123,25 +123,3 @@
 			return
 	else
 		..()
-
-/obj/item/reagent_containers/food/drinks/drinkingglass/attack(obj/target, mob/living/user)
-	if(user.combat_mode && ismob(target) && target.reagents && reagents.total_volume)
-		target.visible_message("<span class='danger'>[user] splashes the contents of [src] onto [target]!</span>", \
-						"<span class='userdanger'>[user] splashes the contents of [src] onto you!</span>")
-		log_combat(user, target, "splashed", src)
-		reagents.expose(target, TOUCH)
-		reagents.clear_reagents()
-		return
-	..()
-
-/obj/item/reagent_containers/food/drinks/drinkingglass/afterattack(obj/target, mob/living/user, proximity)
-	. = ..()
-	if((!proximity) || !check_allowed_items(target,target_self=1))
-		return
-
-	else if(reagents.total_volume && user.combat_mode)
-		user.visible_message("<span class='danger'>[user] splashes the contents of [src] onto [target]!</span>", \
-							"<span class='notice'>You splash the contents of [src] onto [target].</span>")
-		reagents.expose(target, TOUCH)
-		reagents.clear_reagents()
-		return

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -57,13 +57,6 @@
 				to_chat(user, "<span class='notice'>[src]'s transfer amount is now [amount_per_transfer_from_this] units.</span>")
 				return
 
-/obj/item/reagent_containers/pre_attack(atom/A, mob/living/user, params)
-	. = ..()
-
-	var/list/modifiers = params2list(params)
-	if (modifiers["right"] && try_splash(user, A))
-		return TRUE
-
 /obj/item/reagent_containers/pre_attack_secondary(atom/target, mob/living/user, params)
 	if (try_splash(user, target))
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -89,7 +89,7 @@
 		"<span class='danger'>You splash the contents of [src] onto [target][punctuation]</span>",
 		ignored_mobs = target,
 	)
-//
+
 	if (ismob(target))
 		var/mob/target_mob = target
 		target_mob.show_message(

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -88,7 +88,7 @@
 			"<span class='userdanger'>You feel drenched!</span>",
 		)
 
-	for(var/datum/reagent/reagent in reagents.reagent_list)
+	for(var/datum/reagent/reagent as anything in reagents.reagent_list)
 		reagent_text += "[reagent] ([num2text(reagent.volume)]),"
 
 	if(isturf(target) && reagents.reagent_list.len && thrownby)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -61,6 +61,56 @@
 	if(user.combat_mode)
 		return ..()
 
+/obj/item/reagent_containers/pre_attack(atom/A, mob/living/user, params)
+	. = ..()
+
+	if (user.combat_mode && try_splash(user, A))
+		return TRUE
+
+/obj/item/reagent_containers/pre_attack_secondary(atom/target, mob/living/user, params)
+	if (try_splash(user, target))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	return ..()
+
+/// Tries to splash the target. Used on both right-click and normal click when in combat mode.
+/obj/item/reagent_containers/proc/try_splash(mob/user, atom/target)
+	if (!spillable)
+		return FALSE
+
+	if (!reagents?.total_volume)
+		return FALSE
+
+	var/punctuation = ismob(target) ? "!" : "."
+
+	var/reagent_text
+	user.visible_message(
+		"<span class='danger'>[user] splashes the contents of [src] onto [target][punctuation]</span>",
+		"<span class='danger'>You splash the contents of [src] onto [target][punctuation]</span>",
+		ignored_mobs = target,
+	)
+//
+	if (ismob(target))
+		var/mob/target_mob = target
+		target_mob.show_message(
+			"<span class='userdanger'>[user] splash the contents of [src] onto you!</span>",
+			MSG_VISUAL,
+			"<span class='userdanger'>You feel drenched!</span>",
+		)
+
+	for(var/datum/reagent/reagent in reagents.reagent_list)
+		reagent_text += "[reagent] ([num2text(reagent.volume)]),"
+
+	if(isturf(target) && reagents.reagent_list.len && thrownby)
+		log_combat(thrownby, target, "splashed (thrown) [english_list(reagents.reagent_list)]")
+		message_admins("[ADMIN_LOOKUPFLW(thrownby)] splashed (thrown) [english_list(reagents.reagent_list)] on [target] at [ADMIN_VERBOSEJMP(target)].")
+
+	reagents.expose(target, TOUCH)
+	log_combat(user, target, "splashed", reagent_text)
+	reagents.clear_reagents()
+
+	return TRUE
+
 /obj/item/reagent_containers/proc/canconsume(mob/eater, mob/user)
 	if(!iscarbon(eater))
 		return FALSE

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -57,14 +57,11 @@
 				to_chat(user, "<span class='notice'>[src]'s transfer amount is now [amount_per_transfer_from_this] units.</span>")
 				return
 
-/obj/item/reagent_containers/attack(mob/M, mob/living/user, def_zone)
-	if(user.combat_mode)
-		return ..()
-
 /obj/item/reagent_containers/pre_attack(atom/A, mob/living/user, params)
 	. = ..()
 
-	if (user.combat_mode && try_splash(user, A))
+	var/list/modifiers = params2list(params)
+	if (modifiers["right"] && try_splash(user, A))
 		return TRUE
 
 /obj/item/reagent_containers/pre_attack_secondary(atom/target, mob/living/user, params)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -21,47 +21,32 @@
 		return
 
 	if(istype(M))
-		if(user.combat_mode)
-			var/R
-			M.visible_message("<span class='danger'>[user] splashes the contents of [src] onto [M]!</span>", \
-							"<span class='userdanger'>[user] splashes the contents of [src] onto you!</span>")
-			if(reagents)
-				for(var/datum/reagent/A in reagents.reagent_list)
-					R += "[A] ([num2text(A.volume)]),"
-
-			if(isturf(target) && reagents.reagent_list.len && thrownby)
-				log_combat(thrownby, target, "splashed (thrown) [english_list(reagents.reagent_list)]")
-				message_admins("[ADMIN_LOOKUPFLW(thrownby)] splashed (thrown) [english_list(reagents.reagent_list)] on [target] at [ADMIN_VERBOSEJMP(target)].")
-			reagents.expose(M, TOUCH)
-			log_combat(user, M, "splashed", R)
-			reagents.clear_reagents()
+		if(M != user)
+			M.visible_message("<span class='danger'>[user] attempts to feed [M] something from [src].</span>", \
+						"<span class='userdanger'>[user] attempts to feed you something from [src].</span>")
+			if(!do_mob(user, M))
+				return
+			if(!reagents || !reagents.total_volume)
+				return // The drink might be empty after the delay, such as by spam-feeding
+			M.visible_message("<span class='danger'>[user] feeds [M] something from [src].</span>", \
+						"<span class='userdanger'>[user] feeds you something from [src].</span>")
+			log_combat(user, M, "fed", reagents.log_list())
 		else
-			if(M != user)
-				M.visible_message("<span class='danger'>[user] attempts to feed [M] something from [src].</span>", \
-							"<span class='userdanger'>[user] attempts to feed you something from [src].</span>")
-				if(!do_mob(user, M))
-					return
-				if(!reagents || !reagents.total_volume)
-					return // The drink might be empty after the delay, such as by spam-feeding
-				M.visible_message("<span class='danger'>[user] feeds [M] something from [src].</span>", \
-							"<span class='userdanger'>[user] feeds you something from [src].</span>")
-				log_combat(user, M, "fed", reagents.log_list())
-			else
-				to_chat(user, "<span class='notice'>You swallow a gulp of [src].</span>")
-			SEND_SIGNAL(src, COMSIG_GLASS_DRANK, M, user)
-			addtimer(CALLBACK(reagents, /datum/reagents.proc/trans_to, M, 5, TRUE, TRUE, FALSE, user, FALSE, INGEST), 5)
-			playsound(M.loc,'sound/items/drink.ogg', rand(10,50), TRUE)
-			if(iscarbon(M))
-				var/mob/living/carbon/carbon_drinker = M
-				var/list/diseases = carbon_drinker.get_static_viruses()
-				if(LAZYLEN(diseases))
-					var/list/datum/disease/diseases_to_add = list()
-					for(var/d in diseases)
-						var/datum/disease/malady = d
-						if(malady.spread_flags & DISEASE_SPREAD_CONTACT_FLUIDS)
-							diseases_to_add += malady
-					if(LAZYLEN(diseases_to_add))
-						AddComponent(/datum/component/infective, diseases_to_add)
+			to_chat(user, "<span class='notice'>You swallow a gulp of [src].</span>")
+		SEND_SIGNAL(src, COMSIG_GLASS_DRANK, M, user)
+		addtimer(CALLBACK(reagents, /datum/reagents.proc/trans_to, M, 5, TRUE, TRUE, FALSE, user, FALSE, INGEST), 5)
+		playsound(M.loc,'sound/items/drink.ogg', rand(10,50), TRUE)
+		if(iscarbon(M))
+			var/mob/living/carbon/carbon_drinker = M
+			var/list/diseases = carbon_drinker.get_static_viruses()
+			if(LAZYLEN(diseases))
+				var/list/datum/disease/diseases_to_add = list()
+				for(var/d in diseases)
+					var/datum/disease/malady = d
+					if(malady.spread_flags & DISEASE_SPREAD_CONTACT_FLUIDS)
+						diseases_to_add += malady
+				if(LAZYLEN(diseases_to_add))
+					AddComponent(/datum/component/infective, diseases_to_add)
 
 /obj/item/reagent_containers/glass/afterattack(obj/target, mob/living/user, proximity)
 	. = ..()
@@ -94,13 +79,6 @@
 
 		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, transfered_by = user)
 		to_chat(user, "<span class='notice'>You fill [src] with [trans] unit\s of the contents of [target].</span>")
-
-	else if(reagents.total_volume)
-		if(user.combat_mode)
-			user.visible_message("<span class='danger'>[user] splashes the contents of [src] onto [target]!</span>", \
-								"<span class='notice'>You splash the contents of [src] onto [target].</span>")
-			reagents.expose(target, TOUCH)
-			reagents.clear_reagents()
 
 /obj/item/reagent_containers/glass/attackby(obj/item/I, mob/user, params)
 	var/hotness = I.get_temperature()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You used to only be able to splash glass reagent containers and glass...glasses. This code was previously duplicated, but is now a general property of reagent containers with spillable = TRUE (which includes both of these).

Splashing beakers is now also on right click, ~~alongside combat mode left click~~.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less combat mode switching, less copy and pasting.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now right click to splash reagent containers, instead of switching to combat mode.
add: Splashing reagent containers is now a part of any reagent container you can spill, rather than just beakers and drinking glasses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
