### PR TITLE
Removes the spriteless cyborg outfit, replaces a Metastation cyborg suit with a cardborg outfit

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -41216,8 +41216,8 @@
 /area/cargo/sorting)
 "hzy" = (
 /obj/structure/table,
-/obj/item/clothing/suit/cyborg_suit,
-/obj/item/clothing/mask/gas/cyborg,
+/obj/item/clothing/suit/cardborg,
+/obj/item/clothing/head/cardborg,
 /obj/machinery/light/small/broken{
 	dir = 8
 	},

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -196,6 +196,12 @@
 	resistance_flags = FLAMMABLE
 	species_exception = list(/datum/species/golem)
 
+/obj/item/clothing/mask/gas/cyborg
+	name = "cyborg visor"
+	desc = "Beep boop."
+	icon_state = "death"
+	resistance_flags = FLAMMABLE
+
 /obj/item/clothing/mask/gas/owl_mask
 	name = "owl mask"
 	desc = "Twoooo!"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -196,12 +196,6 @@
 	resistance_flags = FLAMMABLE
 	species_exception = list(/datum/species/golem)
 
-/obj/item/clothing/mask/gas/cyborg
-	name = "cyborg visor"
-	desc = "Beep boop."
-	icon_state = "death"
-	resistance_flags = FLAMMABLE
-
 /obj/item/clothing/mask/gas/owl_mask
 	name = "owl mask"
 	desc = "Twoooo!"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -71,16 +71,6 @@
 	equip_delay_other = 20
 
 
-/obj/item/clothing/suit/cyborg_suit
-	name = "cyborg suit"
-	desc = "Suit for a cyborg costume."
-	icon_state = "death"
-	inhand_icon_state = "death"
-	flags_1 = CONDUCT_1
-	fire_resist = T0C+5200
-	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-
-
 /obj/item/clothing/suit/justice
 	name = "justice suit"
 	desc = "this pretty much looks ridiculous" //Needs no fixing


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I can't find the original on_mob sprites for whatever the cyborg suit was meant to be, so frankly I think this is just so old it's not worth retaining.

I replaced the suit on metastation with the cardborg suit. I suspect this was the INTENTION here, but I could be wrong.

closes https://github.com/tgstation/tgstation/issues/56946

## Why It's Good For The Game

I can't be arsed trying to work out what this outfit was meant to be and trying my hand at doing the sprites, so if someone wants to readd the sprites, you're welcome I guess.

## Changelog
:cl:
del: Removes the spriteless cyborg outfit from the code, replaces a Metastation cyborg suit with a cardborg outfit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
