### PR TITLE
Bunnies conjured from top hats each start with no eggs remaining instead of ten

### DIFF
--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -57,7 +57,7 @@
 				barry.say(pick("BUZZ BUZZ", "PULLING A RABBIT OUT OF A HAT IS A TIRED TROPE", "I DIDN'T ASK TO BEE HERE"), forced = "bee hat")
 	else
 		magician.visible_message("<span class='notice'>[magician] taps [src] with [hitby_wand], then reaches in and pulls out a bunny! Cute!</span>", "<span class='notice'>You tap [src] with your [hitby_wand.name] and pull out a cute bunny!</span>")
-		var/mob/living/simple_animal/chicken/rabbit/bunbun = new(get_turf(magician))
+		var/mob/living/simple_animal/chicken/rabbit/empty/bunbun = new(get_turf(magician))
 		bunbun.mob_try_pickup(magician, instant=TRUE)
 
 #undef RABBIT_CD_TIME

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -94,7 +94,8 @@
 	icon_state = "bunnyhead"
 	inhand_icon_state = "bunnyhead"
 	desc = "Considerably more cute than 'Frank'."
-	slowdown = -1
+	slowdown = -0.3
+	clothing_flags = THICKMATERIAL | SNUG_FIT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
 /obj/item/clothing/suit/bunnysuit
@@ -102,7 +103,8 @@
 	desc = "Hop Hop Hop!"
 	icon_state = "bunnysuit"
 	inhand_icon_state = "bunnysuit"
-	slowdown = -1
+	slowdown = -0.3
+	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -53,6 +53,9 @@
 	pet_bonus_emote = "hops around happily!"
 	can_be_held = TRUE
 
+/mob/living/simple_animal/chicken/rabbit/empty //top hats summon these kinds of rabbits instead of the normal kind
+	eggsleft = 0 //if you want to harvest toys and easter bunny gear from these guys, you're gonna need to feed them carrots first
+
 /mob/living/simple_animal/chicken/rabbit/space
 	icon_prefix = "s_rabbit"
 	icon_state = "s_rabbit_white"


### PR DESCRIPTION
## About The Pull Request

This PR adds a subtype of rabbits that starts with eggsleft = 0 instead of eggsleft = 10 to the game, and makes top hats summon them instead of normal rabbits. Note that these rabbits can still lay loaded eggs if you feed them carrots (each carrot will give them 1-4 more eggs, which they will disgorge from themselves with time).

The slowdown values of the Easter Bunny outfit's pieces have been nerfed to be -0.3 each instead of -1 each, which I believe should make someone wearing both pieces of the outfit move at the same speed as a cultist who's wearing berserker robes (which have a slowdown value of -0.6). Both pieces of the Easter Bunny set now also have the THICKCLOTHING flag, and the Easter Bunny head now has the SNUG_FIT flag.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/42606352/110595380-8e973c00-8143-11eb-85c4-6277c12b0659.png)

https://youtu.be/QZj3h7FODhU

So, https://github.com/tgstation/tgstation/pull/56773 added the ability to pull rabbits from hats using wands. It was a great PR, but there was one teensy little issue with it- each rabbit that you pull out of a hat will, over a somewhat long period of time, lay 10 loaded eggs, which you can use in-hand to receive a chocolate egg and an Easter-related item.

Most of these items are just action figures, toys, etc., but two of the items in the pool of prizes are the Easter Bunny head and the Easter Bunny suit, which are two of the very few pieces of clothing in the game that have negative slowdown values. Wearing even one of them will let you zoom across the station at incredible speeds (you can see this demonstrated in the Youtube video I linked above).

You will still be able to farm for Easter Bunny gear after this PR, but you'll now have to acquire a consistent source of carrots and feed each rabbit a carrot whenever you think it's low on remaining egg uses (you can't stockpile eggsleft charges too far, as carrots won't increase the eggsleft variable if it's >=8). You'll also still have to actually collect and open each laid egg and deal with the risk of getting swarmed by bees. This, I think, is a reasonable enough amount of effort to acquire post-nerf Easter Bunny gear.

It should also be noted that you'll still be able to farm pet moodlets and meat slabs from bunnies, which I've decided to leave in because you can already do a similar thing with the kittens produced by Runtime and a cat clone from cytology (which will always be male). Also, petting zoos are fun, and I like the idea of the chef using small, innocent creatures (and some bees) that have been summoned by stage magic as the primary source of his food's meat.

The new clothing flags are there because the Easter Bunny set looks like a mascot costume, which should be resistant to syringe injections and dislodgements from thrown hats.

## Changelog
:cl: ATHATH
balance: Rabbits summoned by stage magic will start with 0 loaded eggs remaining instead of 10. You can still feed them carrots to cause them to generate more loaded eggs, though.
balance: The speed boost from wearing the Easter Bunny head and/or the Easter Bunny suit has been nerfed, but is still present.
/:cl: