### PR TITLE
Departmental sec officers now appear on the crew manifest as sec.

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -152,7 +152,7 @@
 	)
 	var/list/departments = list(
 		"Command" = GLOB.command_positions,
-		"Security" = GLOB.security_positions,
+		"Security" = GLOB.security_positions + GLOB.security_sub_positions,
 		"Engineering" = GLOB.engineering_positions,
 		"Medical" = GLOB.medical_positions,
 		"Science" = GLOB.science_positions,

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -61,7 +61,8 @@ GLOBAL_LIST_INIT(security_sub_positions, list(
 	"Security Officer (Cargo)",
 	"Security Officer (Engineering)",
 	"Security Officer (Medical)",
-	"Security Officer (Science)",))
+	"Security Officer (Science)",
+))
 
 GLOBAL_LIST_INIT(nonhuman_positions, list(
 	"AI",

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -56,6 +56,12 @@ GLOBAL_LIST_INIT(security_positions, list(
 	"Detective",
 	"Security Officer"))
 
+/// These aren't defacto jobs, but are the special departmental variants for sec officers.
+GLOBAL_LIST_INIT(security_sub_positions, list(
+	"Security Officer (Cargo)",
+	"Security Officer (Engineering)",
+	"Security Officer (Medical)",
+	"Security Officer (Science)",))
 
 GLOBAL_LIST_INIT(nonhuman_positions, list(
 	"AI",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/109902832-e0971800-7c92-11eb-800b-bdfd14cc1b4c.png)

Just created a sub-departmental list of sec roles to specifically use on the crew manifest.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Consistency.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Departmental sec officers now appear on the crew manifest as sec.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
