### PR TITLE
Fixes the Ratvar ruin on Lavaland

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_dead_ratvar.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_dead_ratvar.dmm
@@ -4,129 +4,129 @@
 /area/template_noop)
 "b" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "c" = (
 /obj/structure/fluff/clockwork/alloy_shards/small,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "d" = (
 /obj/structure/girder/bronze,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "e" = (
 /obj/item/stack/tile/bronze,
 /turf/open/floor/bronze/lavaland,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "f" = (
 /turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "g" = (
 /obj/structure/fluff/clockwork/alloy_shards/medium_gearbit,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "h" = (
 /turf/open/floor/bronze/lavaland,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "i" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "j" = (
 /turf/closed/wall/mineral/bronze,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "k" = (
 /obj/structure/fluff/clockwork/alloy_shards/small,
 /turf/open/floor/bronze/lavaland,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "l" = (
 /turf/open/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "m" = (
 /obj/structure/fluff/clockwork/alloy_shards/medium,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "n" = (
 /obj/structure/fluff/clockwork/blind_eye,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "o" = (
 /obj/structure/fluff/clockwork/alloy_shards/large,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "p" = (
 /obj/structure/fluff/clockwork/alloy_shards/medium,
 /turf/open/floor/bronze/lavaland,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "q" = (
 /obj/structure/lattice,
 /turf/open/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "r" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "s" = (
 /obj/structure/fluff/clockwork/alloy_shards/large,
 /turf/open/floor/bronze/lavaland,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "t" = (
 /obj/item/stack/tile/bronze,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "u" = (
 /obj/structure/grille,
 /turf/open/floor/bronze/lavaland,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "v" = (
 /obj/structure/fluff/clockwork/alloy_shards/medium,
 /obj/structure/lattice,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "w" = (
 /obj/structure/grille/broken,
 /turf/open/floor/bronze/lavaland,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "x" = (
 /obj/structure/girder/bronze,
 /obj/item/stack/tile/bronze,
 /turf/open/floor/bronze/lavaland,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "y" = (
 /obj/structure/fluff/clockwork/fallen_armor,
 /turf/open/floor/bronze/lavaland,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "z" = (
 /obj/structure/girder/bronze,
 /turf/open/floor/bronze/lavaland,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "A" = (
 /obj/structure/fluff/clockwork/clockgolem_remains,
 /turf/open/floor/bronze/lavaland,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "B" = (
 /obj/item/nullrod/spear,
 /turf/open/floor/bronze/lavaland,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "C" = (
 /obj/structure/fluff/clockwork/alloy_shards/medium_gearbit,
 /turf/open/floor/bronze/lavaland,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "D" = (
 /obj/structure/grille,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "E" = (
 /obj/structure/fluff/clockwork/clockgolem_remains,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "F" = (
 /obj/structure/dead_ratvar,
 /turf/open/floor/bronze/lavaland,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 "G" = (
 /obj/item/stack/tile/bronze/thirty,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
+/area/ruin/unpowered/ratvar)
 
 (1,1,1) = {"
 a
@@ -755,7 +755,7 @@ a
 (25,1,1) = {"
 a
 a
-a
+b
 l
 l
 l
@@ -781,7 +781,7 @@ a
 (26,1,1) = {"
 a
 a
-a
+b
 c
 b
 l

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -99,3 +99,7 @@
 //ash walker nest
 /area/ruin/unpowered/ash_walkers
 	icon_state = "red"
+
+/area/ruin/unpowered/ratvar
+	icon_state = "dk_yellow"
+	outdoors = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

While looking into the other ATs I noticed some very bad behavior with the ruined Ratvar on Lavaland. Unlike other ruins , this was designated as a mining exploration area throughout, and lavaland turf generation was stomping all over it. This wraps it up in its own ruin area.

Fixes #52460, other ruins didn't generate ATs for me, so they're already done.
Fixes #48261
Probably #53828, but I couldn't exactly replicate this behavior

## Why It's Good For The Game
Because this is painful:
![ratvaroops](https://user-images.githubusercontent.com/66576896/109369481-ac1df900-7859-11eb-9db9-7011d8e7a653.png)

## Changelog
:cl:
fix: The ruin of Ratvar will now properly spawn in Lavaland
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
