### PR TITLE
Power Sink Rebalance

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1506,7 +1506,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			load on the grid, causing a station-wide blackout. The sink is large and cannot be stored in most \
 			traditional bags and boxes. Caution: Will explode if the powernet contains sufficient amounts of energy."
 	item = /obj/item/powersink
-	cost = 10
+	player_minimum = 25
+	cost = 11
 
 /datum/uplink_item/device_tools/rad_laser
 	name = "Radioactive Microlaser"


### PR DESCRIPTION
## About The Pull Request

Adds a 25 player purchase limit to powersink and increases the cost by 1.

## Why It's Good For The Game

When I have been playing recently on lower pop I have noticed that powersinks completely kill the station and due to the fact they can be hard to find and there is less people the shuttle ends up being called ending the round, additionally if the first one is found someone could just buy another one starting the hunt all over again.

## Changelog
:cl:John Burgerman
balance: Powersink now needs 25 pop to buy and costs 1 more tc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
