### PR TITLE
Fix midround dynamic injection chance always proccing, another 2 year old Dynamic bug

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -647,7 +647,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		message_admins("DYNAMIC: Checking for midround injection.")
 		log_game("DYNAMIC: Checking for midround injection.")
 
-		if (get_injection_chance())
+		if (prob(get_injection_chance()))
 			var/list/drafted_rules = list()
 			for (var/datum/dynamic_ruleset/midround/rule in midround_rules)
 				if (!rule.weight)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A bug introduced 2 years ago through this diff, which I have no idea what it was doing. The developer of this hash has apparently left the SS13 development community, and so I can't ask them their reasoning behind this. `get_injection_chance()` always returns a chance, it has no RNG of its own.

https://github.com/tgstation/tgstation/pull/46027/commits/0b90ce909292cad86117d4c3133a9872553e7fbd

![image](https://user-images.githubusercontent.com/35135081/108623219-af952880-73f2-11eb-864e-f70a54bbfc5f.png)

This is something that shouldn't be taken super lightly, as Dynamic 2021 was balanced entirely around the results of actual rounds, and so it's possible with this that midround injection becomes way too uncommon. Worst case scenario, I'll adjust the timers of injection to try and get a reasonable match.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Midround dynamic injection no longer has a 100% chance of activating.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
