### PR TITLE
Fixes non cultists being able to use cult bolas

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -286,17 +286,21 @@
 	breakouttime = 60
 	knockdown = 30
 
+#define CULT_BOLA_PICKUP_STUN 6 SECONDS
 /obj/item/restraints/legcuffs/bola/cult/attack_hand(mob/living/carbon/user, list/modifiers)
 	. = ..()
-	var/stun = 6 SECONDS
+
 	if(!iscultist(user))
-		if(user.num_legs < 2 || user.legcuffed) //if they can't be ensnared, stun for the same time as it takes to breakout of bola
-			to_chat(user, "<span class='cultlarge'>\"I wouldn't advise that.\"</span>")
-			user.dropItemToGround(src, TRUE)
-			user.Paralyze(stun)
-		else
-			to_chat(user, "<span class='warning'>The bola seems to take on a life of its own!</span>")
-			ensnare(user)
+		if(iscarbon(user))
+			var/mob/living/carbon/C = user
+			if(user.num_legs < 2 || C.legcuffed) //if they can't be ensnared, stun for the same time as it takes to breakout of bola
+				to_chat(user, "<span class='cultlarge'>\"I wouldn't advise that.\"</span>")
+				user.dropItemToGround(src, TRUE)
+				user.Paralyze(CULT_BOLA_PICKUP_STUN)
+			else
+				to_chat(user, "<span class='warning'>The bola seems to take on a life of its own!</span>")
+				ensnare(user)
+#undef CULT_BOLA_PICKUP_STUN
 
 
 /obj/item/restraints/legcuffs/bola/cult/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -286,13 +286,14 @@
 	breakouttime = 60
 	knockdown = 30
 
-/obj/item/restraints/legcuffs/bola/cult/attack_hand(mob/living/user, list/modifiers)
+/obj/item/restraints/legcuffs/bola/cult/attack_hand(mob/living/carbon/user, list/modifiers)
 	. = ..()
+	var/stun = 6 SECONDS
 	if(!iscultist(user))
-		if(user.num_legs <= 1)
+		if(user.num_legs < 2 || user.legcuffed) //if they can't be ensnared, stun for the same time as it takes to breakout of bola
 			to_chat(user, "<span class='cultlarge'>\"I wouldn't advise that.\"</span>")
 			user.dropItemToGround(src, TRUE)
-			user.Paralyze(100)
+			user.Paralyze(stun)
 		else
 			to_chat(user, "<span class='warning'>The bola seems to take on a life of its own!</span>")
 			ensnare(user)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -292,8 +292,8 @@
 
 	if(!iscultist(user))
 		if(iscarbon(user))
-			var/mob/living/carbon/C = user
-			if(user.num_legs < 2 || C.legcuffed) //if they can't be ensnared, stun for the same time as it takes to breakout of bola
+			var/mob/living/carbon/carbon_user = user
+			if(user.num_legs < 2 || carbon_user.legcuffed) //if they can't be ensnared, stun for the same time as it takes to breakout of bola
 				to_chat(user, "<span class='cultlarge'>\"I wouldn't advise that.\"</span>")
 				user.dropItemToGround(src, TRUE)
 				user.Paralyze(CULT_BOLA_PICKUP_STUN)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -289,8 +289,14 @@
 /obj/item/restraints/legcuffs/bola/cult/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
 	if(!iscultist(user))
-		to_chat(user, "<span class='warning'>The bola seems to take on a life of its own!</span>")
-		ensnare(user)
+		if(user.num_legs <= 1)
+			to_chat(user, "<span class='cultlarge'>\"I wouldn't advise that.\"</span>")
+			user.dropItemToGround(src, TRUE)
+			user.Paralyze(100)
+		else
+			to_chat(user, "<span class='warning'>The bola seems to take on a life of its own!</span>")
+			ensnare(user)
+
 
 /obj/item/restraints/legcuffs/bola/cult/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(iscultist(hit_atom))

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -290,16 +290,16 @@
 /obj/item/restraints/legcuffs/bola/cult/attack_hand(mob/living/carbon/user, list/modifiers)
 	. = ..()
 
-	if(!iscultist(user))
-		if(iscarbon(user))
-			var/mob/living/carbon/carbon_user = user
-			if(user.num_legs < 2 || carbon_user.legcuffed) //if they can't be ensnared, stun for the same time as it takes to breakout of bola
-				to_chat(user, "<span class='cultlarge'>\"I wouldn't advise that.\"</span>")
-				user.dropItemToGround(src, TRUE)
-				user.Paralyze(CULT_BOLA_PICKUP_STUN)
-			else
-				to_chat(user, "<span class='warning'>The bola seems to take on a life of its own!</span>")
-				ensnare(user)
+	if(iscultist(user) || !iscarbon(user))
+		return
+	var/mob/living/carbon/carbon_user = user
+	if(user.num_legs < 2 || carbon_user.legcuffed) //if they can't be ensnared, stun for the same time as it takes to breakout of bola
+		to_chat(user, "<span class='cultlarge'>\"I wouldn't advise that.\"</span>")
+		user.dropItemToGround(src, TRUE)
+		user.Paralyze(CULT_BOLA_PICKUP_STUN)
+	else
+		to_chat(user, "<span class='warning'>The bola seems to take on a life of its own!</span>")
+		ensnare(user)
 #undef CULT_BOLA_PICKUP_STUN
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes non cultists being able to use cult bolas

Fixes #57652 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

non cultists shouldnt be able to use blood magic items
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes crippled non cultists being able to use cult bola
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
