### PR TITLE
mime chairs are now anchored by default

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -434,7 +434,6 @@
 /obj/structure/chair/mime
 	name = "invisible chair"
 	desc = "The mime needs to sit down and shut up."
-	anchored = FALSE
 	icon_state = null
 	buildstacktype = null
 	item_chair = null


### PR DESCRIPTION
## About The Pull Request

The invisible chairs summoned by the Invisible Chair mime spell are now anchored by default.

## Why It's Good For The Game

This will make the spell not near-worthless and a complete joke compared to Invisible Wall (or even Invisible Box, which is quite a feat).

Also, the spell's icon shows a normal, anchored chair, not a rolling one.

## Changelog
:cl: ATHATH
balance: The invisible chairs summoned by the Invisible Chair mime spell are now anchored by default.
/:cl: