### PR TITLE
Updates statpanel verb widths to be more dynamic at higher screen resolutions.

### DIFF
--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -154,7 +154,15 @@
 
 	@media only screen and (min-width: 720px) {
 		.grid-item {
-			width: 170px;
+			width: 25%;
+			box-sizing: border-box;
+		}
+	}
+
+	@media only screen and (min-width: 800px) {
+		.grid-item {
+			width: 20%;
+			box-sizing: border-box;
 		}
 	}
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tweaks the statpanel to use percentage-width for verb buttons at 720px and higher widths. 0-719px has fixed-width 150px verb buttons. 720-799px sees the paradigm change to 25% width, aka 4 columns. 800 and above sees 20% width, aka 5 columns. 5 columns intended to happen at 2560x1440 with the viewport scaled to fit.

![0cUL7GUFzv](https://user-images.githubusercontent.com/24975989/110503716-63393080-80f4-11eb-894d-ea456a19cffe.gif)

This is how the 5 column look appears on 3840 x 2160 monitors with viewport scaled to fit.
![image](https://user-images.githubusercontent.com/24975989/110503525-308f3800-80f4-11eb-8688-fd84c3c0cd52.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less dead/useless whitespace on certain resolutions. I don't have to relearn verb panel layout for 4 column widths.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Stat panel and verb tabs now have smoother size scaling to higher resolutions, switching from fixed-width buttons to a fixed number of variable-width columns depending on screen resolution.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
