### PR TITLE
Increases the GBP value of sprite PRs to 3.

### DIFF
--- a/.github/gbp.toml
+++ b/.github/gbp.toml
@@ -16,5 +16,5 @@ reset_label = "GBP: Reset"
 "Quality of Life" = 1
 "Refactor" = 10
 "Sound" = 1
-"Sprites" = 1
+"Sprites" = 3
 "Unit Tests" = 6


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR changes the GBP value of the sprites label from 1 to 3.

![image](https://user-images.githubusercontent.com/49783092/110211896-03931900-7e99-11eb-808e-8eac1c41689c.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You currently need to make 8 sprite PRs to gain enough GBP to do a simple balance change.

That is a lot of sprite work, especially if the PRs contain more than a single sprite each.

By increasing the reward, we can encourage spriters to resprite old lackluster sprites, making the game prettier.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


