### PR TITLE
Fix oversight allowing orbiting players to force the player they're orbitting to *surrender

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -761,15 +761,17 @@ so as to remain in compliance with the most up-to-date laws."
 
 /atom/movable/screen/alert/Click(location, control, params)
 	if(!usr || !usr.client)
-		return
+		return FALSE
 	if(usr != owner)
-		return
+		return FALSE
 	var/list/modifiers = params2list(params)
 	if(LAZYACCESS(modifiers, SHIFT_CLICK)) // screen objects don't do the normal Click() stuff so we'll cheat
 		to_chat(usr, "<span class='boldnotice'>[name]</span> - <span class='info'>[desc]</span>")
-		return
+		return FALSE
 	if(master)
 		return usr.client.Click(master, location, control, params)
+
+	return TRUE
 
 /atom/movable/screen/alert/Destroy()
 	. = ..()

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -236,10 +236,10 @@ or something covering your eyes."
 	var/command
 
 /atom/movable/screen/alert/mind_control/Click()
-	var/mob/living/L = usr
-	if(L != owner)
+	. = ..()
+	if(!.)
 		return
-	to_chat(L, "<span class='mind_control'>[command]</span>")
+	to_chat(owner, "<span class='mind_control'>[command]</span>")
 
 /atom/movable/screen/alert/drunk
 	name = "Drunk"
@@ -253,9 +253,13 @@ If you're feeling frisky, examine yourself and click the underlined item to pull
 	icon_state = "embeddedobject"
 
 /atom/movable/screen/alert/embeddedobject/Click()
-	if(isliving(usr) && usr == owner)
-		var/mob/living/carbon/M = usr
-		return M.help_shake_act(M)
+	. = ..()
+	if(!.)
+		return
+
+	var/mob/living/carbon/carbon_owner = owner
+
+	return carbon_owner.help_shake_act(carbon_owner)
 
 /atom/movable/screen/alert/weightless
 	name = "Weightless"
@@ -281,12 +285,15 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	icon_state = "fire"
 
 /atom/movable/screen/alert/fire/Click()
-	var/mob/living/L = usr
-	if(!istype(L) || !L.can_resist() || L != owner)
+	. = ..()
+	if(!.)
 		return
-	L.changeNext_move(CLICK_CD_RESIST)
-	if(L.mobility_flags & MOBILITY_MOVE)
-		return L.resist_fire() //I just want to start a flame in your hearrrrrrtttttt.
+
+	var/mob/living/living_owner = owner
+
+	living_owner.changeNext_move(CLICK_CD_RESIST)
+	if(living_owner.mobility_flags & MOBILITY_MOVE)
+		return living_owner.resist_fire()
 
 /atom/movable/screen/alert/give // information set when the give alert is made
 	icon_state = "default"
@@ -322,6 +329,12 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/give/Click(location, control, params)
 	. = ..()
+	if(!.)
+		return
+
+	if(!iscarbon(usr))
+		CRASH("User for [src] is of type \[[usr.type]\]. This should never happen.")
+
 	var/mob/living/carbon/C = owner
 	C.take(giver, receiving)
 
@@ -341,6 +354,9 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/highfive/Click(location, control, params)
 	. = ..()
+	if(!.)
+		return
+
 	var/datum/status_effect/high_fiving/high_five_effect = giver.has_status_effect(STATUS_EFFECT_HIGHFIVE)
 	if(high_five_effect)
 		high_five_effect.we_did_it(owner)
@@ -352,7 +368,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	icon_state = "succumb"
 
 /atom/movable/screen/alert/succumb/Click()
-	if (isobserver(usr))
+	. = ..()
+	if(!.)
 		return
 
 	var/mob/living/living_owner = owner
@@ -582,14 +599,14 @@ so as to remain in compliance with the most up-to-date laws."
 	var/atom/target = null
 
 /atom/movable/screen/alert/hackingapc/Click()
-	if(!usr || !usr.client || usr != owner)
+	. = ..()
+	if(!.)
 		return
-	if(!target)
-		return
-	var/mob/living/silicon/ai/AI = usr
-	var/turf/T = get_turf(target)
-	if(T)
-		AI.eyeobj.setLoc(T)
+
+	var/mob/living/silicon/ai/ai_owner = owner
+	var/turf/target_turf = get_turf(target)
+	if(target_turf)
+		ai_owner.eyeobj.setLoc(target_turf)
 
 //MECHS
 
@@ -608,10 +625,11 @@ so as to remain in compliance with the most up-to-date laws."
 	timeout = 300
 
 /atom/movable/screen/alert/notify_cloning/Click()
-	if(!usr || !usr.client || usr != owner)
+	. = ..()
+	if(!.)
 		return
-	var/mob/dead/observer/G = usr
-	G.reenter_corpse()
+	var/mob/dead/observer/dead_owner = owner
+	dead_owner.reenter_corpse()
 
 /atom/movable/screen/alert/notify_action
 	name = "Body created"
@@ -622,22 +640,23 @@ so as to remain in compliance with the most up-to-date laws."
 	var/action = NOTIFY_JUMP
 
 /atom/movable/screen/alert/notify_action/Click()
-	if(!usr || !usr.client || usr != owner)
+	. = ..()
+	if(!.)
 		return
 	if(!target)
 		return
-	var/mob/dead/observer/G = usr
-	if(!istype(G))
+	var/mob/dead/observer/dead_owner = owner
+	if(!istype(dead_owner))
 		return
 	switch(action)
 		if(NOTIFY_ATTACK)
-			target.attack_ghost(G)
+			target.attack_ghost(dead_owner)
 		if(NOTIFY_JUMP)
-			var/turf/T = get_turf(target)
-			if(T && isturf(T))
-				G.forceMove(T)
+			var/turf/target_turf = get_turf(target)
+			if(target_turf && isturf(target_turf))
+				dead_owner.forceMove(target_turf)
 		if(NOTIFY_ORBIT)
-			G.ManualFollow(target)
+			dead_owner.ManualFollow(target)
 
 //OBJECT-BASED
 
@@ -655,20 +674,31 @@ so as to remain in compliance with the most up-to-date laws."
 	desc = "You're legcuffed, which slows you down considerably. Click the alert to free yourself."
 
 /atom/movable/screen/alert/restrained/Click()
-	var/mob/living/L = usr
-	if(!istype(L) || !L.can_resist() || L != owner)
+	. = ..()
+	if(!.)
 		return
-	L.changeNext_move(CLICK_CD_RESIST)
-	if((L.mobility_flags & MOBILITY_MOVE) && (L.last_special <= world.time))
-		return L.resist_restraints()
+
+	var/mob/living/living_owner = owner
+
+	if(!living_owner.can_resist())
+		return
+
+	living_owner.changeNext_move(CLICK_CD_RESIST)
+	if((living_owner.mobility_flags & MOBILITY_MOVE) && (living_owner.last_special <= world.time))
+		return living_owner.resist_restraints()
 
 /atom/movable/screen/alert/restrained/buckled/Click()
-	var/mob/living/L = usr
-	if(!istype(L) || !L.can_resist() || L != owner)
+	. = ..()
+	if(!.)
 		return
-	L.changeNext_move(CLICK_CD_RESIST)
-	if(L.last_special <= world.time)
-		return L.resist_buckle()
+
+	var/mob/living/living_owner = owner
+
+	if(!living_owner.can_resist())
+		return
+	living_owner.changeNext_move(CLICK_CD_RESIST)
+	if(living_owner.last_special <= world.time)
+		return living_owner.resist_buckle()
 
 /atom/movable/screen/alert/shoes/untied
 	name = "Untied Shoes"
@@ -681,11 +711,17 @@ so as to remain in compliance with the most up-to-date laws."
 	icon_state = "shoealert"
 
 /atom/movable/screen/alert/shoes/Click()
-	var/mob/living/carbon/C = usr
-	if(!istype(C) || !C.can_resist() || C != owner || !C.shoes)
+	. = ..()
+	if(!.)
 		return
-	C.changeNext_move(CLICK_CD_RESIST)
-	C.shoes.handle_tying(C)
+
+	var/mob/living/carbon/carbon_owner = owner
+
+	if(!carbon_owner.can_resist() || !carbon_owner.shoes)
+		return
+
+	carbon_owner.changeNext_move(CLICK_CD_RESIST)
+	carbon_owner.shoes.handle_tying(carbon_owner)
 
 // PRIVATE = only edit, use, or override these if you're editing the system as a whole
 
@@ -726,11 +762,11 @@ so as to remain in compliance with the most up-to-date laws."
 /atom/movable/screen/alert/Click(location, control, params)
 	if(!usr || !usr.client)
 		return
+	if(usr != owner)
+		return
 	var/list/modifiers = params2list(params)
 	if(LAZYACCESS(modifiers, SHIFT_CLICK)) // screen objects don't do the normal Click() stuff so we'll cheat
 		to_chat(usr, "<span class='boldnotice'>[name]</span> - <span class='info'>[desc]</span>")
-		return
-	if(usr != owner)
 		return
 	if(master)
 		return usr.client.Click(master, location, control, params)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -268,14 +268,15 @@
 
 /atom/movable/screen/alert/status_effect/strandling/Click(location, control, params)
 	. = ..()
-	if(usr != owner)
+	if(!.)
 		return
+
 	to_chat(owner, "<span class='notice'>You attempt to remove the durathread strand from around your neck.</span>")
 	if(do_after(owner, 3.5 SECONDS, owner))
 		if(isliving(owner))
-			var/mob/living/L = owner
-			to_chat(owner, "<span class='notice'>You succesfuly remove the durathread strand.</span>")
-			L.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
+			var/mob/living/living_owner = owner
+			to_chat(living_owner, "<span class='notice'>You succesfuly remove the durathread strand.</span>")
+			living_owner.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
 
 //OTHER DEBUFFS
 /datum/status_effect/pacify

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -322,6 +322,9 @@
 
 /atom/movable/screen/alert/status_effect/surrender/Click(location, control, params)
 	. = ..()
+	if(!.)
+		return
+
 	owner.emote("surrender")
 
 /*

--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -114,8 +114,12 @@
 	desc = "Your body has sustained serious damage, click here to inspect yourself."
 
 /atom/movable/screen/alert/status_effect/wound/Click()
-	var/mob/living/carbon/C = usr
-	C.check_self_for_injuries()
+	. = ..()
+	if(!.)
+		return
+
+	var/mob/living/carbon/carbon_owner = owner
+	carbon_owner.check_self_for_injuries()
 
 // wound status effect base
 /datum/status_effect/wound


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![OzL0AmRDuJ](https://user-images.githubusercontent.com/24975989/108120912-e1785900-7099-11eb-8d4e-9633a5dc406d.gif)

Observers with auto-observe inherit the HUD of the person they're observing. This includes Alerts. Alerts can be clicked. Alerts have varying levels of snowflaked checks. Some called parent and didn't check the return value. Some perform actions direct on `usr` instead of `owner`.

All of this has been standardised. Every single screen alert now calls ..() on Click() and returns early if the parent proc call returns false.

/atom/movable/screen/alert/Click now returns some useful value to children that call it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Ghosts can no longer force people to surrender when they're held up.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Observers can no longer click on alert icons to perform actions when auto-observing players.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
