### PR TITLE
Improved visual clarity for health scanner text

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -119,8 +119,8 @@ GENE SCANNER
 		user.visible_message("<span class='warning'>[user] analyzes the floor's vitals!</span>", \
 							"<span class='notice'>You stupidly try to analyze the floor's vitals!</span>")
 		to_chat(user, "<span class='info'>Analyzing results for The floor:\n\tOverall status: <b>Healthy</b></span>\
-				\n<span class='info'>Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FF8000'>Burn</font>/<font color='red'>Brute</font></span>\
-				\n<span class='info'>\tDamage specifics: <font color='blue'>0</font>-<font color='green'>0</font>-<font color='#FF8000'>0</font>-<font color='red'>0</font></span>\
+				\n<span class='info'>Key: <font color='#00cccc'>Suffocation</font>/<font color='#00cc66'>Toxin</font>/<font color='#ffcc33'>Burn</font>/<font color='#ff3333'>Brute</font></span>\
+				\n<span class='info'>\tDamage specifics: <font color='#66cccc'>0</font>-<font color='#00cc66'>0</font>-<font color='#ff9933'>0</font>-<font color='#ff3333'>0</font></span>\
 				\n<span class='info'>Body temperature: ???</span>")
 		return
 
@@ -252,22 +252,22 @@ GENE SCANNER
 		if(length(damaged)>0 || oxy_loss>0 || tox_loss>0 || fire_loss>0)
 			var/dmgreport = "<span class='info ml-1'>General status:</span>\
 							<table class='ml-2'><tr><font face='Verdana'>\
-							<td style='width:7em;'><font color='#0000CC'>Damage:</font></td>\
-							<td style='width:5em;'><font color='red'><b>Brute</b></font></td>\
-							<td style='width:4em;'><font color='orange'><b>Burn</b></font></td>\
-							<td style='width:4em;'><font color='green'><b>Toxin</b></font></td>\
-							<td style='width:8em;'><font color='purple'><b>Suffocation</b></font></td></tr>\
-							<tr><td><font color='#0000CC'>Overall:</font></td>\
-							<td><font color='red'>[CEILING(brute_loss,1)]</font></td>\
-							<td><font color='orange'>[CEILING(fire_loss,1)]</font></td>\
-							<td><font color='green'>[CEILING(tox_loss,1)]</font></td>\
-							<td><font color='blue'>[CEILING(oxy_loss,1)]</font></td></tr>"
+							<td style='width:7em;'><font color='#66cccc'>Damage:</font></td>\
+							<td style='width:5em;'><font color='#cc3333'><b>Brute</b></font></td>\
+							<td style='width:4em;'><font color='#ff9933'><b>Burn</b></font></td>\
+							<td style='width:4em;'><font color='#00cc66'><b>Toxin</b></font></td>\
+							<td style='width:8em;'><font color='#00cccc'><b>Suffocation</b></font></td></tr>\
+							<tr><td><font color='#66cc99'>Overall:</font></td>\
+							<td><font color='#cc3333'>[CEILING(brute_loss,1)]</font></td>\
+							<td><font color='#ff9933'>[CEILING(fire_loss,1)]</font></td>\
+							<td><font color='#00cc66'>[CEILING(tox_loss,1)]</font></td>\
+							<td><font color='#33ccff'>[CEILING(oxy_loss,1)]</font></td></tr>"
 
 			for(var/o in damaged)
 				var/obj/item/bodypart/org = o //head, left arm, right arm, etc.
-				dmgreport += "<tr><td><font color='#0000CC'>[capitalize(org.name)]:</font></td>\
-								<td><font color='red'>[(org.brute_dam > 0) ? "[CEILING(org.brute_dam,1)]" : "0"]</font></td>\
-								<td><font color='orange'>[(org.burn_dam > 0) ? "[CEILING(org.burn_dam,1)]" : "0"]</font></td></tr>"
+				dmgreport += "<tr><td><font color='#66cc99'>[capitalize(org.name)]:</font></td>\
+								<td><font color='#cc3333'>[(org.brute_dam > 0) ? "[CEILING(org.brute_dam,1)]" : "0"]</font></td>\
+								<td><font color='#ff9933'>[(org.burn_dam > 0) ? "[CEILING(org.burn_dam,1)]" : "0"]</font></td></tr>"
 			dmgreport += "</font></table>"
 			render_list += dmgreport // tables do not need extra linebreak
 
@@ -318,19 +318,19 @@ GENE SCANNER
 			var/render = FALSE
 			var/toReport = "<span class='info ml-1'>Organs:</span>\
 				<table class='ml-2'><tr>\
-				<td style='width:6em;'><font color='#0000CC'><b>Organ</b></font></td>\
-				[advanced ? "<td style='width:3em;'><font color='#0000CC'><b>Dmg</b></font></td>" : ""]\
-				<td style='width:12em;'><font color='#0000CC'><b>Status</b></font></td>"
+				<td style='width:6em;'><font color='#66cccc'><b>Organ</b></font></td>\
+				[advanced ? "<td style='width:3em;'><font color='#66cccc'><b>Dmg</b></font></td>" : ""]\
+				<td style='width:12em;'><font color='#66cccc'><b>Status</b></font></td>"
 
 			for(var/obj/item/organ/organ in H.internal_organs)
 				var/status = ""
-				if (organ.organ_flags & ORGAN_FAILING) status = "<font color='#E42426'>Non-Functional</font>"
-				else if (organ.damage > organ.high_threshold) status = "<font color='#EC6224'>Severely Damaged</font>"
-				else if (organ.damage > organ.low_threshold) status = "<font color='#F28F1F'>Mildly Damaged</font>"
+				if (organ.organ_flags & ORGAN_FAILING) status = "<font color='#cc3333'>Non-Functional</font>"
+				else if (organ.damage > organ.high_threshold) status = "<font color='#ff9933'>Severely Damaged</font>"
+				else if (organ.damage > organ.low_threshold) status = "<font color='#ffcc33'>Mildly Damaged</font>"
 				if (status != "")
 					render = TRUE
-					toReport += "<tr><td><font color='#0000CC'>[organ.name]</font></td>\
-						[advanced ? "<td><font color='#0000CC'>[CEILING(organ.damage,1)]</font></td>" : ""]\
+					toReport += "<tr><td><font color='#66cc99'>[organ.name]</font></td>\
+						[advanced ? "<td><font color='#cc3333'>[CEILING(organ.damage,1)]</font></td>" : ""]\
 						<td>[status]</td></tr>"
 
 			if (render)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -252,16 +252,16 @@ GENE SCANNER
 		if(length(damaged)>0 || oxy_loss>0 || tox_loss>0 || fire_loss>0)
 			var/dmgreport = "<span class='info ml-1'>General status:</span>\
 							<table class='ml-2'><tr><font face='Verdana'>\
-							<td style='width:7em;'><font color='#66cccc'>Damage:</font></td>\
+							<td style='width:7em;'><font color='#66cccc'><b>Damage:</b></font></td>\
 							<td style='width:5em;'><font color='#cc3333'><b>Brute</b></font></td>\
 							<td style='width:4em;'><font color='#ff9933'><b>Burn</b></font></td>\
 							<td style='width:4em;'><font color='#00cc66'><b>Toxin</b></font></td>\
 							<td style='width:8em;'><font color='#00cccc'><b>Suffocation</b></font></td></tr>\
-							<tr><td><font color='#66cc99'>Overall:</font></td>\
-							<td><font color='#cc3333'>[CEILING(brute_loss,1)]</font></td>\
-							<td><font color='#ff9933'>[CEILING(fire_loss,1)]</font></td>\
-							<td><font color='#00cc66'>[CEILING(tox_loss,1)]</font></td>\
-							<td><font color='#33ccff'>[CEILING(oxy_loss,1)]</font></td></tr>"
+							<tr><td><font color='#66cc99'><b>Overall:</b></font></td>\
+							<td><font color='#cc3333'><b>[CEILING(brute_loss,1)]</b></font></td>\
+							<td><font color='#ff9933'><b>[CEILING(fire_loss,1)]</b></font></td>\
+							<td><font color='#00cc66'><b>[CEILING(tox_loss,1)]</b></font></td>\
+							<td><font color='#33ccff'><b>[CEILING(oxy_loss,1)]</b></font></td></tr>"
 
 			for(var/o in damaged)
 				var/obj/item/bodypart/org = o //head, left arm, right arm, etc.
@@ -318,7 +318,7 @@ GENE SCANNER
 			var/render = FALSE
 			var/toReport = "<span class='info ml-1'>Organs:</span>\
 				<table class='ml-2'><tr>\
-				<td style='width:6em;'><font color='#66cccc'><b>Organ</b></font></td>\
+				<td style='width:6em;'><font color='#66cccc'><b>Organ:</b></font></td>\
 				[advanced ? "<td style='width:3em;'><font color='#66cccc'><b>Dmg</b></font></td>" : ""]\
 				<td style='width:12em;'><font color='#66cccc'><b>Status</b></font></td>"
 
@@ -329,7 +329,7 @@ GENE SCANNER
 				else if (organ.damage > organ.low_threshold) status = "<font color='#ffcc33'>Mildly Damaged</font>"
 				if (status != "")
 					render = TRUE
-					toReport += "<tr><td><font color='#66cc99'>[organ.name]</font></td>\
+					toReport += "<tr><td><font color='#66cc99'>[organ.name]:</font></td>\
 						[advanced ? "<td><font color='#cc3333'>[CEILING(organ.damage,1)]</font></td>" : ""]\
 						<td>[status]</td></tr>"
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -252,12 +252,12 @@ GENE SCANNER
 		if(length(damaged)>0 || oxy_loss>0 || tox_loss>0 || fire_loss>0)
 			var/dmgreport = "<span class='info ml-1'>General status:</span>\
 							<table class='ml-2'><tr><font face='Verdana'>\
-							<td style='width:7em;'><font color='#66cccc'><b>Damage:</b></font></td>\
+							<td style='width:7em;'><font color='#990000'><b>Damage:</b></font></td>\
 							<td style='width:5em;'><font color='#cc3333'><b>Brute</b></font></td>\
 							<td style='width:4em;'><font color='#ff9933'><b>Burn</b></font></td>\
 							<td style='width:4em;'><font color='#00cc66'><b>Toxin</b></font></td>\
 							<td style='width:8em;'><font color='#00cccc'><b>Suffocation</b></font></td></tr>\
-							<tr><td><font color='#66cc99'><b>Overall:</b></font></td>\
+							<tr><td><font color='#cc3333'><b>Overall:</b></font></td>\
 							<td><font color='#cc3333'><b>[CEILING(brute_loss,1)]</b></font></td>\
 							<td><font color='#ff9933'><b>[CEILING(fire_loss,1)]</b></font></td>\
 							<td><font color='#00cc66'><b>[CEILING(tox_loss,1)]</b></font></td>\
@@ -265,7 +265,7 @@ GENE SCANNER
 
 			for(var/o in damaged)
 				var/obj/item/bodypart/org = o //head, left arm, right arm, etc.
-				dmgreport += "<tr><td><font color='#66cc99'>[capitalize(org.name)]:</font></td>\
+				dmgreport += "<tr><td><font color='#cc3333'>[capitalize(org.name)]:</font></td>\
 								<td><font color='#cc3333'>[(org.brute_dam > 0) ? "[CEILING(org.brute_dam,1)]" : "0"]</font></td>\
 								<td><font color='#ff9933'>[(org.burn_dam > 0) ? "[CEILING(org.burn_dam,1)]" : "0"]</font></td></tr>"
 			dmgreport += "</font></table>"
@@ -318,9 +318,9 @@ GENE SCANNER
 			var/render = FALSE
 			var/toReport = "<span class='info ml-1'>Organs:</span>\
 				<table class='ml-2'><tr>\
-				<td style='width:6em;'><font color='#66cccc'><b>Organ:</b></font></td>\
-				[advanced ? "<td style='width:3em;'><font color='#66cccc'><b>Dmg</b></font></td>" : ""]\
-				<td style='width:12em;'><font color='#66cccc'><b>Status</b></font></td>"
+				<td style='width:6em;'><font color='#990000'><b>Organ:</b></font></td>\
+				[advanced ? "<td style='width:3em;'><font color='#990000'><b>Dmg</b></font></td>" : ""]\
+				<td style='width:12em;'><font color='#990000'><b>Status</b></font></td>"
 
 			for(var/obj/item/organ/organ in H.internal_organs)
 				var/status = ""
@@ -329,7 +329,7 @@ GENE SCANNER
 				else if (organ.damage > organ.low_threshold) status = "<font color='#ffcc33'>Mildly Damaged</font>"
 				if (status != "")
 					render = TRUE
-					toReport += "<tr><td><font color='#66cc99'>[organ.name]:</font></td>\
+					toReport += "<tr><td><font color='#cc3333'>[organ.name]:</font></td>\
 						[advanced ? "<td><font color='#cc3333'>[CEILING(organ.damage,1)]</font></td>" : ""]\
 						<td>[status]</td></tr>"
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -253,12 +253,12 @@ GENE SCANNER
 			var/dmgreport = "<span class='info ml-1'>General status:</span>\
 							<table class='ml-2'><tr><font face='Verdana'>\
 							<td style='width:7em;'><font color='#990000'><b>Damage:</b></font></td>\
-							<td style='width:5em;'><font color='#cc3333'><b>Brute</b></font></td>\
+							<td style='width:5em;'><font color='#ff3333'><b>Brute</b></font></td>\
 							<td style='width:4em;'><font color='#ff9933'><b>Burn</b></font></td>\
 							<td style='width:4em;'><font color='#00cc66'><b>Toxin</b></font></td>\
 							<td style='width:8em;'><font color='#00cccc'><b>Suffocation</b></font></td></tr>\
-							<tr><td><font color='#cc3333'><b>Overall:</b></font></td>\
-							<td><font color='#cc3333'><b>[CEILING(brute_loss,1)]</b></font></td>\
+							<tr><td><font color='#ff3333'><b>Overall:</b></font></td>\
+							<td><font color='#ff3333'><b>[CEILING(brute_loss,1)]</b></font></td>\
 							<td><font color='#ff9933'><b>[CEILING(fire_loss,1)]</b></font></td>\
 							<td><font color='#00cc66'><b>[CEILING(tox_loss,1)]</b></font></td>\
 							<td><font color='#33ccff'><b>[CEILING(oxy_loss,1)]</b></font></td></tr>"
@@ -330,7 +330,7 @@ GENE SCANNER
 				if (status != "")
 					render = TRUE
 					toReport += "<tr><td><font color='#cc3333'>[organ.name]:</font></td>\
-						[advanced ? "<td><font color='#cc3333'>[CEILING(organ.damage,1)]</font></td>" : ""]\
+						[advanced ? "<td><font color='#ff3333'>[CEILING(organ.damage,1)]</font></td>" : ""]\
 						<td>[status]</td></tr>"
 
 			if (render)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -252,7 +252,7 @@ GENE SCANNER
 		if(length(damaged)>0 || oxy_loss>0 || tox_loss>0 || fire_loss>0)
 			var/dmgreport = "<span class='info ml-1'>General status:</span>\
 							<table class='ml-2'><tr><font face='Verdana'>\
-							<td style='width:7em;'><font color='#990000'><b>Damage:</b></font></td>\
+							<td style='width:7em;'><font color='#ff0000'><b>Damage:</b></font></td>\
 							<td style='width:5em;'><font color='#ff3333'><b>Brute</b></font></td>\
 							<td style='width:4em;'><font color='#ff9933'><b>Burn</b></font></td>\
 							<td style='width:4em;'><font color='#00cc66'><b>Toxin</b></font></td>\
@@ -318,9 +318,9 @@ GENE SCANNER
 			var/render = FALSE
 			var/toReport = "<span class='info ml-1'>Organs:</span>\
 				<table class='ml-2'><tr>\
-				<td style='width:6em;'><font color='#990000'><b>Organ:</b></font></td>\
-				[advanced ? "<td style='width:3em;'><font color='#990000'><b>Dmg</b></font></td>" : ""]\
-				<td style='width:12em;'><font color='#990000'><b>Status</b></font></td>"
+				<td style='width:6em;'><font color='#ff0000'><b>Organ:</b></font></td>\
+				[advanced ? "<td style='width:3em;'><font color='#ff0000'><b>Dmg</b></font></td>" : ""]\
+				<td style='width:12em;'><font color='#ff0000'><b>Status</b></font></td>"
 
 			for(var/obj/item/organ/organ in H.internal_organs)
 				var/status = ""


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Current: 
![Current](https://i.imgur.com/7L0xRpn.jpg)

New:
![New-dark](https://i.imgur.com/njl5h4c.jpg)

![New-light](https://i.imgur.com/HEXgJL9.jpg)

## Why It's Good For The Game

This got requested on a downstream, but got advice to try upstream. Here's a visual clarity update, let me know how the colors are if you are colorblind. (this may be a downgrade if you have protanopia)

## Changelog
:cl:
qol: Better visual clarity of the health scanner's text colors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
