### PR TITLE
Removes tweak and replaces it with a tag for QoL and Atomic prs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
 add: Added new things
 add: Added more things
 del: Removed old things
-tweak: tweaked a few things
+qol: made something easier to use
 balance: rebalanced something
 fix: fixed a few things
 soundadd: added a new sound thingy

--- a/html/changelog.css
+++ b/html/changelog.css
@@ -12,6 +12,7 @@ a img {border:none;}
 .bugfix {background-image:url(bug-minus.png)}
 .wip {background-image:url(hard-hat-exclamation.png)}
 .tweak {background-image:url(wrench-screwdriver.png)}
+.qol {background-image:url(wrench-screwdriver.png)}
 .soundadd {background-image:url(music-plus.png)}
 .sounddel {background-image:url(music-minus.png)}
 .rscdel {background-image:url(cross-circle.png)}
@@ -29,7 +30,7 @@ a img {border:none;}
 .sansserif {font-family:Tahoma,sans-serif;font-size:12px;}
 .commit {margin-bottom:20px;font-size:100%;font-weight:normal;}
 .changes {list-style:none;margin:5px 0;padding:0 0 0 25px;font-size:0.8em;}
-.date {margin:10px 0;color:blue;border-bottom:2px solid #00f;width:60%;padding:2px 0;font-size:1em;font-weight:bold;}	
+.date {margin:10px 0;color:blue;border-bottom:2px solid #00f;width:60%;padding:2px 0;font-size:1em;font-weight:bold;}
 .author {padding-left:10px;margin:0;font-weight:bold;font-size:0.9em;}
 .drop {cursor:pointer;border:1px solid #999;display:inline;font-size:0.9em;padding:1px 20px 1px 5px;line-height:16px;}
 .hidden {display:none;}

--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -573,15 +573,16 @@ function get_pr_code_friendliness($payload, $oldbalance = null){
 		'Refactor' => 10,
 		'Code Improvement' => 2,
 		'Grammar and Formatting' => 1,
+		'Quality of Life' => 1,
 		'Priority: High' => 15,
 		'Priority: CRITICAL' => 20,
 		'Unit Tests' => 6,
 		'Logging' => 1,
 		'Feedback' => 2,
 		'Performance' => 12,
+		'Atomic' => 2,
 		'Feature' => -10,
 		'Balance/Rebalance' => -8,
-		'Tweak' => -2,
 		'Sound' => 1,
 		'Sprites' => 1,
 		'GBP: Reset' => $startingPRBalance - $oldbalance,
@@ -602,8 +603,7 @@ function get_pr_code_friendliness($payload, $oldbalance = null){
 		}
 	}
 
-	$affecting = abs($maxNegative) >= $maxPositive ? $maxNegative : $maxPositive;
-	return $affecting;
+	return $maxNegative + $maxPositive;
 }
 
 function is_maintainer($payload, $author){

--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -768,12 +768,10 @@ function checkchangelog($payload, $compile = true) {
 					$currentchangelogblock[] = array('type' => 'bugfix', 'body' => $item);
 				}
 				break;
-			case 'rsctweak':
-			case 'tweaks':
-			case 'tweak':
-				if($item != 'tweaked a few things') {
-					$tags[] = 'Tweak';
-					$currentchangelogblock[] = array('type' => 'tweak', 'body' => $item);
+			case 'qol':
+				if($item != 'made something easier to use') {
+					$tags[] = 'Quality of Life';
+					$currentchangelogblock[] = array('type' => 'qol', 'body' => $item);
 				}
 				break;
 			case 'soundadd':


### PR DESCRIPTION
@tgstation/commit-access Let me know what you think, if this is good I'll remove the tweak tag when this is merged

## About The Pull Request

Tweak is too ambiguous to be useful as a tag for most prs and it gets applied to anything from small aesthetic map edits to minor balance changes. If we add tags for indicating specific small changes we can remove it without issue. The two tags are:

- Quality of Life: Changes that don't affect game balance except by making certain actions easier to do for the player. If this significantly changes the capability of the player due to being freed up to do other things, then it's probably a balance change instead. Giving a hotkey to an ability is quality of life, making the clown automatically drop his pda to slip them when switching places with someone is balance.
- Atomic: Small prs that are easy to review. This is to incentivize people to break up their changes.

QoL is worth 1 point. Atomic is worth 2, though it should perhaps be a bit more.

Current gbp calculation only uses one of either the largest positive or negative, this means that if you make a feature you wouldn't be rewarded for making it atomic. To account for this I've also changed the calculation so that it combines the largest positive and negative. For example, a pr that is both a refactor (+10) and feature (-10) would be worth 0 points.

This also removes tweak from the changelog, though only new ones. Old changelog entries for tweak will still be displayed correctly but new ones made from a pr body wont work.