### PR TITLE
Changes the description of the superlingual matrix to mention attunement

### DIFF
--- a/code/modules/antagonists/abductor/equipment/orderable_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/orderable_gear.dm
@@ -47,7 +47,7 @@ GLOBAL_LIST_INIT(abductor_gear, subtypesof(/datum/abductor_gear))
 
 /datum/abductor_gear/superlingual_matrix
 	name = "Superlingual Matrix"
-	description = "A mysterious structure that allows for instant communication between users. Pretty impressive until you need to eat something."
+	description = "A mysterious structure that allows for instant communication between users. Using it inhand will attune it to your mothership's channel. Pretty impressive until you need to eat something."
 	id = "superlingual_matrix"
 	build_path = /obj/item/organ/tongue/abductor
 	category = "Advanced Gear"

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -238,7 +238,7 @@
 
 /obj/item/organ/tongue/abductor/examine(mob/M)
 	. = ..()
-	if(HAS_TRAIT(M, TRAIT_ABDUCTOR_TRAINING) || HAS_TRAIT(M.mind, TRAIT_ABDUCTOR_TRAINING) || isobserver(M))
+	if(HAS_TRAIT(M, TRAIT_ABDUCTOR_TRAINING) || (M.mind && HAS_TRAIT(M.mind, TRAIT_ABDUCTOR_TRAINING)) || isobserver(M))
 		. += "<span class='notice'>It can be attuned to a different channel by using it inhand.</span>"
 		if(!mothership)
 			. += "<span class='notice'>It is not attuned to a specific mothership.</span>"

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -239,6 +239,7 @@
 /obj/item/organ/tongue/abductor/examine(mob/M)
 	. = ..()
 	if(HAS_TRAIT(M, TRAIT_ABDUCTOR_TRAINING) || HAS_TRAIT(M.mind, TRAIT_ABDUCTOR_TRAINING) || isobserver(M))
+		. += "<span class='notice'>It can be attuned to a different channel by using it inhand.</span>"
 		if(!mothership)
 			. += "<span class='notice'>It is not attuned to a specific mothership.</span>"
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the description of the superlingual matrix to mention attunement, and how to do it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It isn't immediately obvious how the tongue is intended to be used, or how to use it, so there wasn't much of a reason for abductors to buy it. This should change that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Abductor tongues now tell you how to attune them on examine, and in the abductor shop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
