### PR TITLE
Fixes missing titles of the Microscope and R&D Console UIs

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -137,7 +137,7 @@ Nothing else in the console has ID requirements.
 /obj/machinery/computer/rdconsole/ui_interact(mob/user, datum/tgui/ui = null)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if (!ui)
-		ui = new(user, src, "Techweb")
+		ui = new(user, src, "Techweb", name)
 		ui.open()
 
 /obj/machinery/computer/rdconsole/ui_assets(mob/user)

--- a/code/modules/research/xenobiology/vatgrowing/microscope.dm
+++ b/code/modules/research/xenobiology/vatgrowing/microscope.dm
@@ -18,7 +18,7 @@
 /obj/structure/microscope/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "Microscope")
+		ui = new(user, src, "Microscope", name)
 		ui.open()
 
 /obj/structure/microscope/ui_data(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR fixes a missing title headers of the Microscope and R&D Console UIs. Titles will now be derived from their object names, as is usual for a similiar UIs, in case there are differently named subtypes. Example of the fix below.

**BEFORE:**
![EmptyTitle](https://user-images.githubusercontent.com/43862960/108928463-7d7a0580-7642-11eb-9e53-d80ac8a2699b.png)

**AFTER:**
![TitleFixed](https://user-images.githubusercontent.com/43862960/108928461-7ce16f00-7642-11eb-9582-4cb8db1ecc46.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugfixes.

## Changelog
:cl: Arkatos
fix: Fixed a missing title header of the Microscope UI.
fix: Fixed a missing title header of the R&D Console UI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
