### PR TITLE
Adds moffins

### DIFF
--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -357,6 +357,12 @@
 	tastes = list("muffin" = 3, "spookiness" = 1)
 	foodtypes = GRAIN | FRUIT | SUGAR | BREAKFAST
 
+/obj/item/food/muffin/moffin
+	name = "moffin"
+	desc = "A delicious and spongy little cake, with little cloth strips embedded inside of it."
+	tastes = list("muffin" = 2, "dust" = 1, "lint" = 1)
+	foodtypes = CLOTH | GRAIN | SUGAR | BREAKFAST
+
 
 
 ////////////////////////////////////////////WAFFLES////////////////////////////////////////////

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -432,6 +432,16 @@
 	result = /obj/item/food/muffin/booberry
 	subcategory = CAT_PASTRY
 
+/datum/crafting_recipe/food/moffin
+	name = "Moffin"
+	reqs = list(
+		/datum/reagent/consumable/milk = 5,
+		/obj/item/food/pastrybase = 1,
+		/obj/item/stack/sheet/cloth = 1
+	)
+	result = /obj/item/food/muffin/moffin
+	subcategory = CAT_PASTRY
+
 
 ////////////////////////////////////////////OTHER////////////////////////////////////////////
 


### PR DESCRIPTION
## About The Pull Request

This PR adds moffins to the game, subtypes of muffins that have the CLOTH foodtype (alongside the normal muffin foodtypes) that can be crafted using 5u of milk, a pastry base, and a roll of cloth. They use the normal muffin sprite, because I don't know how to sprite things/add sprites to the game in a PR.

## Why It's Good For The Game

moff pun

## Changelog
:cl: ATHATH
add: Moffins can now be crafted using 5u of milk, a pastry base, and a roll of cloth. They're like normal muffins, except they have the CLOTH foodtype (in addition to the normal muffin foodtypes), so most moths like them.
/:cl: