### PR TITLE
Fixes icon fetch mapping helper / chasms eating mapping helpers.

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -22,7 +22,8 @@
 		/obj/effect/light_emitter/tendril,
 		/obj/effect/collapse,
 		/obj/effect/particle_effect/ion_trails,
-		/obj/effect/dummy/phased_mob
+		/obj/effect/dummy/phased_mob,
+		/obj/effect/mapping_helpers
 		))
 
 /datum/component/chasm/Initialize(turf/target)

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -514,7 +514,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	var/target_name
 	/// This is the var tha will be set with the fetched icon. In case you want to set some secondary icon sheets like inhands and such.
 	var/target_variable = "icon"
-	/// This should return raw dmi in response to http get request. For example: "https://github.com/tgstation/SS13-sprites/raw/master/mob/medu.dmi"
+	/// This should return raw dmi in response to http get request. For example: "https://github.com/tgstation/SS13-sprites/raw/master/mob/medu.dmi?raw=true"
 	var/icon_url
 
 /obj/effect/mapping_helpers/custom_icon/LateInitialize()
@@ -541,17 +541,23 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 
 /obj/effect/mapping_helpers/custom_icon/proc/fetch_icon(url)
 	var/static/icon_cache = list()
+	var/static/query_in_progress = FALSE //We're using a single tmp file so keep it linear.
+	if(query_in_progress)
+		UNTIL(!query_in_progress)
 	if(icon_cache[url])
 		return icon_cache[url]
 	log_asset("Custom Icon Helper fetching dmi from: [url]")
 	var/datum/http_request/request = new()
 	var/file_name = "tmp/custom_map_icon.dmi"
 	request.prepare(RUSTG_HTTP_METHOD_GET, url , "", "", file_name)
+	query_in_progress = TRUE
 	request.begin_async()
 	UNTIL(request.is_complete())
 	var/datum/http_response/response = request.into_response()
 	if(response.errored || response.status_code != 200)
-		stack_trace("Failed to fetch mapped custom icon from url [url], code: [response.status_code]")
+		query_in_progress = FALSE
+		CRASH("Failed to fetch mapped custom icon from url [url], code: [response.status_code], error: [response.error]")
 	var/icon/I = new(file_name)
 	icon_cache[url] = I
+	query_in_progress = FALSE
 	return I


### PR DESCRIPTION
Doing the fetches asynchronously both made cache irrelevant and caused mixup with icon use.

Also semi-related fix, where chasms could delete mapping helpers.