### PR TITLE
Adds the clear PDA to the list of items that can appear on the Black Market uplink

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -1,6 +1,16 @@
 /datum/blackmarket_item/misc
 	category = "Miscellaneous"
 
+/datum/blackmarket_item/misc/Clear_PDA
+	name = "Clear PDA"
+	desc = "Show off your style with this limited edition clear PDA!."
+	item = /obj/item/pda/clear
+
+	price_min = 250
+	price_max = 600
+	stock_max = 2
+	availability_prob = 50
+
 /datum/blackmarket_item/misc/cap_gun
 	name = "Cap Gun"
 	desc = "Prank your friends with this harmless gun! Harmlessness guranteed."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
PR one of hopefully many that seek to improve the Black Market uplink with more unique items. This adds the clear PDA to the pool, with slightly higher odds of showing up than the holy water flask. Up to two can be found for sale, so if you're lucky you can get one for a friend!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The black market has sad selection of items. I hope to change that, and I figured this was a good start.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Clear PDAs can now be found for sale in the black market occasionally.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
