### PR TITLE
Fixes admin rights message when player attempts to open playtime panel

### DIFF
--- a/code/modules/jobs/job_report.dm
+++ b/code/modules/jobs/job_report.dm
@@ -50,7 +50,7 @@
 	data["livingTime"] = play_records[EXP_TYPE_LIVING]
 	data["ghostTime"] = play_records[EXP_TYPE_GHOST]
 
-	data["isAdmin"] = check_rights(R_ADMIN)
+	data["isAdmin"] = check_rights(R_ADMIN, show_msg = FALSE)
 
 	return data
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'm using check_rights for the boolean value for tgui, not to prevent some admin proc being called. Added the argument to stop the insufficient rights message being shown.

I bwoke it, I feex it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Viewing your playtime panel as a non-admin should no longer yell at you in chat that you have insufficient rights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
