### PR TITLE
Select equipment now has a prompt to change non-humans to backup humans if human authority is enforced.

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -515,6 +515,12 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			if(alert("Drop Items in Pockets? No will delete them.", "Robust quick dress shop", "Yes", "No") == "No")
 				delete_pocket = TRUE
 
+	if(CONFIG_GET(flag/enforce_human_authority) && H.dna.species.id != "human")
+		if(alert("Selected mob is non-human, replace with backup human?", "Robust quick dress shop", "Yes", "No") == "Yes")
+			var/client/preference_source
+			H.set_species(/datum/species/human)
+			H.apply_pref_name("human", preference_source)
+
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Select Equipment") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	for (var/obj/item/I in H.get_equipped_items(delete_pocket))
 		qdel(I)


### PR DESCRIPTION

## About The Pull Request

![da neue prompte](https://i.imgur.com/Wsd693O.png)
This prompt now appears should you change the equipment of a non-human while human authority is enforced.

## Why It's Good For The Game

This allows admins to quickly make someone a backup human if they are in a position of authority like a head of staff or central command. Also works on any other roles in case admins want exclusively humans for their ERP squad or whatever.

## Changelog
:cl:
admin: Select equipment now has a prompt to change non-humans to backup humans if human authority is enforced.
/:cl:

also this isnt a species change according to contributing.md because this doesnt actually affect species at all.