### PR TITLE
Fixes the Deltastation Brig flash

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -25698,7 +25698,7 @@
 	dir = 8
 	},
 /obj/machinery/button/flasher{
-	id = "gulagshuttleflasher";
+	id = "brigflashdoor";
 	name = "Flash Control";
 	pixel_x = 26;
 	pixel_y = 7;


### PR DESCRIPTION
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA

## Changelog
:cl:
fix: The Deltastation wall-mounted flash at the Brig entrance is now properly connected to the Brig Checkpoint flasher button.
/:cl:
