### PR TITLE
Fixes an oversight with monkeys and revenant essence draining

### DIFF
--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -35,9 +35,12 @@
 		if(target.ckey)
 			to_chat(src, "<span class='revennotice'>[target.p_their(TRUE)] soul burns with intelligence.</span>")
 			essence_drained += rand(20, 30)
-		if(target.stat != DEAD)
+		if(target.stat != DEAD && !ismonkey(target))
 			to_chat(src, "<span class='revennotice'>[target.p_their(TRUE)] soul blazes with life!</span>")
 			essence_drained += rand(40, 50)
+		if(ismonkey(target) && !target.ckey)
+			to_chat(src, "<span class='revennotice'>[target.p_their(TRUE)] soul is weak and underdeveloped. They won't be worth very much.</span>")
+			essence_drained = 5
 		else
 			to_chat(src, "<span class='revennotice'>[target.p_their(TRUE)] soul is weak and faltering.</span>")
 		if(do_after(src, rand(15, 20), target, timed_action_flags = IGNORE_HELD_ITEM)) //did they get deleted NOW?
@@ -74,7 +77,7 @@
 				var/datum/beam/B = Beam(target,icon_state="drain_life")
 				if(do_after(src, 46, target, timed_action_flags = IGNORE_HELD_ITEM)) //As one cannot prove the existance of ghosts, ghosts cannot prove the existance of the target they were draining.
 					change_essence_amount(essence_drained, FALSE, target)
-					if(essence_drained <= 90 && target.stat != DEAD)
+					if(essence_drained <= 90 && target.stat != DEAD && !ismonkey(target))
 						essence_regen_cap += 5
 						to_chat(src, "<span class='revenboldnotice'>The absorption of [target]'s living soul has increased your maximum essence level. Your new maximum essence is [essence_regen_cap].</span>")
 					if(essence_drained > 90)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Monkeys no longer contribute to essence pool maximums, and give a very minor amount of essence for draining them (if they lack a ckey). 

Currently they can contribute an amount of essence pool max and essence equal to draining a normal dying human. This was occurring due to the fact that monkeys are now valid targets for revenant essence drain now that they are a subtype of human.

Obviously this does not change interactions with monkeyhumans.

## Why It's Good For The Game

I love infinite health revenant.

## Changelog
:cl:
fix: Stops revenants gaining obscenely large essence (AKA health + power) pools by draining dying monkeys.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
