### PR TITLE
Fix being able to alt-click and ctrl-click while inside cryo tubes

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -489,8 +489,7 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 				. = TRUE
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/can_interact(mob/user)
-	. = ..()
-	return . && user.loc != src
+	return ..() && user.loc != src
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/CtrlClick(mob/user)
 	if(can_interact(user) && !state_open)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -488,6 +488,10 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 				beaker = null
 				. = TRUE
 
+/obj/machinery/atmospherics/components/can_interact(mob/user)
+	. = ..()
+	return . && user.loc != src
+
 /obj/machinery/atmospherics/components/unary/cryo_cell/CtrlClick(mob/user)
 	if(can_interact(user) && !state_open)
 		set_on(!on)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -488,7 +488,7 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 				beaker = null
 				. = TRUE
 
-/obj/machinery/atmospherics/components/can_interact(mob/user)
+/obj/machinery/atmospherics/components/unary/cryo_cell/can_interact(mob/user)
 	. = ..()
 	return . && user.loc != src
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You are currently able to alt-click (to close) and ctrl-click (to toggle) cryo tubes. This is an exploit, as you're not able to do it from the tgui menu, and you need to resist (which has a 30 second timer) to get out manually.

## Changelog
:cl:
fix: You can no longer alt-click and ctrl-click while inside the cryo tube.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
