### PR TITLE
Make gbp-action use master

### DIFF
--- a/.github/workflows/gbp.yml
+++ b/.github/workflows/gbp.yml
@@ -9,6 +9,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: GBP action
-      uses: tgstation/gbp-action@v1.1
+      uses: tgstation/gbp-action@master
       with:
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I don't want to fiddle with versions, and the action is hosted on our own organization.

The tags can already be remotely updated, so this isn't more or less secure.
