### PR TITLE
Fixes roundstart addiction runtime

### DIFF
--- a/code/modules/mob/living/carbon/init_signals.dm
+++ b/code/modules/mob/living/carbon/init_signals.dm
@@ -34,6 +34,6 @@
 /mob/living/carbon/proc/on_nometabolism_trait_gain(datum/source)
 	SIGNAL_HANDLER
 	for(var/addiction_type in subtypesof(/datum/addiction))
-		mind.remove_addiction_points(addiction_type, MAX_ADDICTION_POINTS) //Remove the addiction!
+		mind?.remove_addiction_points(addiction_type, MAX_ADDICTION_POINTS) //Remove the addiction!
 
 	reagents.end_metabolization(keep_liverless = TRUE)


### PR DESCRIPTION
Probably something to do with mindless spawns getting addictions cleared somehow? This just fixes it

:cl:
fix: Fixes roundstart runtime from addictions
/:cl:

Once again, floyd dumb