### PR TITLE
Makes assembly parts not fall out of their holder when picked up

### DIFF
--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -102,9 +102,9 @@
 	if(.)
 		return
 	if(a_left)
-		a_left.attack_hand(user, modifiers)
+		a_left.attack_hand()
 	if(a_right)
-		a_right.attack_hand(user, modifiers)
+		a_right.attack_hand()
 
 /obj/item/assembly_holder/screwdriver_act(mob/user, obj/item/tool)
 	if(..())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Looks like Combat Mode broke these, causing the assembly parts to drop on the ground when picking up the holder. Besides making assemblies pretty much unusable, this also allowed duping holders to some degree.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Thebleh
fix: Assembly parts no longer fall out of their holder when being picked up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
