### PR TITLE
Shuttle Insurance!

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -54,6 +54,8 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/datum/round_event/shuttle_loan/shuttle_loan
 
+	///If the event happens where the crew can purchase shuttle insurance, catastrophe can't run.
+	var/shuttle_insurance = FALSE
 	var/shuttle_purchased = SHUTTLEPURCHASE_PURCHASABLE //If the station has purchased a replacement escape shuttle this round
 	var/list/shuttle_purchase_requirements_met = list() //For keeping track of ingame events that would unlock new shuttles, such as defeating a boss or discovering a secret item
 

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -50,8 +50,8 @@
 		if(PIRATES_ROGUES)
 			ship_template = /datum/map_template/shuttle/pirate/default
 			threat.title = "Sector protection offer"
-			threat.content = "Greetings from the [ship_name]. Your sector needs protection, how about you pay us [payoff] credits, or else you may be left wide open to an attack."
-			threat.possible_answers = list("We'll pay.","That sounds like a scam.")
+			threat.content = "Hey, pal, this is the [ship_name]. Can't help but notice you're rocking a wild and crazy shuttle there with NO INSURANCE! Crazy. What if something happened to it, huh?! We've done a quick evaluation on your rates in this sector and we're offering [payoff] to cover for your shuttle in case of any disaster."
+			threat.possible_answers = list("Purchase Insurance.","Reject Offer.")
 		if(PIRATES_SILVERSCALES)
 			ship_template = /datum/map_template/shuttle/pirate/silverscale
 			threat.title = "Tribute to high society"

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -25,8 +25,7 @@
 
 	if(SSshuttle.shuttle_insurance)
 		message += "Luckily, your shuttle insurance has covered the costs of repair!"
-		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
-		if(D)
+		if(SSeconomy.get_dep_account(ACCOUNT_CAR))
 			message += "You have been awarded a bonus from [command_name()] for smart spending."
 	else
 		message += "Your replacement shuttle will be the [new_shuttle.name] until further notice."
@@ -44,9 +43,8 @@
 
 /datum/round_event/shuttle_catastrophe/start()
 	if(SSshuttle.shuttle_insurance)
-		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
-		if(D)
-			D.adjust_money(8000)
+		var/datum/bank_account/station_balance = SSeconomy.get_dep_account(ACCOUNT_CAR)
+		station_balance?.adjust_money(8000)
 		return
 	SSshuttle.shuttle_purchased = SHUTTLEPURCHASE_FORCED
 	SSshuttle.unload_preview()

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -30,7 +30,7 @@
 			message += "You have been awarded a bonus from [command_name()] for smart spending."
 	else
 		message += "Your replacement shuttle will be the [new_shuttle.name] until further notice."
-	priority_announce(message, "CentCom Spacecraft Engineering")
+	priority_announce(message, "[command_name()] Spacecraft Engineering")
 
 /datum/round_event/shuttle_catastrophe/setup()
 	if(SSshuttle.shuttle_insurance)

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -21,10 +21,20 @@
 	var/cause = pick("was attacked by [syndicate_name()] Operatives", "mysteriously teleported away", "had its refuelling crew mutiny",
 		"was found with its engines stolen", "\[REDACTED\]", "flew into the sunset, and melted", "learned something from a very wise cow, and left on its own",
 		"had cloning devices on it", "had its shuttle inspector put the shuttle in reverse instead of park, causing the shuttle to crash into the hangar")
+	var/message = "Your emergency shuttle [cause]. "
 
-	priority_announce("Your emergency shuttle [cause]. Your replacement shuttle will be the [new_shuttle.name] until further notice.", "CentCom Spacecraft Engineering")
+	if(SSshuttle.shuttle_insurance)
+		message += "Luckily, your shuttle insurance has covered the costs of repair!"
+		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
+		if(D)
+			message += "You have been awarded a bonus from [command_name()] for smart spending."
+	else
+		message += "Your replacement shuttle will be the [new_shuttle.name] until further notice."
+	priority_announce(message, "CentCom Spacecraft Engineering")
 
 /datum/round_event/shuttle_catastrophe/setup()
+	if(SSshuttle.shuttle_insurance)
+		return
 	var/list/valid_shuttle_templates = list()
 	for(var/shuttle_id in SSmapping.shuttle_templates)
 		var/datum/map_template/shuttle/template = SSmapping.shuttle_templates[shuttle_id]
@@ -33,6 +43,11 @@
 	new_shuttle = pick(valid_shuttle_templates)
 
 /datum/round_event/shuttle_catastrophe/start()
+	if(SSshuttle.shuttle_insurance)
+		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
+		if(D)
+			D.adjust_money(8000)
+		return
 	SSshuttle.shuttle_purchased = SHUTTLEPURCHASE_FORCED
 	SSshuttle.unload_preview()
 	SSshuttle.existing_shuttle = SSshuttle.emergency

--- a/code/modules/events/shuttle_insurance.dm
+++ b/code/modules/events/shuttle_insurance.dm
@@ -34,7 +34,7 @@
 		insurance_evaluation = 5000 //gee i dunno
 
 /datum/round_event/shuttle_insurance/start()
-	insurance_message = new("Shuttle Insurance", "Hey, pal. Can't help but notice you're rocking a wild and crazy shuttle there with NO INSURANCE! Crazy. What if something happened to it, huh?! We've done a quick evaluation on your rates in this sector and we're offering [insurance_evaluation] to cover for your shuttle in case of any disaster.", list("Purchase Insurance.","Reject Offer."))
+	insurance_message = new("Shuttle Insurance", "Hey, pal, this is the [ship_name]. Can't help but notice you're rocking a wild and crazy shuttle there with NO INSURANCE! Crazy. What if something happened to it, huh?! We've done a quick evaluation on your rates in this sector and we're offering [insurance_evaluation] to cover for your shuttle in case of any disaster.", list("Purchase Insurance.","Reject Offer."))
 	insurance_message.answer_callback = CALLBACK(src,.proc/answered)
 	SScommunications.send_message(insurance_message, unique = TRUE)
 

--- a/code/modules/events/shuttle_insurance.dm
+++ b/code/modules/events/shuttle_insurance.dm
@@ -1,0 +1,52 @@
+
+
+/datum/round_event_control/shuttle_insurance
+	name = "Shuttle Insurance"
+	typepath = /datum/round_event/shuttle_insurance
+	weight = 200 //you're basically bound to get it
+	max_occurrences = 1
+
+/datum/round_event_control/shuttle_insurance/canSpawnEvent(players, gamemode)
+	if(!SSeconomy.get_dep_account(ACCOUNT_CAR))
+		return FALSE //They can't pay?
+	if(SSshuttle.shuttle_purchased != SHUTTLEPURCHASE_FORCED)
+		return FALSE //don't do it if there's nothing to insure
+	if(EMERGENCY_AT_LEAST_DOCKED)
+		return FALSE //catastrophes won't trigger so no point
+	return ..()
+
+/datum/round_event/shuttle_insurance
+	var/ship_name = "\"In the Unlikely Event\""
+	var/datum/comm_message/insurance_message
+	var/insurance_evaluation = 0
+
+/datum/round_event/shuttle_insurance/announce(fake)
+	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.get_rand_report_sound())
+
+/datum/round_event/shuttle_insurance/setup()
+	ship_name = pick(strings(PIRATE_NAMES_FILE, "rogue_names"))
+	for(var/shuttle_id in SSmapping.shuttle_templates)
+		var/datum/map_template/shuttle/template = SSmapping.shuttle_templates[shuttle_id]
+		if(template.name == SSshuttle.emergency.name) //found you slackin
+			insurance_evaluation = template.credit_cost/2
+			break
+	if(!insurance_evaluation)
+		insurance_evaluation = 5000 //gee i dunno
+
+/datum/round_event/shuttle_insurance/start()
+	insurance_message = new("Shuttle Insurance", "Hey, pal. Can't help but notice you're rocking a wild and crazy shuttle there with NO INSURANCE! Crazy. What if something happened to it, huh?! We've done a quick evaluation on your rates in this sector and we're offering [insurance_evaluation] to cover for your shuttle in case of any disaster.", list("Purchase Insurance.","Reject Offer."))
+	insurance_message.answer_callback = CALLBACK(src,.proc/answered)
+	SScommunications.send_message(insurance_message, unique = TRUE)
+
+/datum/round_event/shuttle_insurance/proc/answered()
+	if(EMERGENCY_AT_LEAST_DOCKED)
+		priority_announce("You are definitely too late to purchase insurance, my friends. Our agents don't work on site.",sender_override = ship_name)
+	if(insurance_message && insurance_message.answered == 1)
+		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
+		if(!D)
+			return
+		if(!D.adjust_money(-insurance_evaluation))
+			priority_announce("You didn't send us enough money for shuttle insurance. This, in the space layman's terms, is considered scamming. We're keeping your money, scammers!",sender_override = ship_name)
+			return
+		priority_announce("Thank you for purchasing shuttle insurance!",sender_override = ship_name)
+		SSshuttle.shuttle_insurance = TRUE

--- a/code/modules/events/shuttle_insurance.dm
+++ b/code/modules/events/shuttle_insurance.dm
@@ -42,10 +42,10 @@
 	if(EMERGENCY_AT_LEAST_DOCKED)
 		priority_announce("You are definitely too late to purchase insurance, my friends. Our agents don't work on site.",sender_override = ship_name)
 	if(insurance_message && insurance_message.answered == 1)
-		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
-		if(!D)
+		var/datum/bank_account/station_balance = SSeconomy.get_dep_account(ACCOUNT_CAR)
+		if(!station_balance)
 			return
-		if(!D.adjust_money(-insurance_evaluation))
+		if(!station_balance.adjust_money(-insurance_evaluation))
 			priority_announce("You didn't send us enough money for shuttle insurance. This, in the space layman's terms, is considered scamming. We're keeping your money, scammers!",sender_override = ship_name)
 			return
 		priority_announce("Thank you for purchasing shuttle insurance!",sender_override = ship_name)

--- a/code/modules/events/shuttle_insurance.dm
+++ b/code/modules/events/shuttle_insurance.dm
@@ -43,9 +43,7 @@
 		priority_announce("You are definitely too late to purchase insurance, my friends. Our agents don't work on site.",sender_override = ship_name)
 	if(insurance_message && insurance_message.answered == 1)
 		var/datum/bank_account/station_balance = SSeconomy.get_dep_account(ACCOUNT_CAR)
-		if(!station_balance)
-			return
-		if(!station_balance.adjust_money(-insurance_evaluation))
+		if(!station_balance?.adjust_money(-insurance_evaluation))
 			priority_announce("You didn't send us enough money for shuttle insurance. This, in the space layman's terms, is considered scamming. We're keeping your money, scammers!",sender_override = ship_name)
 			return
 		priority_announce("Thank you for purchasing shuttle insurance!",sender_override = ship_name)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2013,6 +2013,7 @@
 #include "code\modules\events\radiation_storm.dm"
 #include "code\modules\events\sentience.dm"
 #include "code\modules\events\shuttle_catastrophe.dm"
+#include "code\modules\events\shuttle_insurance.dm"
 #include "code\modules\events\shuttle_loan.dm"
 #include "code\modules\events\space_dragon.dm"
 #include "code\modules\events\space_ninja.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Space Insurance Agents will appraise your current shuttle and give you a rate. Pay it, and you're insured! If a catastrophe happens, your shuttle will be safe and sound and you'll get a payout from Centcom for smart spending

Also, the human pirates (arguably the most boring ones now that we got silverscales and flying dutchman) copy the message sent by insurance agents to try and trick you out of some money.

## Why It's Good For The Game

Shuttle Catastrophes on suicide watch, yes, this is the best way to silence complaints. Should have bought insurance bitchhhhhh

## Changelog
:cl:
add: New Event: Shuttle Insurance!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
