### PR TITLE
Fixes an edgecase where an area can be deleted, but still be stored inside GLOB.sortedAreas

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -230,6 +230,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 /area/Destroy()
 	if(GLOB.areas_by_type[type] == src)
 		GLOB.areas_by_type[type] = null
+	GLOB.sortedAreas -= src
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes an edgecase where an area can be deleted, but still be stored inside GLOB.sortedAreas, which can cause a runtime on player related Initialize(), which can cause mobs to improperly init. No I don't know why this would happen, but it happen to me.

## Why It's Good For The Game
Ided pls fix. Oh also fixes areas harddeleting sometimes? I guess?
## Changelog
:cl:
fix: Fixes a very rare edgecase that could cause spawned ghosts to be unable to move
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
