### PR TITLE
If I fix a holobug before its reported do i gain? no! money down. 🤔 Fixes issue with holodeck items being accepted into custom vendors

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1037,7 +1037,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 /obj/machinery/vending/custom/canLoadItem(obj/item/I, mob/user)
 	. = FALSE
 	if(I.flags_1 & HOLOGRAM_1)
-		say("This vendor cannot accept nonexistant items.")
+		say("This vendor cannot accept nonexistent items.")
 		return
 	if(loaded_items >= max_loaded_items)
 		say("There are too many items in stock.")

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1151,10 +1151,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 			last_slogan = world.time + rand(0, slogan_delay)
 			return
 
-	if(panel_open && is_wire_tool(I))
-		wires.interact(user)
-		return
-
 	return ..()
 
 /obj/machinery/vending/custom/crowbar_act(mob/living/user, obj/item/I)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1036,11 +1036,14 @@ GLOBAL_LIST_EMPTY(vending_products)
 
 /obj/machinery/vending/custom/canLoadItem(obj/item/I, mob/user)
 	. = FALSE
+	if(I.flags_1 & HOLOGRAM_1)
+		say("This vendor cannot accept nonexistant items.")
+		return
 	if(loaded_items >= max_loaded_items)
 		say("There are too many items in stock.")
 		return
 	if(istype(I, /obj/item/stack))
-		say("Loose items may cause problems, try use it inside wrapping paper.")
+		say("Loose items may cause problems, try to use it inside wrapping paper.")
 		return
 	if(I.custom_price)
 		return TRUE
@@ -1146,11 +1149,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 			desc = stripped_input(user,"Set description","Description", desc, 60)
 			slogan_list += stripped_input(user,"Set slogan","Slogan","Epic", 60)
 			last_slogan = world.time + rand(0, slogan_delay)
-			return
-
-		if(canLoadItem(I))
-			loadingAttempt(I,user)
-			updateUsrDialog()
 			return
 
 	if(panel_open && is_wire_tool(I))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
(thank you omega) On master you can put an item spawned from the holodeck into a custom vendor. luckily the item cant actually come out so you cant dupe anything from the holodeck with it. also fixes a minor issue with vendor/custom/attackby where if canLoadItem returns false it will say the message twice because canLoadItem is in the attackby of both custom and generic vendors.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
an ounce of prevention is worth more than a pound of cure
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: you can no longer use holodeck items to get stuck in custom vendors and do nothing else
fix: custom vendors will no longer tell you an item cant be accepted twice in a row
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
