### PR TITLE
Luxury bar capsule no longer throws a runtime when deployed

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -30,7 +30,7 @@
 	flags_1 &= ~PREVENT_CLICK_UNDER_1
 	if(set_dir)
 		setDir(set_dir)
-	if(req_access?.len)
+	if(req_access && req_access.len)
 		icon_state = "[icon_state]"
 		base_state = icon_state
 	for(var/i in 1 to shards)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -30,7 +30,7 @@
 	flags_1 &= ~PREVENT_CLICK_UNDER_1
 	if(set_dir)
 		setDir(set_dir)
-	if(req_access && req_access.len)
+	if(LAZYLEN(req_access))
 		icon_state = "[icon_state]"
 		base_state = icon_state
 	for(var/i in 1 to shards)


### PR DESCRIPTION
## About The Pull Request
<details>
  <summary>Runtime message</summary>
  
![image](https://user-images.githubusercontent.com/60656530/109432155-31481000-7a0a-11eb-95ce-10edb36cddb9.png)
  
</details>

This runtime would get thrown whenever player tried to activate `/obj/item/survivalcapsule/luxuryelite`.
The runtime itself was caused by this search&replace PR: https://github.com/tgstation/tgstation/pull/54342

## Changelog
:cl: Dex
fix: Luxury bar capsule no longer runtimes when deployed.
/:cl:
