### PR TITLE
Updates the lifebringer flavor text to be less ambivalent about their goals

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -14,7 +14,7 @@
 	short_desc = "You are a sentient ecosystem, an example of the mastery over life that your creators possessed."
 	flavour_text = "Your masters, benevolent as they were, created uncounted seed vaults and spread them across \
 	the universe to every planet they could chart. You are in one such seed vault. \
-	Your goal is to protect the vault you are assigned to, cultivate the seeds passed onto you by your creators, \
+	Your goal is to protect the vault you are assigned to, cultivate the seeds passed onto you, \
 	and eventually bring life to this desolate planet while waiting for contact from your creators. \
 	Estimated time of last contact: Deployment, 5000 millennia ago."
 	assignedrole = "Lifebringer"

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -14,7 +14,8 @@
 	short_desc = "You are a sentient ecosystem, an example of the mastery over life that your creators possessed."
 	flavour_text = "Your masters, benevolent as they were, created uncounted seed vaults and spread them across \
 	the universe to every planet they could chart. You are in one such seed vault. \
-	Your goal is to cultivate and spread life wherever it will go while waiting for contact from your creators. \
+	Your goal is to protect the vault you are assigned to, cultivate the seeds passed onto you by your creators, \
+	and eventually bring life to this desolate planet while waiting for contact from your creators. \
 	Estimated time of last contact: Deployment, 5000 millennia ago."
 	assignedrole = "Lifebringer"
 


### PR DESCRIPTION
## About The Pull Request

This PR updates the lifebringer's flavor text to be less ambivalent. Instead of only saying "spread life wherever" which could mean just about anything is allowed, the flavor text specifies they should stick to the vault and grow plants there.

## Why It's Good For The Game

Seeing lifebringers bee-line the station to either grief or pass out bombs/guns because they're "spreading life to the station" is annoying and bad.

## Changelog
:cl: Melbert
spellcheck: The flavor text of the lifebringers has been adjusted for clarification. 
/:cl:

