### PR TITLE
Fixes the foam finger rocket launcher killing the server

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/grenade.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/grenade.dm
@@ -15,9 +15,3 @@
 	ammo_type = /obj/item/ammo_casing/caseless/rocket
 	caliber = CALIBER_84MM
 	max_ammo = 1
-
-/obj/item/ammo_box/magazine/internal/foamfinger
-	name = "foam finger magazine"
-	ammo_type = /obj/item/ammo_casing/caseless/rocket
-	caliber = CALIBER_84MM
-	max_ammo = 5000

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -108,26 +108,3 @@
 			"<span class='userdanger'>You look around after realizing you're still here, then proceed to choke yourself to death with [src]!</span>")
 		sleep(20)
 		return OXYLOSS
-
-/obj/item/gun/ballistic/foamfinger
-	name = "foam finger"
-	desc = "pull my finger. unless your hand has gotten blown off by it"
-	icon_state = "foamfinger"
-	inhand_icon_state = "foamfinger"
-	mag_type = /obj/item/ammo_box/magazine/internal/foamfinger
-	fire_sound = 'sound/weapons/gun/general/rocket_launch.ogg'
-	w_class = WEIGHT_CLASS_NORMAL
-	can_suppress = FALSE
-	pin = /obj/item/firing_pin
-	burst_size = 1
-	fire_delay = 0
-	casing_ejector = FALSE
-	weapon_weight = WEAPON_LIGHT
-	bolt_type = BOLT_TYPE_NO_BOLT
-	internal_magazine = TRUE
-	cartridge_wording = "rocket"
-	empty_indicator = TRUE
-	tac_reloads = FALSE
-
-
-

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -246,4 +246,18 @@
 	desc = "It's not just a stick, it's a MAGIC stick?"
 	ammo_type = /obj/item/ammo_casing/magic/nothing
 
+/////////////////////////////////////
+//foam finger that shoots rockets??
+/////////////////////////////////////
 
+/obj/item/gun/magic/wand/foamfinger
+	name = "foam finger"
+	desc = "Pull my finger- unless, like, it blew off your hand."
+	icon_state = "foamfinger"
+	inhand_icon_state = "foamfinger"
+	fire_sound = 'sound/weapons/gun/general/rocket_launch.ogg'
+	w_class = WEIGHT_CLASS_NORMAL
+	max_charges = 5000
+	variable_charges = FALSE
+	checks_antimagic = FALSE
+	ammo_type = /obj/item/ammo_casing/caseless/rocket


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
#57013 added a foam finger that shoots rockets, and made the classic laser gatling mistake of being a ballistic gun and thus spawning 5000 rockets in its internal magazine when spawned. I don't know what this is a reference to or why a foam finger was chosen for its appearance, but I do know spawning 5000 rockets is a bad idea. This avoids that issue by making it a subtype of wand (just about as good as magic anyway)

Fixes: #57413
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Spawning this won't kill the server anymore
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: The foam finger rocket launcher will no longer make 5000 rockets and freeze the server when spawned
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
