### PR TITLE
Fixes ethereals being unable to channel power into APCs, readds some defines

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -565,12 +565,12 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 
 /atom/movable/screen/alert/etherealcharge
 	name = "Low Blood Charge"
-	desc = "Your blood's electric charge is running low, find a source of charge for your blood. Use a recharging station found in robotics or the dormitory bathrooms, or eat some Ethereal-friendly food."
+	desc = "Your charge is running low, find a source of energy! Use a recharging station, eat some Ethereal-friendly food, or syphon some power from lights, a power cell, or an APC (done by right clicking on combat mode)."
 	icon_state = "etherealcharge"
 
 /atom/movable/screen/alert/ethereal_overcharge
 	name = "Blood Overcharge"
-	desc = "Your blood's electric charge is becoming dangerously high, find an outlet for your energy. Use Grab Intent on an APC to channel your energy into it."
+	desc = "Your charge is running dangerously high, find an outlet for your energy! Right click an APC while not in combat mode."
 	icon_state = "ethereal_overcharge"
 
 //Need to cover all use cases - emag, illegal upgrade module, malf AI hack, traitor cyborg

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -48,7 +48,7 @@
 /// The APCs external powernet has enough power to charge the APC.
 #define APC_HAS_POWER 2
 
-// Etherials:
+// Ethereals:
 /// How long it takes an ethereal to drain or charge APCs. Also used as a spam limiter.
 #define APC_DRAIN_TIME (7.5 SECONDS)
 /// How much power ethereals gain/drain from APCs.
@@ -839,46 +839,48 @@
 		var/mob/living/carbon/human/H = user
 		var/datum/species/ethereal/E = H.dna.species
 		var/charge_limit = ETHEREAL_CHARGE_DANGEROUS - APC_POWER_GAIN
-		if(H.combat_mode && E.drain_time < world.time)
-			if(LAZYACCESS(modifiers, RIGHT_CLICK)) //Disarm
-				if(cell.charge == cell.maxcharge)
-					to_chat(H, "<span class='warning'>The APC is full!</span>")
+		if((E.drain_time < world.time) && LAZYACCESS(modifiers, RIGHT_CLICK))
+			if(H.combat_mode)
+				if(cell.charge <= (cell.maxcharge / 2)) // ethereals can't drain APCs under half charge, this is so that they are forced to look to alternative power sources if the station is running low
+					to_chat(H, "<span class='warning'>The APC's syphon safeties prevent you from draining power!</span>")
 					return
 				var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
-				if(stomach.crystal_charge < 10)
+				if(stomach.crystal_charge > charge_limit)
+					to_chat(H, "<span class='warning'>Your charge is full!</span>")
+					return
+				E.drain_time = world.time + APC_DRAIN_TIME
+				to_chat(H, "<span class='notice'>You start channeling some power through the APC into your body.</span>")
+				if(do_after(user, APC_DRAIN_TIME, target = src))
+					if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > charge_limit))
+						return
+					if(istype(stomach))
+						to_chat(H, "<span class='notice'>You receive some charge from the APC.</span>")
+						stomach.adjust_charge(APC_POWER_GAIN)
+						cell.charge -= APC_POWER_GAIN
+					else
+						to_chat(H, "<span class='warning'>You can't receive charge from the APC!</span>")
+				return
+			else
+				if(cell.charge >= cell.maxcharge - APC_POWER_GAIN)
+					to_chat(H, "<span class='warning'>The APC can't receive anymore power!</span>")
+					return
+				var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+				if(stomach.crystal_charge < APC_POWER_GAIN)
 					to_chat(H, "<span class='warning'>Your charge is too low!</span>")
 					return
 				E.drain_time = world.time + APC_DRAIN_TIME
 				to_chat(H, "<span class='notice'>You start channeling power through your body into the APC.</span>")
 				if(do_after(user, APC_DRAIN_TIME, target = src))
-					if(cell.charge == cell.maxcharge || (stomach.crystal_charge < 10))
+					if((cell.charge >= (cell.maxcharge - APC_POWER_GAIN)) || (stomach.crystal_charge < APC_POWER_GAIN))
+						to_chat(H, "<span class='warning'>You can't transfer power to the APC!</span>")
 						return
 					if(istype(stomach))
 						to_chat(H, "<span class='notice'>You transfer some power to the APC.</span>")
-						stomach.adjust_charge(-10)
-						cell.charge += 10
+						stomach.adjust_charge(-APC_POWER_GAIN)
+						cell.charge += APC_POWER_GAIN
 					else
 						to_chat(H, "<span class='warning'>You can't transfer power to the APC!</span>")
 				return
-			if(cell.charge <= (cell.maxcharge / 2)) // ethereals can't drain APCs under half charge, this is so that they are forced to look to alternative power sources if the station is running low
-				to_chat(H, "<span class='warning'>The APC's syphon safeties prevent you from draining power!</span>")
-				return
-			var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
-			if(stomach.crystal_charge > charge_limit)
-				to_chat(H, "<span class='warning'>Your charge is full!</span>")
-				return
-			E.drain_time = world.time + APC_DRAIN_TIME
-			to_chat(H, "<span class='notice'>You start channeling some power through the APC into your body.</span>")
-			if(do_after(user, APC_DRAIN_TIME, target = src))
-				if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > charge_limit))
-					return
-				if(istype(stomach))
-					to_chat(H, "<span class='notice'>You receive some charge from the APC.</span>")
-					stomach.adjust_charge(APC_POWER_GAIN)
-					cell.charge -= APC_POWER_GAIN
-				else
-					to_chat(H, "<span class='warning'>You can't receive charge from the APC!</span>")
-			return
 
 	if(opened && (!issilicon(user)))
 		if(cell)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -839,12 +839,12 @@
 		var/mob/living/carbon/human/H = user
 		var/datum/species/ethereal/E = H.dna.species
 		var/charge_limit = ETHEREAL_CHARGE_DANGEROUS - APC_POWER_GAIN
-		if((E.drain_time < world.time) && LAZYACCESS(modifiers, RIGHT_CLICK))
+		var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+		if((E.drain_time < world.time) && LAZYACCESS(modifiers, RIGHT_CLICK) && stomach)
 			if(H.combat_mode)
 				if(cell.charge <= (cell.maxcharge / 2)) // ethereals can't drain APCs under half charge, this is so that they are forced to look to alternative power sources if the station is running low
 					to_chat(H, "<span class='warning'>The APC's syphon safeties prevent you from draining power!</span>")
 					return
-				var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 				if(stomach.crystal_charge > charge_limit)
 					to_chat(H, "<span class='warning'>Your charge is full!</span>")
 					return
@@ -864,7 +864,6 @@
 				if(cell.charge >= cell.maxcharge - APC_POWER_GAIN)
 					to_chat(H, "<span class='warning'>The APC can't receive anymore power!</span>")
 					return
-				var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 				if(stomach.crystal_charge < APC_POWER_GAIN)
 					to_chat(H, "<span class='warning'>Your charge is too low!</span>")
 					return

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -152,7 +152,7 @@
 		var/datum/species/ethereal/E = H.dna.species
 		var/charge_limit = ETHEREAL_CHARGE_DANGEROUS - CELL_POWER_GAIN
 		var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
-		if((E.drain_time > world.time) && !stomach)
+		if((E.drain_time > world.time) || !stomach)
 			return
 		if(charge < CELL_POWER_DRAIN)
 			to_chat(H, "<span class='warning'>[src] doesn't have enough power!</span>")

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -152,7 +152,7 @@
 		var/datum/species/ethereal/E = H.dna.species
 		var/charge_limit = ETHEREAL_CHARGE_DANGEROUS - CELL_POWER_GAIN
 		var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
-		if((E.drain_time > world.time) && stomach)
+		if((E.drain_time > world.time) && !stomach)
 			return
 		if(charge < CELL_POWER_DRAIN)
 			to_chat(H, "<span class='warning'>[src] doesn't have enough power!</span>")

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -151,12 +151,12 @@
 		var/mob/living/carbon/human/H = user
 		var/datum/species/ethereal/E = H.dna.species
 		var/charge_limit = ETHEREAL_CHARGE_DANGEROUS - CELL_POWER_GAIN
-		if(E.drain_time > world.time)
+		var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+		if((E.drain_time > world.time) && stomach)
 			return
 		if(charge < CELL_POWER_DRAIN)
 			to_chat(H, "<span class='warning'>[src] doesn't have enough power!</span>")
 			return
-		var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 		if(stomach.crystal_charge > charge_limit)
 			to_chat(H, "<span class='warning'>Your charge is full!</span>")
 			return

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -715,12 +715,12 @@
 			var/datum/species/ethereal/eth_species = H.dna?.species
 			if(istype(eth_species))
 				var/datum/species/ethereal/E = H.dna.species
-				if(E.drain_time > world.time)
+				var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+				if((E.drain_time > world.time) || !stomach)
 					return
 				to_chat(H, "<span class='notice'>You start channeling some power through the [fitting] into your body.</span>")
 				E.drain_time = world.time + LIGHT_DRAIN_TIME
 				if(do_after(user, LIGHT_DRAIN_TIME, target = src))
-					var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 					if(istype(stomach))
 						to_chat(H, "<span class='notice'>You receive some charge from the [fitting].</span>")
 						stomach.adjust_charge(LIGHT_POWER_GAIN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Got messed up by the combat mode PR.

Fixes: #56670

Right click on combat mode to drain an APC, right click off combat mode to channel power into it.

## Why It's Good For The Game

Returns old functionality. 

## Changelog
:cl:
fix: Ethereals can once again channel power into APCs. Right click an APC with an open hand off of combat mode to do so (and to drain, do it on combat mode).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
