### PR TITLE
[s] Fixes wallhack grabs with all martial arts

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -327,11 +327,15 @@
 		ML.pulled(src)
 
 /mob/living/CtrlClick(mob/user)
-	if (isliving(user))
+	if(isliving(user) && Adjacent(user) && !user.incapacitated())
+		if(world.time < user.next_move)
+			return FALSE
 		var/mob/living/user_living = user
-		if (user_living.apply_martial_art(src, null, is_grab=TRUE) == MARTIAL_ATTACK_SUCCESS)
+		if(user_living.apply_martial_art(src, null, is_grab=TRUE) == MARTIAL_ATTACK_SUCCESS)
+			user_living.changeNext_move(CLICK_CD_MELEE)
 			return
-	..()
+	else
+		..()
 
 
 /mob/living/carbon/human/CtrlClick(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the ability for anyone to grab anyone from any viewable distance with martial arts.

fixes #57582 

## Why It's Good For The Game

Only level 9 spellcasters (or powergaming 6th level fighters) are allowed the ability to grab people via telekinesis, and STILL with respect to line of effect!

## Changelog
:cl:
fix: Prevents martial arts warping people that they can view into their killing hands with the power of their martial prowess. And a missing adjacency check.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
