### PR TITLE
Fixes Cigarettes being lit in no-oxygen environments

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -160,8 +160,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(lit || smoketime <= 0)
 		return ..()
 	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen
-		var/turf/open/O = get_turf(src)
-		if(!isopenturf(O) || !O.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
+		var/turf/open/location = get_turf(src)
+		if(!isopenturf(location) || !location.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
 			to_chat(user, "<span class='notice'>Your [name] needs a source of oxygen to burn.</span>")
 			return ..()
 	var/lighting_text = W.ignition_effect(src, user)
@@ -268,17 +268,17 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		reagents.remove_any(to_smoke)
 
 /obj/item/clothing/mask/cigarette/process(delta_time)
-	var/turf/open/O = get_turf(src)
+	var/turf/open/location = get_turf(src)
 	var/mob/living/M = loc
 	if(isliving(loc))
 		M.IgniteMob()
 	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen
-		if(!isopenturf(O) || !O.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
+		if(!isopenturf(location) || !location.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
 			extinguish()
 			return
 	smoketime -= delta_time
 	if(smoketime <= 0)
-		new type_butt(O)
+		new type_butt(location)
 		if(ismob(loc))
 			to_chat(M, "<span class='notice'>Your [name] goes out.</span>")
 		qdel(src)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -162,7 +162,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen
 		var/turf/open/O = get_turf(src)
 		if(!isopenturf(O) || !O.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
-			to_chat(M, "<span class='notice'>Your [name] needs a source of oxygen to burn.</span>")
+			to_chat(user, "<span class='notice'>Your [name] needs a source of oxygen to burn.</span>")
 			return ..()
 	var/lighting_text = W.ignition_effect(src, user)
 	if(lighting_text)
@@ -268,13 +268,17 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		reagents.remove_any(to_smoke)
 
 /obj/item/clothing/mask/cigarette/process(delta_time)
-	var/turf/location = get_turf(src)
+	var/turf/open/O = get_turf(src)
 	var/mob/living/M = loc
 	if(isliving(loc))
 		M.IgniteMob()
+	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen
+		if(!isopenturf(O) || !O.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
+			extinguish()
+			return
 	smoketime -= delta_time
 	if(smoketime <= 0)
-		new type_butt(location)
+		new type_butt(O)
 		if(ismob(loc))
 			to_chat(M, "<span class='notice'>Your [name] goes out.</span>")
 		qdel(src)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -278,7 +278,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			return
 	smoketime -= delta_time
 	if(smoketime <= 0)
-		new type_butt(location)
+		new type_butt(loc)
 		if(ismob(loc))
 			to_chat(M, "<span class='notice'>Your [name] goes out.</span>")
 		qdel(src)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -274,7 +274,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		M.IgniteMob()
 	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen
 		var/datum/gas_mixture/air = return_air()
-		if(air || !air.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
+		if(!air || !air.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
 			extinguish()
 			return
 	smoketime -= delta_time

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -161,7 +161,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return ..()
 	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen
 		var/datum/gas_mixture/air = return_air()
-		if(!air | !air.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
+		if(!air || !air.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
 			to_chat(user, "<span class='notice'>Your [name] needs a source of oxygen to burn.</span>")
 			return ..()
 	var/lighting_text = W.ignition_effect(src, user)
@@ -274,7 +274,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		M.IgniteMob()
 	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen
 		var/datum/gas_mixture/air = return_air()
-		if(air | !air.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
+		if(air || !air.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
 			extinguish()
 			return
 	smoketime -= delta_time

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -268,6 +268,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		reagents.remove_any(to_smoke)
 
 /obj/item/clothing/mask/cigarette/process(delta_time)
+	var/turf/location = get_turf(src)
 	var/mob/living/M = loc
 	if(isliving(loc))
 		M.IgniteMob()
@@ -278,7 +279,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			return
 	smoketime -= delta_time
 	if(smoketime <= 0)
-		new type_butt(loc)
+		new type_butt(location)
 		if(ismob(loc))
 			to_chat(M, "<span class='notice'>Your [name] goes out.</span>")
 		qdel(src)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -322,7 +322,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 // Cigarette brands.
 
 /obj/item/clothing/mask/cigarette/space_cigarette
-	desc = "A Space Cigarette brand cigarette."
+	desc = "A Space Cigarette brand cigarette. On the back it advertises to be the only brand that can be smoked in space."
+	list_reagents = list(/datum/reagent/drug/nicotine = 13, /datum/reagent/oxygen = 15)
 
 /obj/item/clothing/mask/cigarette/dromedary
 	desc = "A DromedaryCo brand cigarette. Contrary to popular belief, does not contain Calomel, but is reported to have a watery taste."

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -157,12 +157,15 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	. = ..()
 
 /obj/item/clothing/mask/cigarette/attackby(obj/item/W, mob/user, params)
-	if(!lit && smoketime > 0)
-		var/lighting_text = W.ignition_effect(src, user)
-		if(lighting_text)
-			light(lighting_text)
-	else
+	if(lit || smoketime <= 0)
 		return ..()
+	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen to burn
+		var/turf/open/O = get_turf(src)
+		if(!isopenturf(O) || !O.has_gas(/datum/gas/oxygen, 1)) // no oxygen on tile
+			return ..()
+	var/lighting_text = W.ignition_effect(src, user)
+	if(lighting_text)
+		light(lighting_text)
 
 /obj/item/clothing/mask/cigarette/afterattack(obj/item/reagent_containers/glass/glass, mob/user, proximity)
 	. = ..()
@@ -176,7 +179,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				to_chat(user, "<span class='warning'>[glass] is empty!</span>")
 			else
 				to_chat(user, "<span class='warning'>[src] is full!</span>")
-
 
 /obj/item/clothing/mask/cigarette/proc/light(flavor_text = null)
 	if(lit)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -322,7 +322,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 // Cigarette brands.
 
 /obj/item/clothing/mask/cigarette/space_cigarette
-	desc = "A Space Cigarette brand cigarette. On the back it advertises to be the only brand that can be smoked in space."
+	desc = "A Space brand cigarette that can be smoked anywhere."
 	list_reagents = list(/datum/reagent/drug/nicotine = 13, /datum/reagent/oxygen = 15)
 
 /obj/item/clothing/mask/cigarette/dromedary

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -159,9 +159,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/attackby(obj/item/W, mob/user, params)
 	if(lit || smoketime <= 0)
 		return ..()
-	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen to burn
+	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen
 		var/turf/open/O = get_turf(src)
-		if(!isopenturf(O) || !O.has_gas(/datum/gas/oxygen, 1)) // no oxygen on tile
+		if(!isopenturf(O) || !O.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
+			to_chat(M, "<span class='notice'>Your [name] needs a source of oxygen to burn.</span>")
 			return ..()
 	var/lighting_text = W.ignition_effect(src, user)
 	if(lighting_text)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -160,8 +160,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(lit || smoketime <= 0)
 		return ..()
 	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen
-		var/turf/open/location = get_turf(src)
-		if(!isopenturf(location) || !location.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
+		var/datum/gas_mixture/air = return_air()
+		if(!air.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
 			to_chat(user, "<span class='notice'>Your [name] needs a source of oxygen to burn.</span>")
 			return ..()
 	var/lighting_text = W.ignition_effect(src, user)
@@ -268,12 +268,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		reagents.remove_any(to_smoke)
 
 /obj/item/clothing/mask/cigarette/process(delta_time)
-	var/turf/open/location = get_turf(src)
 	var/mob/living/M = loc
 	if(isliving(loc))
 		M.IgniteMob()
 	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen
-		if(!isopenturf(location) || !location.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
+		var/datum/gas_mixture/air = return_air()
+		if(!air.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
 			extinguish()
 			return
 	smoketime -= delta_time
@@ -323,7 +323,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/space_cigarette
 	desc = "A Space brand cigarette that can be smoked anywhere."
-	list_reagents = list(/datum/reagent/drug/nicotine = 13, /datum/reagent/oxygen = 15)
+	list_reagents = list(/datum/reagent/drug/nicotine = 9, /datum/reagent/oxygen = 9)
+	smoketime = 240 // space cigs have a shorter burn time than normal cigs
+	smoke_all = TRUE // so that it doesn't runout of oxygen while being smoked in space
 
 /obj/item/clothing/mask/cigarette/dromedary
 	desc = "A DromedaryCo brand cigarette. Contrary to popular belief, does not contain Calomel, but is reported to have a watery taste."

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -161,7 +161,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return ..()
 	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen
 		var/datum/gas_mixture/air = return_air()
-		if(!air.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
+		if(!air | !air.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
 			to_chat(user, "<span class='notice'>Your [name] needs a source of oxygen to burn.</span>")
 			return ..()
 	var/lighting_text = W.ignition_effect(src, user)
@@ -274,7 +274,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		M.IgniteMob()
 	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen
 		var/datum/gas_mixture/air = return_air()
-		if(!air.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
+		if(air | !air.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
 			extinguish()
 			return
 	smoketime -= delta_time

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -170,7 +170,7 @@
 ////////////
 /obj/item/storage/fancy/cigarettes
 	name = "\improper Space Cigarettes packet"
-	desc = "The most popular brand of cigarettes, sponsors of the Space Olympics."
+	desc = "The most popular brand of cigarettes, sponsors of the Space Olympics. On the back it advertises to be the only brand that can be smoked in the vaccum of space."
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "cig"
 	inhand_icon_state = "cigpacket"

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -92,6 +92,13 @@
 /turf/open/return_analyzable_air()
 	return return_air()
 
+/turf/open/proc/has_gas(datum/gas, mole_amount)
+	if(air && air.total_moles())
+		var/loc_gases = air.gases
+		if(loc_gases[gas] && loc_gases[gas][MOLES] >= mole_amount)
+			return TRUE
+	return FALSE
+
 /turf/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
 	return (exposed_temperature >= heat_capacity || to_be_destroyed)
 

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -92,13 +92,6 @@
 /turf/open/return_analyzable_air()
 	return return_air()
 
-/turf/open/proc/has_gas(datum/gas, mole_amount)
-	if(air && air.total_moles())
-		var/loc_gases = air.gases
-		if(loc_gases[gas] && loc_gases[gas][MOLES] >= mole_amount)
-			return TRUE
-	return FALSE
-
 /turf/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
 	return (exposed_temperature >= heat_capacity || to_be_destroyed)
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -106,6 +106,12 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/cached_gases = gases
 	TOTAL_MOLES(cached_gases, .)
 
+	/// Checks to see if gas amount exists in mixture
+/datum/gas_mixture/proc/has_gas(gas_id, amount=0)
+	ASSERT_GAS(gas_id, src)
+	var/list/cached_gases = gases
+	return amount < cached_gases[gas_id][MOLES]
+
 	/// Calculate pressure in kilopascals
 /datum/gas_mixture/proc/return_pressure()
 	if(volume) // to prevent division by zero

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -108,7 +108,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 /// Checks to see if gas amount exists in mixture.
 /// Do NOT use this in code where performance matters!
-/// It's faster to just manually check the gas with a direct var lookup
+/// It's better to batch calls to garbage_collect(), especially in places where you're checking many gastypes
 /datum/gas_mixture/proc/has_gas(gas_id, amount=0)
 	ASSERT_GAS(gas_id, src)
 	var/is_there_gas = amount < gases[gas_id][MOLES]

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 //use the macros in performance intensive areas. for their definitions, refer to code/__DEFINES/atmospherics.dm
 
 ///assert_gas(gas_id) - used to guarantee that the gas list for this id exists in gas_mixture.gases.
-//Must be used before adding to a gas. May be used before reading from a gas.
+///Must be used before adding to a gas. May be used before reading from a gas.
 /datum/gas_mixture/proc/assert_gas(gas_id)
 	ASSERT_GAS(gas_id, src)
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -107,6 +107,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	TOTAL_MOLES(cached_gases, .)
 
 	/// Checks to see if gas amount exists in mixture
+	/// WARNING - DO NOT USE THIS IN PERFORMANCE INTENSIVE CODE!!!
 /datum/gas_mixture/proc/has_gas(gas_id, amount=0)
 	ASSERT_GAS(gas_id, src)
 	var/list/cached_gases = gases

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -106,12 +106,14 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/cached_gases = gases
 	TOTAL_MOLES(cached_gases, .)
 
-/// Checks to see if gas amount exists in mixture
-/// WARNING - DO NOT USE THIS IN PERFORMANCE INTENSIVE CODE!!!
+/// Checks to see if gas amount exists in mixture.
+/// Do NOT use this in code where performance matters!
+/// It's faster to just manually check the gas with a direct var lookup
 /datum/gas_mixture/proc/has_gas(gas_id, amount=0)
 	ASSERT_GAS(gas_id, src)
-	var/list/cached_gases = gases
-	return amount < cached_gases[gas_id][MOLES]
+	var/is_there_gas = amount < gases[gas_id][MOLES]
+	garbage_collect()
+	return is_there_gas
 
 /// Calculate pressure in kilopascals
 /datum/gas_mixture/proc/return_pressure()

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -49,41 +49,41 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 //listmos procs
 //use the macros in performance intensive areas. for their definitions, refer to code/__DEFINES/atmospherics.dm
 
-	///assert_gas(gas_id) - used to guarantee that the gas list for this id exists in gas_mixture.gases.
-	//Must be used before adding to a gas. May be used before reading from a gas.
+///assert_gas(gas_id) - used to guarantee that the gas list for this id exists in gas_mixture.gases.
+//Must be used before adding to a gas. May be used before reading from a gas.
 /datum/gas_mixture/proc/assert_gas(gas_id)
 	ASSERT_GAS(gas_id, src)
 
-	///assert_gases(args) - shorthand for calling ASSERT_GAS() once for each gas type.
+///assert_gases(args) - shorthand for calling ASSERT_GAS() once for each gas type.
 /datum/gas_mixture/proc/assert_gases(...)
 	for(var/id in args)
 		ASSERT_GAS(id, src)
 
-	///add_gas(gas_id) - similar to assert_gas(), but does not check for an existing gas list for this id. This can clobber existing gases.
-	///Used instead of assert_gas() when you know the gas does not exist. Faster than assert_gas().
+///add_gas(gas_id) - similar to assert_gas(), but does not check for an existing gas list for this id. This can clobber existing gases.
+///Used instead of assert_gas() when you know the gas does not exist. Faster than assert_gas().
 /datum/gas_mixture/proc/add_gas(gas_id)
 	ADD_GAS(gas_id, gases)
 
-	///add_gases(args) - shorthand for calling add_gas() once for each gas_type.
+///add_gases(args) - shorthand for calling add_gas() once for each gas_type.
 /datum/gas_mixture/proc/add_gases(...)
 	var/cached_gases = gases
 	for(var/id in args)
 		ADD_GAS(id, cached_gases)
 
-	///garbage_collect() - removes any gas list which is empty.
-	///If called with a list as an argument, only removes gas lists with IDs from that list.
-	///Must be used after subtracting from a gas. Must be used after assert_gas()
-		///if assert_gas() was called only to read from the gas.
-	///By removing empty gases, processing speed is increased.
+///garbage_collect() - removes any gas list which is empty.
+///If called with a list as an argument, only removes gas lists with IDs from that list.
+///Must be used after subtracting from a gas. Must be used after assert_gas()
+///if assert_gas() was called only to read from the gas.
+///By removing empty gases, processing speed is increased.
 /datum/gas_mixture/proc/garbage_collect(list/tocheck)
 	var/list/cached_gases = gases
 	for(var/id in (tocheck || cached_gases))
 		if(QUANTIZE(cached_gases[id][MOLES]) <= 0)
 			cached_gases -= id
 
-	//PV = nRT
+//PV = nRT
 
-	///joules per kelvin
+///joules per kelvin
 /datum/gas_mixture/proc/heat_capacity(data = MOLES)
 	var/list/cached_gases = gases
 	. = 0
@@ -91,7 +91,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		var/gas_data = cached_gases[id]
 		. += gas_data[data] * gas_data[GAS_META][META_GAS_SPECIFIC_HEAT]
 
-	/// Same as above except vacuums return HEAT_CAPACITY_VACUUM
+/// Same as above except vacuums return HEAT_CAPACITY_VACUUM
 /datum/gas_mixture/turf/heat_capacity(data = MOLES)
 	var/list/cached_gases = gases
 	. = 0
@@ -101,19 +101,19 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	if(!.)
 		. += HEAT_CAPACITY_VACUUM //we want vacuums in turfs to have the same heat capacity as space
 
-	/// Calculate moles
+/// Calculate moles
 /datum/gas_mixture/proc/total_moles()
 	var/cached_gases = gases
 	TOTAL_MOLES(cached_gases, .)
 
-	/// Checks to see if gas amount exists in mixture
-	/// WARNING - DO NOT USE THIS IN PERFORMANCE INTENSIVE CODE!!!
+/// Checks to see if gas amount exists in mixture
+/// WARNING - DO NOT USE THIS IN PERFORMANCE INTENSIVE CODE!!!
 /datum/gas_mixture/proc/has_gas(gas_id, amount=0)
 	ASSERT_GAS(gas_id, src)
 	var/list/cached_gases = gases
 	return amount < cached_gases[gas_id][MOLES]
 
-	/// Calculate pressure in kilopascals
+/// Calculate pressure in kilopascals
 /datum/gas_mixture/proc/return_pressure()
 	if(volume) // to prevent division by zero
 		var/cached_gases = gases
@@ -122,19 +122,19 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		return
 	return 0
 
-	/// Calculate temperature in kelvins
+/// Calculate temperature in kelvins
 /datum/gas_mixture/proc/return_temperature()
 	return temperature
 
-	/// Calculate volume in liters
+/// Calculate volume in liters
 /datum/gas_mixture/proc/return_volume()
 	return max(0, volume)
 
-	/// Calculate thermal energy in joules
+/// Calculate thermal energy in joules
 /datum/gas_mixture/proc/thermal_energy()
 	return THERMAL_ENERGY(src) //see code/__DEFINES/atmospherics.dm; use the define in performance critical areas
 
-	///Update archived versions of variables. Returns: 1 in all cases
+///Update archived versions of variables. Returns: 1 in all cases
 /datum/gas_mixture/proc/archive()
 	var/list/cached_gases = gases
 
@@ -144,7 +144,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	return TRUE
 
-	///Merges all air from giver into self. Deletes giver. Returns: 1 if we are mutable, 0 otherwise
+///Merges all air from giver into self. Deletes giver. Returns: 1 if we are mutable, 0 otherwise
 /datum/gas_mixture/proc/merge(datum/gas_mixture/giver)
 	if(!giver)
 		return FALSE
@@ -166,8 +166,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	return TRUE
 
-	///Proportionally removes amount of gas from the gas_mixture.
-	///Returns: gas_mixture with the gases removed
+///Proportionally removes amount of gas from the gas_mixture.
+///Returns: gas_mixture with the gases removed
 /datum/gas_mixture/proc/remove(amount)
 	var/sum
 	var/list/cached_gases = gases
@@ -187,8 +187,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	return removed
 
-	///Proportionally removes amount of gas from the gas_mixture.
-	///Returns: gas_mixture with the gases removed
+///Proportionally removes amount of gas from the gas_mixture.
+///Returns: gas_mixture with the gases removed
 /datum/gas_mixture/proc/remove_ratio(ratio)
 	if(ratio <= 0)
 		return null
@@ -208,8 +208,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	return removed
 
-	///Removes an amount of a specific gas from the gas_mixture.
-	///Returns: gas_mixture with the gas removed
+///Removes an amount of a specific gas from the gas_mixture.
+///Returns: gas_mixture with the gas removed
 /datum/gas_mixture/proc/remove_specific(gas_id, amount)
 	var/list/cached_gases = gases
 	amount = min(amount, cached_gases[gas_id][MOLES])
@@ -225,8 +225,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	garbage_collect(list(gas_id))
 	return removed
 
-	///Distributes the contents of two mixes equally between themselves
-	//Returns: bool indicating whether gases moved between the two mixes
+///Distributes the contents of two mixes equally between themselves
+//Returns: bool indicating whether gases moved between the two mixes
 /datum/gas_mixture/proc/equalize(datum/gas_mixture/other)
 	. = FALSE
 	if(abs(return_temperature() - other.return_temperature()) > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND)
@@ -251,8 +251,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 			other.gases[gas_id][MOLES] = total_moles * (other.volume/total_volume)
 
 
-	///Creates new, identical gas mixture
-	///Returns: duplicate gas mixture
+///Creates new, identical gas mixture
+///Returns: duplicate gas mixture
 /datum/gas_mixture/proc/copy()
 	var/list/cached_gases = gases
 	var/datum/gas_mixture/copy = new type
@@ -265,8 +265,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	return copy
 
-	///Copies variables from sample, moles multiplicated by partial
-	///Returns: 1 if we are mutable, 0 otherwise
+///Copies variables from sample, moles multiplicated by partial
+///Returns: 1 if we are mutable, 0 otherwise
 /datum/gas_mixture/proc/copy_from(datum/gas_mixture/sample, partial = 1)
 	var/list/cached_gases = gases //accessing datum vars is slower than proc vars
 	var/list/sample_gases = sample.gases
@@ -281,8 +281,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	return 1
 
-	///Copies all gas info from the turf into the gas list along with temperature
-	///Returns: TRUE if we are mutable, FALSE otherwise
+///Copies all gas info from the turf into the gas list along with temperature
+///Returns: TRUE if we are mutable, FALSE otherwise
 /datum/gas_mixture/proc/copy_from_turf(turf/model)
 	parse_gas_string(model.initial_gas_mix)
 
@@ -293,8 +293,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	return TRUE
 
-	///Copies variables from a particularly formatted string.
-	///Returns: 1 if we are mutable, 0 otherwise
+///Copies variables from a particularly formatted string.
+///Returns: 1 if we are mutable, 0 otherwise
 /datum/gas_mixture/proc/parse_gas_string(gas_string)
 	gas_string = SSair.preprocess_gas_string(gas_string)
 
@@ -315,8 +315,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		gases[path][MOLES] = text2num(gas[id])
 	return 1
 
-	///Performs air sharing calculations between two gas_mixtures assuming only 1 boundary length
-	///Returns: amount of gas exchanged (+ if sharer received)
+///Performs air sharing calculations between two gas_mixtures assuming only 1 boundary length
+///Returns: amount of gas exchanged (+ if sharer received)
 /datum/gas_mixture/proc/share(datum/gas_mixture/sharer, atmos_adjacent_turfs = 4)
 	var/list/cached_gases = gases
 	var/list/sharer_gases = sharer.gases
@@ -387,8 +387,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		TOTAL_MOLES(sharer_gases,their_moles)
 		return (temperature_archived*(our_moles + moved_moles) - sharer.temperature_archived*(their_moles - moved_moles)) * R_IDEAL_GAS_EQUATION / volume
 
-	///Performs temperature sharing calculations (via conduction) between two gas_mixtures assuming only 1 boundary length
-	///Returns: new temperature of the sharer
+///Performs temperature sharing calculations (via conduction) between two gas_mixtures assuming only 1 boundary length
+///Returns: new temperature of the sharer
 /datum/gas_mixture/proc/temperature_share(datum/gas_mixture/sharer, conduction_coefficient, sharer_temperature, sharer_heat_capacity)
 	//transfer of thermal energy (via conduction) between self and sharer
 	if(sharer)
@@ -411,8 +411,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	return sharer_temperature
 	//thermal energy of the system (self and sharer) is unchanged
 
-	///Compares sample to self to see if within acceptable ranges that group processing may be enabled
-	///Returns: a string indicating what check failed, or "" if check passes
+///Compares sample to self to see if within acceptable ranges that group processing may be enabled
+///Returns: a string indicating what check failed, or "" if check passes
 /datum/gas_mixture/proc/compare(datum/gas_mixture/sample)
 	var/list/sample_gases = sample.gases //accessing datum vars is slower than proc vars
 	var/list/cached_gases = gases
@@ -439,8 +439,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	return ""
 
-	///Performs various reactions such as combustion or fusion (LOL)
-	///Returns: 1 if any reaction took place; 0 otherwise
+///Performs various reactions such as combustion or fusion (LOL)
+///Returns: 1 if any reaction took place; 0 otherwise
 /datum/gas_mixture/proc/react(datum/holder)
 	. = NO_REACTION
 	var/list/cached_gases = gases


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This closes #26487 which has been a known bug for years.  Everyone knows how **EXTREMELY CRITICAL** cigarettes are to game balance.   Plasmamen being able to smoke in a room with _no oxygen_?  Spessmen smoking in the _hard vacuum of space_?  What is this madness?!?  

I must put an end to these OP tactics.

My changes make it so that if a cigarette has either one mole of oxygen in the current atmosphere or is injected with oxygen reagents, then it can be smoked. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Realism for the most part.  I thought that issue was hilarious and wanted to add it just for the meme.  I did make it so that "Space" cigarettes can be smoked in space by changing the default starting reagents to include oxygen.  The description was also updated to hint that they can be smoked anywhere. 

Also I added a `has_gas` proc to the turf class.  I have seen a few places in the code where this can be used and once this gets merged, I will be doing a refactor to clean some code involving it.  (bonfires, plasmamen code, etc.)  

## Changelog
:cl:
fix: Fixed cigarettes being lit in no-oxygen environments
add: Cigarettes can be injected with oxygen to allow smoking anywhere
code: The cigarette brand 'Space cigarettes' now has oxygen in it's default reagents (allowing it to be smoked in space)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
