### PR TITLE
Make greentext a component

### DIFF
--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -128,7 +128,7 @@
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "az" = (
-/obj/item/greentext/quiet{
+/obj/item/greentext{
 	anchored = 1
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -357,6 +357,10 @@ SUBSYSTEM_DEF(ticker)
 	else
 		LAZYADD(round_end_events, cb)
 
+//Remove a callback from this list to be called on roundend
+/datum/controller/subsystem/ticker/proc/remove_roundend_callback(datum/callback/cb)
+	LAZYREMOVE(round_end_events, cb)
+
 /datum/controller/subsystem/ticker/proc/station_explosion_detonation(atom/bomb)
 	if(bomb) //BOOM
 		qdel(bomb)

--- a/code/datums/components/greentext.dm
+++ b/code/datums/components/greentext.dm
@@ -9,7 +9,7 @@
 		return COMPONENT_INCOMPATIBLE
 	RegisterSignal(parent, COMSIG_ITEM_PICKUP, .proc/equip)
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/unequip)
-	roundend_callback = CALLBACK(src, .proc/check_winner)
+	var/roundend_callback = CALLBACK(src, .proc/check_winner)
 	SSticker.OnRoundend(roundend_callback)
 
 /datum/component/greentext/proc/equip(item , mob/living/user as mob)

--- a/code/datums/components/greentext.dm
+++ b/code/datums/components/greentext.dm
@@ -1,0 +1,50 @@
+/datum/component/greentext
+	var/mob/living/last_holder = null
+	var/mob/living/current_holder
+	var/list/color_altered_mobs = list()
+	var/datum/callback/roundend_callback
+	var/quiet = FALSE
+
+/datum/component/greentext/Initialize()
+	if (!isitem(parent))
+		return COMPONENT_INCOMPATIBLE
+	RegisterSignal(parent, COMSIG_ITEM_PICKUP, .proc/equip)
+	RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/unequip)
+	roundend_callback = CALLBACK(src, .proc/check_winner)
+	SSticker.OnRoundend(roundend_callback)
+
+/datum/component/greentext/proc/equip(item , mob/living/user as mob)
+	if (user == current_holder)
+		return
+	to_chat(user, "<font color='green'>So long as you leave this place with greentext in hand you know will be happy...</font>")
+	var/list/other_objectives = user.mind.get_all_objectives()
+	if(user.mind && other_objectives.len > 0)
+		to_chat(user, "<span class='warning'>... so long as you still perform your other objectives that is!</span>")
+	current_holder = user
+	if(!last_holder)
+		last_holder = user
+	if(!(user in color_altered_mobs))
+		color_altered_mobs += user
+	user.add_atom_colour("#00FF00", ADMIN_COLOUR_PRIORITY)
+	START_PROCESSING(SSobj, src)
+	..()
+
+/datum/component/greentext/proc/unequip(item , mob/living/user as mob)
+	if(user in color_altered_mobs)
+		to_chat(user, "<span class='warning'>A sudden wave of failure washes over you...</span>")
+		user.add_atom_colour("#FF0000", ADMIN_COLOUR_PRIORITY) //ya blew it
+	last_holder = null
+	current_holder = null
+	STOP_PROCESSING(SSobj, src)
+	..()
+
+/datum/component/greentext/proc/check_winner()
+	if(!current_holder)
+		return
+
+	if(is_centcom_level(current_holder.z))//you're winner!
+		to_chat(current_holder, "<font color='green'>At last it feels like victory is assured!</font>")
+		current_holder.mind.add_antag_datum(/datum/antagonist/greentext)
+		current_holder.log_message("won with greentext!!!", LOG_ATTACK, color="green")
+		color_altered_mobs -= current_holder
+		qdel(src)

--- a/code/datums/components/greentext.dm
+++ b/code/datums/components/greentext.dm
@@ -2,7 +2,6 @@
 	var/mob/living/last_holder = null
 	var/mob/living/current_holder
 	var/list/color_altered_mobs = list()
-	var/datum/callback/roundend_callback
 	var/quiet = FALSE
 
 /datum/component/greentext/Initialize()
@@ -14,6 +13,7 @@
 	SSticker.OnRoundend(roundend_callback)
 
 /datum/component/greentext/proc/equip(item , mob/living/user as mob)
+	SIGNAL_HANDLER
 	if (user == current_holder)
 		return
 	to_chat(user, "<font color='green'>So long as you leave this place with greentext in hand you know will be happy...</font>")
@@ -27,16 +27,15 @@
 		color_altered_mobs += user
 	user.add_atom_colour("#00FF00", ADMIN_COLOUR_PRIORITY)
 	START_PROCESSING(SSobj, src)
-	..()
 
 /datum/component/greentext/proc/unequip(item , mob/living/user as mob)
+	SIGNAL_HANDLER
 	if(user in color_altered_mobs)
 		to_chat(user, "<span class='warning'>A sudden wave of failure washes over you...</span>")
 		user.add_atom_colour("#FF0000", ADMIN_COLOUR_PRIORITY) //ya blew it
 	last_holder = null
 	current_holder = null
 	STOP_PROCESSING(SSobj, src)
-	..()
 
 /datum/component/greentext/proc/check_winner()
 	if(!current_holder)

--- a/code/datums/components/greentext.dm
+++ b/code/datums/components/greentext.dm
@@ -13,7 +13,7 @@
 	var/roundend_callback = CALLBACK(src, .proc/check_winner)
 	SSticker.OnRoundend(roundend_callback)
 
-/datum/component/greentext/proc/equip(mob/living/user)
+/datum/component/greentext/proc/equip(source, mob/living/user)
 	SIGNAL_HANDLER
 	if (user == current_holder)
 		return
@@ -29,7 +29,7 @@
 	user.add_atom_colour("#00FF00", ADMIN_COLOUR_PRIORITY)
 	START_PROCESSING(SSobj, src)
 
-/datum/component/greentext/proc/unequip(mob/living/user)
+/datum/component/greentext/proc/unequip(source, mob/living/user)
 	SIGNAL_HANDLER
 	if(user in color_altered_mobs)
 		to_chat(user, "<span class='warning'>A sudden wave of failure washes over you...</span>")

--- a/code/datums/components/greentext.dm
+++ b/code/datums/components/greentext.dm
@@ -4,19 +4,20 @@
 	var/list/color_altered_mobs = list()
 	var/quiet = FALSE
 
-/datum/component/greentext/Initialize()
+/datum/component/greentext/Initialize(_quiet = FALSE)
 	if (!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
+	quiet = _quiet
 	RegisterSignal(parent, COMSIG_ITEM_PICKUP, .proc/equip)
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/unequip)
 	var/roundend_callback = CALLBACK(src, .proc/check_winner)
 	SSticker.OnRoundend(roundend_callback)
 
-/datum/component/greentext/proc/equip(item , mob/living/user as mob)
+/datum/component/greentext/proc/equip(mob/living/user)
 	SIGNAL_HANDLER
 	if (user == current_holder)
 		return
-	to_chat(user, "<font color='green'>So long as you leave this place with greentext in hand you know will be happy...</font>")
+	to_chat(user, "<font color='green'>So long as you leave this place with [parent] in hand you know will be happy...</font>")
 	var/list/other_objectives = user.mind.get_all_objectives()
 	if(user.mind && other_objectives.len > 0)
 		to_chat(user, "<span class='warning'>... so long as you still perform your other objectives that is!</span>")
@@ -28,7 +29,7 @@
 	user.add_atom_colour("#00FF00", ADMIN_COLOUR_PRIORITY)
 	START_PROCESSING(SSobj, src)
 
-/datum/component/greentext/proc/unequip(item , mob/living/user as mob)
+/datum/component/greentext/proc/unequip(mob/living/user)
 	SIGNAL_HANDLER
 	if(user in color_altered_mobs)
 		to_chat(user, "<span class='warning'>A sudden wave of failure washes over you...</span>")

--- a/code/modules/events/wizard/greentext.dm
+++ b/code/modules/events/wizard/greentext.dm
@@ -30,3 +30,4 @@
 /obj/item/greentext/Initialize()
 	AddElement(/datum/element/point_of_interest)
 	AddComponent(/datum/component/greentext)
+	. = ..()

--- a/code/modules/events/wizard/greentext.dm
+++ b/code/modules/events/wizard/greentext.dm
@@ -25,77 +25,8 @@
 	w_class = WEIGHT_CLASS_BULKY
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "greentext"
-	var/mob/living/last_holder
-	var/mob/living/new_holder
-	var/list/color_altered_mobs = list()
-	var/datum/callback/roundend_callback
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	var/quiet = FALSE
 
-/obj/item/greentext/Initialize(mapload)
-	. = ..()
+/obj/item/greentext/ComponentInitialize()
 	AddElement(/datum/element/point_of_interest)
-	roundend_callback = CALLBACK(src,.proc/check_winner)
-	SSticker.OnRoundend(roundend_callback)
-
-/obj/item/greentext/equipped(mob/living/user as mob)
-	to_chat(user, "<font color='green'>So long as you leave this place with greentext in hand you know will be happy...</font>")
-	var/list/other_objectives = user.mind.get_all_objectives()
-	if(user.mind && other_objectives.len > 0)
-		to_chat(user, "<span class='warning'>... so long as you still perform your other objectives that is!</span>")
-	new_holder = user
-	if(!last_holder)
-		last_holder = user
-	if(!(user in color_altered_mobs))
-		color_altered_mobs += user
-	user.add_atom_colour("#00FF00", ADMIN_COLOUR_PRIORITY)
-	START_PROCESSING(SSobj, src)
-	..()
-
-/obj/item/greentext/dropped(mob/living/user as mob)
-	if(user in color_altered_mobs)
-		to_chat(user, "<span class='warning'>A sudden wave of failure washes over you...</span>")
-		user.add_atom_colour("#FF0000", ADMIN_COLOUR_PRIORITY) //ya blew it
-	last_holder = null
-	new_holder = null
-	STOP_PROCESSING(SSobj, src)
-	..()
-
-/obj/item/greentext/proc/check_winner()
-	if(!new_holder)
-		return
-
-	if(is_centcom_level(new_holder.z))//you're winner!
-		to_chat(new_holder, "<font color='green'>At last it feels like victory is assured!</font>")
-		new_holder.mind.add_antag_datum(/datum/antagonist/greentext)
-		new_holder.log_message("won with greentext!!!", LOG_ATTACK, color="green")
-		color_altered_mobs -= new_holder
-		resistance_flags |= ON_FIRE
-		qdel(src)
-
-/obj/item/greentext/process()
-	if(last_holder && last_holder != new_holder) //Somehow it was swiped without ever getting dropped
-		to_chat(last_holder, "<span class='warning'>A sudden wave of failure washes over you...</span>")
-		last_holder.add_atom_colour("#FF0000", ADMIN_COLOUR_PRIORITY)
-		last_holder = new_holder //long live the king
-
-/obj/item/greentext/Destroy(force)
-	if(!(resistance_flags & ON_FIRE) && !force)
-		return QDEL_HINT_LETMELIVE
-
-	SSticker.round_end_events -= roundend_callback
-	for(var/i in GLOB.player_list)
-		var/mob/M = i
-		var/message = "<span class='warning'>A dark temptation has passed from this world"
-		if(M in color_altered_mobs)
-			message += " and you're finally able to forgive yourself"
-			if(M.color == "#FF0000" || M.color == "#00FF00")
-				M.remove_atom_colour(ADMIN_COLOUR_PRIORITY)
-		message += "...</span>"
-		// can't skip the mob check as it also does the decolouring
-		if(!quiet)
-			to_chat(M, message)
-	. = ..()
-
-/obj/item/greentext/quiet
-	quiet = TRUE
+	AddComponent(/datum/component/greentext)

--- a/code/modules/events/wizard/greentext.dm
+++ b/code/modules/events/wizard/greentext.dm
@@ -27,6 +27,6 @@
 	icon_state = "greentext"
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
-/obj/item/greentext/ComponentInitialize()
+/obj/item/greentext/Initialize()
 	AddElement(/datum/element/point_of_interest)
 	AddComponent(/datum/component/greentext)

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -142,3 +142,4 @@ Skoglol = Game Master
 Time-Green = Game Master
 StyleMistake = Game Master
 actioninja = Game Master
+Wineallwine = Game Master

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -142,4 +142,3 @@ Skoglol = Game Master
 Time-Green = Game Master
 StyleMistake = Game Master
 actioninja = Game Master
-Wineallwine = Game Master

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -464,6 +464,7 @@
 #include "code\datums\components\footstep.dm"
 #include "code\datums\components\forensics.dm"
 #include "code\datums\components\gps.dm"
+#include "code\datums\components\greentext.dm"
 #include "code\datums\components\grillable.dm"
 #include "code\datums\components\gunpoint.dm"
 #include "code\datums\components\heirloom.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns the greentext (an item from the wizard gamemode that makes you an antag as long as you have it) into a component rather than a specific item. 
This will allow admins to make arbitrary items give you an antag status while you possess it. 

## Why It's Good For The Game

Cleaner, more reusable code.
More opportunities for badmin shittery.

## Changelog
:cl: WineAllWine
code: Greentext is a component now
admin: Admins can make arbitrary items give an antag status while posessed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
