### PR TITLE
[i ded] Removes thermoconductivity from the vacuum of space

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -90,8 +90,10 @@
 #define OPEN_HEAT_TRANSFER_COEFFICIENT 0.4
 /// a hack for now
 #define WINDOW_HEAT_TRANSFER_COEFFICIENT 0.1
-/// a hack to help make vacuums "cold", sacrificing realism for gameplay
-#define HEAT_CAPACITY_VACUUM 7000
+/// vacuum thermoconductivity has been a thorn in many a crew's side for too long
+#define HEAT_CAPACITY_VACUUM 0
+/// a hack to keep heat exchangers functional in vacuum
+#define RADIATIVE_EFFECTIVE_HEAT_CAPACITY_VACUUM 7000
 
 //FIRE
 #define FIRE_MINIMUM_TEMPERATURE_TO_SPREAD (150+T0C)

--- a/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
@@ -56,6 +56,8 @@
 
 	var/datum/gas_mixture/air_contents = airs[1]
 	var/datum/gas_mixture/partner_air_contents = partner.airs[1]
+	if(istype(partner,/turf/open/space))
+		other_air_heat_capacity = RADIATIVE_EFFECTIVE_HEAT_CAPACITY_VACUUM
 
 	var/air_heat_capacity = air_contents.heat_capacity()
 	var/other_air_heat_capacity = partner_air_contents.heat_capacity()

--- a/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
@@ -56,11 +56,11 @@
 
 	var/datum/gas_mixture/air_contents = airs[1]
 	var/datum/gas_mixture/partner_air_contents = partner.airs[1]
-	if(istype(partner,/turf/open/space))
-		other_air_heat_capacity = RADIATIVE_EFFECTIVE_HEAT_CAPACITY_VACUUM
 
 	var/air_heat_capacity = air_contents.heat_capacity()
 	var/other_air_heat_capacity = partner_air_contents.heat_capacity()
+	if(istype(partner,/turf/open/space))
+		other_air_heat_capacity = RADIATIVE_EFFECTIVE_HEAT_CAPACITY_VACUUM
 	var/combined_heat_capacity = other_air_heat_capacity + air_heat_capacity
 
 	var/old_temperature = air_contents.temperature


### PR DESCRIPTION
## About The Pull Request

Alternative to #56571 that entirely eliminates thermoconductivity from vacuum.

## Why It's Good For The Game

Less rounds devolving into firelockstation due to a single path to space being opened by a ninja or small explosion.

## Changelog
:cl:
balance: Anomalous dimensional activity resulting in the vacuum of space having 70% the heat capacity of Earth's atmosphere has subsided. The radiative cooling performed by heat transfer pipes should remain unaffected.
/:cl:
