### PR TITLE
Nerfs the roundstart planetary gasmixes, cleans up the code a bit

### DIFF
--- a/code/datums/atmosphere/_atmosphere.dm
+++ b/code/datums/atmosphere/_atmosphere.dm
@@ -43,7 +43,7 @@
 		else
 			gastype = pick(spicy_gas)
 			amount = spicy_gas[gastype]
-			spicy_gas -= gastype //You can only pick each resricted gas once
+			spicy_gas -= gastype //You can only pick each restricted gas once
 
 		amount *= rand(50, 200) / 100	// Randomly modifes the amount from half to double the base for some variety
 		amount *= pressure_scalar		// If we pick a really small target pressure we want roughly the same mix but less of it all

--- a/code/datums/atmosphere/_atmosphere.dm
+++ b/code/datums/atmosphere/_atmosphere.dm
@@ -17,11 +17,12 @@
 	generate_gas_string()
 
 /datum/atmosphere/proc/generate_gas_string()
+	var/list/spicy_gas = restricted_gases.Copy()
 	var/target_pressure = rand(minimum_pressure, maximum_pressure)
 	var/pressure_scalar = target_pressure / maximum_pressure
 
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_UNNATURAL_ATMOSPHERE))
-		restricted_chance = restricted_chance + 30
+		restricted_chance = restricted_chance + 40
 
 	// First let's set up the gasmix and base gases for this template
 	// We make the string from a gasmix in this proc because gases need to calculate their pressure
@@ -36,14 +37,13 @@
 	var/datum/gas/gastype
 	var/amount
 	while(gasmix.return_pressure() < target_pressure)
-		if(!prob(restricted_chance))
+		if(!prob(restricted_chance) || !length(spicy_gas))
 			gastype = pick(normal_gases)
 			amount = normal_gases[gastype]
 		else
-			gastype = pick(restricted_gases)
-			amount = restricted_gases[gastype]
-			if(!HAS_TRAIT(SSstation, STATION_TRAIT_UNNATURAL_ATMOSPHERE) && gaslist[gastype])
-				continue
+			gastype = pick(spicy_gas)
+			amount = spicy_gas[gastype]
+			spicy_gas -= gastype //You can only pick each resricted gas once
 
 		amount *= rand(50, 200) / 100	// Randomly modifes the amount from half to double the base for some variety
 		amount *= pressure_scalar		// If we pick a really small target pressure we want roughly the same mix but less of it all

--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -17,7 +17,7 @@
 		/datum/gas/miasma=1.2,
 		/datum/gas/water_vapor=0.1,
 	)
-	restricted_chance = 50
+	restricted_chance = 30
 
 	minimum_pressure = HAZARD_LOW_PRESSURE + 10
 	maximum_pressure = LAVALAND_EQUIPMENT_EFFECT_PRESSURE - 1
@@ -42,7 +42,7 @@
 		/datum/gas/water_vapor=0.1,
 		/datum/gas/miasma=1.2,
 	)
-	restricted_chance = 50
+	restricted_chance = 20
 
 	minimum_pressure = HAZARD_LOW_PRESSURE + 10
 	maximum_pressure = LAVALAND_EQUIPMENT_EFFECT_PRESSURE - 1


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When floyd added station traits, he made the unusual atmosphere trait uncap the amount of restricted gas that can be generated. I didn't put as much thought into it as I should have, as all restricted gases are in low enough concentrations that they cannot react on their own, this prevents infinite plasmafires and such.

In light of that, I removed it from that check. However, this means the trait doesn't do a whole lot, since restricted chance for both icemoon and lavaland is 50, which means most of the time they'll roll most if not all their restricted gases.

The probability on this is actually a bit hard to calculate, since not only does rolling a restricted gas increase the amount of chances you have to roll a restricted gas, it's in theory possible to roll restricted gasses every other time, and only get one type out of it. I've removed this aspect by making it pick and subtract from an existing list.

In any case, I also lowered the base chance of rolling restricted gases, and increased the trait additive. I hope this will make seeing odd gasses on icebox and lavaland more rare, and make the stationtrait feel more impactful without causing hell behavior

## Changelog
:cl:
tweak: Planetary gasmixes are less likely to be filled with rare gasmixes now, unless the right station trait rolls.
fix: Lavaland and icebox can no longer cause infinite fires in rare edgecases
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
