### PR TITLE
brand_intelligence no longer makes explosions which make holes in station

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -57,13 +57,9 @@
 	vendingMachines = removeNullsFromList(vendingMachines)
 	if(!vendingMachines.len) //if every machine is infected
 		for(var/obj/machinery/vending/upriser in infectedMachines)
-			if(prob(70) && !QDELETED(upriser))
+			if(!QDELETED(upriser))
 				upriser.ai_controller = new /datum/ai_controller/vending_machine(upriser)
 				infectedMachines.Remove(upriser)
-			else
-				explosion(upriser.loc, -1, 1, 2, 4, 0)
-				qdel(upriser)
-
 		kill()
 		return
 	if(ISMULTIPLE(activeFor, 2))


### PR DESCRIPTION
:cl:
qol: brand_intelligence event no longer has 30% prob of making an hull breaking explosion and destoying the machine when converting them to rogue vending machines which means there  is 30% more vending machines that get turned into rogue ones aka all the ones that got hit with the vending machine virus
/:cl:

the random holes in the whole station are just bad as it depressurizes whole departments at the same time and its more dangerous than the vending machine, no air event exists and its called meteors
