### PR TITLE
freezers can't be build on same layer pipes

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -53,7 +53,7 @@
 		piping_layer = board.pipe_layer
 		set_layer = piping_layer
 
-	for(var/obj/machinery/atmospherics/device as anything in get_turf(src))
+	for(var/obj/machinery/atmospherics/device in get_turf(src))
 		if(device.piping_layer != piping_layer || device == src)
 			continue
 		deconstruct(FALSE)

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -53,13 +53,9 @@
 		piping_layer = board.pipe_layer
 		set_layer = piping_layer
 
-	var/turf/turf = get_turf(src)
-	var/obj/machinery/atmospherics/device
-	for(device in turf.contents)
+	for(var/obj/machinery/atmospherics/device as anything in get_turf(src))
 		if(device.piping_layer != piping_layer || device == src)
 			continue
-		to_chat(user, "<span class='notice'>You can't finish the construction because something is hogging the pipe,\
-		 try to remove the obstruction or change the thermomachine pipe layer to a non obstucted one.</span>")
 		deconstruct(FALSE)
 		return
 	return..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -52,6 +52,16 @@
 	if(board)
 		piping_layer = board.pipe_layer
 		set_layer = piping_layer
+
+	var/turf/turf = get_turf(src)
+	var/obj/machinery/atmospherics/device
+	for(device in turf.contents)
+		if(device.piping_layer != piping_layer || device == src)
+			continue
+		to_chat(user, "<span class='notice'>You can't finish the construction because something is hogging the pipe,\
+		 try to remove the obstruction or change the thermomachine pipe layer to a non obstucted one.</span>")
+		deconstruct(FALSE)
+		return
 	return..()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/RefreshParts()

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -56,7 +56,8 @@
 	for(var/obj/machinery/atmospherics/device in get_turf(src))
 		if(device.piping_layer != piping_layer || device == src)
 			continue
-		deconstruct(FALSE)
+		visible_message("<span class='warning'>Something is hogging the pipe, remove the obstruction or change the machine piping layer.</span>")
+		deconstruct(TRUE)
 		return
 	return..()
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -56,7 +56,7 @@
 	for(var/obj/machinery/atmospherics/device in get_turf(src))
 		if(device.piping_layer != piping_layer || device == src)
 			continue
-		visible_message("<span class='warning'>Something is hogging the pipe, remove the obstruction or change the machine piping layer.</span>")
+		visible_message("<span class='warning'>A pipe is hogging the output, remove the obstruction or change the machine piping layer.</span>")
 		deconstruct(TRUE)
 		return
 	return..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fix  #51993
Thermomachines can't be built on the same pipe layer of existing pipes, this still allows piping on other layers under the machine
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: thermomachines can't be built on same layer pipes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
