### PR TITLE
Adds cooldown feedback to emotes

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -82,7 +82,8 @@
 	if(!intentional)
 		return TRUE
 	if(user.emotes_used && user.emotes_used[src] + cooldown > world.time)
-		if(cooldown >= 1 SECONDS)
+		var/datum/emote/default_emote = /datum/emote
+		if(cooldown > initial(default_emote.cooldown)) // only worry about longer-than-normal emotes
 			to_chat(user, "<span class='danger'>You must wait another [DisplayTimeText(user.emotes_used[src] - world.time + cooldown)] before using that emote.</span>")
 		return FALSE
 	if(!user.emotes_used)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -82,6 +82,7 @@
 	if(!intentional)
 		return TRUE
 	if(user.emotes_used && user.emotes_used[src] + cooldown > world.time)
+		to_chat(user, "<span class='danger'>You must wait another [(user.emotes_used[src] - world.time + cooldown) * 0.1] seconds before using that emote.</span>")
 		return FALSE
 	if(!user.emotes_used)
 		user.emotes_used = list()

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -82,7 +82,8 @@
 	if(!intentional)
 		return TRUE
 	if(user.emotes_used && user.emotes_used[src] + cooldown > world.time)
-		to_chat(user, "<span class='danger'>You must wait another [(user.emotes_used[src] - world.time + cooldown) * 0.1] seconds before using that emote.</span>")
+		if(cooldown >= 1 SECONDS)
+			to_chat(user, "<span class='danger'>You must wait another [DisplayTimeText(user.emotes_used[src] - world.time + cooldown)] before using that emote.</span>")
 		return FALSE
 	if(!user.emotes_used)
 		user.emotes_used = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When I added a 3 second cooldown to the *kiss emote, some people got confused about why the emote would sometimes fail to work, because it turns out there's no message telling you an emote is on cooldown. This adds a message telling you to hold your horses a bit longer, and for how long those horses need to be held.

This message will only be displayed if it's an emote that has a cooldown of at least 1 second, because if you're managing to trigger the standard 0.8 second cooldown, you're probably just mashing a hotkey and not paying attention to the chat anyway
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Improved feedback
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
qol: Trying to use an emote while it's cooling down will now tell you how much longer you have to wait. This will only show for emotes with longer than normal wait times.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
