### PR TITLE
Makes wallets physically show first ID in the row, highest ranking ID on sechud

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -67,7 +67,7 @@
 		var/card_tally = SSid_access.tally_access(id_card, ACCESS_FLAG_COMMAND)
 		if(card_tally > winning_tally)
 			winning_tally = card_tally
-			front_id = id_card
+			front_id = id_card //searches for the id that will show on secHUD
 		LAZYINITLIST(combined_access)
 		combined_access |= id_card.access
 
@@ -79,7 +79,8 @@
 	if(ishuman(loc))
 		var/mob/living/carbon/human/wearing_human = loc
 		if(wearing_human.wear_id == src)
-			wearing_human.sec_hud_set_ID()
+			wearing_human.sec_hud_set_ID() //sets the sechud icon
+			front_id = (locate(/obj/item/card/id) in contents) //picks first id in the wallet as the appearance of it
 
 	update_label()
 	update_appearance(UPDATE_ICON)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I seriously disliked that the first ID that shows up in the wallet always is the highest ranking ID, in my opinion it should be able to physically hide it and just make secHUDs see if someone has higher access than they have on the card, here is an example of how it works now. 
![image](https://user-images.githubusercontent.com/53384660/110481697-236c4c00-80e8-11eb-9419-4362d2b990cc.png)


## Why It's Good For The Game
Wallets once more have some more use among people that want to hide their id from collegues, it still won't escape from sight of security though.

## Changelog
:cl:
qol: The order you put IDs into the wallets matters again. It won't hide your secHUD icon though!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
