### PR TITLE
Gets Rid of Both Sleeps In Transit Tubes, Replaces Them With Timers

### DIFF
--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -69,11 +69,18 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	else
 		direction = pick(GLOB.alldirs)
 	var/steps_amt = pick(1,2,3)
-	for(var/j in 1 to steps_amt)
-		sleep(5)
-		step(E,direction)
+	addtimer(CALLBACK(src, .proc/step_effect, E, direction, steps_amt), 5)
+	//for(var/j in 1 to steps_amt)
+	//	sleep(5)
+	//	step(E,direction)
 	if(!QDELETED(src))
 		addtimer(CALLBACK(src, .proc/decrement_total_effect), 20)
+
+/datum/effect_system/proc/step_effect(obj/effect/to_step, direction, steps_left)
+	steps_left--
+	step(to_step, direction)
+	if (steps_left > 0)
+		addtimer(CALLBACK(src, .proc/step_effect, to_step, direction, steps_left), 5)
 
 /datum/effect_system/proc/decrement_total_effect()
 	total_effects--

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -69,18 +69,11 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	else
 		direction = pick(GLOB.alldirs)
 	var/steps_amt = pick(1,2,3)
-	addtimer(CALLBACK(src, .proc/step_effect, E, direction, steps_amt), 5)
-	//for(var/j in 1 to steps_amt)
-	//	sleep(5)
-	//	step(E,direction)
+	for(var/j in 1 to steps_amt)
+		sleep(5)
+		step(E,direction)
 	if(!QDELETED(src))
 		addtimer(CALLBACK(src, .proc/decrement_total_effect), 20)
-
-/datum/effect_system/proc/step_effect(obj/effect/to_step, direction, steps_left)
-	steps_left--
-	step(to_step, direction)
-	if (steps_left > 0)
-		addtimer(CALLBACK(src, .proc/step_effect, to_step, direction, steps_left), 5)
 
 /datum/effect_system/proc/decrement_total_effect()
 	total_effects--

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -1,3 +1,7 @@
+#define MOVE_ANIMATION_STAGE_ONE 1
+#define MOVE_ANIMATION_STAGE_TWO 2
+#define MOVE_ANIMATION_STAGE_THREE 3
+
 /obj/structure/transit_tube_pod
 	icon = 'icons/obj/atmospherics/pipes/transit_tube.dmi'
 	icon_state = "pod"
@@ -116,13 +120,13 @@
 			break
 
 	while(current_tube)
-		next_dir = current_tube.get_exit(dir)
+		//next_dir = current_tube.get_exit(dir)
 
-		if(!next_dir)
-			break
+		//if(!next_dir)
+			//break
 
-		exit_delay = current_tube.exit_delay(src, dir)
-		last_delay += exit_delay
+		//exit_delay = current_tube.exit_delay(src, dir)
+		//last_delay += exit_delay
 
 		sleep(exit_delay)
 
@@ -149,13 +153,25 @@
 		if(current_tube?.should_stop_pod(src, next_dir))
 			current_tube.pod_stopped(src, dir)
 			break
-
+				///FUTURE KYLER: USE LAST_DELAY FOR BOTH TIMES WHEN REPLACING
 	density = TRUE
 	moving = FALSE
 
 	var/obj/structure/transit_tube/TT = locate(/obj/structure/transit_tube) in loc
 	if(!TT || (!(dir in TT.tube_dirs) && !(turn(dir,180) in TT.tube_dirs)))	//landed on a turf without transit tube or not in our direction
 		outside_tube()
+
+/obj/structure/transit_tube_pod/proc/move_animation(stage = MOVE_ANIMATION_STAGE_ONE)
+	switch(stage)
+		if(MOVE_ANIMATION_STAGE_ONE)
+			next_dir = current_tube.get_exit(dir)
+
+			if(!next_dir)
+				break
+
+			exit_delay = current_tube.exit_delay(src, dir)
+			last_delay += exit_delay
+
 
 /obj/structure/transit_tube_pod/proc/outside_tube()
 	var/list/savedcontents = contents.Copy()
@@ -220,3 +236,7 @@
 
 /obj/structure/transit_tube_pod/dispensed/outside_tube()
 	qdel(src)
+
+#undef MOVE_ANIMATION_STAGE_ONE
+#undef MOVE_ANIMATION_STAGE_TWO
+#undef MOVE_ANIMATION_STAGE_THREE

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -122,44 +122,43 @@
 
 ///timer loop that handles the pod moving from tube to tube
 /obj/structure/transit_tube_pod/proc/move_animation(stage = MOVE_ANIMATION_STAGE_ONE)
-	switch(stage)
-		if(MOVE_ANIMATION_STAGE_ONE)
-			next_dir = current_tube.get_exit(dir)
+	if(stage == MOVE_ANIMATION_STAGE_ONE)
+		next_dir = current_tube.get_exit(dir)
 
-			if(!next_dir)
-				return
+		if(!next_dir)
+			return
 
-			exit_delay = current_tube.exit_delay(src, dir)
-			next_loc = get_step(loc, next_dir)
+		exit_delay = current_tube.exit_delay(src, dir)
+		next_loc = get_step(loc, next_dir)
 
-			current_tube = null
-			for(var/obj/structure/transit_tube/tube in next_loc)
-				if(tube.has_entrance(next_dir))
-					current_tube = tube
-					break
+		current_tube = null
+		for(var/obj/structure/transit_tube/tube in next_loc)
+			if(tube.has_entrance(next_dir))
+				current_tube = tube
+				break
 
-			if(current_tube == null)
-				setDir(next_dir)
-				Move(get_step(loc, dir), dir, DELAY_TO_GLIDE_SIZE(exit_delay)) // Allow collisions when leaving the tubes.
-				return
-
-			enter_delay = current_tube.enter_delay(src, next_dir)
-			if(enter_delay > 0)
-				addtimer(CALLBACK(src, .proc/move_animation, MOVE_ANIMATION_STAGE_TWO), enter_delay)
-				return
-			else
-				return .(MOVE_ANIMATION_STAGE_TWO)
-		if(MOVE_ANIMATION_STAGE_TWO)
+		if(current_tube == null)
 			setDir(next_dir)
-			set_glide_size(DELAY_TO_GLIDE_SIZE(enter_delay + exit_delay))
-			forceMove(next_loc) // When moving from one tube to another, skip collision and such.
-			density = current_tube.density
+			Move(get_step(loc, dir), dir, DELAY_TO_GLIDE_SIZE(exit_delay)) // Allow collisions when leaving the tubes.
+			return
 
-			if(current_tube?.should_stop_pod(src, next_dir))
-				current_tube.pod_stopped(src, dir)
-			else
-				addtimer(CALLBACK(src, .proc/move_animation, MOVE_ANIMATION_STAGE_ONE), exit_delay)
-				return
+		enter_delay = current_tube.enter_delay(src, next_dir)
+		if(enter_delay > 0)
+			addtimer(CALLBACK(src, .proc/move_animation, MOVE_ANIMATION_STAGE_TWO), enter_delay)
+			return
+		else
+			stage = MOVE_ANIMATION_STAGE_TWO
+	if(stage == MOVE_ANIMATION_STAGE_TWO)
+		setDir(next_dir)
+		set_glide_size(DELAY_TO_GLIDE_SIZE(enter_delay + exit_delay))
+		forceMove(next_loc) // When moving from one tube to another, skip collision and such.
+		density = current_tube.density
+
+		if(current_tube?.should_stop_pod(src, next_dir))
+			current_tube.pod_stopped(src, dir)
+		else
+			addtimer(CALLBACK(src, .proc/move_animation, MOVE_ANIMATION_STAGE_ONE), exit_delay)
+			return
 	density = TRUE
 	moving = FALSE
 

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -1,6 +1,5 @@
 #define MOVE_ANIMATION_STAGE_ONE 1
 #define MOVE_ANIMATION_STAGE_TWO 2
-#define MOVE_ANIMATION_STAGE_THREE 3
 
 /obj/structure/transit_tube_pod
 	icon = 'icons/obj/atmospherics/pipes/transit_tube.dmi'
@@ -234,6 +233,3 @@
 
 #undef MOVE_ANIMATION_STAGE_ONE
 #undef MOVE_ANIMATION_STAGE_TWO
-#undef MOVE_ANIMATION_STAGE_THREE
-
-//currently transit tubes use two different sleeps for two different delays for every tube tile it goes through until it stops. i have a timer version working but is there a way to make it use delta_time as a process without getting rid of the two different delays?


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Every tube that the transit pod moves through causes two sleeps, each at most 2 deciseconds. now it uses a timer on the delay that is always > 0 and on the delay thats usually 0 it checks whether to make a timer. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
sleeps bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: transit tubes are less sleepy now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
