### PR TITLE
Metastation Xenobio Fixes (See #56597 for full history)

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -32405,7 +32405,7 @@
 	name = "Xenobiology Lockdown"
 	},
 /turf/open/floor/iron,
-/area/science/cytology)
+/area/science/xenobiology)
 "dUA" = (
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
@@ -39146,6 +39146,15 @@
 	},
 /turf/open/floor/wood,
 /area/cargo/qm)
+"gDh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio1";
+	name = "Xenobio Pen 1 Blast Door"
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "gDo" = (
 /obj/structure/table,
 /obj/item/clothing/mask/gas/sechailer{
@@ -39908,7 +39917,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -51754,6 +51762,10 @@
 "lQN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio8";
+	name = "Xenobio Pen 8 Blast Door"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "lQP" = (
@@ -60207,7 +60219,7 @@
 /obj/machinery/smartfridge/extract/preloaded,
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron,
-/area/science/cytology)
+/area/science/xenobiology)
 "pjE" = (
 /obj/machinery/recharger,
 /obj/item/storage/secure/safe{
@@ -60635,7 +60647,7 @@
 	name = "Xenobiology Lockdown"
 	},
 /turf/open/floor/iron,
-/area/science/cytology)
+/area/science/xenobiology)
 "pui" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -60790,7 +60802,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
-/area/science/cytology)
+/area/science/xenobiology)
 "pwt" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -62998,7 +63010,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "qrc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -63730,6 +63742,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
+"qCL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/sign/warning/electricshock,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio8";
+	name = "Xenobio Pen 8 Blast Door"
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "qCO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -65349,7 +65371,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
-	name = "Xenobio Pen 7 Blast Door"
+	name = "Xenobio Pen 8 Blast Door"
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
@@ -73139,7 +73161,7 @@
 /obj/structure/cable,
 /obj/machinery/monkey_recycler,
 /turf/open/floor/iron,
-/area/science/cytology)
+/area/science/xenobiology)
 "uxP" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -76138,6 +76160,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vIl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/sign/warning/electricshock,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio1";
+	name = "Xenobio Pen 1 Blast Door"
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "vIA" = (
 /obj/machinery/light{
 	dir = 1
@@ -79359,7 +79391,7 @@
 /obj/machinery/processor/slime,
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron,
-/area/science/cytology)
+/area/science/xenobiology)
 "wZw" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -80176,7 +80208,7 @@
 /obj/structure/cable,
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/iron,
-/area/science/cytology)
+/area/science/xenobiology)
 "xpZ" = (
 /turf/closed/wall,
 /area/medical/abandoned)
@@ -80725,7 +80757,7 @@
 	name = "Xenobiology Lockdown"
 	},
 /turf/open/floor/iron,
-/area/science/cytology)
+/area/science/xenobiology)
 "xDd" = (
 /obj/machinery/light{
 	dir = 4
@@ -81430,7 +81462,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/science/cytology)
+/area/science/xenobiology)
 "xSC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -81492,7 +81524,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "xTK" = (
 /obj/machinery/button/door{
@@ -125886,7 +125918,7 @@ qKh
 cSn
 omN
 tQb
-lQN
+gDh
 xpX
 qie
 hSD
@@ -126143,13 +126175,13 @@ qKh
 cSn
 cSy
 cSn
-wXQ
+vIl
 pjC
 mTR
 xey
 dEM
 wZr
-wXQ
+qCL
 cSn
 cSy
 cSn
@@ -126400,7 +126432,7 @@ cRi
 ltH
 xNj
 ltH
-lQN
+gDh
 xSB
 gYm
 tlO


### PR DESCRIPTION
This adds the same changes as #56597

## About The Pull Request

Fixes Xenobiology so that slime ranchers may focus squarely on those alien life forms instead doing some minor engineering work. Also addresses some issues where there were a few active turfs and a pesky doublewire.
This is a redo of #56597 because my branch locked up and it was just faster to remake the whole fork. 

## Why It's Good For The Game

Xenobiologists should be able to use their consoles without moving them.

## Changelog
:cl:
fix: Rearea's Xenobiology so that Monkey Recycler and Slime Grinder are accessable to the Slime Consoles at game start. 
fix: Changes some active turfs in space to inactive
fix: Removes a second wire at the bridge-side door 
/:cl:


