### PR TITLE
Makes the spy bug pocket protector a suit accessory

### DIFF
--- a/code/game/objects/items/devices/spyglasses.dm
+++ b/code/game/objects/items/devices/spyglasses.dm
@@ -46,7 +46,6 @@
 	icon = 'icons/obj/clothing/accessories.dmi'
 	icon_state = "pocketprotector"
 	desc = "An advanced piece of espionage equipment in the shape of a pocket protector. It has a built in 360 degree camera for all your \"admirable\" needs. Microphone not included."
-	w_class = WEIGHT_CLASS_SMALL
 	var/obj/item/clothing/glasses/sunglasses/spy/linked_glasses
 	var/atom/movable/screen/map_view/cam_screen
 	var/list/cam_plane_masters

--- a/code/game/objects/items/devices/spyglasses.dm
+++ b/code/game/objects/items/devices/spyglasses.dm
@@ -2,7 +2,7 @@
 /obj/item/clothing/glasses/sunglasses/spy
 	desc = "Made by Nerd. Co's infiltration and surveillance department. Upon closer inspection, there's a small screen in each lens."
 	actions_types = list(/datum/action/item_action/activate_remote_view)
-	var/obj/item/spy_bug/linked_bug
+	var/obj/item/clothing/accessory/spy_bug/linked_bug
 
 /obj/item/clothing/glasses/sunglasses/spy/proc/show_to_user(mob/user)//this is the meat of it. most of the map_popup usage is in this.
 	if(!user)
@@ -41,7 +41,7 @@
 	. = ..()
 
 
-/obj/item/spy_bug
+/obj/item/clothing/accessory/spy_bug
 	name = "pocket protector"
 	icon = 'icons/obj/clothing/accessories.dmi'
 	icon_state = "pocketprotector"
@@ -54,7 +54,7 @@
 	var/cam_range = 1
 	var/datum/movement_detector/tracker
 
-/obj/item/spy_bug/Initialize()
+/obj/item/clothing/accessory/spy_bug/Initialize()
 	. = ..()
 	tracker = new /datum/movement_detector(src, CALLBACK(src, .proc/update_view))
 
@@ -76,7 +76,7 @@
 		instance.screen_loc = "spypopup_map:CENTER"
 		cam_plane_masters += instance
 
-/obj/item/spy_bug/Destroy()
+/obj/item/clothing/accessory/spy_bug/Destroy()
 	if(linked_glasses)
 		linked_glasses.linked_bug = null
 	qdel(cam_screen)
@@ -84,7 +84,7 @@
 	qdel(tracker)
 	. = ..()
 
-/obj/item/spy_bug/proc/update_view()//this doesn't do anything too crazy, just updates the vis_contents of its screen obj
+/obj/item/clothing/accessory/spy_bug/proc/update_view()//this doesn't do anything too crazy, just updates the vis_contents of its screen obj
 	cam_screen.vis_contents.Cut()
 	for(var/turf/visible_turf in view(1,get_turf(src)))//fuck you usr
 		cam_screen.vis_contents += visible_turf
@@ -110,7 +110,7 @@ A shrill beep coming from your SpySpeks means that they can't connect to the inc
 	"}
 
 /obj/item/storage/box/rxglasses/spyglasskit/PopulateContents()
-	var/obj/item/spy_bug/newbug = new(src)
+	var/obj/item/clothing/accessory/spy_bug/newbug = new(src)
 	var/obj/item/clothing/glasses/sunglasses/spy/newglasses = new(src)
 	newbug.linked_glasses = newglasses
 	newglasses.linked_bug = newbug

--- a/code/game/objects/items/devices/spyglasses.dm
+++ b/code/game/objects/items/devices/spyglasses.dm
@@ -46,7 +46,7 @@
 	icon = 'icons/obj/clothing/accessories.dmi'
 	icon_state = "pocketprotector"
 	desc = "An advanced piece of espionage equipment in the shape of a pocket protector. It has a built in 360 degree camera for all your \"admirable\" needs. Microphone not included."
-
+	w_class = WEIGHT_CLASS_SMALL
 	var/obj/item/clothing/glasses/sunglasses/spy/linked_glasses
 	var/atom/movable/screen/map_view/cam_screen
 	var/list/cam_plane_masters


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the spy bug an accessory so it can be worn on your jumpsuit.

Fixes https://github.com/tgstation/tgstation/issues/54541

## Why It's Good For The Game

If this is intentional, why?

## Changelog
:cl:
fix: Makes it possible to wear the spy bug by making it actually an accessory clothing item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
