### PR TITLE
Deletes the red corner siding haunting Kilo's security office

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -68995,9 +68995,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/siding/red/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/security/office)
 "lst" = (


### PR DESCRIPTION
## About The Pull Request

Kilostation has a SINGLE red dot in the middle of the security office. And of course, my disgust for it is endless. It was hidden right underneath a generic event spawner. Sneaky.

Before (bad, dumb)
![image](https://user-images.githubusercontent.com/68669754/110035600-a5d8c280-7d1a-11eb-8dc6-6c30e6d0f8a7.png)

After (cool, tidy)
![image](https://user-images.githubusercontent.com/68669754/110035699-be48dd00-7d1a-11eb-95aa-27779c4a5b99.png)


## Changelog
:cl:
fix: Kilostation's security office is no longer haunted by a red siding in one of the security office's tiles.
/:cl: