### PR TITLE
Lavaland clownplanet ruin no longer kills clowns

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -1028,6 +1028,11 @@
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
 	},
 /area/ruin/powered/clownplanet)
+"os" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/machinery/door/airlock/external,
+/turf/open/floor/noslip,
+/area/ruin/powered/clownplanet)
 "pv" = (
 /obj/machinery/light{
 	dir = 4
@@ -1079,13 +1084,6 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/noslip,
 /area/ruin/powered/clownplanet)
-"Mv" = (
-/obj/effect/mapping_helpers/no_lava,
-/mob/living/simple_animal/hostile/retaliate/clown,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
-/area/lavaland/surface/outdoors/explored)
 "MR" = (
 /obj/machinery/light{
 	dir = 8
@@ -1443,7 +1441,7 @@ aa
 "}
 (10,1,1) = {"
 aa
-Mv
+XO
 cc
 ye
 an
@@ -1546,9 +1544,9 @@ cc
 (13,1,1) = {"
 eE
 eE
-cc
-ye
-cc
+eE
+eE
+cu
 at
 ar
 aB
@@ -1579,10 +1577,10 @@ cc
 "}
 (14,1,1) = {"
 eE
+RW
 Xm
+eE
 cc
-cc
-ye
 an
 ar
 ar
@@ -1612,10 +1610,10 @@ ye
 cc
 "}
 (15,1,1) = {"
-eX
+eE
+RW
 RW
 LH
-ch
 ch
 au
 ar
@@ -1646,11 +1644,11 @@ ye
 cc
 "}
 (16,1,1) = {"
-RW
+os
+eX
 CB
 YI
 cc
-ye
 ao
 ar
 aJ
@@ -1680,10 +1678,10 @@ ye
 cc
 "}
 (17,1,1) = {"
+eE
 eX
 RW
 TD
-ch
 ch
 av
 ay
@@ -1716,9 +1714,9 @@ cc
 (18,1,1) = {"
 eE
 RW
+RW
+eE
 cc
-cc
-ye
 cc
 az
 az
@@ -1750,8 +1748,8 @@ cc
 (19,1,1) = {"
 eE
 eE
-cc
-ye
+eE
+eE
 ye
 cc
 az
@@ -1783,7 +1781,7 @@ cc
 "}
 (20,1,1) = {"
 aa
-Mv
+XO
 cc
 ye
 cc

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -1015,9 +1015,7 @@
 /area/ruin/powered/clownplanet)
 "eX" = (
 /obj/effect/mapping_helpers/no_lava,
-/turf/open/floor/noslip{
-	initial_gas_mix = "LAVALAND_ATMOS"
-	},
+/turf/open/floor/noslip,
 /area/ruin/powered/clownplanet)
 "gX" = (
 /obj/effect/mapping_helpers/no_lava,
@@ -1026,13 +1024,17 @@
 "hY" = (
 /obj/machinery/light,
 /obj/effect/mapping_helpers/no_lava,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
 /area/ruin/powered/clownplanet)
 "pv" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
 /area/ruin/powered/clownplanet)
 "ye" = (
 /turf/open/lava/smooth,
@@ -1041,9 +1043,7 @@
 /obj/item/paper/crumpled/bloody/ruins/lavaland/clown_planet/hope,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/mapping_helpers/no_lava,
-/turf/open/floor/noslip{
-	initial_gas_mix = "LAVALAND_ATMOS"
-	},
+/turf/open/floor/noslip,
 /area/ruin/powered/clownplanet)
 "Hj" = (
 /obj/effect/decal/cleanable/food/pie_smudge,
@@ -1065,7 +1065,9 @@
 	name = "stealth banana peel"
 	},
 /obj/effect/mapping_helpers/no_lava,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
 /area/lavaland/surface/outdoors/explored)
 "LH" = (
 /obj/machinery/disposal/delivery_chute{
@@ -1075,28 +1077,28 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/effect/mapping_helpers/no_lava,
-/turf/open/floor/noslip{
-	initial_gas_mix = "LAVALAND_ATMOS"
-	},
+/turf/open/floor/noslip,
 /area/ruin/powered/clownplanet)
 "Mv" = (
 /obj/effect/mapping_helpers/no_lava,
 /mob/living/simple_animal/hostile/retaliate/clown,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
 /area/lavaland/surface/outdoors/explored)
 "MR" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/no_lava,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
 /area/ruin/powered/clownplanet)
 "RW" = (
 /obj/effect/mapping_helpers/no_lava,
 /mob/living/simple_animal/hostile/retaliate/clown,
-/turf/open/floor/noslip{
-	initial_gas_mix = "LAVALAND_ATMOS"
-	},
+/turf/open/floor/noslip,
 /area/ruin/powered/clownplanet)
 "TD" = (
 /obj/structure/disposalpipe/trunk,
@@ -1104,35 +1106,33 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/no_lava,
-/turf/open/floor/noslip{
-	initial_gas_mix = "LAVALAND_ATMOS"
-	},
+/turf/open/floor/noslip,
 /area/ruin/powered/clownplanet)
 "Xm" = (
 /obj/item/clothing/head/cone,
 /obj/effect/mapping_helpers/no_lava,
-/turf/open/floor/noslip{
-	initial_gas_mix = "LAVALAND_ATMOS"
-	},
+/turf/open/floor/noslip,
 /area/ruin/powered/clownplanet)
 "XO" = (
 /obj/effect/mapping_helpers/no_lava,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
 /area/lavaland/surface/outdoors/explored)
 "Yf" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/no_lava,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
 /area/ruin/powered/clownplanet)
 "YI" = (
 /obj/machinery/light/small,
 /obj/effect/mapping_helpers/no_lava,
 /mob/living/simple_animal/hostile/retaliate/clown,
-/turf/open/floor/noslip{
-	initial_gas_mix = "LAVALAND_ATMOS"
-	},
+/turf/open/floor/noslip,
 /area/ruin/powered/clownplanet)
 
 (1,1,1) = {"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The floors of the lavaland clown ruin now all contain normal gasmix so that the clowns defending the entrance won't die, also stopping unwanted miasma generation sources
closes #55448
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: lavaland clownplanet ruin outside turfs now spawn with normal air, no longer will kill the clowns near roundstart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
