### PR TITLE
Hieroclub teleportation now calls do_teleport() as it should be .

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1297,8 +1297,7 @@
 
 /obj/item/hierophant_club/proc/teleport_mob(turf/source, mob/M, turf/target, mob/user)
 	var/turf/turf_to_teleport_to = get_step(target, get_dir(source, M)) //get position relative to caster
-	var/area/destination_area = turf_to_teleport_to.loc
-	if(!turf_to_teleport_to || turf_to_teleport_to.is_blocked_turf(TRUE) || destination_area.area_flags & NOTELEPORT)
+	if(!turf_to_teleport_to || turf_to_teleport_to.is_blocked_turf(TRUE))
 		return
 	animate(M, alpha = 0, time = 2, easing = EASE_OUT) //fade out
 	sleep(1)
@@ -1308,7 +1307,7 @@
 	sleep(2)
 	if(!M)
 		return
-	M.forceMove(turf_to_teleport_to)
+	var/success = do_teleport(M, turf_to_teleport_to, no_effects = TRUE, channel = TELEPORT_CHANNEL_MAGIC)
 	sleep(1)
 	if(!M)
 		return
@@ -1317,7 +1316,7 @@
 	if(!M)
 		return
 	M.visible_message("<span class='hierophant_warning'>[M] fades in!</span>")
-	if(user != M)
+	if(user != M && success)
 		log_combat(user, M, "teleported", null, "from [AREACOORD(source)]")
 
 /obj/item/hierophant_club/pickup(mob/living/user)


### PR DESCRIPTION
## About The Pull Request
It should now respect Megafauna no-teleport trait.

## Why It's Good For The Game
This will fix #53102

## Changelog
:cl:
fix: Hieroclub teleportation now respects unteleportable mobs such as anchored AIs and megafauna.
/:cl:
