### PR TITLE
fixes bane backbreaker from making customers flee

### DIFF
--- a/code/datums/ai/robot_customer/robot_customer_behaviors.dm
+++ b/code/datums/ai/robot_customer/robot_customer_behaviors.dm
@@ -95,6 +95,9 @@
 	. = ..()
 	var/mob/living/simple_animal/robot_customer/customer_pawn = controller.pawn
 	var/datum/customer_data/customer_data = controller.blackboard[BB_CUSTOMER_CUSTOMERINFO]
+	var/mob/living/greytider = controller.blackboard[BB_CUSTOMER_CURRENT_TARGET]
+	if(greytider) //usually if we stop waiting, it's because we're done with the venue. but in this case we're beating some dude up so don't switch to leaving
+		return
 	controller.blackboard[BB_CUSTOMER_LEAVING] = TRUE
 	customer_pawn.update_icon() //They might have a special leaving accesoiry (french flag)
 	if(succeeded)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If the wait for food action was cancelled in any way, it would make the customer leave which takes precedence over retaliation. What does this mean? It means if the robot sits down, it becomes a SCAREDY PANTS.

## Why It's Good For The Game

fix


## Changelog
:cl:
fix: bane back breaker fixed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
