### PR TITLE
Juice boxes no longer turn into paper cups

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -557,6 +557,8 @@
 			icon_state = "chocolatebox"
 		if(/datum/reagent/consumable/ethanol/eggnog)
 			icon_state = "nog2"
+		else
+			icon_state = "juicebox"
 
 /obj/item/reagent_containers/food/drinks/sillycup/smallcarton/smash(atom/target, mob/thrower, ranged = FALSE)
 	if(bartender_check(target) && ranged)


### PR DESCRIPTION
## About The Pull Request
Juice boxes no longer turn into paper cups when you pour most liquids into them.
Fixes #57292

<details>
  <summary>Oh, heavens, my eyes!</summary>
  
![image](https://user-images.githubusercontent.com/60656530/109863096-83cf3980-7c61-11eb-87a6-c495a3a7d0e7.png)
why
  
</details>

## Changelog
:cl: Dex
fix: Juice boxes no longer turn into paper cups.
/:cl:
