### PR TITLE
Jukeboxes and disco balls are no longer invisible

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -80,7 +80,7 @@
 	return ..()
 
 /obj/machinery/jukebox/update_icon_state()
-	icon_state = "[initial(icon_state)]-[active ? "active" : null]"
+	icon_state = "[initial(icon_state)][active ? "-active" : null]"
 	return ..()
 
 /obj/machinery/jukebox/ui_status(mob/user)


### PR DESCRIPTION
## About The Pull Request
Jukeboxes and disco balls used to be invisible because `jukebox/update_icon_state()` would set the `icon_state` to "disco-" or "jukebox-" which are not valid icons.

## Changelog
:cl: Dex
fix: Jukeboxes and disco balls are no longer invisible.
/:cl:
