### PR TITLE
Makes the 'snowman head' follow the naming norm

### DIFF
--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -117,7 +117,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
 /obj/item/clothing/head/snowman
-	name = "Snowman Head"
+	name = "snowman head"
 	desc = "A ball of white styrofoam. So festive."
 	icon_state = "snowman_h"
 	inhand_icon_state = "snowman_h"


### PR DESCRIPTION
## About The Pull Request

All other head slot items (apart from improper ones) maintain themselves lowercase, the snowman head shouldn't be an exception.

## Changelog
:cl:
spellcheck: The snowman head's name is now full lowercase.
/:cl: