### PR TITLE
twohandend-required items shouldn't fall down when equipped on another slot.

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -103,8 +103,8 @@
 /datum/component/two_handed/proc/on_drop(datum/source, mob/user)
 	SIGNAL_HANDLER
 
-	if(require_twohands)
-		unwield(user, show_message=TRUE)
+	if(require_twohands) //Don't let the item fall to the ground and cause bugs if it's actually being equipped on another slot.
+		unwield(user, FALSE, FALSE)
 	if(wielded)
 		unwield(user)
 	if(source == offhand_item && !QDELETED(source))
@@ -188,8 +188,9 @@
  * vars:
  * * user The mob/living/carbon that is unwielding the item
  * * show_message (option) show a message to chat on unwield
+ * * can_drop (option) whether 'dropItemToGround' can be called or not.
  */
-/datum/component/two_handed/proc/unwield(mob/living/carbon/user, show_message=TRUE)
+/datum/component/two_handed/proc/unwield(mob/living/carbon/user, show_message=TRUE, can_drop = TRUE)
 	if(!wielded)
 		return
 
@@ -224,7 +225,7 @@
 			user.update_inv_hands()
 
 		// if the item requires two handed drop the item on unwield
-		if(require_twohands)
+		if(require_twohands && can_drop)
 			user.dropItemToGround(parent, force=TRUE)
 
 		// Show message if requested


### PR DESCRIPTION
## About The Pull Request
`component/twohanded/on_drop` as it is right now causes items that require two hands to be held to fall off if worn on non-hand inventory slots, as shown in #57411. This PR aims to fix that nuisance by adding another argument to the proc.

## Why It's Good For The Game
This will fix #57411.

## Changelog
:cl:
fix: twohandend-required items shouldn't fall down when equipped on another slot.
/:cl: