### PR TITLE
Atmos machineries can connect to a single pipeline in more than one nodes

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -251,9 +251,9 @@
 	return
 
 /**
- * Called by addMachineryMember() in datum_pipeline.dm, returns the gas_mixture of the network the device is connected to
+ * Called by addMachineryMember() in datum_pipeline.dm, returns a list of gas_mixtures and assigns them into other_airs (by addMachineryMember) to allow pressure redistribution for the machineries.
  */
-/obj/machinery/atmospherics/proc/returnPipenetAir()
+/obj/machinery/atmospherics/proc/returnPipenetAirs()
 	return
 
 /**

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -90,26 +90,16 @@
 			P.build_pipeline(src)
 
 /obj/machinery/atmospherics/components/proc/nullifyPipenet(datum/pipeline/reference)
-	// Crash when we call a null pipenet here. Pretty straightforward.
 	if(!reference)
 		CRASH("nullifyPipenet(null) called by [type] on [COORD(src)]")
 
-	// Disconnect each air mixtures from the other_airs list in the pipeline. 
-	// Also nullifies the specific entry in the parents list. This is mainly used when a machinery is rotated.
 	for (var/i in 1 to parents.len)
 		if (parents[i] == reference)
-			reference.other_airs -= airs[i]
-			parents[i] = null
+			reference.other_airs -= airs[i] // Disconnects from the pieline side
+			parents[i] = null // Disconnects from the machinery side.
 
-	// Deletes any reference of the atmos machinery as listed in the other_atmosmch list from the pipeine.
 	reference.other_atmosmch -= src
-
-	// Cleans pipenet up
-	if(!length(reference.other_atmosmch) && !length(reference.members))
-		if(QDESTROYING(reference))
-			CRASH("nullifyPipenet() called on qdeleting [reference]")
-		qdel(reference)
-
+	
 	/**
 	 *  We explicitly qdel pipeline when this particular pipeline
 	 *  is projected to have no member and cause GC problems.
@@ -118,13 +108,13 @@
 	 *	again every time they are qdeleted.
 	 */
 
+	if(!length(reference.other_atmosmch) && !length(reference.members))
+		if(QDESTROYING(reference))
+			CRASH("nullifyPipenet() called on qdeleting [reference]")
+		qdel(reference)
+
 /obj/machinery/atmospherics/components/returnPipenetAirs(datum/pipeline/reference)
 	var/list/returned_air = list()
-	// We return a list filled with a single null entry if we dont have a proper parents list.
-	// This will get picked up by addMachineryMember to call a stack_trace.
-	if (!parents || !length(parents))
-		returned_air += null
-		return returned_air
 
 	for (var/i in 1 to parents.len)
 		if (parents[i] == reference)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -110,7 +110,6 @@
 	parents[i] = null
 
 /obj/machinery/atmospherics/components/returnPipenetAir(datum/pipeline/reference)
-	//return airs[parents.Find(reference)]
 	var/list/returned_air = new()
 	for (var/i in 1 to parents.len)
 		if (parents[i] == reference)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -95,7 +95,7 @@
 		CRASH("nullifyPipenet(null) called by [type] on [COORD(src)]")
 
 	// Crash if the pipeline that we are supposed to be connected to doesnt have members and machineries. 
-	// How does it even connect in the first place, right?
+	// How does it even not get removed in the first place, right?
 
 	/**
 	 *  We explicitly qdel pipeline when this particular pipeline
@@ -109,12 +109,10 @@
 		if(QDESTROYING(reference))
 			for (var/i in 1 to parents.len)
 				if (parents[i] == reference)
+					parents[i] = null
 					CRASH("nullifyPipenet() called on qdeleting [reference] indexed on parents\[[i]\]")
 					parents[i] = null
 		qdel(reference)
-
-		// Early return to avoid problems down the line.
-		return
 
 	// Deletes any reference of the atmos machinery as listed in the other_atmosmch list from the pipeine.
 	reference.other_atmosmch -= src
@@ -128,6 +126,12 @@
 
 /obj/machinery/atmospherics/components/returnPipenetAirs(datum/pipeline/reference)
 	var/list/returned_air = list()
+	// We return a list filled with a single null entry if we dont have a proper parents list.
+	// This will get picked up by addMachineryMember to call a stack_trace.
+	if (!parents || !length(parents))
+		returned_air += null
+		return returned_air
+
 	for (var/i in 1 to parents.len)
 		if (parents[i] == reference)
 			returned_air += airs[i]

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -110,7 +110,12 @@
 	parents[i] = null
 
 /obj/machinery/atmospherics/components/returnPipenetAir(datum/pipeline/reference)
-	return airs[parents.Find(reference)]
+	//return airs[parents.Find(reference)]
+	var/list/returned_air = new()
+	for (var/i in 1 to parents.len)
+		if (parents[i] == reference)
+			returned_air.Add(airs[i])
+	return returned_air
 
 /obj/machinery/atmospherics/components/pipeline_expansion(datum/pipeline/reference)
 	if(reference)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -107,7 +107,7 @@
 	// Cleans pipenet up
 	if(!length(reference.other_atmosmch) && !length(reference.members))
 		if(QDESTROYING(reference))
-			CRASH("nullifyPipenet() called on qdeleting [reference] indexed on parents\[[i]\]")
+			CRASH("nullifyPipenet() called on qdeleting [reference]")
 		qdel(reference)
 
 	/**

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -94,8 +94,21 @@
 	if(!reference)
 		CRASH("nullifyPipenet(null) called by [type] on [COORD(src)]")
 
-	// Crash if the pipeline that we are supposed to be connected to doesnt have members and machineries. 
-	// How does it even not get removed in the first place, right?
+	// Disconnect each air mixtures from the other_airs list in the pipeline. 
+	// Also nullifies the specific entry in the parents list. This is mainly used when a machinery is rotated.
+	for (var/i in 1 to parents.len)
+		if (parents[i] == reference)
+			reference.other_airs -= airs[i]
+			parents[i] = null
+
+	// Deletes any reference of the atmos machinery as listed in the other_atmosmch list from the pipeine.
+	reference.other_atmosmch -= src
+
+	// Cleans pipenet up
+	if(!length(reference.other_atmosmch) && !length(reference.members))
+		if(QDESTROYING(reference))
+			CRASH("nullifyPipenet() called on qdeleting [reference] indexed on parents\[[i]\]")
+		qdel(reference)
 
 	/**
 	 *  We explicitly qdel pipeline when this particular pipeline
@@ -104,25 +117,6 @@
 	 *  while pipes must and will happily wreck and rebuild everything
 	 *	again every time they are qdeleted.
 	 */
-
-	if(!length(reference.other_atmosmch) && !length(reference.members))
-		if(QDESTROYING(reference))
-			for (var/i in 1 to parents.len)
-				if (parents[i] == reference)
-					parents[i] = null
-					CRASH("nullifyPipenet() called on qdeleting [reference] indexed on parents\[[i]\]")
-					parents[i] = null
-		qdel(reference)
-
-	// Deletes any reference of the atmos machinery as listed in the other_atmosmch list from the pipeine.
-	reference.other_atmosmch -= src
-
-	// Disconnect each air mixtures from the other_airs list in the pipeline. 
-	// Also nullifies the specific entry in the parents list. This is mainly used when a machinery is rotated.
-	for (var/i in 1 to parents.len)
-		if (parents[i] == reference)
-			reference.other_airs -= airs[i]
-			parents[i] = null
 
 /obj/machinery/atmospherics/components/returnPipenetAirs(datum/pipeline/reference)
 	var/list/returned_air = list()

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -110,10 +110,10 @@
 	parents[i] = null
 
 /obj/machinery/atmospherics/components/returnPipenetAir(datum/pipeline/reference)
-	var/list/returned_air = new()
+	var/list/returned_air = list()
 	for (var/i in 1 to parents.len)
 		if (parents[i] == reference)
-			returned_air.Add(airs[i])
+			returned_air += airs[i]
 	return returned_air
 
 /obj/machinery/atmospherics/components/pipeline_expansion(datum/pipeline/reference)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -95,10 +95,10 @@
 
 	for (var/i in 1 to parents.len)
 		if (parents[i] == reference)
-			reference.other_airs -= airs[i] // Disconnects from the pieline side
+			reference.other_airs -= airs[i] // Disconnects from the pipeline side
 			parents[i] = null // Disconnects from the machinery side.
 
-	reference.other_atmosmch -= src
+	reference.other_atmosmch -= src 
 	
 	/**
 	 *  We explicitly qdel pipeline when this particular pipeline

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -96,7 +96,7 @@
 	other_atmosmch |= considered_component
 	var/list/returned_airs = considered_component.returnPipenetAirs(src)
 	if (!length(returned_airs) || (null in returned_airs))
-		stack_trace("addMachineryMember: Null gasmix added to pipeline datum from [considered_component] \
+		stack_trace("addMachineryMember: Nonexistent (empty list) or null machinery gasmix added to pipeline datum from [considered_component] \
 		which is of type [considered_component.type]. Nearby: ([considered_component.x], [considered_component.y], [considered_component.z])")
 	other_airs |= returned_airs
 

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -85,7 +85,11 @@
 
 /datum/pipeline/proc/addMachineryMember(obj/machinery/atmospherics/components/considered_component)
 	other_atmosmch |= considered_component
-	other_airs |= considered_component.returnPipenetAir(src)
+	var/list/returned_airs = considered_component.returnPipenetAir(src)
+	if (!returned_airs.len)
+		stack_trace("addMachineryMember: Null gasmix added to pipeline datum from [considered_component] \
+		which is of type [considered_component.type]. Nearby: ([considered_component.x], [considered_component.y], [considered_component.z])")
+	other_airs |= returned_airs
 
 /datum/pipeline/proc/addMember(obj/machinery/atmospherics/reference_device, obj/machinery/atmospherics/device_to_add)
 	if(!istype(reference_device, /obj/machinery/atmospherics/pipe))

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -85,11 +85,7 @@
 
 /datum/pipeline/proc/addMachineryMember(obj/machinery/atmospherics/components/considered_component)
 	other_atmosmch |= considered_component
-	var/datum/gas_mixture/component_mixture = considered_component.returnPipenetAir(src)
-	if(!component_mixture)
-		stack_trace("addMachineryMember: Null gasmix added to pipeline datum from [considered_component] \
-		which is of type [considered_component.type]. Nearby: ([considered_component.x], [considered_component.y], [considered_component.z])")
-	other_airs |= component_mixture
+	other_airs |= considered_component.returnPipenetAir(src)
 
 /datum/pipeline/proc/addMember(obj/machinery/atmospherics/reference_device, obj/machinery/atmospherics/device_to_add)
 	if(!istype(reference_device, /obj/machinery/atmospherics/pipe))

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -84,8 +84,8 @@
 	air.volume = volume
 
 	/**
-	 *  For a machinery to properly "connect" to a pipenet and share gasses, 
-	 *  the pipenet needs to acknowledge a gas mixture as it's member.
+	 *  For a machine to properly "connect" to a pipeline and share gases, 
+	 *  the pipeline needs to acknowledge a gas mixture as it's member.
 	 *  This is currently handled by the other_airs list in the pipeline datum.
 	 *  
 	 *	Other_airs itself is populated by gas mixtures through the parents list that each machineries have.

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -116,8 +116,8 @@
 	air.merge(parent_pipeline.air)
 	for(var/obj/machinery/atmospherics/components/reference_component in parent_pipeline.other_atmosmch)
 		reference_component.replacePipenet(parent_pipeline, src)
-	other_atmosmch.Add(parent_pipeline.other_atmosmch)
-	other_airs.Add(parent_pipeline.other_airs)
+	other_atmosmch |= parent_pipeline.other_atmosmch
+	other_airs |= parent_pipeline.other_airs
 	parent_pipeline.members.Cut()
 	parent_pipeline.other_atmosmch.Cut()
 	update = TRUE

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -83,10 +83,19 @@
 
 	air.volume = volume
 
+	/**
+	 *  For a machinery to properly "connect" to a pipenet and share gasses, 
+	 *  the pipenet needs to acknowledge a gas mixture as it's member.
+	 *  This is currently handled by the other_airs list in the pipeline datum.
+	 *  
+	 *	Other_airs itself is populated by gas mixtures through the parents list that each machineries have.
+	 *	This parents list is populated when a machinery calls update_parents and is then added into the queue by the controller.
+	 */
+
 /datum/pipeline/proc/addMachineryMember(obj/machinery/atmospherics/components/considered_component)
 	other_atmosmch |= considered_component
-	var/list/returned_airs = considered_component.returnPipenetAir(src)
-	if (!returned_airs.len)
+	var/list/returned_airs = considered_component.returnPipenetAirs(src)
+	if (!length(returned_airs) || (null in returned_airs))
 		stack_trace("addMachineryMember: Null gasmix added to pipeline datum from [considered_component] \
 		which is of type [considered_component.type]. Nearby: ([considered_component.x], [considered_component.y], [considered_component.z])")
 	other_airs |= returned_airs


### PR DESCRIPTION
## About The Pull Request

Some devices break when they are connected with a single pipeline in more than one nodes. This happens because `returnPipenetAir` uses a `Find` proc that only returns the first element in the list, making `other_airs` miss out on several `gas_mixture`s. This attempts to solve that.

Tested this on local and behavior seems well, I hope that this will not break anything.

No longer relevant:
_The `stack_trace` part of the code is deleted for now, mostly because I don't know if a list containing null items or a null list itself is more problematic, or both are, or that those things aren't even problematic when using `|=` operators. I am confused._ 

## Why It's Good For The Game

Prevents things like this
![image](https://user-images.githubusercontent.com/54709710/107674222-5548e900-6cc9-11eb-858c-a8711813b457.png)
on a pipenet like this
![image](https://user-images.githubusercontent.com/54709710/107674257-5e39ba80-6cc9-11eb-929f-5f256bb7e69c.png)


## Changelog
:cl:
fix: atmos devices with multiple ends that is hooked to the same line can now redistribute pressure more consistently. (can connect to a single pipeline in more than one nodes)
/:cl: