### PR TITLE
Kilo air alarm fixes.

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -4049,10 +4049,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/item/stack/cable_coil{
 	pixel_y = 8
 	},
@@ -4983,10 +4979,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -37380,10 +37372,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/light_switch{
 	pixel_x = -24;
 	pixel_y = -24
@@ -43799,10 +43787,6 @@
 "cje" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -78655,10 +78639,6 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "qHv" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
 	name = "BrewMaster 2199"
@@ -78812,10 +78792,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
@@ -81047,10 +81023,10 @@
 "rZn" = (
 /obj/structure/bed/dogbed/ian,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
 /mob/living/simple_animal/pet/dog/corgi/ian{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "rZN" = (


### PR DESCRIPTION
## About The Pull Request

Mapped onto kilo, there's several rooms that appear to have multiple air alarms in the single room.
This is bad practice, and has been corrected where it's been found on the list.

## Why It's Good For The Game

Fixes #57373.

## Changelog
:cl:
fix: Fixes some duplicate air alarms on kilostation.
/:cl:
