### PR TITLE
PDA & ID Painter minor fixes.

### DIFF
--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -115,11 +115,11 @@
 
 	// Chameleon checks first so they can exit the logic early if they're detected.
 	if(istype(O, /obj/item/card/id/advanced/chameleon))
-		to_chat(user, "<span class='warning'>The machine rejects your [src]. It's clearly not a compatible ID card.</span>")
+		to_chat(user, "<span class='warning'>The machine rejects your [O]. This ID card does not appear to be compatible with the PDA Painter.</span>")
 		return
 
 	if(istype(O, /obj/item/pda/chameleon))
-		to_chat(user, "<span class='warning'>The machine rejects your [src]. It's clearly not a compatible PDA.</span>")
+		to_chat(user, "<span class='warning'>The machine rejects your [O]. This PDA does not appear to be compatible with the PDA Painter.</span>")
 		return
 
 	if(istype(O, /obj/item/pda))
@@ -322,7 +322,7 @@
 				if(SSid_access.apply_trim_to_card(stored_id_card, path, copy_access = FALSE))
 					return TRUE
 
-				to_chat(usr, "<span class='warning'>The trim you selected could not be added to \the [src]. You will need a rarer ID card to imprint that trim data.</span>")
+				to_chat(usr, "<span class='warning'>The trim you selected could not be added to \the [stored_id_card]. You will need a rarer ID card to imprint that trim data.</span>")
 
 			return TRUE
 

--- a/tgui/packages/tgui/interfaces/PaintingMachine.js
+++ b/tgui/packages/tgui/interfaces/PaintingMachine.js
@@ -16,11 +16,13 @@ export const PaintingMachine = (props, context) => {
 
   const [
     selectedPDA,
-  ] = useSharedState(context, "pdaSelection");
+  ] = useSharedState(context, "pdaSelection", pdaTypes[Object.keys(pdaTypes)[0]]);
 
   const [
     selectedTrim,
-  ] = useSharedState(context, "trimSelection");
+  ] = useSharedState(context, "trimSelection", cardTrims[Object.keys(cardTrims)[0]]);
+
+
 
   return (
     <Window


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Default value of state variables could init to null states and these null states may get pushed through to the game via `act()` calls. This led to inconsistent behaviour where the Assistant trim and clown PDA skin could not be applied despite the interface suggesting it would be.

Fixed some copypasta incorrectly referencing [src] instead of the appropriate object.

![image](https://user-images.githubusercontent.com/24975989/110401349-50c9e300-8071-11eb-9bb6-67d984593bb2.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Incremental fixes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: PDA & ID Painter no longer talks about itself so much in warning messages.
fix: PDA & ID Painter will now correctly paint Assistant trims and clown PDA skins instead of failing in certain edge cases.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
