### PR TITLE
Held Up status effect no longer permanent.

### DIFF
--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -41,8 +41,8 @@
 		"<span class='danger'>You aim [weapon] point blank at [target]!</span>", ignored_mobs = target)
 	to_chat(target, "<span class='userdanger'>[shooter] aims [weapon] point blank at you!</span>")
 
-	shooter.apply_status_effect(STATUS_EFFECT_HOLDUP)
-	target.apply_status_effect(STATUS_EFFECT_HELDUP)
+	shooter.apply_status_effect(STATUS_EFFECT_HOLDUP, shooter)
+	target.apply_status_effect(STATUS_EFFECT_HELDUP, shooter)
 
 	if(istype(weapon, /obj/item/gun/ballistic/rocketlauncher) && weapon.chambered)
 		if(target.stat == CONSCIOUS && is_nuclear_operative(shooter) && !is_nuclear_operative(target) && (locate(/obj/item/disk/nuclear) in target.get_contents()) && shooter.client)
@@ -57,7 +57,7 @@
 /datum/component/gunpoint/Destroy(force, silent)
 	var/mob/living/shooter = parent
 	shooter.remove_status_effect(STATUS_EFFECT_HOLDUP)
-	target.remove_status_effect(STATUS_EFFECT_HELDUP)
+	target.remove_status_effect(STATUS_EFFECT_HELDUP, shooter)
 	return ..()
 
 /datum/component/gunpoint/RegisterWithParent()
@@ -121,7 +121,7 @@
 
 	var/mob/living/shooter = parent
 	shooter.remove_status_effect(STATUS_EFFECT_HOLDUP) // try doing these before the trigger gets pulled since the target (or shooter even) may not exist after pulling the trigger, dig?
-	target.remove_status_effect(STATUS_EFFECT_HELDUP)
+	target.remove_status_effect(STATUS_EFFECT_HELDUP, shooter)
 	SEND_SIGNAL(target, COMSIG_CLEAR_MOOD_EVENT, "gunpoint")
 
 	if(point_of_no_return)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Heldup status effect is "grouped" and is only removed when all sources of it are removed.

A source is never passed into it, so the sources list just contains a single null element.

Once put on a player, the status effect will never be removed without admin intervention and will forever display the HUD alerts as a result.

I pass in the "shooter" as a source and as such this should now clear appropriately while staying around when a player is being held up by multiple people at once.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: When a player is held up at gunpoint, the HUD alert is no longer permanent and will be removed when the player is no longer held up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
