### PR TITLE
Fixes broken bottles not splashing the poor fellow hit by said bottle

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -126,7 +126,7 @@
 	log_combat(user, target, "attacked", src)
 
 	//The reagents in the bottle splash all over the target, thanks for the idea Nodrak
-	SplashReagents(target)
+	SplashReagents(target, override_spillable = TRUE)
 
 	//Finally, smash the bottle. This kills (del) the bottle.
 	smash(target, user)
@@ -567,7 +567,7 @@
 		for(var/i in 1 to 2)
 			if(istype(target, /obj/item/storage))
 				target = target.loc
-		SplashReagents(target)
+		SplashReagents(target, override_spillable = TRUE)
 		target.fire_act()
 	qdel(src)
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -149,8 +149,8 @@
 	if(target.CanPass(src, get_turf(src)) && thrownby && HAS_TRAIT(thrownby, TRAIT_BOOZE_SLIDER))
 		. = TRUE
 
-/obj/item/reagent_containers/proc/SplashReagents(atom/target, thrown = FALSE)
-	if(!reagents || !reagents.total_volume || !spillable)
+/obj/item/reagent_containers/proc/SplashReagents(atom/target, thrown = FALSE, override_spillable = FALSE)
+	if(!reagents || !reagents.total_volume || (!spillable && !override_spillable))
 		return
 
 	if(ismob(target) && target.reagents)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#57042 reported that bottles aren't splashing people properly, so this fixes that by setting the SplashReagents() function to have a spillable override. (I think the override was added recently, and this isan oversight, since bottles don't spill?)

Though - there's nothing in the code that I can find about transferal of the bottle reagents to the recipients reagents. Did this used to happen?

## Why It's Good For The Game

Restoration of intended function to an object.

## Changelog
:cl:
fix: Fixes smashed bottles not applying their splashing effect on people
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
