### PR TITLE
Doomsday now cancels if the AI shunts mid-activation

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -184,12 +184,12 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	var/pass = prob(10) ? "******" : "hunter2"
 	to_chat(owner, "<span class='small boldannounce'>run -o -a 'selfdestruct'</span>")
 	sleep(5)
-	if(!owner || QDELETED(owner) || owner_AI.shunted)
+	if(QDELETED(owner) || owner_AI.shunted)
 		active = FALSE
 		return
 	to_chat(owner, "<span class='small boldannounce'>Running executable 'selfdestruct'...</span>")
 	sleep(rand(10, 30))
-	if(!owner || QDELETED(owner) || owner_AI.shunted)
+	if(QDELETED(owner) || owner_AI.shunted)
 		active = FALSE
 		return
 	owner.playsound_local(owner, 'sound/misc/bloblarm.ogg', 50, 0, use_reverb = FALSE)
@@ -197,63 +197,63 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	to_chat(owner, "<span class='boldannounce'>This is a class-3 security violation. This incident will be reported to Central Command.</span>")
 	for(var/i in 1 to 3)
 		sleep(20)
-		if(!owner || QDELETED(owner) || owner_AI.shunted)
+		if(QDELETED(owner) || owner_AI.shunted)
 			active = FALSE
 			return
 		to_chat(owner, "<span class='boldannounce'>Sending security report to Central Command.....[rand(0, 9) + (rand(20, 30) * i)]%</span>")
 	sleep(3)
-	if(!owner || QDELETED(owner) || owner_AI.shunted)
+	if(QDELETED(owner) || owner_AI.shunted)
 		active = FALSE
 		return
 	to_chat(owner, "<span class='small boldannounce'>auth 'akjv9c88asdf12nb' [pass]</span>")
 	owner.playsound_local(owner, 'sound/items/timer.ogg', 50, 0, use_reverb = FALSE)
 	sleep(30)
-	if(!owner || QDELETED(owner) || owner_AI.shunted)
+	if(QDELETED(owner) || owner_AI.shunted)
 		active = FALSE
 		return
 	to_chat(owner, "<span class='boldnotice'>Credentials accepted. Welcome, akjv9c88asdf12nb.</span>")
 	owner.playsound_local(owner, 'sound/misc/server-ready.ogg', 50, 0, use_reverb = FALSE)
 	sleep(5)
-	if(!owner || QDELETED(owner) || owner_AI.shunted)
+	if(QDELETED(owner) || owner_AI.shunted)
 		active = FALSE
 		return
 	to_chat(owner, "<span class='boldnotice'>Arm self-destruct device? (Y/N)</span>")
 	owner.playsound_local(owner, 'sound/misc/compiler-stage1.ogg', 50, 0, use_reverb = FALSE)
 	sleep(20)
-	if(!owner || QDELETED(owner) || owner_AI.shunted)
+	if(QDELETED(owner) || owner_AI.shunted)
 		active = FALSE
 		return
 	to_chat(owner, "<span class='small boldannounce'>Y</span>")
 	sleep(15)
-	if(!owner || QDELETED(owner) || owner_AI.shunted)
+	if(QDELETED(owner) || owner_AI.shunted)
 		active = FALSE
 		return
 	to_chat(owner, "<span class='boldnotice'>Confirm arming of self-destruct device? (Y/N)</span>")
 	owner.playsound_local(owner, 'sound/misc/compiler-stage2.ogg', 50, 0, use_reverb = FALSE)
 	sleep(10)
-	if(!owner || QDELETED(owner) || owner_AI.shunted)
+	if(QDELETED(owner) || owner_AI.shunted)
 		active = FALSE
 		return
 	to_chat(owner, "<span class='small boldannounce'>Y</span>")
 	sleep(rand(15, 25))
-	if(!owner || QDELETED(owner) || owner_AI.shunted)
+	if(QDELETED(owner) || owner_AI.shunted)
 		active = FALSE
 		return
 	to_chat(owner, "<span class='boldnotice'>Please repeat password to confirm.</span>")
 	owner.playsound_local(owner, 'sound/misc/compiler-stage2.ogg', 50, 0, use_reverb = FALSE)
 	sleep(14)
-	if(!owner || QDELETED(owner) || owner_AI.shunted)
+	if(QDELETED(owner) || owner_AI.shunted)
 		active = FALSE
 		return
 	to_chat(owner, "<span class='small boldannounce'>[pass]</span>")
 	sleep(40)
-	if(!owner || QDELETED(owner) || owner_AI.shunted)
+	if(QDELETED(owner) || owner_AI.shunted)
 		active = FALSE
 		return
 	to_chat(owner, "<span class='boldnotice'>Credentials accepted. Transmitting arming signal...</span>")
 	owner.playsound_local(owner, 'sound/misc/server-ready.ogg', 50, 0, use_reverb = FALSE)
 	sleep(30)
-	if(!owner || QDELETED(owner) || owner_AI.shunted)
+	if(QDELETED(owner) || owner_AI.shunted)
 		active = FALSE
 		return
 	if (owner_AI.stat != DEAD)

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -176,71 +176,85 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	if (owner_AI.shunted)
 		return //prevent AI from activating doomsday while shunted, fucking abusers
 	active = TRUE
-	set_us_up_the_bomb(owner)
+	set_up_us_the_bomb(owner)
 
-/datum/action/innate/ai/nuke_station/proc/set_us_up_the_bomb(mob/living/owner)
-	var/pass = prob(10) ? "******" : "hunter2"
+/datum/action/innate/ai/nuke_station/proc/set_up_us_the_bomb(mob/living/owner)
 	set waitfor = FALSE
+	message_admins("[key_name_admin(owner)][ADMIN_FLW(owner)] has activated AI Doomsday.")
+	var/pass = prob(10) ? "******" : "hunter2"
 	to_chat(owner, "<span class='small boldannounce'>run -o -a 'selfdestruct'</span>")
 	sleep(5)
-	if(!owner || QDELETED(owner))
+	if(!owner || QDELETED(owner) || owner_AI.shunted)
+		active = FALSE
 		return
 	to_chat(owner, "<span class='small boldannounce'>Running executable 'selfdestruct'...</span>")
 	sleep(rand(10, 30))
-	if(!owner || QDELETED(owner))
+	if(!owner || QDELETED(owner) || owner_AI.shunted)
+		active = FALSE
 		return
 	owner.playsound_local(owner, 'sound/misc/bloblarm.ogg', 50, 0, use_reverb = FALSE)
 	to_chat(owner, "<span class='userdanger'>!!! UNAUTHORIZED SELF-DESTRUCT ACCESS !!!</span>")
 	to_chat(owner, "<span class='boldannounce'>This is a class-3 security violation. This incident will be reported to Central Command.</span>")
 	for(var/i in 1 to 3)
 		sleep(20)
-		if(!owner || QDELETED(owner))
+		if(!owner || QDELETED(owner) || owner_AI.shunted)
+			active = FALSE
 			return
 		to_chat(owner, "<span class='boldannounce'>Sending security report to Central Command.....[rand(0, 9) + (rand(20, 30) * i)]%</span>")
 	sleep(3)
-	if(!owner || QDELETED(owner))
+	if(!owner || QDELETED(owner) || owner_AI.shunted)
+		active = FALSE
 		return
 	to_chat(owner, "<span class='small boldannounce'>auth 'akjv9c88asdf12nb' [pass]</span>")
 	owner.playsound_local(owner, 'sound/items/timer.ogg', 50, 0, use_reverb = FALSE)
 	sleep(30)
-	if(!owner || QDELETED(owner))
+	if(!owner || QDELETED(owner) || owner_AI.shunted)
+		active = FALSE
 		return
 	to_chat(owner, "<span class='boldnotice'>Credentials accepted. Welcome, akjv9c88asdf12nb.</span>")
 	owner.playsound_local(owner, 'sound/misc/server-ready.ogg', 50, 0, use_reverb = FALSE)
 	sleep(5)
-	if(!owner || QDELETED(owner))
+	if(!owner || QDELETED(owner) || owner_AI.shunted)
+		active = FALSE
 		return
 	to_chat(owner, "<span class='boldnotice'>Arm self-destruct device? (Y/N)</span>")
 	owner.playsound_local(owner, 'sound/misc/compiler-stage1.ogg', 50, 0, use_reverb = FALSE)
 	sleep(20)
-	if(!owner || QDELETED(owner))
+	if(!owner || QDELETED(owner) || owner_AI.shunted)
+		active = FALSE
 		return
 	to_chat(owner, "<span class='small boldannounce'>Y</span>")
 	sleep(15)
-	if(!owner || QDELETED(owner))
+	if(!owner || QDELETED(owner) || owner_AI.shunted)
+		active = FALSE
 		return
 	to_chat(owner, "<span class='boldnotice'>Confirm arming of self-destruct device? (Y/N)</span>")
 	owner.playsound_local(owner, 'sound/misc/compiler-stage2.ogg', 50, 0, use_reverb = FALSE)
 	sleep(10)
-	if(!owner || QDELETED(owner))
+	if(!owner || QDELETED(owner) || owner_AI.shunted)
+		active = FALSE
 		return
 	to_chat(owner, "<span class='small boldannounce'>Y</span>")
 	sleep(rand(15, 25))
-	if(!owner || QDELETED(owner))
+	if(!owner || QDELETED(owner) || owner_AI.shunted)
+		active = FALSE
 		return
 	to_chat(owner, "<span class='boldnotice'>Please repeat password to confirm.</span>")
 	owner.playsound_local(owner, 'sound/misc/compiler-stage2.ogg', 50, 0, use_reverb = FALSE)
 	sleep(14)
-	if(!owner || QDELETED(owner))
+	if(!owner || QDELETED(owner) || owner_AI.shunted)
+		active = FALSE
 		return
 	to_chat(owner, "<span class='small boldannounce'>[pass]</span>")
 	sleep(40)
-	if(!owner || QDELETED(owner))
+	if(!owner || QDELETED(owner) || owner_AI.shunted)
+		active = FALSE
 		return
 	to_chat(owner, "<span class='boldnotice'>Credentials accepted. Transmitting arming signal...</span>")
 	owner.playsound_local(owner, 'sound/misc/server-ready.ogg', 50, 0, use_reverb = FALSE)
 	sleep(30)
-	if(!owner || QDELETED(owner))
+	if(!owner || QDELETED(owner) || owner_AI.shunted)
+		active = FALSE
 		return
 	if (owner_AI.stat != DEAD)
 		priority_announce("Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core.", "Anomaly Alert", ANNOUNCER_AIMALF)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If the AI shunts while the doomsday flufftext proc is activating, the doomsday will now revert to idle. It can be re-activated if and when the AI returns to their core. A fully activated doomsday event (when the crew is given a delta alert) will still be properly disabled if the AI shunts, and cannot be reactivated. Closes #56785

Also fixes the name of the doomsday flufftext proc, which was arguably the bigger issue.

Finally, adds an admin message, sent when the AI starts the flufftext proc.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: AIs can no longer shunt while activating the Doomsday Device and still expect it to finish setup on its own.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
