### PR TITLE
Build mode fill tool asks for confirmation if filling area is large

### DIFF
--- a/code/modules/buildmode/submodes/fill.dm
+++ b/code/modules/buildmode/submodes/fill.dm
@@ -56,7 +56,7 @@
 			var/selection_size = abs(cornerA.x - cornerB.x) * abs(cornerA.y - cornerB.y)
 
 			if(selection_size > FILL_WARNING_MIN) // Confirm fill if the number of tiles in the selection is greater than FILL_WARNING_MIN
-				var/choice = alert("Your selected area is [num2text(selection_size)] tiles! Continue?", "Large Fill Confirmation", "Yes", "No")
+				var/choice = alert("Your selected area is [selection_size] tiles! Continue?", "Large Fill Confirmation", "Yes", "No")
 				if(choice != "Yes")
 					return
 

--- a/code/modules/buildmode/submodes/fill.dm
+++ b/code/modules/buildmode/submodes/fill.dm
@@ -57,7 +57,7 @@
 			var/selection_size = abs(cornerA.x - cornerB.x) * abs(cornerA.y - cornerB.y)
 
 			if(selection_size > FILL_WARNING_MIN) // Confirm fill if the number of tiles in the selection is greater than FILL_WARNING_MIN
-				var/choice = alert(addtext("Your selected area is ", num2text(selection_size), " tiles! Continue?"), "Large Fill Confirmation", "Yes", "No")
+				var/choice = alert("Your selected area is [num2text(selection_size)] tiles! Continue?", "Large Fill Confirmation", "Yes", "No")
 				if(choice != "Yes")
 					return
 

--- a/code/modules/buildmode/submodes/fill.dm
+++ b/code/modules/buildmode/submodes/fill.dm
@@ -1,4 +1,3 @@
-#ifndef FILL_WARNING_MIN
 #define FILL_WARNING_MIN 150
 
 /datum/buildmode_mode/fill
@@ -70,4 +69,3 @@
 			log_admin("Build Mode: [key_name(c)] with path [objholder], filled the region from [AREACOORD(cornerA)] through [AREACOORD(cornerB)]")
 
 #undef FILL_WARNING_MIN
-#endif

--- a/code/modules/buildmode/submodes/fill.dm
+++ b/code/modules/buildmode/submodes/fill.dm
@@ -57,7 +57,7 @@
 			var/selection_size = abs(cornerA.x - cornerB.x) * abs(cornerA.y - cornerB.y)
 
 			if(selection_size > FILL_WARNING_MIN) // Confirm fill if the number of tiles in the selection is greater than FILL_WARNING_MIN
-				var/choice = alert(addtext("Your selected input is ", num2text(selection_size), " tiles! Continue?"), "Large Fill Confirmation", "Yes", "No")
+				var/choice = alert(addtext("Your selected area is ", num2text(selection_size), " tiles! Continue?"), "Large Fill Confirmation", "Yes", "No")
 				if(choice != "Yes")
 					return
 

--- a/code/modules/buildmode/submodes/fill.dm
+++ b/code/modules/buildmode/submodes/fill.dm
@@ -1,6 +1,9 @@
+#ifndef FILL_WARNING_MIN
+#define FILL_WARNING_MIN 150
+
 /datum/buildmode_mode/fill
 	key = "fill"
-	
+
 	use_corner_selection = TRUE
 	var/objholder = null
 
@@ -34,7 +37,7 @@
 
 /datum/buildmode_mode/fill/handle_selected_area(client/c, params)
 	var/list/modifiers = params2list(params)
-	
+
 	if(LAZYACCESS(modifiers, LEFT_CLICK)) //rectangular
 		if(LAZYACCESS(modifiers, ALT_CLICK))
 			var/list/deletion_area = block(get_turf(cornerA),get_turf(cornerB))
@@ -51,6 +54,13 @@
 			// if there's an analogous proc for this on tg lmk
 			// empty_region(block(get_turf(cornerA),get_turf(cornerB)))
 		else
+			var/selection_size = abs(cornerA.x - cornerB.x) * abs(cornerA.y - cornerB.y)
+
+			if(selection_size > FILL_WARNING_MIN) // Confirm fill if the number of tiles in the selection is greater than FILL_WARNING_MIN
+				var/choice = alert(addtext("Your selected input is ", num2text(selection_size), " tiles! Continue?"), "Large Fill Confirmation", "Yes", "No")
+				if(choice != "Yes")
+					return
+
 			for(var/turf/T in block(get_turf(cornerA),get_turf(cornerB)))
 				if(ispath(objholder,/turf))
 					T.PlaceOnTop(objholder)
@@ -58,3 +68,6 @@
 					var/obj/A = new objholder(T)
 					A.setDir(BM.build_dir)
 			log_admin("Build Mode: [key_name(c)] with path [objholder], filled the region from [AREACOORD(cornerA)] through [AREACOORD(cornerB)]")
+
+#undef FILL_WARNING_MIN
+#endif


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Prompts admins to confirm their selection with the build mode fill tool if the selected area is over 150 tiles. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I've seen this happen a few times now (to both myself and others), accidentally filling a massive area because they either forgot that the tool was still on or were moved unexpectedly. This should prevent these kinds of mistakes from happening easily. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: build mode fill tool now asks for confirmation when filling an area greater than 150 tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
