### PR TITLE
Fixes two bugs with chairs in the holodeck and non generic chairs being able to be turned into electric chairs 

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -75,20 +75,21 @@
 	qdel(src)
 
 /obj/structure/chair/attackby(obj/item/W, mob/user, params)
-	if(W.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1))
-		W.play_tool_sound(src)
-		deconstruct()
-	else if(istype(W, /obj/item/assembly/shock_kit))
-		if(!user.temporarilyRemoveItemFromInventory(W))
-			return
-		var/obj/item/assembly/shock_kit/SK = W
-		var/obj/structure/chair/e_chair/E = new /obj/structure/chair/e_chair(src.loc)
-		playsound(src.loc, 'sound/items/deconstruct.ogg', 50, TRUE)
-		E.setDir(dir)
-		E.part = SK
-		SK.forceMove(E)
-		SK.master = E
-		qdel(src)
+	if(!(flags_1 & NODECONSTRUCT_1))
+		if(W.tool_behaviour == TOOL_WRENCH)
+			W.play_tool_sound(src)
+			deconstruct()
+		else if(istype(W, /obj/item/assembly/shock_kit) && type == /obj/structure/chair)
+			if(!user.temporarilyRemoveItemFromInventory(W))
+				return
+			var/obj/item/assembly/shock_kit/new_shock_kit = W
+			var/obj/structure/chair/e_chair/new_e_chair = new /obj/structure/chair/e_chair(src.loc)
+			playsound(src.loc, 'sound/items/deconstruct.ogg', 50, TRUE)
+			new_e_chair.setDir(dir)
+			new_e_chair.part = new_shock_kit
+			new_shock_kit.forceMove(new_e_chair)
+			new_shock_kit.master = new_e_chair
+			qdel(src)
 	else
 		return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
THIS WAS REPORTED TO ME ONLY 23 HOURS AGO AS A HOLOBUG SO I DONT HAVE TO GIVE MY MONEY BACK
turns out every chair in the game can be turned into an electric chair with the use of a shock_kit, but the electric chair has no idea about what it was before, so it disassembles into an ordinary chair

![Screenshot_898](https://user-images.githubusercontent.com/15794172/108155916-9576e580-7094-11eb-89cd-0b0b9b18a8c5.png)
![Screenshot_899](https://user-images.githubusercontent.com/15794172/108155918-97d93f80-7094-11eb-9e33-5923c32cce32.png)
![Screenshot_900](https://user-images.githubusercontent.com/15794172/108155921-9a3b9980-7094-11eb-8f8d-92adc3287b65.png)

ANY SUBTYPE OF CHAIR can be done like this 
![Screenshot_901](https://user-images.githubusercontent.com/15794172/108156030-cd7e2880-7094-11eb-9a5c-c0b173901c6f.png)
![Screenshot_902](https://user-images.githubusercontent.com/15794172/108156035-d1aa4600-7094-11eb-9dde-a3126d58a8f4.png)

this makes sure that the original chairs type == /obj/structure/chair and that its only possible if the chair doesnt have the NODECONSTRUCT_1 flag

Fixes #56955

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
dumb bugs
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: NanoTrasen has pushed a firmware update to its shock kits that makes the alchemic transmutation of arbitrary chair material into metal impossible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
