### PR TITLE
Fixes null rod's heretic rune dispel

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -26,9 +26,11 @@
 	if(!is_in_use)
 		INVOKE_ASYNC(src, .proc/activate , user)
 
-/obj/effect/eldritch/attacked_by(obj/item/I, mob/living/user)
+/obj/effect/eldritch/attackby(obj/item/I, mob/living/user)
 	. = ..()
 	if(istype(I,/obj/item/nullrod))
+		user.say("BEGONE FOUL MAGIKS!!", forced = "nullrod")
+		to_chat(user, "<span class='danger'>You disrupt the magic of [src] with [I].</span>")
 		qdel(src)
 
 /obj/effect/eldritch/proc/activate(mob/living/user)


### PR DESCRIPTION
## About The Pull Request

Fixes #57207.

## Changelog

:cl:
fix: The chaplain's null rod can now dispel the heretic's transmutation rune. Note that as with with the Nar'Sie rune, you must stand on it.
/:cl: