### PR TITLE
breaching missiles breach windows and rwindows

### DIFF
--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -83,7 +83,9 @@
 	/turf/closed,
 	/obj/vehicle/sealed/mecha,
 	/obj/machinery/door/,
-	/obj/machinery/door/poddoor/shutters
+	/obj/machinery/door/poddoor/shutters,
+	/obj/structure/window/,
+	/obj/structure/grille
 	)
 
 /obj/item/broken_missile

--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -82,7 +82,7 @@
 	var/sturdy = list(
 	/turf/closed,
 	/obj/vehicle/sealed/mecha,
-	/obj/machinery/door/,
+	/obj/machinery/door,
 	/obj/machinery/door/poddoor/shutters,
 	/obj/structure/window/,
 	/obj/structure/grille

--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -83,8 +83,7 @@
 	/turf/closed,
 	/obj/vehicle/sealed/mecha,
 	/obj/machinery/door,
-	/obj/machinery/door/poddoor/shutters,
-	/obj/structure/window/,
+	/obj/structure/window,
 	/obj/structure/grille
 	)
 


### PR DESCRIPTION
:cl:
fix: breaching missile works on windows with low bomb resistance
/:cl:

it didnt make sense that the breaching missile can break rwalls but not windows, windows with high bomb resist like plasma ones wont break