### PR TITLE
Beauty element fixes for hard-dels and super-beauty

### DIFF
--- a/code/datums/elements/beauty.dm
+++ b/code/datums/elements/beauty.dm
@@ -50,6 +50,8 @@
 	old_area.update_beauty()
 
 /datum/element/beauty/Detach(datum/source, force)
+	if(!beauty_counter[source])
+		return ..()
 	var/area/current_area = get_area(source)
 	if(QDELETED(source))
 		. = ..()

--- a/code/datums/elements/beauty.dm
+++ b/code/datums/elements/beauty.dm
@@ -59,6 +59,7 @@
 		if(current_area)
 			exit_area(source, current_area)
 		beauty_counter -= source
+		REMOVE_TRAIT(source, TRAIT_AREA_SENSITIVE, BEAUTY_ELEMENT_TRAIT)
 	else //lower the 'counter' down by one, update the area, and call parent if it's reached zero.
 		beauty_counter[source]--
 		if(current_area && !current_area.outdoors)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1632,7 +1632,7 @@
 	if(custom_materials) //Only runs if custom materials existed at first. Should usually be the case but check anyways
 		for(var/i in custom_materials)
 			var/datum/material/custom_material = GET_MATERIAL_REF(i)
-			custom_material.on_removed(src, custom_materials[i], material_flags) //Remove the current materials
+			custom_material.on_removed(src, custom_materials[i] * material_modifier, material_flags) //Remove the current materials
 
 	if(!length(materials))
 		custom_materials = null


### PR DESCRIPTION
## About The Pull Request
This fixes a few sources of hard-dels within the beauty element (which Azarak noticed) and also corrects the material "amount" passed to `/datum/material/proc/on_removed` to match the amount passed to `/datum/material/proc/on_applied`.

The latter was causing stacks of materials to end up with 50 unique beauty elements instead of a single element because the `RemoveElement` call in `on_removed` was passing the incorrect beauty parameter. It also happened to cause a couple of other things to remove material effects incorrectly (such as plasteel, which ended up with negative slowdown... but this didn't cause anything noticable in game afaik)

## Why It's Good For The Game
less bugs!

## Changelog
:cl:
fix: merging stacks of materials no longer increases beauty more than it should
/:cl: