### PR TITLE
Fixes cargo barcode payouts paying 50x what the sale is worth

### DIFF
--- a/code/modules/modular_computers/file_system/programs/cargoship.dm
+++ b/code/modules/modular_computers/file_system/programs/cargoship.dm
@@ -11,6 +11,10 @@
 	var/datum/bank_account/payments_acc
 	///The person who tagged this will receive the sale value multiplied by this number.
 	var/cut_multiplier = 0.5
+	///Maximum value for cut_multiplier.
+	var/cut_max = 0.5
+	///Minimum value for cut_multiplier.
+	var/cut_min = 0.01
 
 /datum/computer_file/program/shipping/ui_data(mob/user)
 	var/list/data = get_header_data()
@@ -55,8 +59,8 @@
 		if("resetid")
 			payments_acc = null
 		if("setsplit")
-			var/potential_cut = input("How much would you like to payout to the registered card?","Percentage Profit") as num|null
-			cut_multiplier = potential_cut ? clamp(round(potential_cut, 1), 1, 50) / 100 : initial(cut_multiplier)
+			var/potential_cut = input("How much would you like to pay out to the registered card?","Percentage Profit ([round(cut_min*100)]% - [round(cut_max*100)]%)") as num|null
+			cut_multiplier = potential_cut ? clamp(round(potential_cut/100, cut_min), cut_min, cut_max) : initial(cut_multiplier)
 		if("print")
 			if(!printer)
 				to_chat(usr, "<span class='notice'>Hardware error: A printer is required to print barcodes.</span>")

--- a/code/modules/modular_computers/file_system/programs/cargoship.dm
+++ b/code/modules/modular_computers/file_system/programs/cargoship.dm
@@ -9,8 +9,8 @@
 	program_icon = "tags"
 	///Account used for creating barcodes.
 	var/datum/bank_account/payments_acc
-	///The amount which the tagger will receive for the sale.
-	var/percent_cut = 20
+	///The person who tagged this will receive the sale value multiplied by this number.
+	var/cut_multiplier = 0.2
 
 /datum/computer_file/program/shipping/ui_data(mob/user)
 	var/list/data = get_header_data()
@@ -23,7 +23,7 @@
 	data["paperamt"] = printer ? "[printer.stored_paper] / [printer.max_paper]" : null
 	data["card_owner"] = card_slot?.stored_card ? id_card.registered_name : "No Card Inserted."
 	data["current_user"] = payments_acc ? payments_acc.account_holder : null
-	data["barcode_split"] = percent_cut
+	data["barcode_split"] = cut_multiplier * 100
 	return data
 
 /datum/computer_file/program/shipping/ui_act(action, list/params)
@@ -56,7 +56,7 @@
 			payments_acc = null
 		if("setsplit")
 			var/potential_cut = input("How much would you like to payout to the registered card?","Percentage Profit") as num|null
-			percent_cut = potential_cut ? clamp(round(potential_cut, 1), 1, 50) : 20
+			cut_multiplier = potential_cut ? clamp(round(potential_cut, 1), 1, 50) / 100 : initial(cut_multiplier)
 		if("print")
 			if(!printer)
 				to_chat(usr, "<span class='notice'>Hardware error: A printer is required to print barcodes.</span>")
@@ -69,6 +69,6 @@
 				return
 			var/obj/item/barcode/barcode = new /obj/item/barcode(get_turf(ui_host()))
 			barcode.payments_acc = payments_acc
-			barcode.percent_cut = percent_cut
+			barcode.cut_multiplier = cut_multiplier
 			printer.stored_paper--
 			to_chat(usr, "<span class='notice'>The computer prints out a barcode.</span>")

--- a/code/modules/modular_computers/file_system/programs/cargoship.dm
+++ b/code/modules/modular_computers/file_system/programs/cargoship.dm
@@ -10,7 +10,7 @@
 	///Account used for creating barcodes.
 	var/datum/bank_account/payments_acc
 	///The person who tagged this will receive the sale value multiplied by this number.
-	var/cut_multiplier = 0.2
+	var/cut_multiplier = 0.5
 
 /datum/computer_file/program/shipping/ui_data(mob/user)
 	var/list/data = get_header_data()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -383,7 +383,7 @@
 
 /obj/item/sales_tagger
 	name = "sales tagger"
-	desc = "A scanner that lets you tag wrapped items for sale, splitting the profit between you and cargo. Ctrl-Click to clear the registered account."
+	desc = "A scanner that lets you tag wrapped items for sale, splitting the profit between you and cargo."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "salestagger"
 	worn_icon_state = "salestagger"
@@ -401,8 +401,10 @@
 
 /obj/item/sales_tagger/examine(mob/user)
 	. = ..()
-	. += "[src] has [paper_count]/[max_paper_count] available barcodes. Refill with paper."
-	. += "Profit split on sale is currently set to [round(cut_multiplier*100)]%."
+	. += "<span class='notice'>[src] has [paper_count]/[max_paper_count] available barcodes. Refill with paper.</span>"
+	. += "<span class='notice'>Profit split on sale is currently set to [round(cut_multiplier*100)]%. <b>Alt-click</b> to change.</span>"
+	if(payments_acc)
+		. += "<span class='notice'><b>Ctrl-click</b> to clear the registered account.</span>"
 
 /obj/item/sales_tagger/attackby(obj/item/I, mob/living/user, params)
 	. = ..()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -106,12 +106,12 @@
 		user.visible_message("<span class='notice'>[user] attaches a barcode to [src].</span>", "<span class='notice'>You attach a barcode to [src].</span>")
 		tagger.paper_count -= 1
 		sticker = new /obj/item/barcode(src)
-		sticker.payments_acc = tagger.payments_acc //new tag gets the tagger's current account.
-		sticker.percent_cut = tagger.percent_cut //same, but for the percentage taken.
+		sticker.payments_acc = tagger.payments_acc	//new tag gets the tagger's current account.
+		sticker.cut_multiplier = tagger.cut_multiplier	//same, but for the percentage taken.
 
 		var/list/wrap_contents = src.GetAllContents()
 		for(var/obj/I in wrap_contents)
-			I.AddComponent(/datum/component/pricetag, sticker.payments_acc, tagger.percent_cut)
+			I.AddComponent(/datum/component/pricetag, sticker.payments_acc, tagger.cut_multiplier)
 		var/overlaystring = "[icon_state]_tag"
 		if(giftwrapped)
 			overlaystring = copytext(overlaystring, 5)
@@ -130,7 +130,7 @@
 		sticker = stickerA
 		var/list/wrap_contents = src.GetAllContents()
 		for(var/obj/I in wrap_contents)
-			I.AddComponent(/datum/component/pricetag, sticker.payments_acc, sticker.percent_cut)
+			I.AddComponent(/datum/component/pricetag, sticker.payments_acc, sticker.cut_multiplier)
 		var/overlaystring = "[icon_state]_tag"
 		if(giftwrapped)
 			overlaystring = copytext_char(overlaystring, 5) //5 == length("gift") + 1
@@ -289,12 +289,12 @@
 		user.visible_message("<span class='notice'>[user] attaches a barcode to [src].</span>", "<span class='notice'>You attach a barcode to [src].</span>")
 		tagger.paper_count -= 1
 		sticker = new /obj/item/barcode(src)
-		sticker.payments_acc = tagger.payments_acc //new tag gets the tagger's current account.
-		sticker.percent_cut = tagger.percent_cut //as above, as before.
+		sticker.payments_acc = tagger.payments_acc	//new tag gets the tagger's current account.
+		sticker.cut_multiplier = tagger.cut_multiplier	//as above, as before.
 
 		var/list/wrap_contents = src.GetAllContents()
 		for(var/obj/I in wrap_contents)
-			I.AddComponent(/datum/component/pricetag, sticker.payments_acc, tagger.percent_cut)
+			I.AddComponent(/datum/component/pricetag, sticker.payments_acc, tagger.cut_multiplier)
 		var/overlaystring = "[icon_state]_tag"
 		if(giftwrapped)
 			overlaystring = copytext(overlaystring, 5)
@@ -314,7 +314,7 @@
 		sticker = stickerA
 		var/list/wrap_contents = src.GetAllContents()
 		for(var/obj/I in wrap_contents)
-			I.AddComponent(/datum/component/pricetag, sticker.payments_acc, sticker.percent_cut)
+			I.AddComponent(/datum/component/pricetag, sticker.payments_acc, sticker.cut_multiplier)
 		var/overlaystring = "[icon_state]_tag"
 		if(giftwrapped)
 			overlaystring = copytext_char(overlaystring, 5) //5 == length("gift") + 1
@@ -396,13 +396,13 @@
 	var/datum/bank_account/payments_acc = null
 	var/paper_count = 10
 	var/max_paper_count = 20
-	///Details the percentage the scanned account receives off the final sale.
-	var/percent_cut = 20
+	///Multiplier of the sale's value the scanned account receives.
+	var/cut_multiplier = 0.2
 
 /obj/item/sales_tagger/examine(mob/user)
 	. = ..()
 	. += "[src] has [paper_count]/[max_paper_count] available barcodes. Refill with paper."
-	. += "Profit split on sale is currently set to [percent_cut]%."
+	. += "Profit split on sale is currently set to [cut_multiplier*100]%."
 
 /obj/item/sales_tagger/attackby(obj/item/I, mob/living/user, params)
 	. = ..()
@@ -445,8 +445,8 @@
 	playsound(src, 'sound/machines/click.ogg', 40, TRUE)
 	to_chat(user, "<span class='notice'>You print a new barcode.</span>")
 	var/obj/item/barcode/new_barcode = new /obj/item/barcode(src)
-	new_barcode.payments_acc = payments_acc // The sticker gets the scanner's registered account.
-	new_barcode.percent_cut = percent_cut // Also the registered percent cut.
+	new_barcode.payments_acc = payments_acc		// The sticker gets the scanner's registered account.
+	new_barcode.cut_multiplier = cut_multiplier		// Also the registered percent cut.
 	user.put_in_hands(new_barcode)
 
 /obj/item/sales_tagger/CtrlClick(mob/user)
@@ -458,9 +458,9 @@
 	. = ..()
 	var/potential_cut = input("How much would you like to payout to the registered card?","Percentage Profit") as num|null
 	if(!potential_cut)
-		percent_cut = 50
-	percent_cut = clamp(round(potential_cut, 1), 1, 50)
-	to_chat(user, "<span class='notice'>[percent_cut]% profit will be received if a package with a barcode is sold.</span>")
+		cut_multiplier = 0.2
+	cut_multiplier = clamp(round(potential_cut, 1), 1, 50) / 100
+	to_chat(user, "<span class='notice'>[cut_multiplier*100]% profit will be received if a package with a barcode is sold.</span>")
 
 /obj/item/barcode
 	name = "Barcode tag"
@@ -470,4 +470,4 @@
 	w_class = WEIGHT_CLASS_TINY
 	///All values inheirited from the sales tagger it came from.
 	var/datum/bank_account/payments_acc = null
-	var/percent_cut = 5
+	var/cut_multiplier = 0.2

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -396,8 +396,12 @@
 	var/datum/bank_account/payments_acc = null
 	var/paper_count = 10
 	var/max_paper_count = 20
-	///Multiplier of the sale's value the scanned account receives.
+	///The person who tagged this will receive the sale value multiplied by this number.
 	var/cut_multiplier = 0.5
+	///Maximum value for cut_multiplier.
+	var/cut_max = 0.5
+	///Minimum value for cut_multiplier.
+	var/cut_min = 0.01
 
 /obj/item/sales_tagger/examine(mob/user)
 	. = ..()
@@ -458,10 +462,10 @@
 
 /obj/item/sales_tagger/AltClick(mob/user)
 	. = ..()
-	var/potential_cut = input("How much would you like to payout to the registered card?","Percentage Profit") as num|null
+	var/potential_cut = input("How much would you like to pay out to the registered card?","Percentage Profit ([round(cut_min*100)]% - [round(cut_max*100)]%)") as num|null
 	if(!potential_cut)
 		cut_multiplier = initial(cut_multiplier)
-	cut_multiplier = clamp(round(potential_cut, 1), 1, 50) / 100
+	cut_multiplier = clamp(round(potential_cut/100, cut_min), cut_min, cut_max)
 	to_chat(user, "<span class='notice'>[round(cut_multiplier*100)]% profit will be received if a package with a barcode is sold.</span>")
 
 /obj/item/barcode

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -402,7 +402,7 @@
 /obj/item/sales_tagger/examine(mob/user)
 	. = ..()
 	. += "[src] has [paper_count]/[max_paper_count] available barcodes. Refill with paper."
-	. += "Profit split on sale is currently set to [cut_multiplier*100]%."
+	. += "Profit split on sale is currently set to [round(cut_multiplier*100)]%."
 
 /obj/item/sales_tagger/attackby(obj/item/I, mob/living/user, params)
 	. = ..()
@@ -463,7 +463,7 @@
 	to_chat(user, "<span class='notice'>[round(cut_multiplier*100)]% profit will be received if a package with a barcode is sold.</span>")
 
 /obj/item/barcode
-	name = "Barcode tag"
+	name = "barcode tag"
 	desc = "A tiny tag, associated with a crewmember's account. Attach to a wrapped item to give that account a portion of the wrapped item's profit."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "barcode"

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -460,7 +460,7 @@
 	if(!potential_cut)
 		cut_multiplier = 0.2
 	cut_multiplier = clamp(round(potential_cut, 1), 1, 50) / 100
-	to_chat(user, "<span class='notice'>[cut_multiplier*100]% profit will be received if a package with a barcode is sold.</span>")
+	to_chat(user, "<span class='notice'>[round(cut_multiplier*100)]% profit will be received if a package with a barcode is sold.</span>")
 
 /obj/item/barcode
 	name = "Barcode tag"

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -397,7 +397,7 @@
 	var/paper_count = 10
 	var/max_paper_count = 20
 	///Multiplier of the sale's value the scanned account receives.
-	var/cut_multiplier = 0.2
+	var/cut_multiplier = 0.5
 
 /obj/item/sales_tagger/examine(mob/user)
 	. = ..()
@@ -458,7 +458,7 @@
 	. = ..()
 	var/potential_cut = input("How much would you like to payout to the registered card?","Percentage Profit") as num|null
 	if(!potential_cut)
-		cut_multiplier = 0.2
+		cut_multiplier = initial(cut_multiplier)
 	cut_multiplier = clamp(round(potential_cut, 1), 1, 50) / 100
 	to_chat(user, "<span class='notice'>[round(cut_multiplier*100)]% profit will be received if a package with a barcode is sold.</span>")
 
@@ -470,4 +470,4 @@
 	w_class = WEIGHT_CLASS_TINY
 	///All values inheirited from the sales tagger it came from.
 	var/datum/bank_account/payments_acc = null
-	var/cut_multiplier = 0.2
+	var/cut_multiplier = 0.5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so sales barcodes set the modifier the pricetag component uses to calculate the sale's cut correctly again.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People will no longer receive 50x the value of items sold with barcodes on the Supply shuttle.

Fixes #56842
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
fix: You can no longer receive 50x the value of items sold with barcodes on the Supply shuttle
tweak: Sales barcode profit splits will consistently default to 50% (you can still set this to less, but there's no reason to at the moment)
tweak: Sales tagger examine message improvements
tweak: Sales tagger and GrandArk Exporter tablet app both tell you the valid range to set the profit split in now
spellcheck: 'Barcode tag' is now called 'barcode tag'
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
