### PR TITLE
Fixed material exports reporting 1/2000th of the amount of material exported.

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -64,15 +64,23 @@ Then the player gets the profit from selling his own wasted time.
 	return report
 
 /datum/export
-	var/unit_name = "" // Unit name. Only used in "Received [total_amount] [name]s [message]." message
+	/// Unit name. Only used in "Received [total_amount] [name]s [message]." message
+	var/unit_name = ""
 	var/message = ""
-	var/cost = 1 // Cost of item, in cargo credits. Must not alow for infinite price dupes, see above.
-	var/k_elasticity = 1/30 //coefficient used in marginal price calculation that roughly corresponds to the inverse of price elasticity, or "quantity elasticity"
-	var/list/export_types = list() // Type of the exported object. If none, the export datum is considered base type.
-	var/include_subtypes = TRUE // Set to FALSE to make the datum apply only to a strict type.
-	var/list/exclude_types = list() // Types excluded from export
+	/// Cost of item, in cargo credits. Must not allow for infinite price dupes, see above.
+	var/cost = 1
+	/// coefficient used in marginal price calculation that roughly corresponds to the inverse of price elasticity, or "quantity elasticity"
+	var/k_elasticity = 1/30
+	/// The multiplier of the amount sold shown on the report. Useful for exports, such as material, which costs are not strictly per single units sold.
+	var/amount_report_multiplier = 1
+	/// Type of the exported object. If none, the export datum is considered base type.
+	var/list/export_types = list()
+	/// Set to FALSE to make the datum apply only to a strict type.
+	var/include_subtypes = TRUE
+	/// Types excluded from export
+	var/list/exclude_types = list()
 
-	//cost includes elasticity, this does not.
+	/// cost includes elasticity, this does not.
 	var/init_cost
 
 
@@ -149,10 +157,7 @@ Then the player gets the profit from selling his own wasted time.
 		the_cost = the_cost * ((100 - profit_ratio) * 0.01)
 	report.total_value[src] += the_cost
 
-	if(istype(O, /datum/export/material))
-		report.total_amount[src] += amount*MINERAL_MATERIAL_AMOUNT
-	else
-		report.total_amount[src] += amount
+	report.total_amount[src] += amount*amount_report_multiplier
 
 	if(!dry_run)
 		if(apply_elastic)

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -1,6 +1,7 @@
 /datum/export/material
 	cost = 5 // Cost per MINERAL_MATERIAL_AMOUNT, which is 2000cm3 as of April 2016.
 	message = "cm3 of developer's tears. Please, report this on github"
+	amount_report_multiplier = MINERAL_MATERIAL_AMOUNT
 	var/material_id = null
 	export_types = list(
 		/obj/item/stack/sheet/mineral, /obj/item/stack/tile/mineral,


### PR DESCRIPTION
## About The Pull Request
Done by adding a new var `amount_report_multiplier` and setting it to `MINERAL_MATERIAL_AMOUNT` for material export datums.

## Why It's Good For The Game
This will close  #55418.

## Changelog
:cl:
fix: Fixed material exports reporting 1/2000th of the amount of material exported.
/:cl:
