### PR TITLE
Adds ability to open firelocks with an empty hand

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -77,15 +77,15 @@
 	return FALSE
 
 /obj/machinery/door/firedoor/try_safety_unlock(mob/user)
-	if(iscarbon(user))
-		var/mob/living/carbon/carbon_user = user
-		if(world.time - carbon_user.last_bumped <= 1 SECONDS)
+	if(isliving(user))
+		var/mob/living/living_user = user
+		if(world.time - living_user.last_bumped <= 1 SECONDS)
 			return
-		carbon_user.last_bumped = world.time
-	if(density && user.get_empty_held_indexes())
-		to_chat(user, "<span class='notice'>You begin unlocking [src]'s safety mechanism...</span>")
-		if(do_after(user, hand_open_time, src))
-			try_to_crowbar(null, user)
+		living_user.last_bumped = world.time
+		if(density && living_user.get_empty_held_indexes() && !HAS_TRAIT(living_user, TRAIT_HANDS_BLOCKED))
+			to_chat(living_user, "<span class='notice'>You begin unlocking [src]'s safety mechanism...</span>")
+			if(do_after(living_user, hand_open_time, src))
+				try_to_crowbar(null, living_user)
 			return TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If you have an empty hand and walk into or click a firelock you can open it with a five second do_after. Firelocks have an examine message that explains this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fastmos often triggers firelocks across the station. This creates a great deal of frustration on behalf of the players and can lead to shuttle calls. Getting a crowbar roundstart is basically mandatory now, but not enough people have them to alleviate the issue.

This reduces the frustration of mass firelocks and the amount of resulting shuttle calls. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
balance: Firelocks can be opened with an empty hand after five seconds by walking into or clicking them now 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
