### PR TITLE
Adds GPS to bounty cubes

### DIFF
--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -293,7 +293,7 @@
 	//if our nag cooldown has finished and we aren't on Centcom or in transit, then nag
 	if(COOLDOWN_FINISHED(src, next_nag_time) && !is_centcom_level(z) && !is_reserved_level(z))
 		//set up our nag message
-		var/nag_message = "\The [src] is unsent in [get_area(src)]."
+		var/nag_message = "[src] is unsent in [get_area(src)]."
 
 		//nag on Supply channel and reduce the speed bonus multiplier to nothing
 		var/speed_bonus_lost = "[speed_bonus ? " Speedy delivery bonus of [bounty_value * speed_bonus] credit\s lost." : ""]"

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -262,10 +262,10 @@
 	var/bounty_holder_job
 	///What the bounty was for.
 	var/bounty_name
-	///Bank account of the person who receives the handling tip.
-	var/datum/bank_account/bounty_handler_account
 	///Bank account of the person who completed the bounty.
 	var/datum/bank_account/bounty_holder_account
+	///Bank account of the person who receives the handling tip.
+	var/datum/bank_account/bounty_handler_account
 	///Our internal radio.
 	var/obj/item/radio/radio
 	///The key our internal radio uses.
@@ -290,13 +290,24 @@
 		. += "<span class='notice'>Scan this in the cargo shuttle with an export scanner to register your bank account for the <b>[bounty_value * handler_tip]</b> credit handling tip.</span>"
 
 /obj/item/bounty_cube/process(delta_time)
-	if(COOLDOWN_FINISHED(src, next_nag_time))
-		if(!is_centcom_level(z) && !is_reserved_level(z)) //don't send message if we're on Centcom or in transit
-			radio.talk_into(src, "Unsent in [get_area(src)].[speed_bonus ? " Speedy delivery bonus of [bounty_value * speed_bonus] credit\s lost." : ""]", RADIO_CHANNEL_SUPPLY)
-			speed_bonus = 0
-			bounty_holder_account.bank_card_talk("\The [src] is unsent in <b>[get_area(src)]</b>.")
-			if(bounty_handler_account)
-				bounty_handler_account.bank_card_talk("\The [src] is unsent in <b>[get_area(src)]</b>.")
+	//if our nag cooldown has finished and we aren't on Centcom or in transit, then nag
+	if(COOLDOWN_FINISHED(src, next_nag_time) && !is_centcom_level(z) && !is_reserved_level(z))
+		//set up our nag message
+		var/nag_message = "\The [src] is unsent in [get_area(src)]."
+
+		//nag on Supply channel and reduce the speed bonus multiplier to nothing
+		var/speed_bonus_lost = "[speed_bonus ? " Speedy delivery bonus of [bounty_value * speed_bonus] credit\s lost." : ""]"
+		radio.talk_into(src, "[nag_message][speed_bonus_lost]", RADIO_CHANNEL_SUPPLY)
+		speed_bonus = 0
+
+		//alert the holder
+		bounty_holder_account.bank_card_talk("[nag_message]")
+
+		//if someone has registered for the handling tip, nag them
+		if(bounty_handler_account)
+			bounty_handler_account.bank_card_talk("[nag_message]")
+
+		//increase our cooldown length and start it again
 		nag_cooldown = nag_cooldown * nag_cooldown_multiplier
 		COOLDOWN_START(src, next_nag_time, nag_cooldown)
 
@@ -309,18 +320,19 @@
 	name = "\improper [bounty_value] cr [name]"
 	desc += " The sales tag indicates it was <i>[bounty_holder] ([bounty_holder_job])</i>'s reward for completing the <i>[bounty_name]</i> bounty."
 	AddComponent(/datum/component/pricetag, holder_id.registered_account, holder_cut)
+	AddComponent(/datum/component/gps, "[src]")
 	START_PROCESSING(SSobj, src)
 	COOLDOWN_START(src, next_nag_time, nag_cooldown)
 	radio.talk_into(src,"Created in [get_area(src)] by [bounty_holder] ([bounty_holder_job]). Speedy delivery bonus lost in [time2text(next_nag_time - world.time,"mm:ss")].", RADIO_CHANNEL_SUPPLY)
 
 //for when you need a REAL bounty cube to test with and don't want to do a bounty each time your code changes
-/obj/item/bounty_cube/test_cube
+/obj/item/bounty_cube/debug_cube
 	name = "debug bounty cube"
 	desc = "Use in-hand to set it up with a random bounty. Requires an ID it can detect with a bank account attached. \
-	This will alert Supply over the radio with your name and location, and cargo techs will be dispatched to your location with kill on sight clearance."
+	This will alert Supply over the radio with your name and location, and cargo techs will be dispatched with kill on sight clearance."
 	var/set_up = FALSE
 
-/obj/item/bounty_cube/test_cube/attack_self(mob/user)
+/obj/item/bounty_cube/debug_cube/attack_self(mob/user)
 	if(!isliving(user))
 		to_chat(user, "<span class='warning'>You aren't eligible to use this!</span>")
 		return ..()

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -304,8 +304,7 @@
 		bounty_holder_account.bank_card_talk("[nag_message]")
 
 		//if someone has registered for the handling tip, nag them
-		if(bounty_handler_account)
-			bounty_handler_account.bank_card_talk("[nag_message]")
+		bounty_handler_account?.bank_card_talk(nag_message)
 
 		//increase our cooldown length and start it again
 		nag_cooldown = nag_cooldown * nag_cooldown_multiplier

--- a/code/modules/cargo/export_scanner.dm
+++ b/code/modules/cargo/export_scanner.dm
@@ -38,9 +38,14 @@
 
 			else if(scan_human.get_bank_account() && cube.GetComponent(/datum/component/pricetag))
 				var/datum/component/pricetag/pricetag = cube.GetComponent(/datum/component/pricetag)
+
 				cube.bounty_handler_account = scan_human.get_bank_account()
 				pricetag.payees[cube.bounty_handler_account] += cube.handler_tip
+
 				cube.bounty_handler_account.bank_card_talk("Bank account for [price ? "<b>[price * cube.handler_tip]</b> credit " : ""]handling tip successfully registered.")
-				cube.bounty_holder_account.bank_card_talk("<b>[cube]</b> was scanned in \the <b>[get_area(cube)]</b> by <b>[scan_human] ([scan_human.job])</b>.")
+
+				if(cube.bounty_holder_account != cube.bounty_handler_account) //No need to send a tracking update to the person scanning it
+					cube.bounty_holder_account.bank_card_talk("<b>[cube]</b> was scanned in \the <b>[get_area(cube)]</b> by <b>[scan_human] ([scan_human.job])</b>.")
+
 			else
 				to_chat(user, "<span class='warning'>Bank account not detected. Handling tip not registered.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Played a round today where cubes had ended up in space somehow (I guess the shutters were left open with the loading belt on) and while a miner did his best to track them down he couldn't find them. They kept nagging on Supply every so often, which would've sent a message to the IDs of the people who'd completed them too.

While I'm happy with how often they nag from what I saw that round (wasn't too often or disruptive) they should be trackable.

I tested it and you can send these with the GPS signal on the supply shuttle fine.

**Also does the following**
- Increases readability in export_scanner.dm and civilian_bounties.dm
- Don't send tracking update to bounty completer if they're the one who registered for the handling tip
- Improve description for debug bounty cube
- Repaths test_cube as debug_cube for clarity of purpose in spawn list

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game


You can track these now. You can also bait cargo with them more easily.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
add: Bounty cubes have GPS signals now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
