### PR TITLE
Fix tgui reloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 #Ignore byond config folder.
 /cfg/**/*
 
+# Ignore compiled linux libs in the root folder, e.g. librust_g.so
+/*.so
+
 #Ignore compiled files and other files generated during compilation.
 *.mdme
 *.dmb

--- a/tgui/packages/tgui-dev-server/reloader.js
+++ b/tgui/packages/tgui-dev-server/reloader.js
@@ -67,7 +67,7 @@ export const findCacheRoot = async () => {
 
 const onCacheRootFound = cacheRoot => {
   logger.log(`found cache at '${cacheRoot}'`);
-  // Plant dummy
+  // Plant a dummy
   fs.closeSync(fs.openSync(cacheRoot + '/dummy', 'w'));
 };
 
@@ -94,12 +94,12 @@ export const reloadByondCache = async bundleDir => {
     const garbage = await resolveGlob(cacheDir, './*.+(bundle|chunk|hot-update).*');
     try {
       for (let file of garbage) {
-        fs.unlink(file);
+        fs.unlinkSync(file);
       }
       // Copy assets
       for (let asset of assets) {
         const destination = resolvePath(cacheDir, basename(asset));
-        fs.copyFile(asset, destination);
+        fs.writeFileSync(destination, fs.readFileSync(asset));
       }
       logger.log(`copied ${assets.length} files to '${cacheDir}'`);
     }


### PR DESCRIPTION
## About The Pull Request

- Fixed a regression in tgui-dev-server, which made it reload before it finished copying files.
- Made copying work on Linux over SMB shares by using `readFileSync` and `writeFileSync` instead of `copyFileSync`, because copyfile kernel call doesn't work for this. It is slightly slower, but not very noticeable.
- Added `/*.so` to gitignore, because `librust_g.so` has to be compiled on linux, and it must be ignored.
