### PR TITLE
Laughter gains new functionality on recently slipped people

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -294,6 +294,11 @@
 	mood_events -= category
 	qdel(event)
 	update_mood()
+	
+/datum/component/mood/proc/has_event(category)
+	if(!istext(category))
+		category = REF(category)
+	return mood_events[category]
 
 /datum/component/mood/proc/remove_temp_moods() //Removes all temp moods
 	for(var/i in mood_events)

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -295,7 +295,7 @@
 	qdel(event)
 	update_mood()
 	
-/datum/component/mood/proc/has_event(category)
+/datum/component/mood/proc/get_event(category)
 	if(!istext(category))
 		category = REF(category)
 	return mood_events[category]

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -187,6 +187,11 @@
 /datum/mood_event/nanite_happiness/add_effects(message)
 	description = "<span class='nicegreen robot'>+++++++[message]+++++++</span>\n"
 
+/datum/mood_event/funny_prank
+	description = "<span class='nicegreen'>That was a funny prank, clown!</span>\n"
+	mood_change = 2
+	timeout = 2 MINUTES
+
 /datum/mood_event/area
 	description = "" //Fill this out in the area
 	mood_change = 0

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -185,7 +185,8 @@
 		if (mood.get_event("slipped"))
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "laughter", /datum/mood_event/funny_prank)
 			SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "slipped")
-			reactor.AdjustKnockdown(-2 SECONDS)
+			reactor.emote("laugh")
+			reactor.AdjustKnockdown(-4 SECONDS)
 
 /datum/reagent/consumable/superlaughter
 	name = "Super Laughter"

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -178,6 +178,15 @@
 	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "chemical_laughter", /datum/mood_event/chemical_laughter)
 	..()
 
+/datum/reagent/consumable/laughter/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
+	var/mob/living/carbon/human/reactor = M
+	if(istype(reactor))
+		var/datum/component/mood/mood = reactor.GetComponent(/datum/component/mood)
+		if (mood.get_event("slipped"))
+			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "laughter", /datum/mood_event/funny_prank)
+			SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "slipped")
+			reactor.AdjustKnockdown(-20)
+
 /datum/reagent/consumable/superlaughter
 	name = "Super Laughter"
 	description = "Funny until you're the one laughing."

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -185,7 +185,7 @@
 		if (mood.get_event("slipped"))
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "laughter", /datum/mood_event/funny_prank)
 			SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "slipped")
-			reactor.AdjustKnockdown(-20)
+			reactor.AdjustKnockdown(-2 SECONDS)
 
 /datum/reagent/consumable/superlaughter
 	name = "Super Laughter"
@@ -1028,4 +1028,3 @@
 	if(M.drowsyness < 3)
 		M.drowsyness += 1 * REM * delta_time
 	return ..()
-

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -178,7 +178,7 @@
 	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "chemical_laughter", /datum/mood_event/chemical_laughter)
 	..()
 
-/datum/reagent/consumable/laughter/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
+/datum/reagent/consumable/laughter/expose_mob(mob/living/M, method=TOUCH, reac_volume)
 	var/mob/living/carbon/human/reactor = M
 	if(istype(reactor))
 		var/datum/component/mood/mood = reactor.GetComponent(/datum/component/mood)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Laughter now further increases your mood with a positive moodlet if you have been recently slipped. It now removes the negative slipped moodlet, reduce knockdown and add a new positive moodlet.

## Why It's Good For The Game

Makes a difference between shitter clown and prankster clown; prankster clown will try to slip people and then spray them with laughter to cheer them up and give them positive mood, while shitter clown will just slip people.

## Changelog
:cl:
add: laughter now has extra benefits to people recently slipped; flips the negative 'slipped' moodlet into a positive one and reduces knockdown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
