### PR TITLE
Improves SecHUD logic in modcom tablets when worn in the wear_id slot

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -147,6 +147,10 @@
 
 	var/removed_id = (card_slot2?.try_eject() || card_slot?.try_eject())
 	if(removed_id)
+		if(ishuman(loc))
+			var/mob/living/carbon/human/human_wearer = loc
+			if(human_wearer.wear_id == src)
+				human_wearer.sec_hud_set_ID()
 		update_slot_icon()
 		return removed_id
 
@@ -163,6 +167,10 @@
 		return FALSE
 
 	if((card_slot?.try_insert(inserting_id)) || (card_slot2?.try_insert(inserting_id)))
+		if(ishuman(loc))
+			var/mob/living/carbon/human/human_wearer = loc
+			if(human_wearer.wear_id == src)
+				human_wearer.sec_hud_set_ID()
 		update_slot_icon()
 		return TRUE
 

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -61,10 +61,12 @@
 	stored_card = I
 	to_chat(user, "<span class='notice'>You insert \the [I] into \the [expansion_hw ? "secondary":"primary"] [src].</span>")
 	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		H.sec_hud_set_ID()
 
+	var/holder_loc = holder.loc
+	if(ishuman(holder_loc))
+		var/mob/living/carbon/human/human_wearer = holder_loc
+		if(human_wearer.wear_id == holder)
+			human_wearer.sec_hud_set_ID()
 	holder.update_slot_icon()
 
 	return TRUE
@@ -91,9 +93,11 @@
 
 		holder.update_slot_icon()
 
-	if(ishuman(user))
-		var/mob/living/carbon/human/human_user = user
-		human_user.sec_hud_set_ID()
+	var/holder_loc = holder.loc
+	if(ishuman(holder_loc))
+		var/mob/living/carbon/human/human_wearer = holder_loc
+		if(human_wearer.wear_id == holder)
+			human_wearer.sec_hud_set_ID()
 
 	to_chat(user, "<span class='notice'>You remove the card from \the [src].</span>")
 	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds SecHUD icon updates to tablets when ID cards are inserted or removed from them. It has historically never had this functionality, and thus could show hud_noid icon states for SecHUDs despite a tablet holding an ID if that ID was inserted when the tablet was already in the worn_id slot.

Improved SecHUD icon logic for the Plexagon Access Management app to use the more modular "loc of the ID card slot's holder" instead of "modular computer's user". This prevents excess sec_hud_set_ID() calls when the modular computer is on the floor, not in the user's wear_id slot or is one of the buildable machine variants. No change to former functionality.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Improve.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Modular Computer Tablets held in the ID slot will now correctly show SecHUD icons for their contained ID cards in all scenarios.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
