### PR TITLE
Fixes sending topics when clicking anywhere in chat.

### DIFF
--- a/tgui/packages/tgui/links.js
+++ b/tgui/packages/tgui/links.js
@@ -13,16 +13,16 @@ export const captureExternalLinks = () => {
     /** @type {HTMLElement} */
     let target = e.target;
     // Recurse down the tree to find a valid link
-    while (target && target !== document.body) {
+    while (true) {
+      // Reached the end, bail.
+      if (!target || target === document.body) {
+        return;
+      }
       const tagName = String(target.tagName).toLowerCase();
       if (tagName === 'a') {
         break;
       }
       target = target.parentElement;
-    }
-    // Not a link, do nothing.
-    if (!target || target === document.body) {
-      return;
     }
     const hrefAttr = target.getAttribute('href') || '';
     // Leave BYOND links alone

--- a/tgui/packages/tgui/links.js
+++ b/tgui/packages/tgui/links.js
@@ -21,7 +21,7 @@ export const captureExternalLinks = () => {
       target = target.parentElement;
     }
     // Not a link, do nothing.
-    if (!target) {
+    if (!target || target === document.body) {
       return;
     }
     const hrefAttr = target.getAttribute('href') || '';


### PR DESCRIPTION
So yes, turns out this was an issue. It would bubble up to document body and try to use it as link.