### PR TITLE
[s] Fixes maintpill farm exploit

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -55,7 +55,7 @@ GLOBAL_LIST_INIT(trash_loot, list(//junk: useless, very easy to get, or ghetto c
 		/obj/item/clothing/mask/breath = 1,
 		/obj/item/shard = 1,
 
-		/obj/item/reagent_containers/pill/maintenance = 1,
+		/obj/item/reagent_containers/pill/maintenance/achievement = 1,
 		/obj/item/toy/eightball = 1,
 		) = 8,
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -275,7 +275,7 @@
 	if(prob(30))
 		desc = pick(descs)
 
-/obj/item/reagent_containers/pill/maintenance/on_consumption(mob/M, mob/user)
+/obj/item/reagent_containers/pill/maintenance/achievement/on_consumption(mob/M, mob/user)
 	. = ..()
 
 	M.client?.give_award(/datum/award/score/maintenance_pill, M)


### PR DESCRIPTION
Honestly shame on me for thinking there was no way someone would go out of their way this much to get ridiculous scores

:cl:
fix: Only maintenance maintpills now give you maintpill score
/:cl:

(Im referring to the blackmarket being able to buy like 20 of them each round)

Leaderboard is polluted with people that abused it, but purging it wouldn't be fair for everyone either so I'm hoping it'll even out eventually

