### PR TITLE
Cayenne now has 200 maxHealth

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -209,11 +209,11 @@
 	gold_core_spawnable = NO_SPAWN
 	faction = list("neutral")
 	health = 200
+	maxHealth = 200
 	icon_dead = "magicarp_dead"
 	icon_gib = "magicarp_gib"
 	icon_living = "magicarp"
 	icon_state = "magicarp"
-	maxHealth = 200
 	random_color = FALSE
 	food_type = list()
 	tame_chance = 0
@@ -229,6 +229,8 @@
 	speak_emote = list("squeaks")
 	gold_core_spawnable = NO_SPAWN
 	faction = list(ROLE_SYNDICATE)
+	health = 200
+	maxHealth = 200
 	rarechance = 10
 	food_type = list()
 	tame_chance = 0


### PR DESCRIPTION
## About The Pull Request

Cayenne now has 200 maxHealth (and starts with 200 health).

## Why It's Good For The Game

I want to like Cayenne. I really, really do. I know that she's loved by the community and that using a syndicate sentience potion on her SOUNDS like a great idea (especially since https://github.com/tgstation/tgstation/pull/57395 has been merged recently), but she is currently a massive trap option.

This is because, for some unknowable reason, Cayenne inherits the maxHealth of normal carp: 25. This means that your dreams of stealing the disk as a carp (or even just suiciding a crowd of people with a macrobomb) can be shattered by a single stray hellfire shot from the captain's antique laser gun, which does 25 burn damage per shot. This also means that it is more optimal to break into the HoS's office and syndicate sentience potion Lia than it is to sentience potion Cayenne, because Lia has 8x the maxHealth of Cayenne (200 maxHealth).

This PR buffs Cayenne's maxHealth to be equal to that of her Nanotrasen counterpart. Perfectly balanced, as all things should be.

## Changelog
:cl: ATHATH
balance: Cayenne now has 200 maxHealth (increased from her previous maxHealth value of 25).
/:cl: