### PR TITLE
Adds moodlet for moth wings burning off

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -312,6 +312,6 @@
 	timeout = 90 SECONDS
 
 /datum/mood_event/burnt_wings
-	description = "<span class='boldwarning'>My wings were RUINED!!</span>\n"
+	description = "<span class='boldwarning'>MY PRECIOUS WINGS!!</span>\n"
 	mood_change = -10
 	timeout = 10 MINUTES

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -310,3 +310,8 @@
 	description = "<span class='warning'>All the fish are dead...</span>\n"
 	mood_change = -3
 	timeout = 90 SECONDS
+
+/datum/mood_event/burnt_wings
+	description = "<span class='boldwarning'>My wings were RUINED!!</span>\n"
+	mood_change = -10
+	timeout = 10 MINUTES

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -43,6 +43,7 @@
 		return
 	if(H.dna.features["moth_wings"] != "Burnt Off" && H.bodytemperature >= 800 && H.fire_stacks > 0) //do not go into the extremely hot light. you will not survive
 		to_chat(H, "<span class='danger'>Your precious wings burn to a crisp!</span>")
+		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "burnt_wings", /datum/mood_event/burnt_wings)
 		if(!H.dna.features["original_moth_wings"]) //Fire apparently destroys DNA, so let's preserve that elsewhere, checks if an original was already stored to prevent bugs
 			H.dna.features["original_moth_wings"] = H.dna.features["moth_wings"]
 		H.dna.features["moth_wings"] = "Burnt Off"


### PR DESCRIPTION
## About The Pull Request
Gives moths a bad moodlet when their wings burn off that is the same change as dismemberment, but 2 minutes longer, so it's not just the mood changes of being on fire and having been hot.

Mothblocks said someone could do this, and I guess no one took that offer up before I got home.

## Why It's Good For The Game
Better mechanical representation of the suffering inflicted upon mothpeople improves the experience for everybody.

## Changelog
:cl:
add: Mothpeople now actually have their mood worsened when their wings burn off.
/:cl: