### PR TITLE
All Holobugs Must Die the Same Day Theyre Born or You Are Money Back Part Two

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -242,10 +242,8 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 	//holo effects are taken out of the spawned list and added to the effects list
 	//turfs and overlay objects are taken out of the spawned list
 	//objects get resistance flags added to them
-	for (var/_atom in spawned)
-		var/atom/atoms = _atom
-
-		if (isturf(atoms) || istype(atoms, /obj/effect/overlay/vis) || !atoms)
+	for (var/atom/atoms in spawned)
+		if (isturf(atoms) || istype(atoms, /obj/effect/overlay/vis))
 			spawned -= atoms
 			continue
 

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -189,8 +189,11 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 		map_id = offline_program
 		force = TRUE
 
-	if ((!COOLDOWN_FINISHED(src, holodeck_cooldown) && !force) || spawning_simulation)
+	if (!force && (!COOLDOWN_FINISHED(src, holodeck_cooldown) || spawning_simulation))
 		say("ERROR. Recalibrating projection apparatus.")
+		return
+
+	if(spawning_simulation)
 		return
 
 	if (add_delay)
@@ -225,6 +228,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 	template.load(bottom_left) //this is what actually loads the holodeck simulation into the map
 
 	spawned = template.created_atoms //populate the spawned list with the atoms belonging to the holodeck
+	spawned += null
 
 	if(istype(template, /datum/map_template/holodeck/thunderdome1218) && !SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_MEDISIM])
 		say("Special note from \"1218 AD\" developer: I see you too are interested in the REAL dark ages of humanity! I've made this program also unlock some interesting shuttle designs on any communication console around. Have fun!")
@@ -242,12 +246,12 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 	for (var/_atom in spawned)
 		var/atom/atoms = _atom
 
-		if (isturf(atoms) || istype(atoms, /obj/effect/overlay/vis)) //ssatoms
+		if (isturf(atoms) || istype(atoms, /obj/effect/overlay/vis) || !atoms)
 			spawned -= atoms
 			continue
 
-		atoms.flags_1 |= HOLOGRAM_1
 		RegisterSignal(atoms, COMSIG_PARENT_PREQDELETED, .proc/remove_from_holo_lists)
+		atoms.flags_1 |= HOLOGRAM_1
 
 		if (isholoeffect(atoms))//activates holo effects and transfers them from the spawned list into the effects list
 			var/obj/effect/holodeck_effect/holo_effect = atoms
@@ -278,10 +282,9 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 
 ///this qdels holoitems that should no longer exist for whatever reason
 /obj/machinery/computer/holodeck/proc/derez(obj/object, silent = TRUE, forced = FALSE)
+	spawned -= object
 	if(!object)
 		return
-
-	spawned -= object
 	UnregisterSignal(object, COMSIG_PARENT_PREQDELETED)
 	var/turf/target_turf = get_turf(object)
 	for(var/c in object) //make sure that things inside of a holoitem are moved outside before destroying it

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -228,7 +228,6 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 	template.load(bottom_left) //this is what actually loads the holodeck simulation into the map
 
 	spawned = template.created_atoms //populate the spawned list with the atoms belonging to the holodeck
-	spawned += null
 
 	if(istype(template, /datum/map_template/holodeck/thunderdome1218) && !SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_MEDISIM])
 		say("Special note from \"1218 AD\" developer: I see you too are interested in the REAL dark ages of humanity! I've made this program also unlock some interesting shuttle designs on any communication console around. Have fun!")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #56874 

```
[date] runtime error: Cannot read null.flags_1
 - proc name: finish spawn (/obj/machinery/computer/holodeck/proc/finish_spawn)
 -   source file: computer.dm,249
 -   usr: the player
 -   src: the holodeck control console (/obj/machinery/computer/holodeck)
 -   usr.loc: the floor (214,143,2) (/turf/open/floor/circuit/green)
 -   src.loc: the floor (159,177,2) (/turf/open/floor/iron)
 -   call stack:
 - the holodeck control console (/obj/machinery/computer/holodeck): finish spawn()
 - the holodeck control console (/obj/machinery/computer/holodeck): load program("holodeck_medicalsim", 0, 1)
...
```

runtime in holodeck/finish_spawn() that dealt with doing shit with the atoms in the spawned list, which in some cases cease to exist. now finish_spawn has a check to see if the entry in the spawned list actually exists.

also fixes another small issue with the holodeck process() continually trying to load the offline program and getting rejected which causes the holodeck to give the "ERROR. Recalibrating projection apparatus." message, which it no longer does if the program is forced.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
holobugs must die
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: holodecks no longer get performance anxiety when one of the items it was supposed to spawn decides to not show up to the rehearsal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
