### PR TITLE
Various cult equipment rebalances to address energy weapon immunities being too common

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -670,7 +670,7 @@
 //Armor: Gives the target (cultist) a basic cultist combat loadout
 /obj/item/melee/blood_magic/armor
 	name = "Arming Aura"
-	desc = "Will equipt cult combat gear onto a cultist on contact."
+	desc = "Will equip cult combat gear onto a cultist on contact."
 	color = "#33cc33" // green
 
 /obj/item/melee/blood_magic/armor/afterattack(atom/target, mob/living/carbon/user, proximity)
@@ -684,7 +684,7 @@
 		C.equip_to_slot_or_del(new /obj/item/storage/backpack/cultpack(user), ITEM_SLOT_BACK)
 		if(C == user)
 			qdel(src) //Clears the hands
-		C.put_in_hands(new /obj/item/melee/cultblade(user))
+		C.put_in_hands(new /obj/item/melee/cultblade/dagger(user))
 		C.put_in_hands(new /obj/item/restraints/legcuffs/bola/cult(user))
 		..()
 

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -474,7 +474,7 @@
 
 /obj/item/clothing/glasses/hud/health/night/cultblind/equipped(mob/living/user, slot)
 	..()
-	if(!iscultist(user))
+	if(!iscultist(user) && slot == ITEM_SLOT_EYES)
 		to_chat(user, "<span class='cultlarge'>\"You want to be blind, do you?\"</span>")
 		user.dropItemToGround(src, TRUE)
 		user.Dizzy(30)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -20,6 +20,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	force = 15
 	throwforce = 25
+	block_chance = 25
 	wound_bonus = -10
 	bare_wound_bonus = 20
 	armour_penetration = 35
@@ -31,6 +32,19 @@
 	var/image/I = image(icon = 'icons/effects/blood.dmi' , icon_state = null, loc = src)
 	I.override = TRUE
 	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/silicons, "cult_dagger", I)
+
+/obj/item/melee/cultblade/dagger/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	var/block_message = "[owner] parries [attack_text] with [src]"
+	if(owner.get_active_held_item() != src)
+		block_message = "[owner] parries [attack_text] with [src] in their offhand"
+
+	if(iscultist(owner) && prob(final_block_chance) && attack_type != PROJECTILE_ATTACK)
+		new /obj/effect/temp_visual/cult/sparks(get_turf(owner))
+		playsound(src, 'sound/weapons/parry.ogg', 100, TRUE)
+		owner.visible_message("<span class='danger'>[block_message]</span>")
+		return TRUE
+	else
+		return FALSE
 
 /obj/item/melee/cultblade
 	name = "eldritch longsword"
@@ -47,6 +61,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	force = 30 // whoever balanced this got beat in the head by a bible too many times good lord
 	throwforce = 10
+	block_chance = 50 // now it's officially a cult esword
 	wound_bonus = -50
 	bare_wound_bonus = 20
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -56,6 +71,15 @@
 /obj/item/melee/cultblade/Initialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 40, 100)
+
+/obj/item/melee/cultblade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(iscultist(owner) && prob(final_block_chance))
+		new /obj/effect/temp_visual/cult/sparks(get_turf(owner))
+		playsound(src, 'sound/weapons/parry.ogg', 100, TRUE)
+		owner.visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
+		return TRUE
+	else
+		return FALSE
 
 /obj/item/melee/cultblade/attack(mob/living/target, mob/living/carbon/human/user)
 	if(!iscultist(user))
@@ -76,6 +100,7 @@
 	force = 19 //can't break normal airlocks
 	item_flags = NEEDS_PERMIT | DROPDEL
 	flags_1 = NONE
+	block_chance = 25 //these dweebs don't get full block chance, because they're free cultists
 
 /obj/item/melee/cultblade/ghost/Initialize()
 	. = ..()
@@ -346,7 +371,7 @@
 	desc = "A heavily-armored helmet worn by warriors of the Nar'Sien cult. It can withstand hard vacuum."
 	icon_state = "cult_helmet"
 	inhand_icon_state = "cult_helmet"
-	armor = list(MELEE = 70, BULLET = 50, LASER = 30,ENERGY = 40, BOMB = 30, BIO = 30, RAD = 30, FIRE = 40, ACID = 75)
+	armor = list(MELEE = 50, BULLET = 40, LASER = 50, ENERGY = 60, BOMB = 50, BIO = 30, RAD = 30, FIRE = 100, ACID = 100)
 	light_system = NO_LIGHT_SUPPORT
 	light_range = 0
 	actions_types = list()
@@ -358,8 +383,11 @@
 	desc = "A heavily-armored exosuit worn by warriors of the Nar'Sien cult. It can withstand hard vacuum."
 	w_class = WEIGHT_CLASS_BULKY
 	allowed = list(/obj/item/tome, /obj/item/melee/cultblade, /obj/item/tank/internals/)
-	armor = list(MELEE = 70, BULLET = 50, LASER = 30,ENERGY = 40, BOMB = 30, BIO = 30, RAD = 30, FIRE = 40, ACID = 75)
+	armor = list(MELEE = 50, BULLET = 40, LASER = 50, ENERGY = 60, BOMB = 50, BIO = 30, RAD = 30, FIRE = 100, ACID = 100)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/cult
+
+/obj/item/clothing/suit/space/hardsuit/cult/real
+	slowdown = 0
 
 /obj/item/sharpener/cult
 	name = "eldritch whetstone"
@@ -720,11 +748,13 @@
 	if(prob(final_block_chance))
 		if(attack_type == PROJECTILE_ATTACK)
 			owner.visible_message("<span class='danger'>[owner] deflects [attack_text] with [src]!</span>")
-			playsound(src, pick('sound/weapons/effects/ric1.ogg', 'sound/weapons/effects/ric2.ogg', 'sound/weapons/effects/ric3.ogg', 'sound/weapons/effects/ric4.ogg', 'sound/weapons/effects/ric5.ogg'), 100, TRUE)
+			playsound(get_turf(owner), pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
+			new /obj/effect/temp_visual/cult/sparks(get_turf(owner))
 			return TRUE
 		else
 			playsound(src, 'sound/weapons/parry.ogg', 100, TRUE)
 			owner.visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
+			new /obj/effect/temp_visual/cult/sparks(get_turf(owner))
 			return TRUE
 	return FALSE
 

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -745,7 +745,7 @@
 /obj/item/melee/cultblade/halberd/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(wielded)
 		final_block_chance *= 2
-	if(prob(final_block_chance))
+	if(iscultist(owner) && prob(final_block_chance))
 		if(attack_type == PROJECTILE_ATTACK)
 			owner.visible_message("<span class='danger'>[owner] deflects [attack_text] with [src]!</span>")
 			playsound(get_turf(owner), pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
@@ -756,7 +756,8 @@
 			owner.visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
 			new /obj/effect/temp_visual/cult/sparks(get_turf(owner))
 			return TRUE
-	return FALSE
+	else
+		return FALSE
 
 /datum/action/innate/cult/halberd
 	name = "Bloody Bond"

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -148,19 +148,19 @@
 		to_chat(user, "<span class='cult italic'>The magic in [src] is weak, it will be ready to use again in [DisplayTimeText(cooldowntime - world.time)].</span>")
 		return
 	var/list/items = list(
-		"Shielded Robe" = image(icon = 'icons/obj/clothing/suits.dmi', icon_state = "cult_armor"),
+		"Nar'sien Hardened Armor" = image(icon = 'icons/obj/clothing/suits.dmi', icon_state = "cult_armor"),
 		"Flagellant's Robe" = image(icon = 'icons/obj/clothing/suits.dmi', icon_state = "cultrobes"),
-		"Mirror Shield" = image(icon = 'icons/obj/shields.dmi', icon_state = "mirror_shield")
+		"Eldritch Longsword" = image(icon = 'icons/obj/items_and_weapons.dmi', icon_state = "cultblade")
 		)
 	var/choice = show_radial_menu(user, src, items, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE, tooltips = TRUE)
 	var/list/pickedtype = list()
 	switch(choice)
-		if("Shielded Robe")
-			pickedtype += /obj/item/clothing/suit/hooded/cultrobes/cult_shield
+		if("Nar'sien Hardened Armor")
+			pickedtype += /obj/item/clothing/suit/space/hardsuit/cult/real
 		if("Flagellant's Robe")
 			pickedtype += /obj/item/clothing/suit/hooded/cultrobes/berserker
-		if("Mirror Shield")
-			pickedtype += /obj/item/shield/mirror
+		if("Eldritch Longsword")
+			pickedtype += /obj/item/melee/cultblade
 		else
 			return
 	if(src && !QDELETED(src) && anchored && pickedtype && Adjacent(user) && !user.incapacitated() && iscultist(user) && cooldowntime <= world.time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevents cultists from acquiring the shielded robe and mirror shield from the daemon forge. Also replaces the eldritch longsword in the equipment spell with a cult dagger.

Eldritch Longswords now have block chances, and are made in the forge instead of the mirror shield. They have a 50% block chance.

Cult dagger also have block, but only 25% and cannot block projectiles.

Nar'sian Hardened Armor are able to be acquired from the daemon forge instead of the shielded robe. They have had their stats tweaked to match the old robe, but the cult version doesn't have slowdown.

## Why It's Good For The Game

When I was doing my revisit to pipeguns, I was pretty plainly told by Rohesie we need to start towards getting rid of weapons like the pipegun, and what I was doing was a waste of time. Maintainers in general would be looking to move in that direction, so I closed the PR but said I feel then it would be appropriate to look to what would severely impact the game should those stop existing.

I argued that the primary reason most ballistics are somewhat necessary for the sake of game stability _right now_ is that many game modes actually have anti-energy weapon gear or energy weapon immunity gear in them, or just weapons that deliberately punish using anything but the hardest hitting weapons with as many attacks as possible (AKA shotguns). Cult specifically was an example I was, straight from the horses mouth, told was balanced entirely around the crew needing to use ballistics to get anywhere in defeating them.

The two items removed were mostly meant to stop tasers (and for shielded robes, hardstun stun batons as well). Tasers have been gone for nearly two years. The only good they do now is mandating ballistic weapons like autorifles, shotguns and such to deal with cult.

As such, these items do next to nothing for the cult due to everyone quickly and easily moving to use their main weakness to bypass these immunities, so they often go untouched. They only exist to give reason for crew to produce shotguns as expediently as possible.

Since the cult have less fears about instant stuns than in the past when these items were first added, they now need more generalized defences that decent block and reasonable armor can provide. Worse case scenario, they still have EMP if they need to turn off an egun or two.

Moving the eldritch longsword into the mirror shield slot was primarily because lol it's an esword bro, why can you just conjure that shit in your hand? For free? From anywhere? Fucked up.

_(real question is when is cult being disabled so this isn't a problem anymore because gosh there are so many problems with cult that a single balance pr like this is more or less just paving over this horrible problem child of a mode)_

## Changelog
:cl:
balance: Shielded Robes and Mirror Shields can no longer be made from daemon forges.
balance: Eldritch Longswords and True Nar'sian Hardened Armor can be made from daemon forges. True Nar'sian Hardened Armor has no slowdown, unlike the lavaland version.
balance: The equipment spell now grants you a cult dagger. Still separate from the other spell so that you can acquire a dagger without being slapped with a validsuit.
balance: Eldritch longswords and cult daggers have block chance (50% and 25% respectively). Cult daggers cannot block projectiles and the cult ghost longsword only has 25% block chance.
balance: The cult blindfold only stuns you if you actually are stupid enough to put it over your eyes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
