### PR TITLE
Fix some announcement sounds

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -3,8 +3,10 @@
 		return
 
 	var/announcement
-	if(!istype(sound, /sound))
-		sound = SSstation.announcer.event_sounds[sound] || SSstation.announcer.get_rand_alert_sound()
+	if(!sound)
+		sound = SSstation.announcer.get_rand_alert_sound()
+	else if(SSstation.announcer.event_sounds[sound])
+		sound = SSstation.announcer.event_sounds[sound]
 
 	if(type == "Priority")
 		announcement += "<h1 class='alert'>Priority Announcement</h1>"

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -30,7 +30,7 @@
 
 /proc/power_restore()
 
-	priority_announce("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal", ANNOUNCER_POWEROFF)
+	priority_announce("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal", ANNOUNCER_POWERON)
 	for(var/obj/machinery/power/apc/C in GLOB.machines)
 		if(C.cell && is_station_level(C.z))
 			C.cell.charge = C.cell.maxcharge
@@ -63,4 +63,3 @@
 		S.output_attempt = TRUE
 		S.update_icon()
 		S.power_change()
-

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -560,7 +560,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	var/announce_command_report = TRUE
 	switch(confirm)
 		if("Yes")
-			priority_announce(input, null, SSstation.announcer.get_rand_report_sound())
+			priority_announce(input, null, SSstation.announcer.get_rand_report_sound(), has_important_message = TRUE)
 			announce_command_report = FALSE
 		if("Cancel")
 			return


### PR DESCRIPTION
## About The Pull Request

This PR fixes some announcement sounds for things like declarations of war, centcom command reports, and captain's announcements. 

Priority announcements were never passed a `/sound` - instead either a key to an associated list, or a path to a sound file - so the check always failed. Meaning every priority annoncement attempted to check if the sound was in the event list, and if it wasn't it got a random sound. Announcements that passed paths like command reports, declarations of war, captain's announcements, families announcements, and probably more defaulted to the normal announcement sound because of it.

fixes #56947

## Why It's Good For The Game

I miss the dings of the captain's announcements.

I miss the blaring of war declaration.

I miss `new command report created`.

## Changelog
:cl: Melbert
fix: Fixes certain announcements (captain's announcements, nuclear operative war declaration, command reports, etc) not playing their respective sounds.
fix: Interns no longer override their superior's announced command reports.
/:cl:
