### PR TITLE
Fixes the randomly failing unit test that sometimes happens.

### DIFF
--- a/code/modules/projectiles/projectile/special/curse.dm
+++ b/code/modules/projectiles/projectile/special/curse.dm
@@ -26,8 +26,8 @@
 	return ..()
 
 /obj/projectile/curse_hand/fire(setAngle)
-	if(QDELETED(src))
-		return ..()
+	if(QDELETED(src)) //I'm going to try returning nothing because if it's being deleted, surely we don't want anything to happen?
+		return
 	if(starting)
 		arm = starting.Beam(src, icon_state = "curse[handedness]", beam_type=/obj/effect/ebeam/curse_arm)
 	..()

--- a/code/modules/projectiles/projectile/special/curse.dm
+++ b/code/modules/projectiles/projectile/special/curse.dm
@@ -45,6 +45,8 @@
 	leftover.icon_state = icon_state
 	for(var/obj/effect/temp_visual/dir_setting/curse/grasp_portal/G in starting)
 		qdel(G)
+	if(!T) //T can be in nullspace when src is set to QDEL
+		return
 	new /obj/effect/temp_visual/dir_setting/curse/grasp_portal/fading(starting, dir)
 	var/datum/beam/D = starting.Beam(T, icon_state = "curse[handedness]", time = 32, beam_type=/obj/effect/ebeam/curse_arm)
 	animate(D.visuals, alpha = 0, time = 32)

--- a/code/modules/projectiles/projectile/special/curse.dm
+++ b/code/modules/projectiles/projectile/special/curse.dm
@@ -26,6 +26,8 @@
 	return ..()
 
 /obj/projectile/curse_hand/fire(setAngle)
+	if(QDELETED(src))
+		return ..()
 	if(starting)
 		arm = starting.Beam(src, icon_state = "curse[handedness]", beam_type=/obj/effect/ebeam/curse_arm)
 	..()

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -82,6 +82,8 @@
 	playsound(spawn_turf, 'sound/effects/curse2.ogg', 80, TRUE, -1)
 	var/obj/projectile/curse_hand/hel/hand = new (spawn_turf)
 	hand.preparePixelProjectile(owner, spawn_turf)
+	if(QDELETED(hand)) //safety check if above fails - above has a stack trace if it does fail
+		return
 	hand.fire()
 
 /datum/reagent/inverse/helgrasp/on_mob_delete(mob/living/owner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There's a unit test failure to do with beams losing their target hands. I believe it's because, strangely, the hand sets up a beam when it's destroyed, but it can also can set up a beam if it's fired. In essence - it's Destroy() having new functions within it causing jank and I unearthed the jank by using a child in a reagent.

## Why It's Good For The Game

Fixes a rare unit test failure.

## Changelog
:cl:
fix: Fixes the randomly failing unit test that sometimes happens.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
