### PR TITLE
Patch runtime from unequip before equip

### DIFF
--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -108,8 +108,8 @@
 /datum/component/squeak/proc/on_drop(datum/source, mob/user)
 	SIGNAL_HANDLER
 
-	UnregisterSignal(holder, COMSIG_MOVABLE_CROSSED)
-	UnregisterSignal(holder, COMSIG_MOVABLE_DISPOSING)
+	UnregisterSignal(user, COMSIG_MOVABLE_CROSSED)
+	UnregisterSignal(user, COMSIG_MOVABLE_DISPOSING)
 	holder = null
 
 ///just gets rid of the reference to holder in the case that theyre qdeleted


### PR DESCRIPTION
https://gist.github.com/Gurkenglas/1a8c40afb1106a4233ef65a36af3148c

This "harmless" runtime resulted from trying to unregister a squeak from its bananium's holder before it was ever finished equipping - perhaps https://github.com/tgstation/tgstation/pull/56820 did not expect https://github.com/tgstation/tgstation/blob/master/code/datums/components/storage/concrete/_concrete.dm#L160.