### PR TITLE
Halves ssair run rate and kills lag comp

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -2,8 +2,8 @@ SUBSYSTEM_DEF(air)
 	name = "Atmospherics"
 	init_order = INIT_ORDER_AIR
 	priority = FIRE_PRIORITY_AIR
-	wait = 0.5 SECONDS
-	flags = SS_BACKGROUND
+	wait = 1 SECONDS
+	flags = SS_BACKGROUND | SS_POST_FIRE_TIMING
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
 	var/cached_cost = 0


### PR DESCRIPTION
## Changelog
:cl:
balance: Halved atmos run rate. Atmos no longer tries to run sooner the following tick to make up for it taking longer then a tick to run the previous tick.
/:cl:
@LemonInTheDark - made you look.