### PR TITLE
Fixes limbs getting stuck in surgeons when they fail to attach during prosthetic replacement

### DIFF
--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -71,11 +71,12 @@
 		tool.cut_overlays()
 		tool = tool.contents[1]
 	if(istype(tool, /obj/item/bodypart) && user.temporarilyRemoveItemFromInventory(tool))
-		var/obj/item/bodypart/L = tool
-		if(!L.attach_limb(target))
-			display_results(user, target, "<span class='warning'>You fail in replacing [target]'s [parse_zone(target_zone)]! Their body has rejected [L]!</span>",
+		var/obj/item/bodypart/limb = tool
+		if(!limb.attach_limb(target))
+			display_results(user, target, "<span class='warning'>You fail in replacing [target]'s [parse_zone(target_zone)]! Their body has rejected [limb]!</span>",
 				"<span class='warning'>[user] fails to replace [target]'s [parse_zone(target_zone)]!</span>",
 				"<span class='warning'>[user] fails to replaces [target]'s [parse_zone(target_zone)]!</span>")
+			limb.forceMove(target.loc)
 			return
 		if(organ_rejection_dam)
 			target.adjustToxLoss(organ_rejection_dam)
@@ -84,13 +85,13 @@
 			"<span class='notice'>[user] successfully replaces [target]'s [parse_zone(target_zone)]!</span>")
 		return
 	else
-		var/obj/item/bodypart/L = target.newBodyPart(target_zone, FALSE, FALSE)
-		L.is_pseudopart = TRUE
-		if(!L.attach_limb(target))
-			display_results(user, target, "<span class='warning'>You fail in attaching [target]'s [parse_zone(target_zone)]! Their body has rejected [L]!</span>",
+		var/obj/item/bodypart/limb = target.newBodyPart(target_zone, FALSE, FALSE)
+		limb.is_pseudopart = TRUE
+		if(!limb.attach_limb(target))
+			display_results(user, target, "<span class='warning'>You fail in attaching [target]'s [parse_zone(target_zone)]! Their body has rejected [limb]!</span>",
 				"<span class='warning'>[user] fails to attach [target]'s [parse_zone(target_zone)]!</span>",
 				"<span class='warning'>[user] fails to attach [target]'s [parse_zone(target_zone)]!</span>")
-			L.forceMove(target.loc)
+			limb.forceMove(target.loc)
 			return
 		user.visible_message("<span class='notice'>[user] finishes attaching [tool]!</span>", "<span class='notice'>You attach [tool].</span>")
 		display_results(user, target, "<span class='notice'>You attach [tool].</span>",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a forceMove to limbs when prosthetic replacement fails so that the limb drops where the patient is instead of moving inside the surgeon.

## Why It's Good For The Game

Fixes a bug

## Changelog
:cl:
fix: When a body rejects a limb during prosthetic replacement, the limb will drop where the patient is instead of disappearing inside the surgeon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
