### PR TITLE
bans fugu gland and rainbow swap from robots and spirits

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
@@ -137,6 +137,12 @@
 		if(A.buffed || (A.type in banned_mobs) || A.stat)
 			to_chat(user, "<span class='warning'>Something's interfering with [src]'s effects. It's no use.</span>")
 			return
+		if(A.mob_biotypes & MOB_ROBOTIC)
+			to_chat(user, "<span class='warning'>[src] doesn't work on robotic lifeforms! That makes no sense!</span>")
+			return
+		if(A.mob_biotypes & MOB_SPIRIT)
+			to_chat(user, "<span class='warning'>You can't apply [src] to [A], they're a spirit!</span>")
+			return
 		A.buffed++
 		A.maxHealth *= 1.5
 		A.health = min(A.maxHealth,A.health*1.5)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -762,6 +762,12 @@
 	if(SM.sentience_type != animal_type)
 		to_chat(user, "<span class='warning'>You cannot transfer your consciousness to [SM].</span>" )
 		return ..()
+	if(SM.mob_biotypes & MOB_ROBOTIC)
+		to_chat(user, "<span class='warning'>[src] doesn't work on robotic lifeforms...</span>")
+		return ..()
+	if(SM.mob_biotypes & MOB_SPIRIT)
+		to_chat(user, "<span class='warning'>[src] doesn't work on paranormal entities!</span>")
+		return ..()
 	var/jb = is_banned_from(user.ckey, ROLE_MIND_TRANSFER)
 	if(QDELETED(src) || QDELETED(M) || QDELETED(user))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Someone showed me something incredibly disturbing you could do with these and honestly there are a ton of these biotype mobs that break the game when used with these. Honestly the real issue is fugu gland and rainbow swap being an unprotected mess, but whatever the solution to that is removing them

## Why It's Good For The Game

Exploits like robo customers gaining sentience and punch powers

## Changelog
:cl:
balance: fugu gland and rainbow swap potion no longer works on spirits and robots!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
