### PR TITLE
Makes repairing clothing update the clothing's icon.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -164,6 +164,7 @@
 	body_parts_covered = initial(body_parts_covered)
 	slot_flags = initial(slot_flags)
 	damage_by_parts = null
+	update_icon()
 	if(user)
 		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 		to_chat(user, "<span class='notice'>You fix the damage on [src].</span>")


### PR DESCRIPTION

## About The Pull Request

This pr makes repairing clothing update the icon so that you don't get left with the old icon that still has the damage on it.

## Changelog
:cl: Pepsiman0
fix: Repairing clothing now also updates the clothing's icon.
/:cl:

