### PR TITLE
Fixes warden hat leaving a space before message when in Canadian mode

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -233,7 +233,7 @@
 			if(DRILL_YELLING)
 				message += "!!"
 			if(DRILL_CANADIAN)
-				message = " [message]"
+				message = "[message]"
 				var/list/canadian_words = strings("canadian_replacement.json", "canadian")
 
 				for(var/key in canadian_words)

--- a/strings/canadian_replacement.json
+++ b/strings/canadian_replacement.json
@@ -16,7 +16,7 @@
 		"give": "give'r",
 		"bar": "boozecan",
 		"leave": "leave'r",
-		"scruffle": "kerfuffle",
+		"scuffle": "kerfuffle",
 		"couch": "chesterfield",
 		"sofa": "chesterfield",
 		"alcohol": "mickey",

--- a/strings/canadian_replacement.json
+++ b/strings/canadian_replacement.json
@@ -21,7 +21,7 @@
 		"sofa": "chesterfield",
 		"alcohol": "mickey",
 		"shoes": "runners",
-		"cigarrete": "dart",
+		"cigarette": "dart",
 		"cig": "dart",
 		"color": "colour",
 		"armor": "armour",


### PR DESCRIPTION
## About The Pull Request
This pull request fixes the warden's hat whilst it is in Canadian mode by stopping it leaving a space before your message, example if I were to say E it would show up in chat bar with a space before the e like " E", also fixes typos in canadian_replacement.json 
## Why It's Good For The Game
This is good for the game because it fixes an annoying bug/error in the chat and the typos will have made it so people didn't get the conversion after typing a message

## Changelog
:cl:John Burgerman
fix: warden's police hat now no longer leaves a space before your message and people should now get Canadian conversions when they did not previously, cigarette will now convert to dart and scuffle will now convert to kerfuffle 
/:cl: