### PR TITLE
'Server's Last Round' fix

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -371,7 +371,7 @@
  * the file will be overwritten at the end of each shift.
  */
 /datum/controller/subsystem/ticker/proc/log_roundend_report()
-	var/filename = "[GLOB.log_directory]/round_end_data.html"
+	var/roundend_file = file("[GLOB.log_directory]/round_end_data.html")
 	var/list/parts = list()
 	parts += "<div class='panel stationborder'>"
 	parts += GLOB.survivor_report
@@ -379,12 +379,12 @@
 	parts += GLOB.common_report
 	var/content = parts.Join()
 	//Log the rendered HTML in the round log directory
-	fdel(filename)
-	text2file(content, filename)
+	fdel(roundend_file)
+	WRITE_FILE(content, roundend_file)
 	//Place a copy in the root folder, to be overwritten each round.
-	filename = "data/server_last_roundend_report.html"
-	fdel(filename)
-	text2file(content, filename)
+	roundend_file = file("data/server_last_roundend_report.html")
+	fdel(roundend_file)
+	WRITE_FILE(content, roundend_file)
 
 /datum/controller/subsystem/ticker/proc/show_roundend_report(client/C, report_type = null)
 	var/datum/browser/roundend_report = new(C, "roundend")
@@ -399,7 +399,6 @@
 	else //report_type is null, so make a new report based on the current round and show that to the player
 		var/list/report_parts = list(personal_report(C), GLOB.common_report)
 		content = report_parts.Join()
-		remove_verb(C, /client/proc/show_previous_roundend_report)
 		fdel(filename)
 		text2file(content, filename)
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -380,11 +380,11 @@
 	var/content = parts.Join()
 	//Log the rendered HTML in the round log directory
 	fdel(roundend_file)
-	WRITE_FILE(content, roundend_file)
+	WRITE_FILE(roundend_file, content)
 	//Place a copy in the root folder, to be overwritten each round.
 	roundend_file = file("data/server_last_roundend_report.html")
 	fdel(roundend_file)
-	WRITE_FILE(content, roundend_file)
+	WRITE_FILE(roundend_file, content)
 
 /datum/controller/subsystem/ticker/proc/show_roundend_report(client/C, report_type = null)
 	var/datum/browser/roundend_report = new(C, "roundend")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -255,7 +255,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(fexists(roundend_report_file()))
 		add_verb(src, /client/proc/show_previous_roundend_report)
 
-	if(fexists("data/last_roundend/server_last_roundend_report.html"))
+	if(fexists("data/server_last_roundend_report.html"))
 		add_verb(src, /client/proc/show_servers_last_roundend_report)
 
 	var/full_version = "[byond_version].[byond_build ? byond_build : "xxx"]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes viewing the server's last round actually work
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes #56805
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The server's last round should be actually viewable now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
