### PR TITLE
lowers the size of torches, and lets them be made with leafy mushrooms 

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -340,7 +340,7 @@
 /obj/item/flashlight/flare/torch
 	name = "torch"
 	desc = "A torch fashioned from some leaves and a log."
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_SMALL
 	light_range = 4
 	icon_state = "torch"
 	inhand_icon_state = "torch"

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -49,6 +49,7 @@
 	var/plank_name = "wooden planks"
 	var/static/list/accepted = typecacheof(list(/obj/item/food/grown/tobacco,
 	/obj/item/food/grown/tea,
+	/obj/item/food/grown/ash_flora/mushroom_leaf,
 	/obj/item/food/grown/ambrosia/vulgaris,
 	/obj/item/food/grown/ambrosia/deus,
 	/obj/item/food/grown/wheat))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

lowering the item size of a really unused and useless light item to fit into pockets, while allowing ash walkers to have a way to craft more weak light sources , 

## Why It's Good For The Game

torches are a child of flairs that are harder to get, aren't storable at all without a boh, have less light range (4 vs 7) with only 3 more damage at 10 so they we're at a very bad state where there's never really ever a point to use them where a flare or a welder does the same job but better. this pr at least makes it useful to be allowed to fit in your pocket like almost every other light item in the game. (as if you couldn't just use a lathe to print flashlights faster then botany can grow the two plants) while also adding another leafy plant to be used to make them from lavaland. 

## Changelog
:cl:
add: Added leafy mushrooms as a plant useable to make torches 
balance: rebalanced the size of torches to be tiny and not bulky 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
