### PR TITLE
Allow admins to cancel dynamic midround events (+ another 2 year old Dynamic fix!)

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -535,39 +535,52 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	stack_trace("The starting rule \"[rule.name]\" failed to execute.")
 	return FALSE
 
-/// Picks a random midround OR latejoin rule from the list given as an argument and executes it.
-/// Also this could be named better.
-/datum/game_mode/dynamic/proc/picking_midround_latejoin_rule(list/drafted_rules = list(), forced = FALSE)
-	var/datum/dynamic_ruleset/rule = pickweight(drafted_rules)
-	if(!rule)
-		return FALSE
+/// From a list of rulesets, returns one based on weight and availability.
+/// Mutates the list that is passed into it to remove invalid rules.
+/datum/game_mode/dynamic/proc/pick_ruleset(list/drafted_rules)
+	if (only_ruleset_executed)
+		return null
 
-	if(!forced)
-		if(only_ruleset_executed)
-			return FALSE
-		// Check if a blocking ruleset has been executed.
-		else if(check_blocking(rule.blocking_rules, executed_rules))
+	while (TRUE)
+		var/datum/dynamic_ruleset/rule = pickweight(drafted_rules)
+		if (!rule)
+			return null
+
+		if (check_blocking(rule.blocking_rules, executed_rules))
 			drafted_rules -= rule
 			if(drafted_rules.len <= 0)
-				return FALSE
-			rule = pickweight(drafted_rules)
-		// Check if the ruleset is high impact and if a high impact ruleset has been executed
-		else if(rule.flags & HIGH_IMPACT_RULESET)
-			if(threat_level < GLOB.dynamic_stacking_limit && GLOB.dynamic_no_stacking)
-				if(high_impact_ruleset_executed)
-					drafted_rules -= rule
-					if(drafted_rules.len <= 0)
-						return FALSE
-					rule = pickweight(drafted_rules)
+				return null
+			continue
+		else if (
+			rule.flags & HIGH_IMPACT_RULESET \
+			&& threat_level < GLOB.dynamic_stacking_limit \
+			&& GLOB.dynamic_no_stacking \
+			&& high_impact_ruleset_executed \
+		)
+			drafted_rules -= rule
+			if(drafted_rules.len <= 0)
+				return null
+			continue
 
-	if(!rule.repeatable)
-		if(rule.ruletype == "Latejoin")
-			latejoin_rules = remove_from_list(latejoin_rules, rule.type)
-		else if(rule.ruletype == "Midround")
-			midround_rules = remove_from_list(midround_rules, rule.type)
+		return rule
 
+/// Executes a random midround ruleset from the list of drafted rules.
+/datum/game_mode/dynamic/proc/pick_midround_rule(list/drafted_rules)
+	var/datum/dynamic_ruleset/rule = pick_ruleset(drafted_rules)
+	if (isnull(rule))
+		return
+	if (!rule.repeatable)
+		midround_rules = remove_from_list(midround_rules, rule.type)
 	addtimer(CALLBACK(src, /datum/game_mode/dynamic/.proc/execute_midround_latejoin_rule, rule), rule.delay)
-	return TRUE
+
+/// Executes a random latejoin ruleset from the list of drafted rules.
+/datum/game_mode/dynamic/proc/pick_latejoin_rule(list/drafted_rules)
+	var/datum/dynamic_ruleset/rule = pick_ruleset(drafted_rules)
+	if (isnull(rule))
+		return
+	if (!rule.repeatable)
+		latejoin_rules = remove_from_list(latejoin_rules, rule.type)
+	addtimer(CALLBACK(src, /datum/game_mode/dynamic/.proc/execute_midround_latejoin_rule, rule), rule.delay)
 
 /// An experimental proc to allow admins to call rules on the fly or have rules call other rules.
 /datum/game_mode/dynamic/proc/picking_specific_rule(ruletype, forced = FALSE)
@@ -678,7 +691,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 					if (rule.ready())
 						drafted_rules[rule] = rule.get_weight()
 			if (drafted_rules.len > 0)
-				picking_midround_latejoin_rule(drafted_rules)
+				pick_midround_rule(drafted_rules)
 		else if (random_event_hijacked == HIJACKED_TOO_SOON)
 			log_game("DYNAMIC: Midround injection failed when random event was hijacked. Spawning another random event in its place.")
 
@@ -759,7 +772,9 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		forced_latejoin_rule.trim_candidates()
 		log_game("DYNAMIC: Forcing ruleset [forced_latejoin_rule]")
 		if (forced_latejoin_rule.ready(TRUE))
-			picking_midround_latejoin_rule(list(forced_latejoin_rule), forced = TRUE)
+			if (!forced_latejoin_rule.repeatable)
+				latejoin_rules = remove_from_list(latejoin_rules, forced_latejoin_rule.type)
+			addtimer(CALLBACK(src, /datum/game_mode/dynamic/.proc/execute_midround_latejoin_rule, forced_latejoin_rule), forced_latejoin_rule.delay)
 		forced_latejoin_rule = null
 
 	else if (latejoin_injection_cooldown < world.time && prob(get_injection_chance()))
@@ -778,7 +793,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 				if (rule.ready())
 					drafted_rules[rule] = rule.get_weight()
 
-		if (drafted_rules.len > 0 && picking_midround_latejoin_rule(drafted_rules))
+		if (drafted_rules.len > 0 && pick_latejoin_rule(drafted_rules))
 			var/latejoin_injection_cooldown_middle = 0.5*(latejoin_delay_max + latejoin_delay_min)
 			latejoin_injection_cooldown = round(clamp(EXP_DISTRIBUTION(latejoin_injection_cooldown_middle), latejoin_delay_min, latejoin_delay_max)) + world.time
 

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -147,6 +147,13 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	/// Whether or not a random event has been hijacked this midround cycle
 	var/random_event_hijacked = HIJACKED_NOTHING
 
+	/// The timer ID for the cancellable midround rule injection
+	var/midround_injection_timer_id
+
+	/// The last drafted midround rulesets (without the current one included).
+	/// Used for choosing different midround injections.
+	var/list/current_midround_rulesets
+
 /datum/game_mode/dynamic/admin_panel()
 	var/list/dat = list("<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Game Mode Panel</title></head><body><h1><B>Game Mode Panel</B></h1>")
 	dat += "Dynamic Mode <a href='?_src_=vars;[HrefToken()];Vars=[REF(src)]'>\[VV\]</a> <a href='?src=\ref[src];[HrefToken()]'>\[Refresh\]</a><BR>"
@@ -230,6 +237,12 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		log_admin("[key_name(usr)] executed the [added_rule] ruleset.")
 		message_admins("[key_name(usr)] executed the [added_rule] ruleset.")
 		picking_specific_rule(added_rule, TRUE)
+	else if(href_list["cancelmidround"])
+		admin_cancel_midround(usr, href_list["cancelmidround"])
+		return
+	else if (href_list["differentmidround"])
+		admin_different_midround(usr, href_list["differentmidround"])
+		return
 
 	admin_panel() // Refreshes the window
 
@@ -632,7 +645,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 /// Gets the chance for latejoin injection, the dry_run argument is only used for forced injection.
 /datum/game_mode/dynamic/proc/get_injection_chance(dry_run = FALSE)
 	if(forced_injection)
-		forced_injection = !dry_run
+		forced_injection = dry_run
 		return 100
 	var/chance = 0
 	var/max_pop_per_antag = max(5,15 - round(threat_level/10) - round(current_players[CURRENT_LIVING_PLAYERS].len/5))

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -535,53 +535,6 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	stack_trace("The starting rule \"[rule.name]\" failed to execute.")
 	return FALSE
 
-/// From a list of rulesets, returns one based on weight and availability.
-/// Mutates the list that is passed into it to remove invalid rules.
-/datum/game_mode/dynamic/proc/pick_ruleset(list/drafted_rules)
-	if (only_ruleset_executed)
-		return null
-
-	while (TRUE)
-		var/datum/dynamic_ruleset/rule = pickweight(drafted_rules)
-		if (!rule)
-			return null
-
-		if (check_blocking(rule.blocking_rules, executed_rules))
-			drafted_rules -= rule
-			if(drafted_rules.len <= 0)
-				return null
-			continue
-		else if (
-			rule.flags & HIGH_IMPACT_RULESET \
-			&& threat_level < GLOB.dynamic_stacking_limit \
-			&& GLOB.dynamic_no_stacking \
-			&& high_impact_ruleset_executed \
-		)
-			drafted_rules -= rule
-			if(drafted_rules.len <= 0)
-				return null
-			continue
-
-		return rule
-
-/// Executes a random midround ruleset from the list of drafted rules.
-/datum/game_mode/dynamic/proc/pick_midround_rule(list/drafted_rules)
-	var/datum/dynamic_ruleset/rule = pick_ruleset(drafted_rules)
-	if (isnull(rule))
-		return
-	if (!rule.repeatable)
-		midround_rules = remove_from_list(midround_rules, rule.type)
-	addtimer(CALLBACK(src, /datum/game_mode/dynamic/.proc/execute_midround_latejoin_rule, rule), rule.delay)
-
-/// Executes a random latejoin ruleset from the list of drafted rules.
-/datum/game_mode/dynamic/proc/pick_latejoin_rule(list/drafted_rules)
-	var/datum/dynamic_ruleset/rule = pick_ruleset(drafted_rules)
-	if (isnull(rule))
-		return
-	if (!rule.repeatable)
-		latejoin_rules = remove_from_list(latejoin_rules, rule.type)
-	addtimer(CALLBACK(src, /datum/game_mode/dynamic/.proc/execute_midround_latejoin_rule, rule), rule.delay)
-
 /// An experimental proc to allow admins to call rules on the fly or have rules call other rules.
 /datum/game_mode/dynamic/proc/picking_specific_rule(ruletype, forced = FALSE)
 	var/datum/dynamic_ruleset/midround/new_rule
@@ -627,32 +580,6 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 				return TRUE
 		else if (forced)
 			log_game("DYNAMIC: The ruleset [new_rule.name] couldn't be executed due to lack of elligible players.")
-	return FALSE
-
-/// Mainly here to facilitate delayed rulesets. All midround/latejoin rulesets are executed with a timered callback to this proc.
-/datum/game_mode/dynamic/proc/execute_midround_latejoin_rule(sent_rule)
-	var/datum/dynamic_ruleset/rule = sent_rule
-	spend_midround_budget(rule.cost)
-	threat_log += "[worldtime2text()]: [rule.ruletype] [rule.name] spent [rule.cost]"
-	rule.pre_execute(current_players[CURRENT_LIVING_PLAYERS].len)
-	if (rule.execute())
-		log_game("DYNAMIC: Injected a [rule.ruletype == "latejoin" ? "latejoin" : "midround"] ruleset [rule.name].")
-		if(rule.flags & HIGH_IMPACT_RULESET)
-			high_impact_ruleset_executed = TRUE
-		else if(rule.flags & ONLY_RULESET)
-			only_ruleset_executed = TRUE
-		if(rule.ruletype == "Latejoin")
-			var/mob/M = pick(rule.candidates)
-			message_admins("[key_name(M)] joined the station, and was selected by the [rule.name] ruleset.")
-			log_game("DYNAMIC: [key_name(M)] joined the station, and was selected by the [rule.name] ruleset.")
-		executed_rules += rule
-		rule.candidates.Cut()
-		if (rule.persistent)
-			current_rules += rule
-		new_snapshot(rule)
-		return TRUE
-	rule.clean_up()
-	stack_trace("The [rule.ruletype] rule \"[rule.name]\" failed to execute.")
 	return FALSE
 
 /datum/game_mode/dynamic/process()

--- a/code/game/gamemodes/dynamic/ruleset_picking.dm
+++ b/code/game/gamemodes/dynamic/ruleset_picking.dm
@@ -34,9 +34,26 @@
 	var/datum/dynamic_ruleset/rule = pick_ruleset(drafted_rules)
 	if (isnull(rule))
 		return
+	current_midround_rulesets = drafted_rules - rule
+
+	midround_injection_timer_id = addtimer(
+		CALLBACK(src, .proc/execute_midround_rule, rule), \
+		ADMIN_CANCEL_MIDROUND_TIME, \
+		TIMER_STOPPABLE, \
+	)
+
+	log_game("DYNAMIC: [rule] ruleset executing...")
+	message_admins("DYNAMIC: Executing midround ruleset [rule] in [DisplayTimeText(ADMIN_CANCEL_MIDROUND_TIME)]. \
+		<a href='?src=[REF(src)];cancelmidround=[midround_injection_timer_id]'>CANCEL</a> | \
+		<a href='?src=[REF(src)];differentmidround=[midround_injection_timer_id]'>SOMETHING ELSE</a>")
+
+/// Fired after admins do not cancel a midround injection.
+/datum/game_mode/dynamic/proc/execute_midround_rule(datum/dynamic_ruleset/rule)
+	current_midround_rulesets = null
+	midround_injection_timer_id = null
 	if (!rule.repeatable)
 		midround_rules = remove_from_list(midround_rules, rule.type)
-	addtimer(CALLBACK(src, /datum/game_mode/dynamic/.proc/execute_midround_latejoin_rule, rule), rule.delay)
+	addtimer(CALLBACK(src, .proc/execute_midround_latejoin_rule, rule), rule.delay)
 
 /// Executes a random latejoin ruleset from the list of drafted rules.
 /datum/game_mode/dynamic/proc/pick_latejoin_rule(list/drafted_rules)
@@ -45,7 +62,7 @@
 		return
 	if (!rule.repeatable)
 		latejoin_rules = remove_from_list(latejoin_rules, rule.type)
-	addtimer(CALLBACK(src, /datum/game_mode/dynamic/.proc/execute_midround_latejoin_rule, rule), rule.delay)
+	addtimer(CALLBACK(src, .proc/execute_midround_latejoin_rule, rule), rule.delay)
 
 /// Mainly here to facilitate delayed rulesets. All midround/latejoin rulesets are executed with a timered callback to this proc.
 /datum/game_mode/dynamic/proc/execute_midround_latejoin_rule(sent_rule)
@@ -72,5 +89,33 @@
 	rule.clean_up()
 	stack_trace("The [rule.ruletype] rule \"[rule.name]\" failed to execute.")
 	return FALSE
+
+/// Fired when an admin cancels the current midround injection.
+/datum/game_mode/dynamic/proc/admin_cancel_midround(mob/user, timer_id)
+	if (midround_injection_timer_id != timer_id || !deltimer(midround_injection_timer_id))
+		to_chat(user, "<span class='notice'>Too late!</span>")
+		return
+
+	log_admin("[key_name(user)] cancelled the next midround injection.")
+	message_admins("[key_name(user)] cancelled the next midround injection.")
+	midround_injection_timer_id = null
+	current_midround_rulesets = null
+
+/// Fired when an admin requests a different midround injection.
+/datum/game_mode/dynamic/proc/admin_different_midround(mob/user, timer_id)
+	if (midround_injection_timer_id != timer_id || !deltimer(midround_injection_timer_id))
+		to_chat(user, "<span class='notice'>Too late!</span>")
+		return
+
+	midround_injection_timer_id = null
+
+	if (isnull(current_midround_rulesets) || current_midround_rulesets.len == 0)
+		log_admin("[key_name(user)] asked for a different midround injection, but there were none left.")
+		message_admins("[key_name(user)] asked for a different midround injection, but there were none left.")
+		return
+
+	log_admin("[key_name(user)] asked for a different midround injection.")
+	message_admins("[key_name(user)] asked for a different midround injection.")
+	pick_midround_rule(current_midround_rulesets)
 
 #undef ADMIN_CANCEL_MIDROUND_TIME

--- a/code/game/gamemodes/dynamic/ruleset_picking.dm
+++ b/code/game/gamemodes/dynamic/ruleset_picking.dm
@@ -1,0 +1,76 @@
+#define ADMIN_CANCEL_MIDROUND_TIME (10 SECONDS)
+
+/// From a list of rulesets, returns one based on weight and availability.
+/// Mutates the list that is passed into it to remove invalid rules.
+/datum/game_mode/dynamic/proc/pick_ruleset(list/drafted_rules)
+	if (only_ruleset_executed)
+		return null
+
+	while (TRUE)
+		var/datum/dynamic_ruleset/rule = pickweight(drafted_rules)
+		if (!rule)
+			return null
+
+		if (check_blocking(rule.blocking_rules, executed_rules))
+			drafted_rules -= rule
+			if(drafted_rules.len <= 0)
+				return null
+			continue
+		else if (
+			rule.flags & HIGH_IMPACT_RULESET \
+			&& threat_level < GLOB.dynamic_stacking_limit \
+			&& GLOB.dynamic_no_stacking \
+			&& high_impact_ruleset_executed \
+		)
+			drafted_rules -= rule
+			if(drafted_rules.len <= 0)
+				return null
+			continue
+
+		return rule
+
+/// Executes a random midround ruleset from the list of drafted rules.
+/datum/game_mode/dynamic/proc/pick_midround_rule(list/drafted_rules)
+	var/datum/dynamic_ruleset/rule = pick_ruleset(drafted_rules)
+	if (isnull(rule))
+		return
+	if (!rule.repeatable)
+		midround_rules = remove_from_list(midround_rules, rule.type)
+	addtimer(CALLBACK(src, /datum/game_mode/dynamic/.proc/execute_midround_latejoin_rule, rule), rule.delay)
+
+/// Executes a random latejoin ruleset from the list of drafted rules.
+/datum/game_mode/dynamic/proc/pick_latejoin_rule(list/drafted_rules)
+	var/datum/dynamic_ruleset/rule = pick_ruleset(drafted_rules)
+	if (isnull(rule))
+		return
+	if (!rule.repeatable)
+		latejoin_rules = remove_from_list(latejoin_rules, rule.type)
+	addtimer(CALLBACK(src, /datum/game_mode/dynamic/.proc/execute_midround_latejoin_rule, rule), rule.delay)
+
+/// Mainly here to facilitate delayed rulesets. All midround/latejoin rulesets are executed with a timered callback to this proc.
+/datum/game_mode/dynamic/proc/execute_midround_latejoin_rule(sent_rule)
+	var/datum/dynamic_ruleset/rule = sent_rule
+	spend_midround_budget(rule.cost)
+	threat_log += "[worldtime2text()]: [rule.ruletype] [rule.name] spent [rule.cost]"
+	rule.pre_execute(current_players[CURRENT_LIVING_PLAYERS].len)
+	if (rule.execute())
+		log_game("DYNAMIC: Injected a [rule.ruletype == "latejoin" ? "latejoin" : "midround"] ruleset [rule.name].")
+		if(rule.flags & HIGH_IMPACT_RULESET)
+			high_impact_ruleset_executed = TRUE
+		else if(rule.flags & ONLY_RULESET)
+			only_ruleset_executed = TRUE
+		if(rule.ruletype == "Latejoin")
+			var/mob/M = pick(rule.candidates)
+			message_admins("[key_name(M)] joined the station, and was selected by the [rule.name] ruleset.")
+			log_game("DYNAMIC: [key_name(M)] joined the station, and was selected by the [rule.name] ruleset.")
+		executed_rules += rule
+		rule.candidates.Cut()
+		if (rule.persistent)
+			current_rules += rule
+		new_snapshot(rule)
+		return TRUE
+	rule.clean_up()
+	stack_trace("The [rule.ruletype] rule \"[rule.name]\" failed to execute.")
+	return FALSE
+
+#undef ADMIN_CANCEL_MIDROUND_TIME

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -822,6 +822,7 @@
 #include "code\game\gamemodes\dynamic\dynamic_rulesets_midround.dm"
 #include "code\game\gamemodes\dynamic\dynamic_rulesets_roundstart.dm"
 #include "code\game\gamemodes\dynamic\dynamic_simulations.dm"
+#include "code\game\gamemodes\dynamic\ruleset_picking.dm"
 #include "code\game\gamemodes\eldritch_cult\eldritch_cult.dm"
 #include "code\game\gamemodes\extended\extended.dm"
 #include "code\game\gamemodes\gang\gang.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Admins will now be warned with a 10 second timer about a midround event. They will have the option to cancel it, or to replace it with a different midround event.

Fixes a bug where the "Execute" midround ruleset button would not force the chance correctly (FUCK the term "dry_run").

Moves out dynamic ruleset picking to its own file, as in line with the rest of the code splitting I've done. Makes it nicer to work with, as opposed to a several thousand line script.

## Why It's Good For The Game
Highly requested by admins, especially MRP ones.

## Changelog
:cl:
admin: Admins can now cancel or replace midround rulesets.
fix: Admins can now correctly force midround rulesets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
