### PR TITLE
Fixes crafted foods not getting reagents from its contents

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -194,7 +194,7 @@ Behavior that's still missing from this component that original food items had t
 
 	this_food.reagents.multiply_reagents(CRAFTED_FOOD_BASE_REAGENT_MODIFIER)
 
-	for(var/obj/item/crafted_part in this_food.contents)
+	for(var/obj/item/food/crafted_part in this_food.contents)
 		crafted_part.reagents?.trans_to(this_food.reagents, crafted_part.reagents.maximum_volume, CRAFTED_FOOD_INGREDIENT_REAGENT_MODIFIER)
 
 	var/list/objects_to_delete = list()

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -194,19 +194,8 @@ Behavior that's still missing from this component that original food items had t
 
 	this_food.reagents.multiply_reagents(CRAFTED_FOOD_BASE_REAGENT_MODIFIER)
 
-	for(var/obj/item/food/crafted_part in this_food.contents)
+	for(var/obj/item/food/crafted_part in parts_list)
 		crafted_part.reagents?.trans_to(this_food.reagents, crafted_part.reagents.maximum_volume, CRAFTED_FOOD_INGREDIENT_REAGENT_MODIFIER)
-
-	var/list/objects_to_delete = list()
-
-	// Remove all non recipe objects from the contents
-	for(var/content_object in this_food.contents)
-		for(var/recipe_object in recipe.real_parts)
-			if(istype(content_object, recipe_object))
-				continue
-		objects_to_delete += content_object
-
-	QDEL_LIST(objects_to_delete)
 
 	SSblackbox.record_feedback("tally", "food_made", 1, type)
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -423,7 +423,6 @@
  * Otherwise it simply forceMoves the atom into this atom
  */
 /atom/proc/CheckParts(list/parts_list, datum/crafting_recipe/R)
-	SEND_SIGNAL(src, COMSIG_ATOM_CHECKPARTS, parts_list, R)
 	if(parts_list)
 		for(var/A in parts_list)
 			if(istype(A, /datum/reagent))
@@ -440,6 +439,7 @@
 					M.forceMove(src)
 				SEND_SIGNAL(M, COMSIG_ATOM_USED_IN_CRAFT, src)
 		parts_list.Cut()
+	SEND_SIGNAL(src, COMSIG_ATOM_CHECKPARTS, parts_list, R)
 
 ///Take air from the passed in gas mixture datum
 /atom/proc/assume_air(datum/gas_mixture/giver)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -423,6 +423,7 @@
  * Otherwise it simply forceMoves the atom into this atom
  */
 /atom/proc/CheckParts(list/parts_list, datum/crafting_recipe/R)
+	SEND_SIGNAL(src, COMSIG_ATOM_CHECKPARTS, parts_list, R)
 	if(parts_list)
 		for(var/A in parts_list)
 			if(istype(A, /datum/reagent))
@@ -438,7 +439,6 @@
 				else
 					M.forceMove(src)
 				SEND_SIGNAL(M, COMSIG_ATOM_USED_IN_CRAFT, src)
-		SEND_SIGNAL(src, COMSIG_ATOM_CHECKPARTS, parts_list, R)
 		parts_list.Cut()
 
 ///Take air from the passed in gas mixture datum

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -438,8 +438,8 @@
 				else
 					M.forceMove(src)
 				SEND_SIGNAL(M, COMSIG_ATOM_USED_IN_CRAFT, src)
+		SEND_SIGNAL(src, COMSIG_ATOM_CHECKPARTS, parts_list, R)
 		parts_list.Cut()
-	SEND_SIGNAL(src, COMSIG_ATOM_CHECKPARTS, parts_list, R)
 
 ///Take air from the passed in gas mixture datum
 /atom/proc/assume_air(datum/gas_mixture/giver)


### PR DESCRIPTION
## About The Pull Request

Fixes crafted foods not gaining the reagents from the foods in their contents.

`CheckParts` sent `COMSIG_ATOM_CHECKPARTS` before it added the parts to the atom's `contents`. Meanwhile, in the edible component `OnCraft` relied on the `contents` list being filled out, meaning at the time it caught the signal, `contents` was empty and nothing happened.

Food now checks the passed `parts_list` instead of the `contents` to deal with this.

## Why It's Good For The Game

Botany can now poison the chef's food with drugs once again.

## Changelog
:cl: Melbert
fix: Crafted foods now inherit their component food's reagents again.
/:cl:

