### PR TITLE
Small plant tweaks, addition of chemicals to under utilized plants.

### DIFF
--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -146,7 +146,7 @@
 	plantname = "Blue Cherry Tree"
 	product = /obj/item/food/grown/bluecherries
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/consumable/nutriment = 0.07, /datum/reagent/consumable/sugar = 0.07)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.07, /datum/reagent/consumable/sugar = 0.07, /datum/reagent/oxygen = 0.07)
 	rarity = 10
 
 /obj/item/food/grown/bluecherries

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -45,7 +45,7 @@
 	product = /obj/item/food/grown/parsnip
 	icon_dead = "carrot-dead"
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.05, /datum/reagent/consumable/nutriment = 0.05)
+	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.05, /datum/reagent/consumable/nutriment = 0.05, /datum/reagent/aluminium = 0.05)
 
 /obj/item/food/grown/parsnip
 	seed = /obj/item/seeds/carrot/parsnip


### PR DESCRIPTION
## About The Pull Request

So uh, I made it so parsnips have aluminium and blue cherries have oxygen.

Oxygen is blue and aluminium was found to cause Alzheimer's, it seemed appropriate considering the fact we have cemented parsnip as the old person vegetable in-game.

## Why It's Good For The Game

More chemicals is always neat and I don't think oxygen and aluminium will be able to do too much damage to botany.

## Changelog
:cl:
balance: Oxidates blue cherries and makes parsnips cause Alzheimer's 
/:cl: