### PR TITLE
Increased holo count for atmos holofans. Added one to the CE's locker.

### DIFF
--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -94,7 +94,7 @@
 	icon_state = "signmaker_atmos"
 	holosign_type = /obj/structure/holosign/barrier/atmos
 	creation_time = 0
-	max_signs = 3
+	max_signs = 6
 
 /obj/item/holosign_creator/medical
 	name = "\improper PENLITE barrier projector"

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -17,7 +17,7 @@
 	new /obj/item/radio/headset/heads/ce(src)
 	new /obj/item/megaphone/command(src)
 	new /obj/item/areaeditor/blueprints(src)
-	new /obj/item/holosign_creator/engineering(src)
+	new /obj/item/holosign_creator/atmos(src)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/clothing/glasses/meson/engine(src)
 	new /obj/item/door_remote/chief_engineer(src)


### PR DESCRIPTION
## About The Pull Request

Atmos holofans can now make six holos instead of three. Swapped the (useless) engineering holo with the atmos holo in the CE locker.

## Why It's Good For The Game

Atmos holofans are needed now more than ever, and they cost a fair bit of mats. You still need to print if you want to use a LOT of holos, but this makes them a bit more useful. Also makes CEs stop stealing from atmos lockers. 
With permission from @LemonInTheDark 

## Changelog
:cl: Kathy Ryals
balance: Atmos holofan projectors can now project up to six holograms.
tweak: Swapped the engineering holofan projector in the CE locker for an atmos projector.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
