### PR TITLE
Crafting menu tells you which colour of crayon is needed

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -566,7 +566,7 @@
 	dye_color = DYE_WHITE
 
 /obj/item/toy/crayon/mime
-	name = "mime crayon"
+//	name = "mime crayon"
 	icon_state = "crayonmime"
 	desc = "A very sad-looking crayon."
 	paint_color = "#FFFFFF"

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -19,7 +19,7 @@
  */
 
 /obj/item/toy/crayon
-	name = "crayon"
+	name = "red crayon"
 	desc = "A colourful crayon. Looks tasty. Mmmm..."
 	icon = 'icons/obj/crayons.dmi'
 	icon_state = "crayonred"
@@ -81,9 +81,6 @@
 
 /obj/item/toy/crayon/Initialize()
 	. = ..()
-	// Makes crayons identifiable in things like grinders
-	if(name == "crayon")
-		name = "[crayon_color] crayon"
 
 	dye_color = crayon_color
 
@@ -566,7 +563,7 @@
 	dye_color = DYE_WHITE
 
 /obj/item/toy/crayon/mime
-//	name = "mime crayon"
+	name = "mime crayon"
 	icon_state = "crayonmime"
 	desc = "A very sad-looking crayon."
 	paint_color = "#FFFFFF"

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -502,6 +502,7 @@
 			return G
 
 /obj/item/toy/crayon/red
+	name = "red crayon"
 	icon_state = "crayonred"
 	paint_color = "#DA0000"
 	crayon_color = "red"
@@ -509,6 +510,7 @@
 	dye_color = DYE_RED
 
 /obj/item/toy/crayon/orange
+	name = "orange crayon"
 	icon_state = "crayonorange"
 	paint_color = "#FF9300"
 	crayon_color = "orange"
@@ -516,6 +518,7 @@
 	dye_color = DYE_ORANGE
 
 /obj/item/toy/crayon/yellow
+	name = "yellow crayon"
 	icon_state = "crayonyellow"
 	paint_color = "#FFF200"
 	crayon_color = "yellow"
@@ -523,6 +526,7 @@
 	dye_color = DYE_YELLOW
 
 /obj/item/toy/crayon/green
+	name = "green crayon"
 	icon_state = "crayongreen"
 	paint_color = "#A8E61D"
 	crayon_color = "green"
@@ -530,6 +534,7 @@
 	dye_color = DYE_GREEN
 
 /obj/item/toy/crayon/blue
+	name = "blue crayon"
 	icon_state = "crayonblue"
 	paint_color = "#00B7EF"
 	crayon_color = "blue"
@@ -537,6 +542,7 @@
 	dye_color = DYE_BLUE
 
 /obj/item/toy/crayon/purple
+	name = "purple crayon"
 	icon_state = "crayonpurple"
 	paint_color = "#DA00FF"
 	crayon_color = "purple"
@@ -544,6 +550,7 @@
 	dye_color = DYE_PURPLE
 
 /obj/item/toy/crayon/black
+	name = "black crayon"
 	icon_state = "crayonblack"
 	paint_color = "#1C1C1C" //Not completely black because total black looks bad. So Mostly Black.
 	crayon_color = "black"
@@ -551,6 +558,7 @@
 	dye_color = DYE_BLACK
 
 /obj/item/toy/crayon/white
+	name = "white crayon"
 	icon_state = "crayonwhite"
 	paint_color = "#FFFFFF"
 	crayon_color = "white"
@@ -558,6 +566,7 @@
 	dye_color = DYE_WHITE
 
 /obj/item/toy/crayon/mime
+	name = "mime crayon"
 	icon_state = "crayonmime"
 	desc = "A very sad-looking crayon."
 	paint_color = "#FFFFFF"
@@ -567,6 +576,7 @@
 	dye_color = DYE_MIME
 
 /obj/item/toy/crayon/rainbow
+	name = "rainbow crayon"
 	icon_state = "crayonrainbow"
 	paint_color = "#FFF000"
 	crayon_color = "rainbow"

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -45,6 +45,7 @@
 #include "combat.dm"
 #include "component_tests.dm"
 #include "confusion.dm"
+#include "crayons.dm"
 #include "designs.dm"
 #include "dynamic_ruleset_sanity.dm"
 #include "emoting.dm"

--- a/code/modules/unit_tests/crayons.dm
+++ b/code/modules/unit_tests/crayons.dm
@@ -1,4 +1,4 @@
-/// Makes sure that crayons have their crayon_color in their initial name.
+/// Makes sure that crayons have their crayon_color in their initial name (to differentiate them in the crafting menu).
 
 /datum/unit_test/crayon_naming/Run()
 	for(var/obj/item/toy/crayon/crayon_path as anything in typesof(/obj/item/toy/crayon))

--- a/code/modules/unit_tests/crayons.dm
+++ b/code/modules/unit_tests/crayons.dm
@@ -1,0 +1,8 @@
+///Makes sure that crayons have their crayon_color in their initial name.
+
+/datum/unit_test/crayon_naming/Run()
+	for(var/obj/item/toy/crayon/this_crayon as anything in typesof(/obj/item/toy/crayon))
+		if(is_type(this_crayon, /obj/item/toy/crayon/spraycan))
+			continue
+		if(!findtext("[this_crayon]","[this_crayon.crayon_color]"))
+			Fail("[this_crayon.type] does not have its crayon_color ([crayon_color]) in its initial name ([this_crayon]).")

--- a/code/modules/unit_tests/crayons.dm
+++ b/code/modules/unit_tests/crayons.dm
@@ -2,7 +2,7 @@
 
 /datum/unit_test/crayon_naming/Run()
 	for(var/obj/item/toy/crayon/this_crayon as anything in typesof(/obj/item/toy/crayon))
-		if(is_type(this_crayon, /obj/item/toy/crayon/spraycan))
+		if(istype(this_crayon, /obj/item/toy/crayon/spraycan))
 			continue
 		if(!findtext("[this_crayon]","[this_crayon.crayon_color]"))
-			Fail("[this_crayon.type] does not have its crayon_color ([crayon_color]) in its initial name ([this_crayon]).")
+			Fail("[this_crayon.type] does not have its crayon_color ([this_crayon.crayon_color]) in its initial name ([this_crayon]).")

--- a/code/modules/unit_tests/crayons.dm
+++ b/code/modules/unit_tests/crayons.dm
@@ -1,4 +1,5 @@
 /// Makes sure that crayons have their crayon_color in their initial name (to differentiate them in the crafting menu).
+/datum/unit_test/crayon_naming
 
 /datum/unit_test/crayon_naming/Run()
 	for(var/obj/item/toy/crayon/crayon_path as anything in typesof(/obj/item/toy/crayon))

--- a/code/modules/unit_tests/crayons.dm
+++ b/code/modules/unit_tests/crayons.dm
@@ -1,8 +1,10 @@
-///Makes sure that crayons have their crayon_color in their initial name.
+/// Makes sure that crayons have their crayon_color in their initial name.
 
 /datum/unit_test/crayon_naming/Run()
-	for(var/obj/item/toy/crayon/this_crayon as anything in typesof(/obj/item/toy/crayon))
-		if(istype(this_crayon, /obj/item/toy/crayon/spraycan))
+	for(var/obj/item/toy/crayon/crayon_path as anything in typesof(/obj/item/toy/crayon))
+		if(ispath(crayon_path, /obj/item/toy/crayon/spraycan))
 			continue
-		if(!findtext("[this_crayon]","[this_crayon.crayon_color]"))
-			Fail("[this_crayon.type] does not have its crayon_color ([this_crayon.crayon_color]) in its initial name ([this_crayon]).")
+		var/obj/item/toy/crayon/real_crayon = new crayon_path
+		if(!findtext(initial(real_crayon.name),real_crayon.crayon_color))
+			Fail("[real_crayon] does not have its crayon_color ([real_crayon.crayon_color]) in its initial name ([initial(real_crayon.name)]).")
+		qdel(real_crayon)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I named the crayons.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The crafting menu will tell you which colour of crayon is needed in a given recipe now. Helpful when collecting ingredients for the crazy burger.

Fixes #56906
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
qol: Crafting menu will now tell you which colour of crayon is needed (useful for recipes like the crazy burger)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
