### PR TITLE
Fixing sweet potatoes and potato wedges outputting tatortots.

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -33,7 +33,10 @@
 			continue
 		recipe = new recipe
 		var/list/typecache = list()
-		for(var/input_type in typesof(recipe.input))
+		var/list/bad_types
+		for(var/bad_type in recipe.blacklist)
+			LAZYADD(bad_types, typesof(bad_type))
+		for(var/input_type in typesof(recipe.input) - bad_types)
 			typecache[input_type] = recipe
 		for(var/machine_type in typesof(recipe.required_machine))
 			LAZYADD(processor_inputs[machine_type], typecache)

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -1,6 +1,8 @@
 /datum/food_processor_process
 	/// What this recipe takes
 	var/input
+	/// Subtypes of what the recipe takes that it can't actually take.
+	var/list/blacklist
 	/// What this recipe creates
 	var/output
 	/// The amount of time this recipe takes.
@@ -15,10 +17,19 @@
 /datum/food_processor_process/meat
 	input = /obj/item/food/meat/slab
 	output = /obj/item/food/raw_meatball
+	blacklist = list(/obj/item/food/meat/slab/human,
+		/obj/item/food/meat/slab/corgi,
+		/obj/item/food/meat/slab/xeno,
+		/obj/item/food/meat/slab/bear,
+		/obj/item/food/meat/slab/chicken)
 	multiplier = 3
 
 /datum/food_processor_process/cutlet
 	input = /obj/item/food/meat/cutlet/plain
+	blacklist = list(/obj/item/food/meat/cutlet/plain/human,
+		/obj/item/food/meat/cutlet/xeno,
+		/obj/item/food/meat/cutlet/bear,
+		/obj/item/food/meat/cutlet/chicken)
 	output = /obj/item/food/raw_meatball
 
 /datum/food_processor_process/meat/human
@@ -72,6 +83,7 @@
 
 /datum/food_processor_process/potato
 	input = /obj/item/food/grown/potato
+	blacklist = list(/obj/item/food/grown/potato/sweet, /obj/item/food/grown/potato/wedges)
 	output = /obj/item/food/tatortot
 
 /datum/food_processor_process/carrot


### PR DESCRIPTION
## About The Pull Request
Added a blacklist list variable to processor recipe datums. It's used to avoid certain subtype paths from being associated with a specific recipe while the processor_inputs static list is being populated. This will stop sweet potatoes and wedges from outputting tator tots instead of yaki imo and fries, as well as various meat slabs resulting in generic meatballs.

## Why It's Good For The Game
This will close #57601.

## Changelog
:cl:
fix: sweet potatoes and potato wedges no longer output tator tots instead of yaki imo or french fries when processed through the food processor. Same deal for various kinds of meat slabs or cutlets outputting generic meatballs.
/:cl:
