### PR TITLE
Fixes plungers missing worn icon states

### DIFF
--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -59,6 +59,7 @@
 	desc = "It's a plunger for plunging."
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "plunger"
+	worn_icon_state = "plunger"
 
 	slot_flags = ITEM_SLOT_MASK
 	flags_inv = HIDESNOUT
@@ -122,6 +123,7 @@
 	name = "reinforced plunger"
 	desc = "It's an M. 7 Reinforced Plunger© for heavy duty plunging."
 	icon_state = "reinforced_plunger"
+	worn_icon_state = "reinforced_plunger"
 	reinforced = TRUE
 	plunge_mod = 0.8
 	layer_mode_sprite = "reinforced_plunger_layer"


### PR DESCRIPTION
## About The Pull Request
It's two lines that fix a bugged sprite when plungers are set to the layer mode and then worn

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/51932756/109334681-452f1e80-781e-11eb-9816-57380b1efe30.png)
You forgot to install source

## Changelog
:cl:
fix: Plungers on layer mode won't turn into the pink/black error sprite when worn on the face
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
