### PR TITLE
Fixes ID trim singletons ignoring config flags.

### DIFF
--- a/code/controllers/subsystem/id_access.dm
+++ b/code/controllers/subsystem/id_access.dm
@@ -48,6 +48,23 @@ SUBSYSTEM_DEF(id_access)
 
 	return ..()
 
+/**
+ * Called by [/datum/controller/subsystem/ticker/proc/setup]
+ *
+ * This runs through every /datum/id_trim singleton and ensures that its access is setup according to
+ * appropriate config entries.
+ */
+/datum/controller/subsystem/id_access/proc/refresh_job_trim_singletons()
+	for(var/trim in typesof(/datum/id_trim/job))
+		var/datum/id_trim/job/job_trim = trim_singletons_by_path[trim]
+
+		if(QDELETED(job_trim))
+			stack_trace("Trim \[[trim]\] missing from trim singleton list. Reinitialising this trim.")
+			trim_singletons_by_path[trim] = new trim()
+			continue
+
+		job_trim.refresh_trim_access()
+
 /// Build access flag lists.
 /datum/controller/subsystem/id_access/proc/setup_access_flags()
 	accesses_by_flag["[ACCESS_FLAG_COMMON]"] = COMMON_ACCESS

--- a/code/controllers/subsystem/id_access.dm
+++ b/code/controllers/subsystem/id_access.dm
@@ -51,7 +51,7 @@ SUBSYSTEM_DEF(id_access)
 /**
  * Called by [/datum/controller/subsystem/ticker/proc/setup]
  *
- * This runs through every /datum/id_trim singleton and ensures that its access is setup according to
+ * This runs through every /datum/id_trim/job singleton and ensures that its access is setup according to
  * appropriate config entries.
  */
 /datum/controller/subsystem/id_access/proc/refresh_job_trim_singletons()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -263,6 +263,13 @@ SUBSYSTEM_DEF(ticker)
 		message_admins("<span class='notice'>DEBUG: Bypassing prestart checks...</span>")
 
 	CHECK_TICK
+
+	// There may be various config settings that have been set or modified by this point.
+	// This is the point of no return before spawning in new players, let's run over the
+	// job trim singletons and update them based on any config settings.
+	SSid_access.refresh_job_trim_singletons()
+
+	CHECK_TICK
 	if(hide_mode)
 		var/list/modes = new
 		for (var/datum/game_mode/M in runnable_modes)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When turning ID trims into singletons, I misunderstood when the config JOBS_HAVE_MINIMAL_ACCESS was set.

It CAN be hard set in the config, but it can also be overridden by MINIMAL_ACCESS_THRESHOLD - If I am correct, we use the MINIMAL_ACCESS_THRESHOLD override instead which sets JOBS_HAVE_MINIMAL_ACCESS if the player count is over a given number.

MINIMAL_ACCESS_THRESHOLD is checked just before everyone spawns in at shift start. Trim singletons have been initialised loooong before that.

End result? We completely ignore MINIMAL_ACCESS_THRESHOLD and JOBS_HAVE_MINIMAL_ACCESS is always unset/FALSE. ** So since the ID card rework has gone live, everyone has had lowpop access even on highpop.**

This fixes that. I've pulled out logic for job trim accesses to its own proc and have given SSid_access the ability to update the trim singletons with new accesses based on the currently set config flags. This SSid_access proc can be called whenever, but in this case I call it just before the point of no return when the game is assigning jobs to everyone who has readied up.

### I have asked and the headmins have agreed to disable the MINIMAL_ACCESS_THRESHOLD and JOBS_HAVE_MINIMAL_ACCESS config entries.

As a result, this PR should not have any change to in-game functionality - There will be no difference between lowpop and highpop access levels. All jobs should continue to get maximum departmental access regardless of pop unless another config change happens.

Reverting to the former highpop limited access is still just a config change away if players are dissatisfied with the overall additional baseline accesses everyone now has on highpop.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Ignoring the config is bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The new ID card system no longer ignores server config settings and will respect lowpop/highpop access settings in the config. This mean that highpop shifts no longer grant players lowpop access levels when the appropriate config entries are set.
config: As I am happy with the status quo, the headmins have agreed to disable the config entry that was being ignored due to the above bug. Players should not notice any new roundstart ID access changes by the time they're reading this changelog entry and will hopefully start with maximum job access at any population level because it is intended, rather than because of a bug.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
