### PR TITLE
Vines get destroyed on bud's Destroy()

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -48,8 +48,7 @@
 	countdown.start()
 
 /obj/structure/alien/resin/flower_bud/Destroy()
-	for(var/datum/beam/B in vines)
-		B.Destroy()
+	QDEL_LIST(vines)
 	return ..()
 
 
@@ -61,7 +60,7 @@
 /obj/structure/alien/resin/flower_bud/proc/bear_fruit()
 	visible_message("<span class='danger'>The plant has borne fruit!</span>")
 	new /mob/living/simple_animal/hostile/venus_human_trap(get_turf(src))
-	src.Destroy()
+	qdel(src)
 
 
 /obj/structure/alien/resin/flower_bud/proc/progress_growth()

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -62,7 +62,6 @@
 	new /mob/living/simple_animal/hostile/venus_human_trap(get_turf(src))
 	qdel(src)
 
-
 /obj/structure/alien/resin/flower_bud/proc/progress_growth()
 	growth_icon++
 	icon_state = "bud[growth_icon]"

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -28,6 +28,8 @@
 	/// The countdown ghosts see to when the plant will hatch
 	var/obj/effect/countdown/flower_bud/countdown
 
+	var/list/vines = list()
+
 /obj/structure/alien/resin/flower_bud/Initialize()
 	. = ..()
 	countdown = new(src)
@@ -37,12 +39,19 @@
 	anchors += locate(x-2,y-2,z)
 	anchors += locate(x+2,y-2,z)
 
+
 	for(var/turf/T in anchors)
-		Beam(T, "vine", maxdistance=5, beam_type=/obj/effect/ebeam/vine)
+		vines += Beam(T, "vine", maxdistance=5, beam_type=/obj/effect/ebeam/vine)
 	finish_time = world.time + growth_time
 	addtimer(CALLBACK(src, .proc/bear_fruit), growth_time)
 	addtimer(CALLBACK(src, .proc/progress_growth), growth_time/4)
 	countdown.start()
+
+/obj/structure/alien/resin/flower_bud/Destroy()
+	for(var/datum/beam/B in vines)
+		B.Destroy()
+	return ..()
+
 
 /**
  * Spawns a venus human trap, then qdels itself.
@@ -52,7 +61,8 @@
 /obj/structure/alien/resin/flower_bud/proc/bear_fruit()
 	visible_message("<span class='danger'>The plant has borne fruit!</span>")
 	new /mob/living/simple_animal/hostile/venus_human_trap(get_turf(src))
-	qdel(src)
+	src.Destroy()
+
 
 /obj/structure/alien/resin/flower_bud/proc/progress_growth()
 	growth_icon++

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -39,7 +39,6 @@
 	anchors += locate(x-2,y-2,z)
 	anchors += locate(x+2,y-2,z)
 
-
 	for(var/turf/T in anchors)
 		vines += Beam(T, "vine", maxdistance=5, beam_type=/obj/effect/ebeam/vine)
 	finish_time = world.time + growth_time
@@ -50,7 +49,6 @@
 /obj/structure/alien/resin/flower_bud/Destroy()
 	QDEL_LIST(vines)
 	return ..()
-
 
 /**
  * Spawns a venus human trap, then qdels itself.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simple fix for https://github.com/tgstation/tgstation/issues/56879 caused by qdelling the bud without clearing up the vines.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No more persistent deadly kudzu thorns that can't have anything done about.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Hadza
fix: Thorny vines now get deleted after their venus human trap bud is removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
