### PR TITLE
Nicotine is now addictive again, adds nicotine withdrawal effects.

### DIFF
--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -78,3 +78,11 @@
 	description = "<span class='nicegreen'>Eh ah AAAAH! HA HA HA HA HAA! Uuuh.</span>\n"
 	mood_change = 6
 	timeout = 3 MINUTES
+
+/datum/mood_event/nicotine_withdrawal_moderate
+	description = "<span class='warning'>Haven't had a smoke in a while. Feeling a little on edge... </span>\n"
+	mood_change = -5
+
+/datum/mood_event/nicotine_withdrawal_severe
+	description = "<span class='boldwarning'>Head pounding. Cold sweating. Feeling anxious. Need a smoke to calm down!</span>\n"
+	mood_change = -8

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -45,7 +45,7 @@
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	ph = 8
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	addiction_types = list(/datum/addiction/nicotine = 50) // pretty dang addictive
+	addiction_types = list(/datum/addiction/nicotine = 18) // 7.2 per 2 seconds
 
 	//Nicotine is used as a pesticide IRL.
 /datum/reagent/drug/nicotine/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray, mob/user)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -45,6 +45,7 @@
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	ph = 8
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	addiction_types = list(/datum/addiction/nicotine = 50) // pretty dang addictive
 
 	//Nicotine is used as a pesticide IRL.
 /datum/reagent/drug/nicotine/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray, mob/user)

--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -232,7 +232,7 @@
 ///Nicotine
 /datum/addiction/nicotine
 	name = "nicotine"
-	withdrawal_stage_messages = list("Feel like having a smoke...", "Can't concentrate. Really need a smoke now.", "I can't take it! Need a smoke NOW!")
+	withdrawal_stage_messages = list("Feel like having a smoke...", "Getting antsy. Really need a smoke now.", "I can't take it! Need a smoke NOW!")
 
 /datum/addiction/nicotine/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
@@ -241,13 +241,13 @@
 /datum/addiction/nicotine/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
 	affected_carbon.Jitter(10 * delta_time)
-	SEND_SIGNAL(affected_carbon, COMSIG_ADD_MOOD_EVENT, "depression_minimal", /datum/mood_event/depression_minimal)
+	SEND_SIGNAL(affected_carbon, COMSIG_ADD_MOOD_EVENT, "nicotine_withdrawal_moderate", /datum/mood_event/nicotine_withdrawal_moderate)
 	if(DT_PROB(10, delta_time))
 		affected_carbon.emote("cough")
 
 /datum/addiction/nicotine/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
 	affected_carbon.Jitter(15 * delta_time)
-	SEND_SIGNAL(affected_carbon, COMSIG_ADD_MOOD_EVENT, "depression_moderate", /datum/mood_event/depression_moderate)
+	SEND_SIGNAL(affected_carbon, COMSIG_ADD_MOOD_EVENT, "nicotine_withdrawal_severe", /datum/mood_event/nicotine_withdrawal_severe)
 	if(DT_PROB(15, delta_time))
 		affected_carbon.emote("cough")

--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -228,3 +228,26 @@
 		affected_carbon.hal_screwyhud = SCREWYHUD_NONE
 	hallucination.cleanup()
 	QDEL_NULL(hallucination2)
+
+///Nicotine
+/datum/addiction/nicotine
+	name = "nicotine"
+	withdrawal_stage_messages = list("Feel like having a smoke...", "Can't concentrate. Really need a smoke now.", "I can't take it! Need a smoke NOW!")
+
+/datum/addiction/nicotine/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	affected_carbon.Jitter(5 * delta_time)
+
+/datum/addiction/nicotine/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	affected_carbon.Jitter(10 * delta_time)
+	SEND_SIGNAL(affected_carbon, COMSIG_ADD_MOOD_EVENT, "depression_minimal", /datum/mood_event/depression_minimal)
+	if(DT_PROB(10, delta_time))
+		affected_carbon.emote("cough")
+
+/datum/addiction/nicotine/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
+	. = ..()
+	affected_carbon.Jitter(15 * delta_time)
+	SEND_SIGNAL(affected_carbon, COMSIG_ADD_MOOD_EVENT, "depression_moderate", /datum/mood_event/depression_moderate)
+	if(DT_PROB(15, delta_time))
+		affected_carbon.emote("cough")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes #57631 

Nicotine didn't have an `addiction_types` value added to it after the addiction rework here: #56923

About 9u of pure liquid Nicotine or 2 Robust cigarettes back to back should cause addiction.

Added new nicotine withdrawal effects as the existing withdrawal effects did not seem like they fit well enough. What's there is still pretty boring though, so I'm open for suggestions!

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Smokers can properly get their fix now!

## Changelog
:cl:
fix: Nicotine is addictive again.
add: New nicotine withdrawal effects. Time to feel miserable and jittery if you don't get your fix!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
