### PR TITLE
No More Calling get_equipped_items() in mob/living/Crossed(), Makes Slippery Component Work Without it

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -603,8 +603,6 @@
 	#define COMPONENT_BLOCK_MARK_RETRIEVAL (1<<0)
 ///from base of obj/item/hit_reaction(): (list/args)
 #define COMSIG_ITEM_HIT_REACT "item_hit_react"
-///called on item when crossed by something (): (/atom/movable, mob/living/crossed)
-#define COMSIG_ITEM_WEARERCROSSED "wearer_crossed"
 ///called on item when microwaved (): (obj/machinery/microwave/M)
 #define COMSIG_ITEM_MICROWAVE_ACT "microwave_act"
 	#define COMPONENT_SUCCESFUL_MICROWAVE (1<<0)

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -4,6 +4,7 @@
 	var/paralyze_time = 0
 	var/lube_flags
 	var/datum/callback/callback
+	var/mob/living/holder
 
 /datum/component/slippery/Initialize(_knockdown, _lube_flags = NONE, datum/callback/_callback, _paralyze, _force_drop = FALSE)
 	knockdown_time = max(_knockdown, 0)
@@ -11,8 +12,13 @@
 	force_drop_items = _force_drop
 	lube_flags = _lube_flags
 	callback = _callback
-	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/Slip)
-	RegisterSignal(parent, COMSIG_ITEM_WEARERCROSSED, .proc/Slip_on_wearer)
+	RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/Slip)
+	if(isitem(parent))
+		holder = parent
+		RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
+		RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/on_drop)
+	else
+		RegisterSignal(parent, COMSIG_ATOM_ENTERED, .proc/Slip)
 
 /datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
 	SIGNAL_HANDLER
@@ -21,21 +27,33 @@
 	if(istype(victim) && !(victim.movement_type & FLYING) && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
 		callback.Invoke(victim)
 
-
-/datum/component/slippery/proc/Slip_on_wearer(datum/source, atom/movable/AM, mob/living/crossed)
+///gets called when COMSIG_ITEM_EQUIPPED is sent to parent
+/datum/component/slippery/proc/on_equip(datum/source, mob/equipper, slot)
 	SIGNAL_HANDLER
 
-	if(crossed.body_position == LYING_DOWN && !crossed.buckled)
-		Slip(source, AM)
+	if((slot in list(ITEM_SLOT_ID, ITEM_SLOT_BELT)) && isliving(equipper))
+		holder = equipper
+		RegisterSignal(equipper, COMSIG_MOVABLE_CROSSED, .proc/Slip_on_wearer, TRUE)
 
+///gets called when COMSIG_ITEM_DROPPED is sent to parent
+/datum/component/slippery/proc/on_drop(datum/source, mob/user)
+	SIGNAL_HANDLER
+
+	holder = null
+	UnregisterSignal(user, COMSIG_MOVABLE_CROSSED)
+
+/datum/component/slippery/proc/Slip_on_wearer(datum/source, atom/movable/AM)
+	SIGNAL_HANDLER
+
+	if(holder.body_position == LYING_DOWN && !holder.buckled)
+		Slip(source, AM)
 
 /datum/component/slippery/clowning //used for making the clown PDA only slip if the clown is wearing his shoes and the elusive banana-skin belt
 
-
-/datum/component/slippery/clowning/Slip_on_wearer(datum/source, atom/movable/AM, mob/living/crossed)
-	var/obj/item/I = crossed.get_item_by_slot(ITEM_SLOT_FEET)
-	if(crossed.body_position == LYING_DOWN && !crossed.buckled)
+/datum/component/slippery/clowning/Slip_on_wearer(datum/source, atom/movable/AM)
+	var/obj/item/I = holder.get_item_by_slot(ITEM_SLOT_FEET)
+	if(holder.body_position == LYING_DOWN && !holder.buckled)
 		if(istype(I, /obj/item/clothing/shoes/clown_shoes))
 			Slip(source, AM)
 		else
-			to_chat(crossed,"<span class='warning'>[parent] failed to slip anyone. Perhaps I shouldn't have abandoned my legacy...</span>")
+			to_chat(holder,"<span class='warning'>[parent] failed to slip anyone. Perhaps I shouldn't have abandoned my legacy...</span>")

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -33,7 +33,14 @@
 
 	if((slot in list(ITEM_SLOT_ID, ITEM_SLOT_BELT)) && isliving(equipper))
 		holder = equipper
-		RegisterSignal(equipper, COMSIG_MOVABLE_CROSSED, .proc/Slip_on_wearer, TRUE)
+		RegisterSignal(holder, COMSIG_MOVABLE_CROSSED, .proc/Slip_on_wearer)
+		RegisterSignal(holder, COMSIG_PARENT_PREQDELETED, .proc/holder_deleted)
+
+/datum/component/slippery/proc/holder_deleted(datum/source, datum/possible_holder)
+	SIGNAL_HANDLER
+
+	if(possible_holder == holder)
+		holder = null
 
 ///gets called when COMSIG_ITEM_DROPPED is sent to parent
 /datum/component/slippery/proc/on_drop(datum/source, mob/user)

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -1,6 +1,7 @@
 /datum/component/squeak
 	var/static/list/default_squeak_sounds = list('sound/items/toysqueak1.ogg'=1, 'sound/items/toysqueak2.ogg'=1, 'sound/items/toysqueak3.ogg'=1)
 	var/list/override_squeak_sounds
+	var/mob/holder
 
 	var/squeak_chance = 100
 	var/volume = 30
@@ -27,7 +28,6 @@
 	if(ismovable(parent))
 		RegisterSignal(parent, list(COMSIG_MOVABLE_BUMP, COMSIG_MOVABLE_IMPACT, COMSIG_PROJECTILE_BEFORE_FIRE), .proc/play_squeak)
 		RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/play_squeak_crossed)
-		RegisterSignal(parent, COMSIG_ITEM_WEARERCROSSED, .proc/play_squeak_crossed)
 		RegisterSignal(parent, COMSIG_MOVABLE_DISPOSING, .proc/disposing_react)
 		if(isitem(parent))
 			RegisterSignal(parent, list(COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_HIT_REACT), .proc/play_squeak)
@@ -100,12 +100,23 @@
 /datum/component/squeak/proc/on_equip(datum/source, mob/equipper, slot)
 	SIGNAL_HANDLER
 
-	RegisterSignal(equipper, COMSIG_MOVABLE_DISPOSING, .proc/disposing_react, TRUE)
+	holder = equipper
+	RegisterSignal(holder, COMSIG_MOVABLE_CROSSED, .proc/play_squeak_crossed)
+	RegisterSignal(holder, COMSIG_MOVABLE_DISPOSING, .proc/disposing_react, TRUE)
+	RegisterSignal(holder, COMSIG_PARENT_PREQDELETED, .proc/holder_deleted)
 
 /datum/component/squeak/proc/on_drop(datum/source, mob/user)
 	SIGNAL_HANDLER
 
-	UnregisterSignal(user, COMSIG_MOVABLE_DISPOSING)
+	UnregisterSignal(holder, COMSIG_MOVABLE_CROSSED)
+	UnregisterSignal(holder, COMSIG_MOVABLE_DISPOSING)
+	holder = null
+
+///just gets rid of the reference to holder in the case that theyre qdeleted
+/datum/component/squeak/proc/holder_deleted(datum/source, datum/possible_holder)
+	SIGNAL_HANDLER
+	if(possible_holder == holder)
+		holder = null
 
 // Disposal pipes related shit
 /datum/component/squeak/proc/disposing_react(datum/source, obj/structure/disposalholder/holder, obj/machinery/disposal/source)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -693,11 +693,6 @@
 	SetUnconscious(0)
 
 
-/mob/living/Crossed(atom/movable/AM)
-	. = ..()
-	for(var/i in get_equipped_items())
-		var/obj/item/item = i
-		SEND_SIGNAL(item, COMSIG_ITEM_WEARERCROSSED, AM, src)
 
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
turns out every time a mob/living is crossed it checks the entire inventory of src for use in the slippery component. this is poop so i redid slippery component to not be built on poop and then got rid of the poop. idk if this counts as a performance thing but its one of the procs making tramstation more expensive and it doesnt need to exist anyways
edit: squeaky component is fixed too, COMSIG_ITEM_WEARERCROSSED is unused now so i deleted it
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
maaybe help tramstation and cuts down on unneeded cost
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: slight performance improvement to clown pdas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
