### PR TITLE
Prevents abuse of the BEPIS to syphon cash from cargo.

### DIFF
--- a/code/modules/research/bepis.dm
+++ b/code/modules/research/bepis.dm
@@ -183,7 +183,7 @@
 /obj/machinery/rnd/bepis/ui_data(mob/user)
 	var/list/data = list()
 	var/powered = FALSE
-	var/zvalue = (banked_cash - (major_threshold - positive_cash_offset - negative_cash_offset))/(std)
+	var/zvalue = ((banking_amount + banked_cash) - (major_threshold - positive_cash_offset - negative_cash_offset))/(std)
 	var/std_success = 0
 	var/prob_success = 0
 	//Admittedly this is messy, but not nearly as messy as the alternative, which is jury-rigging an entire Z-table into the code, or making an adaptive z-table.

--- a/code/modules/research/bepis.dm
+++ b/code/modules/research/bepis.dm
@@ -178,7 +178,7 @@
 	RefreshParts()
 	if(isliving(user))
 		var/mob/living/customer = user
-		account = customer?.get_bank_account()
+		account = customer.get_bank_account()
 
 /obj/machinery/rnd/bepis/ui_data(mob/user)
 	var/list/data = list()

--- a/code/modules/research/bepis.dm
+++ b/code/modules/research/bepis.dm
@@ -61,6 +61,9 @@
 		return
 	if(istype(O, /obj/item/card/id))
 		var/obj/item/card/id/Card = O
+		if(istype(Card, /obj/item/card/id/departmental_budget)
+			say("Nanotrasen legal accountability services would like you remind you not to try and siphon funds from your department. Please use another card.")
+			return
 		if(Card.registered_account)
 			account = Card.registered_account
 			account_name = Card.registered_name

--- a/code/modules/research/bepis.dm
+++ b/code/modules/research/bepis.dm
@@ -61,7 +61,7 @@
 		return
 	if(istype(O, /obj/item/card/id))
 		var/obj/item/card/id/Card = O
-		if(istype(Card, /obj/item/card/id/departmental_budget)
+		if(istype(Card, /obj/item/card/id/departmental_budget))
 			say("Nanotrasen legal accountability services would like you remind you not to try and siphon funds from your department. Please use another card.")
 			return
 		if(Card.registered_account)

--- a/code/modules/research/bepis.dm
+++ b/code/modules/research/bepis.dm
@@ -61,9 +61,6 @@
 		return
 	if(istype(O, /obj/item/card/id))
 		var/obj/item/card/id/Card = O
-		if(istype(Card, /obj/item/card/id/departmental_budget))
-			say("Nanotrasen legal accountability services would like you remind you not to try and siphon funds from your department. Please use another card.")
-			return
 		if(Card.registered_account)
 			account = Card.registered_account
 			account_name = Card.registered_name
@@ -110,20 +107,6 @@
 	log_econ("[deposit_value] credits were inserted into [src] by [account.account_holder]")
 	banked_cash += deposit_value
 	use_power(1000 * power_saver)
-	say("Cash deposit successful. There is [banked_cash] in the chamber.")
-	update_appearance()
-	return
-
-/obj/machinery/rnd/bepis/proc/withdrawcash()
-	var/withdraw_value = 0
-	withdraw_value = banking_amount
-	if(withdraw_value > banked_cash)
-		say("Cannot withdraw more than stored funds. Aborting.")
-	else
-		banked_cash -= withdraw_value
-		new /obj/item/holochip(src.loc, withdraw_value)
-		say("Withdrawing [withdraw_value] credits from the chamber.")
-	update_appearance()
 	return
 
 /obj/machinery/rnd/bepis/proc/calcsuccess()
@@ -193,6 +176,9 @@
 		ui = new(user, src, "Bepis", name)
 		ui.open()
 	RefreshParts()
+	if(isliving(user))
+		var/mob/living/customer = user
+		account = customer?.get_bank_account()
 
 /obj/machinery/rnd/bepis/ui_data(mob/user)
 	var/list/data = list()
@@ -225,7 +211,7 @@
 		powered = TRUE
 	data["account_owner"] = account_name
 	data["amount"] = banking_amount
-	data["stored_cash"] = banked_cash
+	data["stored_cash"] = account?.account_balance
 	data["mean_value"] = (major_threshold - positive_cash_offset - negative_cash_offset)
 	data["error_name"] = error_cause
 	data["power_saver"] = power_saver
@@ -242,19 +228,12 @@
 	if(.)
 		return
 	switch(action)
-		if("deposit_cash")
-			if(use_power == IDLE_POWER_USE)
-				return
-			depositcash()
-		if("withdraw_cash")
-			if(use_power == IDLE_POWER_USE)
-				return
-			withdrawcash()
 		if("begin_experiment")
 			if(use_power == IDLE_POWER_USE)
 				return
+			depositcash()
 			if(banked_cash == 0)
-				say("Please deposit funds to begin testing.")
+				say("Please select funds to deposit to begin testing.")
 				return
 			calcsuccess()
 			use_power(MACHINE_OPERATION * power_saver) //This thing should eat your APC battery if you're not careful.

--- a/tgui/packages/tgui/interfaces/Bepis.js
+++ b/tgui/packages/tgui/interfaces/Bepis.js
@@ -44,7 +44,7 @@ export const Bepis = (props, context) => {
             <Grid.Column size={1.5}>
               <Section title="Stored Data and Statistics">
                 <LabeledList>
-                  <LabeledList.Item label="Deposited Credits">
+                  <LabeledList.Item label="Available Credits">
                     {data.stored_cash}
                   </LabeledList.Item>
                   <LabeledList.Item label="Investment Variability">
@@ -57,7 +57,7 @@ export const Bepis = (props, context) => {
                     color="bad">
                     {data.negative_cash_offset}
                   </LabeledList.Item>
-                  <LabeledList.Item label="Deposit Amount">
+                  <LabeledList.Item label="Deposit and Start">
                     <NumberInput
                       value={amount}
                       unit="Credits"
@@ -71,20 +71,6 @@ export const Bepis = (props, context) => {
                   </LabeledList.Item>
                 </LabeledList>
               </Section>
-              <Box>
-                <Button
-                  icon="donate"
-                  content="Deposit Credits"
-                  disabled={data.manual_power === 1
-                    || data.silicon_check === 1}
-                  onClick={() => act('deposit_cash')}
-                />
-                <Button
-                  icon="eject"
-                  content="Withdraw Credits"
-                  disabled={data.manual_power === 1}
-                  onClick={() => act('withdraw_cash')} />
-              </Box>
             </Grid.Column>
             <Grid.Column>
               <Section title="Market Data and Analysis">
@@ -100,12 +86,6 @@ export const Bepis = (props, context) => {
                     Please insert more money for future success.
                   </Box>
                 )}
-                <Box m={1} />
-                <Button
-                  icon="microscope"
-                  disabled={data.manual_power === 1}
-                  onClick={() => act('begin_experiment')}
-                  content="Begin Testing" />
               </Section>
             </Grid.Column>
           </Grid>

--- a/tgui/packages/tgui/interfaces/Bepis.js
+++ b/tgui/packages/tgui/interfaces/Bepis.js
@@ -57,7 +57,7 @@ export const Bepis = (props, context) => {
                     color="bad">
                     {data.negative_cash_offset}
                   </LabeledList.Item>
-                  <LabeledList.Item label="Deposit and Start">
+                  <LabeledList.Item label="Deposit Amount">
                     <NumberInput
                       value={amount}
                       unit="Credits"
@@ -71,6 +71,15 @@ export const Bepis = (props, context) => {
                   </LabeledList.Item>
                 </LabeledList>
               </Section>
+              <Box>
+                <Button
+                  icon="donate"
+                  content="Deposit Credits and Start"
+                  disabled={data.manual_power === 1
+                    || data.silicon_check === 1}
+                  onClick={() => act('begin_experiment')}
+                />
+              </Box>
             </Grid.Column>
             <Grid.Column>
               <Section title="Market Data and Analysis">


### PR DESCRIPTION
## About The Pull Request

Yeah I didn't really get around to this until now, I apologize.
New solution:
**The BEPIS no longer stores an internal quantity of credits inside of itself before starting, with the chance of success being determined by the attempted amount of credits being deposited. Once deposited, the machine automatically activates, spitting out rewards/failure alerts.**
**This is also reflected in the required UI changes to make this simplification work, bare with me as I will probably need to tweak a bit more to get it perfect, but it's easily going in a more reasonable direction.**
_Plus, this means that the BEPIS doesn't need to be manually swiped, instead autograbbing the target's active ID! Manual swiping can still be used to overwrite the old value._

## Why It's Good For The Game

Fixes #52705, and prevents cheesing of the core mechanic of the BEPIS.

## Changelog
:cl:
fix: You can no longer use the BEPIS to rob the cargo budget blind. It now auto-starts depending on the attempted deposited credits.
/:cl:
