### PR TITLE
Combo streaks (not just the hud icons) now reset after half a dozen seconds (amount subject to change).

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -750,7 +750,7 @@
 	icon_state = ""
 
 /atom/movable/screen/combo/update_icon_state(streak = "", time = 2 SECONDS)
-	clear_streak()
+	reset_icons()
 	if(timerid)
 		deltimer(timerid)
 	alpha = 255

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -742,16 +742,21 @@
 	var/timerid
 
 /atom/movable/screen/combo/proc/clear_streak()
+	animate(src, alpha = 0, 2 SECONDS, SINE_EASING)
+	timerid = addtimer(CALLBACK(src, .proc/reset_icons), 2 SECONDS, TIMER_UNIQUE | TIMER_STOPPABLE)
+
+/atom/movable/screen/combo/proc/reset_icons()
 	cut_overlays()
 	icon_state = ""
 
-/atom/movable/screen/combo/update_icon_state(streak = "")
+/atom/movable/screen/combo/update_icon_state(streak = "", time = 2 SECONDS)
 	clear_streak()
 	if(timerid)
 		deltimer(timerid)
+	alpha = 255
 	if(!streak)
 		return ..()
-	timerid = addtimer(CALLBACK(src, .proc/clear_streak), 20, TIMER_UNIQUE | TIMER_STOPPABLE)
+	timerid = addtimer(CALLBACK(src, .proc/clear_streak), time, TIMER_UNIQUE | TIMER_STOPPABLE)
 	icon_state = "combo"
 	for(var/i = 1; i <= length(streak); ++i)
 		var/intent_text = copytext(streak, i, i + 1)

--- a/code/datums/martial/_martial.dm
+++ b/code/datums/martial/_martial.dm
@@ -11,6 +11,8 @@
 	var/smashes_tables = FALSE //If the martial art smashes tables when performing table slams and head smashes
 	var/datum/weakref/holder //owner of the martial art
 	var/display_combos = FALSE //shows combo meter if true
+	var/combo_timer = 5 SECONDS // period of time after which the combo streak is reset.
+	var/timerid
 
 /datum/martial_art/proc/help_act(mob/living/A, mob/living/D)
 	return FALSE
@@ -35,13 +37,17 @@
 		streak = copytext(streak, 1 + length(streak[1]))
 	if (display_combos)
 		var/mob/living/holder_living = holder.resolve()
-		holder_living?.hud_used?.combo_display.update_icon_state(streak)
+		timerid = addtimer(CALLBACK(src, .proc/reset_streak, null, FALSE), combo_timer, TIMER_UNIQUE | TIMER_STOPPABLE)
+		holder_living?.hud_used?.combo_display.update_icon_state(streak, combo_timer - 2 SECONDS)
 
-/datum/martial_art/proc/reset_streak(mob/living/new_target)
+/datum/martial_art/proc/reset_streak(mob/living/new_target, update_icon = TRUE)
+	if(timerid)
+		deltimer(timerid)
 	current_target = new_target
 	streak = ""
-	var/mob/living/holder_living = holder.resolve()
-	holder_living?.hud_used?.combo_display.update_icon_state(streak)
+	if(update_icon)
+		var/mob/living/holder_living = holder?.resolve()
+		holder_living?.hud_used?.combo_display.update_icon_state(streak)
 
 /datum/martial_art/proc/teach(mob/living/holder_living, make_temporary=FALSE)
 	if(!istype(holder_living) || !holder_living.mind)

--- a/code/datums/martial/_martial.dm
+++ b/code/datums/martial/_martial.dm
@@ -11,7 +11,7 @@
 	var/smashes_tables = FALSE //If the martial art smashes tables when performing table slams and head smashes
 	var/datum/weakref/holder //owner of the martial art
 	var/display_combos = FALSE //shows combo meter if true
-	var/combo_timer = 5 SECONDS // period of time after which the combo streak is reset.
+	var/combo_timer = 6 SECONDS // period of time after which the combo streak is reset.
 	var/timerid
 
 /datum/martial_art/proc/help_act(mob/living/A, mob/living/D)


### PR DESCRIPTION
## About The Pull Request
Exactly what it says on the tin. I won't debate about it too much, but as it has been said in #56826, it's, while goofy in hindsight, though not as much as screen-wide gibs streak, a consistency issue.
The exact value of the combo timer might be changed later. In fact, I made it a variable so it can be adjusted item-by-item, but I believe 6 seconds - **keep in mind the timer replenishes each time an unarmed act, minus help intent, is performed** - are a pretty ample fraction of time, enough to perform even the most arduous plasmafist combos - which are actually only three; the longest a mere five steps split between two intents -, let alone a simple jab.

## Why It's Good For The Game
This will fix #56826.

## Changelog
:cl:
fix: combo streaks now reset after a while (default to 6 seconds), and not just visually, if no unarmed action is performed during that time period. Also, the combo hud now fades out, starting 2 seconds before the timed combo streak reset. Of course, the animation is halted and the opaqueness restored when the aforementioned "countdown" is interrupted.
/:cl:
