### PR TITLE
Partial revert of datum poll creation, fixes duplicated irv votes

### DIFF
--- a/code/modules/mob/dead/new_player/poll.dm
+++ b/code/modules/mob/dead/new_player/poll.dm
@@ -239,15 +239,13 @@
 	//if they've already voted we use the order they voted in plus a shuffle of any options they haven't voted for, if any
 	if(length(voted_for))
 		for(var/vote_id in voted_for)
-			for(var/o in poll.options)
+			var/list/option_copy = poll.options.Copy()
+			for(var/o in option_copy)
 				var/datum/poll_option/option = o
 				if(option.option_id == vote_id)
 					prepared_options += option
-		var/list/shuffle_options = poll.options - prepared_options
-		if(length(shuffle_options))
-			shuffle_options = shuffle(shuffle_options)
-			for(var/shuffled in shuffle_options)
-				prepared_options += shuffled
+					option_copy -= option
+		prepared_options += option_copy
 	//otherwise just shuffle the options
 	else
 		prepared_options = shuffle(poll.options)
@@ -547,9 +545,12 @@
 		"ip" = "INET_ATON(?)",
 	)
 
-	var/sql_votes = list()
+	var/list/sql_votes = list()
+	var/list/option_copy = poll.options.Copy()
 	for(var/o in votelist)
-		var/datum/poll_option/option = locate(o) in poll.options
+		var/datum/poll_option/option = locate(o) in option_copy
+		if (!option)
+			to_chat(src, "<span class='warning'>invalid votes were trimmed from your ballot, please revote .</span>")
 		sql_votes += list(list(
 			"pollid" = sql_poll_id,
 			"optionid" = option.option_id,

--- a/code/modules/mob/dead/new_player/poll.dm
+++ b/code/modules/mob/dead/new_player/poll.dm
@@ -238,8 +238,8 @@
 	var/list/prepared_options = list()
 	//if they've already voted we use the order they voted in plus a shuffle of any options they haven't voted for, if any
 	if(length(voted_for))
+		var/list/option_copy = poll.options.Copy()
 		for(var/vote_id in voted_for)
-			var/list/option_copy = poll.options.Copy()
 			for(var/o in option_copy)
 				var/datum/poll_option/option = o
 				if(option.option_id == vote_id)

--- a/code/modules/mob/dead/new_player/poll.dm
+++ b/code/modules/mob/dead/new_player/poll.dm
@@ -245,7 +245,7 @@
 				if(option.option_id == vote_id)
 					prepared_options += option
 					option_copy -= option
-		prepared_options += option_copy
+		prepared_options += shuffle(option_copy)
 	//otherwise just shuffle the options
 	else
 		prepared_options = shuffle(poll.options)


### PR DESCRIPTION
Partially reverts #50843 by @Jordie0608 - Datum based poll creation and vote handling update.

Reverts the part that removed a check for duplicated votes in IRV when displaying them to the player

Also fixes the code that would accept duplicated votes passed from the client. (not from jordie's poll refactor pr.)

The race condition still exists, thats harder to fix, counting code handles this correctly, and now at least the duplicated votes won't be re-displayed or multiplied exponentially.