### PR TITLE
(Fix) Metastation AI should not be the victim of anti-cable activists

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -64397,6 +64397,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "qQr" = (


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/53862927/109437012-960b6680-7a1a-11eb-8ea7-bcd1913f8996.png)
https://www.youtube.com/watch?v=3WShMzwT-nM

## Why It's Good For The Game
admin why i got no power why tcomms off???

## Changelog
:cl:
fix: Metastation's AI satellite is now wired to the station again.
/:cl:
