### PR TITLE
Adds ghost baseball bat.  Also refactors baseball bats slightly.

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -643,6 +643,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	var/homeruns_ready = 0
 	///The chance the bat will be renamed to "cricket bat", and gain a new description.
 	var/cricket_chance = 1
+	///The number of homeruns the bat has already performed.  Right now it's only used in a sanity check to prevent the bat from being charged WHILE being used, by making sure it wasn't used during the charge.
+	var/homeruns_performed = 0
 
 /obj/item/melee/baseball_bat/Initialize()
 	. = ..()
@@ -668,7 +670,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		return
 	to_chat(user, "<span class='warning'>You begin gathering strength...</span>")
 	playsound(get_turf(src), 'sound/magic/lightning_chargeup.ogg', 65, TRUE)
-	if(do_after(user, 9 SECONDS, target = src))
+	var/homeruns_before_charge = homeruns_performed
+	if(do_after(user, 9 SECONDS, target = src) && (homeruns_before_charge == homeruns_performed))
 		to_chat(user, "<span class='userdanger'>You gather power! Time for a home run!</span>")
 		homeruns_ready = homerun_limit
 	..()
@@ -685,6 +688,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		SSexplosions.medturf += throw_target
 		playsound(get_turf(src), 'sound/weapons/homerun.ogg', 100, TRUE)
 		homeruns_ready -= 1
+		homeruns_performed += 1
 		return
 	else if(!to_throw.anchored)
 		var/whack_speed = (prob(60) ? 1 : 4)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -683,17 +683,18 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		return
 	var/atom/movable/to_throw = prepare_and_get_throw_target(target, homeruns_ready)
 	var/atom/throw_target = get_edge_target_turf(to_throw, user.dir)
-	if(homeruns_ready)
-		user.visible_message("<span class='userdanger'>It's a home run!</span>")
-		to_throw.throw_at(throw_target, rand(8,10), 14, user)
-		SSexplosions.medturf += throw_target
-		playsound(get_turf(src), 'sound/weapons/homerun.ogg', 100, TRUE)
-		homeruns_ready -= 1
-		homeruns_performed += 1
-		return
-	else if(!to_throw.anchored)
-		var/whack_speed = (prob(60) ? 1 : 4)
-		to_throw.throw_at(throw_target, rand(1, 2), whack_speed, user) // sorry friends, 7 speed batting caused wounds to absolutely delete whoever you knocked your target into (and said target)
+	if(!QDELETED(to_throw))
+		if(homeruns_ready)
+			user.visible_message("<span class='userdanger'>It's a home run!</span>")
+			to_throw.throw_at(throw_target, rand(8,10), 14, user)
+			SSexplosions.medturf += throw_target
+			playsound(get_turf(src), 'sound/weapons/homerun.ogg', 100, TRUE)
+			homeruns_ready -= 1
+			homeruns_performed += 1
+			return
+		else if(!to_throw.anchored)
+			var/whack_speed = (prob(60) ? 1 : 4)
+			to_throw.throw_at(throw_target, rand(1, 2), whack_speed, user) // sorry friends, 7 speed batting caused wounds to absolutely delete whoever you knocked your target into (and said target)
 
 /**
  * Returns the target to be thrown, AND prepares the target to be thrown if needed.

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -643,7 +643,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	var/homeruns_ready = 0
 	///The chance the bat will be renamed to "cricket bat", and gain a new description.
 	var/cricket_chance = 1
-	///The number of homeruns the bat has already performed.  Right now it's only used in a sanity check to prevent the bat from being charged WHILE being used, by making sure it wasn't used during the charge.
+	///The number of homeruns the bat has already performed.
 	var/homeruns_performed = 0
 
 /obj/item/melee/baseball_bat/Initialize()
@@ -671,6 +671,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	to_chat(user, "<span class='warning'>You begin gathering strength...</span>")
 	playsound(get_turf(src), 'sound/magic/lightning_chargeup.ogg', 65, TRUE)
 	var/homeruns_before_charge = homeruns_performed
+	//If the bat was used for a homerun DURING the charge, don't recharge the bat.
 	if(do_after(user, 9 SECONDS, target = src) && (homeruns_before_charge == homeruns_performed))
 		to_chat(user, "<span class='userdanger'>You gather power! Time for a home run!</span>")
 		homeruns_ready = homerun_limit

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -668,7 +668,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		return
 	to_chat(user, "<span class='warning'>You begin gathering strength...</span>")
 	playsound(get_turf(src), 'sound/magic/lightning_chargeup.ogg', 65, TRUE)
-	if(do_after(user, 90, target = src))
+	if(do_after(user, 9 SECONDS, target = src))
 		to_chat(user, "<span class='userdanger'>You gather power! Time for a home run!</span>")
 		homeruns_ready = homerun_limit
 	..()
@@ -677,7 +677,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	. = ..()
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		return
-	var/atom/movable/to_throw = prepare_and_get_throw_target(target)
+	var/atom/movable/to_throw = prepare_and_get_throw_target(target, homeruns_ready)
 	var/atom/throw_target = get_edge_target_turf(to_throw, user.dir)
 	if(homeruns_ready)
 		user.visible_message("<span class='userdanger'>It's a home run!</span>")
@@ -696,9 +696,10 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
  * For most baseball bats, this will simply return the struck target, but on a few special baseball bats, something OTHER than the target will be thrown.
  * For those bats, overwrite this proc, and perform any needed preparations, and then return the object to be thrown.
  * * struck_target - This is the target the baseball bat hit.
+ * * is_homerun - A boolean, for if this particular swing used a charged homerun
  */
-/obj/item/melee/baseball_bat/proc/prepare_and_get_throw_target(mob/struck_target)
-	return struck_target
+/obj/item/melee/baseball_bat/proc/prepare_and_get_throw_target(mob/struck_target, is_homerun)
+	return is_homerun
 
 /obj/item/melee/baseball_bat/ablative
 	name = "metal baseball bat"

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -491,3 +491,32 @@
 /obj/effect/temp_visual/tornado/Initialize()
 	. = ..()
 	animate(src, pixel_x = -500, time = 40)
+
+/**
+ * # Ghostly baseball bat
+ *
+ * A baseball bat that knocks people's ghost out.
+ *
+ * A wizard summonable item, it's a baseball bat that forcibly ghosts the target, IF they have a client, 
+ * and sends the ghost flying, making them visible for a brief period.  The ghost can immediately re-enter their corpse.
+ * When homerun charged, can perform three consecutive homeruns.
+ */
+/obj/item/melee/baseball_bat/ghostly
+	name = "Ghostly baseball bat"
+	desc = "This looks like it could knock the life straight out of someone."
+	cricket_chance = 0
+	homerun_limit = 3
+
+/obj/item/melee/baseball_bat/ghostly/prepare_and_get_throw_target(mob/struck_target)
+	if(!istype(struck_target, /mob/living))
+		return struck_target
+	if(!struck_target.client)
+		return struck_target
+	var/mob/dead/observer/ghost = struck_target.ghostize(TRUE)
+	if(QDELETED(ghost))
+		return struck_target
+	var/old_invisibility = ghost.invisibility
+	ghost.set_invisibility(0)
+	to_chat(ghost, "<span class='notice'>You feel like you were knocked out of your body!</span>")
+	addtimer(CALLBACK(ghost, /mob/dead/observer/proc/set_invisibility, old_invisibility), 20)
+	return ghost

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -473,6 +473,13 @@
 	category = "Mobility"
 	cost = 1
 
+/datum/spellbook_entry/item/ghostbat
+	name = "Ghostly Baseball bat"
+	desc = "A strange baseball bat that will hit a homerun with the target's soul."
+	item_path = /obj/item/melee/baseball_bat/ghostly
+	category = "Defensive"
+	cost = 1
+
 /datum/spellbook_entry/duffelbag
 	name = "Bestow Cursed Duffel Bag"
 	desc = "A curse that firmly attaches a demonic duffel bag to the target's back. The duffel bag will make the person it's attached to take periodical damage if it is not fed regularly, and regardless of whether or not it's been fed, it will slow the person wearing it down significantly."

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -478,7 +478,6 @@
 	desc = "A strange baseball bat that will hit a homerun with the target's soul."
 	item_path = /obj/item/melee/baseball_bat/ghostly
 	category = "Defensive"
-	cost = 1
 
 /datum/spellbook_entry/duffelbag
 	name = "Bestow Cursed Duffel Bag"


### PR DESCRIPTION
## About The Pull Request

Adds a new wizard summonable item, a ghostly baseball bat, that knocks people's ghosts out, who can instantly re-enter their corpse.  Yes, you can knock your own ghost out with this.

The bat can only be effectively used when charged.  It takes 9 seconds to charge, and gains three uses upon charging.  If used uncharged, the victim will re-enter their body in less than a second, automatically.

I chose a cost of two, as it's similar in power to the scrying orb.  It's most useful function will be knocking your own soul out.  However, this has two major balancing factors compared to the scrying orb.  No X-ray vision, and you have to injure yourself to ghost out.  I estimate that those downsides balance out the ability to temporarily ghost other people.

## Why It's Good For The Game

Mildly hilarious wizard ability, it's low cost, unique, and super magical sounding in nature.  Plus, giving wizards more ability to disable people without killing them is a plus.

Also refactors baseball bats slightly, as well as prevents special baseball bat variants from having their names randomly overwritten.

## Changelog
:cl: lordpidey
add: Added a new wizard item, a ghostly baseball bat, that will send people's ghosts flying.
fix: special baseball bat varieties will no longer have their name randomly overwritten.
/:cl: