### PR TITLE
ethereals no longer have their weakness to brute damage scale up based on their current charge level

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -138,26 +138,23 @@
 	H.visible_message("<span class='danger'>[H] stops flickering and goes back to their normal state!</span>")
 
 /datum/species/ethereal/proc/handle_charge(mob/living/carbon/human/H)
-	brutemod = 1.25
 	switch(get_charge(H))
-		if(ETHEREAL_CHARGE_NONE)
+		if(-INFINITY to ETHEREAL_CHARGE_NONE)
 			H.throw_alert("ethereal_charge", /atom/movable/screen/alert/etherealcharge, 3)
+			if(H.health > 10.5)
+				apply_damage(0.65, TOX, null, null, H)
 		if(ETHEREAL_CHARGE_NONE to ETHEREAL_CHARGE_LOWPOWER)
 			H.throw_alert("ethereal_charge", /atom/movable/screen/alert/etherealcharge, 2)
 			if(H.health > 10.5)
 				apply_damage(0.65, TOX, null, null, H)
-			brutemod = 1.75
 		if(ETHEREAL_CHARGE_LOWPOWER to ETHEREAL_CHARGE_NORMAL)
 			H.throw_alert("ethereal_charge", /atom/movable/screen/alert/etherealcharge, 1)
-			brutemod = 1.5
 		if(ETHEREAL_CHARGE_FULL to ETHEREAL_CHARGE_OVERLOAD)
 			H.throw_alert("ethereal_overcharge", /atom/movable/screen/alert/ethereal_overcharge, 1)
 			apply_damage(0.2, TOX, null, null, H)
-			brutemod = 1.5
 		if(ETHEREAL_CHARGE_OVERLOAD to ETHEREAL_CHARGE_DANGEROUS)
 			H.throw_alert("ethereal_overcharge", /atom/movable/screen/alert/ethereal_overcharge, 2)
 			apply_damage(0.65, TOX, null, null, H)
-			brutemod = 1.75
 			if(prob(10)) //10% each tick for ethereals to explosively release excess energy if it reaches dangerous levels
 				discharge_process(H)
 		else


### PR DESCRIPTION
## About The Pull Request

Ethereals now always have a brutemod of 1.25x, instead of a brutemod of 1.25x-1.75x depending on their charge level. For reference, plasmamen have a brutemod of 1.5x, and humans have a brutemod of 1x.

Ethereals will now receive the special screen alert that they're supposed to receive when they reach 0 charge. They previously couldn't, as for some reason, switches in byond favor ranges over individual values, regardless of positioning.

Even if ethereals had been allowed to actually enter their 0 charge state, they wouldn't take tox damage over time in it like they would while in a very low power state. This has been fixed; ethereals with no power remaining will now take tox damage at the same rate that ethereals who are in a very low power state do.

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/56584 .

![image](https://user-images.githubusercontent.com/42606352/107604653-637a0500-6bf6-11eb-9b10-259d8eee5ebb.png)

~~Quustinus is a maintainer (and the guy who added ethereals to the game in the first place, IIRC), so this PR has maintainer approval.~~ EDIT: Shit, Floyd just made ethereals, he's not actually a maintainer.

EDIT EDIT: Saved by actioninja:
![image](https://user-images.githubusercontent.com/42606352/107605145-f10a2480-6bf7-11eb-910c-a24e94838cd1.png)

Ethereals are already one of the mechanically weakest species in the game; they don't need to be kicked while they're down with a brute damage multiplier that can match or exceed that of _plasmamen_.

## Changelog
:cl: ATHATH
balance: Ethereals now always take 1.25x as much brute damage as humans do, instead of 1.25x-1.75x as much brute damage (depending on their charge level) as humans do.
fix: The special alert message for reaching 0 charge as an ethereal now actually appears.
/:cl: