### PR TITLE
clown livers now contain a dad joke under certain circumstances

### DIFF
--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -127,6 +127,14 @@
 /obj/item/organ/liver/get_availability(datum/species/S)
 	return !(TRAIT_NOMETABOLISM in S.inherent_traits)
 
+/obj/item/organ/liver/check_damage_thresholds(M)
+	. = ..()
+	if(HAS_TRAIT(src, TRAIT_COMEDY_METABOLISM))
+		if(organ_flags & ORGAN_FAILING)
+			name = "deader" //dad joke
+		else
+			name = initial(name)
+
 /obj/item/organ/liver/plasmaman
 	name = "reagent processing crystal"
 	icon_state = "liver-p"


### PR DESCRIPTION
## About The Pull Request

If a clown's liver fails (outside or inside of their body), it will be renamed to a "deader". It will return to its original name if it becomes functional again later.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/42606352/107710408-7c34fa00-6c8c-11eb-9c22-c0185766a95d.png)

## Changelog
:cl: ATHATH
add: Clown livers now contain a dad joke under certain circumstances.
/:cl: