### PR TITLE
Makes client timers not able to perma block normal timers

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -133,9 +133,6 @@ SUBSYSTEM_DEF(timer)
 		clienttime_timers.Cut(1, next_clienttime_timer_index+1)
 		next_clienttime_timer_index = 0
 
-	if (MC_TICK_CHECK)
-		return
-
 	// Check for when we need to loop the buckets, this occurs when
 	// the head_offset is approaching BUCKET_LEN ticks in the past
 	if (practical_offset > BUCKET_LEN)


### PR DESCRIPTION
## About The Pull Request
This isn't a full fix but deals with the worst of the issues. This makes it so client timers can't stop the timer subsystem from doing normal book keeping work and at least 1 normal timer will run per fire instead of potentially none when client timers are clogging the works.

As an additional temporary measure we could also increase the allowed percentage of a tick the timer subsystem is allowed to take up.

I'll discuss with @MrStonedOne what a full fix would look like at some point when both of us are miraculously online and paying attention at the same time.