### PR TITLE
Purges two redundant proc calls with human icon updates.

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -403,7 +403,7 @@
 	facial_hairstyle = GLOB.facial_hairstyles_list[deconstruct_block(getblock(structure, DNA_FACIAL_HAIRSTYLE_BLOCK), GLOB.facial_hairstyles_list.len)]
 	hairstyle = GLOB.hairstyles_list[deconstruct_block(getblock(structure, DNA_HAIRSTYLE_BLOCK), GLOB.hairstyles_list.len)]
 	if(icon_update)
-		update_body()
+		dna.species.handle_body(src) // We want 'update_body_parts()' to be called only if mutcolor_update is TRUE, so no 'update_body()' here.
 		update_hair()
 		if(mutcolor_update)
 			update_body_parts()

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -58,7 +58,6 @@ There are several things that need to be remembered:
 
 
 /mob/living/carbon/human/update_body()
-	remove_overlay(BODY_LAYER)
 	dna.species.handle_body(src)
 	..()
 


### PR DESCRIPTION
## About The Pull Request
Title.  `dna.species.handle_body()` calls `remove_overlay(BODY_LAYER)` already. I added a comment about the other one.

## Why It's Good For The Game
Should be self-evident. Mob icons related code is a slew of problems.

## Changelog
N/A.