### PR TITLE
Blob: Explosive Lattice now actually works, reactive spines retaliation applies reagent, description consistency

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -2,7 +2,7 @@
 //sets you on fire, does burn damage, explodes into flame when burnt, weak to water
 /datum/blobstrain/reagent/blazing_oil
 	name = "Blazing Oil"
-	description = "will do medium-high burn damage, ignoring armor, and set targets on fire."
+	description = "will do medium-high burn damage ignoring armor, and set targets on fire."
 	effectdesc = "will also release bursts of flame when burnt, but takes damage from water."
 	analyzerdescdamage = "Does medium-high burn damage and sets targets on fire."
 	analyzerdesceffect = "Releases fire when burnt, but takes damage from water and other extinguishing liquids."

--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -2,9 +2,9 @@
 //sets you on fire, does burn damage, explodes into flame when burnt, weak to water
 /datum/blobstrain/reagent/blazing_oil
 	name = "Blazing Oil"
-	description = "will do medium burn damage and set targets on fire."
+	description = "will do medium-high burn damage, ignoring armor, and set targets on fire."
 	effectdesc = "will also release bursts of flame when burnt, but takes damage from water."
-	analyzerdescdamage = "Does medium burn damage and sets targets on fire."
+	analyzerdescdamage = "Does medium-high burn damage and sets targets on fire."
 	analyzerdesceffect = "Releases fire when burnt, but takes damage from water and other extinguishing liquids."
 	color = "#B68D00"
 	complementary_color = "#BE5532"

--- a/code/modules/antagonists/blob/blobstrains/cryogenic_poison.dm
+++ b/code/modules/antagonists/blob/blobstrains/cryogenic_poison.dm
@@ -1,7 +1,7 @@
 //does brute, burn, and toxin damage, and cools targets down
 /datum/blobstrain/reagent/cryogenic_poison
 	name = "Cryogenic Poison"
-	description = "will inject targets with a freezing poison that does high damage over time."
+	description = "will inject targets with a freezing poison, applying little impact damage but dealing high damage over time."
 	analyzerdescdamage = "Injects targets with a freezing poison that will gradually solidify the target's internal organs."
 	color = "#8BA6E9"
 	complementary_color = "#7D6EB4"

--- a/code/modules/antagonists/blob/blobstrains/debris_devourer.dm
+++ b/code/modules/antagonists/blob/blobstrains/debris_devourer.dm
@@ -3,8 +3,8 @@
 // Accumulates junk liberally
 /datum/blobstrain/debris_devourer
 	name = "Debris Devourer"
-	description = "will launch accumulated debris into targets."
-	analyzerdescdamage = "Does medium brute damage and may grab onto melee weapons."
+	description = "will launch accumulated debris into targets. Does very low brute damage without debris-launching."
+	analyzerdescdamage = "Does very low brute damage and may grab onto melee weapons."
 	analyzerdesceffect = "Devours loose items left on the station, and releases them when attacking or attacked."
 	color = "#8B1000"
 	complementary_color = "#00558B"

--- a/code/modules/antagonists/blob/blobstrains/distributed_neurons.dm
+++ b/code/modules/antagonists/blob/blobstrains/distributed_neurons.dm
@@ -1,10 +1,10 @@
 //kills unconscious targets and turns them into blob zombies, produces fragile spores when killed.  Spore produced by factories are sentient.
 /datum/blobstrain/reagent/distributed_neurons
 	name = "Distributed Neurons"
-	description = "will do very low toxin damage and turns unconscious targets into blob zombies."
+	description = "will do medium-low toxin damage and turns unconscious targets into blob zombies."
 	effectdesc = "will also produce fragile spores when killed.  Spores produced by factories are sentient."
-	shortdesc = "will do very low toxin damage and will kill any unconcious targets when attacked.  Spores produced by factories are sentient."
-	analyzerdescdamage = "Does very low toxin damage and kills unconscious humans."
+	shortdesc = "will do medium-low toxin damage and will kill any unconcious targets when attacked.  Spores produced by factories are sentient."
+	analyzerdescdamage = "Does medium-low toxin damage and kills unconscious humans."
 	analyzerdesceffect = "Produces spores when killed.  Spores produced by factories are sentient."
 	color = "#E88D5D"
 	complementary_color = "#823ABB"

--- a/code/modules/antagonists/blob/blobstrains/energized_jelly.dm
+++ b/code/modules/antagonists/blob/blobstrains/energized_jelly.dm
@@ -1,9 +1,9 @@
 //does tons of oxygen damage and a little stamina, immune to tesla bolts, weak to EMP
 /datum/blobstrain/reagent/energized_jelly
 	name = "Energized Jelly"
-	description = "will cause low stamina and high oxygen damage, and cause targets to be unable to breathe."
+	description = "will cause high stamina and medium oxygen damage, and cause targets to be unable to breathe."
 	effectdesc = "will also conduct electricity, but takes damage from EMPs."
-	analyzerdescdamage = "Does low stamina damage, high oxygen damage, and prevents targets from breathing."
+	analyzerdescdamage = "Does high stamina damage, medium oxygen damage, and prevents targets from breathing."
 	analyzerdesceffect = "Is immune to electricity and will easily conduct it, but is weak to EMPs."
 	color = "#EFD65A"
 	complementary_color = "#00E5B1"

--- a/code/modules/antagonists/blob/blobstrains/explosive_lattice.dm
+++ b/code/modules/antagonists/blob/blobstrains/explosive_lattice.dm
@@ -35,26 +35,26 @@
 	. = ..()
 	var/brute_loss = 0
 	var/burn_loss = 0
-	var/bomb_armor = 0
+	var/bomb_armor = 
 	reac_volume = return_mob_expose_reac_volume(exposed_mob, methods, reac_volume, show_message, touch_protection, overmind)
 
 	if(reac_volume >= 10) // If it's not coming from a sporecloud, AOE 'explosion' damage
+		var/epicenter_turf = get_turf(exposed_mob)
 		var/obj/effect/temp_visual/explosion/fast/ex_effect = new /obj/effect/temp_visual/explosion/fast(get_turf(exposed_mob))
 		ex_effect.alpha = 150
 
-		if(exposed_mob)
-			// Total damage to epicenter mob of 0.7*reac_volume, like a mid-tier strain
-			brute_loss = reac_volume*0.35
+		// Total damage to epicenter mob of 0.7*reac_volume, like a mid-tier strain
+		brute_loss = reac_volume*0.35
+		burn_loss = brute_loss
+
+		bomb_armor = exposed_mob.getarmor(null, BOMB)
+		if(bomb_armor) // Same calculation and proc that ex_act uses on mobs
+			brute_loss = brute_loss*(2 - round(bomb_armor*0.01, 0.05))
 			burn_loss = brute_loss
+			
+		exposed_mob.take_overall_damage(brute_loss, burn_loss)
 
-			bomb_armor = exposed_mob.getarmor(null, BOMB)
-			if(bomb_armor) // Same calculation and proc that ex_act uses on mobs
-				brute_loss = brute_loss*(2 - round(bomb_armor*0.01, 0.05))
-				burn_loss = brute_loss
-
-			exposed_mob.take_overall_damage(brute_loss, burn_loss)
-
-		for(var/mob/living/nearby_mob in orange(get_turf(exposed_mob), 1))
+		for(var/mob/living/nearby_mob in orange(epicenter_turf, 1))
 			if(ROLE_BLOB in nearby_mob.faction) // No friendly fire.
 				continue
 			if(nearby_mob == exposed_mob) // We've already hit the epicenter mob

--- a/code/modules/antagonists/blob/blobstrains/explosive_lattice.dm
+++ b/code/modules/antagonists/blob/blobstrains/explosive_lattice.dm
@@ -1,9 +1,9 @@
 //does aoe brute damage when hitting targets, is immune to explosions
 /datum/blobstrain/reagent/explosive_lattice
 	name = "Explosive Lattice"
-	description = "will do brute damage in an area around targets."
+	description = "will attack with small explosions, dealing a medium mix of brute and burn damage to everyone nearby. Spores explode on death."
 	effectdesc = "will also resist explosions, but takes increased damage from fire and other energy sources."
-	analyzerdescdamage = "Does medium brute damage and causes damage to everyone near its targets.  Spores explode on death."
+	analyzerdescdamage = "Does a medium mix of brute and burn damage in a small explosion around its targets.  Spores explode on death."
 	analyzerdesceffect = "Is highly resistant to explosions, but takes increased damage from fire and other energy sources."
 	color = "#8B2500"
 	complementary_color = "#00668B"
@@ -22,9 +22,9 @@
 	var/obj/effect/temp_visual/explosion/fast/effect = new /obj/effect/temp_visual/explosion/fast(get_turf(spore))
 	effect.alpha = 150
 	for(var/mob/living/actor in orange(get_turf(spore), 1))
-		if(ROLE_BLOB in actor.faction) //no friendly fire
+		if(ROLE_BLOB in actor.faction) // No friendly fire
 			continue
-		actor.apply_damage(20, BRUTE, wound_bonus=CANT_WOUND)
+		actor.take_overall_damage(10, 10)
 
 /datum/reagent/blob/explosive_lattice
 	name = "Explosive Lattice"
@@ -33,22 +33,42 @@
 
 /datum/reagent/blob/explosive_lattice/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/overmind)
 	. = ..()
-	var/initial_volume = reac_volume
+	var/brute_loss = 0
+	var/burn_loss = 0
+	var/bomb_armor = 0
 	reac_volume = return_mob_expose_reac_volume(exposed_mob, methods, reac_volume, show_message, touch_protection, overmind)
-	if(reac_volume >= 10) //if it's not a spore cloud, bad time incoming
+
+	if(reac_volume >= 10) // If it's not coming from a sporecloud, AOE 'explosion' damage
 		var/obj/effect/temp_visual/explosion/fast/ex_effect = new /obj/effect/temp_visual/explosion/fast(get_turf(exposed_mob))
 		ex_effect.alpha = 150
-		for(var/mob/living/nearby_mob in orange(get_turf(exposed_mob), 1))
-			if(ROLE_BLOB in nearby_mob.faction) //no friendly fire
-				continue
-			exposed_mob = nearby_mob
-			methods = TOUCH
-			reac_volume = initial_volume
-			show_message = FALSE
-			touch_protection = nearby_mob.get_permeability_protection()
-			var/aoe_volume = ..()
-			nearby_mob.apply_damage(0.4*aoe_volume, BRUTE, wound_bonus=CANT_WOUND)
+
 		if(exposed_mob)
-			exposed_mob.apply_damage(0.6*reac_volume, BRUTE, wound_bonus=CANT_WOUND)
+			// Total damage to epicenter mob of 0.7*reac_volume, like a mid-tier strain
+			brute_loss = reac_volume*0.35
+			burn_loss = brute_loss
+
+			bomb_armor = exposed_mob.getarmor(null, BOMB)
+			if(bomb_armor) // Same calculation and proc that ex_act uses on mobs
+				brute_loss = brute_loss*(2 - round(bomb_armor*0.01, 0.05))
+				burn_loss = brute_loss
+
+			exposed_mob.take_overall_damage(brute_loss, burn_loss)
+
+		for(var/mob/living/nearby_mob in orange(get_turf(exposed_mob), 1))
+			if(ROLE_BLOB in nearby_mob.faction) // No friendly fire.
+				continue
+			if(nearby_mob == exposed_mob) // We've already hit the epicenter mob
+				continue
+			// AoE damage of 0.5*reac_volume to everyone in a 1 tile range
+			brute_loss = reac_volume*0.25
+			burn_loss = brute_loss
+
+			bomb_armor = nearby_mob.getarmor(null, BOMB)
+			if(bomb_armor) // Same calculation and prod that ex_act uses on mobs
+				brute_loss = brute_loss*(2 - round(bomb_armor*0.01, 0.05))
+				burn_loss = brute_loss
+
+			nearby_mob.take_overall_damage(brute_loss, burn_loss)
+		
 	else
 		exposed_mob.apply_damage(0.6*reac_volume, BRUTE, wound_bonus=CANT_WOUND)

--- a/code/modules/antagonists/blob/blobstrains/explosive_lattice.dm
+++ b/code/modules/antagonists/blob/blobstrains/explosive_lattice.dm
@@ -45,12 +45,12 @@
 
 		// Total damage to epicenter mob of 0.7*reac_volume, like a mid-tier strain
 		brute_loss = reac_volume*0.35
-		burn_loss = brute_loss
 
 		bomb_armor = exposed_mob.getarmor(null, BOMB)
 		if(bomb_armor) // Same calculation and proc that ex_act uses on mobs
 			brute_loss = brute_loss*(2 - round(bomb_armor*0.01, 0.05))
-			burn_loss = brute_loss
+
+		burn_loss = brute_loss
 			
 		exposed_mob.take_overall_damage(brute_loss, burn_loss)
 

--- a/code/modules/antagonists/blob/blobstrains/explosive_lattice.dm
+++ b/code/modules/antagonists/blob/blobstrains/explosive_lattice.dm
@@ -35,7 +35,7 @@
 	. = ..()
 	var/brute_loss = 0
 	var/burn_loss = 0
-	var/bomb_armor = 
+	var/bomb_armor = 0
 	reac_volume = return_mob_expose_reac_volume(exposed_mob, methods, reac_volume, show_message, touch_protection, overmind)
 
 	if(reac_volume >= 10) // If it's not coming from a sporecloud, AOE 'explosion' damage

--- a/code/modules/antagonists/blob/blobstrains/networked_fibers.dm
+++ b/code/modules/antagonists/blob/blobstrains/networked_fibers.dm
@@ -1,11 +1,11 @@
 //does massive brute and burn damage, but can only expand manually
 /datum/blobstrain/reagent/networked_fibers
 	name = "Networked Fibers"
-	description = "will do high brute and burn damage and will generate resources quicker, but can only expand manually using the core or nodes."
-	shortdesc = "will do high brute and burn damage."
+	description = "will do a high mix of brute and burn damage, and will generate resources quicker, but can only expand manually using the core or nodes."
+	shortdesc = "will do a high mix of brute and burn damage."
 	effectdesc = "will move your core or node when manually expanding near it."
-	analyzerdescdamage = "Does high brute and burn damage."
-	analyzerdesceffect = "Is highly mobile and generates resources rapidly."
+	analyzerdescdamage = "Does a high mix of brute and burn damage."
+	analyzerdesceffect = "Is mobile and generates resources rapidly."
 	color = "#4F4441"
 	complementary_color = "#414C4F"
 	reagent = /datum/reagent/blob/networked_fibers

--- a/code/modules/antagonists/blob/blobstrains/pressurized_slime.dm
+++ b/code/modules/antagonists/blob/blobstrains/pressurized_slime.dm
@@ -1,9 +1,9 @@
 //does low brute damage, oxygen damage, and stamina damage and wets tiles when damaged
 /datum/blobstrain/reagent/pressurized_slime
 	name = "Pressurized Slime"
-	description = "will do low brute, oxygen, and stamina damage, and wet tiles under targets."
-	effectdesc = "will also wet tiles near blobs that are attacked or killed."
-	analyzerdescdamage = "Does low brute damage, low oxygen damage, drains stamina, and wets tiles under targets, extinguishing them.  Is resistant to brute attacks."
+	description = "will do low brute and oxygen damage, high stamina damage, and makes tiles under targets very slippery."
+	effectdesc = "will also make tiles slippery near attacked blobs."
+	analyzerdescdamage = "Does low brute and oxygen damage, high stamina damage, and makes tiles under targets very slippery, extinguishing them. Is resistant to brute attacks."
 	analyzerdesceffect = "When attacked or killed, lubricates nearby tiles, extinguishing anything on them."
 	color = "#AAAABB"
 	complementary_color = "#BBBBAA"

--- a/code/modules/antagonists/blob/blobstrains/reactive_spines.dm
+++ b/code/modules/antagonists/blob/blobstrains/reactive_spines.dm
@@ -1,22 +1,26 @@
 //does brute damage through armor and bio resistance
 /datum/blobstrain/reagent/reactive_spines
 	name = "Reactive Spines"
-	description = "will do medium brute damage through armor and bio resistance."
+	description = "will do high brute damage through armor and bio resistance."
 	effectdesc = "will also react when attacked with burn or brute damage, attacking everything in melee range."
-	analyzerdescdamage = "Does medium brute damage, ignoring armor and bio resistance."
+	analyzerdescdamage = "Does high brute damage, ignoring armor and bio resistance."
 	analyzerdesceffect = "When attacked with burn or brute damage it violently lashes out, attacking everything nearby."
 	color = "#9ACD32"
 	complementary_color = "#FFA500"
 	blobbernaut_message = "stabs"
 	message = "The blob stabs you"
 	reagent = /datum/reagent/blob/reactive_spines
+	COOLDOWN_DECLARE(retaliate_cooldown)
 
 /datum/blobstrain/reagent/reactive_spines/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
-	if(damage && ((damage_type == BRUTE) || (damage_type == BURN)) && B.obj_integrity - damage > 0) //is there any damage, is it burn or brute, and will we be alive
-		if(damage_flag == MELEE)
-			B.visible_message("<span class='boldwarning'>The blob retaliates, lashing out!</span>")
+	if(damage && ((damage_type == BRUTE) || (damage_type == BURN)) && B.obj_integrity - damage > 0 && COOLDOWN_FINISHED(src, retaliate_cooldown)) // Is there any damage, is it burn or brute, will we be alive, and has the cooldown finished?
+		COOLDOWN_START(src, retaliate_cooldown, 25) // 2.5 seconds before auto-retaliate can whack everything within 1 tile again
+		B.visible_message("<span class='boldwarning'>The blob retaliates, lashing out!</span>")
 		for(var/atom/A in range(1, B))
-			A.blob_act(B)
+			if(isliving(A) && !isblobmonster(A)) // Make sure to inject strain-reagents with automatic attacks when needed.
+				attack_living(A)
+			else
+				A.blob_act(B)
 	return ..()
 
 /datum/reagent/blob/reactive_spines

--- a/code/modules/antagonists/blob/blobstrains/reactive_spines.dm
+++ b/code/modules/antagonists/blob/blobstrains/reactive_spines.dm
@@ -17,10 +17,14 @@
 		COOLDOWN_START(src, retaliate_cooldown, 2.5 SECONDS) // 2.5 seconds before auto-retaliate can whack everything within 1 tile again
 		B.visible_message("<span class='boldwarning'>The blob retaliates, lashing out!</span>")
 		for(var/atom/A in range(1, B))
-			if(isliving(A) && !isblobmonster(A)) // Make sure to inject strain-reagents with automatic attacks when needed.
+			var/attacked_turf = get_turf(A)
+			if(isliving(A) && !isblobmonster(A)) // Make sure to inject strain-reagents with automatic attacks when needed. 
+				B.blob_attack_animation(attacked_turf, overmind)
 				attack_living(A)
-			else
-				A.blob_act(B)
+
+			else if(A.blob_act(B)) // After checking for mobs, whack everything else with the standard attack
+				B.blob_attack_animation(attacked_turf, overmind) // Only play the animation if the attack did something meaningful
+				
 	return ..()
 
 /datum/reagent/blob/reactive_spines

--- a/code/modules/antagonists/blob/blobstrains/reactive_spines.dm
+++ b/code/modules/antagonists/blob/blobstrains/reactive_spines.dm
@@ -14,7 +14,7 @@
 
 /datum/blobstrain/reagent/reactive_spines/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if(damage && ((damage_type == BRUTE) || (damage_type == BURN)) && B.obj_integrity - damage > 0 && COOLDOWN_FINISHED(src, retaliate_cooldown)) // Is there any damage, is it burn or brute, will we be alive, and has the cooldown finished?
-		COOLDOWN_START(src, retaliate_cooldown, 25) // 2.5 seconds before auto-retaliate can whack everything within 1 tile again
+		COOLDOWN_START(src, retaliate_cooldown, 2.5 SECONDS) // 2.5 seconds before auto-retaliate can whack everything within 1 tile again
 		B.visible_message("<span class='boldwarning'>The blob retaliates, lashing out!</span>")
 		for(var/atom/A in range(1, B))
 			if(isliving(A) && !isblobmonster(A)) // Make sure to inject strain-reagents with automatic attacks when needed.

--- a/code/modules/antagonists/blob/blobstrains/regenerative_materia.dm
+++ b/code/modules/antagonists/blob/blobstrains/regenerative_materia.dm
@@ -1,8 +1,8 @@
 //does toxin damage, hallucination, targets think they're not hurt at all
 /datum/blobstrain/reagent/regenerative_materia
 	name = "Regenerative Materia"
-	description = "will do toxin damage and cause targets to believe they are fully healed."
-	analyzerdescdamage = "Does toxin damage and injects a toxin that causes the target to believe they are fully healed.  Core regenerates much faster."
+	description = "will do medium initial toxin damage, injecting a poison which does more toxin damage and makes targets believe they are fully healed. The core regenerates much faster."
+	analyzerdescdamage = "Does medium initial toxin damage, injecting a poison which does more toxin damage and makes targets believe they are fully healed. Core regenerates much faster."
 	color = "#A88FB7"
 	complementary_color = "#AF7B8D"
 	message_living = ", and you feel <i>alive</i>"

--- a/code/modules/antagonists/blob/blobstrains/synchronous_mesh.dm
+++ b/code/modules/antagonists/blob/blobstrains/synchronous_mesh.dm
@@ -1,9 +1,9 @@
 //does brute damage, bonus damage for each nearby blob, and spreads damage out
 /datum/blobstrain/reagent/synchronous_mesh
 	name = "Synchronous Mesh"
-	description = "will do massively increased brute damage for each blob near the target."
+	description = "will do low brute damage, but each blob nearby attacks the target as well with stacking damage."
 	effectdesc = "will also spread damage between each blob near the attacked blob."
-	analyzerdescdamage = "Does brute damage, increasing for each blob near the target."
+	analyzerdescdamage = "Does low brute damage, increasing for each blob near the target."
 	analyzerdesceffect = "When attacked, spreads damage between all blobs near the attacked blob."
 	color = "#65ADA2"
 	complementary_color = "#AD6570"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Explosive Lattice strain was _completely_ broken. In the images below, the middle mob is attacked once.
![image](https://user-images.githubusercontent.com/20977204/107782939-f5465700-6d49-11eb-9a6d-fd32cf5505b6.png)

It doesn't do an AoE at all, does 5 dmg from the default blob_act on the target, and gives a single guy in the 'AoE' 15 damage.

Explosive Lattice has been changed to use the same damage calculations as ex_act, dealing a mix of brute/burn in the AoE properly.

![image](https://user-images.githubusercontent.com/20977204/107783167-3dfe1000-6d4a-11eb-8e1e-4c32cc258148.png)



Additionally, the Reactive Spines retaliation now properly smacks living mobs with the reagents that the strain should apply. A small 2.5 second cooldown has been added between these retaliatory attacks, considering the increased damage they do to mobs now.

The strain effect descriptions were also _all over the place_ in terms of damage applied, and have been made more consistent. E.g. an 0.6 reagent mod was called 'high oxy damage' while a 1.0 mod was called 'medium brute' elsewhere.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Blob code is an inconsistent fucking mess that I've been slowly working away at making more bearable, this is another step forward (I hope). Broken strain fixed, another strain's behavior made more sensible, and various comment/description fixes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The Reactive Spines blob strain's retaliation now applies the strain's reagents, and can trigger once every 2.5 seconds.
fix: Fixed and changed the Explosive Lattice blob strain. It didn't work at all, but now actually applies an AoE of light burn/brute.
code: Changed comments and descriptions of various blob strains to be more consistent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
