### PR TITLE
Fixes overdose_start() not being called on reagents

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1136,7 +1136,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		H.blood_volume = min(H.blood_volume + round(chem.volume, 0.1), BLOOD_VOLUME_MAXIMUM)
 		H.reagents.del_reagent(chem.type)
 		return TRUE
-	if(chem.overdose_threshold && chem.volume >= chem.overdose_threshold && !chem.overdosed)
+	if(!chem.overdosed && chem.overdose_threshold && chem.volume >= chem.overdose_threshold)
 		chem.overdosed = TRUE
 		chem.overdose_start(H)
 		log_game("[key_name(H)] has started overdosing on [chem.name] at [chem.volume] units.")

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1136,7 +1136,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		H.blood_volume = min(H.blood_volume + round(chem.volume, 0.1), BLOOD_VOLUME_MAXIMUM)
 		H.reagents.del_reagent(chem.type)
 		return TRUE
-	if(chem.overdose_threshold && chem.volume >= chem.overdose_threshold)
+	if(chem.overdose_threshold && chem.volume >= chem.overdose_threshold && !chem.overdosed)
 		chem.overdosed = TRUE
 		chem.overdose_start(H)
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1139,7 +1139,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	if(chem.overdose_threshold && chem.volume >= chem.overdose_threshold && !chem.overdosed)
 		chem.overdosed = TRUE
 		chem.overdose_start(H)
-		log_game("[key_name(owner)] has started overdosing on [reagent.name] at [reagent.volume] units.")
+		log_game("[key_name(H)] has started overdosing on [chem.name] at [chem.volume] units.")
 
 /datum/species/proc/check_species_weakness(obj/item, mob/living/attacker)
 	return 1 //This is not a boolean, it's the multiplier for the damage that the user takes from the item. The force of the item is multiplied by this value

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1138,6 +1138,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		return TRUE
 	if(chem.overdose_threshold && chem.volume >= chem.overdose_threshold)
 		chem.overdosed = TRUE
+		chem.overdose_start(H)
 
 /datum/species/proc/check_species_weakness(obj/item, mob/living/attacker)
 	return 1 //This is not a boolean, it's the multiplier for the damage that the user takes from the item. The force of the item is multiplied by this value

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1139,6 +1139,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	if(chem.overdose_threshold && chem.volume >= chem.overdose_threshold && !chem.overdosed)
 		chem.overdosed = TRUE
 		chem.overdose_start(H)
+		log_game("[key_name(owner)] has started overdosing on [reagent.name] at [reagent.volume] units.")
 
 /datum/species/proc/check_species_weakness(obj/item, mob/living/attacker)
 	return 1 //This is not a boolean, it's the multiplier for the damage that the user takes from the item. The force of the item is multiplied by this value


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently `overdose_start(`) isn't called because `metabolize()` calls `overdose_start()` when overdosed is toggled to TRUE. This competes with `/datum/species/proc/handle_chemicals` which sets overdosed = TRUE before the liver can, and therefore blocks the `overdose_start()` proc being called. See below for context:

```dm
/datum/species/proc/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
	if(chem.type == exotic_blood)
		H.blood_volume = min(H.blood_volume + round(chem.volume, 0.1), BLOOD_VOLUME_MAXIMUM)
		H.reagents.del_reagent(chem.type)
		return TRUE
	if(chem.overdose_threshold && chem.volume >= chem.overdose_threshold)
		chem.overdosed = TRUE ///THIS LINE
```

```dm
/datum/reagents/proc/metabolize(mob/living/carbon/owner, can_overdose = FALSE, liverless = FALSE)
	var/list/cached_reagents = reagent_list
	if(owner)
		expose_temperature(owner.bodytemperature, 0.25)
	var/need_mob_update = 0
	for(var/datum/reagent/reagent as anything in cached_reagents)
		if(QDELETED(reagent.holder))
			continue

		if(!owner)
			owner = reagent.holder.my_atom

		if(owner && reagent)
			if(owner.reagent_check(reagent) != TRUE)
				if(liverless && !reagent.self_consuming) //need to be metabolized
					continue
				if(!reagent.metabolizing)
					reagent.metabolizing = TRUE
					reagent.on_mob_metabolize(owner)
				if(can_overdose)
					if(reagent.overdose_threshold)
						if(reagent.volume >= reagent.overdose_threshold && !reagent.overdosed)
							reagent.overdosed = TRUE //THESE LINES
							need_mob_update += reagent.overdose_start(owner) //THESE LINES
							log_game("[key_name(owner)] has started overdosing on [reagent.name] at [reagent.volume] units.")
					for(var/addiction in reagent.addiction_types)
						owner.mind?.add_addiction_points(addiction, reagent.addiction_types[addiction] * REAGENTS_METABOLISM)

					if(reagent.overdosed)
						need_mob_update += reagent.overdose_process(owner)

				need_mob_update += reagent.on_mob_life(owner)
	if(owner && need_mob_update) //some of the metabolized reagents had effects on the mob that requires some updates.
		owner.updatehealth()
		owner.update_stamina()
	update_total()
```
## Why It's Good For The Game

Fixes a fundemental part of overdose mechanics (mood and on start proc calls)

## Changelog
:cl:
fix: fixed addictions not applying moods and start procs correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
