### PR TITLE
Makes spawned hot cross buns edible again

### DIFF
--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -173,7 +173,7 @@
 	icon_state = "hotcrossbun"
 	foodtypes = SUGAR | GRAIN
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/sugar = 1)
-	tastes = list("easter")
+	tastes = list("easter" = 1)
 
 /datum/crafting_recipe/food/hotcrossbun
 	name = "Hot-Cross Bun"

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -167,23 +167,23 @@
 
 //Easter Recipes + food
 /obj/item/food/hotcrossbun
-	bite_consumption = 2
-	name = "hot-cross bun"
-	desc = "The Cross represents the Assistants that died for your sins."
+	name = "hot cross bun"
+	desc = "The cross represents the Assistants that died for your sins."
 	icon_state = "hotcrossbun"
-	foodtypes = SUGAR | GRAIN
 	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/sugar = 1)
-	tastes = list("easter" = 1)
+	foodtypes = SUGAR | GRAIN | BREAKFAST
+	tastes = list("pastry" = 1, "easter" = 1)
+	bite_consumption = 2
 
 /datum/crafting_recipe/food/hotcrossbun
-	name = "Hot-Cross Bun"
+	name = "Hot Cross Bun"
 	reqs = list(
-		/obj/item/food/bread/plain = 1,
+		/obj/item/food/breadslice/plain = 1,
 		/datum/reagent/consumable/sugar = 1
 	)
 	result = /obj/item/food/hotcrossbun
 
-	subcategory = CAT_MISCFOOD
+	subcategory = CAT_BREAD
 
 /datum/crafting_recipe/food/briochecake
 	name = "Brioche cake"

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -172,6 +172,7 @@
 	desc = "The Cross represents the Assistants that died for your sins."
 	icon_state = "hotcrossbun"
 	foodtypes = SUGAR | GRAIN
+	food_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/sugar = 1)
 	tastes = list("easter")
 
 /datum/crafting_recipe/food/hotcrossbun


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #57135. 

You no longer hit yourself in the face with these. 

Also does the following:
- Formats the taste list properly (so it doesn't taste indescribable)
- Fixes grammar in name and desc
- Adds BREAKFAST foodtype
- Adds pastry taste
- Makes it require a bread slice rather than a whole loaf (not economical)
- Moves it to the bread category

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You can eat spawned hot cross buns.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
fix: Spawned hot cross buns (e.g. one in cafe on MetaStation) are edible again
balance: Hot cross buns now use a bread slice instead of a loaf of bread (more economical)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
