### PR TITLE
Allows pAI to be emagged

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -329,11 +329,11 @@
 	return ..()
 
 /obj/item/paicard/emag_act(mob/user) // Emag to wipe the master DNA and supplemental directive
-	if(pai)
-		to_chat(user, "<span class='notice'>You override [pai]'s directive system, clearing its master string and supplied directive.</span>")
-		to_chat(pai, "<span class='danger'>Warning: System override detected, check directive sub-system for any changes.'</span>")
-		log_game("[key_name(user)] emagged [key_name(pai)], wiping their master DNA and supplemental directive.")
-		pai.master = null
-		pai.master_dna = null
-		pai.laws.supplied[1] = "None." // Set supplemental directive to this
-	return
+	if(!pai)
+		return
+	to_chat(user, "<span class='notice'>You override [pai]'s directive system, clearing its master string and supplied directive.</span>")
+	to_chat(pai, "<span class='danger'>Warning: System override detected, check directive sub-system for any changes.'</span>")
+	log_game("[key_name(user)] emagged [key_name(pai)], wiping their master DNA and supplemental directive.")
+	pai.master = null
+	pai.master_dna = null
+	pai.laws.supplied[1] = "None." // Sets supplemental directive to this

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -328,11 +328,12 @@
 
 	return ..()
 
-/obj/item/paicard/emag_act(mob/user) // Emag to wipe the master DNA
+/obj/item/paicard/emag_act(mob/user) // Emag to wipe the master DNA and supplemental directive
 	if(pai)
-		to_chat(user, "<span class='notice'>You override [pai]'s master string, clearing it.</span>")
+		to_chat(user, "<span class='notice'>You override [pai]'s directive system, clearing its master string and supplied directive.</span>")
 		to_chat(pai, "<span class='danger'>Warning: System override detected, check directive sub-system for any changes.'</span>")
-		log_game("[key_name(user)] emagged [key_name(pai)], wiping their master DNA.")
+		log_game("[key_name(user)] emagged [key_name(pai)], wiping their master DNA and supplemental directive.")
 		pai.master = null
 		pai.master_dna = null
+		pai.laws.supplied[1] = "None." // Set supplemental directive to this
 	return

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -327,3 +327,12 @@
 		return
 
 	return ..()
+
+/obj/item/paicard/emag_act(mob/user) // Emag to wipe the master DNA
+	if(pai)
+		to_chat(user, "<span class='notice'>You override [pai]'s master string, clearing it.</span>")
+		to_chat(pai, "<span class='danger'>Warning: System override detected, check directive sub-system for any changes.'</span>")
+		log_game("[key_name(user)] emagged [key_name(pai)], wiping their master DNA.")
+		pai.master = null
+		pai.master_dna = null
+	return


### PR DESCRIPTION
## About The Pull Request

Allows pAIs that have a master already set to be emagged to have their master string removed, freeing the pAI to be bound to someone else, likely whoever emagged the pAI.

## Why It's Good For The Game

This is something some players thought was possible for a long while, but it wasn't, now pAIs are prone to emags like the rest of the silicons.

Also addresses #56849
## Changelog
:cl:
add: pAIs can now be emagged
/:cl:
