### PR TITLE
Fix inability to demote certain subordinates with the ID card app.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -152,7 +152,7 @@
 			if(!computer || !authenticated_user)
 				return TRUE
 			if(minor)
-				if(!(target_id_card.trim?.type in job_templates) && target_id_card.trim?.assignment != "Assistant")
+				if(!(target_id_card.trim?.type in job_templates))
 					to_chat(usr, "<span class='notice'>Software error: You do not have the necessary permissions to demote this card.</span>")
 					return TRUE
 

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -18,8 +18,6 @@
 	var/authenticated_user
 	/// The regions this program has access to based on the authenticated ID.
 	var/list/region_access = list()
-	/// List of subordinate jobs for head roles on the authenticated ID.
-	var/list/head_subordinates = list()
 	/// List of job templates that can be applied to ID cards from this program.
 	var/list/job_templates = list()
 	/// Which departments this program has access to. See region defines.
@@ -59,14 +57,6 @@
 			region_access |= info["regions"]
 			head_types |= info["head"]
 			job_templates |= info["templates"]
-
-	head_subordinates.Cut()
-	if(length(head_types))
-		for(var/occupation in SSjob.occupations)
-			var/datum/job/job = occupation
-			for(var/head in head_types)
-				if(head in job.department_head)
-					head_subordinates += job.title
 
 	if(length(region_access))
 		minor = TRUE
@@ -162,7 +152,7 @@
 			if(!computer || !authenticated_user)
 				return TRUE
 			if(minor)
-				if(!(target_id_card.trim?.assignment in head_subordinates) && target_id_card.trim?.assignment != "Assistant")
+				if(!(target_id_card.trim?.type in job_templates) && target_id_card.trim?.assignment != "Assistant")
 					to_chat(usr, "<span class='notice'>Software error: You do not have the necessary permissions to demote this card.</span>")
 					return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The trim system handles the interaction between heads and their air quotes "subordinates" differently. Instead of checking for head_subordinates - Which is a compiled list for who is and isn't a subordinate of who based on job datums - We instead check for the ability to apply a trim's access template to a card.

This means that if you're able to assign a trim's access as a template, you're able to demote that trim too.

This fixes some edge cases like being unable to demote Security Officer (Department) cards because technically Security Officer (Engineering) and Security Officer (Science) aren't real jobs (insert joke here) - They lack job datums and never get assigned as the HoS's subordinates. 

This is a much more modular and intuitive way of handling demotions.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The Plexagon Access Management app has been upgraded and allows Heads of Staff to demote any ID card that has a trim they'd ordinarily be able to apply as a template. This means the HoS can now demote departmental sec officers like Security Officer (Science).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
