### PR TITLE
Adds more admin memery and deadchat_control options to immovable rods.

### DIFF
--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -189,3 +189,20 @@
 	inputs["down"] = CALLBACK(GLOBAL_PROC, .proc/_step, parent, SOUTH)
 	inputs["left"] = CALLBACK(GLOBAL_PROC, .proc/_step, parent, WEST)
 	inputs["right"] = CALLBACK(GLOBAL_PROC, .proc/_step, parent, EAST)
+
+/**
+ * Deadchat Moves Things
+ *
+ * A special variant of the deadchat_control component that comes pre-baked with all the hottest inputs for spicy
+ * immovable rod.
+ */
+/datum/component/deadchat_control/immovable_rod/Initialize(_deadchat_mode, _inputs, _input_cooldown, _on_removal)
+	if(!istype(parent, /obj/effect/immovablerod))
+		return COMPONENT_INCOMPATIBLE
+
+	. = ..()
+
+	inputs["up"] = CALLBACK(parent, /obj/effect/immovablerod.proc/walk_in_direction, NORTH)
+	inputs["down"] = CALLBACK(parent, /obj/effect/immovablerod.proc/walk_in_direction, SOUTH)
+	inputs["left"] = CALLBACK(parent, /obj/effect/immovablerod.proc/walk_in_direction, WEST)
+	inputs["right"] = CALLBACK(parent, /obj/effect/immovablerod.proc/walk_in_direction, EAST)

--- a/code/modules/admin/smites/rod.dm
+++ b/code/modules/admin/smites/rod.dm
@@ -1,6 +1,7 @@
 /// Throw an immovable rod at the target
 /datum/smite/rod
 	name = "Immovable Rod"
+	var/force_looping = FALSE
 
 /datum/smite/rod/effect(client/user, mob/living/target)
 	. = ..()
@@ -8,4 +9,8 @@
 	var/startside = pick(GLOB.cardinals)
 	var/turf/start_turf = spaceDebrisStartLoc(startside, target_turf.z)
 	var/turf/end_turf = spaceDebrisFinishLoc(startside, target_turf.z)
-	new /obj/effect/immovablerod(start_turf, end_turf, target)
+	new /obj/effect/immovablerod(start_turf, end_turf, target, force_looping)
+
+/datum/smite/rod/loopy
+	name = "Immovable Rod (Looping)"
+	force_looping = TRUE

--- a/code/modules/admin/smites/rod.dm
+++ b/code/modules/admin/smites/rod.dm
@@ -3,6 +3,11 @@
 	name = "Immovable Rod"
 	var/force_looping = FALSE
 
+/datum/smite/rod/configure(client/user)
+	var/loop_input = alert("Would you like this rod to force-loop across space z-levels?", "Loopy McLoopface", "Yes", "No")
+
+	force_looping = (loop_input == "Yes")
+
 /datum/smite/rod/effect(client/user, mob/living/target)
 	. = ..()
 	var/turf/target_turf = get_turf(target)
@@ -10,7 +15,3 @@
 	var/turf/start_turf = spaceDebrisStartLoc(startside, target_turf.z)
 	var/turf/end_turf = spaceDebrisFinishLoc(startside, target_turf.z)
 	new /obj/effect/immovablerod(start_turf, end_turf, target, force_looping)
-
-/datum/smite/rod/loopy
-	name = "Immovable Rod (Looping)"
-	force_looping = TRUE

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -303,7 +303,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	complete_trajectory()
 
 /obj/effect/immovablerod/deadchat_plays(mode = DEMOCRACY_MODE, cooldown = 6 SECONDS)
-	. = AddComponent(/datum/component/deadchat_control/immovable_rod, mode, list(), cooldown)
+	return AddComponent(/datum/component/deadchat_control/immovable_rod, mode, list(), cooldown)
 
 /**
  * Rod will walk towards edge turf in the specified direction.

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -115,7 +115,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	if(loc.density)
 		Bump(loc)
 
-	// So, we're phasing as will harmlessly glide through things. Let's noogie everything in our loc's contents.
+	// So, we're phasing and will harmlessly glide through things. Let's noogie everything in our loc's contents.
 	for(var/clong in loc.contents)
 		if(clong == src)
 			continue
@@ -176,8 +176,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /obj/effect/immovablerod/proc/complete_trajectory()
 	// We hit what we wanted to hit, time to go.
 	special_target = null
-	destination = get_edge_target_turf(src, dir)
-	walk_towards(src, destination, 1)
+	walk_in_direction(dir)
 
 /obj/effect/immovablerod/singularity_act()
 	return
@@ -278,3 +277,40 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		qdel(src)
 
 	return TRUE
+
+/* Below are a couple of admin helper procs when dealing with immovable rod memes. */
+/**
+ * Stops your rod's automated movement. Sit... Stay... Good rod!
+ */
+/obj/effect/immovablerod/proc/stay_good_rod()
+	walk(src, 0)
+
+/**
+ * Allows your rod to release restraint level zero and go for a walk.
+ *
+ * If walkies_location is set, rod will walk_towards the location, chasing it across z-levels if necessary.
+ * If walkies_location is not set, rod will call complete_trajectory() and follow the logic from that proc.
+ *
+ * Arguments:
+ * * walkies_location - Any atom that the immovable rod will now chase down as a special target.
+ */
+/obj/effect/immovablerod/proc/go_for_a_walk(walkies_location = null)
+	if(walkies_location)
+		special_target = walkies_location
+		walk_towards(src, special_target, 1)
+		return
+
+	complete_trajectory()
+
+/obj/effect/immovablerod/deadchat_plays(mode = DEMOCRACY_MODE, cooldown = 6 SECONDS)
+	. = AddComponent(/datum/component/deadchat_control/immovable_rod, mode, list(), cooldown)
+
+/**
+ * Rod will walk towards edge turf in the specified direction.
+ *
+ * Arguments:
+ * * direction - The direction to walk the rod towards: NORTH, SOUTH, EAST, WEST.
+ */
+/obj/effect/immovablerod/proc/walk_in_direction(direction)
+	destination = get_edge_target_turf(src, direction)
+	walk_towards(src, destination, 1)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -282,7 +282,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /**
  * Stops your rod's automated movement. Sit... Stay... Good rod!
  */
-/obj/effect/immovablerod/proc/stay_good_rod()
+/obj/effect/immovablerod/proc/sit_stay_good_rod()
 	walk(src, 0)
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new Immovable Rod (Looping) smite, since I know admins like to mass-throw rods in build mode and adding a confirmation box would just interfere with this.

Adds the ability for admins to have a loopy rod when triggering an event through the Trigger Event menu,

There are no practical changes to the Immovable Rod event when it spawns naturally. This merely gives admins the option to force loopy rods to happen.

Redoes some immovable rod procs and adds a couple of helper procs intended for admins to call, `go_for_a_walk()` which takes a single argument of a new special_target for the rod to go towards and sends the rod on its merry way towards it and `sit_stay_good_rod()` which stops the rod in its tracks.

Also adds a new deadchat_controls component to the rod, which allows deadchat to control an immovable rod's trajectory through voting. By default, this does not include allowing the rod to traverse z-levels - If an admin wants their deadchat controlled rod to be able to orbit the stars, then they need to set the `loopy_rod` var manually or spawn in an admin-abuse looping rod.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It probably isn't. I'm working on this to give me a break from coding the new ID Card tgui interfaces.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Admins can now create special z-level looping rods through the Trigger Event and Smite menus.
admin: Added a unqiue deadchat_control component for immovable rods. This is easily applied through the VV dropdown menu. This lets deadchat control the immovable rod by voting on its trajectory every 6 seconds. This does not make the rod loop and if admins want a deadchat controlled rod to traverse z-levels, they should var edit it to allow that to happen,
admin: There's a new pair of helper procs, sit_stay_good_rod() and go_for_a_walk() which allow admins to stop a rod or send it at a specific target respectively. This was possible before with enough knowledge, but has been condensed into two helper procs for ease of access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
