### PR TITLE
ID trims no longer apply to cards when visualsOnly is TRUE on equip()

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -186,7 +186,7 @@
 		H.equip_to_slot_or_del(new glasses(H),ITEM_SLOT_EYES, TRUE)
 	if(id)
 		H.equip_to_slot_or_del(new id(H),ITEM_SLOT_ID, TRUE)
-	if(id_trim && H.wear_id)
+	if(!visualsOnly && id_trim && H.wear_id)
 		var/obj/item/card/id/id_card = H.wear_id
 		if(istype(id_card) && !SSid_access.apply_trim_to_card(id_card, id_trim))
 			WARNING("Unable to apply trim [id_trim] to [id_card] in outfit [name].")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

```
[2021-03-04 18:51:29.987] runtime error: Cannot read null.wildcard_access
 - proc name: apply trim to card (/datum/controller/subsystem/id_access/proc/apply_trim_to_card)
 -   source file: id_access.dm,364
 -   usr: Jhyrachy (/mob/dead/new_player)
 -   src: IDs and Access (/datum/controller/subsystem/id_access)
 -   usr.loc: the plating (8,174,1) (/turf/open/floor/plating)
 -   call stack:
 - IDs and Access (/datum/controller/subsystem/id_access): apply trim to card(the identification card (/obj/item/card/id/advanced), /datum/id_trim/job/station_eng... (/datum/id_trim/job/station_engineer), 1)
 - Station Engineer (/datum/outfit/job/engineer): equip(Halo Z (/mob/living/carbon/human/dummy), 1)
 - Halo Z (/mob/living/carbon/human/dummy): equipOutfit(/datum/outfit/job/engineer (/datum/outfit/job/engineer), 1)
 - /datum/job/station_engineer (/datum/job/station_engineer): equip(Halo Z (/mob/living/carbon/human/dummy), 1, 1, 0, null, Jhyrachy (/client), 0)
 - /datum/preferences (/datum/preferences): update preview icon()
 - /datum/preferences (/datum/preferences): ShowChoices(Jhyrachy (/mob/dead/new_player))
 - Jhyrachy (/mob/dead/new_player): Topic("src=\[mob_27];show_preferences...", /list (/list))
 - Jhyrachy (/client): Topic("src=\[mob_27];show_preferences...", /list (/list), Jhyrachy (/mob/dead/new_player))
 - Jhyrachy (/client): Topic("src=\[mob_27];show_preferences...", /list (/list), Jhyrachy (/mob/dead/new_player))
```

This was during server Init and was likely the player opening up their character preferences before SSid_access had been Init'd, as the mob was a /dummy

`// If visualsOnly is true, you can omit any work that doesn't visually appear on the character sprite`

visualsOnly was TRUE for this proc call. I should be able to fix this without much issue by not applying the id_trim - Which has no impact on the ID card's on-sprite visuals - when visualsOnly is true.

No CL as no player-facing or functionality changes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtime feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
