### PR TITLE
Fix light floors

### DIFF
--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -393,9 +393,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "ni" = (
-/turf/open/floor/light/colour_cycle{
-	name = "dancefloor"
-	},
+/turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/shuttle/escape)
 "nU" = (
 /obj/structure/chair/comfy/brown{
@@ -1041,6 +1039,9 @@
 /area/shuttle/escape)
 "Iu" = (
 /obj/machinery/computer/slot_machine,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "IL" = (
@@ -1554,12 +1555,6 @@
 "WT" = (
 /turf/open/floor/wood,
 /area/shuttle/escape)
-"Xa" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/shuttle/escape)
 "Xd" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -2008,7 +2003,7 @@ KD
 Vv
 Vm
 Vm
-Xa
+WT
 WT
 NH
 NH
@@ -2103,8 +2098,8 @@ qX
 WT
 WT
 OJ
-OJ
 ni
+OJ
 WT
 uV
 uV
@@ -2148,7 +2143,7 @@ jW
 Vm
 Iu
 WT
-OJ
+ni
 OJ
 ni
 WT
@@ -2194,8 +2189,8 @@ tB
 Vm
 Iu
 WT
-ni
 OJ
+ni
 OJ
 WT
 Sp
@@ -2242,7 +2237,7 @@ WT
 WT
 ni
 OJ
-OJ
+ni
 WT
 uV
 uV
@@ -2330,7 +2325,7 @@ KD
 Kc
 Vm
 Vm
-Xa
+WT
 WT
 nU
 nU

--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -90,7 +90,7 @@
 	anchored = 1;
 	custom_materials = list(/datum/material/plasma = 100000)
 	},
-/turf/open/floor/light/colour_cycle,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/shuttle/escape)
 "r" = (
 /turf/open/floor/mineral/plasma/disco,
@@ -99,7 +99,7 @@
 /turf/open/floor/mineral/silver,
 /area/shuttle/escape)
 "t" = (
-/turf/open/floor/light/colour_cycle,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/shuttle/escape)
 "u" = (
 /obj/docking_port/mobile/emergency{
@@ -114,7 +114,7 @@
 /area/shuttle/escape)
 "v" = (
 /obj/machinery/jukebox/disco/indestructible,
-/turf/open/floor/light/colour_cycle,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/shuttle/escape)
 "w" = (
 /obj/machinery/door/airlock/gold,
@@ -217,6 +217,9 @@
 /area/shuttle/escape)
 "O" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/escape)
+"R" = (
+/turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -326,7 +329,7 @@ r
 s
 j
 t
-t
+R
 t
 j
 s
@@ -349,9 +352,9 @@ r
 j
 j
 t
-t
+R
 v
-t
+R
 t
 j
 j
@@ -374,7 +377,7 @@ r
 s
 j
 t
-t
+R
 t
 j
 s

--- a/code/game/turfs/open/floor/light_floor.dm
+++ b/code/game/turfs/open/floor/light_floor.dm
@@ -89,15 +89,15 @@
 
 	switch(state)
 		if(LIGHTFLOOR_FINE)
-			if(!cycle)
-				icon_state = "light_on-[LAZYFIND(coloredlights, currentcolor)]"
-			else
+			if(cycle)
 				if(istype(src, /turf/open/floor/light/colour_cycle/dancefloor_a))
 					icon_state = "light_on-dancefloor_A"
 				else if(istype(src, /turf/open/floor/light/colour_cycle/dancefloor_b))
 					icon_state = "light_on-dancefloor_B"
 				else
 					icon_state = "light_on-cycle_all"
+			else
+				icon_state = "light_on-[LAZYFIND(coloredlights, currentcolor)]"
 		if(LIGHTFLOOR_FLICKER)
 			icon_state = "light_on_flicker-[LAZYFIND(coloredlights, currentcolor)]"
 		if(LIGHTFLOOR_BREAKING)

--- a/code/game/turfs/open/floor/light_floor.dm
+++ b/code/game/turfs/open/floor/light_floor.dm
@@ -22,7 +22,7 @@
 	tiled_dirt = FALSE
 	///icons for radial menu
 	var/static/list/lighttile_designs
-	///used for floor light that cycle colours
+	///used for light floors that cycle colours
 	var/cycle = FALSE
 
 /turf/open/floor/light/setup_broken_states()

--- a/code/game/turfs/open/floor/light_floor.dm
+++ b/code/game/turfs/open/floor/light_floor.dm
@@ -22,6 +22,8 @@
 	tiled_dirt = FALSE
 	///icons for radial menu
 	var/static/list/lighttile_designs
+	///used for floor light that cycle colours
+	var/cycle = FALSE
 
 /turf/open/floor/light/setup_broken_states()
 	return list("light_broken")
@@ -87,7 +89,15 @@
 
 	switch(state)
 		if(LIGHTFLOOR_FINE)
-			icon_state = "light_on-[LAZYFIND(coloredlights, currentcolor)]"
+			if(!cycle)
+				icon_state = "light_on-[LAZYFIND(coloredlights, currentcolor)]"
+			else
+				if(istype(src, /turf/open/floor/light/colour_cycle/dancefloor_a))
+					icon_state = "light_on-dancefloor_A"
+				else if(istype(src, /turf/open/floor/light/colour_cycle/dancefloor_b))
+					icon_state = "light_on-dancefloor_B"
+				else
+					icon_state = "light_on-cycle_all"
 		if(LIGHTFLOOR_FLICKER)
 			icon_state = "light_on_flicker-[LAZYFIND(coloredlights, currentcolor)]"
 		if(LIGHTFLOOR_BREAKING)
@@ -102,7 +112,7 @@
 
 /turf/open/floor/light/screwdriver_act(mob/living/user, obj/item/I)
 	. = ..()
-	if(!can_modify_colour)
+	if(!can_modify_colour && !cycle)
 		return
 	on = !on
 	update_appearance()
@@ -149,25 +159,20 @@
 
 //Cycles through all of the colours
 /turf/open/floor/light/colour_cycle
-	icon_state = "cycle_all"
+	name = "dancefloor"
+	desc = "Funky floor."
+	icon_state = "light_on-cycle_all"
 	light_color = LIGHT_COLOR_SLIME_LAMP
 	can_modify_colour = FALSE
+	cycle = TRUE
 
 //Two different "dancefloor" types so that you can have a checkered pattern
 // (also has a longer delay than colour_cycle between cycling colours)
 /turf/open/floor/light/colour_cycle/dancefloor_a
-	name = "dancefloor"
-	desc = "Funky floor."
 	icon_state = "light_on-dancefloor_A"
-	light_color =LIGHT_COLOR_SLIME_LAMP
-	can_modify_colour = FALSE
 
 /turf/open/floor/light/colour_cycle/dancefloor_b
-	name = "dancefloor"
-	desc = "Funky floor."
 	icon_state = "light_on-dancefloor_B"
-	light_color = LIGHT_COLOR_SLIME_LAMP
-	can_modify_colour = FALSE
 
 /**
  * check_menu: Checks if we are allowed to interact with a radial menu


### PR DESCRIPTION
## About The Pull Request
`/turf/open/floor/light/colour_cycle` floors now cycle colours properly and you can use screwdrivers on them to turn them on and off.
Fixes #57141 

## Changelog
:cl: Dex
fix: Fixed light floors not working properly.
/:cl:
