### PR TITLE
Nanotrasen Minebots now also use the rolling robot footstep

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -43,6 +43,9 @@
 
 /mob/living/simple_animal/hostile/mining_drone/Initialize()
 	. = ..()
+	
+	AddComponent(/datum/component/footstep, FOOTSTEP_OBJ_ROBOT, 1, -6, vary = TRUE)
+	
 	stored_gun = new(src)
 	var/datum/action/innate/minedrone/toggle_light/toggle_light_action = new()
 	toggle_light_action.Grant(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Minebots use the same footstep as the tourist robots.

## Why It's Good For The Game

Hey, we have it, why not make use of it!

![image](https://user-images.githubusercontent.com/40974010/109626484-72691e80-7af5-11eb-9ff5-62268e9bc118.png)


## Changelog
:cl:
add: Minebots treads now make noise as they move!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
