### PR TITLE
Allows ghosts to start messages with asterisks in deadchat again

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -157,7 +157,7 @@
 	to_chat(src, "<span class='warning'>You cannot speak, your other self is controlling your body!</span>")
 	return FALSE
 
-/mob/living/split_personality/emote(act, m_type = null, message = null, intentional = FALSE)
+/mob/living/split_personality/emote(act, m_type = null, message = null, intentional = FALSE, force_silence = FALSE)
 	return FALSE
 
 ///////////////BRAINWASHING////////////////////

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -23,5 +23,5 @@
 /mob/camera/canUseStorage()
 	return FALSE
 
-/mob/camera/emote(act, m_type=1, message = null, intentional = FALSE)
+/mob/camera/emote(act, m_type=1, message = null, intentional = FALSE, force_silence = FALSE)
 	return FALSE

--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -1,8 +1,5 @@
 /mob/dead/observer/check_emote(message, forced)
-	if(message == "*spin" || message == "*flip")
-		emote(copytext(message, length(message[1]) + 1), intentional = !forced)
-		return TRUE
-
+	return emote(copytext(message, length(message[1]) + 1), intentional = !forced, force_silence = TRUE)
 
 //Modified version of get_message_mods, removes the trimming, the only thing we care about here is admin channels
 /mob/dead/observer/get_message_mods(message, list/mods)

--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -1,5 +1,5 @@
 /mob/dead/observer/check_emote(message, forced)
-	if(message[1] == "*")
+	if(message == "*spin" || message == "*flip")
 		emote(copytext(message, length(message[1]) + 1), intentional = !forced)
 		return TRUE
 

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -6,7 +6,7 @@
 #define BEYBLADE_CONFUSION_LIMIT 40 //A max for how penalized a carbon will be for beyblading
 
 //The code execution of the emote datum is located at code/datums/emotes.dm
-/mob/proc/emote(act, m_type = null, message = null, intentional = FALSE)
+/mob/proc/emote(act, m_type = null, message = null, intentional = FALSE, force_silence = FALSE)
 	act = lowertext(act)
 	var/param = message
 	var/custom_param = findchar(act, " ")
@@ -17,7 +17,7 @@
 	var/list/key_emotes = GLOB.emote_list[act]
 
 	if(!length(key_emotes))
-		if(intentional)
+		if(intentional && !force_silence)
 			to_chat(src, "<span class='notice'>'[act]' emote does not exist. Say *help for a list.</span>")
 		return FALSE
 	var/silenced = FALSE
@@ -28,7 +28,7 @@
 		if(P.run_emote(src, param, m_type, intentional))
 			SEND_SIGNAL(src, COMSIG_MOB_EMOTE, P, act, m_type, message, intentional)
 			return TRUE
-	if(intentional && !silenced)
+	if(intentional && !silenced && !force_silence)
 		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
 	return FALSE
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -457,7 +457,7 @@
 	return ..()
 
 
-/mob/living/simple_animal/emote(act, m_type=1, message = null, intentional = FALSE)
+/mob/living/simple_animal/emote(act, m_type=1, message = null, intentional = FALSE, force_silence = FALSE)
 	if(stat)
 		return FALSE
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
#56519 had noble goals in trying to make emote code more robust for ghosts, but in doing so it undid #47144, which was made to allow people to start messages with asterisks in deadchat without getting hassled by the game thinking you're emoting. This re-limits the emote checker to the only two emotes ghosts have ever had, *spin and *flip.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I want to fake emote in deadchat again
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
qol: Ghosts can start their messages in deadchat with asterisks again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
