### PR TITLE
Fixes various bugs in sticky tape code, cleans up the code a little too.

### DIFF
--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -19,8 +19,15 @@
 	var/list/conferred_embed = EMBED_HARMLESS
 	var/overwrite_existing = FALSE
 
-/obj/item/stack/sticky_tape/afterattack(obj/item/I, mob/living/user)
+/obj/item/stack/sticky_tape/afterattack(obj/item/I, mob/living/user, proximity)
+	if(!proximity)
+		return
+
 	if(!istype(I))
+		return
+
+	if(I.embedding)
+		to_chat(user, "<span class='warning'>[I] is already capable of sticking to people!</span>")
 		return
 
 	if(I.embedding && I.embedding == conferred_embed)
@@ -30,7 +37,10 @@
 	user.visible_message("<span class='notice'>[user] begins wrapping [I] with [src].</span>", "<span class='notice'>You begin wrapping [I] with [src].</span>")
 
 	if(do_after(user, 30, target=I))
-		use(1)
+		if(!proximity)
+			to_chat(user, "<span class='notice'>You couldn't hold down [I] long enough to tape it down.</span>")
+			return
+		
 		if(istype(I, /obj/item/clothing/gloves/fingerless))
 			var/obj/item/clothing/gloves/tackler/offbrand/O = new /obj/item/clothing/gloves/tackler/offbrand
 			to_chat(user, "<span class='notice'>You turn [I] into [O] with [src].</span>")
@@ -38,10 +48,14 @@
 			user.put_in_hands(O)
 			return
 
+		if(I.embedding)
+			to_chat(user, "<span class='warning'>[I] is already capable of sticking to people!</span>")
+
 		if(I.embedding && I.embedding == conferred_embed)
 			to_chat(user, "<span class='warning'>[I] is already coated in [src]!</span>")
 			return
-
+		
+		use(1)
 		I.embedding = conferred_embed
 		I.updateEmbedding()
 		to_chat(user, "<span class='notice'>You finish wrapping [I] with [src].</span>")

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -25,37 +25,19 @@
 
 	if(!istype(I))
 		return
-
+	
 	if(I.embedding)
 		to_chat(user, "<span class='warning'>[I] is already capable of sticking to people!</span>")
-		return
-
-	if(I.embedding && I.embedding == conferred_embed)
-		to_chat(user, "<span class='warning'>[I] is already coated in [src]!</span>")
 		return
 
 	user.visible_message("<span class='notice'>[user] begins wrapping [I] with [src].</span>", "<span class='notice'>You begin wrapping [I] with [src].</span>")
 
 	if(do_after(user, 30, target=I))
-		if(!proximity)
-			to_chat(user, "<span class='notice'>You couldn't hold down [I] long enough to tape it down.</span>")
-			return
-		
-		if(istype(I, /obj/item/clothing/gloves/fingerless))
-			var/obj/item/clothing/gloves/tackler/offbrand/O = new /obj/item/clothing/gloves/tackler/offbrand
-			to_chat(user, "<span class='notice'>You turn [I] into [O] with [src].</span>")
-			QDEL_NULL(I)
-			user.put_in_hands(O)
-			return
-
 		if(I.embedding)
 			to_chat(user, "<span class='warning'>[I] is already capable of sticking to people!</span>")
-
-		if(I.embedding && I.embedding == conferred_embed)
-			to_chat(user, "<span class='warning'>[I] is already coated in [src]!</span>")
-			return
 		
 		use(1)
+
 		I.embedding = conferred_embed
 		I.updateEmbedding()
 		to_chat(user, "<span class='notice'>You finish wrapping [I] with [src].</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cleans up tape code by making it respect proximity. It also moves the use below it's returns so you aren't losing stacks of tape when it shouldn't be using tape in the first place (in the odd instance when the item's state changes during the do_after).

Additionally, you can't add tape to an item that already embeds. If you weren't aware, this was only ever making items worse at embedding except for like, iunno, rods I guess. 

## Why It's Good For The Game

Someone taped my tail to my head, help help help help

## Changelog
:cl:
code: Cleans up the tape code so that it isn't doing really janky stuff anymore.
fix: Tape respects proximity to the object you're taping.
fix: If the object can already embed (because it was already taped or it just can embed already), you can't tape it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
