### PR TITLE
Removes delta_time from the atmos system.

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -224,9 +224,9 @@
 /// (kPa) What pressure pumps and powered equipment max out at.
 #define MAX_OUTPUT_PRESSURE 4500
 /// (L/s) Maximum speed powered equipment can work at.
-#define MAX_TRANSFER_RATE 400
+#define MAX_TRANSFER_RATE 200
 /// How many percent of the contents that an overclocked volume pumps leak into the air
-#define VOLUME_PUMP_LEAK_AMOUNT 0.2
+#define VOLUME_PUMP_LEAK_AMOUNT 0.1
 //used for device_type vars
 #define UNARY 1
 #define BINARY 2

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -82,7 +82,6 @@ SUBSYSTEM_DEF(air)
 
 /datum/controller/subsystem/air/fire(resumed = FALSE)
 	var/timer = TICK_USAGE_REAL
-	var/delta_time = wait * 0.1
 
 	// Every time we fire, we want to make sure pipenets are rebuilt. The game state could have changed between each fire() proc call
 	// and anything missing a pipenet can lead to unintended behaviour at worse and various runtimes at best.
@@ -103,7 +102,7 @@ SUBSYSTEM_DEF(air)
 		timer = TICK_USAGE_REAL
 		if(!resumed)
 			cached_cost = 0
-		process_pipenets(delta_time, resumed)
+		process_pipenets(resumed)
 		cached_cost += TICK_USAGE_REAL - timer
 		if(state != SS_RUNNING)
 			return
@@ -115,7 +114,7 @@ SUBSYSTEM_DEF(air)
 		timer = TICK_USAGE_REAL
 		if(!resumed)
 			cached_cost = 0
-		process_atmos_machinery(delta_time, resumed)
+		process_atmos_machinery(resumed)
 		cached_cost += TICK_USAGE_REAL - timer
 		if(state != SS_RUNNING)
 			return
@@ -139,7 +138,7 @@ SUBSYSTEM_DEF(air)
 		timer = TICK_USAGE_REAL
 		if(!resumed)
 			cached_cost = 0
-		process_hotspots(delta_time, resumed)
+		process_hotspots(resumed)
 		cached_cost += TICK_USAGE_REAL - timer
 		if(state != SS_RUNNING)
 			return
@@ -198,7 +197,7 @@ SUBSYSTEM_DEF(air)
 	SStgui.update_uis(SSair) //Lightning fast debugging motherfucker
 
 
-/datum/controller/subsystem/air/proc/process_pipenets(delta_time, resumed = FALSE)
+/datum/controller/subsystem/air/proc/process_pipenets(resumed = FALSE)
 	if (!resumed)
 		src.currentrun = networks.Copy()
 	//cache for sanic speed (lists are references anyways)
@@ -207,7 +206,7 @@ SUBSYSTEM_DEF(air)
 		var/datum/thing = currentrun[currentrun.len]
 		currentrun.len--
 		if(thing)
-			thing.process(delta_time)
+			thing.process()
 		else
 			networks.Remove(thing)
 		if(MC_TICK_CHECK)
@@ -231,7 +230,7 @@ SUBSYSTEM_DEF(air)
 		if(MC_TICK_CHECK)
 			return
 
-/datum/controller/subsystem/air/proc/process_atmos_machinery(delta_time, resumed = FALSE)
+/datum/controller/subsystem/air/proc/process_atmos_machinery(resumed = FALSE)
 	if (!resumed)
 		src.currentrun = atmos_machinery.Copy()
 	//cache for sanic speed (lists are references anyways)
@@ -239,7 +238,7 @@ SUBSYSTEM_DEF(air)
 	while(currentrun.len)
 		var/obj/machinery/M = currentrun[currentrun.len]
 		currentrun.len--
-		if(!M || (M.process_atmos(delta_time) == PROCESS_KILL))
+		if(!M || (M.process_atmos() == PROCESS_KILL))
 			atmos_machinery.Remove(M)
 		if(MC_TICK_CHECK)
 			return
@@ -257,7 +256,7 @@ SUBSYSTEM_DEF(air)
 		if(MC_TICK_CHECK)
 			return
 
-/datum/controller/subsystem/air/proc/process_hotspots(delta_time, resumed = FALSE)
+/datum/controller/subsystem/air/proc/process_hotspots(resumed = FALSE)
 	if (!resumed)
 		src.currentrun = hotspots.Copy()
 	//cache for sanic speed (lists are references anyways)
@@ -266,7 +265,7 @@ SUBSYSTEM_DEF(air)
 		var/obj/effect/hotspot/H = currentrun[currentrun.len]
 		currentrun.len--
 		if (H)
-			H.process(delta_time)
+			H.process()
 		else
 			hotspots -= H
 		if(MC_TICK_CHECK)

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -51,7 +51,7 @@
 /obj/machinery/atmospherics/components/binary/volume_pump/update_icon_nopipes()
 	icon_state = on && is_operational ? "volpump_on-[set_overlay_offset(piping_layer)]" : "volpump_off-[set_overlay_offset(piping_layer)]"
 
-/obj/machinery/atmospherics/components/binary/volume_pump/process_atmos(delta_time)
+/obj/machinery/atmospherics/components/binary/volume_pump/process_atmos()
 	if(!on || !is_operational)
 		return
 
@@ -70,14 +70,14 @@
 		return
 
 
-	var/transfer_ratio = (transfer_rate * delta_time) / air1.volume
+	var/transfer_ratio = transfer_rate / air1.volume
 
 	var/datum/gas_mixture/removed = air1.remove_ratio(transfer_ratio)
 
 	if(overclocked)//Some of the gas from the mixture leaks to the environment when overclocked
 		var/turf/open/T = loc
 		if(istype(T))
-			var/datum/gas_mixture/leaked = removed.remove_ratio(DT_PROB_RATE(VOLUME_PUMP_LEAK_AMOUNT, delta_time))
+			var/datum/gas_mixture/leaked = removed.remove_ratio(VOLUME_PUMP_LEAK_AMOUNT)
 			T.assume_air(leaked)
 			T.air_update_turf(FALSE, FALSE)
 

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
@@ -19,7 +19,7 @@
 	var/base_icon = "crystallizer"
 	///Internal Gas mix used for processing the gases that have been put in
 	var/datum/gas_mixture/internal
-	///Var that controls how much gas gets injected in moles/S
+	///Var that controls how much gas gets injected in moles per tick
 	var/gas_input = 0
 	///Saves the progress during the processing of the items
 	var/progress_bar = 0
@@ -115,10 +115,10 @@
 	return FALSE
 
 ///Injects the gases from the input inside the internal gasmix, the amount is dependant on the gas_input var
-/obj/machinery/atmospherics/components/binary/crystallizer/proc/inject_gases(delta_time)
+/obj/machinery/atmospherics/components/binary/crystallizer/proc/inject_gases()
 	var/datum/gas_mixture/contents = airs[2]
 	for(var/gas_type in selected_recipe.requirements)
-		internal.merge(contents.remove_specific(gas_type, contents.gases[gas_type][MOLES] * (gas_input  * delta_time)))
+		internal.merge(contents.remove_specific(gas_type, contents.gases[gas_type][MOLES] * gas_input))
 
 ///Checks if the gases required are all inside
 /obj/machinery/atmospherics/components/binary/crystallizer/proc/internal_check()
@@ -171,14 +171,14 @@
 	airs[2].merge(remove)
 	internal.garbage_collect()
 
-/obj/machinery/atmospherics/components/binary/crystallizer/process_atmos(delta_time)
+/obj/machinery/atmospherics/components/binary/crystallizer/process_atmos()
 	if(!on || !is_operational || selected_recipe == null)
 		return
 
 	if(!check_gas_requirements())
 		return
 
-	inject_gases(delta_time)
+	inject_gases()
 
 	if(!internal.total_moles())
 		update_parents()
@@ -328,7 +328,7 @@
 			. = TRUE
 		if("gas_input")
 			var/_gas_input = params["gas_input"]
-			gas_input = clamp(_gas_input, 0, 500)
+			gas_input = clamp(_gas_input, 0, 250)
 	update_icon()
 
 #undef MIN_PROGRESS_AMOUNT

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -52,7 +52,7 @@
 	var/on_state = on && nodes[1] && nodes[2] && nodes[3] && is_operational
 	icon_state = "filter_[on_state ? "on" : "off"]-[set_overlay_offset(piping_layer)][flipped ? "_f" : ""]"
 
-/obj/machinery/atmospherics/components/trinary/filter/process_atmos(delta_time)
+/obj/machinery/atmospherics/components/trinary/filter/process_atmos()
 	..()
 	if(!on || !(nodes[1] && nodes[2] && nodes[3]) || !is_operational)
 		return
@@ -71,7 +71,7 @@
 		//No need to transfer if target is already full!
 		return
 
-	var/transfer_ratio = (transfer_rate * delta_time) / air1.volume
+	var/transfer_ratio = transfer_rate / air1.volume
 
 	//Actually transfer the gas
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -270,7 +270,7 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 			consume_gas = TRUE
 	return TRUE
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/process_atmos(delta_time)
+/obj/machinery/atmospherics/components/unary/cryo_cell/process_atmos()
 	..()
 
 	if(!on)
@@ -298,8 +298,8 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 
 			var/heat = ((1 - cold_protection) * 0.1 + conduction_coefficient) * temperature_delta * (air_heat_capacity * heat_capacity / (air_heat_capacity + heat_capacity))
 
-			air1.temperature = clamp(air1.temperature - heat * delta_time / air_heat_capacity, TCMB, MAX_TEMPERATURE)
-			mob_occupant.adjust_bodytemperature(heat * delta_time / heat_capacity, TCMB)
+			air1.temperature = clamp(air1.temperature - heat / air_heat_capacity, TCMB, MAX_TEMPERATURE)
+			mob_occupant.adjust_bodytemperature(heat / heat_capacity, TCMB)
 
 			//lets have the core temp match the body temp in humans
 			if(ishuman(mob_occupant))
@@ -307,10 +307,10 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 				humi.adjust_coretemperature(humi.bodytemperature - humi.coretemperature)
 
 		if(consume_gas) // Transferring reagent costs us extra gas
-			air1.gases[/datum/gas/oxygen][MOLES] -= max(0, delta_time / efficiency + 1 / efficiency) // Magically consume gas? Why not, we run on cryo magic.
+			air1.gases[/datum/gas/oxygen][MOLES] -= max(0, 2 / efficiency + 1 / efficiency) // Magically consume gas? Why not, we run on cryo magic.
 			consume_gas = FALSE
 		if(!consume_gas)
-			air1.gases[/datum/gas/oxygen][MOLES] -= max(0, delta_time / efficiency)
+			air1.gases[/datum/gas/oxygen][MOLES] -= max(0, 2 / efficiency)
 		air1.garbage_collect()
 
 		if(air1.temperature > 2000)

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -13,7 +13,7 @@
 
 	var/injecting = 0
 
-	var/volume_rate = 100
+	var/volume_rate = 50
 
 	var/frequency = 0
 	var/id = null
@@ -53,7 +53,7 @@
 	else
 		icon_state = "inje_on"
 
-/obj/machinery/atmospherics/components/unary/outlet_injector/process_atmos(delta_time)
+/obj/machinery/atmospherics/components/unary/outlet_injector/process_atmos()
 	..()
 
 	injecting = 0
@@ -64,7 +64,7 @@
 	var/datum/gas_mixture/air_contents = airs[1]
 
 	if(air_contents.temperature > 0)
-		var/transfer_moles = (air_contents.return_pressure() * volume_rate * delta_time) / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
+		var/transfer_moles = (air_contents.return_pressure() * volume_rate) / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
 
 		var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -18,7 +18,7 @@
 	var/scrubbing = SCRUBBING //0 = siphoning, 1 = scrubbing
 
 	var/filter_types = list(/datum/gas/carbon_dioxide)
-	var/volume_rate = 400
+	var/volume_rate = 200
 	var/widenet = 0 //is this scrubber acting on the 3x3 area around it.
 	var/list/turf/adjacent_turfs = list()
 
@@ -136,20 +136,20 @@
 	check_turfs()
 	..()
 
-/obj/machinery/atmospherics/components/unary/vent_scrubber/process_atmos(delta_time)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/process_atmos()
 	..()
 	if(welded || !is_operational)
 		return FALSE
 	if(!nodes[1] || !on)
 		on = FALSE
 		return FALSE
-	scrub(loc, delta_time)
+	scrub(loc)
 	if(widenet)
 		for(var/turf/tile in adjacent_turfs)
-			scrub(tile, delta_time)
+			scrub(tile)
 	return TRUE
 
-/obj/machinery/atmospherics/components/unary/vent_scrubber/proc/scrub(turf/tile, delta_time = 0.5)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/proc/scrub(turf/tile)
 	if(!istype(tile))
 		return FALSE
 	var/datum/gas_mixture/environment = tile.return_air()
@@ -161,7 +161,7 @@
 
 	if(scrubbing & SCRUBBING)
 		if(length(env_gases & filter_types))
-			var/transfer_moles = min(1, volume_rate * delta_time / environment.volume)*environment.total_moles()
+			var/transfer_moles = min(1, volume_rate / environment.volume) * environment.total_moles()
 
 			//Take a gas sample
 			var/datum/gas_mixture/removed = tile.remove_air(transfer_moles)
@@ -191,7 +191,7 @@
 
 	else //Just siphoning all air
 
-		var/transfer_moles = environment.total_moles() * (volume_rate * delta_time / environment.volume)
+		var/transfer_moles = environment.total_moles() * (volume_rate / environment.volume)
 
 		var/datum/gas_mixture/removed = tile.remove_air(transfer_moles)
 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -474,7 +474,7 @@
 		else if(valve_open && holding)
 			investigate_log("[key_name(user)] started a transfer into [holding].", INVESTIGATE_ATMOS)
 
-/obj/machinery/portable_atmospherics/canister/process_atmos(delta_time)
+/obj/machinery/portable_atmospherics/canister/process_atmos()
 	. = ..()
 	if(machine_stat & BROKEN)
 		return PROCESS_KILL
@@ -495,7 +495,7 @@
 
 	///function used to check the limit of the canisters and also set the amount of damage that the canister can receive, if the heat and pressure are way higher than the limit the more damage will be done
 	if(our_temperature > heat_limit || our_pressure > pressure_limit)
-		take_damage(clamp((our_temperature/heat_limit) * (our_pressure/pressure_limit) * delta_time * 2, 5, 50), BURN, 0)
+		take_damage(clamp((our_temperature/heat_limit) * (our_pressure/pressure_limit), 5, 50), BURN, 0)
 	update_appearance()
 
 /obj/machinery/portable_atmospherics/canister/ui_state(mob/user)

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -44,13 +44,13 @@
 	if(connected_port)
 		. += "siphon-connector"
 
-/obj/machinery/portable_atmospherics/pump/process_atmos(delta_time)
+/obj/machinery/portable_atmospherics/pump/process_atmos()
 	. = ..()
 	var/pressure = air_contents.return_pressure()
 	var/temperature = air_contents.return_temperature()
 	///function used to check the limit of the pumps and also set the amount of damage that the pump can receive, if the heat and pressure are way higher than the limit the more damage will be done
 	if(temperature > heat_limit || pressure > pressure_limit)
-		take_damage(clamp((temperature/heat_limit) * (pressure/pressure_limit) * delta_time * 0.5, 5, 50), BURN, 0)
+		take_damage(clamp((temperature/heat_limit) * (pressure/pressure_limit), 5, 50), BURN, 0)
 		return
 
 	if(!on)

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -12,7 +12,7 @@
 	///Is the machine on?
 	var/on = FALSE
 	///the rate the machine will scrub air
-	var/volume_rate = 500
+	var/volume_rate = 1000
 	///Multiplier with ONE_ATMOSPHERE, if the enviroment pressure is higher than that, the scrubber won't work
 	var/overpressure_m = 80
 	///Should the machine use overlay in update_overlays() when open/close?
@@ -54,7 +54,7 @@
 	if(connected_port)
 		. += "scrubber-connector"
 
-/obj/machinery/portable_atmospherics/scrubber/process_atmos(delta_time)
+/obj/machinery/portable_atmospherics/scrubber/process_atmos()
 	. = ..()
 	var/pressure = air_contents.return_pressure()
 	var/temperature = air_contents.return_temperature()
@@ -67,22 +67,21 @@
 		return
 
 	if(holding)
-		scrub(holding.air_contents, delta_time)
+		scrub(holding.air_contents)
 	else
 		var/turf/T = get_turf(src)
-		scrub(T.return_air(), delta_time)
+		scrub(T.return_air())
 
 /**
  * Called in process_atmos(), handles the scrubbing of the given gas_mixture
  * Arguments:
  * * mixture: the gas mixture to be scrubbed
- * * delta_time: multiplier for transfer_moles that depends on the time between ticks
  */
-/obj/machinery/portable_atmospherics/scrubber/proc/scrub(datum/gas_mixture/mixture, delta_time = 2)
+/obj/machinery/portable_atmospherics/scrubber/proc/scrub(datum/gas_mixture/mixture)
 	if(air_contents.return_pressure() >= overpressure_m * ONE_ATMOSPHERE)
 		return
 
-	var/transfer_moles = min(1, volume_rate * delta_time / mixture.volume) * mixture.total_moles()
+	var/transfer_moles = min(1, volume_rate / mixture.volume) * mixture.total_moles()
 
 	var/datum/gas_mixture/filtering = mixture.remove(transfer_moles) // Remove part of the mixture to filter.
 	var/datum/gas_mixture/filtered = new
@@ -188,7 +187,7 @@
 	icon_state = "scrubber:[on]"
 	return ..()
 
-/obj/machinery/portable_atmospherics/scrubber/huge/process_atmos(delta_time)
+/obj/machinery/portable_atmospherics/scrubber/huge/process_atmos()
 	if((!anchored && !movable) || !is_operational)
 		on = FALSE
 		update_appearance()
@@ -200,7 +199,7 @@
 	if(!holding)
 		var/turf/T = get_turf(src)
 		for(var/turf/AT in T.GetAtmosAdjacentTurfs(alldir = TRUE))
-			scrub(AT.return_air(), delta_time)
+			scrub(AT.return_air())
 
 /obj/machinery/portable_atmospherics/scrubber/huge/attackby(obj/item/W, mob/user)
 	if(default_unfasten_wrench(user, W))

--- a/tgui/packages/tgui/interfaces/Crystallizer.js
+++ b/tgui/packages/tgui/interfaces/Crystallizer.js
@@ -47,7 +47,7 @@ export const Crystallizer = (props, context) => {
                 width="63px"
                 unit="moles/s"
                 minValue={0}
-                maxValue={500}
+                maxValue={250}
                 onDrag={(e, value) => act('gas_input', {
                   gas_input: value,
                 })} />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes delta_time from SSair. I've also done some rectification, when the initial conversion happen I think there was some confusion around what the value of delta_time would be. This ended up quartering the rate at which portable scrubbers work at, for instance. 

There is some annoying stuff inherent to this pr mind, mostly around the descriptions of say, volume pump rates. The player facing stuff implies the rate is done based on time. 

There isn't a clean way of solving with this, I consider it a worthwhile loss.

## Why It's Good For The Game
delta_time is about maintaining behavior when changing the wait of subsystems
SSair's wait is dynamic by design, we hardly ever hit below it. What is important then, is maintaining behavior
across each process.

The key point here is making sure excited groups and turfs share the same amoumt of gas each process, no matter
how high or low wait is. This is why subprocesses are a thing in the first place, to maintain this consistency.
delta_time fucks with this, and will end up changing behavior if wait is ever changed.

## Changelog
:cl:
balance: Portable scrubbers are 4x stronger now. This was a bug, but I've got gbp to burn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
