### PR TITLE
Stops histamine and toxin damage from being applied to allergy sufferers while in stasis.

### DIFF
--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -719,6 +719,8 @@
 	. = ..()
 	if(!iscarbon(quirk_holder))
 		return
+	if(IS_IN_STASIS(quirk_holder))
+		return
 	var/mob/living/carbon/carbon_quirk_holder = quirk_holder
 	for(var/M in allergies)
 		var/datum/reagent/instantiated_med = carbon_quirk_holder.reagents.has_reagent(M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #57109 

Simply early returns allergy on_process if mob is in stasis.

Allergy sufferers will no longer accumulate histamine and die on the stasis bed while in stasis.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Allergy sufferers suffer a little less now.

## Changelog
:cl:
fix: Allergy suffers should now stop accumulating histamine and toxin damage while in stasis.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
