### PR TITLE
Tweak how the ID Console displays wildcard and trim information.

### DIFF
--- a/tgui/packages/tgui/interfaces/common/AccessList.js
+++ b/tgui/packages/tgui/interfaces/common/AccessList.js
@@ -173,7 +173,7 @@ export const FormatWildcards = (props, context) => {
         if (wcLeft < 0) {
           wcLimit = "∞";
         }
-        const wcLeftStr = "" + wcUsage + "/" + wcLimit;
+        const wcLeftStr = `${wcUsage}/${wcLimit}`;
         return (
           <Tabs.Tab
             key={wildcard}

--- a/tgui/packages/tgui/interfaces/common/AccessList.js
+++ b/tgui/packages/tgui/interfaces/common/AccessList.js
@@ -32,6 +32,7 @@ export const AccessList = (props, context) => {
   }
 
   const parsedRegions = [];
+  const selectedTrimAccess = [];
   accesses.forEach(region => {
     const regionName = region.name;
     const regionAccess = region.accesses;
@@ -41,6 +42,21 @@ export const AccessList = (props, context) => {
       hasSelected: false,
       allSelected: true,
     };
+
+    // If we're showing the basic accesses included as part of the trim,
+    // we want to figure out how many are selected for later formatting
+    // logic.
+    if (showBasic) {
+      regionAccess.forEach(access => {
+        if (trimAccess.includes(access.ref)
+          && selectedList.includes(access.ref)
+          && !selectedTrimAccess.includes(access.ref)
+        ) {
+          selectedTrimAccess.push(access.ref);
+        }
+      });
+    }
+
     // If there's no wildcard selected, grab accesses in
     // the trimAccess list as they require no wildcard.
     if (selectedWildcard === "None") {
@@ -92,7 +108,9 @@ export const AccessList = (props, context) => {
           <FormatWildcards
             wildcardSlots={wildcardSlots}
             selectedList={selectedList}
-            showBasic={showBasic} />
+            showBasic={showBasic}
+            basicUsed={selectedTrimAccess.length}
+            basicMax={trimAccess.length} />
         </Flex.Item>
         <Flex.Item>
           <RegionTabList
@@ -118,6 +136,8 @@ export const FormatWildcards = (props, context) => {
   const {
     wildcardSlots = {},
     showBasic,
+    basicUsed = 0,
+    basicMax = 0,
   } = props;
 
   const [
@@ -141,22 +161,25 @@ export const FormatWildcards = (props, context) => {
         <Tabs.Tab
           selected={selectedWildcard === "None"}
           onClick={() => setWildcardTab("None")} >
-          Basic
+          Trim:<br />{basicUsed + "/" + basicMax}
         </Tabs.Tab>
       )}
 
       {Object.keys(wildcardSlots).map(wildcard => {
         const wcObj = wildcardSlots[wildcard];
-        const wcLimit = wcObj.limit;
+        let wcLimit = wcObj.limit;
         const wcUsage = wcObj.usage.length;
         const wcLeft = wcLimit - wcUsage;
-        const wcLeftStr = (wcLeft >= 0) ? "" + wcLeft + "/" + wcLimit : "∞";
+        if (wcLeft < 0) {
+          wcLimit = "∞";
+        }
+        const wcLeftStr = "" + wcUsage + "/" + wcLimit;
         return (
           <Tabs.Tab
             key={wildcard}
             selected={selectedWildcard === wildcard}
             onClick={() => setWildcardTab(wildcard)} >
-            {wildcard + ": " + (wcLeftStr)}
+            {wildcard + ":"}<br />{wcLeftStr}
           </Tabs.Tab>
         );
       })}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![GiKQExLxFH](https://user-images.githubusercontent.com/24975989/109557983-bdbd0600-7ad0-11eb-94ed-0f4995824858.gif)

Renamed the Basic tab to Trim and added an access counter to it. Players often got confused and didn't realise "Basic" access was even a thing. Adding an access counter indicates that it's a thing that can be looked at and changing the tab to Trim indicates that it's linked to the card's trim.

Inverted the logic, instead of showing `Available out of Max` access slots, now shows `Used out of Max` - Testing and research seems to indicate that that is more intuitive.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Incremental improvements based on feedback and research.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Plexus Access Management app has had the Basic tab renamed to Trim to indicate that these accesses are available because of the card's trim. It also has an access counter so players can see they're able to change it.
qol: Plexus Access Management app has had the logic for displaying the used/available accesses for any given wildcard inverted. It now shows Used/Max instead of Available/Max.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
