### PR TITLE
Rune carvers are consistent with other heretic items and are properly babyproofed + some code improvements

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -338,3 +338,8 @@
 	description = "<span class='boldwarning'>MY PRECIOUS WINGS!!</span>\n"
 	mood_change = -10
 	timeout = 10 MINUTES
+
+/datum/mood_event/saw_empherimal_hues_bad
+	description = "<span class='hypnophrase'>THE COLORS! THE COLORS! THE COLORS! THE COLORS!\nTHE COLORS! THE COLORS! THE COLORS! THE COLORS!\nTHE COLORS! THE COLORS! THE COLORS! THE COLORS!</span>"
+	mood_change = -30
+	timeout = 20 MINUTES

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -236,3 +236,8 @@
 /datum/mood_event/kiss/add_effects(mob/beau)
 	if(beau)
 		description = "<span class='nicegreen'>[beau.name] blew a kiss at me, I must be a real catch!</span>\n"
+
+/datum/mood_event/saw_empherimal_hues_good
+	description = "<span class='nicegreen'>I feel inspired to paint the pretty things I saw!</span>\n"
+	mood_change = 20
+	timeout = 10 MINUTES

--- a/code/modules/antagonists/eldritch_cult/eldritch_structures.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_structures.dm
@@ -124,7 +124,7 @@
 
 /obj/structure/trap/eldritch/attacked_by(obj/item/I, mob/living/user)
 	. = ..()
-	if(istype(I,/obj/item/melee/rune_knife) || istype(I,/obj/item/nullrod))
+	if(istype(I,/obj/item/melee/rune_carver) || istype(I,/obj/item/nullrod))
 		qdel(src)
 
 ///Proc that sets the owner

--- a/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
@@ -105,7 +105,7 @@
 	cost = 1
 	next_knowledge = list(/datum/eldritch_knowledge/spell/void_phase,/datum/eldritch_knowledge/summon/raw_prophet)
 	required_atoms = list(/obj/item/kitchen/knife,/obj/item/shard,/obj/item/paper)
-	result_atoms = list(/obj/item/melee/rune_knife)
+	result_atoms = list(/obj/item/melee/rune_carver)
 
 /datum/eldritch_knowledge/crucible
 	name = "Mawed Crucible"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Rune carvers were able to be used by literally anyone who got one, allowing full access to their grief runes for nonheretics. Which seems entirely unusual compared to how any other heretic item seems to work, so I feel this is an oversight _or just incredibly bad decision making_.

If @EdgeLordExe would like to come comment on this, that'd be great.

So now they are properly babyproofed. Nonheretics who use them will get slapped with a nasty debuff for doing so, unless they're a clown. Because they can't truly comprehend what they're seeing, so it's fine.

Does some further code improvements including fixing up the ability to carve runes on any and all atoms, not just turfs.

## Why It's Good For The Game

![Morsel_Excavator](https://user-images.githubusercontent.com/40847847/108561510-7c9b5800-7352-11eb-80d4-77edc57faaeb.png)

## Changelog
:cl:
code: Brings rune carvers inline with other heretic items, making them unusable by nonheretics.
code: Nonheretics who do use a rune carver on the floor will get a surprise. Clowns especially.
fix: Stops rune carvers carving on almost any atom, ever.
fix: Removes a hard delete from eldritch potions.
add: Gives the rune carver some new flavour.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
