### PR TITLE
[webedit] Pulsing the open wire toggles airlocks, even when it is cut

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -96,9 +96,9 @@
 				return
 			if(!A.requiresID() || A.check_access(null))
 				if(A.density)
-					INVOKE_ASYNC(A, /obj/machinery/door/airlock.proc/open)
+					INVOKE_ASYNC(A, /obj/machinery/door/airlock.proc/open, 1)
 				else
-					INVOKE_ASYNC(A, /obj/machinery/door/airlock.proc/close)
+					INVOKE_ASYNC(A, /obj/machinery/door/airlock.proc/close, 1)
 		if(WIRE_BOLTS) // Pulse to toggle bolts (but only raise if power is on).
 			if(!A.locked)
 				A.bolt()


### PR DESCRIPTION
## About The Pull Request

This PR makes it so that pulsing the open wire on an airlock will toggle it open/closed, even when the wire is cut. All this does is make it so that you can make an airlock only openable using assemblies.

On a technical level, pulsing the open wire calls the open/close procs with `forced=1`, which is the same arg that airlock control buttons call those procs with.

If desired, I can make AI door operation and door remotes also use `forced=1` if it makes sense to put them in line with this PR, though if you ask me, cutting the wire and attaching an assembly is like disconnecting the stuff that handles automatic and remote operation and replacing that with the assembly.

## Why It's Good For The Game

Currently, since airlocks need to be public for pulsing the open wire to open/close them, anyone could just waltz through your voice-operated door without giving the password. You COULD cut the open wire to prevent people from opening the airlock by touching it, but currently, that also makes it so pulsing the open wire does nothing.

## Changelog
:cl: Y0SH1_M4S73R
qol: Pulsing a cut open wire on airlocks will now open it. Since cutting the open wire prevents airlocks from being opened by physical contact, this allows you to make airlocks only openable using assemblies. Try connecting a voice analyzer to the cut open wire.
/:cl:
