### PR TITLE
You can print multiple sheets of sticky tape. A redo of #55994, because #56017 didn't fix this.

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1168,6 +1168,7 @@
 	materials = list(/datum/material/plastic = 500)
 	build_path = /obj/item/stack/sticky_tape
 	category = list("initial", "Misc")
+	maxstack = 5
 
 /datum/design/sticky_tape/surgical
 	name = "Surgical Tape"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the autolathe maxstack 5. This lets you print more than a single sheet of tape at once even if you have more than one sheet.

I tested this.

Currently you can only ever print one sheet.

Fixes https://github.com/tgstation/tgstation/issues/55882

## Why It's Good For The Game

I just want to print off my sticky tape, PLEASE.

## Changelog
:cl:
fix: You can print more than a single sheet of tape at a time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
