### PR TITLE
map templates placing being centered is now a selection

### DIFF
--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -30,7 +30,7 @@
 	images += preview
 	if(alert(src,"Confirm location.","Template Confirm","Yes","No") == "Yes")
 		if(template.load(T, centered = TRUE))
-			var/affected = template.get_affected_turfs(T, centered=TRUE)
+			var/affected = template.get_affected_turfs(T, centered = center)
 			for(var/AT in affected)
 				for(var/obj/docking_port/mobile/P in AT)
 					if(istype(P, /obj/docking_port/mobile))

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -14,7 +14,16 @@
 		return
 
 	var/list/preview = list()
-	for(var/S in template.get_affected_turfs(T,centered = TRUE))
+	var/center
+	var/centeralert = alert(src,"Center Template.","Template Centering","Yes","No")
+	switch(centeralert)
+		if("Yes")
+			center = TRUE
+		if("No")
+			center = FALSE
+		else
+			return
+	for(var/S in template.get_affected_turfs(T,centered = center))
 		var/image/item = image('icons/turf/overlays.dmi',S,"greenOverlay")
 		item.plane = ABOVE_LIGHTING_PLANE
 		preview += item


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

does what the title says

## Why It's Good For The Game

if you want to fit a map template inside some room and dont want to fuck it up, you can now just get it from the corner

## Changelog
:cl:
admin: map template placing being centered is now a selection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
