### PR TITLE
Fixing (cult) slurring and stuttering never going away from non-carbon mobs.

### DIFF
--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -31,9 +31,6 @@
 	else
 		emp_damage = max(emp_damage - (0.5 * delta_time), 0)
 
-/mob/living/brain/handle_status_effects(delta_time, times_fired)
-	return
-
 /mob/living/brain/handle_traits(delta_time, times_fired)
 	return
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -489,20 +489,11 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	else
 		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "jittery")
 
-	if(stuttering)
-		stuttering = max(stuttering - (0.5 * delta_time), 0)
-
-	if(slurring)
-		slurring = max(slurring - (0.5 * delta_time),0)
-
-	if(cultslurring)
-		cultslurring = max(cultslurring - (0.5 * delta_time), 0)
+	if(druggy)
+		adjust_drugginess(-0.5 * delta_time)
 
 	if(silent)
 		silent = max(silent - (0.5 * delta_time), 0)
-
-	if(druggy)
-		adjust_drugginess(-0.5 * delta_time)
 
 	if(hallucination)
 		handle_hallucinations(delta_time, times_fired)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -150,9 +150,17 @@
 /mob/living/proc/has_reagent(reagent, amount = -1, needs_metabolizing = FALSE)
 	return reagents.has_reagent(reagent, amount, needs_metabolizing)
 
-//this updates all special effects: knockdown, druggy, stuttering, etc..
+/*
+ * this updates some effects: mostly old stuff such as drunkness, druggy, stuttering, etc.
+ * that should be converted to status effect datums one day.
+ */
 /mob/living/proc/handle_status_effects(delta_time, times_fired)
-	return
+	if(stuttering)
+		stuttering = max(stuttering - (0.5 * delta_time), 0)
+	if(slurring)
+		slurring = max(slurring - (0.5 * delta_time),0)
+	if(cultslurring)
+		cultslurring = max(cultslurring - (0.5 * delta_time), 0)
 
 /mob/living/proc/handle_traits(delta_time, times_fired)
 	//Eyes

--- a/code/modules/mob/living/silicon/pai/pai_defense.dm
+++ b/code/modules/mob/living/silicon/pai/pai_defense.dm
@@ -15,13 +15,13 @@
 	//Ask and you shall receive
 	switch(rand(1, 3))
 		if(1)
-			stuttering = 1
+			stuttering += 30/severity //temporary, clears in a few ticks after silent is over.
 			to_chat(src, "<span class='danger'>Warning: Feedback loop detected in speech module.</span>")
 		if(2)
-			slurring = 1
+			slurring = INFINITY // permanent until speech is fixed through the pAI card UI by someone else.
 			to_chat(src, "<span class='danger'>Warning: Audio synthesizer CPU stuck.</span>")
 		if(3)
-			derpspeech = 1
+			derpspeech = 1 // Ditto.
 			to_chat(src, "<span class='danger'>Warning: Vocabulary databank corrupted.</span>")
 	if(prob(40))
 		mind.language_holder.selected_language = get_random_spoken_language()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -275,11 +275,6 @@
 			set_stat(CONSCIOUS)
 	med_hud_set_status()
 
-/mob/living/simple_animal/handle_status_effects(delta_time, times_fired)
-	..()
-	if(stuttering)
-		stuttering = 0
-
 /**
  * Updates the simple mob's stamina loss.
  *


### PR DESCRIPTION
## About The Pull Request
The code for (cult) slurring and stuttering and their variables are found on living_say, yet the code for the effects wearing out is only found in some subtypes despite the presence of functionalities that can affect the stuttering/slurring of any living mob.
Also removing stutter immunity from simple animals. I see no harm in that.

## Why It's Good For The Game
This will fix #23875.

## Changelog
:cl:
del: Animals are no loner n(e)igh-immune to stuttering.
fix: Silicons and animals won't keep stuttering or slurring forever after being struck by something that made them like that in the first place (such as a Blue Space Artillery).
/:cl:
