### PR TITLE
Gives ERT Medical Officers a box of plushies

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -848,6 +848,27 @@
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
 		new /obj/item/flashlight/flare(src)
 		new /obj/item/radio/off(src)
+
+/obj/item/storage/box/hug/plushes
+	name = "tactical cuddle kit"
+	desc = "A lovely little box filled with soft, cute plushies, perfect for calming down people who have just suffered a traumatic event. Legend has it there's a special part of hell\
+	for Medical Officers who just take the box for themselves."
+
+	/// the plushies that aren't of things trying to kill you
+	var/list/static/approved_by_corporate = list(/obj/item/toy/plush/carpplushie, // well, maybe they can be something that tries to kill you a little bit
+		/obj/item/toy/plush/slimeplushie,
+		/obj/item/toy/plush/lizardplushie,
+		/obj/item/toy/plush/snakeplushie,
+		/obj/item/toy/plush/plasmamanplushie,
+		/obj/item/toy/plush/beeplushie,
+		/obj/item/toy/plush/moth,
+		/obj/item/toy/plush/pkplush)
+
+/obj/item/storage/box/hug/plushes/PopulateContents()
+	for(var/i in 1 to 7)
+		var/plush_path = pick(approved_by_corporate)
+		new plush_path(src)
+
 /obj/item/storage/box/rubbershot
 	name = "box of rubber shots"
 	desc = "A box full of rubber shots, designed for riot shotguns."

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -102,7 +102,8 @@
 	backpack_contents = list(/obj/item/storage/box/survival/engineer=1,\
 		/obj/item/melee/baton/loaded=1,\
 		/obj/item/reagent_containers/hypospray/combat=1,\
-		/obj/item/gun/medbeam=1)
+		/obj/item/gun/medbeam=1,\
+		/obj/item/storage/box/hug/plushes=1)
 
 /datum/outfit/centcom/ert/medic/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -122,7 +123,8 @@
 		/obj/item/melee/baton/loaded=1,\
 		/obj/item/gun/energy/pulse/pistol/loyalpin=1,\
 		/obj/item/reagent_containers/hypospray/combat/nanites=1,\
-		/obj/item/gun/medbeam=1)
+		/obj/item/gun/medbeam=1,\
+		/obj/item/storage/box/hug/plushes=1)
 
 /datum/outfit/centcom/ert/engineer
 	name = "ERT Engineer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When someone has gone through a stressful or traumatic event, little comforts can go a long way in helping calm them down and speed their recovery. To that end, some emergency services and humanitarian organizations like to carry around teddy bears to give to people after a crisis, [like the Red Cross talks about here](https://www.redcross.org.au/get-involved/connect/volunteer/knitting-for-kindness-trauma-teddies).

So this PR gives the medical officers a box of plushies to hand out to people on station when they're not busy crossing medigun beams or wandering off and getting killed silently in maint. I think it's a nice little way to reinforce that the ERT's are there to help the crew, and give them a little more to do.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives medical ERT's something to do when they're not holding down LMB to heal people, plus it gives them a prompt to engage with the crew more than as a free heals dispenser.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
add: ERT Medical Officers now come equipped with a box of plushies to give to crewmembers in crisis
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
