### PR TITLE
Fixed customizable reagent holders for held holders

### DIFF
--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -123,10 +123,11 @@
 		return
 	if (replacement)
 		var/atom/replacement_parent = new replacement(atom_parent.loc)
-		if(atom_parent.loc == attacker && isitem(replacement_parent))
-			var/obj/item/I = replacement_parent
-			if(attacker.is_holding(atom_parent))
-				attacker.put_in_hands(I)
+		if(atom_parent.loc == attacker && isitem(replacement_parent) && isitem(atom_parent))
+			var/obj/item/I = atom_parent
+			if(attacker.is_holding(I))
+				var/obj/item/R = replacement_parent
+				attacker.put_in_hands(R)
 		ingredient.forceMove(replacement_parent)
 		replacement = null
 		RemoveComponent()

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -124,10 +124,10 @@
 	if (replacement)
 		var/atom/replacement_parent = new replacement(atom_parent.loc)
 		if(atom_parent.loc == attacker && isitem(replacement_parent) && isitem(atom_parent))
-			var/obj/item/I = atom_parent
-			if(attacker.is_holding(I))
-				var/obj/item/R = replacement_parent
-				attacker.put_in_hands(R)
+			var/obj/item/old_item = atom_parent
+			if(attacker.is_holding(old_item))
+				var/obj/item/replacement_item = replacement_parent
+				attacker.put_in_hands(replacement_item)
 		ingredient.forceMove(replacement_parent)
 		replacement = null
 		RemoveComponent()

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -123,6 +123,10 @@
 		return
 	if (replacement)
 		var/atom/replacement_parent = new replacement(atom_parent.loc)
+		if(atom_parent.loc == attacker && isitem(replacement_parent))
+			var/obj/item/I = replacement_parent
+			if(attacker.is_holding(atom_parent))
+				attacker.put_in_hands(I)
 		ingredient.forceMove(replacement_parent)
 		replacement = null
 		RemoveComponent()

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -127,7 +127,7 @@
 			var/obj/item/old_item = atom_parent
 			if(attacker.is_holding(old_item))
 				var/obj/item/replacement_item = replacement_parent
-				attacker.put_in_hands(replacement_item)
+				attacker.put_in_hand(replacement_item, attacker.get_held_index_of_item(old_item), TRUE)
 		ingredient.forceMove(replacement_parent)
 		replacement = null
 		RemoveComponent()

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -127,7 +127,7 @@
 			var/obj/item/old_item = atom_parent
 			if(attacker.is_holding(old_item))
 				var/obj/item/replacement_item = replacement_parent
-				attacker.put_in_hand(replacement_item, attacker.get_held_index_of_item(old_item), TRUE)
+				attacker.put_in_hand(replacement_item, attacker.get_held_index_of_item(old_item), forced=TRUE)
 		ingredient.forceMove(replacement_parent)
 		replacement = null
 		RemoveComponent()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes customizable_reagent_holder to put the new parent item in the hands of the attacker when the old parent is being held by the attacker.

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/56544

## Changelog
:cl:
fix: Fixed tablecrafted foods being put inside their creators when they are held.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
