### PR TITLE
Jumpsuits should now drop attachments on destroy

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -235,6 +235,7 @@
 			name = "tattered [initial(name)]"
 
 	update_clothes_damaged_state(CLOTHING_DAMAGED)
+	update_appearance()
 
 /obj/item/clothing/Destroy()
 	user_vars_remembered = null //Oh god somebody put REFERENCES in here? not to worry, we'll clean it up
@@ -503,6 +504,7 @@ BLIND     // can't see anything
 			else
 				M.visible_message("<span class='danger'>[src] fall[p_s()] apart, completely shredded!</span>", vision_distance = COMBAT_MESSAGE_RANGE)
 		name = "shredded [initial(name)]" // change the name -after- the message, not before.
+		update_appearance()
 	else
 		..()
 

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -305,3 +305,17 @@
 
 /obj/item/clothing/under/rank
 	dying_key = DYE_REGISTRY_UNDER
+
+/obj/item/clothing/under/proc/dump_attachment()
+	if(!attached_accessory)
+		return
+	var/atom/L = drop_location()
+	attached_accessory.transform *= 2
+	attached_accessory.pixel_x -= 8
+	attached_accessory.pixel_y += 8
+	if(L)
+		attached_accessory.forceMove(L)
+
+/obj/item/clothing/under/rank/Destroy()
+	dump_attachment()
+	return ..()

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -315,7 +315,11 @@
 	attached_accessory.pixel_y += 8
 	if(L)
 		attached_accessory.forceMove(L)
+	src.cut_overlays()
+	src.attached_accessory = null
+	src.accessory_overlay = null
+	update_appearance()
 
-/obj/item/clothing/under/rank/Destroy()
+/obj/item/clothing/under/rank/obj_destruction(damage_flag)
 	dump_attachment()
 	return ..()

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -309,15 +309,15 @@
 /obj/item/clothing/under/proc/dump_attachment()
 	if(!attached_accessory)
 		return
-	var/atom/L = drop_location()
+	var/atom/drop_location = drop_location()
 	attached_accessory.transform *= 2
 	attached_accessory.pixel_x -= 8
 	attached_accessory.pixel_y += 8
-	if(L)
-		attached_accessory.forceMove(L)
-	src.cut_overlays()
-	src.attached_accessory = null
-	src.accessory_overlay = null
+	if(drop_location)
+		attached_accessory.forceMove(drop_location)
+	cut_overlays()
+	attached_accessory = null
+	accessory_overlay = null
 	update_appearance()
 
 /obj/item/clothing/under/rank/obj_destruction(damage_flag)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

When jumpsuits are destroyed, drop attachments like medals or ribbons. Stops them from getting deleted from existence instantly alongside the jumpsuit in cases like plasmafires, which the attachments should be immune to.

Clothing sprits should now also update properly when receiving damage.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Many of these attachments have resists such as fire resistance which are bypassed by the destruction of the jumpsuit they are attached to.

Stops important traitor objectives from being accidentally wiped from existence.

## Changelog
:cl:
fix: Jumpsuits should now drop attachments such as medals or ribbons when they are destroyed instead of making the attachments disappear as well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
