### PR TITLE
Fixes Lavaland ruin turf generation and round start active turfs

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_elite_tumor.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_elite_tumor.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/lavaland/surface/outdoors)
+/area/template_noop)
 "b" = (
 /obj/structure/elite_tumor,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_puzzle.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_puzzle.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/lavaland/surface/outdoors)
+/area/template_noop)
 "b" = (
 /obj/effect/sliding_puzzle/lavaland,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_random_ripley.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_random_ripley.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/lavaland/surface/outdoors)
+/area/template_noop)
 "b" = (
 /turf/closed/mineral/volcanic/lava_land_surface,
 /area/lavaland/surface/outdoors)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_xeno_nest.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_xeno_nest.dmm
@@ -157,10 +157,6 @@
 /obj/item/clothing/head/helmet/space/syndicate/orange,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
-"O" = (
-/obj/structure/alien/weeds/node,
-/turf/template_noop,
-/area/ruin/unpowered/xenonest)
 "Q" = (
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood,
@@ -168,10 +164,6 @@
 	plants_off = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
-"R" = (
-/obj/structure/alien/weeds,
-/turf/template_noop,
 /area/ruin/unpowered/xenonest)
 
 (1,1,1) = {"
@@ -1065,8 +1057,8 @@ g
 g
 g
 b
-O
-R
+l
+g
 g
 g
 "}
@@ -1097,8 +1089,8 @@ b
 g
 l
 b
-O
-R
+l
+f
 g
 g
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A bunch of ruins were using the wrong areas which caused turf generation to fail when these ruins were used.

The xeno hive ruin also had several incorrect base turfs inside non-generated areas, which created round start active turfs. 

Fixes #57060 and fixes #57079

## Why It's Good For The Game
In addition to generating the intended terrain, this should clear up an enormous pile of roundstart active turfs.


## Changelog
:cl:
fix: Fixes several lavaland ruins failing to generate the correct turfs
fix: Fixes xeno hive ruin using space as it's baseturf
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
