### PR TITLE
pAI's with Binary Encryption keys installed can use them

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai_say.dm
+++ b/code/modules/mob/living/silicon/pai/pai_say.dm
@@ -5,4 +5,4 @@
 		..(message)
 
 /mob/living/silicon/pai/binarycheck()
-	return 0
+	return radio.translate_binary

--- a/code/modules/mob/living/silicon/pai/pai_say.dm
+++ b/code/modules/mob/living/silicon/pai/pai_say.dm
@@ -5,4 +5,4 @@
 		..(message)
 
 /mob/living/silicon/pai/binarycheck()
-	return radio.translate_binary
+	return radio?.translate_binary


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Waaaaaaay back in #43603 I added encryption key abilities to pAI headsets. Unfortunately the concept of returning a variable was beyond my understanding and the pre-existing `Return 0` that keeps pAIs off the binary channel remained even when they had a binary encryption key installed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix, if a traitor wants to spend TC on an encryption key for their little friend, they should be able to.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Binary Encryption keys work in pAIs that have downloaded the encryption key software.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
