### PR TITLE
Removes Chef's CQC Chip from chameleon skillchip selection

### DIFF
--- a/code/modules/library/skill_learning/job_skillchips/chef.dm
+++ b/code/modules/library/skill_learning/job_skillchips/chef.dm
@@ -4,6 +4,7 @@
 	skill_name = "Close Quarters Cooking"
 	skill_description = "A specialised form of self defence, developed by skilled sous-chef de cuisines. No man fights harder than a chef to defend his kitchen."
 	skill_icon = "utensils"
+	skillchip_flags = SKILLCHIP_CHAMELEON_INCOMPATIBLE | SKILLCHIP_RESTRICTED_CATEGORIES
 	activate_message = "<span class='notice'>You can visualize how to defend your kitchen with martial arts.</span>"
 	deactivate_message = "<span class='notice'>You forget how to control your muscles to execute kicks, slams and restraints while in a kitchen environment.</span>"
 	var/datum/martial_art/cqc/under_siege/style


### PR DESCRIPTION
## About The Pull Request

Disallows the chef CQC skillchip from being selected by chameleon skillchips.

## Why It's Good For The Game

If we're gonna be expanding the chef CQC areas for some reason, we probably shouldn't allow traitors to get (almost) free CQC. If a traitor really wants the CQC chip they can kill a cook for it.

## Changelog
:cl: Melbert
del: The chameleon skillchip can no longer transform into the Chef's CQC chip. Only chefs (and those who best them) are powerful enough to contain Close Quarters Cooking.
/:cl:
