### PR TITLE
Fixes projectile damage multiplier not applying to stamina damage dealt by projectiles.

### DIFF
--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -39,6 +39,7 @@
 	if(isgun(fired_from))
 		var/obj/item/gun/G = fired_from
 		loaded_projectile.damage *= G.projectile_damage_multiplier
+		loaded_projectile.stamina *= G.projectile_damage_multiplier
 
 	if(reagents && loaded_projectile.reagents)
 		reagents.trans_to(loaded_projectile, reagents.total_volume, transfered_by = user) //For chemical darts/bullets


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Atomized out of the pipegun PR, this fixes the projectile damage multiplier ignoring stamina damage.

## Why It's Good For The Game

Give em beanbag. Medium style.

## Changelog
:cl:
fix: Fixes projectile_damage_multiplier not applying to stamina damage dealt by projectiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
