### PR TITLE
[DNM] Remove ping counter, as an experiment to see if it fixes the auto reconnect issue

### DIFF
--- a/tgui/packages/tgui-panel/index.js
+++ b/tgui/packages/tgui-panel/index.js
@@ -37,7 +37,7 @@ const store = configureStore({
   middleware: {
     pre: [
       chatMiddleware,
-      pingMiddleware,
+      // pingMiddleware,
       telemetryMiddleware,
       settingsMiddleware,
       audioMiddleware,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the ping counter to see if it will fix the reconnect issue.

With @stylemistake 's review, I will test merge this. If it works, I'm thinking just move the `roundrestart` message to not when the server is restarting, but when the round ends. You don't really have any reason to know your ping at that point anyway.