### PR TITLE
Rebalances bz, makes it less of a self antag tool

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -21,6 +21,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/medicine/salbutamol = 5)
 
 	//Breath damage
+	//These numbers are roughly equivilant to molar count at room temperature, they scale up and down with temp tho
 
 	var/safe_oxygen_min = 16 // Minimum safe partial pressure of O2, in kPa
 	var/safe_oxygen_max = 0
@@ -34,6 +35,7 @@
 	var/SA_para_min = 1 //Sleeping agent
 	var/SA_sleep_min = 5 //Sleeping agent
 	var/BZ_trip_balls_min = 1 //BZ gas
+	var/BZ_brain_damage_min = 10 //Give people some room to play around without killing the station
 	var/gas_stimulation_min = 0.002 //Nitryl, Stimulum and Freon
 	///Minimum amount of healium to make you unconscious for 4 seconds
 	var/healium_para_min = 3
@@ -286,13 +288,8 @@
 		if(bz_pp > BZ_trip_balls_min)
 			H.hallucination += 10
 			H.reagents.add_reagent(/datum/reagent/bz_metabolites,5)
-			if(prob(33))
-				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3, 150)
-
-		else if(bz_pp > 0.01)
-			H.hallucination += 5
-			H.reagents.add_reagent(/datum/reagent/bz_metabolites,1)
-
+		if(bz_pp > BZ_brain_damage_min && prob(33))
+			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3, 150)
 
 	// Tritium
 		var/trit_pp = breath.get_breath_partial_pressure(breath_gases[/datum/gas/tritium][MOLES])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes hyper low amounts of bz not cause hallucinations
Makes the brain damage portion of bz breathing only take effect at higher pressures, roughly 10 mols at room temp on a turf

## Why It's Good For The Game

This is effectively always going to proc if bz has been in a space, and bz will enter the atmosphere very easily. Why god, why.
I'd like all our gasses to be at least occasionally used for things, and having one that's pretty much very slight self antag + fuck lings the gas is stupid.

## Changelog
:cl:
del: BZ will no longer cause hallucinations or kill changelings at hyper low percentages of the gasmix, put some effort into your ling murder why don't you.
tweak: BZ now only causes brain damage when it's greater then 10 kpa of the mix, its hallucinations and effects on lings are still locked to 1 kpa or above. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
