### PR TITLE
becoming a skeleton will now cure your husking

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -21,6 +21,7 @@
 /datum/species/skeleton/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	. = ..()
 	C.set_safe_hunger_level()
+	C.cure_husk() //skeletons shouldn't be husks.
 
 /datum/species/skeleton/check_roundstart_eligible()
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])


### PR DESCRIPTION
## About The Pull Request

Upon having your species changed to the skeleton species, any forms of husking you may have endured will be cured.

## Why It's Good For The Game

According to the comments and code in https://github.com/tgstation/tgstation/blob/master/code/modules/mob/living/carbon/human/status_procs.dm , skeletons are not intended to ever be husks. If something attempts to husk a skeleton, the cure_husk() proc is called to cure any existing huskings and the become_husk() proc returns out early.

However, if a husked corpse with a stage 4+ necrotic metabolism + metabolic boost virus is allowed to process a dosage of skeleton mutation toxin for long enough to turn into a skeleton, they can be turned into a skeleton while still a husk, and this will not cure their husking. A similar thing can occur if a ghoul or a voiceless dead (with or without the aforementioned virus) is allowed to process a dosage of skeleton mutation toxin for long enough to turn into a skeleton. There are probably also some pride mirror or summon events shenanigans you can pull to become a husked skeleton.

This PR patches the above extreme edge cases by making it so that if you get turned into a skeleton for any reason, your husking(s) will be cured.

**tldr;
skeleton no husk except in edge case. pr fix edge case. pr good.**

## Changelog
:cl: ATHATH
fix: You can no longer become a husked skeleton by becoming a skeleton after being husked.
/:cl:
