### PR TITLE
Fixes mute pAI message typo

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai_say.dm
+++ b/code/modules/mob/living/silicon/pai/pai_say.dm
@@ -1,6 +1,6 @@
 /mob/living/silicon/pai/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	if(silent)
-		to_chat(src, "<span class='warning'>Communication circuits remain unitialized.</span>")
+		to_chat(src, "<span class='warning'>Communication circuits remain uninitialized.</span>")
 	else
 		..(message)
 


### PR DESCRIPTION
## About The Pull Request

Fixes the 'unitialized' typo for pAIs that are muted.

## Why It's Good For The Game

Grammar fixes are good.

## Changelog
:cl:
spellcheck: Fixed a typo for muted pAIs.
/:cl: