### PR TITLE
improves fire extinguisher code, and makes fire extinguisher water go through machinery, lockers, and crates

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -125,6 +125,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define PASSMACHINE (1<<7)
 #define PASSSTRUCTURE (1<<8)
 #define PASSFLAPS (1<<9)
+#define PASSDOORS (1<<10)
 
 //Movement Types
 #define GROUND (1<<0)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -380,13 +380,13 @@
 	. = ..()
 	to_chat(owner,"<span class='notice'>You phase through reality, nothing is out of bounds!</span>")
 	owner.alpha = 180
-	owner.pass_flags |= PASSCLOSEDTURF | PASSGLASS | PASSGRILLE | PASSMACHINE | PASSSTRUCTURE | PASSTABLE | PASSMOB
+	owner.pass_flags |= PASSCLOSEDTURF | PASSGLASS | PASSGRILLE | PASSMACHINE | PASSSTRUCTURE | PASSTABLE | PASSMOB | PASSDOORS
 	location = get_turf(owner)
 
 /datum/status_effect/crucible_soul/on_remove()
 	to_chat(owner,"<span class='notice'>You regain your physicality, returning you to your original location...</span>")
 	owner.alpha = initial(owner.alpha)
-	owner.pass_flags &= ~(PASSCLOSEDTURF | PASSGLASS | PASSGRILLE | PASSMACHINE | PASSSTRUCTURE | PASSTABLE | PASSMOB)
+	owner.pass_flags &= ~(PASSCLOSEDTURF | PASSGLASS | PASSGRILLE | PASSMACHINE | PASSSTRUCTURE | PASSTABLE | PASSMOB | PASSDOORS)
 	owner.forceMove(location)
 	location = null
 	return ..()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -9,6 +9,7 @@
 	move_resist = MOVE_FORCE_VERY_STRONG
 	layer = OPEN_DOOR_LAYER
 	power_channel = AREA_USAGE_ENVIRON
+	pass_flags_self = PASSDOORS
 	max_integrity = 350
 	armor = list(MELEE = 30, BULLET = 30, LASER = 20, ENERGY = 20, BOMB = 10, BIO = 100, RAD = 100, FIRE = 80, ACID = 70)
 	CanAtmosPass = ATMOS_PASS_DENSITY

--- a/code/game/objects/effects/effect_system/effects_water.dm
+++ b/code/game/objects/effects/effect_system/effects_water.dm
@@ -3,7 +3,7 @@
 /obj/effect/particle_effect/water
 	name = "water"
 	icon_state = "extinguish"
-	pass_flags = PASSTABLE | PASSMACHINE | PASSSTRUCTURE
+	pass_flags = PASSTABLE | PASSMACHINE | PASSSTRUCTURE | PASSGRILLE
 	var/life = 15
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 

--- a/code/game/objects/effects/effect_system/effects_water.dm
+++ b/code/game/objects/effects/effect_system/effects_water.dm
@@ -3,6 +3,7 @@
 /obj/effect/particle_effect/water
 	name = "water"
 	icon_state = "extinguish"
+	pass_flags = PASSTABLE | PASSMACHINE | PASSSTRUCTURE
 	var/life = 15
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
@@ -14,8 +15,6 @@
 /obj/effect/particle_effect/water/Move(turf/newloc)
 	if (--src.life < 1)
 		qdel(src)
-		return FALSE
-	if(newloc.density)
 		return FALSE
 	return ..()
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -77,7 +77,7 @@
 	damage = 15
 	irradiate = 300
 	range = 15
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE | PASSDOORS
 
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -11,7 +11,7 @@
 	icon_state = "gaussphase"
 	damage = 20
 	armour_penetration = 70
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE | PASSDOORS
 
 // 7.62 (Nagant Rifle)
 


### PR DESCRIPTION
:cl:
fix: fire extinguisher particles can go through machinery, lockers, crates and extinguish the air on top of them
code: fire extinguisher uses modern pass_flags code instead of shit code
code: new passflag : PASSDOOR instead of being ''''PASSMACHINERY'''' added  it to xray , some sniper thing and crucible pot to have same effects as before
/:cl:

it was dumb that fires from rooms couldnt be extinguished cause there were not air blocking  things like vending machines, disposals chutes , lockers that will keep having a hot spot and re ignite everything you extinguished unless you did something dumb like entering the bin and extinguishing on top of it 