### PR TITLE
Fixes borg module buckets dropping to the floor

### DIFF
--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -50,8 +50,11 @@
 		return
 	if(iscyborg(hit_atom))
 		var/mob/living/silicon/robot/R = hit_atom
-		///hats in the borg's blacklist bounce off
-		if(is_type_in_typecache(src, GLOB.blacklisted_borg_hats))
+		var/obj/item/worn_hat = R.hat
+		if(worn_hat && HAS_TRAIT(worn_hat, TRAIT_NODROP))
+			R.visible_message("<span class='warning'>[src] bounces off [worn_hat], without an effect!</span>", "<span class='warning'>[src] bounces off your mighty [worn_hat.name], falling to the floor in defeat.</span>")
+			return
+		if(is_type_in_typecache(src, GLOB.blacklisted_borg_hats))//hats in the borg's blacklist bounce off
 			R.visible_message("<span class='warning'>[src] bounces off [R]!</span>", "<span class='warning'>[src] bounces off you, falling to the floor.</span>")
 			return
 		else

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -100,6 +100,9 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		return
 
 	if(W.slot_flags & ITEM_SLOT_HEAD && hat_offset != INFINITY && !user.combat_mode && !is_type_in_typecache(W, GLOB.blacklisted_borg_hats))
+		if(user == src)
+			to_chat(user,  "<span class='notice'>You can't seem to manage to place [W] on your head by yourself!</span>" )
+			return
 		if(hat && HAS_TRAIT(hat, TRAIT_NODROP))
 			to_chat(user, "<span class='warn'>You can't seem to remove [src]'s existing headwear!</span>")
 			return


### PR DESCRIPTION
## About The Pull Request
Adds a check when someone tries to put a hat on a borg to make sure a borg can't put one of its own modules on itself, preventing janiborgs from having nodrop borg module buckets on their head

Also makes thrown hats respect nodrop hats that are already worn, so that you can't easily remove a placed nodrop hat with any old hat.

fixes https://github.com/tgstation/tgstation/issues/54205

## Why It's Good For The Game
Prevents janny borgs from memeing on people by giving them a cursed bucket that fuses with their hand and utterly ruins their day.

## Changelog
:cl:
fix: Janitor cyborgs are no longer capable of placing their bucket module on their own head, and feeble attempts to replace a no drop hat atop a cyborg's head will be met with failure.
/:cl: