### PR TITLE
Right-click to remove carbon-copies

### DIFF
--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -44,8 +44,8 @@
 		C.update_icon_state()
 		user.put_in_hands(Copy)
 
-/obj/item/paper/carbon/attack_hand(mob/living/user, list/modifiers)
-	if(loc == user && user.is_holding(src) && LAZYACCESS(modifiers, RIGHT_CLICK))
+/obj/item/paper/carbon/attack_hand_secondary(mob/user, list/modifiers)
+	if(loc == user && user.is_holding(src))
 		removecopy(user)
-		return
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	return ..()

--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -17,6 +17,12 @@
 		icon_state = "[icon_state]_words"
 	return ..()
 
+/obj/item/paper/carbon/examine()
+	. = ..()
+	if(copied || iscopy)
+		return
+	. += "<span class='notice'>Right-click to tear off the carbon-copy (you must use both hands).</span>"
+
 /obj/item/paper/carbon/proc/removecopy(mob/living/user)
 	if(copied || iscopy)
 		to_chat(user, "<span class='notice'>There are no more carbon copies attached to this paper!</span>")
@@ -39,7 +45,7 @@
 		user.put_in_hands(Copy)
 
 /obj/item/paper/carbon/attack_hand(mob/living/user, list/modifiers)
-	if(loc == user && user.is_holding(src))
+	if(loc == user && user.is_holding(src) && LAZYACCESS(modifiers, RIGHT_CLICK))
 		removecopy(user)
 		return
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Enforce Right-click to tear off a carbon copy instead of any click.
- Add examine text to explain this
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents accidental premature ripping off of carbon copies. HoPs hate(d) this!
Also [improves](https://github.com/tgstation/tgstation/pull/57289#discussion_r585076647) [consistency](https://github.com/tgstation/tgstation/pull/57400#issue-584302253).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: mozi_h
qol: Carbon-copies can now only be removed with a right-click. HoPs, you are welcome (yet again)!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
