### PR TITLE
Chef Produce Console, for cases where there are no botanists

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -76246,6 +76246,10 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/chef,
 /obj/effect/turf_decal/bot,
+/obj/item/food/mint,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_y = 5
+	},
 /turf/open/floor/iron,
 /area/service/kitchen)
 "khj" = (
@@ -93124,12 +93128,10 @@
 /turf/open/floor/iron,
 /area/science/misc_lab/range)
 "qhn" = (
-/obj/structure/table/reinforced,
-/obj/item/food/mint,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/computer/chef_order{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/service/kitchen)
 "qhE" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -49286,6 +49286,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"sTS" = (
+/obj/machinery/computer/chef_order{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "sUk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -95009,7 +95015,7 @@ dfW
 mjA
 rLD
 nUo
-nUo
+sTS
 nUo
 nUo
 tIN

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -65525,6 +65525,10 @@
 /obj/item/food/dough,
 /obj/item/kitchen/rollingpin,
 /obj/item/kitchen/rollingpin,
+/obj/item/paper/crumpled{
+	info = "Hey whoever designed this shithole didn't give us space to install the produce computer so it's in maintenance near the theatre.";
+	name = "hastily written note"
+	},
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
 "jAY" = (
@@ -90733,6 +90737,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/qm)
+"xwt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/chef_order{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/central)
 "xww" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/newscaster{
@@ -124435,7 +124448,7 @@ aox
 aox
 buB
 ajq
-akM
+xwt
 uuQ
 sox
 ref

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -36432,6 +36432,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/chef_order{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "fDd" = (

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -45,6 +45,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/list/discoveredPlants = list() //Typepaths for unusual plants we've already sent CentCom, associated with their potencies
 
 	var/list/supply_packs = list()
+	var/list/chef_groceries = list()
 	var/list/shoppinglist = list()
 	var/list/requestlist = list()
 	var/list/orderhistory = list()

--- a/code/game/machinery/computer/chef_orders/chef_order.dm
+++ b/code/game/machinery/computer/chef_orders/chef_order.dm
@@ -25,7 +25,7 @@
 	. = 0
 	for(var/datum/orderable_item/item as anything in grocery_list)
 		for(var/i in 1 to grocery_list[item]) //for how many times we bought it
-			. += item.cost_per_order //add it's price
+			. += item.cost_per_order //add its price
 
 /obj/machinery/computer/chef_order/ui_state(mob/user)
 	return GLOB.not_incapacitated_state

--- a/code/game/machinery/computer/chef_orders/chef_order.dm
+++ b/code/game/machinery/computer/chef_orders/chef_order.dm
@@ -17,6 +17,7 @@
 /obj/machinery/computer/chef_order/Initialize()
 	. = ..()
 	radio = new(src)
+	radio.frequency = FREQ_SUPPLY
 	radio.subspace_transmission = TRUE
 	radio.canhear_range = 0
 	radio.recalculateChannels()
@@ -89,7 +90,7 @@
 				say("Sorry, but you do not have enough money.")
 				return
 			say("Thank you for your purchase! It will arrive on the next cargo shuttle!")
-			var/message = "The chef has ordered groceries! Please make sure it gets to them pronto!"
+			var/message = "The chef has ordered groceries which will arrive on the cargo shuttle! Please make sure it gets to them as soon as possible!"
 			radio.talk_into(src, message, radio_channel)
 			SSshuttle.chef_groceries = grocery_list.Copy()
 			grocery_list.Cut()

--- a/code/game/machinery/computer/chef_orders/chef_order.dm
+++ b/code/game/machinery/computer/chef_orders/chef_order.dm
@@ -9,17 +9,25 @@
 	var/list/order_datums = list()
 	var/list/grocery_list = list()
 
+	var/obj/item/radio/radio
+	var/radio_channel = RADIO_CHANNEL_SUPPLY
+
 	light_color = LIGHT_COLOR_ORANGE
 
 /obj/machinery/computer/chef_order/Initialize()
 	. = ..()
+	radio = new(src)
+	radio.subspace_transmission = TRUE
+	radio.canhear_range = 0
+	radio.recalculateChannels()
 
 	for(var/path in subtypesof(/datum/orderable_item))
 		order_datums += new path
 
 /obj/machinery/computer/chef_order/Destroy()
-	. = ..()
+	QDEL_NULL(radio)
 	QDEL_LIST(order_datums)
+	. = ..()
 
 /obj/machinery/computer/chef_order/proc/get_total_cost()
 	. = 0
@@ -81,6 +89,8 @@
 				say("Sorry, but you do not have enough money.")
 				return
 			say("Thank you for your purchase! It will arrive on the next cargo shuttle!")
+			var/message = "The chef has ordered groceries! Please make sure it gets to them pronto!"
+			radio.talk_into(src, message, radio_channel)
 			SSshuttle.chef_groceries = grocery_list.Copy()
 			grocery_list.Cut()
 			update_static_data(chef)

--- a/code/game/machinery/computer/chef_orders/chef_order.dm
+++ b/code/game/machinery/computer/chef_orders/chef_order.dm
@@ -38,6 +38,7 @@
 
 /obj/machinery/computer/chef_order/ui_static_data(mob/user)
 	. = ..()
+	.["already_ordered"] = SSshuttle.chef_groceries.len
 	.["total_cost"] = get_total_cost()
 	.["order_datums"] = list()
 	for(var/datum/orderable_item/item as anything in order_datums)
@@ -66,13 +67,18 @@
 				grocery_list -= wanted_item
 			update_static_data(chef)
 		if("purchase")
+			if(SSshuttle.chef_groceries.len)
+				return
 			var/obj/item/card/id/chef_card = chef.get_idcard(TRUE)
+			if(!chef_card || !chef_card.registered_account)
+				say("No bank account detected!")
+				return
 			var/final_cost = get_total_cost()
 			if(!chef_card.registered_account.adjust_money(-final_cost))
 				say("Sorry, but you do not have enough money.")
 				return
 			say("purchased [english_list(grocery_list)] items")
+			SSshuttle.chef_groceries = grocery_list.Copy()
 			grocery_list.Cut()
 			update_static_data(chef)
-	to_chat(world, action)
 	. = TRUE

--- a/code/game/machinery/computer/chef_orders/chef_order.dm
+++ b/code/game/machinery/computer/chef_orders/chef_order.dm
@@ -8,7 +8,7 @@
 	light_color = LIGHT_COLOR_ORANGE
 
 	COOLDOWN_DECLARE(order_cooldown)
-	var/list/order_datums = list()
+	var/static/list/order_datums = list()
 	var/list/grocery_list = list()
 
 	var/obj/item/radio/radio
@@ -22,12 +22,12 @@
 	radio.canhear_range = 0
 	radio.recalculateChannels()
 
-	for(var/path in subtypesof(/datum/orderable_item))
-		order_datums += new path
+	if(!order_datums.len)
+		for(var/path in subtypesof(/datum/orderable_item))
+			order_datums += new path
 
 /obj/machinery/computer/chef_order/Destroy()
 	QDEL_NULL(radio)
-	QDEL_LIST(order_datums)
 	. = ..()
 
 /obj/machinery/computer/chef_order/proc/get_total_cost()
@@ -35,9 +35,6 @@
 	for(var/datum/orderable_item/item as anything in grocery_list)
 		for(var/i in 1 to grocery_list[item]) //for how many times we bought it
 			. += item.cost_per_order //add its price
-
-/obj/machinery/computer/chef_order/ui_state(mob/user)
-	return GLOB.not_incapacitated_state
 
 /obj/machinery/computer/chef_order/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -119,8 +116,8 @@
 			for(var/datum/orderable_item/item as anything in grocery_list)//every order
 				for(var/amt in 1 to grocery_list[item])//every order amount
 					new item.item_instance.type(pod)
-			var/turf/T = get_turf(chef)
-			new /obj/effect/pod_landingzone(T, pod)
+			var/turf/landing_location = get_turf(chef)
+			new /obj/effect/pod_landingzone(landing_location, pod)
 			grocery_list.Cut()
 			update_static_data(chef)
 	. = TRUE

--- a/code/game/machinery/computer/chef_orders/chef_order.dm
+++ b/code/game/machinery/computer/chef_orders/chef_order.dm
@@ -36,9 +36,12 @@
 		ui = new(user, src, "ProduceConsole", name)
 		ui.open()
 
-/obj/machinery/computer/chef_order/ui_static_data(mob/user)
+/obj/machinery/computer/chef_order/ui_data(mob/user)
 	. = ..()
 	.["already_ordered"] = SSshuttle.chef_groceries.len
+
+/obj/machinery/computer/chef_order/ui_static_data(mob/user)
+	. = ..()
 	.["total_cost"] = get_total_cost()
 	.["order_datums"] = list()
 	for(var/datum/orderable_item/item as anything in order_datums)
@@ -55,9 +58,9 @@
 	. = ..()
 	if(.)
 		return
-	var/mob/living/chef = usr
-	if(!istype(chef))
+	if(!isliving(usr))
 		return
+	var/mob/living/chef = usr
 	//this is null if the action doesn't need it (purchase, quickpurchase)
 	var/datum/orderable_item/wanted_item = locate(params["target"]) in order_datums
 	switch(action)
@@ -67,7 +70,7 @@
 				grocery_list -= wanted_item
 			update_static_data(chef)
 		if("purchase")
-			if(SSshuttle.chef_groceries.len)
+			if(SSshuttle.chef_groceries.len || !grocery_list.len)
 				return
 			var/obj/item/card/id/chef_card = chef.get_idcard(TRUE)
 			if(!chef_card || !chef_card.registered_account)
@@ -77,8 +80,29 @@
 			if(!chef_card.registered_account.adjust_money(-final_cost))
 				say("Sorry, but you do not have enough money.")
 				return
-			say("purchased [english_list(grocery_list)] items")
+			say("Thank you for your purchase! It will arrive on the next cargo shuttle!")
 			SSshuttle.chef_groceries = grocery_list.Copy()
+			grocery_list.Cut()
+			update_static_data(chef)
+		if("express")
+			if(SSshuttle.chef_groceries.len || !grocery_list.len)
+				return
+			var/obj/item/card/id/chef_card = chef.get_idcard(TRUE)
+			if(!chef_card || !chef_card.registered_account)
+				say("No bank account detected!")
+				return
+			var/final_cost = get_total_cost()
+			final_cost *= 1.25
+			if(!chef_card.registered_account.adjust_money(-final_cost))
+				say("Sorry, but you do not have enough money. Remember, Express upcharges the cost!")
+				return
+			var/obj/structure/closet/supplypod/bluespacepod/pod = new()
+			pod.explosionSize = list(0,0,0,0)
+			for(var/datum/orderable_item/item as anything in grocery_list)//every order
+				for(var/amt in 1 to grocery_list[item])//every order amount
+					new item.item_instance.type(pod)
+			var/turf/T = get_turf(chef)
+			new /obj/effect/pod_landingzone(T, pod)
 			grocery_list.Cut()
 			update_static_data(chef)
 	. = TRUE

--- a/code/game/machinery/computer/chef_orders/chef_order.dm
+++ b/code/game/machinery/computer/chef_orders/chef_order.dm
@@ -1,0 +1,78 @@
+
+/obj/machinery/computer/chef_order
+	name = "Produce Orders Console"
+	desc = "An interface for ordering fresh produce and other. A far more expensive option than the botanists, but oh well."
+	icon_screen = "request"
+	icon_keyboard = "generic_key"
+	circuit = /obj/item/circuitboard/computer/chef_order
+
+	var/list/order_datums = list()
+	var/list/grocery_list = list()
+
+	light_color = LIGHT_COLOR_ORANGE
+
+/obj/machinery/computer/chef_order/Initialize()
+	. = ..()
+
+	for(var/path in subtypesof(/datum/orderable_item))
+		order_datums += new path
+
+/obj/machinery/computer/chef_order/Destroy()
+	. = ..()
+	QDEL_LIST(order_datums)
+
+/obj/machinery/computer/chef_order/proc/get_total_cost()
+	. = 0
+	for(var/datum/orderable_item/item as anything in grocery_list)
+		for(var/i in 1 to grocery_list[item]) //for how many times we bought it
+			. += item.cost_per_order //add it's price
+
+/obj/machinery/computer/chef_order/ui_state(mob/user)
+	return GLOB.not_incapacitated_state
+
+/obj/machinery/computer/chef_order/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "ProduceConsole", name)
+		ui.open()
+
+/obj/machinery/computer/chef_order/ui_static_data(mob/user)
+	. = ..()
+	.["total_cost"] = get_total_cost()
+	.["order_datums"] = list()
+	for(var/datum/orderable_item/item as anything in order_datums)
+		.["order_datums"] += list(list(
+			"name" = item.name,
+			"desc" = item.desc,
+			"cat" = item.category_index,
+			"ref" = REF(item),
+			"cost" = item.cost_per_order,
+			"amt" = grocery_list[item]
+			))
+
+/obj/machinery/computer/chef_order/ui_act(action, params)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/chef = usr
+	if(!istype(chef))
+		return
+	//this is null if the action doesn't need it (purchase, quickpurchase)
+	var/datum/orderable_item/wanted_item = locate(params["target"]) in order_datums
+	switch(action)
+		if("cart_set")
+			grocery_list[wanted_item] = params["amt"]
+			if(!grocery_list[wanted_item])
+				grocery_list -= wanted_item
+			update_static_data(chef)
+		if("purchase")
+			var/obj/item/card/id/chef_card = chef.get_idcard(TRUE)
+			var/final_cost = get_total_cost()
+			if(!chef_card.registered_account.adjust_money(-final_cost))
+				say("Sorry, but you do not have enough money.")
+				return
+			say("purchased [english_list(grocery_list)] items")
+			grocery_list.Cut()
+			update_static_data(chef)
+	to_chat(world, action)
+	. = TRUE

--- a/code/game/machinery/computer/chef_orders/order_datum.dm
+++ b/code/game/machinery/computer/chef_orders/order_datum.dm
@@ -91,6 +91,12 @@
 	item_instance = /obj/item/storage/fancy/egg_box
 	cost_per_order = 40
 
+/datum/orderable_item/fillet
+	name = "Fish Fillet"
+	category_index = CATEGORY_MILK_EGGS
+	item_instance = /obj/item/food/fishmeat
+	cost_per_order = 12
+
 //Reagents
 
 /datum/orderable_item/flour

--- a/code/game/machinery/computer/chef_orders/order_datum.dm
+++ b/code/game/machinery/computer/chef_orders/order_datum.dm
@@ -6,7 +6,8 @@
 ///A datum for chef ordering options from the chef's computer.
 /datum/orderable_item
 	var/name = "Orderable Item Name"
-	var/desc = "Description Gets Set By The Item Itself"
+	//description set automatically unless it's hard set by the subtype
+	var/desc
 	var/category_index = CATEGORY_FRUITS_VEGGIES
 	var/obj/item/item_instance
 	var/cost_per_order = 10
@@ -18,7 +19,8 @@
 	if(!item_instance)
 		CRASH("[type] orderable item datum has NO ITEM PATH!")
 	item_instance = new item_instance
-	desc = item_instance.desc
+	if(!desc)
+		desc = item_instance.desc
 
 /datum/orderable_item/Destroy(force, ...)
 	. = ..()
@@ -48,6 +50,7 @@
 
 /datum/orderable_item/mushroom
 	name = "Plump Helmet"
+	desc = "Plumus Hellmus: Plump, soft and s-so inviting~"
 	category_index = CATEGORY_FRUITS_VEGGIES
 	item_instance = /obj/item/food/grown/mushroom/plumphelmet
 
@@ -66,10 +69,35 @@
 	category_index = CATEGORY_FRUITS_VEGGIES
 	item_instance =/obj/item/food/grown/apple
 
+/datum/orderable_item/pumpkin
+	name = "Pumpkin"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance =/obj/item/food/grown/pumpkin
+
+/datum/orderable_item/watermelon
+	name = "Watermelon"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance =/obj/item/food/grown/watermelon
+
+/datum/orderable_item/corn
+	name = "Corn"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/food/grown/corn
+
+/datum/orderable_item/soybean
+	name = "Soybeans"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/food/grown/soybeans
+
 /datum/orderable_item/garlic
 	name = "Garlic"
 	category_index = CATEGORY_FRUITS_VEGGIES
 	item_instance = /obj/item/food/grown/garlic
+
+/datum/orderable_item/cherries
+	name = "Cherries"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/food/grown/cherries
 
 //Milk and Eggs
 
@@ -96,6 +124,11 @@
 	category_index = CATEGORY_MILK_EGGS
 	item_instance = /obj/item/food/fishmeat
 	cost_per_order = 12
+
+/datum/orderable_item/spider_eggs
+	name = "Spider Eggs"
+	category_index = CATEGORY_MILK_EGGS
+	item_instance = /obj/item/food/spidereggs
 
 //Reagents
 

--- a/code/game/machinery/computer/chef_orders/order_datum.dm
+++ b/code/game/machinery/computer/chef_orders/order_datum.dm
@@ -26,15 +26,45 @@
 
 //Fruits and Veggies
 
-/datum/orderable_item/potatoes
+/datum/orderable_item/potato
 	name = "Potato"
 	category_index = CATEGORY_FRUITS_VEGGIES
 	item_instance = /obj/item/food/grown/potato
 
-/datum/orderable_item/tomatoes
+/datum/orderable_item/tomato
 	name = "Tomato"
 	category_index = CATEGORY_FRUITS_VEGGIES
 	item_instance = /obj/item/food/grown/tomato
+
+/datum/orderable_item/carrot
+	name = "Carrot"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/food/grown/carrot
+
+/datum/orderable_item/eggplant
+	name = "Eggplant"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/food/grown/eggplant
+
+/datum/orderable_item/mushroom
+	name = "Plump Helmet"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/food/grown/mushroom/plumphelmet
+
+/datum/orderable_item/cabbage
+	name = "Cabbage"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/food/grown/cabbage
+
+/datum/orderable_item/beets
+	name = "Onion"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/food/grown/onion
+
+/datum/orderable_item/apple
+	name = "Apple"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance =/obj/item/food/grown/apple
 
 /datum/orderable_item/garlic
 	name = "Garlic"
@@ -81,3 +111,20 @@
 	item_instance = /obj/item/reagent_containers/food/condiment/enzyme
 	cost_per_order = 40
 
+/datum/orderable_item/salt
+	name = "Salt Shaker"
+	category_index = CATEGORY_SAUCES_REAGENTS
+	item_instance = /obj/item/reagent_containers/food/condiment/saltshaker
+	cost_per_order = 15
+
+/datum/orderable_item/pepper
+	name = "Pepper Mill"
+	category_index = CATEGORY_SAUCES_REAGENTS
+	item_instance = /obj/item/reagent_containers/food/condiment/peppermill
+	cost_per_order = 15
+
+/datum/orderable_item/soysauce
+	name = "Soy Sauce"
+	category_index = CATEGORY_SAUCES_REAGENTS
+	item_instance = /obj/item/reagent_containers/food/condiment/soysauce
+	cost_per_order = 15

--- a/code/game/machinery/computer/chef_orders/order_datum.dm
+++ b/code/game/machinery/computer/chef_orders/order_datum.dm
@@ -45,19 +45,19 @@
 
 /datum/orderable_item/milk
 	name = "Milk"
-	category_index = CATEGORY_FRUITS_VEGGIES
+	category_index = CATEGORY_MILK_EGGS
 	item_instance = /obj/item/reagent_containers/food/condiment/milk
 	cost_per_order = 30
 
 /datum/orderable_item/soymilk
 	name = "Soy Milk"
-	category_index = CATEGORY_FRUITS_VEGGIES
+	category_index = CATEGORY_MILK_EGGS
 	item_instance = /obj/item/reagent_containers/food/condiment/soymilk
 	cost_per_order = 30
 
 /datum/orderable_item/eggs
 	name = "Egg Carton"
-	category_index = CATEGORY_FRUITS_VEGGIES
+	category_index = CATEGORY_MILK_EGGS
 	item_instance = /obj/item/storage/fancy/egg_box
 	cost_per_order = 40
 
@@ -69,8 +69,15 @@
 	item_instance = /obj/item/reagent_containers/food/condiment/flour
 	cost_per_order = 30
 
+/datum/orderable_item/sugar
+	name = "Sugar Sack"
+	category_index = CATEGORY_SAUCES_REAGENTS
+	item_instance = /obj/item/reagent_containers/food/condiment/sugar
+	cost_per_order = 30
+
 /datum/orderable_item/enzyme
 	name = "Universal Enzyme"
 	category_index = CATEGORY_SAUCES_REAGENTS
 	item_instance = /obj/item/reagent_containers/food/condiment/enzyme
 	cost_per_order = 40
+

--- a/code/game/machinery/computer/chef_orders/order_datum.dm
+++ b/code/game/machinery/computer/chef_orders/order_datum.dm
@@ -1,0 +1,76 @@
+
+#define CATEGORY_FRUITS_VEGGIES 1
+#define CATEGORY_MILK_EGGS 2
+#define CATEGORY_SAUCES_REAGENTS 3
+
+///A datum for chef ordering options from the chef's computer.
+/datum/orderable_item
+	var/name = "Orderable Item Name"
+	var/desc = "Description Gets Set By The Item Itself"
+	var/category_index = CATEGORY_FRUITS_VEGGIES
+	var/obj/item/item_instance
+	var/cost_per_order = 10
+
+/datum/orderable_item/New()
+	. = ..()
+	if(type == /datum/orderable_item)
+		return
+	if(!item_instance)
+		CRASH("[type] orderable item datum has NO ITEM PATH!")
+	item_instance = new item_instance
+	desc = item_instance.desc
+
+/datum/orderable_item/Destroy(force, ...)
+	. = ..()
+	qdel(item_instance)
+
+//Fruits and Veggies
+
+/datum/orderable_item/potatoes
+	name = "Potato"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/food/grown/potato
+
+/datum/orderable_item/tomatoes
+	name = "Tomato"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/food/grown/tomato
+
+/datum/orderable_item/garlic
+	name = "Garlic"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/food/grown/garlic
+
+//Milk and Eggs
+
+/datum/orderable_item/milk
+	name = "Milk"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/reagent_containers/food/condiment/milk
+	cost_per_order = 30
+
+/datum/orderable_item/soymilk
+	name = "Soy Milk"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/reagent_containers/food/condiment/soymilk
+	cost_per_order = 30
+
+/datum/orderable_item/eggs
+	name = "Egg Carton"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/storage/fancy/egg_box
+	cost_per_order = 40
+
+//Reagents
+
+/datum/orderable_item/flour
+	name = "Flour Sack"
+	category_index = CATEGORY_SAUCES_REAGENTS
+	item_instance = /obj/item/reagent_containers/food/condiment/flour
+	cost_per_order = 30
+
+/datum/orderable_item/enzyme
+	name = "Universal Enzyme"
+	category_index = CATEGORY_SAUCES_REAGENTS
+	item_instance = /obj/item/reagent_containers/food/condiment/enzyme
+	cost_per_order = 40

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -459,6 +459,11 @@
 
 //Service
 
+/obj/item/circuitboard/computer/chef_order
+	name = "Produce Orders Console (Computer Board)"
+	icon_state = "supply"
+	build_path = /obj/machinery/computer/chef_order
+
 //Supply
 
 /obj/item/circuitboard/computer/cargo

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -82,6 +82,7 @@
 	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	if(D)
 		data["points"] = D.account_balance
+	data["grocery"] = SSshuttle.chef_groceries.len
 	data["away"] = SSshuttle.supply.getDockedId() == "supply_away"
 	data["self_paid"] = self_paid
 	data["docked"] = SSshuttle.supply.mode == SHUTTLE_IDLE

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -92,8 +92,6 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	var/list/obj/miscboxes = list() //miscboxes are combo boxes that contain all goody orders grouped
 	var/list/misc_order_num = list() //list of strings of order numbers, so that the manifest can show all orders in a box
 	var/list/misc_contents = list() //list of lists of items that each box will contain
-	if(!SSshuttle.shoppinglist.len)
-		return
 
 	var/list/empty_turfs = list()
 	for(var/place in shuttle_areas)
@@ -102,6 +100,21 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			if(T.is_blocked_turf())
 				continue
 			empty_turfs += T
+
+	//quickly and greedily handle chef's grocery runs first, there are a few reasons why this isn't attached to the rest of cargo...
+	//but the biggest reason is that the chef requires produce to cook and do their job, and if they are using this system they
+	//already got let down by the botanists. So to open a new chance for cargo to also screw them over any more than is necessary is bad.
+	if(SSshuttle.chef_groceries.len)
+		var/obj/structure/closet/crate/freezer/grocery_crate = new(pick_n_take(empty_turfs))
+		grocery_crate.name = "kitchen produce freezer"
+		investigate_log("Chef's [SSshuttle.chef_groceries.len] sized produce order arrived. Cost was deducted from orderer, not cargo.", INVESTIGATE_CARGO)
+		for(var/datum/orderable_item/item as anything in SSshuttle.chef_groceries)//every order
+			for(var/amt in 1 to SSshuttle.chef_groceries[item])//every order amount
+				new item.item_instance.type(grocery_crate)
+		SSshuttle.chef_groceries.Cut() //This lets the console know it can order another round.
+
+	if(!SSshuttle.shoppinglist.len)
+		return
 
 	var/value = 0
 	var/purchases = 0

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -933,6 +933,8 @@
 #include "code\game\machinery\computer\station_alert.dm"
 #include "code\game\machinery\computer\teleporter.dm"
 #include "code\game\machinery\computer\warrant.dm"
+#include "code\game\machinery\computer\chef_orders\chef_order.dm"
+#include "code\game\machinery\computer\chef_orders\order_datum.dm"
 #include "code\game\machinery\computer\prisoner\_prisoner.dm"
 #include "code\game\machinery\computer\prisoner\gulag_teleporter.dm"
 #include "code\game\machinery\computer\prisoner\management.dm"

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -1,6 +1,6 @@
 import { toArray } from 'common/collections';
 import { useBackend, useSharedState } from '../backend';
-import { AnimatedNumber, Box, Button, Divider, Flex, LabeledList, NoticeBox, Section, Table, Tabs } from '../components';
+import { AnimatedNumber, Box, Button, Flex, LabeledList, Section, Table, Tabs } from '../components';
 import { formatMoney } from '../format';
 import { Window } from '../layouts';
 

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -1,6 +1,6 @@
 import { toArray } from 'common/collections';
 import { useBackend, useSharedState } from '../backend';
-import { AnimatedNumber, Box, Button, Flex, LabeledList, Section, Table, Tabs } from '../components';
+import { AnimatedNumber, Box, Button, Divider, Flex, LabeledList, NoticeBox, Section, Table, Tabs } from '../components';
 import { formatMoney } from '../format';
 import { Window } from '../layouts';
 
@@ -73,6 +73,7 @@ export const CargoContent = (props, context) => {
 const CargoStatus = (props, context) => {
   const { act, data } = useBackend(context);
   const {
+    grocery,
     away,
     docked,
     loan,
@@ -98,7 +99,10 @@ const CargoStatus = (props, context) => {
         <LabeledList.Item label="Shuttle">
           {docked && !requestonly && can_send &&(
             <Button
+              color={grocery && "orange" || "green"}
               content={location}
+              tooltip={grocery && "The chef is waiting on their grocery supplies." || ""}
+              tooltipPosition="right"
               onClick={() => act('send')} />
           ) || location}
         </LabeledList.Item>

--- a/tgui/packages/tgui/interfaces/ProduceConsole.js
+++ b/tgui/packages/tgui/interfaces/ProduceConsole.js
@@ -24,7 +24,7 @@ const ShoppingTab = (props, context) => {
   ] = useLocalState(context, 'shop-index', 1);
   const mapped_food = order_datums.filter(food => (
     food && food.cat === shopIndex
-  ))
+  ));
   return (
     <Stack fill vertical>
       <Section mb={-0.9}>
@@ -57,30 +57,30 @@ const ShoppingTab = (props, context) => {
             <Divider />
             {mapped_food.map(item => (
               <Stack.Item key={item}>
-                  <Stack>
-                    <Stack.Item grow>
-                      {item.name}
-                    </Stack.Item>
-                    <Stack.Item mt={-1} color="label" fontSize="10px">
-                        {"\""+item.desc+"\""}
-                        <br/>
-                        <Box textAlign="right">
-                          {item.name+" costs "+item.cost+" per order."}
-                        </Box>
-                    </Stack.Item>
-                    <Stack.Item mt={-0.5}>
-                      <NumberInput
-                        animated
-                        value={item.amt && item.amt || 0}
-                        width="41px"
-                        minValue={0}
-                        maxValue={50}
-                        onChange={(e, value) => act('cart_set', {
-                          target: item.ref,
-                          amt: value,
-                        })} />
-                    </Stack.Item>
-                  </Stack>
+                <Stack>
+                  <Stack.Item grow>
+                    {item.name}
+                  </Stack.Item>
+                  <Stack.Item mt={-1} color="label" fontSize="10px">
+                    {"\""+item.desc+"\""}
+                    <br />
+                    <Box textAlign="right">
+                      {item.name+" costs "+item.cost+" per order."}
+                    </Box>
+                  </Stack.Item>
+                  <Stack.Item mt={-0.5}>
+                    <NumberInput
+                      animated
+                      value={item.amt && item.amt || 0}
+                      width="41px"
+                      minValue={0}
+                      maxValue={50}
+                      onChange={(e, value) => act('cart_set', {
+                        target: item.ref,
+                        amt: value,
+                      })} />
+                  </Stack.Item>
+                </Stack>
                 <Divider />
               </Stack.Item>
             ))}
@@ -99,7 +99,7 @@ const CheckoutTab = (props, context) => {
   } = data;
   const checkout_list = order_datums.filter(food => (
     food && food.amt
-  ))
+  ));
   return (
     <Stack vertical fill>
       <Stack.Item grow>
@@ -112,18 +112,18 @@ const CheckoutTab = (props, context) => {
               <Divider />
             )}
             <Stack.Item grow>
-            {checkout_list.map(item => (
-              <Stack.Item key={item}>
+              {checkout_list.map(item => (
+                <Stack.Item key={item}>
                   <Stack>
                     <Stack.Item grow>
                       {item.name}
                     </Stack.Item>
                     <Stack.Item mt={-1} color="label" fontSize="10px">
-                        {"\""+item.desc+"\""}
-                        <br/>
-                        <Box textAlign="right">
-                          {item.name+" costs "+item.cost+" per order."}
-                        </Box>
+                      {"\""+item.desc+"\""}
+                      <br />
+                      <Box textAlign="right">
+                        {item.name+" costs "+item.cost+" per order."}
+                      </Box>
                     </Stack.Item>
                     <Stack.Item mt={-0.5}>
                       <NumberInput
@@ -138,9 +138,9 @@ const CheckoutTab = (props, context) => {
                         })} />
                     </Stack.Item>
                   </Stack>
-                <Divider />
-              </Stack.Item>
-            ))}
+                  <Divider />
+                </Stack.Item>
+              ))}
             </Stack.Item>
 
           </Stack>

--- a/tgui/packages/tgui/interfaces/ProduceConsole.js
+++ b/tgui/packages/tgui/interfaces/ProduceConsole.js
@@ -1,5 +1,5 @@
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, Divider, Flex, NoticeBox, NumberInput, Section, Stack } from '../components';
+import { Box, Button, Dimmer, Divider, Icon, NoticeBox, NumberInput, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 const buttonWidth = 2;
@@ -30,20 +30,23 @@ const ShoppingTab = (props, context) => {
       <Section mb={-0.9}>
         <Stack.Item>
           <Stack>
-            <Stack.Item>
+            <Stack.Item grow>
               <Button
+                fluid
                 color="green"
                 content="Fruits and Veggies"
                 onClick={() => setShopIndex(1)} />
             </Stack.Item>
-            <Stack.Item>
+            <Stack.Item grow>
               <Button
+                fluid
                 color="white"
                 content="Milk and Eggs"
                 onClick={() => setShopIndex(2)} />
             </Stack.Item>
-            <Stack.Item>
+            <Stack.Item grow>
               <Button
+                fluid
                 color="olive"
                 content="Sauces and Reagents"
                 onClick={() => setShopIndex(3)} />
@@ -108,8 +111,17 @@ const CheckoutTab = (props, context) => {
             <Stack.Item textAlign="center">
               Checkout list:
             </Stack.Item>
-            {checkout_list.length && (
-              <Divider />
+            <Divider />
+            {!checkout_list.length && (
+              <>
+                <Box align="center" mt="15%" fontSize="40px">
+                  Nothing!
+                </Box>
+                <br />
+                <Box align="center" mt={2} fontSize="15px">
+                  (Go order something, will ya?)
+                </Box>
+              </>
             )}
             <Stack.Item grow>
               {checkout_list.map(item => (
@@ -127,11 +139,10 @@ const CheckoutTab = (props, context) => {
                     </Stack.Item>
                     <Stack.Item mt={-0.5}>
                       <NumberInput
-                        animated
                         value={item.amt && item.amt || 0}
                         width="41px"
                         minValue={0}
-                        maxValue={50}
+                        maxValue={item.cost > 10 && 50 || 10}
                         onChange={(e, value) => act('cart_set', {
                           target: item.ref,
                           amt: value,
@@ -142,7 +153,6 @@ const CheckoutTab = (props, context) => {
                 </Stack.Item>
               ))}
             </Stack.Item>
-
           </Stack>
         </Section>
       </Stack.Item>
@@ -163,7 +173,7 @@ const CheckoutTab = (props, context) => {
                 fluid
                 color="yellow"
                 content="Express"
-                onClick={() => act('purchase')} />
+                onClick={() => act('express')} />
             </Stack.Item>
           </Stack>
         </Section>
@@ -172,8 +182,31 @@ const CheckoutTab = (props, context) => {
   );
 };
 
+const OrderSent = (props, context) => {
+  const { act, data } = useBackend(context);
+  return (
+    <Dimmer>
+      <Stack vertical>
+        <Stack.Item>
+          <Icon
+            color="green"
+            name="plane-arrival"
+            size={10}
+          />
+        </Stack.Item>
+        <Stack.Item mt={40} fontSize="15px" color="green">
+          Order sent! Locked until the cargo shuttle arrives...
+        </Stack.Item>
+      </Stack>
+    </Dimmer>
+  );
+};
+
 export const ProduceConsole = (props, context) => {
   const { act, data } = useBackend(context);
+  const {
+    already_ordered,
+  } = data;
   const [
     tabIndex,
     setTabIndex,
@@ -185,6 +218,9 @@ export const ProduceConsole = (props, context) => {
       width={400}
       height={400}>
       <Window.Content>
+        {!!already_ordered && (
+          <OrderSent />
+        )}
         <Stack vertical fill>
           <Stack.Item>
             <Section fill>

--- a/tgui/packages/tgui/interfaces/ProduceConsole.js
+++ b/tgui/packages/tgui/interfaces/ProduceConsole.js
@@ -1,3 +1,4 @@
+import { multiline } from 'common/string';
 import { useBackend, useLocalState } from '../backend';
 import { Box, Button, Dimmer, Divider, Icon, NumberInput, Section, Stack } from '../components';
 import { Window } from '../layouts';
@@ -29,7 +30,7 @@ const ShoppingTab = (props, context) => {
     <Stack fill vertical>
       <Section mb={-0.9}>
         <Stack.Item>
-          <Stack>
+          <Stack textAlign="center">
             <Stack.Item grow>
               <Button
                 fluid
@@ -77,7 +78,7 @@ const ShoppingTab = (props, context) => {
                       value={item.amt && item.amt || 0}
                       width="41px"
                       minValue={0}
-                      maxValue={50}
+                      maxValue={20}
                       onChange={(e, value) => act('cart_set', {
                         target: item.ref,
                         amt: value,
@@ -159,20 +160,32 @@ const CheckoutTab = (props, context) => {
       <Stack.Item>
         <Section>
           <Stack>
-            <Stack.Item mt={0.5}>
+            <Stack.Item grow mt={0.5}>
               Total Cost: {total_cost}
             </Stack.Item>
             <Stack.Item grow textAlign="center">
               <Button
                 fluid
+                icon="plane-departure"
                 content="Purchase"
+                tooltip={multiline`
+                Your groceries will arrive at cargo,
+                and hopefully get delivered by them.
+                `}
+                tooltipPosition="top"
                 onClick={() => act('purchase')} />
             </Stack.Item>
-            <Stack.Item textAlign="center">
+            <Stack.Item grow textAlign="center">
               <Button
                 fluid
+                icon="parachute-box"
                 color="yellow"
                 content="Express"
+                tooltip={multiline`
+                Sends the ingredients instantly,
+                and doesn't lock the console. 25% upcharge!
+                `}
+                tooltipPosition="top-left"
                 onClick={() => act('express')} />
             </Stack.Item>
           </Stack>
@@ -189,12 +202,13 @@ const OrderSent = (props, context) => {
       <Stack vertical>
         <Stack.Item>
           <Icon
+            ml="30%"
             color="green"
             name="plane-arrival"
             size={10}
           />
         </Stack.Item>
-        <Stack.Item mt={40} fontSize="15px" color="green">
+        <Stack.Item fontSize="15px" color="green">
           Order sent! Locked until the cargo shuttle arrives...
         </Stack.Item>
       </Stack>
@@ -215,7 +229,7 @@ export const ProduceConsole = (props, context) => {
   return (
     <Window
       title="Produce Orders"
-      width={400}
+      width={500}
       height={400}>
       <Window.Content>
         {!!already_ordered && (

--- a/tgui/packages/tgui/interfaces/ProduceConsole.js
+++ b/tgui/packages/tgui/interfaces/ProduceConsole.js
@@ -65,17 +65,17 @@ const ShoppingTab = (props, context) => {
                         {"\""+item.desc+"\""}
                         <br/>
                         <Box textAlign="right">
-                          {item.name+" cost "+item.cost+" per order."}
+                          {item.name+" costs "+item.cost+" per order."}
                         </Box>
                     </Stack.Item>
                     <Stack.Item mt={-0.5}>
                       <NumberInput
                         animated
-                        value={item.amt && item.amt}
+                        value={item.amt && item.amt || 0}
                         width="41px"
                         minValue={0}
-                        maxValue={100}
-                        onChange={(value) => act('set_code', {
+                        maxValue={50}
+                        onChange={(e, value) => act('cart_set', {
                           target: item.ref,
                           amt: value,
                         })} />
@@ -93,10 +93,82 @@ const ShoppingTab = (props, context) => {
 
 const CheckoutTab = (props, context) => {
   const { data, act } = useBackend(context);
+  const {
+    order_datums,
+    total_cost,
+  } = data;
+  const checkout_list = order_datums.filter(food => (
+    food && food.amt
+  ))
   return (
-    <Section fill>
-      Checkout!!
-    </Section>
+    <Stack vertical fill>
+      <Stack.Item grow>
+        <Section fill scrollable>
+          <Stack vertical fill>
+            <Stack.Item textAlign="center">
+              Checkout list:
+            </Stack.Item>
+            {checkout_list.length && (
+              <Divider />
+            )}
+            <Stack.Item grow>
+            {checkout_list.map(item => (
+              <Stack.Item key={item}>
+                  <Stack>
+                    <Stack.Item grow>
+                      {item.name}
+                    </Stack.Item>
+                    <Stack.Item mt={-1} color="label" fontSize="10px">
+                        {"\""+item.desc+"\""}
+                        <br/>
+                        <Box textAlign="right">
+                          {item.name+" costs "+item.cost+" per order."}
+                        </Box>
+                    </Stack.Item>
+                    <Stack.Item mt={-0.5}>
+                      <NumberInput
+                        animated
+                        value={item.amt && item.amt || 0}
+                        width="41px"
+                        minValue={0}
+                        maxValue={50}
+                        onChange={(e, value) => act('cart_set', {
+                          target: item.ref,
+                          amt: value,
+                        })} />
+                    </Stack.Item>
+                  </Stack>
+                <Divider />
+              </Stack.Item>
+            ))}
+            </Stack.Item>
+
+          </Stack>
+        </Section>
+      </Stack.Item>
+      <Stack.Item>
+        <Section>
+          <Stack>
+            <Stack.Item mt={0.5}>
+              Total Cost: {total_cost}
+            </Stack.Item>
+            <Stack.Item grow textAlign="center">
+              <Button
+                fluid
+                content="Purchase"
+                onClick={() => act('purchase')} />
+            </Stack.Item>
+            <Stack.Item textAlign="center">
+              <Button
+                fluid
+                color="yellow"
+                content="Express"
+                onClick={() => act('purchase')} />
+            </Stack.Item>
+          </Stack>
+        </Section>
+      </Stack.Item>
+    </Stack>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/ProduceConsole.js
+++ b/tgui/packages/tgui/interfaces/ProduceConsole.js
@@ -183,7 +183,7 @@ const CheckoutTab = (props, context) => {
                 content="Express"
                 tooltip={multiline`
                 Sends the ingredients instantly,
-                and doesn't lock the console. 25% upcharge!
+                and locks the console longer. Doubles the price!
                 `}
                 tooltipPosition="top-left"
                 onClick={() => act('express')} />
@@ -202,14 +202,14 @@ const OrderSent = (props, context) => {
       <Stack vertical>
         <Stack.Item>
           <Icon
-            ml="30%"
+            ml="28%"
             color="green"
             name="plane-arrival"
             size={10}
           />
         </Stack.Item>
-        <Stack.Item fontSize="15px" color="green">
-          Order sent! Locked until the cargo shuttle arrives...
+        <Stack.Item fontSize="18px" color="green">
+          Order sent! Machine on cooldown...
         </Stack.Item>
       </Stack>
     </Dimmer>
@@ -219,7 +219,7 @@ const OrderSent = (props, context) => {
 export const ProduceConsole = (props, context) => {
   const { act, data } = useBackend(context);
   const {
-    already_ordered,
+    off_cooldown,
   } = data;
   const [
     tabIndex,
@@ -232,7 +232,7 @@ export const ProduceConsole = (props, context) => {
       width={500}
       height={400}>
       <Window.Content>
-        {!!already_ordered && (
+        {!off_cooldown && (
           <OrderSent />
         )}
         <Stack vertical fill>

--- a/tgui/packages/tgui/interfaces/ProduceConsole.js
+++ b/tgui/packages/tgui/interfaces/ProduceConsole.js
@@ -1,5 +1,5 @@
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, Dimmer, Divider, Icon, NoticeBox, NumberInput, Section, Stack } from '../components';
+import { Box, Button, Dimmer, Divider, Icon, NumberInput, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 const buttonWidth = 2;

--- a/tgui/packages/tgui/interfaces/ProduceConsole.js
+++ b/tgui/packages/tgui/interfaces/ProduceConsole.js
@@ -1,0 +1,148 @@
+import { useBackend, useLocalState } from '../backend';
+import { Box, Button, Divider, Flex, NoticeBox, NumberInput, Section, Stack } from '../components';
+import { Window } from '../layouts';
+
+const buttonWidth = 2;
+
+const TAB2NAME = [
+  {
+    component: () => ShoppingTab,
+  },
+  {
+    component: () => CheckoutTab,
+  },
+];
+
+const ShoppingTab = (props, context) => {
+  const { data, act } = useBackend(context);
+  const {
+    order_datums,
+  } = data;
+  const [
+    shopIndex,
+    setShopIndex,
+  ] = useLocalState(context, 'shop-index', 1);
+  const mapped_food = order_datums.filter(food => (
+    food && food.cat === shopIndex
+  ))
+  return (
+    <Stack fill vertical>
+      <Section mb={-0.9}>
+        <Stack.Item>
+          <Stack>
+            <Stack.Item>
+              <Button
+                color="green"
+                content="Fruits and Veggies"
+                onClick={() => setShopIndex(1)} />
+            </Stack.Item>
+            <Stack.Item>
+              <Button
+                color="white"
+                content="Milk and Eggs"
+                onClick={() => setShopIndex(2)} />
+            </Stack.Item>
+            <Stack.Item>
+              <Button
+                color="olive"
+                content="Sauces and Reagents"
+                onClick={() => setShopIndex(3)} />
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
+      </Section>
+      <Stack.Item grow>
+        <Section fill scrollable>
+          <Stack vertical mt={-2}>
+            <Divider />
+            {mapped_food.map(item => (
+              <Stack.Item key={item}>
+                  <Stack>
+                    <Stack.Item grow>
+                      {item.name}
+                    </Stack.Item>
+                    <Stack.Item mt={-1} color="label" fontSize="10px">
+                        {"\""+item.desc+"\""}
+                        <br/>
+                        <Box textAlign="right">
+                          {item.name+" cost "+item.cost+" per order."}
+                        </Box>
+                    </Stack.Item>
+                    <Stack.Item mt={-0.5}>
+                      <NumberInput
+                        animated
+                        value={item.amt && item.amt}
+                        width="41px"
+                        minValue={0}
+                        maxValue={100}
+                        onChange={(value) => act('set_code', {
+                          target: item.ref,
+                          amt: value,
+                        })} />
+                    </Stack.Item>
+                  </Stack>
+                <Divider />
+              </Stack.Item>
+            ))}
+          </Stack>
+        </Section>
+      </Stack.Item>
+    </Stack>
+  );
+};
+
+const CheckoutTab = (props, context) => {
+  const { data, act } = useBackend(context);
+  return (
+    <Section fill>
+      Checkout!!
+    </Section>
+  );
+};
+
+export const ProduceConsole = (props, context) => {
+  const { act, data } = useBackend(context);
+  const [
+    tabIndex,
+    setTabIndex,
+  ] = useLocalState(context, 'tab-index', 1);
+  const TabComponent = TAB2NAME[tabIndex-1].component();
+  return (
+    <Window
+      title="Produce Orders"
+      width={400}
+      height={400}>
+      <Window.Content>
+        <Stack vertical fill>
+          <Stack.Item>
+            <Section fill>
+              <Stack textAlign="center">
+                <Stack.Item grow={3}>
+                  <Button
+                    fluid
+                    color="green"
+                    lineHeight={buttonWidth}
+                    icon="cart-plus"
+                    content="Shopping"
+                    onClick={() => setTabIndex(1)} />
+                </Stack.Item>
+                <Stack.Item grow>
+                  <Button
+                    fluid
+                    color="green"
+                    lineHeight={buttonWidth}
+                    icon="dollar-sign"
+                    content="Checkout"
+                    onClick={() => setTabIndex(2)} />
+                </Stack.Item>
+              </Stack>
+            </Section>
+          </Stack.Item>
+          <Stack.Item grow>
+            <TabComponent />
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For some god forsaken reason, icons don't work right now. Here's what it looks like with no icons!
![image](https://user-images.githubusercontent.com/40974010/109445982-a2c99380-79f5-11eb-856e-05817628dbfd.png)

The chef now has a console that they can load up groceries. The next time the cargo shuttle lands at the station it will have a crate with everything the chef ordered. The chef can also pay for a 25% upcharge on their total cart for an instant delivery, though this is pretty damn expensive so is really not too worth it outside of missing one ingredient in a recipe that you wanna quickly nab.

#### Botanists are still the BEST way to get good produce!

one side of this done, the actual ordering needs to be finished.

## Why It's Good For The Game

Requested by @Qustinnus , chef runs out of food for this job if there are no botanists.

## Changelog
:cl:
add: The Chef now has a produce console for ordering ingredients! Botanists are still the best way to get stuff, though.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
