### PR TITLE
Can no longer immediately return a wayfinding pinpointer for a costume

### DIFF
--- a/code/game/objects/items/wayfinding.dm
+++ b/code/game/objects/items/wayfinding.dm
@@ -170,7 +170,7 @@
 
 		var/is_a_thing = "are [refund_amt] credit\s."
 		if(refund_amt > 0 && synth_acc.has_money(refund_amt) && !attacking_pinpointer.roundstart)
-			synth_acc._adjust_money(-refund_amt)
+			synth_acc.adjust_money(-refund_amt)
 			var/obj/item/holochip/holochip = new (user.loc)
 			holochip.credits = refund_amt
 			holochip.name = "[holochip.credits] credit holochip"

--- a/code/game/objects/items/wayfinding.dm
+++ b/code/game/objects/items/wayfinding.dm
@@ -112,7 +112,7 @@
 
 	user_interact_cooldowns[user.real_name] = world.time + COOLDOWN_INTERACT
 
-	for(var/obj/item/pinpointer/wayfinding/WP in user.GetAllContents())
+	for(var/obj/item/pinpointer/wayfinding/held_pinpointer in user.GetAllContents())
 		set_expression("veryhappy", 2 SECONDS)
 		say("<span class='robot'>You already have a pinpointer!</span>")
 		return
@@ -120,8 +120,8 @@
 	var/msg
 	var/dispense = TRUE
 	var/pnpts_found = 0
-	for(var/obj/item/pinpointer/wayfinding/WP in view(9, src))
-		point_at(WP)
+	for(var/obj/item/pinpointer/wayfinding/found_pinpointer in view(9, src))
+		point_at(found_pinpointer)
 		pnpts_found++
 
 	if(pnpts_found)
@@ -162,21 +162,19 @@
 		return ..()
 
 	if(istype(I, /obj/item/pinpointer/wayfinding))
-		var/obj/item/pinpointer/wayfinding/WP = I
+		var/obj/item/pinpointer/wayfinding/attacking_pinpointer = I
 
 		var/itsmypinpointer = TRUE
-		if(WP.owner != user.real_name)
+		if(attacking_pinpointer.owner != user.real_name)
 			itsmypinpointer = FALSE
 
 		var/is_a_thing = "are [refund_amt] credit\s."
-		if(refund_amt > 0 && synth_acc.has_money(refund_amt) && !WP.roundstart)
+		if(refund_amt > 0 && synth_acc.has_money(refund_amt) && !attacking_pinpointer.roundstart)
 			synth_acc._adjust_money(-refund_amt)
 			var/obj/item/holochip/holochip = new (user.loc)
 			holochip.credits = refund_amt
 			holochip.name = "[holochip.credits] credit holochip"
-			if(ishuman(user))
-				var/mob/living/carbon/human/customer = user
-				customer.put_in_hands(holochip)
+			user.put_in_hands(holochip)
 		else if(!itsmypinpointer)
 			var/costume = pick(subtypesof(/obj/effect/spawner/bundle/costume))
 			new costume(user.loc)
@@ -194,8 +192,8 @@
 		if(!itsmypinpointer)
 			the_pinpointer = "that pinpointer"
 
-		to_chat(user, "<span class='notice'>You put \the [WP] in the return slot.</span>")
-		qdel(WP)
+		to_chat(user, "<span class='notice'>You put [attacking_pinpointer] in the return slot.</span>")
+		qdel(attacking_pinpointer)
 
 		set_expression("veryhappy", 2 SECONDS)
 		say("<span class='robot'>Thank you for [recycling] [the_pinpointer]! Here [is_a_thing]</span>")
@@ -208,7 +206,7 @@
 		//Any other type of pinpointer can make it throw up.
 		if(COOLDOWN_FINISHED(src, next_spew_tick))
 			I.forceMove(loc)
-			visible_message("<span class='warning'>\The [src] smartly rejects [I].</span>")
+			visible_message("<span class='warning'>[src] smartly rejects [I].</span>")
 			say("BLEURRRRGH!")
 			I.throw_at(user, 2, 3)
 			COOLDOWN_START(src, next_spew_tick, COOLDOWN_SPEW)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can buy a wayfinding pinpointer and immediately return it for a chance at a non-shitty costume spawning. This allows people to circumvent theatre access and costume crates.

This makes it so returning your own pinpointer gives you nothing if it's roundstart, the refund amount is 0 or the dispenser can't afford the refund. Otherwise, you'll be given 2/3 of what you bought it for.

If you return someone else's pinpointer, you'll either be given 2/3 of what they paid or a costume if it's from the quirk, 2/3 is 0 credits or it can't afford to pay out a 2/3 refund.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less costumes littering arrivals. Less people out of uniform whose jobs you can't tell at a glance. More fighting the clown and/or the mime to use the theatre autodrobe. More costume crate-driven economic interaction. More waiting in line to ask the HoP for theatre access (gripping roleplay)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
del: You can't return your own wayfinding pinpointer to get a costume now
code: Improves code a bit in wayfinding.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
