### PR TITLE
Nerfs Quad/Quins additional healing

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1689,7 +1689,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	var/obj/item/organ/liver/liver = M.getorganslot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		M.heal_bodypart_damage(1 * REM * delta_time, 1 * REM * delta_time)
-		M.adjustBruteLoss(-2 * REM * delta_time, 0)
 		. = TRUE
 	return ..()
 
@@ -1710,10 +1709,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	var/obj/item/organ/liver/liver = M.getorganslot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		M.heal_bodypart_damage(2 * REM * delta_time, 2 * REM *  delta_time, 2 * REM * delta_time)
-		M.adjustBruteLoss(-5 * REM * delta_time, 0)
-		M.adjustOxyLoss(-5 * REM * delta_time, 0)
-		M.adjustFireLoss(-5 * REM * delta_time, 0)
-		M.adjustToxLoss(-5 * REM * delta_time, 0)
 		. = TRUE
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR rebalances two security oriented drinks - Quadruple sec and Quintuple Sec.

**Quadruple Sec** - removed extra brute healing, which makes it have **exact same** healing properties like Banana Honk has for clowns, or Blank Paper has for vow-keeping mimes. This is inline with code comments for this drink, as its supposed to be their equivalent, just for security personnel. It is still very easy to make, and has low boozepower compared to equivalent drinks, so it should still prove very useful.

**Quintuple Sec** - removed extra brute, burn, oxygen and toxin healing. Now it has exactly double the amount of healing power of the Quadruple Sec, with stamina healing as a a bonus. Not a problematic drink, because its quite hard to make, but a rarity should not justify having insane healing stats. Also in line with code comments - it is supposed to be just a stronger Quadruple Sec.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Security drinks power in line with similiar drinks, like Banana Honk or Blank Paper.

## Changelog
:cl: Arkatos
balance: Removed extra brute healing from Quadruple Sec drink for security personnel.
balance: Removed extra brute, burn, oxygen and toxin healing from Quintuple Sec drink for security personnel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
