### PR TITLE
Fixes an incorrectly assigned var in syndicate turrets, allowing them to shoot again

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -709,7 +709,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	installation = null
 	always_up = TRUE
 	use_power = NO_POWER_USE
-	has_cover = TRUE
+	has_cover = FALSE
 	scan_range = 9
 	req_access = list(ACCESS_SYNDICATE)
 	uses_stored = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sets a var that was FALSE to TRUE again, so that these turrets can fire once again.

## Why It's Good For The Game

Pew pew pew

## Changelog
:cl:
fix: Corrects an incorrectly set var in syndicate portable turrets that prevented them from firing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
