### PR TITLE
Replaces "tweak" with "qol" in CI Changelog valid prefixes list

### DIFF
--- a/tools/ss13_genchangelog.py
+++ b/tools/ss13_genchangelog.py
@@ -47,7 +47,7 @@ all_changelog_entries = {}
 validPrefixes = [
     'bugfix',
     'wip',
-    'tweak',
+    'qol',
     'soundadd',
     'sounddel',
     'rscdel',


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/110230653-65d83200-7f0a-11eb-9889-3ebe5500602b.png)

I think this is the appropriate method of fixing this issue?
