### PR TITLE
Spiders on web now ignore an absence of gravity.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -102,9 +102,7 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/poison/giant_spider/mob_negates_gravity()
-	. = ..()
-	var/obj/structure/spider/stickyweb/web = locate() in loc
-	return (. || web)
+	return ..() || (locate(/obj/structure/spider/stickyweb) in loc)
 
 /**
  * # Spider Hunter

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -101,6 +101,11 @@
 	GLOB.spidermobs -= src
 	return ..()
 
+/mob/living/simple_animal/hostile/poison/giant_spider/mob_negates_gravity()
+	. = ..()
+	var/obj/structure/spider/stickyweb/web = locate() in loc
+	return (. || web)
+
 /**
  * # Spider Hunter
  *


### PR DESCRIPTION
## About The Pull Request

Being on a web (not next to one, as is the case with rods in space) lets spiders ignore an absence of gravity.

## Why It's Good For The Game

It's in-flavor and it lets broodmothers that spawn into zero gravity lay a web to move around. Yes, I'm salty.

## Changelog
:cl:
add: Spiders on web now ignore an absence of gravity.
/:cl: