### PR TITLE
IceBox space heater restoration

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -3217,6 +3217,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "akO" = (
@@ -8590,6 +8591,7 @@
 	dir = 4;
 	sortType = 17
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGH" = (
@@ -8951,6 +8953,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aIm" = (
@@ -11146,6 +11149,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"aXx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "aXz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -26079,6 +26087,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "czh" = (
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "czk" = (
@@ -29868,6 +29877,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"eVX" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "eWw" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/secure/briefcase,
@@ -31779,6 +31792,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"gmM" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "gmO" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/iron,
@@ -44081,6 +44102,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "pmJ" = (
@@ -46269,6 +46291,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "qMW" = (
@@ -47454,6 +47477,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "rFl" = (
@@ -48611,6 +48635,10 @@
 /obj/structure/chair/stool,
 /turf/open/floor/iron,
 /area/command/gateway)
+"stf" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "str" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -89037,7 +89065,7 @@ aXf
 pxI
 nkQ
 pxI
-bAw
+stf
 bAw
 hxs
 bBR
@@ -91542,7 +91570,7 @@ lLe
 hDi
 ahn
 aic
-aoJ
+aXx
 aoJ
 aoJ
 aoJ
@@ -98786,7 +98814,7 @@ beB
 bfS
 bfS
 kQk
-ipA
+eVX
 yjJ
 ipA
 iIT
@@ -98798,8 +98826,8 @@ bpJ
 buG
 bvA
 bzs
-bAw
-bAw
+stf
+stf
 bAw
 oFI
 bzs
@@ -107548,7 +107576,7 @@ cNW
 bMB
 bNA
 pmE
-nXU
+gmM
 nXU
 bSm
 nXU


### PR DESCRIPTION
## About The Pull Request

Icebox's various reworks, particularly of Science and Medbay have significantly altered its maintenance areas. They were rebuilt with a deficit of space heaters, which no one cared about or noticed because they were rarely important. Then someone went and fixed temperature so it actually moves now. 

Ice was left with a grand total of 3 space heaters between all the departments in the east wing, none of which were easily accessible. This makes it unpleasant to combat any sort of temperature loss on this map. For comparison, Meta and Delta generally have 2-4 space heaters in maint around each department.

This adds a dozen or so odd heaters to Icebox's maint, focusing on the areas that lacked them.

## Why It's Good For The Game

With Fastmos merged it's now very noticeable that Icebox does not have enough of these. Our glorious maptainer agrees.

## Changelog
:cl:
tweak: Adds a number of space heaters back to Icebox
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
