### PR TITLE
Adds a new type of botany experiment that tests plants.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -328,6 +328,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_NEEDS_TWO_HANDS "needstwohands" //The items needs two hands to be carried
 #define TRAIT_FISH_SAFE_STORAGE "fish_case" //Fish in this won't die
 #define TRAIT_FISH_CASE_COMPATIBILE "fish_case_compatibile" //Stuff that can go inside fish cases
+#define TRAIT_PLANT_WILDMUTATE "wildmutation" //Plants that were mutated as a result of passive instability, not a mutation threshold.
 
 //quirk traits
 #define TRAIT_ALCOHOL_TOLERANCE "alcohol_tolerance"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -328,7 +328,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_NEEDS_TWO_HANDS "needstwohands" //The items needs two hands to be carried
 #define TRAIT_FISH_SAFE_STORAGE "fish_case" //Fish in this won't die
 #define TRAIT_FISH_CASE_COMPATIBILE "fish_case_compatibile" //Stuff that can go inside fish cases
-#define TRAIT_PLANT_WILDMUTATE "wildmutation" //Plants that were mutated as a result of passive instability, not a mutation threshold.
+/// Plants that were mutated as a result of passive instability, not a mutation threshold.
+#define TRAIT_PLANT_WILDMUTATE "wildmutation"
 
 //quirk traits
 #define TRAIT_ALCOHOL_TOLERANCE "alcohol_tolerance"

--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -138,3 +138,16 @@
 
 /datum/experiment/scanning/random/material/hard/three
 	name = "High Grade Material Scanning Experiment Three"
+
+/datum/experiment/scanning/random/plants/wild
+	name = "Wild Biomatter Mutation Sample"
+	description = "Due to a number of reasons, (Solar Rays, a diet consisting only of unstable mutagen, entropy) plants with lower levels of instability may occasionally mutate with little reason. Scan one of these samples for us."
+	performance_hint = "\"Wild\" mutations have been recorded to occur above 30 points of instability, while species mutations occur above 60 points of instability."
+	total_requirement = 1
+
+/datum/experiment/scanning/random/plants/traits
+	name = "Unique Biomatter Mutation Sample"
+	description = "We here at centcom are on the look out for rare and exotic plants with unique properties to brag about to our shareholders. We're looking for a sample with a very specific genes currently."
+	performance_hint = "The wide varities of plants on station each carry various traits, some unique to them. Look for plants that may mutate into what we're looking for."
+	total_requirement = 3
+	possible_plant_genes = list(/datum/plant_gene/trait/squash, /datum/plant_gene/trait/cell_charge, /datum/plant_gene/trait/glow/shadow, /datum/plant_gene/trait/teleport, /datum/plant_gene/trait/brewing, /datum/plant_gene/trait/juicing, /datum/plant_gene/trait/eyes, /datum/plant_gene/trait/sticky)

--- a/code/modules/experisci/experiment/types/scanning_plants.dm
+++ b/code/modules/experisci/experiment/types/scanning_plants.dm
@@ -1,0 +1,39 @@
+/datum/experiment/scanning/random/plants
+	name = "Botanical Scanning Experiment"
+	description = "Base experiment for scanning edible plant biomass."
+	exp_tag = "Plant Biomatter Scan"
+	total_requirement = 1
+	possible_types = list(/obj/item/food/grown)
+	traits = EXPERIMENT_TRAIT_DESTRUCTIVE
+	///List of materials that can be required.
+	var/list/possible_plant_genes = list()
+	///List of materials actually required, indexed by the atom that is required.
+	var/list/required_genes = list()
+
+/datum/experiment/scanning/random/plants/New()
+	. = ..()
+	if(possible_plant_genes.len)
+		for(var/req_atom in required_atoms)
+			var/chosen_gene = pick(possible_plant_genes)
+			required_genes[req_atom] = chosen_gene
+
+/datum/experiment/scanning/random/plants/serialize_progress_stage(atom/target, list/seen_instances)
+	return EXPERIMENT_PROG_INT("Scan samples of \a harvested plant.", \
+		traits & EXPERIMENT_TRAIT_DESTRUCTIVE ? scanned[target] : seen_instances.len, required_atoms[target])
+
+/datum/experiment/scanning/random/plants/traits/final_contributing_index_checks(atom/target, typepath)
+	if(!istype(target, /obj/item/food/grown))
+		return FALSE
+	var/obj/item/food/grown/crop = target
+	if(possible_plant_genes.len)
+		return ..() && crop?.seed.get_gene(required_genes[typepath])
+	return ..()
+
+/datum/experiment/scanning/random/plants/traits/serialize_progress_stage(atom/target, list/seen_instances)
+	if(possible_plant_genes.len)
+		var/datum/plant_gene/gene = required_genes[target]
+		return EXPERIMENT_PROG_INT("Scan samples of harvested plants with the trait: [initial(gene.name)].", \
+			traits & EXPERIMENT_TRAIT_DESTRUCTIVE ? scanned[target] : seen_instances.len, required_atoms[target])
+
+/datum/experiment/scanning/random/plants/wild/final_contributing_index_checks(atom/target, typepath)
+	return ..() && HAS_TRAIT(target, TRAIT_PLANT_WILDMUTATE)

--- a/code/modules/experisci/experiment/types/scanning_plants.dm
+++ b/code/modules/experisci/experiment/types/scanning_plants.dm
@@ -5,9 +5,9 @@
 	total_requirement = 1
 	possible_types = list(/obj/item/food/grown)
 	traits = EXPERIMENT_TRAIT_DESTRUCTIVE
-	///List of materials that can be required.
+	///List of possible plant genes the experiment may ask for.
 	var/list/possible_plant_genes = list()
-	///List of materials actually required, indexed by the atom that is required.
+	///List of plant genes actually required, indexed by the atom that is required.
 	var/list/required_genes = list()
 
 /datum/experiment/scanning/random/plants/New()
@@ -26,7 +26,7 @@
 		return FALSE
 	var/obj/item/food/grown/crop = target
 	if(possible_plant_genes.len)
-		return ..() && crop?.seed.get_gene(required_genes[typepath])
+		return ..() && crop.seed.get_gene(required_genes[typepath])
 	return ..()
 
 /datum/experiment/scanning/random/plants/traits/serialize_progress_stage(atom/target, list/seen_instances)

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -231,6 +231,7 @@
 					t_prod.seed.genes += trait
 			t_prod.transform = initial(t_prod.transform)
 			t_prod.transform *= TRANSFORM_USING_VARIABLE(t_prod.seed.potency, 100) + 0.5
+			ADD_TRAIT(t_prod, TRAIT_PLANT_WILDMUTATE, user)
 			t_amount++
 			if(t_prod.seed)
 				t_prod.seed.set_instability(round(instability * 0.5))

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -116,8 +116,8 @@
 	description = "When evolution isn't fast enough."
 	prereq_ids = list("adv_surgery")
 	design_ids = list("surgery_pacify","surgery_vein_thread","surgery_muscled_veins","surgery_nerve_splice","surgery_nerve_ground","surgery_ligament_hook","surgery_ligament_reinforcement","surgery_cortex_imprint","surgery_cortex_folding","surgery_viral_bond", "surgery_heal_combo_upgrade")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
-	discount_experiments = list(/datum/experiment/scanning/random/plants/traits = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+	discount_experiments = list(/datum/experiment/scanning/random/plants/traits = 4500)
 
 /datum/techweb_node/alien_surgery
 	id = "alien_surgery"
@@ -523,8 +523,8 @@
 	description = "Botanical tools"
 	prereq_ids = list("adv_engi", "biotech")
 	design_ids = list("portaseeder", "flora_gun", "hydro_tray", "biogenerator", "seed_extractor")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-	discount_experiments = list(/datum/experiment/scanning/random/plants/wild = 1500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
+	discount_experiments = list(/datum/experiment/scanning/random/plants/wild = 3000)
 
 /datum/techweb_node/exp_tools
 	id = "exp_tools"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -117,6 +117,7 @@
 	prereq_ids = list("adv_surgery")
 	design_ids = list("surgery_pacify","surgery_vein_thread","surgery_muscled_veins","surgery_nerve_splice","surgery_nerve_ground","surgery_ligament_hook","surgery_ligament_reinforcement","surgery_cortex_imprint","surgery_cortex_folding","surgery_viral_bond", "surgery_heal_combo_upgrade")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	discount_experiments = list(/datum/experiment/scanning/random/plants/traits = 2500)
 
 /datum/techweb_node/alien_surgery
 	id = "alien_surgery"
@@ -523,6 +524,7 @@
 	prereq_ids = list("adv_engi", "biotech")
 	design_ids = list("portaseeder", "flora_gun", "hydro_tray", "biogenerator", "seed_extractor")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	discount_experiments = list(/datum/experiment/scanning/random/plants/wild = 1500)
 
 /datum/techweb_node/exp_tools
 	id = "exp_tools"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2061,6 +2061,7 @@
 #include "code\modules\experisci\experiment\types\random_scanning.dm"
 #include "code\modules\experisci\experiment\types\scanning.dm"
 #include "code\modules\experisci\experiment\types\scanning_material.dm"
+#include "code\modules\experisci\experiment\types\scanning_plants.dm"
 #include "code\modules\experisci\experiment\types\scanning_points.dm"
 #include "code\modules\experisci\experiment\types\scanning_vatgrown.dm"
 #include "code\modules\fields\fields.dm"


### PR DESCRIPTION
## About The Pull Request

Adds two new experiments, the plant trait experiment and the wild mutation plant experiment which boosts experimental surgery and the botany node respectively.

The wild mutation experiment is rather simple, and actually helps teach players on how to use wild experiments in order to get free mutations out of plants without having to fiddle with instability for as long. Just go and use the deconstructive scanner (which is a public machine on each map) with a plant that was mutated with this method, and the botany node is now cheaper.

The plant trait experiment looks for a few plants with a collection of random traits, all selected from some of the harder traits to aquire. You might need to acquire some plants with googly eyes, or shadowshrooms, or perhaps even prickly adhesion. Regardless, any plant with one of the requested traits will be all it takes, and it boosts the surgery node.

## Why It's Good For The Game

This gives botany another way to interact with the crew, makes their own stuff a little cheaper if science is being cheapstakes, and gives a neat framework to enable botany to hit unique milestones within the round to benefit the rest of the crew. More per-round engagement and inter-departmental cooperation creates a more lively round. Plus it gives the new and old botany powergamers something to do that isn't feeding toxic soybeans into the tapwater.

## Changelog
:cl:
add: There are now two experiments that botany can perform that boosts botany tech and experimental surgery.
/:cl:
