### PR TITLE
Fixes dumb code breaking toggle of playtime exempt status.

### DIFF
--- a/code/modules/jobs/job_report.dm
+++ b/code/modules/jobs/job_report.dm
@@ -75,13 +75,11 @@
 				to_chat(usr, "<span class='danger'>ERROR: Insufficient admin rights.</span>", confidential = TRUE)
 				return TRUE
 
-			var/client/owner_client = (locate(owner) in GLOB.clients)
-
-			if(!owner_client)
+			if(QDELETED(owner))
 				to_chat(usr, "<span class='danger'>ERROR: Client not found.</span>", confidential = TRUE)
 				return TRUE
 
-			viewer_admin_datum.toggle_exempt_status(owner_client)
+			viewer_admin_datum.toggle_exempt_status(owner)
 			return TRUE
 
 #undef JOB_REPORT_MENU_FAIL_REASON_TRACKING_DISABLED

--- a/code/modules/jobs/job_report.dm
+++ b/code/modules/jobs/job_report.dm
@@ -75,7 +75,7 @@
 				to_chat(usr, "<span class='danger'>ERROR: Insufficient admin rights.</span>", confidential = TRUE)
 				return TRUE
 
-			var/client/owner_client = locate(owner) in GLOB.clients
+			var/client/owner_client = (locate(owner) in GLOB.clients)
 
 			if(!owner_client)
 				to_chat(usr, "<span class='danger'>ERROR: Client not found.</span>", confidential = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

`locate(owner) in GLOB.clients` returns GLOB.clients[1] - Likely because `owner` is a client so it just returns the first `owner.type` it finds, which is the first client.

We don't need to locate() anything in GLOB.clients, as we already know the client that owns the playtime info the admin is looking at. `owner` **is** the client we're intereted in.

So we just use owner.

Now works as expected on local.

![image](https://user-images.githubusercontent.com/24975989/110068869-84092b00-7d6e-11eb-95f4-91677c473fa9.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fix bug that prevented admins toggling playtime exempt status on accounts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
