### PR TITLE
Fix bad weakref usage in heretic traps

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_structures.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_structures.dm
@@ -109,14 +109,14 @@
 	desc = "Collection of unknown symbols, they remind you of days long gone..."
 	icon = 'icons/obj/eldritch.dmi'
 	charges = 1
-	/// Weakref containing the owner of the trap
-	var/datum/weakref/owner
+	/// Reference to trap owner mob
+	var/mob/owner
 
 /obj/structure/trap/eldritch/Crossed(atom/movable/AM)
 	if(!isliving(AM))
 		return ..()
 	var/mob/living/living_mob = AM
-	if(living_mob == owner?.resolve() || IS_HERETIC(living_mob) || IS_HERETIC_MONSTER(living_mob))
+	if(living_mob == owner || IS_HERETIC(living_mob) || IS_HERETIC_MONSTER(living_mob))
 		return
 	return ..()
 
@@ -126,8 +126,14 @@
 		qdel(src)
 
 ///Proc that sets the owner
-/obj/structure/trap/eldritch/proc/set_owner(mob/owner)
-	src.owner = WEAKREF(owner)
+/obj/structure/trap/eldritch/proc/set_owner(mob/new_owner)
+	owner = new_owner
+	RegisterSignal(owner, COMSIG_PARENT_QDELETING, .proc/unset_owner)
+
+///Unsets the owner in case of deletion
+/obj/structure/trap/eldritch/proc/unset_owner()
+	SIGNAL_HANDLER
+	owner = null
 
 /obj/structure/trap/eldritch/alert
 	name = "alert carving"


### PR DESCRIPTION
This was causing alert traps to not work at all

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It's literally freeeeeee
Please stop using weakrefs when signals work bettterrrrrr


## Changelog
🆑
fix: Alert heretic traps work now
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
