### PR TITLE
SecHUD icon generation fixes and code improvement.

### DIFF
--- a/code/controllers/subsystem/id_access.dm
+++ b/code/controllers/subsystem/id_access.dm
@@ -428,6 +428,7 @@ SUBSYSTEM_DEF(id_access)
 	var/datum/id_trim/trim = trim_singletons_by_path[trim_path]
 	id_card.trim_icon_override = trim.trim_icon
 	id_card.trim_state_override = trim.trim_state
+	id_card.trim_assignment_override = trim.assignment
 
 	if(!check_forged || !id_card.forged)
 		id_card.assignment = trim.assignment
@@ -443,6 +444,7 @@ SUBSYSTEM_DEF(id_access)
 /datum/controller/subsystem/id_access/proc/remove_trim_from_chameleon_card(obj/item/card/id/advanced/chameleon/id_card)
 	id_card.trim_icon_override = null
 	id_card.trim_state_override = null
+	id_card.trim_assignment_override = null
 
 /**
  * Adds the accesses associated with a trim to an ID card.

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -241,9 +241,10 @@ Security HUDs! Basic mode shows only the job.
 	var/image/holder = hud_list[ID_HUD]
 	var/icon/I = icon(icon, icon_state, dir)
 	holder.pixel_y = I.Height() - world.icon_size
-	holder.icon_state = "hudno_id"
-	if(wear_id?.GetID())
-		holder.icon_state = "hud[ckey(wear_id.GetJobName())]"
+	var/sechud_icon_state = wear_id?.get_sechud_job_icon_state()
+	if(!sechud_icon_state)
+		sechud_icon_state = "hudno_id"
+	holder.icon_state = sechud_icon_state
 	sec_hud_set_security_status()
 
 /mob/living/proc/sec_hud_set_implants()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -695,6 +695,8 @@
 	var/trim_icon_override
 	/// If this is set, will manually override the icon state for the trim. Intended for admins to VV edit and chameleon ID cards.
 	var/trim_state_override
+	/// If this is set, will manually override the trim's assignmment for SecHUDs. Intended for admins to VV edit and chameleon ID cards.
+	var/trim_assignment_override
 
 /obj/item/card/id/advanced/get_icon_source()
 	return get_cached_flat_icon()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -289,8 +289,7 @@
 	entry.overlays = H.get_overlays_copy(list(HANDS_LAYER, HANDCUFF_LAYER, LEGCUFF_LAYER))
 	prof.profile_snapshot = entry
 
-	if(H.wear_id?.GetID())
-		prof.id_icon = "hud[ckey(H.wear_id.GetJobName())]"
+	prof.id_icon = H.wear_id?.get_sechud_job_icon_state()
 
 	var/list/slots = list("head", "wear_mask", "back", "wear_suit", "w_uniform", "shoes", "belt", "gloves", "glasses", "ears", "wear_id", "s_store")
 	for(var/slot in slots)

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -102,19 +102,32 @@
 /obj/proc/check_access_ntnet(list/passkey)
 	return check_access_list(passkey)
 
-/obj/item/proc/GetJobName() //Used in secHUD icon generation
+/// Returns the SecHUD job icon state for whatever this object's ID card is, if it has one.
+/obj/item/proc/get_sechud_job_icon_state()
 	var/obj/item/card/id/id_card = GetID()
 
 	if(!id_card)
-		return
+		return "hudno_id"
 
-	var/card_assignment = id_card.trim?.assignment
+	var/card_assignment
+	if(istype(id_card, /obj/item/card/id/advanced))
+		var/obj/item/card/id/advanced/advanced_id_card = id_card
+		card_assignment = advanced_id_card.trim_assignment_override ? advanced_id_card.trim_assignment_override : advanced_id_card.trim?.assignment
+	else
+		card_assignment = id_card.trim?.assignment
 
 	if(!card_assignment)
 		card_assignment = id_card.assignment
 
-	if(card_assignment in (SSjob.station_jobs + SSjob.additional_jobs_with_icons)) //Check if the job has a hud icon
-		return card_assignment
-	if(card_assignment in SSjob.centcom_jobs) //Return with the NT logo if it is a CentCom job
-		return "CentCom"
-	return "Unknown" //Return unknown if none of the above apply
+	// Is this one of the jobs with dedicated HUD icons?
+	if(card_assignment in SSjob.station_jobs)
+		return "hud[ckey(card_assignment)]"
+	if(card_assignment in SSjob.additional_jobs_with_icons)
+		return "hud[ckey(card_assignment)]"
+
+	// If not, is it one of the jobs that should use the NT logo?
+	if(card_assignment in SSjob.centcom_jobs)
+		return "hudcentcom"
+
+	// If none of the above apply, job name is unknown.
+	return "hudunknown"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #57552

Changes the stupidly named /obj/item/proc/GetJobName() proc to /obj/item/proc/get_sechud_job_icon_state() - Since that's all the damn code was ever used for.

Updates its janky-ass code to work alongside Agent ID cards.

Pulls functionality that was used outside of the proc to inside the proc. Instead of returning a job name or equivalent based on what we have icon states for, it now returns the full icon state itself or null if there's no suitable ID as part of the object. All the SecHUD icon generation code in one place.

Very minor improvement in not making the proc concat two cached lists every time it tries to generate an icon.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fix, code improvement.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Agent ID cards now show the same SecHUD icons that their forged trim otherwise would instead of always showing as blank.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
