### PR TITLE
Fix paper carbon invisibility and duplication

### DIFF
--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -7,21 +7,19 @@
 	var/iscopy = FALSE
 
 /obj/item/paper/carbon/update_icon_state()
-	if(info)
-		icon_state = "[icon_state]_words"
-		return ..()
 	if(iscopy)
 		icon_state = "cpaper"
-		return ..()
-	if(copied)
+	else if(copied)
 		icon_state = "paper"
-		return ..()
-
-	icon_state = "paper_stack"
-	return ..()
+	else
+		icon_state = "paper_stack"
+	if(info)
+		icon_state = "[icon_state]_words"
 
 /obj/item/paper/carbon/proc/removecopy(mob/living/user)
-	if(!copied)
+	if(copied || iscopy)
+		to_chat(user, "<span class='notice'>There are no more carbon copies attached to this paper!</span>")
+	else
 		var/obj/item/paper/carbon/C = src
 		var/copycontents = C.info
 		var/obj/item/paper/carbon/Copy = new /obj/item/paper/carbon(user.loc)
@@ -38,8 +36,6 @@
 		Copy.update_icon_state()
 		C.update_icon_state()
 		user.put_in_hands(Copy)
-	else
-		to_chat(user, "<span class='notice'>There are no more carbon copies attached to this paper!</span>")
 
 /obj/item/paper/carbon/attack_hand(mob/living/user, list/modifiers)
 	if(loc == user && user.is_holding(src))

--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -15,6 +15,7 @@
 		icon_state = "paper_stack"
 	if(info)
 		icon_state = "[icon_state]_words"
+	return ..()
 
 /obj/item/paper/carbon/proc/removecopy(mob/living/user)
 	if(copied || iscopy)

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -30,6 +30,8 @@
 		newPaper.forceMove(src)
 	else
 		internalPaper = new(src)
+	if(internalPaper.icon_state == "cpaper" || internalPaper.icon_state == "cpaper_words")
+		icon_state = "paperplane_carbon" // It's the purple carbon copy. Use the purple paper plane
 	update_appearance()
 
 /obj/item/paperplane/Exited(atom/movable/AM, atom/newLoc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Fixes sheets of carbon being invisible when copied
- Fixes allowing infinite copies
- Use carbon's paper plane icon when appropriate
- Closes #57094
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes an important part of the HoP's arsenal.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: mozi_h
fix: Sheets of carbon will no longer be infinite or invisible when copying.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
