### PR TITLE
Refactors pen and sleepypen attack code.

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -128,21 +128,15 @@
 		to_chat(user, "<span class='notice'>You rotate the top of the pen to [degrees] degrees.</span>")
 		SEND_SIGNAL(src, COMSIG_PEN_ROTATED, deg, user)
 
-/obj/item/pen/attack(mob/living/M, mob/user,stealth)
-	if(!istype(M))
-		return
-
-	if(!force)
-		if(M.try_inject(user, injection_flags = INJECT_TRY_SHOW_ERROR_MESSAGE))
-			to_chat(user, "<span class='warning'>You stab [M] with the pen.</span>")
-			if(!stealth)
-				to_chat(M, "<span class='danger'>You feel a tiny prick!</span>")
-			. = 1
-
-		log_combat(user, M, "stabbed", src)
-
-	else
-		. = ..()
+/obj/item/pen/attack(mob/living/M, mob/user, params)
+	if(force)	// If the pen has a force value, call the normal attack procs. Used for e-daggers and captain's pen mostly.
+		return ..()
+	if(!M.try_inject(user, injection_flags = INJECT_TRY_SHOW_ERROR_MESSAGE))
+		return FALSE
+	to_chat(user, "<span class='warning'>You stab [M] with the pen.</span>")
+	to_chat(M, "<span class='danger'>You feel a tiny prick!</span>")
+	log_combat(user, M, "stabbed", src)
+	return TRUE
 
 /obj/item/pen/afterattack(obj/O, mob/living/user, proximity)
 	. = ..()
@@ -195,15 +189,15 @@
  * Sleepypens
  */
 
-/obj/item/pen/sleepy/attack(mob/living/M, mob/user)
-	if(!istype(M))
+/obj/item/pen/sleepy/attack(mob/living/M, mob/user, params)
+	. = ..()
+	if(!.) //If we didn't stab them, no injection.
 		return
-
-	if(..())
-		if(reagents.total_volume)
-			if(M.reagents)
-
-				reagents.trans_to(M, reagents.total_volume, transfered_by = user, methods = INJECT)
+	if(!reagents.total_volume) //If we don't have reagents in the pen, no injection.
+		return
+	if(!M.reagents) //If the target doesn't have a reagents container, no injection.
+		return
+	reagents.trans_to(M, reagents.total_volume, transfered_by = user, methods = INJECT)
 
 
 /obj/item/pen/sleepy/Initialize()

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -129,7 +129,7 @@
 		SEND_SIGNAL(src, COMSIG_PEN_ROTATED, deg, user)
 
 /obj/item/pen/attack(mob/living/M, mob/user, params)
-	if(force)	// If the pen has a force value, call the normal attack procs. Used for e-daggers and captain's pen mostly.
+	if(force) // If the pen has a force value, call the normal attack procs. Used for e-daggers and captain's pen mostly.
 		return ..()
 	if(!M.try_inject(user, injection_flags = INJECT_TRY_SHOW_ERROR_MESSAGE))
 		return FALSE
@@ -191,11 +191,11 @@
 
 /obj/item/pen/sleepy/attack(mob/living/M, mob/user, params)
 	. = ..()
-	if(!.) //If we didn't stab them, no injection.
+	if(!.)
 		return
-	if(!reagents.total_volume) //If we don't have reagents in the pen, no injection.
+	if(!reagents.total_volume)
 		return
-	if(!M.reagents) //If the target doesn't have a reagents container, no injection.
+	if(!M.reagents)
 		return
 	reagents.trans_to(M, reagents.total_volume, transfered_by = user, methods = INJECT)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently getting stabbed with a pen doesn't alert the stabbed person. This fixes it by removing an unsused parameter that has been there for six years and was never used.
It became truthy when the combat rework added a third parameter `param` to attackby() and previous procs, which led to a value being passed all the way down to /pen/attack().

Also refactored attack() procs for pens and sleepypens.

Fixes #57410.

- [x] Refactor the whole thing because it's bad and I hate it.

## Why It's Good For The Game

I would like to know when I'm getting injected with 45 units of poison. And better code.

## Changelog
:cl: Kathy Ryals & Timberpoes
fix: Pens now alert the stabbed person again.
refactor: Refactored attack() code pens and sleepypens.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
