### PR TITLE
Fixes free buffers in reaction chambers (sorry!)

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -234,7 +234,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
@@ -794,7 +794,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -3515,7 +3515,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/rnd)
 "iF" = (
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -40280,7 +40280,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "dcP" = (
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -43273,7 +43273,7 @@
 /turf/open/floor/iron,
 /area/medical/pharmacy)
 "dkh" = (
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/machinery/requests_console{
 	department = "Pharmacy";
 	name = "Pharmacy RC";
@@ -44427,7 +44427,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "dnr" = (
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = 28

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -13685,7 +13685,7 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "bjO" = (
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -13974,7 +13974,7 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "bkL" = (
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -18754,7 +18754,7 @@
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "bCP" = (
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -18022,7 +18022,7 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/port)
 "aRN" = (
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -23981,7 +23981,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "bdr" = (
-/obj/machinery/chem_heater{
+/obj/machinery/chem_heater/withbuffer{
 	pixel_x = 6
 	},
 /obj/effect/turf_decal/bot,
@@ -26081,7 +26081,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bgM" = (
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -87029,7 +87029,7 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "voc" = (
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -22501,7 +22501,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "che" = (
@@ -23747,7 +23747,7 @@
 	},
 /area/maintenance/starboard/secondary)
 "cnc" = (
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "cne" = (
@@ -59555,7 +59555,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -60722,7 +60722,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
@@ -79774,7 +79774,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "xgQ" = (
-/obj/machinery/chem_heater{
+/obj/machinery/chem_heater/withbuffer{
 	pixel_x = 4
 	},
 /obj/effect/turf_decal/tile/yellow,

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -535,7 +535,7 @@
 /area/medical/chemistry)
 "bR" = (
 /obj/machinery/camera/autoname,
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /obj/machinery/power/apc{
 	dir = 1;
 	pixel_y = 23

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -278,7 +278,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aQ" = (
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "aR" = (

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -476,13 +476,13 @@ To continue set your target temperature to 390K."}
 /obj/machinery/chem_heater/debug/Initialize()
 	. = ..()
 	reagents.maximum_volume = 2000
-	reagents.add_reagent(/datum/reagent/reaction_agent/basic_buffer, 980)
-	reagents.add_reagent(/datum/reagent/reaction_agent/acidic_buffer, 980)
+	reagents.add_reagent(/datum/reagent/reaction_agent/basic_buffer, 1000)
+	reagents.add_reagent(/datum/reagent/reaction_agent/acidic_buffer, 1000)
 	heater_coefficient = 0.4 //hack way to upgrade
 
 //map load types
 /obj/machinery/chem_heater/withbuffer
-	desc = "This [name] comes with a bit of buffer to help get you started."
+	desc = "This Reaction Chamber comes with a bit of buffer to help get you started."
 
 /obj/machinery/chem_heater/withbuffer/Initialize()
 	. = ..()

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -33,12 +33,9 @@
 	///What state we're at in the tutorial
 	var/tutorial_state = 0
 
-/obj/machinery/chem_heater/Initialize(mapload)
+/obj/machinery/chem_heater/Initialize()
 	. = ..()
-	create_reagents(200, NO_REACT)//Lets save some calculations here
-	if(mapload)
-		reagents.add_reagent(/datum/reagent/reaction_agent/basic_buffer, 20)
-		reagents.add_reagent(/datum/reagent/reaction_agent/acidic_buffer, 20)
+	create_reagents(200, NO_REACT)//Lets save some calculations here		
 	//TODO: comsig reaction_start and reaction_end to enable/disable the UI autoupdater - this doesn't work presently as there's a hard divide between instant and processed reactions
 	
 /obj/machinery/chem_heater/Destroy()
@@ -482,3 +479,12 @@ To continue set your target temperature to 390K."}
 	reagents.add_reagent(/datum/reagent/reaction_agent/basic_buffer, 980)
 	reagents.add_reagent(/datum/reagent/reaction_agent/acidic_buffer, 980)
 	heater_coefficient = 0.4 //hack way to upgrade
+
+//map load types
+/obj/machinery/chem_heater/withbuffer
+	desc = "This [name] comes with a bit of buffer to help get you started."
+
+/obj/machinery/chem_heater/withbuffer/Initialize()
+	. = ..()
+	reagents.add_reagent(/datum/reagent/reaction_agent/basic_buffer, 20)
+	reagents.add_reagent(/datum/reagent/reaction_agent/acidic_buffer, 20)

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -35,8 +35,8 @@
 
 /obj/machinery/chem_heater/Initialize(mapload)
 	. = ..()
+	create_reagents(200, NO_REACT)//Lets save some calculations here
 	if(mapload)
-		create_reagents(200, NO_REACT)//Lets save some calculations here
 		reagents.add_reagent(/datum/reagent/reaction_agent/basic_buffer, 20)
 		reagents.add_reagent(/datum/reagent/reaction_agent/acidic_buffer, 20)
 	//TODO: comsig reaction_start and reaction_end to enable/disable the UI autoupdater - this doesn't work presently as there's a hard divide between instant and processed reactions

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -33,11 +33,12 @@
 	///What state we're at in the tutorial
 	var/tutorial_state = 0
 
-/obj/machinery/chem_heater/Initialize()
+/obj/machinery/chem_heater/Initialize(mapload)
 	. = ..()
-	create_reagents(200, NO_REACT)//Lets save some calculations here
-	reagents.add_reagent(/datum/reagent/reaction_agent/basic_buffer, 20)
-	reagents.add_reagent(/datum/reagent/reaction_agent/acidic_buffer, 20)
+	if(mapload)
+		create_reagents(200, NO_REACT)//Lets save some calculations here
+		reagents.add_reagent(/datum/reagent/reaction_agent/basic_buffer, 20)
+		reagents.add_reagent(/datum/reagent/reaction_agent/acidic_buffer, 20)
 	//TODO: comsig reaction_start and reaction_end to enable/disable the UI autoupdater - this doesn't work presently as there's a hard divide between instant and processed reactions
 	
 /obj/machinery/chem_heater/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Presently if you deconstruct then reconstruct a reaction chamber, you get free buffer. It doesn't make sense to have free magic buffer so I should probably fix this.

## Why It's Good For The Game

Fixes a source of infinite matter.

## Changelog
:cl:
fix: fixes reaction chambers giving free buffer on deconstruct/reconstruct
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
