### PR TITLE
Adds stat tracking for civilian bounties

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -90,6 +90,9 @@ SUBSYSTEM_DEF(blackbox)
 		var/datum/player_details/PD = GLOB.player_details[player_key]
 		record_feedback("tally", "client_byond_version", 1, PD.byond_version)
 
+	for(var/datum/bounty/current_bounty in GLOB.incomplete_civilian_bounties)
+		record_feedback("associative", "civilian_bounties", 1, list("[SQLtime()]" = list("Name" = "[current_bounty.name]", "Type" = "[current_bounty.type]", "Status" = "Incomplete")))
+
 /datum/controller/subsystem/blackbox/Shutdown()
 	sealed = FALSE
 	FinalFeedback()

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -4,6 +4,7 @@
 	var/reward = 1000 // In credits.
 	var/claimed = FALSE
 	var/high_priority = FALSE
+	var/start_time
 
 /datum/bounty/proc/can_claim()
 	return !claimed


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds stat tracking for civilian bounties to view on Statbus. Records bounties when they're completed, replaced or incomplete at the end of the round. Logs their name, path, completion status, time taken to complete, and payout per minute taken.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Useful for players curious about the most profitable bounties and for coders to make sure that bounty payouts are balanced correctly. Not sure if I did this right so feedback would be appreciated. I don't know how to test stat tracking locally.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
add: Stat tracking for bounties (view per round on AtlantaNed's Statbus)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
