### PR TITLE
Tweak cargo filth to include package scraps

### DIFF
--- a/code/game/turfs/open/dirtystation.dm
+++ b/code/game/turfs/open/dirtystation.dm
@@ -69,11 +69,14 @@
 				new /obj/effect/decal/cleanable/blood/old(src)
 		return
 
-		//Hangars and pods covered in oil.
+	// Cargo bays covered in oil.
 	var/static/list/oily_areas = typecacheof(/area/cargo)
 	if(is_type_in_typecache(A, oily_areas))
 		if(prob(25))
 			new /obj/effect/decal/cleanable/oil(src)
+		else if(prob(20))
+			// or occasionally the signs of opened packages
+			new /obj/effect/decal/cleanable/wrapping(src)
 		return
 
 


### PR DESCRIPTION
:cl: coiax
tweak: Shift start messes in cargo can now include package scraps, the
same sort of stuff you get when opening packages.
/:cl:

The most I've seen package scraps is accidentally wrapping items in
cargo, and then undoing my mistake. Give a tiny bit more variety to just
lots of oil puddles.

---

![image](https://user-images.githubusercontent.com/609465/107563574-281d0d80-6bd9-11eb-87a5-68f0a2f7180e.png)

An example metastation cargo with this change.