### PR TITLE
Making blood less frustrating

### DIFF
--- a/code/datums/components/bloodysoles.dm
+++ b/code/datums/components/bloodysoles.dm
@@ -68,6 +68,9 @@
 	bloody_shoes[last_blood_state] = new_our_bloodiness
 	pool.bloodiness = total_bloodiness - new_our_bloodiness // Give the pool the remaining blood incase we were limited
 
+	if(HAS_TRAIT(parent_atom, TRAIT_LIGHT_STEP)) //the character is agile enough to don't mess their clothing and hands just from one blood splatter at floor
+		return TRUE
+
 	parent_atom.add_blood_DNA(pool.return_blood_DNA())
 	update_icon()
 

--- a/code/datums/quirks/good.dm
+++ b/code/datums/quirks/good.dm
@@ -128,7 +128,7 @@
 
 /datum/quirk/light_step
 	name = "Light Step"
-	desc = "You walk with a gentle step; footsteps and stepping on sharp objects is quieter and less painful."
+	desc = "You walk with a gentle step; footsteps and stepping on sharp objects is quieter and less painful. Also, your hands and clothes will not get messed in case of stepping in blood."
 	value = 4
 	mob_trait = TRAIT_LIGHT_STEP
 	gain_text = "<span class='notice'>You walk with a little more litheness.</span>"

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -85,7 +85,7 @@
 //This is on /cleanable because fuck this ancient mess
 /obj/effect/decal/cleanable/Crossed(atom/movable/AM)
 	..()
-	if(iscarbon(AM) && blood_state && bloodiness > 0)
+	if(iscarbon(AM) && blood_state && bloodiness > 40)
 		SEND_SIGNAL(AM, COMSIG_STEP_ON_BLOOD, src)
 		update_icon()
 

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -85,7 +85,7 @@
 //This is on /cleanable because fuck this ancient mess
 /obj/effect/decal/cleanable/Crossed(atom/movable/AM)
 	..()
-	if(iscarbon(AM) && blood_state && bloodiness > 40)
+	if(iscarbon(AM) && blood_state && bloodiness >= 40)
 		SEND_SIGNAL(AM, COMSIG_STEP_ON_BLOOD, src)
 		update_icon()
 

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -10,6 +10,7 @@
 	clean_type = CLEAN_TYPE_BLOOD
 	var/dryname = "dried blood" //when the blood lasts long enough, it becomes dry and gets a new name
 	var/drydesc = "Looks like it's been here a while. Eew." //as above
+	var/drytime = 0
 
 /obj/effect/decal/cleanable/blood/Initialize()
 	. = ..()
@@ -18,18 +19,31 @@
 	else
 		dry()
 
+/obj/effect/decal/cleanable/blood/process()
+	if(world.time > drytime)
+		dry()
+
+/obj/effect/decal/cleanable/blood/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/effect/decal/cleanable/blood/proc/get_timer()
+	drytime = world.time + 3 MINUTES
+
 /obj/effect/decal/cleanable/blood/proc/start_drying()
-	addtimer(CALLBACK(src, .proc/dry), 3 MINUTES)
+	get_timer()
+	START_PROCESSING(SSobj, src)
 
 /obj/effect/decal/cleanable/blood/proc/dry()
 	if(bloodiness > 20)
 		bloodiness -= BLOOD_AMOUNT_PER_DECAL
-		start_drying()
+		get_timer()
 	else
 		name = dryname
 		desc = drydesc
 		bloodiness = 0
 		color =  COLOR_GRAY //not all blood splatters have their own sprites... It still looks pretty nice
+		STOP_PROCESSING(SSobj, src)
 
 /obj/effect/decal/cleanable/blood/replace_decal(obj/effect/decal/cleanable/blood/C)
 	C.add_blood_DNA(return_blood_DNA())

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -8,6 +8,28 @@
 	bloodiness = BLOOD_AMOUNT_PER_DECAL
 	beauty = -100
 	clean_type = CLEAN_TYPE_BLOOD
+	var/dryname = "dried blood" //when the blood lasts long enough, it becomes dry and gets a new name
+	var/drydesc = "Looks like it's been here a while. Eew." //as above
+
+/obj/effect/decal/cleanable/blood/Initialize()
+	. = ..()
+	if(bloodiness)
+		start_drying()
+	else
+		dry()
+
+/obj/effect/decal/cleanable/blood/proc/start_drying()
+	addtimer(CALLBACK(src, .proc/dry), 3 MINUTES)
+
+/obj/effect/decal/cleanable/blood/proc/dry()
+	if(bloodiness > 20)
+		bloodiness -= BLOOD_AMOUNT_PER_DECAL
+		start_drying()
+	else
+		name = dryname
+		desc = drydesc
+		bloodiness = 0
+		color =  COLOR_GRAY //not all blood splatters have their own sprites... It still looks pretty nice
 
 /obj/effect/decal/cleanable/blood/replace_decal(obj/effect/decal/cleanable/blood/C)
 	C.add_blood_DNA(return_blood_DNA())
@@ -16,15 +38,12 @@
 	return ..()
 
 /obj/effect/decal/cleanable/blood/old
-	name = "dried blood"
-	desc = "Looks like it's been here a while.  Eew."
 	bloodiness = 0
 	icon_state = "floor1-old"
 
 /obj/effect/decal/cleanable/blood/old/Initialize(mapload, list/datum/disease/diseases)
 	add_blood_DNA(list("Non-human DNA" = random_blood_type())) // Needs to happen before ..()
 	. = ..()
-	icon_state = "[icon_state]-old" //change from the normal blood icon selected from random_icon_states in the parent's Initialize to the old dried up blood.
 
 /obj/effect/decal/cleanable/blood/splatter
 	icon_state = "gibbl1"
@@ -35,6 +54,8 @@
 	desc = "They look like tracks left by wheels."
 	random_icon_states = null
 	beauty = -50
+	dryname = "dried tracks"
+	drydesc = "Some old bloody tracks left by wheels. Machines are evil, perhaps."
 
 /obj/effect/decal/cleanable/trail_holder //not a child of blood on purpose
 	name = "blood"
@@ -55,7 +76,8 @@
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6")
 	mergeable_decal = FALSE
 
-	var/already_rotting = FALSE
+	dryname = "rotting gibs"
+	drydesc = "They look bloody and gruesome while some terrible smell fills the air."
 
 /obj/effect/decal/cleanable/blood/gibs/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()
@@ -63,15 +85,9 @@
 	RegisterSignal(src, COMSIG_MOVABLE_PIPE_EJECTING, .proc/on_pipe_eject)
 	if(mapload) //Don't rot at roundstart for the love of god
 		return
-	if(already_rotting)
-		start_rotting(rename=FALSE)
-	else
-		addtimer(CALLBACK(src, .proc/start_rotting), 2 MINUTES)
 
-/obj/effect/decal/cleanable/blood/gibs/proc/start_rotting(rename=TRUE)
-	if(rename)
-		name = "rotting [initial(name)]"
-		desc += " They smell terrible."
+/obj/effect/decal/cleanable/blood/gibs/dry()
+	. = ..()
 	AddComponent(/datum/component/rot/gibs)
 
 /obj/effect/decal/cleanable/blood/gibs/ex_act(severity, target)
@@ -133,13 +149,14 @@
 /obj/effect/decal/cleanable/blood/gibs/old
 	name = "old rotting gibs"
 	desc = "Space Jesus, why didn't anyone clean this up? They smell terrible."
+	icon_state = "gib1-old"
 	bloodiness = 0
-	already_rotting = TRUE
+	dryname = "old rotting gibs"
+	drydesc = "Space Jesus, why didn't anyone clean this up? They smell terrible."
 
 /obj/effect/decal/cleanable/blood/gibs/old/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()
 	setDir(pick(1,2,4,8))
-	icon_state += "-old"
 	add_blood_DNA(list("Non-human DNA" = random_blood_type()))
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_SLUDGE, CELL_VIRUS_TABLE_GENERIC, rand(2,4), 10)
 
@@ -150,6 +167,8 @@
 	random_icon_states = list("drip1","drip2","drip3","drip4","drip5")
 	bloodiness = 0
 	var/drips = 1
+	dryname = "drips of blood"
+	drydesc = "It's red."
 
 /obj/effect/decal/cleanable/blood/drip/can_bloodcrawl_in()
 	return TRUE
@@ -171,6 +190,9 @@
 
 	/// List of species that have made footprints here.
 	var/list/species_types = list()
+
+	dryname = "dried footprints"
+	drydesc = "HMM... SOMEONE WAS HERE!"
 
 /obj/effect/decal/cleanable/blood/footprints/Initialize(mapload)
 	. = ..()

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -81,6 +81,8 @@
 	return TRUE //we bloodied the floor
 
 /mob/living/carbon/human/add_blood_DNA(list/blood_dna, list/datum/disease/diseases)
+	if(HAS_TRAIT(src, TRAIT_LIGHT_STEP)) //the character is agile enough to don't mess their clothing and hands just from one blood splatter at floor
+		return TRUE
 	if(wear_suit)
 		wear_suit.add_blood_DNA(blood_dna)
 		update_inv_wear_suit()

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -81,8 +81,6 @@
 	return TRUE //we bloodied the floor
 
 /mob/living/carbon/human/add_blood_DNA(list/blood_dna, list/datum/disease/diseases)
-	if(HAS_TRAIT(src, TRAIT_LIGHT_STEP)) //the character is agile enough to don't mess their clothing and hands just from one blood splatter at floor
-		return TRUE
 	if(wear_suit)
 		wear_suit.add_blood_DNA(blood_dna)
 		update_inv_wear_suit()


### PR DESCRIPTION
## About The Pull Request

Two changes.
```
1. If a splatter of blood isn't bloody enough, the character will not get bloody shoes.

2. Characters with light steps trait won't get bloody clothes if they step on a bloody tile without shoes.

3. added: Blood dries over time. Usually, 3 or 6 minutes. If a splatter is big enough, it can stay wet up to 15 minutes.
```

## Why It's Good For The Game

The entire crew won't have bloody shoes anymore.
Less time wasted looking for showers or sinks to wash their shoes after stepping on a near invisible blood decal.
Characters without shoes (or who don't want to get their clothes bloody after taking them off) will get more use from a near useless trait.

## Changelog
:cl:
qol: Blood splatters only make your shoes or feet bloody if the tile is bloody enough,
qol: Light steps trait prevents clothing from being covered in blood if you step on a bloody tile with your shoes off.
add: Blood dries over time. Usually, 3 or 6 minutes. If a splatter is big enough, it can stay wet up to 15 minutes.
/:cl:

(grammaticly impoved by @maxymax13)