### PR TITLE
Survival capsules no longer get deleted when deployed at the edge of the map

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -299,6 +299,7 @@ GLOBAL_LIST_INIT(pda_styles, sortList(list(MONO, VT, ORBITRON, SHARE)))
 #define SHELTER_DEPLOY_BAD_TURFS "bad turfs"
 #define SHELTER_DEPLOY_BAD_AREA "bad area"
 #define SHELTER_DEPLOY_ANCHORED_OBJECTS "anchored objects"
+#define SHELTER_DEPLOY_OUTSIDE_MAP "outside map"
 
 //debug printing macros
 #define debug_world(msg) if (GLOB.Debug2) to_chat(world, \

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -53,20 +53,20 @@
 				var/width = template.width
 				var/height = template.height
 				src.loc.visible_message("<span class='warning'>\The [src] doesn't have room to deploy! You need to clear a [width]x[height] area!</span>")
-
 		if(status != SHELTER_DEPLOY_ALLOWED)
 			used = FALSE
 			return
-
-		playsound(src, 'sound/effects/phasein.ogg', 100, TRUE)
-
-		var/turf/T = deploy_location
-		if(!is_mining_level(T.z)) //only report capsules away from the mining/lavaland level
-			message_admins("[ADMIN_LOOKUPFLW(usr)] activated a bluespace capsule away from the mining level! [ADMIN_VERBOSEJMP(T)]")
-			log_admin("[key_name(usr)] activated a bluespace capsule away from the mining level at [AREACOORD(T)]")
-		template.load(deploy_location, centered = TRUE)
-		new /obj/effect/particle_effect/smoke(get_turf(src))
-		qdel(src)
+		if(template.load(deploy_location, centered = TRUE)) // Did capsule deploy?
+			var/turf/T = deploy_location
+			if(!is_mining_level(T.z)) //only report capsules away from the mining/lavaland level
+				message_admins("[ADMIN_LOOKUPFLW(usr)] activated a bluespace capsule away from the mining level! [ADMIN_VERBOSEJMP(T)]")
+				log_admin("[key_name(usr)] activated a bluespace capsule away from the mining level at [AREACOORD(T)]")
+			playsound(src, 'sound/effects/phasein.ogg', 100, TRUE)
+			new /obj/effect/particle_effect/smoke(get_turf(src))
+			qdel(src)
+		else // Capsule didn't deploy.
+			src.loc.visible_message("<span class='warning'>\The [src] will not function in this area.</span>")
+			used = FALSE
 
 //Non-default pods
 

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -49,24 +49,23 @@
 		switch(status)
 			if(SHELTER_DEPLOY_BAD_AREA)
 				src.loc.visible_message("<span class='warning'>\The [src] will not function in this area.</span>")
-			if(SHELTER_DEPLOY_BAD_TURFS, SHELTER_DEPLOY_ANCHORED_OBJECTS)
+			if(SHELTER_DEPLOY_BAD_TURFS, SHELTER_DEPLOY_ANCHORED_OBJECTS, SHELTER_DEPLOY_OUTSIDE_MAP)
 				var/width = template.width
 				var/height = template.height
 				src.loc.visible_message("<span class='warning'>\The [src] doesn't have room to deploy! You need to clear a [width]x[height] area!</span>")
 		if(status != SHELTER_DEPLOY_ALLOWED)
 			used = FALSE
 			return
-		if(template.load(deploy_location, centered = TRUE)) // Did capsule deploy?
-			var/turf/T = deploy_location
-			if(!is_mining_level(T.z)) //only report capsules away from the mining/lavaland level
-				message_admins("[ADMIN_LOOKUPFLW(usr)] activated a bluespace capsule away from the mining level! [ADMIN_VERBOSEJMP(T)]")
-				log_admin("[key_name(usr)] activated a bluespace capsule away from the mining level at [AREACOORD(T)]")
-			playsound(src, 'sound/effects/phasein.ogg', 100, TRUE)
-			new /obj/effect/particle_effect/smoke(get_turf(src))
-			qdel(src)
-		else // Capsule didn't deploy.
-			src.loc.visible_message("<span class='warning'>\The [src] will not function in this area.</span>")
-			used = FALSE
+
+		template.load(deploy_location, centered = TRUE)
+		var/turf/T = deploy_location
+		if(!is_mining_level(T.z)) //only report capsules away from the mining/lavaland level
+			message_admins("[ADMIN_LOOKUPFLW(usr)] activated a bluespace capsule away from the mining level! [ADMIN_VERBOSEJMP(T)]")
+			log_admin("[key_name(usr)] activated a bluespace capsule away from the mining level at [AREACOORD(T)]")
+
+		playsound(src, 'sound/effects/phasein.ogg', 100, TRUE)
+		new /obj/effect/particle_effect/smoke(get_turf(src))
+		qdel(src)
 
 //Non-default pods
 

--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -28,6 +28,15 @@
 		for(var/obj/O in T)
 			if((O.density && O.anchored) || is_type_in_typecache(O, banned_objects))
 				return SHELTER_DEPLOY_ANCHORED_OBJECTS
+
+	// Check if the shelter sticks out of map borders
+	var/shelter_origin_x = deploy_location.x - round(width/2)
+	if(shelter_origin_x <= 1 || shelter_origin_x+width > world.maxx)
+		return SHELTER_DEPLOY_OUTSIDE_MAP
+	var/shelter_origin_y = deploy_location.y - round(height/2)
+	if(shelter_origin_y <= 1 || shelter_origin_y+height > world.maxy)
+		return SHELTER_DEPLOY_OUTSIDE_MAP
+
 	return SHELTER_DEPLOY_ALLOWED
 
 /datum/map_template/shelter/alpha


### PR DESCRIPTION
## About The Pull Request
Fixes #55674

## Changelog
:cl: Dex
fix: Survival capsules no longer get deleted when deployed at the edge of the map.
/:cl:
