### PR TITLE
Fixes food trash element not generating trash, including fixing gatfruits not dropping guns.

### DIFF
--- a/code/datums/elements/food/food_trash.dm
+++ b/code/datums/elements/food/food_trash.dm
@@ -42,10 +42,9 @@
 
 	var/obj/item/trash_item = generate_trash_procpath ? call(source, generate_trash_procpath)() : new trash(edible_object.drop_location())
 
-	if(istype(edible_object.loc))
-		var/mob/living/food_holding_mob = edible_object.loc
+	var/mob/living/food_holding_mob = edible_object.loc
+	if(istype(food_holding_mob))
 		food_holding_mob.put_in_hands(trash_item)
-		return
 
 /datum/element/food_trash/proc/food_crossed(datum/source, mob/crosser, bitecount)
 	SIGNAL_HANDLER

--- a/code/datums/elements/food/food_trash.dm
+++ b/code/datums/elements/food/food_trash.dm
@@ -6,18 +6,18 @@
 	var/atom/trash
 	///Flags of the trash element that change its behavior
 	var/flags
-	///Generate trash callback
-	var/datum/callback/generate_trash_callback
+	///Generate trash proc path
+	var/generate_trash_procpath
 
-/datum/element/food_trash/Attach(datum/target, atom/trash, flags, generate_trash)
+/datum/element/food_trash/Attach(datum/target, atom/trash, flags, generate_trash_proc)
 	. = ..()
 	if(!isatom(target))
 		return ELEMENT_INCOMPATIBLE
 	src.trash = trash
 	src.flags = flags
 	RegisterSignal(target, COMSIG_FOOD_CONSUMED, .proc/generate_trash)
-	if(!src.generate_trash_callback && generate_trash)
-		generate_trash_callback = CALLBACK(target, generate_trash)
+	if(!generate_trash_procpath && generate_trash_proc)
+		generate_trash_procpath = generate_trash_proc
 	if(flags & FOOD_TRASH_OPENABLE)
 		RegisterSignal(target, COMSIG_ITEM_ATTACK_SELF, .proc/open_trash)
 	if(flags & FOOD_TRASH_POPABLE)
@@ -38,17 +38,14 @@
 	INVOKE_ASYNC(src, .proc/async_generate_trash, source)
 
 /datum/element/food_trash/proc/async_generate_trash(datum/source)
-
-	var/obj/item/trash_item =  generate_trash_callback ? generate_trash_callback.Invoke(source) : new trash()
-
 	var/atom/edible_object = source
 
-	var/mob/living/mob_location = edible_object.loc //The foods location
+	var/obj/item/trash_item = generate_trash_procpath ? call(source, generate_trash_procpath)() : new trash(edible_object.drop_location())
 
-	if(istype(mob_location))
-		mob_location.put_in_hands(trash_item)
-	else
-		trash_item.forceMove(get_turf(edible_object))
+	if(istype(edible_object.loc))
+		var/mob/living/food_holding_mob = edible_object.loc
+		food_holding_mob.put_in_hands(trash_item)
+		return
 
 /datum/element/food_trash/proc/food_crossed(datum/source, mob/crosser, bitecount)
 	SIGNAL_HANDLER

--- a/code/datums/elements/food/food_trash.dm
+++ b/code/datums/elements/food/food_trash.dm
@@ -42,8 +42,8 @@
 
 	var/obj/item/trash_item = generate_trash_procpath ? call(source, generate_trash_procpath)() : new trash(edible_object.drop_location())
 
-	var/mob/living/food_holding_mob = edible_object.loc
-	if(istype(food_holding_mob))
+	if(isliving(edible_object.loc))
+		var/mob/living/food_holding_mob = edible_object.loc
 		food_holding_mob.put_in_hands(trash_item)
 
 /datum/element/food_trash/proc/food_crossed(datum/source, mob/crosser, bitecount)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -75,7 +75,7 @@
 		AddElement(/datum/element/food_trash, trash_type, FOOD_TRASH_OPENABLE, /obj/item/food/grown/.proc/generate_trash)
 	return
 
-///Callback for bonus behavior for generating trash of grown food.
+/// Callback proc for bonus behavior for generating trash of grown food. Used by [/datum/element/food_trash].
 /obj/item/food/grown/proc/generate_trash()
 	// If this is some type of grown thing, we pass a seed arg into its Inititalize()
 	if(istype(trash_type, /obj/item/grown) || istype(trash_type, /obj/item/food/grown))

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -76,8 +76,12 @@
 	return
 
 ///Callback for bonus behavior for generating trash of grown food.
-/obj/item/food/grown/proc/generate_trash(atom/location)
-	return new trash_type(location, seed)
+/obj/item/food/grown/proc/generate_trash()
+	// If this is some type of grown thing, we pass a seed arg into its Inititalize()
+	if(istype(trash_type, /obj/item/grown) || istype(trash_type, /obj/item/food/grown))
+		return new trash_type(src, seed)
+
+	return new trash_type(src)
 
 /obj/item/food/grown/grind_requirements()
 	if(dry_grind && !HAS_TRAIT(src, TRAIT_DRIED))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #55969
Fixes #55168

The old code created a static callback that all objects of the same type would use.

The callback had a target `object`. That object is the first ever instantiated object of that food type path which attempts to attach the food_trash element.

Food generally gets deleted as part of dropping trash.

Del the food and the element is left with a callback to either a QDELETED object or, once the object hard dels as the callback holds a reference to it, a callback with a null `object` which would then go on to early return on Invoke() without ever actually invoking the callback.

This meant that all things of that type path could no longer generate food trash as their trash_food element held what is ostensibly an invalid callback.

Instead of creating a callback, we just hold a proc path and call() it directly.

I've done a bit of code sweeping up around the side as a result of this.

Tested and even though this stuff stil hard dels (a problem for another day) its functionality is no longer negatively impacted by it.

Major thanks to @ninjanomnom for helping me wrap my head around this.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Food that should drop trash should now always drop that trash, including plates dropping from prepared food, food that you have to pull out of shells and gatfruits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
