### PR TITLE
Add new negative station trait: Dufflebags!

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -545,3 +545,4 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_FILLED_MAINT "station_trait_filled_maint"
 #define STATION_TRAIT_EMPTY_MAINT "station_trait_empty_maint"
 #define STATION_TRAIT_PDA_GLITCHED "station_trait_pda_glitched"
+#define STATION_TRAIT_DUFFLEBAGS "station_trait_dufflebags"

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -90,3 +90,24 @@
 /datum/station_trait/slow_shuttle/on_round_start()
 	. = ..()
 	SSshuttle.supply.callTime *= 1.5
+
+/datum/station_trait/dufflebags
+	name = "Dufflebags"
+	trait_type = STATION_TRAIT_NEGATIVE
+	weight = 3
+	show_in_report = TRUE
+	trait_to_give = STATION_TRAIT_DUFFLEBAGS
+
+/datum/station_trait/dufflebags/New()
+	. = ..()
+	report_message = pick(list(
+		"Nanotrasen are interested if the higher volume of dufflebags affect employee productivity; thus all crewmembers have been equipped with them.",
+		"Today's shift is sponsored by DuffleCo.",
+		"An ambassador from the Wizard Federation broke into the employee equipment factory, but only replaced all the bags with dufflebags.",
+		"Cloning is illegal; Nanotrasen doesn't clone new employees; Nanotrasen didn't make a mistake with the cloning template making everyone irrationally prefer dufflebags.",
+		"In a bid to drive up sales of satchels and backpacks, the Nanotrasen Economic Divison has made dufflebags the mandatory shiftstart equipment selection.",
+		"u a big man and need a big bag",
+		"dufflebags cost the company less and therefore are in your best interest to have because you love the company dont you? you wouldnt want to cause us pain? you arent a bad person and love helping the company yes?",
+		"We want you to and that is enough reason.",
+		"Someone on the Commander team keeps trying to have \"duffleskirt\" catch on. To shut them up, we're making you all have dufflebags this shift.",
+	))

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -227,6 +227,15 @@
 	var/pda_slot = ITEM_SLOT_BELT
 
 /datum/outfit/job/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	// If mandatory dufflebags are enabled, we try and respect their
+	// grey vs department preference, but ENFORCE dufflebags.
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_DUFFLEBAGS))
+		switch(H.backpack)
+			if(GBACKPACK, GSATCHEL, GDUFFELBAG, LSATCHEL)
+				H.backpack = GDUFFELBAG
+			if(DSATCHEL, DDUFFELBAG, DBACKPACK)
+				H.backpack = DDUFFELBAG
+
 	switch(H.backpack)
 		if(GBACKPACK)
 			back = /obj/item/storage/backpack //Grey backpack


### PR DESCRIPTION
:cl: coiax
add: A new negative station trait is that everyone spawns with a
duffelbag, instead of their usual bag preference.
/:cl:

- There is no leather version of duffelbags, so that becomes a grey
  duffelbag.
- If there isn't a departmental duffelbag, then you get a grey one
  instead.
- You can still go and get a non-duffelbag from your clothing vending
  machine, I guess if you want.