### PR TITLE
Removes Gnashing Teeth, Makes Keelhaul Harm Harm Instead

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -1,6 +1,5 @@
-#define STRONG_PUNCH_COMBO "HH"
 #define LAUNCH_KICK_COMBO "HD"
-#define DROP_KICK_COMBO "HG"
+#define DROP_KICK_COMBO "HH"
 
 /datum/martial_art/the_sleeping_carp
 	name = "The Sleeping Carp"
@@ -10,10 +9,6 @@
 	display_combos = TRUE
 
 /datum/martial_art/the_sleeping_carp/proc/check_streak(mob/living/A, mob/living/D)
-	if(findtext(streak,STRONG_PUNCH_COMBO))
-		streak = ""
-		strongPunch(A,D)
-		return TRUE
 	if(findtext(streak,LAUNCH_KICK_COMBO))
 		streak = ""
 		launchKick(A,D)
@@ -23,20 +18,6 @@
 		dropKick(A,D)
 		return TRUE
 	return FALSE
-
-///Gnashing Teeth: Harm Harm, consistent 20 force punch on every second harm punch
-/datum/martial_art/the_sleeping_carp/proc/strongPunch(mob/living/A, mob/living/D)
-	///this var is so that the strong punch is always aiming for the body part the user is targeting and not trying to apply to the chest before deviating
-	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
-	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
-	var/atk_verb = pick("precisely kick", "brutally chop", "cleanly hit", "viciously slam")
-	D.visible_message("<span class='danger'>[A] [atk_verb]s [D]!</span>", \
-					"<span class='userdanger'>[A] [atk_verb]s you!</span>", null, null, A)
-	to_chat(A, "<span class='danger'>You [atk_verb] [D]!</span>")
-	playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
-	log_combat(A, D, "strong punched (Sleeping Carp)")
-	D.apply_damage(20, A.get_attack_type(), affecting)
-	return
 
 ///Crashing Wave Kick: Harm Disarm combo, throws people seven tiles backwards
 /datum/martial_art/the_sleeping_carp/proc/launchKick(mob/living/A, mob/living/D)
@@ -50,7 +31,7 @@
 	log_combat(A, D, "launchkicked (Sleeping Carp)")
 	return
 
-///Keelhaul: Harm Grab combo, knocks people down, deals stamina damage while they're on the floor
+///Keelhaul: Harm Harm combo, knocks people down, deals stamina damage while they're on the floor
 /datum/martial_art/the_sleeping_carp/proc/dropKick(mob/living/A, mob/living/D)
 	A.do_attack_animation(D, ATTACK_EFFECT_KICK)
 	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
@@ -70,7 +51,6 @@
 	return
 
 /datum/martial_art/the_sleeping_carp/grab_act(mob/living/A, mob/living/D)
-	add_to_streak("G",D)
 	if(check_streak(A,D))
 		return TRUE
 	log_combat(A, D, "grabbed (Sleeping Carp)")
@@ -142,9 +122,8 @@
 	set category = "Sleeping Carp"
 
 	to_chat(usr, "<b><i>You retreat inward and recall the teachings of the Sleeping Carp...</i></b>\n\
-	<span class='notice'>Gnashing Teeth</span>: Harm Harm. Deal additional damage every second (consecutive) punch!\n\
-	<span class='notice'>Crashing Wave Kick</span>: Harm Disarm. Launch your opponent away from you with incredible force!\n\
-	<span class='notice'>Keelhaul</span>: Harm Grab. Kick an opponent to the floor, knocking them down! If your opponent is already prone, this move will disarm them and deal additional stamina damage to them.\n\
+	<span class='notice'>Crashing Wave Kick</span>: Left Click Right Click. Launch your opponent away from you with incredible force!\n\
+	<span class='notice'>Keelhaul</span>: Left Click Left Click. Kick an opponent to the floor, knocking them down! If your opponent is already prone, this move will disarm them and deal additional stamina damage to them.\n\
 	<span class='notice'>While in throw mode (and not stunned, not a hulk, and not in a mech), you can reflect all projectiles that come your way, sending them back at the people who fired them!\
 	Also, you are more resilient against suffering wounds in combat, and your limbs cannot be dismembered. This grants you extra staying power during extended combat, especially against slashing and other bleeding weapons.\
 	You are not invincible, however- while you may not suffer debilitating wounds often, you must still watch your health and appropriate medical supplies when possible for use during downtime.\

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -7,16 +7,24 @@
 	allow_temp_override = FALSE
 	help_verb = /mob/living/proc/sleeping_carp_help
 	display_combos = TRUE
+	COOLDOWN_DECLARE(dropkick_cooldown)
+	COOLDOWN_DECLARE(launchkick_cooldown)
 
 /datum/martial_art/the_sleeping_carp/proc/check_streak(mob/living/A, mob/living/D)
 	if(findtext(streak,LAUNCH_KICK_COMBO))
 		streak = ""
-		launchKick(A,D)
-		return TRUE
+		if(COOLDOWN_FINISHED(src, launchkick_cooldown))
+			launchKick(A,D)
+			return TRUE
+		else
+			return FALSE
 	if(findtext(streak,DROP_KICK_COMBO))
 		streak = ""
-		dropKick(A,D)
-		return TRUE
+		if(COOLDOWN_FINISHED(src, dropkick_cooldown))
+			dropKick(A,D)
+			return TRUE
+		else
+			return FALSE
 	return FALSE
 
 ///Crashing Wave Kick: Harm Disarm combo, throws people seven tiles backwards
@@ -28,6 +36,7 @@
 	var/atom/throw_target = get_edge_target_turf(D, A.dir)
 	D.throw_at(throw_target, 7, 14, A)
 	D.apply_damage(15, A.get_attack_type(), BODY_ZONE_CHEST, wound_bonus = CANT_WOUND)
+	COOLDOWN_START(src, launchkick_cooldown, 1.4 SECONDS)
 	log_combat(A, D, "launchkicked (Sleeping Carp)")
 	return
 
@@ -47,12 +56,11 @@
 		D.drop_all_held_items()
 		D.visible_message("<span class='warning'>[A] kicks [D] in the head!</span>", \
 					"<span class='userdanger'>You are kicked in the head by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
+	COOLDOWN_START(src, dropkick_cooldown, 1.4 SECONDS)
 	log_combat(A, D, "dropkicked (Sleeping Carp)")
 	return
 
 /datum/martial_art/the_sleeping_carp/grab_act(mob/living/A, mob/living/D)
-	if(check_streak(A,D))
-		return TRUE
 	log_combat(A, D, "grabbed (Sleeping Carp)")
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gnashing Teeth gets removed from sleeping carp, with keelhaul taking its place as the Harm Harm combo, with it no longer being Harm Grab.

It also updates the recall teachings description of Keelhaul and Crashing Wave Kick to be more in line with Combat Mode.

Now, Crashing Wave Kick and Keelhaul have a 1.4 second cooldown when performing them, which mitigates excessive combo spam.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gnashing Teeth is not at all a good move, and does nothing that harm doesn't do already. It also makes the execution for Keelhaul much easier to perform, and much less awkward than quickly left clicking and following with a ctrl click in a short window of time in the context of Combat Mode.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removes Gnashing Teeth (Harm Harm) from Sleeping Carp
qol: Keelhaul now requires a Harm Harm combo to perform instead of Harm Grab
code: Updates the Recall Sleeping Carp Teachings verb to Combat Mode standards
balance: Adds a 1.4 second cooldown to Crashing Wave Kick and Keelhaul when performed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
