### PR TITLE
Fixed the manhattan project reagent having two pound signs in its color var.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -961,7 +961,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/manhattan_proj
 	name = "Manhattan Project"
 	description = "A scientist's drink of choice, for pondering ways to blow up the station."
-	color = "##ff3300" // rgb: 255,51,0
+	color = COLOR_MOSTLY_PURE_RED
 	boozepwr = 45
 	quality = DRINK_VERYGOOD
 	taste_description = "death, the destroyer of worlds"


### PR DESCRIPTION
## About The Pull Request
So, in another PR the food elegibility unit test chose, out of hundreds of different food subtypes, the abductor egglayer gland egg (the one that spawns with a random reagent) as allocated test object, and the same egg, out of hundred of different reagents, then decided to pick the one with such a blunder in its color variable, thus triggering an exception or runtime error on blendRGB() and making me feel a tiny bit bewildered, because it had like a one in one-with-so-many-zeros chance of happening, after all. Maybe we should start to enforce color defines one day.

## Why It's Good For The Game
Fixing a typo.

## Changelog
:cl:
fix: Fixed the manhattan project reagent having two pound signs in its color variable. 
/:cl:
