### PR TITLE
Fix multiz piping issue

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -19,7 +19,7 @@ GLOBAL_LIST_INIT(atmos_pipe_recipes, list(
 		new /datum/pipe_info/pipe("Manifold", /obj/machinery/atmospherics/pipe/manifold, TRUE),
 		new /datum/pipe_info/pipe("4-Way Manifold", /obj/machinery/atmospherics/pipe/manifold4w, TRUE),
 		new /datum/pipe_info/pipe("Layer Adapter", /obj/machinery/atmospherics/pipe/layer_manifold, TRUE),
-		new /datum/pipe_info/pipe("Multi-Deck Adapter", /obj/machinery/atmospherics/pipe/multiz, TRUE),
+		new /datum/pipe_info/pipe("Multi-Deck Adapter", /obj/machinery/atmospherics/pipe/multiz, FALSE),
 	),
 	"Devices" = list(
 		new /datum/pipe_info/pipe("Connector", /obj/machinery/atmospherics/components/unary/portables_connector, TRUE),

--- a/code/modules/atmospherics/machinery/pipes/multiz.dm
+++ b/code/modules/atmospherics/machinery/pipes/multiz.dm
@@ -45,18 +45,11 @@
 ///Attempts to locate a multiz pipe that's above us, if it finds one it merges us into its pipenet
 /obj/machinery/atmospherics/pipe/multiz/pipeline_expansion()
 	var/turf/T = get_turf(src)
-	var/list/above_adapters = list()
-	var/list/below_adapters = list()
 	for(var/obj/machinery/atmospherics/pipe/multiz/above in SSmapping.get_turf_above(T))
-		above_adapters += above
-	for(var/obj/machinery/atmospherics/pipe/multiz/below in SSmapping.get_turf_below(T))
-		below_adapters += below
-
-	for(var/obj/machinery/atmospherics/pipe/multiz/below in below_adapters)
-		if(below && below.piping_layer == piping_layer)
-			below.pipeline_expansion() //If we've got one below us, force it to add us on facebook
-	for(var/obj/machinery/atmospherics/pipe/multiz/above in above_adapters)
 		if(above && above.piping_layer == piping_layer)
 			nodes += above
 			above.nodes += src //Two way travel :)
+	for(var/obj/machinery/atmospherics/pipe/multiz/below in SSmapping.get_turf_below(T))
+		if(below && below.piping_layer == piping_layer)
+			below.pipeline_expansion() //If we've got one below us, force it to add us on facebook
 	return ..()

--- a/code/modules/atmospherics/machinery/pipes/multiz.dm
+++ b/code/modules/atmospherics/machinery/pipes/multiz.dm
@@ -32,26 +32,31 @@
 /obj/machinery/atmospherics/pipe/multiz/SetInitDirections()
 	initialize_directions = dir
 
-/obj/machinery/atmospherics/pipe/multiz/update_layer()
-	return // Noop because we're moving this to /obj/machinery/atmospherics/pipe
-
 /obj/machinery/atmospherics/pipe/multiz/update_overlays()
 	. = ..()
+	cut_overlays()
 	pipe.color = front_node ? front_node.pipe_color : rgb(255, 255, 255)
 	pipe.icon_state = "pipe-[piping_layer]"
 	. += pipe
 	center.pixel_x = PIPING_LAYER_P_X * (piping_layer - PIPING_LAYER_DEFAULT)
 	. += center
-
+	update_layer()
 
 ///Attempts to locate a multiz pipe that's above us, if it finds one it merges us into its pipenet
 /obj/machinery/atmospherics/pipe/multiz/pipeline_expansion()
 	var/turf/T = get_turf(src)
-	var/obj/machinery/atmospherics/pipe/multiz/above = locate(/obj/machinery/atmospherics/pipe/multiz) in(SSmapping.get_turf_above(T))
-	var/obj/machinery/atmospherics/pipe/multiz/below = locate(/obj/machinery/atmospherics/pipe/multiz) in(SSmapping.get_turf_below(T))
-	if(below)
-		below.pipeline_expansion() //If we've got one below us, force it to add us on facebook
-	if(above)
-		nodes += above
-		above.nodes += src //Two way travel :)
+	var/list/above_adapters = list()
+	var/list/below_adapters = list()
+	for(var/obj/machinery/atmospherics/pipe/multiz/above in SSmapping.get_turf_above(T))
+		above_adapters += above
+	for(var/obj/machinery/atmospherics/pipe/multiz/below in SSmapping.get_turf_below(T))
+		below_adapters += below
+
+	for(var/obj/machinery/atmospherics/pipe/multiz/below in below_adapters)
+		if(below && below.piping_layer == piping_layer)
+			below.pipeline_expansion() //If we've got one below us, force it to add us on facebook
+	for(var/obj/machinery/atmospherics/pipe/multiz/above in above_adapters)
+		if(above && above.piping_layer == piping_layer)
+			nodes += above
+			above.nodes += src //Two way travel :)
 	return ..()

--- a/code/modules/atmospherics/machinery/pipes/multiz.dm
+++ b/code/modules/atmospherics/machinery/pipes/multiz.dm
@@ -34,13 +34,11 @@
 
 /obj/machinery/atmospherics/pipe/multiz/update_overlays()
 	. = ..()
-	cut_overlays()
 	pipe.color = front_node ? front_node.pipe_color : rgb(255, 255, 255)
 	pipe.icon_state = "pipe-[piping_layer]"
 	. += pipe
 	center.pixel_x = PIPING_LAYER_P_X * (piping_layer - PIPING_LAYER_DEFAULT)
 	. += center
-	update_layer()
 
 ///Attempts to locate a multiz pipe that's above us, if it finds one it merges us into its pipenet
 /obj/machinery/atmospherics/pipe/multiz/pipeline_expansion()

--- a/code/modules/atmospherics/machinery/pipes/multiz.dm
+++ b/code/modules/atmospherics/machinery/pipes/multiz.dm
@@ -44,10 +44,10 @@
 /obj/machinery/atmospherics/pipe/multiz/pipeline_expansion()
 	var/turf/T = get_turf(src)
 	for(var/obj/machinery/atmospherics/pipe/multiz/above in SSmapping.get_turf_above(T))
-		if(above && above.piping_layer == piping_layer)
+		if(above.piping_layer == piping_layer)
 			nodes += above
 			above.nodes += src //Two way travel :)
 	for(var/obj/machinery/atmospherics/pipe/multiz/below in SSmapping.get_turf_below(T))
-		if(below && below.piping_layer == piping_layer)
+		if(below.piping_layer == piping_layer)
 			below.pipeline_expansion() //If we've got one below us, force it to add us on facebook
 	return ..()

--- a/code/modules/atmospherics/machinery/pipes/multiz.dm
+++ b/code/modules/atmospherics/machinery/pipes/multiz.dm
@@ -32,6 +32,9 @@
 /obj/machinery/atmospherics/pipe/multiz/SetInitDirections()
 	initialize_directions = dir
 
+/obj/machinery/atmospherics/pipe/multiz/update_layer()
+	return // Noop because we're moving this to /obj/machinery/atmospherics/pipe
+
 /obj/machinery/atmospherics/pipe/multiz/update_overlays()
 	. = ..()
 	pipe.color = front_node ? front_node.pipe_color : rgb(255, 255, 255)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fix #57101
multiz adapters are now able to be placed on the same tile with different pipe layer and will keep the pipelines separated
also fix the issue with multiz adapters on layer 1 and 5, breaking the overlays
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fix multiz adapters, now they work on the same tile with different pipe layers and they keep the pipelines separated and sprite fix due to layer 1 and 5
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
