### PR TITLE
right clicking on a ranged attack now calls afterattack when it's supposed to

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -152,7 +152,10 @@
 	else
 		if(W)
 			if(modifiers["right"])
-				W.afterattack_secondary(A,src,0,params)
+				var/after_attack_secondary_result = W.afterattack_secondary(A, src, 0, params)
+
+				if(after_attack_secondary_result == SECONDARY_ATTACK_CALL_NORMAL)
+					W.afterattack(A,src,0,params)
 			else
 				W.afterattack(A,src,0,params)
 		else

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -152,10 +152,10 @@
 	else
 		if(W)
 			if(modifiers["right"])
-				var/after_attack_secondary_result = W.afterattack_secondary(A, src, 0, params)
+				var/after_attack_secondary_result = W.afterattack_secondary(A, src, FALSE, params)
 
 				if(after_attack_secondary_result == SECONDARY_ATTACK_CALL_NORMAL)
-					W.afterattack(A,src,0,params)
+					W.afterattack(A, src, FALSE, params)
 			else
 				W.afterattack(A,src,0,params)
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes right-click ranged attacks run afterattack, if afterattack_secondary returns SECONDARY_ATTACK_CALL_NORMAL, as it's supposed to.

Fixes #56795.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It fixes  #56810,  an oversight I made.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Right clicks on a ranged attack will now call afterattack when it's supposed to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
