### PR TITLE
patches out a radioactive microlaser tech, makes radioactive microlasers not knock out rad-immune creatures

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -69,7 +69,6 @@ effective or pretty fucking useless.
 */
 
 /obj/item/healthanalyzer/rad_laser
-	custom_materials = list(/datum/material/iron=400)
 	var/irradiate = TRUE
 	var/stealth = FALSE
 	var/used = FALSE // is it cooling down?
@@ -89,16 +88,16 @@ effective or pretty fucking useless.
 		addtimer(VARSET_CALLBACK(src, used, FALSE), cooldown)
 		addtimer(VARSET_CALLBACK(src, icon_state, "health"), cooldown)
 		to_chat(user, "<span class='warning'>Successfully irradiated [M].</span>")
-		addtimer(CALLBACK(src, .proc/radiation_aftereffect, M), (wavelength+(intensity*4))*5)
+		addtimer(CALLBACK(src, .proc/radiation_aftereffect, M, intensity), (wavelength+(intensity*4))*5)
 	else
 		to_chat(user, "<span class='warning'>The radioactive microlaser is still recharging.</span>")
 
-/obj/item/healthanalyzer/rad_laser/proc/radiation_aftereffect(mob/living/M)
-	if(QDELETED(M))
+/obj/item/healthanalyzer/rad_laser/proc/radiation_aftereffect(mob/living/M, passed_intensity)
+	if(QDELETED(M) || !ishuman(M) || HAS_TRAIT(M, TRAIT_RADIMMUNE))
 		return
-	if(intensity >= 5)
-		M.apply_effect(round(intensity/0.075), EFFECT_UNCONSCIOUS)
-	M.rad_act(intensity*10)
+	if(passed_intensity >= 5)
+		M.apply_effect(round(passed_intensity/0.075), EFFECT_UNCONSCIOUS) //to save you some math, this is a round(intensity * (4/3)) second long knockout
+	M.rad_act(passed_intensity*10)
 
 /obj/item/healthanalyzer/rad_laser/proc/get_cooldown()
 	return round(max(10, (stealth*30 + intensity*5 - wavelength/4)))


### PR DESCRIPTION
## About The Pull Request

So, there's something very !!FUN!! that you can do with the radioactive microlaser currently.

1. Open up the interface of your radioactive microlaser and keep it open.
2. Set the intensity and wavelength settings of your radioactive microlaser to 0, then ensure that irradiate mode is on and stealth mode is off. This should give your radioactive microlaser a cooldown of 1 second (the capped minimum cooldown duration) and give its delayed knockout effect a delay of 2 seconds, the minimum value.
3. Click on someone you want to have a bad time.
4. Within the next 2 seconds, crank the intensity of your microlaser up to the maximum possible setting.
5. Immediately after those 2 seconds pass, laugh as your target gets knocked out for 26+ seconds.
6. Pull out your amputation shears.
7. jermasus.jpg
8. Give your victim "the snip" (or multiple snips, if you're so inclined).
9. Repeat until satisfied.
10.
![image](https://user-images.githubusercontent.com/42606352/109770789-9db93f80-7bc1-11eb-8394-84cf898d2e99.png)

So, why this works: The radioactive microlaser calculates the delay of its effect and the length of its cooldown period using the settings it has when you click on someone with it, but it calculates the STRENGTH of its effect using the settings it has when it actually tries to irradiate your victim. By following the steps above, you can use an intensity of 1 for the delay and cooldown calculations, but an intensity of 20 for the effect strength calculation, allowing you to knock someone unconscious for 26+ seconds a mere 2 seconds after you scan them. For reference, an intensity 20 radioactive microlaser effect is intended to have a minimum delay period of _40 seconds_.

I've fixed this issue by making the effect strength calculation use the intensity setting that the microlaser was using when it initially scanned your victim(s) (and calculated its delay and cooldown lengths) instead of whatever intensity the microlaser is currently set to.

Also, I've made creatures who're immune to the effects of radiation (most nonhumanoids, plasmamen, etc.) immune to being knocked unconscious by the radioactive microlaser's delayed effect.

Radioactive microlasers no longer contain twice as much iron as normal health analyzers.

## Why It's Good For The Game

This tech basically lets the radioactive microlaser, a 3 TC device, rival an abductor baton in strength. If someone's on to your tricks and has a telebaton, defib, or the like (to interrupt you cranking up the microlaser's intensity setting), then the abductor baton is probably better, but the microlaser has the advantages of not looking like a weapon and not making your victim (and bystanders!) think that they're being attacked.

Anyway, while I personally haven't gotten an opportunity to wield this weapon of mass destruction, Omega's already gotten 2 murderbones done with the radioactive microlaser+amputation shears+chameleon kit wombo-combo, so I think that ~~that's enough to give me a power trip by proxy~~ it's about time I closed this Pandora's Box that I discovered and opened.

As for the rad-immune creatures being immune thing, the microlaser's radiation burst is what's supposed to be knocking your victim out, I think.

As for the materials thing, I really, er, don't get WHY radioactive microlasers should redeem for slightly more iron (still less than a single sheet, IIRC) than a normal health analyzer would. If anything, they should contain uranium or something in their mats list, but... eh, I'm lazy.

## Changelog
:cl: ATHATH
balance: Radioactive microlasers can no longer knock out creatures who are immune to the effects of radiation.
fix: The radioactive microlaser now calculates the strength of its delay effect using the intensity setting it had when you initially used it on your victim, not the intensity setting it currently has. This prevents people from "cheating out" its intensity 20 effect with only a 2 second delay and a 1 second cooldown.
balance: Radioactive microlasers no longer contain twice as much metal as normal health analyzers do.
/:cl: