### PR TITLE
Non-admin observers can now use emoji that start with d or p at the beginning of a message without admin command warnings.

### DIFF
--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -15,7 +15,7 @@
 		return
 	var/list/message_mods = list()
 	message = get_message_mods(message, message_mods)
-	if(client && (message_mods[RADIO_EXTENSION] == MODE_ADMIN || message_mods[RADIO_EXTENSION] == MODE_DEADMIN))
+	if(client?.holder && (message_mods[RADIO_EXTENSION] == MODE_ADMIN || message_mods[RADIO_EXTENSION] == MODE_DEADMIN))
 		message = trim_left(copytext_char(message, length(message_mods[RADIO_KEY]) + 2))
 		if(message_mods[RADIO_EXTENSION] == MODE_ADMIN)
 			client.cmd_admin_say(message)


### PR DESCRIPTION
## About The Pull Request
Added a client.holder check to the line about radio extensions for admin chat and deadchat commands. It means common observers can finally spam dchat with plushie emoji. Admin observers still have to deadmin before using emojis safely, until someone takes the time to refactor saycode mods so these admin commands only acept the comma prefix (luckily, `observer/get_message_mods()` doesn't trim the message).

## Why It's Good For The Game
This will fix #45801.

## Changelog
:cl:
fix: Non-admin observers can now use emoji that start with d or p at the beginning of a deadchat message without admin command warnings.
/:cl:

