### PR TITLE
moves the definition for transfer_blood to the file for gloves

### DIFF
--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -13,6 +13,8 @@
 	equip_delay_other = 40
 	// Path variable. If defined, will produced the type through interaction with wirecutters.
 	var/cut_type = null
+	/// Used for handling bloody gloves leaving behind bloodstains on objects. Will be decremented whenever a bloodstain is left behind, and be incremented when the gloves become bloody.
+	var/transfer_blood = 0
 
 /obj/item/clothing/gloves/wash(clean_types)
 	. = ..()

--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -1,8 +1,3 @@
-
-/obj/item/clothing/gloves
-	var/transfer_blood = 0
-
-
 /obj/item/reagent_containers/glass/rag
 	name = "damp rag"
 	desc = "For cleaning up messes, you suppose."


### PR DESCRIPTION
## About The Pull Request

The definition of the transfer_blood variable (of gloves) has been moved from the file that contains the code of _damp rags_ to the file that defines the other variables of gloves.

The transfer_blood variable has been documented.

## Why It's Good For The Game

Seriously, why is this variable in the file for _damp rag code_?! This file contains NO references to transfer_blood OR TO GLOVES other than this definition! Aaaaaaaaaaaaaaaaahhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh!!!!

## Changelog
:cl: ATHATH
refactor: The definition of the transfer_blood variable (of gloves) has been moved from the file that otherwise only contains the code of damp rags to the file that defines the other variables of gloves, and has also been documented.
/:cl: