### PR TITLE
the cooler "Can no longer immediately return a wayfinding pinpointer for a costume"

### DIFF
--- a/code/game/objects/items/wayfinding.dm
+++ b/code/game/objects/items/wayfinding.dm
@@ -171,7 +171,7 @@
 		if(WP.owner != user.real_name)
 			itsmypinpointer = FALSE
 
-		if(synth_acc.has_money(refund_amt) && (WP.owner != user.real_name || !(WP.roundstart))) //can it afford to refund and is the pinpointer either not from the quirk or not yours
+		if(synth_acc.has_money(refund_amt) && !(itsmypinpointer && WP.roundstart)) //can it afford to refund you, and is the pinpointer either not from the quirk or not yours?
 			refundiscredits = TRUE
 			qdel(WP)
 			synth_acc._adjust_money(-refund_amt)

--- a/code/game/objects/items/wayfinding.dm
+++ b/code/game/objects/items/wayfinding.dm
@@ -171,16 +171,16 @@
 		if(WP.owner != user.real_name)
 			itsmypinpointer = FALSE
 
-			if(synth_acc.has_money(refund_amt) && !WP.roundstart) //can it afford to refund and is the pinpointer not from the quirk
-				refundiscredits = TRUE
-				qdel(WP)
-				synth_acc._adjust_money(-refund_amt)
-				var/obj/item/holochip/holochip = new (loc)
-				holochip.credits = refund_amt
-				holochip.name = "[holochip.credits] credit holochip"
-				if(ishuman(user))
-					var/mob/living/carbon/human/customer = user
-					customer.put_in_hands(holochip)
+		if(synth_acc.has_money(refund_amt) && (WP.owner != user.real_name || !(WP.roundstart))) //can it afford to refund and is the pinpointer either not from the quirk or not yours
+			refundiscredits = TRUE
+			qdel(WP)
+			synth_acc._adjust_money(-refund_amt)
+			var/obj/item/holochip/holochip = new (loc)
+			holochip.credits = refund_amt
+			holochip.name = "[holochip.credits] credit holochip"
+			if(ishuman(user))
+				var/mob/living/carbon/human/customer = user
+				customer.put_in_hands(holochip)
 
 		if(!refundiscredits)
 			qdel(WP)


### PR DESCRIPTION
## About The Pull Request

This should fix the issue mentioned in https://github.com/tgstation/tgstation/pull/56916 by properly fixing the indentation of an if statement block.

## Why It's Good For The Game

See the WIGFTG section of https://github.com/tgstation/tgstation/pull/56916.

This version of the PR won't add a needless cooldown for refunding pinpointers, since they already have a cooldown for being printed and don't give you all of their money back anyway.

It also doesn't add a 50% chance to deal 5 brute damage to your hand and make you scream when you try to return a pinpointer too early for some reason.

The funny thing is, I could've sworn that I've bought and then immediately refunded pinpointers for credits before without issue, but maybe I'm just misremembering or didn't do it right.

## Changelog
:cl: ATHATH
fix: Non-roundstart wayfinding pinpointers that you've bought now refund for credits instead of a costume like they should.
/:cl: