### PR TITLE
RCDs now use right click to deconstruct

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -96,21 +96,21 @@
 #define CAT_ICE	"Frozen"
 #define CAT_DRINK "Drinks"
 
-// these aren't even used as bitflags so who even knows why they are treated like them
-#define RCD_FLOORWALL (1<<0)
-#define RCD_AIRLOCK (1<<1)
-#define RCD_DECONSTRUCT (1<<2)
-#define RCD_WINDOWGRILLE (1<<3)
-#define RCD_MACHINE (1<<4)
-#define RCD_COMPUTER (1<<5)
-#define RCD_FURNISHING (1<<6)
+//rcd modes
+#define RCD_FLOORWALL 0
+#define RCD_AIRLOCK 1
+#define RCD_DECONSTRUCT 2
+#define RCD_WINDOWGRILLE 3
+#define RCD_MACHINE 4
+#define RCD_COMPUTER 5
+#define RCD_FURNISHING 6
 
-#define RCD_UPGRADE_FRAMES (1<<0)
-#define RCD_UPGRADE_SIMPLE_CIRCUITS	(1<<1)
-#define RCD_UPGRADE_SILO_LINK (1<<2)
-#define RCD_UPGRADE_FURNISHING (1<<3)
+#define RCD_UPGRADE_FRAMES 0
+#define RCD_UPGRADE_SIMPLE_CIRCUITS	1
+#define RCD_UPGRADE_SILO_LINK 2
+#define RCD_UPGRADE_FURNISHING 3
 
-#define RPD_UPGRADE_UNWRENCH (1<<0)
+#define RPD_UPGRADE_UNWRENCH 0
 
 #define RCD_WINDOW_FULLTILE "full tile"
 #define RCD_WINDOW_DIRECTIONAL "directional"

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -580,20 +580,21 @@ RLD
 		choices += list(
 		"Furnishing" = image(icon = 'icons/hud/radial.dmi', icon_state = "chair")
 		)
-	if(construction_mode == RCD_AIRLOCK)
-		choices += list(
-		"Change Access" = image(icon = 'icons/hud/radial.dmi', icon_state = "access"),
-		"Change Airlock Type" = image(icon = 'icons/hud/radial.dmi', icon_state = "airlocktype")
-		)
-	else if(construction_mode == RCD_WINDOWGRILLE)
-		choices += list(
-		"Change Window Glass" = image(icon = 'icons/hud/radial.dmi', icon_state = "windowtype"),
-		"Change Window Size" = image(icon = 'icons/hud/radial.dmi', icon_state = "windowsize")
-		)
-	else if(construction_mode == RCD_FURNISHING)
-		choices += list(
-		"Change Furnishing Type" = image(icon = 'icons/hud/radial.dmi', icon_state = "chair")
-		)
+	switch(construction_mode)
+		if(RCD_AIRLOCK)
+			choices += list(
+			"Change Access" = image(icon = 'icons/hud/radial.dmi', icon_state = "access"),
+			"Change Airlock Type" = image(icon = 'icons/hud/radial.dmi', icon_state = "airlocktype")
+			)
+		if(RCD_WINDOWGRILLE)
+			choices += list(
+			"Change Window Glass" = image(icon = 'icons/hud/radial.dmi', icon_state = "windowtype"),
+			"Change Window Size" = image(icon = 'icons/hud/radial.dmi', icon_state = "windowsize")
+			)
+		if(RCD_FURNISHING)
+			choices += list(
+			"Change Furnishing Type" = image(icon = 'icons/hud/radial.dmi', icon_state = "chair")
+			)
 	var/choice = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE, tooltips = TRUE)
 	if(!check_menu(user))
 		return

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -214,6 +214,7 @@ RLD
 	item_flags = NO_MAT_REDEMPTION | NOBLUDGEON
 	has_ammobar = TRUE
 	var/mode = RCD_FLOORWALL
+	var/constructionmode = RCD_FLOORWALL
 	var/ranged = FALSE
 	var/computer_dir = 1
 	var/airlock_type = /obj/machinery/door/airlock
@@ -563,7 +564,6 @@ RLD
 	..()
 	var/list/choices = list(
 		"Airlock" = image(icon = 'icons/hud/radial.dmi', icon_state = "airlock"),
-		"Deconstruct" = image(icon= 'icons/hud/radial.dmi', icon_state = "delete"),
 		"Grilles & Windows" = image(icon = 'icons/hud/radial.dmi', icon_state = "grillewindow"),
 		"Floors & Walls" = image(icon = 'icons/hud/radial.dmi', icon_state = "wallfloor")
 	)
@@ -580,17 +580,17 @@ RLD
 		choices += list(
 		"Furnishing" = image(icon = 'icons/hud/radial.dmi', icon_state = "chair")
 		)
-	if(mode == RCD_AIRLOCK)
+	if(constructionmode == RCD_AIRLOCK)
 		choices += list(
 		"Change Access" = image(icon = 'icons/hud/radial.dmi', icon_state = "access"),
 		"Change Airlock Type" = image(icon = 'icons/hud/radial.dmi', icon_state = "airlocktype")
 		)
-	else if(mode == RCD_WINDOWGRILLE)
+	else if(constructionmode == RCD_WINDOWGRILLE)
 		choices += list(
 		"Change Window Glass" = image(icon = 'icons/hud/radial.dmi', icon_state = "windowtype"),
 		"Change Window Size" = image(icon = 'icons/hud/radial.dmi', icon_state = "windowsize")
 		)
-	else if(mode == RCD_FURNISHING)
+	else if(constructionmode == RCD_FURNISHING)
 		choices += list(
 		"Change Furnishing Type" = image(icon = 'icons/hud/radial.dmi', icon_state = "chair")
 		)
@@ -599,19 +599,17 @@ RLD
 		return
 	switch(choice)
 		if("Floors & Walls")
-			mode = RCD_FLOORWALL
+			constructionmode = RCD_FLOORWALL
 		if("Airlock")
-			mode = RCD_AIRLOCK
-		if("Deconstruct")
-			mode = RCD_DECONSTRUCT
+			constructionmode = RCD_AIRLOCK
 		if("Grilles & Windows")
-			mode = RCD_WINDOWGRILLE
+			constructionmode = RCD_WINDOWGRILLE
 		if("Machine Frames")
-			mode = RCD_MACHINE
+			constructionmode = RCD_MACHINE
 		if("Furnishing")
-			mode = RCD_FURNISHING
+			constructionmode = RCD_FURNISHING
 		if("Computer Frames")
-			mode = RCD_COMPUTER
+			constructionmode = RCD_COMPUTER
 			change_computer_dir(user)
 			return
 		if("Change Access")
@@ -643,11 +641,18 @@ RLD
 	else
 		return FALSE
 
-/obj/item/construction/rcd/afterattack(atom/A, mob/user, proximity)
+/obj/item/construction/rcd/pre_attack(atom/A, mob/user, params)
 	. = ..()
-	if(!prox_check(proximity))
-		return
+	mode = constructionmode
 	rcd_create(A, user)
+	return FALSE
+
+/obj/item/construction/rcd/pre_attack_secondary(atom/A, mob/user, params)
+	. = ..()
+	mode = RCD_DECONSTRUCT
+	rcd_create(A, user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 
 /obj/item/construction/rcd/proc/detonate_pulse()
 	audible_message("<span class='danger'><b>[src] begins to vibrate and \
@@ -766,9 +771,19 @@ RLD
 	. = ..()
 	if(!range_check(A,user))
 		return
-	if(target_check(A,user))
-		user.Beam(A,icon_state="rped_upgrade", time = 3 SECONDS)
-	rcd_create(A,user)
+	pre_attack(A, user)
+
+/obj/item/construction/rcd/arcd/afterattack_secondary(atom/A, mob/user)
+	if(!range_check(A,user))
+		return
+	pre_attack_secondary(A, user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+
+/obj/item/construction/rcd/arcd/rcd_create(atom/A, mob/user)
+	. = ..()
+	user.Beam(A,icon_state="rped_upgrade", time = 3 SECONDS)
+	return
 
 
 

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -782,7 +782,6 @@ RLD
 	. = ..()
 	if(.)
 		user.Beam(A,icon_state="rped_upgrade", time = 3 SECONDS)
-	return .
 
 
 

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -214,7 +214,7 @@ RLD
 	item_flags = NO_MAT_REDEMPTION | NOBLUDGEON
 	has_ammobar = TRUE
 	var/mode = RCD_FLOORWALL
-	var/constructionmode = RCD_FLOORWALL
+	var/construction_mode = RCD_FLOORWALL
 	var/ranged = FALSE
 	var/computer_dir = 1
 	var/airlock_type = /obj/machinery/door/airlock
@@ -580,17 +580,17 @@ RLD
 		choices += list(
 		"Furnishing" = image(icon = 'icons/hud/radial.dmi', icon_state = "chair")
 		)
-	if(constructionmode == RCD_AIRLOCK)
+	if(construction_mode == RCD_AIRLOCK)
 		choices += list(
 		"Change Access" = image(icon = 'icons/hud/radial.dmi', icon_state = "access"),
 		"Change Airlock Type" = image(icon = 'icons/hud/radial.dmi', icon_state = "airlocktype")
 		)
-	else if(constructionmode == RCD_WINDOWGRILLE)
+	else if(construction_mode == RCD_WINDOWGRILLE)
 		choices += list(
 		"Change Window Glass" = image(icon = 'icons/hud/radial.dmi', icon_state = "windowtype"),
 		"Change Window Size" = image(icon = 'icons/hud/radial.dmi', icon_state = "windowsize")
 		)
-	else if(constructionmode == RCD_FURNISHING)
+	else if(construction_mode == RCD_FURNISHING)
 		choices += list(
 		"Change Furnishing Type" = image(icon = 'icons/hud/radial.dmi', icon_state = "chair")
 		)
@@ -599,17 +599,17 @@ RLD
 		return
 	switch(choice)
 		if("Floors & Walls")
-			constructionmode = RCD_FLOORWALL
+			construction_mode = RCD_FLOORWALL
 		if("Airlock")
-			constructionmode = RCD_AIRLOCK
+			construction_mode = RCD_AIRLOCK
 		if("Grilles & Windows")
-			constructionmode = RCD_WINDOWGRILLE
+			construction_mode = RCD_WINDOWGRILLE
 		if("Machine Frames")
-			constructionmode = RCD_MACHINE
+			construction_mode = RCD_MACHINE
 		if("Furnishing")
-			constructionmode = RCD_FURNISHING
+			construction_mode = RCD_FURNISHING
 		if("Computer Frames")
-			constructionmode = RCD_COMPUTER
+			construction_mode = RCD_COMPUTER
 			change_computer_dir(user)
 			return
 		if("Change Access")
@@ -643,7 +643,7 @@ RLD
 
 /obj/item/construction/rcd/pre_attack(atom/A, mob/user, params)
 	. = ..()
-	mode = constructionmode
+	mode = construction_mode
 	rcd_create(A, user)
 	return FALSE
 

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -647,7 +647,7 @@ RLD
 	rcd_create(A, user)
 	return FALSE
 
-/obj/item/construction/rcd/pre_attack_secondary(atom/A, mob/user, params)
+/obj/item/construction/rcd/pre_attack_secondary(atom/target, mob/living/user, params)
 	. = ..()
 	mode = RCD_DECONSTRUCT
 	rcd_create(A, user)
@@ -773,7 +773,7 @@ RLD
 		return
 	pre_attack(A, user)
 
-/obj/item/construction/rcd/arcd/afterattack_secondary(atom/A, mob/user)
+/obj/item/construction/rcd/arcd/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
 	if(!range_check(A,user))
 		return
 	pre_attack_secondary(A, user)

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -650,7 +650,7 @@ RLD
 /obj/item/construction/rcd/pre_attack_secondary(atom/target, mob/living/user, params)
 	. = ..()
 	mode = RCD_DECONSTRUCT
-	rcd_create(A, user)
+	rcd_create(target, user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 
@@ -769,21 +769,20 @@ RLD
 
 /obj/item/construction/rcd/arcd/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!range_check(A,user))
-		return
-	pre_attack(A, user)
+	if(range_check(A,user))
+		pre_attack(A, user)
 
 /obj/item/construction/rcd/arcd/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
-	if(!range_check(A,user))
-		return
-	pre_attack_secondary(A, user)
+	if(range_check(target,user))
+		pre_attack_secondary(target, user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 
 /obj/item/construction/rcd/arcd/rcd_create(atom/A, mob/user)
 	. = ..()
-	user.Beam(A,icon_state="rped_upgrade", time = 3 SECONDS)
-	return
+	if(.)
+		user.Beam(A,icon_state="rped_upgrade", time = 3 SECONDS)
+	return .
 
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
RCDs use right click to deconstruct, everything else is functionally the same. The RCD defines also aren't bitflags anymore, they didn't seem to have any reason to be in the first place.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
What's probably the most used mode of the RCD is now bound to the mouse, which is good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: RCDs deconstruct with right click, instead of it being an option from the menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
