### PR TITLE
Fixes ERT Briefing Officer Outfit pref

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -108,9 +108,6 @@
 	/// Any clothing accessory item
 	var/accessory = null
 
-	/// Set to FALSE if your outfit requires runtime parameters
-	var/can_be_admin_equipped = TRUE
-
 	/**
 	  * extra types for chameleon outfit changes, mostly guns
 	  *

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -534,8 +534,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 
 	for(var/path in paths)
 		var/datum/outfit/O = path //not much to initalize here but whatever
-		if(initial(O.can_be_admin_equipped))
-			outfits[initial(O.name)] = path
+		outfits[initial(O.name)] = path
 
 	var/dresscode = input("Select outfit", "Robust quick dress shop") as null|anything in baseoutfits + sortList(outfits)
 	if (isnull(dresscode))
@@ -549,8 +548,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		var/list/job_outfits = list()
 		for(var/path in job_paths)
 			var/datum/outfit/O = path
-			if(initial(O.can_be_admin_equipped))
-				job_outfits[initial(O.name)] = path
+			job_outfits[initial(O.name)] = path
 
 		dresscode = input("Select job equipment", "Robust quick dress shop") as null|anything in sortList(job_outfits)
 		dresscode = job_outfits[dresscode]
@@ -562,8 +560,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		var/list/plasmaman_outfits = list()
 		for(var/path in plasmaman_paths)
 			var/datum/outfit/O = path
-			if(initial(O.can_be_admin_equipped))
-				plasmaman_outfits[initial(O.name)] = path
+			plasmaman_outfits[initial(O.name)] = path
 
 		dresscode = input("Select plasmeme equipment", "Robust quick dress shop") as null|anything in sortList(plasmaman_outfits)
 		dresscode = plasmaman_outfits[dresscode]

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1526,10 +1526,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						asaycolor = sanitize_ooccolor(new_asaycolor)
 
 				if("briefoutfit")
+					testing("hhhhh")
 					var/list/valid_paths = list()
-					for(var/datum/outfit/iter_outfit in subtypesof(/datum/outfit))
-						if(initial(iter_outfit.can_be_admin_equipped))
-							valid_paths[initial(iter_outfit.name)] = path
+					for(var/outfit_path in subtypesof(/datum/outfit))
+						var/datum/outfit/iter_outfit = outfit_path
+						valid_paths[initial(iter_outfit.name)] = outfit_path
 					var/new_outfit = input(user, "Choose your briefing officer outfit:", "Game Preference") as null|anything in valid_paths
 					new_outfit = valid_paths[new_outfit]
 					if(new_outfit)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1526,11 +1526,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						asaycolor = sanitize_ooccolor(new_asaycolor)
 
 				if("briefoutfit")
-					testing("hhhhh")
 					var/list/valid_paths = list()
-					for(var/outfit_path in subtypesof(/datum/outfit))
-						var/datum/outfit/iter_outfit = outfit_path
-						valid_paths[initial(iter_outfit.name)] = outfit_path
+					for(var/datum/outfit/outfit_path as anything in subtypesof(/datum/outfit))
+						valid_paths[initial(outfit_path.name)] = outfit_path
 					var/new_outfit = input(user, "Choose your briefing officer outfit:", "Game Preference") as null|anything in valid_paths
 					new_outfit = valid_paths[new_outfit]
 					if(new_outfit)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -83,8 +83,7 @@
 		standard_outfit_options = list()
 		for(var/path in subtypesof(/datum/outfit/job))
 			var/datum/outfit/O = path
-			if(initial(O.can_be_admin_equipped))
-				standard_outfit_options[initial(O.name)] = path
+			standard_outfit_options[initial(O.name)] = path
 		sortTim(standard_outfit_options, /proc/cmp_text_asc)
 	outfit_options = standard_outfit_options
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I was dumb in #56345 and committed a suggestion from a maintainer without actually checking what it did, leading to the part where you select what outfit you want in your preferences to not actually let you select an outfit.

This also removes the `can_be_admin_equipped` var from outfit datums, apparently it was supposed to be used for outfits that were only supposed to be spawned in certain ways or some nonsense, but nothing actually used it so bye bye
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Admins can choose briefing officer outfits as intended
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
fixes #57035
## Changelog
:cl: Ryll/Shaps
fix: Admins can actually use the Briefing Officer Outfit preference to set their preferred briefing outfit for ERT's now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
