### PR TITLE
Gives the rune carver a turf check, makes it's pathname more consistent

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -289,7 +289,7 @@
 		if(DT_PROB(25,delta_time))
 			human_in_range.Dizzy(5)
 
-/obj/item/melee/rune_knife
+/obj/item/melee/rune_carver
 	name = "Carving Knife"
 	desc = "Cold Steel, pure, perfect, this knife can carve the floor in many ways, but only few can evoke the dangers that lurk beneath reality."
 	icon = 'icons/obj/eldritch.dmi'
@@ -315,35 +315,35 @@
 	///Linked action
 	var/datum/action/innate/rune_shatter/linked_action
 
-/obj/item/melee/rune_knife/examine(mob/user)
+/obj/item/melee/rune_carver/examine(mob/user)
 	. = ..()
 	. += "This item can carve 'Alert carving' - nearly invisible rune that when stepped on gives you a prompt about where someone stood on it and who it was, doesn't get destroyed by being stepped on."
 	. += "This item can carve 'Grasping carving' - when stepped on it causes heavy damage to the legs and stuns for 5 seconds."
 	. += "This item can carve 'Mad carving' - when stepped on it causes dizzyness, jiterryness, temporary blindness, confusion , stuttering and slurring."
 
-/obj/item/melee/rune_knife/Initialize()
+/obj/item/melee/rune_carver/Initialize()
 	. = ..()
 	linked_action = new(src)
 
-/obj/item/melee/rune_knife/Destroy()
+/obj/item/melee/rune_carver/Destroy()
 	. = ..()
 	QDEL_NULL(linked_action)
 
-/obj/item/melee/rune_knife/pickup(mob/user)
+/obj/item/melee/rune_carver/pickup(mob/user)
 	. = ..()
 	linked_action.Grant(user, src)
 
-/obj/item/melee/rune_knife/dropped(mob/user, silent)
+/obj/item/melee/rune_carver/dropped(mob/user, silent)
 	. = ..()
 	linked_action.Remove(user, src)
 
-/obj/item/melee/rune_knife/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+/obj/item/melee/rune_carver/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
-	if(!is_type_in_typecache(target,blacklisted_turfs) && !drawing && proximity_flag)
+	if(isturf(target) && !is_type_in_typecache(target,blacklisted_turfs) && !drawing && proximity_flag)
 		carve_rune(target,user,proximity_flag,click_parameters)
 
 ///Action of carving runes, gives you the ability to click on floor and choose a rune of your need.
-/obj/item/melee/rune_knife/proc/carve_rune(atom/target, mob/user, proximity_flag, click_parameters)
+/obj/item/melee/rune_carver/proc/carve_rune(atom/target, mob/user, proximity_flag, click_parameters)
 	var/obj/structure/trap/eldritch/elder = locate() in range(1,target)
 	if(elder)
 		to_chat(user,"<span class='notice'>You can't draw runes that close to each other!</span>")
@@ -389,7 +389,7 @@
 	icon_icon = 'icons/mob/actions/actions_ecult.dmi'
 	check_flags = AB_CHECK_CONSCIOUS
 	///Reference to the rune knife it is inside of
-	var/obj/item/melee/rune_knife/sword
+	var/obj/item/melee/rune_carver/sword
 
 /datum/action/innate/rune_shatter/Grant(mob/user, obj/object)
 	sword = object

--- a/code/modules/antagonists/eldritch_cult/eldritch_structures.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_structures.dm
@@ -124,7 +124,7 @@
 
 /obj/structure/trap/eldritch/attacked_by(obj/item/I, mob/living/user)
 	. = ..()
-	if(istype(I,/obj/item/melee/rune_knife) || istype(I,/obj/item/nullrod))
+	if(istype(I,/obj/item/melee/rune_carver) || istype(I,/obj/item/nullrod))
 		qdel(src)
 
 ///Proc that sets the owner

--- a/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
@@ -105,7 +105,7 @@
 	cost = 1
 	next_knowledge = list(/datum/eldritch_knowledge/spell/void_phase,/datum/eldritch_knowledge/summon/raw_prophet)
 	required_atoms = list(/obj/item/kitchen/knife,/obj/item/shard,/obj/item/paper)
-	result_atoms = list(/obj/item/melee/rune_knife)
+	result_atoms = list(/obj/item/melee/rune_carver)
 
 /datum/eldritch_knowledge/crucible
 	name = "Mawed Crucible"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Atomized out of that rune carving pr, this just fixes the lack of a turf check on the rune carver and makes it's name more consistent.

## Why It's Good For The Game

mlem

## Changelog
:cl:
fix: Stops the rune carver from carving on invalid targets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
