### PR TITLE
Fixes virology stat bonuses and fixes narcolepsy

### DIFF
--- a/code/datums/diseases/advance/symptoms/beard.dm
+++ b/code/datums/diseases/advance/symptoms/beard.dm
@@ -30,7 +30,8 @@ BONUS
 	var/list/beard_order = list("Beard (Jensen)", "Beard (Full)", "Beard (Dwarf)", "Beard (Very Long)")
 
 /datum/symptom/beard/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	if(ishuman(M))

--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -34,16 +34,18 @@ Bonus
 	)
 
 /datum/symptom/choking/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stage_rate"] >= 8)
+	if(A.totalStageSpeed() >= 8)
 		symptom_delay_min = 7
 		symptom_delay_max = 24
-	if(A.properties["stealth"] >= 4)
+	if(A.totalStealth() >= 4)
 		suppress_warning = TRUE
 
 /datum/symptom/choking/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)
@@ -108,15 +110,17 @@ Bonus
 
 
 /datum/symptom/asphyxiation/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stage_rate"] >= 8)
+	if(A.totalStageSpeed() >= 8)
 		paralysis = TRUE
-	if(A.properties["transmittable"] >= 8)
+	if(A.totalTransmittable() >= 8)
 		power = 2
 
 /datum/symptom/asphyxiation/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)

--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -35,13 +35,14 @@ Bonus
 	)
 
 /datum/symptom/confusion/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["resistance"] >= 6)
+	if(A.totalResistance() >= 6)
 		brain_damage = TRUE
-	if(A.properties["transmittable"] >= 6)
+	if(A.totalTransmittable() >= 6)
 		power = 1.5
-	if(A.properties["stealth"] >= 4)
+	if(A.totalStealth() >= 4)
 		suppress_warning = TRUE
 
 /datum/symptom/confusion/End(datum/disease/advance/A)
@@ -49,7 +50,8 @@ Bonus
 	return ..()
 
 /datum/symptom/confusion/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -39,21 +39,23 @@ BONUS
 	)
 
 /datum/symptom/cough/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stealth"] >= 4)
+	if(A.totalStealth() >= 4)
 		suppress_warning = TRUE
-	if(A.properties["transmittable"] >= 7)
+	if(A.totalTransmittable() >= 7)
 		spread_range = 2
-	if(A.properties["resistance"] >= 11) //strong enough to drop items
+	if(A.totalResistance() >= 11) //strong enough to drop items
 		power = 1.5
-	if(A.properties["resistance"] >= 15) //strong enough to stun (occasionally)
+	if(A.totalResistance() >= 15) //strong enough to stun (occasionally)
 		power = 2
-	if(A.properties["stage_rate"] >= 6) //cough more often
+	if(A.totalStageSpeed() >= 6) //cough more often
 		symptom_delay_max = 10
 
 /datum/symptom/cough/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	if(HAS_TRAIT(M, TRAIT_SOOTHED_THROAT))

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -34,15 +34,17 @@ Bonus
 	)
 
 /datum/symptom/deafness/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stealth"] >= 4)
+	if(A.totalStealth() >= 4)
 		suppress_warning = TRUE
-	if(A.properties["resistance"] >= 9) //permanent deafness
+	if(A.totalResistance() >= 9) //permanent deafness
 		power = 2
 
 /datum/symptom/deafness/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	var/obj/item/organ/ears/ears = M.getorganslot(ORGAN_SLOT_EARS)

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -33,15 +33,17 @@ Bonus
 	)
 
 /datum/symptom/dizzy/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stealth"] >= 4)
+	if(A.totalStealth() >= 4)
 		suppress_warning = TRUE
-	if(A.properties["transmittable"] >= 6) //druggy
+	if(A.totalTransmittable() >= 6) //druggy
 		power = 2
 
 /datum/symptom/dizzy/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)

--- a/code/datums/diseases/advance/symptoms/fever.dm
+++ b/code/datums/diseases/advance/symptoms/fever.dm
@@ -36,16 +36,18 @@ Bonus
 	)
 
 /datum/symptom/fever/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["resistance"] >= 5) //dangerous fever
+	if(A.totalResistance() >= 5) //dangerous fever
 		power = 1.5
 		unsafe = TRUE
-	if(A.properties["resistance"] >= 10)
+	if(A.totalResistance() >= 10)
 		power = 2.5
 
 /datum/symptom/fever/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	if(!unsafe || A.stage < 4)

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -37,19 +37,21 @@ Bonus
 	)
 
 /datum/symptom/fire/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stage_rate"] >= 4)
+	if(A.totalStageSpeed() >= 4)
 		power = 1.5
-	if(A.properties["stage_rate"] >= 8)
+	if(A.totalStageSpeed() >= 8)
 		power = 2
-	if(A.properties["stealth"] >= 4)
+	if(A.totalStealth() >= 4)
 		suppress_warning = TRUE
-	if(A.properties["transmittable"] >= 8) //burning skin spreads the virus through smoke
+	if(A.totalTransmittable() >= 8) //burning skin spreads the virus through smoke
 		infective = TRUE
 
 /datum/symptom/fire/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)
@@ -121,19 +123,21 @@ Bonus
 	)
 
 /datum/symptom/alkali/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["resistance"] >= 9) //intense but sporadic effect
+	if(A.totalResistance() >= 9) //intense but sporadic effect
 		power = 2
 		symptom_delay_min = 50
 		symptom_delay_max = 140
-	if(A.properties["stage_rate"] >= 8) //serious boom when wet
+	if(A.totalStageSpeed() >= 8) //serious boom when wet
 		explosion_power = 2
-	if(A.properties["transmittable"] >= 8) //extra chemicals
+	if(A.totalTransmittable() >= 8) //extra chemicals
 		chems = TRUE
 
 /datum/symptom/alkali/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -36,15 +36,17 @@ Bonus
 	)
 
 /datum/symptom/flesh_eating/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["resistance"] >= 7) //extra bleeding
+	if(A.totalResistance() >= 7) //extra bleeding
 		bleed = TRUE
-	if(A.properties["transmittable"] >= 8) //extra stamina damage
+	if(A.totalTransmittable() >= 8) //extra stamina damage
 		pain = TRUE
 
 /datum/symptom/flesh_eating/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)
@@ -105,15 +107,17 @@ Bonus
 	)
 
 /datum/symptom/flesh_death/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stealth"] >= 5)
+	if(A.totalStealth() >= 5)
 		suppress_warning = TRUE
-	if(A.properties["stage_rate"] >= 7) //bleeding and hunger
+	if(A.totalStageSpeed() >= 7) //bleeding and hunger
 		chems = TRUE
 
 /datum/symptom/flesh_death/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)

--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -38,20 +38,22 @@ Bonus
 	)
 
 /datum/symptom/genetic_mutation/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stealth"] >= 5) //only give them bad mutations
+	if(A.totalStealth() >= 5) //only give them bad mutations
 		excludemuts = POSITIVE
-	if(A.properties["stage_rate"] >= 10) //activate dormant mutations more often at around 1.5x the pace
-		symptom_delay_min = 20 
+	if(A.totalStageSpeed() >= 10) //activate dormant mutations more often at around 1.5x the pace
+		symptom_delay_min = 20
 		symptom_delay_max = 40
-	if(A.properties["resistance"] >= 8) //mutadone won't save you now
+	if(A.totalResistance() >= 8) //mutadone won't save you now
 		mutadone_proof = (NEGATIVE | MINOR_NEGATIVE)
-	if(A.properties["resistance"] >= 14) //one does not simply escape Nurgle's grasp
+	if(A.totalResistance() >= 14) //one does not simply escape Nurgle's grasp
 		no_reset = TRUE
 
 /datum/symptom/genetic_mutation/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/carbon/C = A.affected_mob
 	if(!C.has_dna())
@@ -62,7 +64,8 @@ Bonus
 			C.easy_randmut((NEGATIVE | MINOR_NEGATIVE | POSITIVE) - excludemuts, TRUE, TRUE, TRUE, mutadone_proof)
 
 /datum/symptom/genetic_mutation/End(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(!no_reset)
 		var/mob/living/carbon/M = A.affected_mob

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -34,16 +34,18 @@ Bonus
 	)
 
 /datum/symptom/hallucigen/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stealth"] >= 4) //fake good symptom messages
+	if(A.totalStealth() >= 4) //fake good symptom messages
 		fake_healthy = TRUE
 		base_message_chance = 50
-	if(A.properties["stage_rate"] >= 7) //stronger hallucinations
+	if(A.totalStageSpeed() >= 7) //stronger hallucinations
 		power = 2
 
 /datum/symptom/hallucigen/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	var/list/healthy_messages = list("Your lungs feel great.", "You realize you haven't been breathing.", "You don't feel the need to breathe.",\

--- a/code/datums/diseases/advance/symptoms/headache.dm
+++ b/code/datums/diseases/advance/symptoms/headache.dm
@@ -36,19 +36,21 @@ BONUS
 	)
 
 /datum/symptom/headache/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stealth"] >= 4)
+	if(A.totalStealth() >= 4)
 		base_message_chance = 50
-	if(A.properties["stage_rate"] >= 6) //severe pain
+	if(A.totalStageSpeed() >= 6) //severe pain
 		power = 2
-	if(A.properties["stage_rate"] >= 9) //cluster headaches
+	if(A.totalStageSpeed() >= 9) //cluster headaches
 		symptom_delay_min = 30
 		symptom_delay_max = 60
 		power = 3
 
 /datum/symptom/headache/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	if(power < 2)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -16,13 +16,15 @@
 	)
 
 /datum/symptom/heal/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stage_rate"] >= 6) //stronger healing
+	if(A.totalStageSpeed() >= 6) //stronger healing
 		power = 2
 
 /datum/symptom/heal/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)
@@ -62,11 +64,12 @@
 	)
 
 /datum/symptom/heal/starlight/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["transmittable"] >= 6)
+	if(A.totalTransmittable() >= 6)
 		nearspace_penalty = 1
-	if(A.properties["stage_rate"] >= 6)
+	if(A.totalStageSpeed() >= 6)
 		power = 2
 
 /datum/symptom/heal/starlight/CanHeal(datum/disease/advance/A)
@@ -115,11 +118,12 @@
 	)
 
 /datum/symptom/heal/chem/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stage_rate"] >= 6)
+	if(A.totalStageSpeed() >= 6)
 		food_conversion = TRUE
-	if(A.properties["resistance"] >= 7)
+	if(A.totalResistance() >= 7)
 		power = 2
 
 /datum/symptom/heal/chem/Heal(mob/living/M, datum/disease/advance/A, actual_power)
@@ -150,11 +154,12 @@
 	)
 
 /datum/symptom/heal/metabolism/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stage_rate"] >= 10)
+	if(A.totalStageSpeed() >= 10)
 		triple_metabolism = TRUE
-	if(A.properties["stealth"] >= 3)
+	if(A.totalStealth() >= 3)
 		reduced_hunger = TRUE
 
 /datum/symptom/heal/metabolism/Heal(mob/living/carbon/C, datum/disease/advance/A, actual_power)
@@ -183,9 +188,10 @@
 	)
 
 /datum/symptom/heal/darkness/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stage_rate"] >= 8)
+	if(A.totalStageSpeed() >= 8)
 		power = 2
 
 /datum/symptom/heal/darkness/CanHeal(datum/disease/advance/A)
@@ -237,17 +243,19 @@
 	)
 
 /datum/symptom/heal/coma/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stage_rate"] >= 7)
+	if(A.totalStageSpeed() >= 7)
 		power = 1.5
-	if(A.properties["resistance"] >= 4)
+	if(A.totalResistance() >= 4)
 		stabilize = TRUE
-	if(A.properties["stealth"] >= 2)
+	if(A.totalStealth() >= 2)
 		deathgasp = TRUE
 
 /datum/symptom/heal/coma/on_stage_change(datum/disease/advance/A)  //mostly copy+pasted from the code for self-respiration's TRAIT_NOBREATH stuff
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 	if(A.stage >= 4 && stabilize)
 		ADD_TRAIT(A.affected_mob, TRAIT_NOCRITDAMAGE, DISEASE_TRAIT)
@@ -256,7 +264,8 @@
 	return TRUE
 
 /datum/symptom/heal/coma/End(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	if(active_coma)
 		uncoma()
@@ -329,11 +338,12 @@
 	)
 
 /datum/symptom/heal/water/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stage_rate"] >= 7)
+	if(A.totalStageSpeed() >= 7)
 		power = 2
-	if(A.properties["resistance"] >= 5)
+	if(A.totalResistance() >= 5)
 		absorption_coeff = 0.25
 
 /datum/symptom/heal/water/CanHeal(datum/disease/advance/A)
@@ -387,11 +397,12 @@
 	)
 
 /datum/symptom/heal/plasma/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stage_rate"] >= 7)
+	if(A.totalStageSpeed() >= 7)
 		power = 2
-	if(A.properties["transmittable"] >= 6)
+	if(A.totalTransmittable() >= 6)
 		temp_rate = 4
 
 /datum/symptom/heal/plasma/CanHeal(datum/disease/advance/A)
@@ -457,11 +468,12 @@
 	)
 
 /datum/symptom/heal/radiation/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["resistance"] >= 7)
+	if(A.totalResistance() >= 7)
 		power = 2
-	if(A.properties["transmittable"] >= 6)
+	if(A.totalTransmittable() >= 6)
 		cellular_damage = TRUE
 
 /datum/symptom/heal/radiation/CanHeal(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/itching.dm
+++ b/code/datums/diseases/advance/symptoms/itching.dm
@@ -35,16 +35,18 @@ BONUS
 	)
 
 /datum/symptom/itching/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["transmittable"] >= 6) //itch more often
+	if(A.totalTransmittable() >= 6) //itch more often
 		symptom_delay_min = 1
 		symptom_delay_max = 4
-	if(A.properties["stage_rate"] >= 7) //scratch
+	if(A.totalStageSpeed() >= 7) //scratch
 		scratch = TRUE
 
 /datum/symptom/itching/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	var/picked_bodypart = pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG)

--- a/code/datums/diseases/advance/symptoms/nanites.dm
+++ b/code/datums/diseases/advance/symptoms/nanites.dm
@@ -16,22 +16,24 @@
 	)
 
 /datum/symptom/nano_boost/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["transmittable"] >= 5) //reverse boost
+	if(A.totalTransmittable() >= 5) //reverse boost
 		reverse_boost = TRUE
-	if(A.properties["stage_rate"] >= 7) //more nanites
+	if(A.totalStageSpeed() >= 7) //more nanites
 		power = 2
 
 /datum/symptom/nano_boost/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	SEND_SIGNAL(M, COMSIG_NANITE_ADJUST_VOLUME, 0.5 * power)
 	if(reverse_boost && SEND_SIGNAL(M, COMSIG_HAS_NANITES))
 		if(prob(A.stage_prob))
 			A.stage = min(A.stage + 1,A.max_stages)
-			
+
 /datum/symptom/nano_destroy
 	name = "Silicolysis"
 	desc = "The virus reacts to nanites in the host's bloodstream by attacking and consuming them."
@@ -50,15 +52,17 @@
 	)
 
 /datum/symptom/nano_destroy/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stage_rate"] >= 5) //reverse boost
+	if(A.totalStageSpeed() >= 5) //reverse boost
 		reverse_boost = TRUE
-	if(A.properties["resistance"] >= 7) //more nanites
+	if(A.totalResistance() >= 7) //more nanites
 		power = 3
 
 /datum/symptom/nano_destroy/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	SEND_SIGNAL(M, COMSIG_NANITE_ADJUST_VOLUME, -0.4 * power)

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -30,11 +30,12 @@ Bonus
 	)
 
 /datum/symptom/narcolepsy/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["transmittable"] >= 4) //yawning (mostly just some copy+pasted code from sneezing, with a few tweaks)
+	if(A.totalTransmittable() >= 4) //yawning (mostly just some copy+pasted code from sneezing, with a few tweaks)
 		yawning = TRUE
-	if(A.properties["stage_speed"] >= 10) //act more often
+	if(A.totalStageSpeed() >= 10) //act more often
 		symptom_delay_min = 20
 		symptom_delay_max = 45
 

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -33,13 +33,15 @@ Bonus
 	)
 
 /datum/symptom/oxygen/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["resistance"] >= 8) //blood regeneration
+	if(A.totalResistance() >= 8) //blood regeneration
 		regenerate_blood = TRUE
 
 /datum/symptom/oxygen/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
@@ -54,7 +56,8 @@ Bonus
 	return
 
 /datum/symptom/oxygen/on_stage_change(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 	var/mob/living/carbon/M = A.affected_mob
 	if(A.stage >= 4)
@@ -64,6 +67,7 @@ Bonus
 	return TRUE
 
 /datum/symptom/oxygen/End(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	REMOVE_TRAIT(A.affected_mob, TRAIT_NOBREATH, DISEASE_TRAIT)

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -18,17 +18,19 @@
 	)
 
 /datum/symptom/mind_restoration/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["resistance"] >= 6) //heal brain damage
+	if(A.totalResistance() >= 6) //heal brain damage
 		trauma_heal_mild = TRUE
-	if(A.properties["resistance"] >= 9) //heal severe traumas
+	if(A.totalResistance() >= 9) //heal severe traumas
 		trauma_heal_severe = TRUE
-	if(A.properties["transmittable"] >= 8) //purge alcohol
+	if(A.totalTransmittable() >= 8) //purge alcohol
 		purge_alcohol = TRUE
 
 /datum/symptom/mind_restoration/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 
@@ -77,7 +79,8 @@
 	symptom_delay_max = 1
 
 /datum/symptom/sensory_restoration/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)

--- a/code/datums/diseases/advance/symptoms/shedding.dm
+++ b/code/datums/diseases/advance/symptoms/shedding.dm
@@ -28,7 +28,8 @@ BONUS
 	symptom_delay_max = 90
 
 /datum/symptom/shedding/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 
 	var/mob/living/M = A.affected_mob

--- a/code/datums/diseases/advance/symptoms/shivering.dm
+++ b/code/datums/diseases/advance/symptoms/shivering.dm
@@ -35,16 +35,18 @@ Bonus
 	)
 
 /datum/symptom/shivering/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stage_rate"] >= 5) //dangerous cold
+	if(A.totalStageSpeed() >= 5) //dangerous cold
 		power = 1.5
 		unsafe = TRUE
-	if(A.properties["stage_rate"] >= 10)
+	if(A.totalStageSpeed() >= 10)
 		power = 2.5
 
 /datum/symptom/shivering/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	if(!unsafe || A.stage < 4)

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -27,7 +27,8 @@ BONUS
 	symptom_delay_max = 14
 
 /datum/symptom/polyvitiligo/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -36,17 +36,19 @@ Bonus
 	)
 
 /datum/symptom/sneeze/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["transmittable"] >= 9) //longer spread range
+	if(A.totalTransmittable() >= 9) //longer spread range
 		spread_range = 6
-	if(A.properties["stealth"] >= 4)
+	if(A.totalStealth() >= 4)
 		suppress_warning = TRUE
-	if(A.properties["stage_rate"] >= 17) //Yep, stage speed 17, not stage speed 7. This is a big boy threshold (effect), like the language-scrambling transmission one for the voice change symptom.
+	if(A.totalStageSpeed() >= 17) //Yep, stage speed 17, not stage speed 7. This is a big boy threshold (effect), like the language-scrambling transmission one for the voice change symptom.
 		cartoon_sneezing = TRUE //for a really fun time, distribute a disease with this threshold met while the gravity generator is down
 
 /datum/symptom/sneeze/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -35,15 +35,17 @@ Bonus
 	)
 
 /datum/symptom/visionloss/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stealth"] >= 4)
+	if(A.totalStealth() >= 4)
 		suppress_warning = TRUE
-	if(A.properties["resistance"] >= 12) //goodbye eyes
+	if(A.totalResistance() >= 12) //goodbye eyes
 		remove_eyes = TRUE
 
 /datum/symptom/visionloss/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	var/obj/item/organ/eyes/eyes = M.getorganslot(ORGAN_SLOT_EYES)

--- a/code/datums/diseases/advance/symptoms/voice_change.dm
+++ b/code/datums/diseases/advance/symptoms/voice_change.dm
@@ -37,19 +37,21 @@ Bonus
 	)
 
 /datum/symptom/voice_change/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stealth"] >= 3)
+	if(A.totalStealth() >= 3)
 		suppress_warning = TRUE
-	if(A.properties["stage_rate"] >= 7) //faster change of voice
+	if(A.totalStageSpeed() >= 7) //faster change of voice
 		base_message_chance = 25
 		symptom_delay_min = 25
 		symptom_delay_max = 85
-	if(A.properties["transmittable"] >= 14) //random language
+	if(A.totalTransmittable() >= 14) //random language
 		scramble_language = TRUE
 
 /datum/symptom/voice_change/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)

--- a/code/datums/diseases/advance/symptoms/vomit.dm
+++ b/code/datums/diseases/advance/symptoms/vomit.dm
@@ -41,17 +41,19 @@ Bonus
 	)
 
 /datum/symptom/vomit/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stealth"] >= 4)
+	if(A.totalStealth() >= 4)
 		suppress_warning = TRUE
-	if(A.properties["resistance"] >= 7) //blood vomit
+	if(A.totalResistance() >= 7) //blood vomit
 		vomit_blood = TRUE
-	if(A.properties["transmittable"] >= 7) //projectile vomit
+	if(A.totalTransmittable() >= 7) //projectile vomit
 		proj_vomit = 5
 
 /datum/symptom/vomit/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)

--- a/code/datums/diseases/advance/symptoms/weight.dm
+++ b/code/datums/diseases/advance/symptoms/weight.dm
@@ -34,13 +34,15 @@ Bonus
 	)
 
 /datum/symptom/weight_loss/Start(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	if(A.properties["stealth"] >= 4) //warn less often
+	if(A.totalStealth() >= 4) //warn less often
 		base_message_chance = 25
 
 /datum/symptom/weight_loss/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)

--- a/code/datums/diseases/advance/symptoms/youth.dm
+++ b/code/datums/diseases/advance/symptoms/youth.dm
@@ -30,7 +30,8 @@ BONUS
 	symptom_delay_max = 50
 
 /datum/symptom/youth/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	if(ishuman(M))


### PR DESCRIPTION
## About The Pull Request

## Why It's Good For The Game

Changes all disease properties accesses with procs so it's harder to mess up _see narcolepsy_

Changes all if(!..()) to . = ..() if(!.) to make stat bonuses work for subtypes of /heal

Fixes narcolepsy accessing the wrong field for increase speed

Bugfixes are good

## Changelog
:cl:
fix: Virology Healing Stat Bonuses Work Again
fix: Virology Narcolepsy Increased Speed Works Now
/:cl:
