### PR TITLE
Mulebots are no longer bugged into horrific, merciless machines of gore and destruction.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -351,6 +351,15 @@
 	#define COMPONENT_MOVABLE_BLOCK_UNCROSS (1<<0)
 ///from base of atom/movable/Uncrossed(): (/atom/movable)
 #define COMSIG_MOVABLE_UNCROSSED "movable_uncrossed"
+///from base of atom/movable/Cross(): (/atom/movable)
+#define COMSIG_MOVABLE_CROSS_AM "movable_cross_am"
+///from base of atom/movable/Crossed(): (/atom/movable)
+#define COMSIG_MOVABLE_CROSSED_AM "movable_crossed_am"
+///from base of atom/movable/Uncross(): (/atom/movable)
+#define COMSIG_MOVABLE_UNCROSS_AM "movable_uncross_am"
+	#define COMPONENT_MOVABLE_BLOCK_UNCROSS_AM (1<<0)
+///from base of atom/movable/Uncrossed(): (/atom/movable)
+#define COMSIG_MOVABLE_UNCROSSED_AM "movable_uncross_am"
 ///from base of atom/movable/Bump(): (/atom)
 #define COMSIG_MOVABLE_BUMP "movable_bump"
 ///from base of atom/movable/throw_impact(): (/atom/hit_atom, /datum/thrownthing/throwingdatum)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -435,11 +435,18 @@
 	#define COMSIG_MOB_CANCEL_CLICKON (1<<0)
 
 /// From base of /mob/living/simple_animal/bot/proc/bot_step()
-#define COMSIG_MOB_BOT_PRESTEP "mob_bot_prestep"
-	/// Cancel the step attempt.
-	#define COMPONENT_MOB_BOT_CANCELSTEP (1<<0)
+#define COMSIG_MOB_BOT_PRE_STEP "mob_bot_pre_step"
+	/// Should always match COMPONENT_MOVABLE_BLOCK_PRE_MOVE as these are interchangeable and used to block movement.
+	#define COMPONENT_MOB_BOT_BLOCK_PRE_STEP COMPONENT_MOVABLE_BLOCK_PRE_MOVE
 /// From base of /mob/living/simple_animal/bot/proc/bot_step()
 #define COMSIG_MOB_BOT_STEP "mob_bot_step"
+
+/// From base of /client/Move()
+#define COMSIG_MOB_CLIENT_PRE_MOVE "mob_client_pre_move"
+	/// Should always match COMPONENT_MOVABLE_BLOCK_PRE_MOVE as these are interchangeable and used to block movement.
+	#define COMSIG_MOB_CLIENT_BLOCK_PRE_MOVE COMPONENT_MOVABLE_BLOCK_PRE_MOVE
+/// From base of /client/Move()
+#define COMSIG_MOB_CLIENT_MOVED "mob_client_moved"
 
 ///from base of obj/allowed(mob/M): (/obj) returns bool, if TRUE the mob has id access to the obj
 #define COMSIG_MOB_ALLOWED "mob_allowed"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -352,14 +352,14 @@
 ///from base of atom/movable/Uncrossed(): (/atom/movable)
 #define COMSIG_MOVABLE_UNCROSSED "movable_uncrossed"
 ///from base of atom/movable/Cross(): (/atom/movable)
-#define COMSIG_MOVABLE_CROSS_AM "movable_cross_am"
+#define COMSIG_MOVABLE_CROSS_OVER "movable_cross_am"
 ///from base of atom/movable/Crossed(): (/atom/movable)
-#define COMSIG_MOVABLE_CROSSED_AM "movable_crossed_am"
+#define COMSIG_MOVABLE_CROSSED_OVER "movable_crossed_am"
 ///from base of atom/movable/Uncross(): (/atom/movable)
-#define COMSIG_MOVABLE_UNCROSS_AM "movable_uncross_am"
-	#define COMPONENT_MOVABLE_BLOCK_UNCROSS_AM (1<<0)
+#define COMSIG_MOVABLE_UNCROSS_OVER "movable_uncross_am"
+	#define COMPONENT_MOVABLE_BLOCK_UNCROSS_OVER (1<<0)
 ///from base of atom/movable/Uncrossed(): (/atom/movable)
-#define COMSIG_MOVABLE_UNCROSSED_AM "movable_uncross_am"
+#define COMSIG_MOVABLE_UNCROSSED_OVER "movable_uncross_am"
 ///from base of atom/movable/Bump(): (/atom)
 #define COMSIG_MOVABLE_BUMP "movable_bump"
 ///from base of atom/movable/throw_impact(): (/atom/hit_atom, /datum/thrownthing/throwingdatum)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -425,6 +425,13 @@
 #define COMSIG_MOB_ALTCLICKON "mob_altclickon"
 	#define COMSIG_MOB_CANCEL_CLICKON (1<<0)
 
+/// From base of /mob/living/simple_animal/bot/proc/bot_step()
+#define COMSIG_MOB_BOT_PRESTEP "mob_bot_prestep"
+	/// Cancel the step attempt.
+	#define COMPONENT_MOB_BOT_CANCELSTEP (1<<0)
+/// From base of /mob/living/simple_animal/bot/proc/bot_step()
+#define COMSIG_MOB_BOT_STEP "mob_bot_step"
+
 ///from base of obj/allowed(mob/M): (/obj) returns bool, if TRUE the mob has id access to the obj
 #define COMSIG_MOB_ALLOWED "mob_allowed"
 ///from base of mob/anti_magic_check(): (mob/user, magic, holy, tinfoil, chargecost, self, protection_sources)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -506,6 +506,7 @@
 /atom/movable/Cross(atom/movable/AM)
 	. = TRUE
 	SEND_SIGNAL(src, COMSIG_MOVABLE_CROSS, AM)
+	SEND_SIGNAL(AM, COMSIG_MOVABLE_CROSS_AM, src)
 	return CanPass(AM, AM.loc, TRUE)
 
 //oldloc = old location on atom, inserted when forceMove is called and ONLY when forceMove is called!
@@ -513,16 +514,20 @@
 	SHOULD_CALL_PARENT(TRUE)
 	. = ..()
 	SEND_SIGNAL(src, COMSIG_MOVABLE_CROSSED, AM)
+	SEND_SIGNAL(AM, COMSIG_MOVABLE_CROSSED_AM, src)
 
 /atom/movable/Uncross(atom/movable/AM, atom/newloc)
 	. = ..()
 	if(SEND_SIGNAL(src, COMSIG_MOVABLE_UNCROSS, AM) & COMPONENT_MOVABLE_BLOCK_UNCROSS)
+		return FALSE
+	if(SEND_SIGNAL(AM, COMSIG_MOVABLE_UNCROSS_AM, src) & COMPONENT_MOVABLE_BLOCK_UNCROSS_AM)
 		return FALSE
 	if(isturf(newloc) && !CheckExit(AM, newloc))
 		return FALSE
 
 /atom/movable/Uncrossed(atom/movable/AM)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_UNCROSSED, AM)
+	SEND_SIGNAL(AM, COMSIG_MOVABLE_UNCROSSED_AM, src)
 
 /atom/movable/Bump(atom/A)
 	if(!A)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -506,7 +506,7 @@
 /atom/movable/Cross(atom/movable/AM)
 	. = TRUE
 	SEND_SIGNAL(src, COMSIG_MOVABLE_CROSS, AM)
-	SEND_SIGNAL(AM, COMSIG_MOVABLE_CROSS_AM, src)
+	SEND_SIGNAL(AM, COMSIG_MOVABLE_CROSS_OVER, src)
 	return CanPass(AM, AM.loc, TRUE)
 
 //oldloc = old location on atom, inserted when forceMove is called and ONLY when forceMove is called!
@@ -514,20 +514,20 @@
 	SHOULD_CALL_PARENT(TRUE)
 	. = ..()
 	SEND_SIGNAL(src, COMSIG_MOVABLE_CROSSED, AM)
-	SEND_SIGNAL(AM, COMSIG_MOVABLE_CROSSED_AM, src)
+	SEND_SIGNAL(AM, COMSIG_MOVABLE_CROSSED_OVER, src)
 
 /atom/movable/Uncross(atom/movable/AM, atom/newloc)
 	. = ..()
 	if(SEND_SIGNAL(src, COMSIG_MOVABLE_UNCROSS, AM) & COMPONENT_MOVABLE_BLOCK_UNCROSS)
 		return FALSE
-	if(SEND_SIGNAL(AM, COMSIG_MOVABLE_UNCROSS_AM, src) & COMPONENT_MOVABLE_BLOCK_UNCROSS_AM)
+	if(SEND_SIGNAL(AM, COMSIG_MOVABLE_UNCROSS_OVER, src) & COMPONENT_MOVABLE_BLOCK_UNCROSS_OVER)
 		return FALSE
 	if(isturf(newloc) && !CheckExit(AM, newloc))
 		return FALSE
 
 /atom/movable/Uncrossed(atom/movable/AM)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_UNCROSSED, AM)
-	SEND_SIGNAL(AM, COMSIG_MOVABLE_UNCROSSED_AM, src)
+	SEND_SIGNAL(AM, COMSIG_MOVABLE_UNCROSSED_OVER, src)
 
 /atom/movable/Bump(atom/A)
 	if(!A)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -188,7 +188,6 @@
 	popup.open()
 
 // called when something steps onto a human
-// this could be made more general, but for now just handle mulebot
 /mob/living/carbon/human/Crossed(atom/movable/AM)
 	. = ..()
 	spreadFire(AM)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -228,10 +228,18 @@
 	if((AM.move_resist * MOVE_FORCE_FORCEPUSH_RATIO) <= force) //trigger move_crush and/or force_push regardless of if we can push it normally
 		if(force_push(AM, move_force, dir_to_target, push_anchored))
 			push_anchored = TRUE
+	if(ismob(AM))
+		var/mob/mob_to_push = AM
+		var/atom/movable/mob_buckle = mob_to_push.buckled
+		// If we can't pull them because of what they're buckled to, make sure we can push the thing they're buckled to instead.
+		// If neither are true, we're not pushing anymore.
+		if(mob_buckle && (mob_buckle.buckle_prevents_pull || (force < (mob_buckle.move_resist * MOVE_FORCE_PUSH_RATIO))))
+			now_pushing = FALSE
+			return
 	if((AM.anchored && !push_anchored) || (force < (AM.move_resist * MOVE_FORCE_PUSH_RATIO)))
 		now_pushing = FALSE
 		return
-	if (istype(AM, /obj/structure/window))
+	if(istype(AM, /obj/structure/window))
 		var/obj/structure/window/W = AM
 		if(W.fulltile)
 			for(var/obj/structure/window/win in get_step(W, dir_to_target))

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -528,26 +528,26 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 	if(step_count >= 1 && tries < BOT_STEP_MAX_RETRIES)
 		for(var/step_number = 0, step_number < step_count,step_number++)
-			addtimer(CALLBACK(src, .proc/bot_step, dest), BOT_STEP_DELAY*step_number)
+			addtimer(CALLBACK(src, .proc/bot_step), BOT_STEP_DELAY*step_number)
 	else
 		return FALSE
 	return TRUE
 
-
-/mob/living/simple_animal/bot/proc/bot_step(dest) //Step,increase tries if failed
-	if(!path)
+/// Performs a step_towards and increments the path if successful. Returns TRUE if the bot moved and FALSE otherwise.
+/mob/living/simple_animal/bot/proc/bot_step()
+	if(!length(path))
 		return FALSE
-	if(path.len > 1)
-		step_towards(src, path[1])
-		if(get_turf(src) == path[1]) //Successful move
-			increment_path()
-			tries = 0
-		else
-			tries++
-			return FALSE
-	else if(path.len == 1)
-		step_to(src, dest)
-		set_path(null)
+
+	if(SEND_SIGNAL(src, COMSIG_MOB_BOT_PRESTEP) & COMPONENT_MOB_BOT_CANCELSTEP)
+		return FALSE
+
+	if(!step_towards(src, path[1]))
+		tries++
+		return FALSE
+
+	increment_path()
+	tries = 0
+	SEND_SIGNAL(src, COMSIG_MOB_BOT_STEP)
 	return TRUE
 
 
@@ -1073,12 +1073,15 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 
 /mob/living/simple_animal/bot/proc/increment_path()
-	if(!path || !path.len)
+	if(!length(path))
 		return
 	var/image/I = path[path[1]]
 	if(I)
 		I.icon_state = null
 	path.Cut(1, 2)
+
+	if(!length(path))
+		set_path(null)
 
 /mob/living/simple_animal/bot/rust_heretic_act()
 	adjustBruteLoss(400)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -538,7 +538,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 	if(!length(path))
 		return FALSE
 
-	if(SEND_SIGNAL(src, COMSIG_MOB_BOT_PRESTEP) & COMPONENT_MOB_BOT_CANCELSTEP)
+	if(SEND_SIGNAL(src, COMSIG_MOB_BOT_PRE_STEP) & COMPONENT_MOB_BOT_BLOCK_PRE_STEP)
 		return FALSE
 
 	if(!step_towards(src, path[1]))

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -60,6 +60,9 @@
 
 /mob/living/simple_animal/bot/mulebot/Initialize(mapload)
 	. = ..()
+
+	ADD_TRAIT(src, TRAIT_NOMOBSWAP, INNATE_TRAIT)
+
 	if(prob(0.666) && mapload)
 		new /mob/living/simple_animal/bot/mulebot/paranormal(loc)
 		return INITIALIZE_HINT_QDEL
@@ -538,8 +541,8 @@
 
 /mob/living/simple_animal/bot/mulebot/Moved() //make sure we always use power after moving.
 	. = ..()
-	if(!cell?.use(cell_move_power_usage))
-		return
+
+	cell?.use(cell_move_power_usage)
 
 	for(var/potential_target in loc.contents)
 		if(potential_target == load)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -118,13 +118,6 @@
 		return
 	return ..()
 
-/mob/living/simple_animal/bot/mulebot/Cross(atom/movable/AM)
-	. = ..()
-	if(ishuman(AM))
-		RunOver(AM)
-
-
-
 /// returns true if the bot is fully powered.
 /mob/living/simple_animal/bot/mulebot/proc/has_power(bypass_open_check)
 	return (!open || bypass_open_check) && cell && cell.charge > 0 && (!wires.is_cut(WIRE_POWER1) && !wires.is_cut(WIRE_POWER2))
@@ -545,11 +538,19 @@
 
 /mob/living/simple_animal/bot/mulebot/Moved() //make sure we always use power after moving.
 	. = ..()
-	if(!cell)
+	if(!cell?.use(cell_move_power_usage))
 		return
-	cell.use(cell_move_power_usage)
+
+	for(var/potential_target in loc.contents)
+		if(potential_target == load)
+			continue
+
+		if(ishuman(potential_target))
+			RunOver(potential_target)
+
 	if(cell.charge < cell_move_power_usage) //make sure we have enough power to move again, otherwise turn off.
 		turn_off()
+
 	diag_hud_set_mulebotcell()
 
 /mob/living/simple_animal/bot/mulebot/handle_automated_action()

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -829,6 +829,9 @@
 		visible_message("<span class='notice'>[src]'s safeties are locked on.</span>")
 
 /mob/living/simple_animal/bot/mulebot/bot_step(dest)
+	if(!on)
+		return FALSE
+
 	if(!(cell?.use(cell_move_power_usage)))
 		turn_off()
 		return FALSE

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -539,10 +539,8 @@
 	B.setDir(direct)
 	bloodiness--
 
-/mob/living/simple_animal/bot/mulebot/Moved() //make sure we always use power after moving.
+/mob/living/simple_animal/bot/mulebot/Moved()
 	. = ..()
-
-	cell?.use(cell_move_power_usage)
 
 	for(var/potential_target in loc.contents)
 		if(potential_target == load)
@@ -550,9 +548,6 @@
 
 		if(ishuman(potential_target))
 			RunOver(potential_target)
-
-	if(cell.charge < cell_move_power_usage) //make sure we have enough power to move again, otherwise turn off.
-		turn_off()
 
 	diag_hud_set_mulebotcell()
 
@@ -833,6 +828,13 @@
 	if(.)
 		visible_message("<span class='notice'>[src]'s safeties are locked on.</span>")
 
+/mob/living/simple_animal/bot/mulebot/bot_step(dest)
+	if(!(cell?.use(cell_move_power_usage)))
+		turn_off()
+		return FALSE
+
+	return ..()
+
 /mob/living/simple_animal/bot/mulebot/paranormal//allows ghosts only unless hacked to actually be useful
 	name = "\improper GHOULbot"
 	desc = "A rather ghastly looking... Multiple Utility Load Effector bot? It only seems to accept paranormal forces, and for this reason is fucking useless."
@@ -887,7 +889,6 @@
 	mode = BOT_IDLE
 	update_appearance()
 
-
 /mob/living/simple_animal/bot/mulebot/paranormal/update_overlays()
 	. = ..()
 	if(!isobserver(load))
@@ -913,3 +914,4 @@
 
 /obj/machinery/bot_core/mulebot
 	req_access = list(ACCESS_CARGO)
+

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -63,7 +63,7 @@
 
 	RegisterSignal(src, COMSIG_MOB_BOT_PRESTEP, .proc/check_pre_step)
 	RegisterSignal(src, COMSIG_MOB_BOT_STEP, .proc/on_bot_step)
-	RegisterSignal(src, COMSIG_MOVABLE_CROSSED_AM, .proc/on_crossed_am)
+	RegisterSignal(src, COMSIG_MOVABLE_CROSSED_OVER, .proc/on_crossed_over)
 
 	ADD_TRAIT(src, TRAIT_NOMOBSWAP, INNATE_TRAIT)
 
@@ -545,11 +545,11 @@
 	bloodiness--
 
 /**
- * Signal handler for COMSIG_MOVABLE_CROSSED_AM signals sent by this mulebot.
+ * Signal handler for COMSIG_MOVABLE_CROSSED_OVER signals sent by this mulebot.
  *
  * Intended to be used to crush various things.
  */
-/mob/living/simple_animal/bot/mulebot/proc/on_crossed_am(atom/movable/source, atom/movable/crossed_atom)
+/mob/living/simple_animal/bot/mulebot/proc/on_crossed_over(atom/movable/source, atom/movable/crossed_atom)
 	SIGNAL_HANDLER
 
 	if(ishuman(crossed_atom))

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -63,6 +63,7 @@
 
 	RegisterSignal(src, COMSIG_MOB_BOT_PRESTEP, .proc/check_pre_step)
 	RegisterSignal(src, COMSIG_MOB_BOT_STEP, .proc/on_bot_step)
+	RegisterSignal(src, COMSIG_MOVABLE_CROSSED_AM, .proc/on_crossed_am)
 
 	ADD_TRAIT(src, TRAIT_NOMOBSWAP, INNATE_TRAIT)
 
@@ -543,15 +544,19 @@
 	B.setDir(direct)
 	bloodiness--
 
+/**
+ * Signal handler for COMSIG_MOVABLE_CROSSED_AM signals sent by this mulebot.
+ *
+ * Intended to be used to crush various things.
+ */
+/mob/living/simple_animal/bot/mulebot/proc/on_crossed_am(atom/movable/source, atom/movable/crossed_atom)
+	SIGNAL_HANDLER
+
+	if(ishuman(crossed_atom))
+		run_over(crossed_atom)
+
 /mob/living/simple_animal/bot/mulebot/Moved()
 	. = ..()
-
-	for(var/potential_target in loc.contents)
-		if(potential_target == load)
-			continue
-
-		if(ishuman(potential_target))
-			RunOver(potential_target)
 
 	diag_hud_set_mulebotcell()
 
@@ -740,7 +745,7 @@
 	return ..()
 
 // when mulebot is in the same loc
-/mob/living/simple_animal/bot/mulebot/proc/RunOver(mob/living/carbon/human/H)
+/mob/living/simple_animal/bot/mulebot/proc/run_over(mob/living/carbon/human/H)
 	log_combat(src, H, "run over", null, "(DAMTYPE: [uppertext(BRUTE)])")
 	H.visible_message("<span class='danger'>[src] drives over [H]!</span>", \
 					"<span class='userdanger'>[src] drives over you!</span>")

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -111,6 +111,7 @@
 
 
 /mob/living/simple_animal/bot/mulebot/Destroy()
+	UnregisterSignal(src, COMSIG_MOB_BOT_PRESTEP, COMSIG_MOB_BOT_STEP)
 	unload(0)
 	QDEL_NULL(wires)
 	QDEL_NULL(cell)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -66,7 +66,7 @@
  * (if you ask me, this should be at the top of the move so you don't dance around)
  *
  */
-/client/Move(n, direct)
+/client/Move(new_loc, direct)
 	if(world.time < move_delay) //do not move anything ahead of this check please
 		return FALSE
 	else
@@ -76,14 +76,14 @@
 	move_delay = world.time + world.tick_lag //this is here because Move() can now be called mutiple times per tick
 	if(!mob || !mob.loc)
 		return FALSE
-	if(!n || !direct)
+	if(!new_loc || !direct)
 		return FALSE
 	if(mob.notransform)
 		return FALSE //This is sota the goto stop mobs from moving var
 	if(mob.control_object)
 		return Move_object(direct)
 	if(!isliving(mob))
-		return mob.Move(n, direct)
+		return mob.Move(new_loc, direct)
 	if(mob.stat == DEAD)
 		mob.ghostize()
 		return FALSE
@@ -99,7 +99,7 @@
 		return mob.remote_control.relaymove(mob, direct)
 
 	if(isAI(mob))
-		return AIMove(n,direct,mob)
+		return AIMove(new_loc,direct,mob)
 
 	if(Process_Grab()) //are we restrained by someone's grip?
 		return
@@ -117,7 +117,7 @@
 	if(!mob.Process_Spacemove(direct))
 		return FALSE
 
-	if(SEND_SIGNAL(mob, COMSIG_MOB_CLIENT_PRE_MOVE, n) & COMSIG_MOB_CLIENT_BLOCK_PRE_MOVE)
+	if(SEND_SIGNAL(mob, COMSIG_MOB_CLIENT_PRE_MOVE, new_loc) & COMSIG_MOB_CLIENT_BLOCK_PRE_MOVE)
 		return FALSE
 
 	//We are now going to move
@@ -139,11 +139,11 @@
 			newdir = angle2dir(dir2angle(direct) + pick(45, -45))
 		if(newdir)
 			direct = newdir
-			n = get_step(L, direct)
+			new_loc = get_step(L, direct)
 
 	. = ..()
 
-	if((direct & (direct - 1)) && mob.loc == n) //moved diagonally successfully
+	if((direct & (direct - 1)) && mob.loc == new_loc) //moved diagonally successfully
 		add_delay *= 2
 	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay))
 	move_delay += add_delay

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -116,6 +116,10 @@
 
 	if(!mob.Process_Spacemove(direct))
 		return FALSE
+
+	if(SEND_SIGNAL(mob, COMSIG_MOB_CLIENT_PRE_MOVE, n) & COMSIG_MOB_CLIENT_BLOCK_PRE_MOVE)
+		return FALSE
+
 	//We are now going to move
 	var/add_delay = mob.cached_multiplicative_slowdown
 	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay * ( (NSCOMPONENT(direct) && EWCOMPONENT(direct)) ? 2 : 1 ) )) // set it now in case of pulled objects
@@ -146,6 +150,10 @@
 	if(.) // If mob is null here, we deserve the runtime
 		if(mob.throwing)
 			mob.throwing.finalize(FALSE)
+
+		// At this point we've moved the client's attached mob. This is one of the only ways to guess that a move was done
+		// as a result of player input and not because they were pulled or any other magic.
+		SEND_SIGNAL(mob, COMSIG_MOB_CLIENT_MOVED)
 
 	var/atom/movable/P = mob.pulling
 	if(P && !ismob(P) && P.density)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In https://github.com/tgstation/tgstation/pull/57010/files#diff-08a9c12575e75bb692c000da3f7eea30c0340da26171c5c788fd2b17afef92b5 Floyd did an undocumented change to Mulebot behaviour.

He moved crushing from the /human/Crossed level to mulebot/Cross.

The problem is:
![image](https://user-images.githubusercontent.com/24975989/109757505-d10bc680-7be1-11eb-8a95-3824ee93d8bf.png)

Cross (and Crossed) are called when **some other object** Crosses us, not when we Cross some other object.

This meant that... Well... Walking into a mulebot was deadly. Buckling to a mulebot was deadly.
![lGrnThJEWG](https://user-images.githubusercontent.com/24975989/109757544-e7b21d80-7be1-11eb-970a-7b7366c11f5e.gif)

And being buckled to a mulebot that ended up moving was deadly multiplied by the number of times the mulebot moved.
![QJNXqBHZ8m](https://user-images.githubusercontent.com/24975989/109757602-0c0dfa00-7be2-11eb-982b-ad04d1bd310b.gif)

Also why can you push mulebots when things are buckled to it? That seems like an oversight.

I added new signals to the atom/movable/...Cross... series of procs that are sent from the thing crossing our AM. The thing crossing our AM can then listen for that signal on itself, and it now knows when it's crossing something! BOOM! CRUSH TIME!

I've also added a check to `/mob/living/proc/PushAM` to prevent pushing an AM buckled to a thing when you wouldn't be able to pull them. This check also takes into account if you'd just have the raw movement force to push the thing they're buckled to as well. This should put a stop to being able to push mulebots around when they have mobs buckled to them.

Also, you can swap places with active Mulebots. This is probably not intended. I've added TRAIT_NOMOBSWAP to them.

The end result? Mulebots that just work.

![c2Yu3wrMll](https://user-images.githubusercontent.com/24975989/109767409-6cefff00-7bef-11eb-8897-0d42c9419277.gif)
![AbU5hazPEg](https://user-images.githubusercontent.com/24975989/109767414-70838600-7bef-11eb-910a-ff1400f40c63.gif)

And don't worry, you can still crawl under them.

![TcNN9cfQpB](https://user-images.githubusercontent.com/24975989/109768365-b3922900-7bf0-11eb-8335-cd38fb1a1ccb.gif)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Mulebots no longer murder people just because that person dared to bump into them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
