### PR TITLE
adds mushrooms and chocolate to the produce orders

### DIFF
--- a/code/game/machinery/computer/chef_orders/order_datum.dm
+++ b/code/game/machinery/computer/chef_orders/order_datum.dm
@@ -99,6 +99,16 @@
 	category_index = CATEGORY_FRUITS_VEGGIES
 	item_instance = /obj/item/food/grown/cherries
 
+/datum/orderable_item/chanterelle
+	name = "Chanterelle"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/food/grown/mushroom/chanterelle
+
+/datum/orderable_item/cocoa
+	name = "Cocoa"
+	category_index = CATEGORY_FRUITS_VEGGIES
+	item_instance = /obj/item/food/grown/cocoapod
+
 //Milk and Eggs
 
 /datum/orderable_item/milk


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Chocolate is used in some high paying bartending drinks, chanterelle is used in chawanmushi but is TECHNICALLY obtainable from waiting for botany to grow mushrooms. basically, they should have been in the produce console to begin with!

## Why It's Good For The Game

Without this you have to constantly send away high payers. Hacking machine for fernet is fine as it's an investment, this is just CBT (crikey, bad tomfoolery)

## Changelog
:cl:
qol: chanterelle mushrooms and chocolate are now in the produce console
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
