### PR TITLE
Improves throat slitting combat log messages

### DIFF
--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -62,7 +62,7 @@
 					"<span class='hear'>You hear a cutting noise!</span>", ignored_mobs = H)
 	H.show_message("<span class='userdanger'>Your throat is being slit by [user]!</span>", MSG_VISUAL, \
 					"<span class = 'userdanger'>Something is cutting into your neck!</span>", NONE)
-	log_combat(user, H, "starts slicing the throat of")
+	log_combat(user, H, "attempted throat slitting with [source.name]")
 
 	playsound(H.loc, butcher_sound, 50, TRUE, -1)
 	if(do_mob(user, H, clamp(500 / source.force, 30, 100)) && H.Adjacent(source))
@@ -73,7 +73,7 @@
 
 		H.visible_message("<span class='danger'>[user] slits [H]'s throat!</span>", \
 					"<span class='userdanger'>[user] slits your throat...</span>")
-		log_combat(user, H, "finishes slicing the throat of")
+		log_combat(user, H, "wounded by throat slitting with [source.name]")
 		H.apply_damage(source.force, BRUTE, BODY_ZONE_HEAD, wound_bonus=CANT_WOUND) // easy tiger, we'll get to that in a sec
 		var/obj/item/bodypart/slit_throat = H.get_bodypart(BODY_ZONE_HEAD)
 		if(slit_throat)

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -62,7 +62,7 @@
 					"<span class='hear'>You hear a cutting noise!</span>", ignored_mobs = H)
 	H.show_message("<span class='userdanger'>Your throat is being slit by [user]!</span>", MSG_VISUAL, \
 					"<span class = 'userdanger'>Something is cutting into your neck!</span>", NONE)
-	log_combat(user, H, "attempted throat slitting with [source.name]")
+	log_combat(user, H, "attempted throat slitting", source)
 
 	playsound(H.loc, butcher_sound, 50, TRUE, -1)
 	if(do_mob(user, H, clamp(500 / source.force, 30, 100)) && H.Adjacent(source))
@@ -73,7 +73,7 @@
 
 		H.visible_message("<span class='danger'>[user] slits [H]'s throat!</span>", \
 					"<span class='userdanger'>[user] slits your throat...</span>")
-		log_combat(user, H, "wounded by throat slitting with [source.name]")
+		log_combat(user, H, "wounded via throat slitting", source)
 		H.apply_damage(source.force, BRUTE, BODY_ZONE_HEAD, wound_bonus=CANT_WOUND) // easy tiger, we'll get to that in a sec
 		var/obj/item/bodypart/slit_throat = H.get_bodypart(BODY_ZONE_HEAD)
 		if(slit_throat)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/57170
Just changes the message given

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/51932756/109073963-52c89500-76b4-11eb-8617-bc9e732d63a0.png)
It's less confusing to read, and tells you what was being used as well

## Changelog
:cl:
spellcheck: Throat slitting combat logs are easier to understand
/:cl:
