### PR TITLE
Fix Raven Cruiser emergency shuttle

### DIFF
--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -28,8 +28,8 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "af" = (
-/obj/machinery/computer/shuttle,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "ag" = (


### PR DESCRIPTION
## About The Pull Request
Fixes #57006 

## Changelog
:cl: Dex
fix: Raven evac shuttle can now early launch
/:cl:
