### PR TITLE
Announced Extended now sends a report for station traits + minor punctuation cleanup

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -3,7 +3,7 @@
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 5
 	show_in_report = TRUE
-	report_message = "Dangerous fauna is present in the area of this station"
+	report_message = "Dangerous fauna is present in the area of this station."
 	trait_to_give = STATION_TRAIT_CARP_INFESTATION
 
 /datum/station_trait/distant_supply_lines

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -117,7 +117,7 @@
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 5
 	show_in_report = TRUE
-	report_message = "Due to proximity to our supply station, the cargo shuttle will have a quicker flight time to your cargo department/"
+	report_message = "Due to proximity to our supply station, the cargo shuttle will have a quicker flight time to your cargo department."
 	blacklist = list(/datum/station_trait/slow_shuttle)
 
 /datum/station_trait/quick_shuttle/on_round_start()

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -258,20 +258,8 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			. += "Your station is somehow in the middle of hostile territory, in clear view of any enemy of the corporation. Your likelihood to survive is low, and station destruction is expected and almost inevitable. Secure any sensitive material and neutralize any enemy you will come across. It is important that you at least try to maintain the station.<BR>"
 			. += "Good luck."
 
-	if(station_goals.len)
-		. += "<hr><b>Special Orders for [station_name()]:</b>"
-		for(var/datum/station_goal/G in station_goals)
-			G.on_report()
-			. += G.get_report()
-
-	if(SSstation.station_traits.len)
-		. += "<hr><b>Identified shift divergencies:</b><BR>"
-		for(var/i in SSstation.station_traits)
-			var/datum/station_trait/station_trait_iterator = i
-			if(!station_trait_iterator.show_in_report)
-				continue
-			. += "[station_trait_iterator.get_report()]<BR>"
-
+	. += generate_station_goal_report()
+	. += generate_station_trait_report()
 
 	print_command_report(., "Central Command Status Summary", announce=FALSE)
 	priority_announce("A summary has been copied and printed to all communications consoles.", "Security level elevated.", ANNOUNCER_INTERCEPT)

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -25,5 +25,11 @@
 		station_goals += G
 		G.on_report()
 
-/datum/game_mode/extended/announced/send_intercept(report = 0)
-	priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", SSstation.announcer.get_rand_report_sound())
+/datum/game_mode/extended/announced/send_intercept()
+	var/greenshift_message = "Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!"
+	. += "<b><i>Central Command Status Summary</i></b><hr>"
+	. += greenshift_message
+	. += generate_station_trait_report()
+
+	print_command_report(., "Central Command Status Summary", announce = FALSE)
+	priority_announce(greenshift_message, "Security Report", SSstation.announcer.get_rand_report_sound())

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -301,24 +301,33 @@
 	if(GLOB.security_level < SEC_LEVEL_BLUE)
 		set_security_level(SEC_LEVEL_BLUE)
 
+/*
+ * Generate a list of station goals available to purchase to report to the crew.
+ *
+ * Returns a formatted string all station goals that are available to the station.
+ */
 /datum/game_mode/proc/generate_station_goal_report()
 	if(!station_goals.len)
 		return
 	. = "<hr><b>Special Orders for [station_name()]:</b><BR>"
-	for(var/datum/station_goal/G in station_goals)
-		G.on_report()
-		. += G.get_report()
+	for(var/datum/station_goal/station_goal in station_goals)
+		station_goal.on_report()
+		. += station_goal.get_report()
 	return
 
+/*
+ * Generate a list of active station traits to report to the crew.
+ *
+ * Returns a formatted string of all station traits (that are shown) affecting the station.
+ */
 /datum/game_mode/proc/generate_station_trait_report()
 	if(!SSstation.station_traits.len)
 		return
 	. = "<hr><b>Identified shift divergencies:</b><BR>"
-	for(var/i in SSstation.station_traits)
-		var/datum/station_trait/station_trait_iterator = i
-		if(!station_trait_iterator.show_in_report)
+	for(var/datum/station_trait/station_trait as anything in SSstation.station_traits)
+		if(!station_trait.show_in_report)
 			continue
-		. += "[station_trait_iterator.get_report()]<BR>"
+		. += "[station_trait.get_report()]<BR>"
 	return
 
 // This is a frequency selection system. You may imagine it like a raffle where each player can have some number of tickets. The more tickets you have the more likely you are to

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -293,25 +293,33 @@
 		intercepttext += "<hr>"
 		intercepttext += report
 
-	if(station_goals.len)
-		intercepttext += "<hr><b>Special Orders for [station_name()]:</b>"
-		for(var/datum/station_goal/G in station_goals)
-			G.on_report()
-			intercepttext += G.get_report()
-
-	if(SSstation.station_traits.len)
-		intercepttext += "<hr><b>Identified shift divergencies:</b>"
-		for(var/i in SSstation.station_traits)
-			var/datum/station_trait/station_trait_iterator = i
-			if(!station_trait_iterator.show_in_report)
-				return
-			intercepttext += station_trait_iterator.get_report()
+	intercepttext += generate_station_goal_report()
+	intercepttext += generate_station_trait_report()
 
 	print_command_report(intercepttext, "Central Command Status Summary", announce=FALSE)
 	priority_announce("A summary has been copied and printed to all communications consoles.", "Enemy communication intercepted. Security level elevated.", ANNOUNCER_INTERCEPT)
 	if(GLOB.security_level < SEC_LEVEL_BLUE)
 		set_security_level(SEC_LEVEL_BLUE)
 
+/datum/game_mode/proc/generate_station_goal_report()
+	if(!station_goals.len)
+		return
+	. = "<hr><b>Special Orders for [station_name()]:</b><BR>"
+	for(var/datum/station_goal/G in station_goals)
+		G.on_report()
+		. += G.get_report()
+	return
+
+/datum/game_mode/proc/generate_station_trait_report()
+	if(!SSstation.station_traits.len)
+		return
+	. = "<hr><b>Identified shift divergencies:</b><BR>"
+	for(var/i in SSstation.station_traits)
+		var/datum/station_trait/station_trait_iterator = i
+		if(!station_trait_iterator.show_in_report)
+			continue
+		. += "[station_trait_iterator.get_report()]<BR>"
+	return
 
 // This is a frequency selection system. You may imagine it like a raffle where each player can have some number of tickets. The more tickets you have the more likely you are to
 // "win". The default is 100 tickets. If no players use any extra tickets (earned with the antagonist rep system) calling this function should be equivalent to calling the normal


### PR DESCRIPTION
## About The Pull Request

- Fixes two minor punctuation errors in station traits.
- Announced greenshifts now send a command report so players can figure out what station traits may be affecting the station.
- Changed some code in game_mode and dynamic `send_intercept()` to be their own procs to reduce copy+paste.

## Why It's Good For The Game

Announced greenshifts aren't run normally / are admin only but if they happen to be ran, and the station has traits, the crew should be able to know what they're affected with.

## Changelog
:cl: Melbert
qol: Announced Extended shifts now send a command report listing station traits.
spellcheck: Fixed some punctuation in station trait reports.
code: Reduced some copy+paste in gamemode intercepts
/:cl: