### PR TITLE
Ice now doesn't melt right away when spilled in an empty container.

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -156,3 +156,6 @@
 /// For the pH meter flashing method
 #define ENABLE_FLASHING -1
 #define DISABLE_FLASHING 14
+
+/// Default reagent temperature when dispensed.
+#define REAGENT_DEFAULT_TEMP 300

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -156,7 +156,7 @@
  * * added_ph - override to force a pH when added
  * * override_base_ph - ingore the present pH of the reagent, and instead use the default (i.e. if buffers/reactions alter it)
  */
-/datum/reagents/proc/add_reagent(reagent, amount, list/data=null, reagtemp = 300, added_purity = null, added_ph, no_react = 0, override_base_ph = FALSE)
+/datum/reagents/proc/add_reagent(reagent, amount, list/data=null, reagtemp, added_purity = null, added_ph, no_react = 0, override_base_ph = FALSE)
 	if(!isnum(amount) || !amount)
 		return FALSE
 
@@ -174,6 +174,9 @@
 
 	if(!added_ph)
 		added_ph = D.ph
+
+	if(isnull(reagtemp))
+		reagtemp = D.default_temp
 
 	update_total()
 	var/cached_total = total_volume

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -92,6 +92,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/burning_temperature = null
 	///How much is consumed when it is burnt per second
 	var/burning_volume = 0.5
+	/// The temperature of the dispensed reagent used in place of the 'reagtemp' arg of [/datum/reagents/add_reagent] if the latter is null.
+	var/default_temp = REAGENT_DEFAULT_TEMP
 	///Assoc list with key type of addiction this reagent feeds, and value amount of addiction points added per unit of reagent metabolzied (which means * REAGENTS_METABOLISM every life())
 	var/list/addiction_types = null
 

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -670,6 +670,7 @@
 	glass_icon_state = "iceglass"
 	glass_name = "glass of ice"
 	glass_desc = "Generally, you're supposed to put something else in there too..."
+	default_temp = T0C - 5 //So it doesn't melt right away.
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/consumable/ice/on_mob_life(mob/living/carbon/M, delta_time, times_fired)


### PR DESCRIPTION
## About The Pull Request
Title. The `default_temp` could be used to make some drink reagents hotter/colder by default as well, but garnishing things isn't my scope here.

## Why It's Good For The Game
This will fix #57110.

## Changelog
:cl:
fix: The ice reagent doesn't start melting right away now, unless you spill it in a container full of hotter liquids (duh!).
/:cl: