### PR TITLE
Fixed picking up items through the dropdown menu.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -545,7 +545,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 			return
 
 	if(usr.get_active_held_item() == null) // Let me know if this has any problems -Yota
-		usr.UnarmedAttack(src)
+		usr.UnarmedAttack(src, modifiers=list())
 
 /**
  *This proc is executed when someone clicks the on-screen UI button.


### PR DESCRIPTION
## About The Pull Request

Due to the verb_pickup() proc calling UnarmedAttack() without the `modifiers` argument filled out, the carbon/human version of it runtimes on this line
https://github.com/tgstation/tgstation/blob/87f14758224637109353913441047df112560d03/code/_onclick/other_mobs.dm#L35

## Changelog
:cl:
fix: Picking items up through the dropdown menu now works once again.
/:cl: