### PR TITLE
Adds basic cybernetic eyes to the medical protolathe/exofabricator

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -664,7 +664,7 @@
 
 /datum/design/cybernetic_eyes
 	name = "Cybernetic Eyes"
-	desc = "A pair of cybernetic ears."
+	desc = "A pair of cybernetic eyes."
 	id = "cybernetic_eyes"
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 30

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -662,6 +662,17 @@
 	category = list("Cybernetics", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
+/datum/design/cybernetic_eyes
+	name = "Cybernetic Eyes"
+	desc = "A pair of cybernetic ears."
+	id = "cybernetic_eyes"
+	build_type = PROTOLATHE | MECHFAB
+	construction_time = 30
+	materials = list(/datum/material/iron = 250, /datum/material/glass = 400)
+	build_path = /obj/item/organ/eyes/robotic
+	category = list("Cybernetics", "Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
 /////////////////////
 ///Surgery Designs///
 /////////////////////

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -663,15 +663,21 @@
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
 /datum/design/cybernetic_eyes
-	name = "Cybernetic Eyes"
-	desc = "A pair of cybernetic eyes."
+	name = "Basic Cybernetic Eyes"
+	desc = "A basic pair of cybernetic eyes."
 	id = "cybernetic_eyes"
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 30
 	materials = list(/datum/material/iron = 250, /datum/material/glass = 400)
-	build_path = /obj/item/organ/eyes/robotic
+	build_path = /obj/item/organ/eyes/robotic/basic
 	category = list("Cybernetics", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
+/datum/design/cybernetic_eyes/improved
+	name = "Cybernetic Eyes"
+	desc = "A pair of cybernetic eyes."
+	id = "cybernetic_eyes_improved"
+	build_path = /obj/item/organ/eyes/robotic
 
 /////////////////////
 ///Surgery Designs///

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -56,7 +56,7 @@
 	starting_node = TRUE
 	display_name = "Basic Medical Equipment"
 	description = "Basic medical tools and equipment."
-	design_ids = list("cybernetic_liver", "cybernetic_heart", "cybernetic_lungs","cybernetic_stomach", "scalpel",
+	design_ids = list("cybernetic_liver", "cybernetic_heart", "cybernetic_lungs","cybernetic_stomach", "cybernetic_eyes", "scalpel",
 					"blood_filter", "circular_saw", "bonesetter", "surgicaldrill", "retractor", "cautery", "hemostat",
 					"stethoscope", "surgical_drapes", "syringe", "plumbing_rcd", "beaker", "large_beaker", "xlarge_beaker",
 					"dropper", "defibmountdefault", "surgical_tape", "portable_chem_mixer")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -454,7 +454,7 @@
 	display_name = "Cybernetic Organs"
 	description = "We have the technology to rebuild him."
 	prereq_ids = list("biotech")
-	design_ids = list("cybernetic_ears", "cybernetic_heart_tier2", "cybernetic_liver_tier2", "cybernetic_lungs_tier2", "cybernetic_stomach_tier2")
+	design_ids = list("cybernetic_ears", "cybernetic_heart_tier2", "cybernetic_liver_tier2", "cybernetic_lungs_tier2", "cybernetic_stomach_tier2", "cybernetic_eyes_improved")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 
 /datum/techweb_node/cyber_organs_upgraded

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -160,6 +160,22 @@
 	to_chat(owner, "<span class='warning'>Static obfuscates your vision!</span>")
 	owner.flash_act(visual = 1)
 
+/obj/item/organ/eyes/robotic/basic
+	name = "basic robotic eyes"
+	desc = "A pair of basic cybernetic eyes that restore vision, but at some vulnerability to light."
+	eye_color = "5500ff"
+	flash_protect = FLASH_PROTECTION_SENSITIVE
+
+/obj/item/organ/eyes/robotic/basic/emp_act(severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	if(prob(10 * severity))
+		damage += 20 * severity
+		to_chat(owner, "<span class='warning'>Your eyes start to fizzle in their sockets!</span>")
+		do_sparks(2, TRUE, owner)
+		owner.emote("scream")
+
 /obj/item/organ/eyes/robotic/xray
 	name = "\improper X-ray eyes"
 	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

With experiment science, getting replacement eyes that aren't pulled out of monkeyhumans requires completing the early parts of xenobiology and getting most of the basic tier 2 slimes, which may not necessarily occur during the course of a round due to RNG or incident.

The reason for this is that the most basic form of cybernetic eyes are flash shielded eyes, which is probably the kind of thing suited for being locked behind the node due being an effective upgraded pair of eyes. 

There is nothing wrong with keeping those locked away behind experiments, but it leaves medical without any round start basic cybernetic alternatives, much like every other basic cybernetic organ. Obviously, in the past, you simply researched towards the fairly cheap and basic cybernetic implants node.

This adds kinda crummy flash vulnerable cybereyes to the basic medical node. The one you get round start. There are also better eyes in the researchable node down the line.

## Why It's Good For The Game

Someone begged me to get them some new eyes, but all of science had exploded from a wizard and these were literally the only organ you couldn't print without experimental tech. We even have cyber ears round start, so eyes don't seem that big a departure from what we have.

## Changelog
:cl:
add: Adds basic cybernetic eyes to the medical protolathe and mechfab. Adds improved cybereyes (equal to human eyes) to the Cybernetic Organs tech node.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
