### PR TITLE
Standardizes the new wall mount subtypes on Delta

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -57,13 +57,10 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "aam" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aan" = (
@@ -217,11 +214,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/item/clothing/head/welding,
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "aaH" = (
@@ -251,16 +246,6 @@
 /area/medical/chemistry)
 "aaI" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
-"aaJ" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -298,16 +283,13 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "abq" = (
@@ -331,11 +313,6 @@
 /turf/open/space/basic,
 /area/space)
 "abx" = (
-/obj/machinery/newscaster/security_unit{
-	dir = 4;
-	pixel_x = -26;
-	pixel_y = 6
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -346,6 +323,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "aby" = (
@@ -782,9 +760,6 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "acv" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/machinery/camera{
 	c_tag = "Solar - Fore Starboard";
 	name = "solar camera"
@@ -799,6 +774,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "acF" = (
@@ -1096,11 +1072,8 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "adj" = (
@@ -1209,14 +1182,6 @@
 	name = "Test Site Materials Crate";
 	req_access_txt = "63"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 32
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -1224,6 +1189,12 @@
 	pixel_x = -36
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 32
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/security/range)
 "adJ" = (
@@ -1430,9 +1401,6 @@
 /obj/item/stack/cable_coil,
 /obj/item/stock_parts/cell/high,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -1440,6 +1408,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "aeF" = (
@@ -2118,13 +2087,6 @@
 /area/hallway/secondary/entry)
 "ahD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -2136,6 +2098,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "ahE" = (
@@ -2150,10 +2114,6 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "ahF" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -3;
@@ -2168,6 +2128,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "ahP" = (
@@ -2370,9 +2331,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -2383,13 +2341,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/fore)
 "aiq" = (
 /obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -2401,6 +2357,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/fore)
 "air" = (
@@ -2564,10 +2521,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aiR" = (
@@ -2594,10 +2548,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aiV" = (
@@ -2906,9 +2857,6 @@
 	},
 /area/hallway/secondary/entry)
 "ajx" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -2918,6 +2866,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -2925,9 +2874,6 @@
 "ajy" = (
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -2938,6 +2884,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -3036,9 +2983,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -3048,6 +2992,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -3185,16 +3130,13 @@
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "ajW" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "ajX" = (
@@ -3282,25 +3224,20 @@
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "akk" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "akl" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "akm" = (
@@ -3315,11 +3252,9 @@
 "akn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/item/storage/toolbox/emergency,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ako" = (
@@ -3371,6 +3306,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "aku" = (
@@ -3598,10 +3534,6 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "ala" = (
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -3721,9 +3653,6 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "alw" = (
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
 /obj/machinery/keycard_auth{
 	pixel_x = 26;
 	pixel_y = 26
@@ -3736,6 +3665,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "alx" = (
@@ -3748,9 +3678,6 @@
 /area/hallway/secondary/entry)
 "alz" = (
 /obj/structure/filingcabinet/security,
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -3760,6 +3687,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "alA" = (
@@ -3883,21 +3811,15 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "alP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "alQ" = (
@@ -4455,9 +4377,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Customs";
 	dir = 4;
@@ -4473,6 +4392,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "aoi" = (
@@ -4580,9 +4500,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -4593,6 +4510,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "aou" = (
@@ -5102,10 +5020,6 @@
 /area/maintenance/port/fore)
 "aqj" = (
 /obj/structure/closet/secure_closet/contraband/heads,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/item/storage/secure/briefcase,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -5114,6 +5028,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "aqk" = (
@@ -5128,9 +5043,6 @@
 /area/security/checkpoint/customs)
 "aql" = (
 /obj/structure/filingcabinet/medical,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -5138,6 +5050,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "aqm" = (
@@ -5151,20 +5064,15 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
 "aqo" = (
 /obj/machinery/light,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
 "aqp" = (
@@ -5182,9 +5090,6 @@
 /area/hallway/secondary/entry)
 "aqr" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -5192,6 +5097,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "aqs" = (
@@ -5204,10 +5110,6 @@
 /area/security/checkpoint)
 "aqt" = (
 /obj/structure/closet/secure_closet/security,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -5215,6 +5117,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "aqu" = (
@@ -5707,10 +5610,8 @@
 /area/hallway/secondary/entry)
 "arP" = (
 /obj/effect/spawner/randomsnackvend,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "arQ" = (
@@ -5812,16 +5713,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "asb" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/coin/iron{
 	icon_state = "coin_bananium_heads";
 	name = "arcade coin"
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "asc" = (
@@ -6942,10 +6840,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -6954,6 +6848,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "auM" = (
@@ -7105,9 +7000,7 @@
 /area/maintenance/port/fore)
 "avt" = (
 /obj/structure/table_frame/wood,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "avu" = (
@@ -7135,9 +7028,7 @@
 /obj/structure/table/wood,
 /obj/item/camera_film,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
 "avy" = (
@@ -8300,9 +8191,7 @@
 /area/hallway/secondary/service)
 "aDE" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/service)
 "aDF" = (
@@ -8355,14 +8244,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aDN" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aDR" = (
@@ -8395,10 +8282,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "aEq" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -8409,6 +8292,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/commons/locker)
 "aEs" = (
@@ -8435,9 +8319,7 @@
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/service)
 "aEI" = (
@@ -8515,15 +8397,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aFd" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aFi" = (
@@ -8694,31 +8573,21 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "aGw" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light_switch{
 	pixel_x = 38
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -8727,6 +8596,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26;
+	pixel_y = 32
+	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "aGH" = (
@@ -8826,9 +8700,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/airalarm/unlocked{
-	pixel_y = 23
-	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral{
@@ -8841,12 +8712,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 23
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "aGT" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Incinerator";
 	name = "atmospherics camera"
@@ -8863,6 +8734,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/tank/toxins,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "aGU" = (
@@ -8957,9 +8829,6 @@
 /area/maintenance/port/fore)
 "aHq" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/machinery/camera{
 	c_tag = "Service Hallway - Fore";
 	dir = 4;
@@ -8969,6 +8838,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "aHr" = (
@@ -9103,9 +8973,7 @@
 "aIf" = (
 /obj/structure/table,
 /obj/machinery/computer/bookmanagement,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "aIg" = (
@@ -9256,10 +9124,6 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "aIy" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light_switch{
 	pixel_x = 24;
 	pixel_y = 24
@@ -9267,6 +9131,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank/large,
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "aIH" = (
@@ -9340,9 +9205,7 @@
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "aIP" = (
@@ -9480,11 +9343,8 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aJG" = (
@@ -9696,9 +9556,7 @@
 "aKm" = (
 /obj/structure/table/wood,
 /obj/item/camera,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "aKn" = (
@@ -9834,9 +9692,6 @@
 /turf/open/floor/iron/white,
 /area/security/prison/safe)
 "aKY" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
@@ -9844,6 +9699,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "aKZ" = (
@@ -10029,10 +9885,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "aLI" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -10042,6 +9894,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "aLT" = (
@@ -10073,10 +9926,6 @@
 /area/security/checkpoint/supply)
 "aLV" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -10091,6 +9940,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "aMa" = (
@@ -10406,14 +10256,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "aNk" = (
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aNr" = (
@@ -10873,14 +10721,12 @@
 /area/maintenance/disposal/incinerator)
 "aPC" = (
 /obj/structure/table/reinforced,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/maintenance/disposal/incinerator)
 "aPD" = (
@@ -11106,19 +10952,19 @@
 	},
 /area/security/prison)
 "aRd" = (
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = 25;
-	pixel_y = -2;
-	prison_radio = 1
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 25;
+	pixel_y = -2;
+	prison_radio = 1
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -11280,10 +11126,6 @@
 /area/security/prison)
 "aSI" = (
 /obj/structure/table/reinforced,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
@@ -11313,6 +11155,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aSJ" = (
@@ -11801,9 +11644,6 @@
 	pixel_y = -26
 	},
 /obj/item/flashlight/lamp,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -11811,6 +11651,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aWm" = (
@@ -11820,9 +11661,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aWo" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -11830,6 +11668,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 5
 	},
+/obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aWp" = (
@@ -11910,15 +11749,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "aWU" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "aXd" = (
@@ -12200,10 +12037,8 @@
 /area/security/prison)
 "aZn" = (
 /obj/structure/cable,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "aZo" = (
@@ -12226,10 +12061,8 @@
 /area/cargo/office)
 "aZq" = (
 /obj/structure/cable,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "aZr" = (
@@ -12248,11 +12081,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aZC" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "aZD" = (
@@ -12469,14 +12300,12 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "baw" = (
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "bax" = (
@@ -12485,15 +12314,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "baG" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "baS" = (
@@ -12552,10 +12379,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "bbg" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -12564,6 +12387,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "bbj" = (
@@ -12602,9 +12426,6 @@
 /area/security/prison)
 "bbl" = (
 /obj/machinery/light,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -12614,6 +12435,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "bbn" = (
@@ -12708,10 +12530,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "bcb" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "bcn" = (
@@ -12841,9 +12660,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/prisoner,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -12854,6 +12670,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "bcR" = (
@@ -12996,9 +12813,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -13008,6 +12822,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bdP" = (
@@ -13104,9 +12919,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bes" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/blobstart,
 /obj/machinery/light/small{
@@ -13115,6 +12927,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "bet" = (
@@ -13650,9 +13463,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "bhI" = (
@@ -13671,13 +13482,11 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "bhQ" = (
@@ -13980,12 +13789,10 @@
 /area/hallway/primary/fore)
 "bjQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bjR" = (
@@ -14218,10 +14025,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bmd" = (
@@ -14250,13 +14054,11 @@
 /area/security/brig)
 "bmf" = (
 /obj/structure/bed/roller,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "bmg" = (
@@ -14396,10 +14198,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -14408,6 +14206,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/security/brig)
 "bnI" = (
@@ -14707,9 +14506,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "boS" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -14719,6 +14515,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "boT" = (
@@ -14876,9 +14673,6 @@
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "bpg" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/machinery/computer/security/labor,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -14890,6 +14684,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "bph" = (
@@ -15568,22 +15363,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bsD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bsF" = (
@@ -15624,13 +15413,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bsJ" = (
@@ -15666,9 +15452,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Fore";
 	dir = 1;
@@ -15677,6 +15460,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L12"
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bsN" = (
@@ -15705,13 +15489,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bsS" = (
@@ -15719,13 +15500,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bsV" = (
@@ -16420,9 +16198,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "bxp" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32
-	},
 /obj/machinery/camera{
 	c_tag = "Security - Brig Fore";
 	dir = 8
@@ -16431,6 +16206,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "bxv" = (
@@ -16569,10 +16345,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/item/wrench,
 /obj/item/clothing/mask/gas,
 /obj/effect/turf_decal/tile/yellow{
@@ -16581,6 +16353,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/corner,
 /area/hallway/primary/port)
 "byc" = (
@@ -16595,12 +16368,10 @@
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
 "byd" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bye" = (
@@ -16733,10 +16504,6 @@
 /area/security/execution/transfer)
 "byI" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -16744,13 +16511,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "byJ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -16759,6 +16523,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/security/brig)
 "byK" = (
@@ -17051,9 +16816,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Bridge Port";
 	dir = 8;
@@ -17066,6 +16828,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bzV" = (
@@ -17556,13 +17319,11 @@
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "bCc" = (
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "bCd" = (
@@ -17612,16 +17373,12 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "bCg" = (
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/south,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "bCh" = (
@@ -17746,11 +17503,6 @@
 /area/security/execution/transfer)
 "bDW" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -17764,6 +17516,11 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = 6
 	},
 /turf/open/floor/iron,
 /area/security/execution/transfer)
@@ -17817,21 +17574,15 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "bEb" = (
 /obj/item/kirbyplants/random,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
@@ -17842,6 +17593,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "bEd" = (
@@ -17859,6 +17611,16 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "bEf" = (
+/obj/machinery/door/window{
+	base_state = "rightsecure";
+	dir = 4;
+	icon_state = "rightsecure";
+	layer = 4.1;
+	name = "Secondary AI Core Access";
+	pixel_x = 4;
+	req_access_txt = "16"
+	},
+/obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
 	freerange = 1;
 	listening = 0;
@@ -17878,16 +17640,6 @@
 	pixel_x = -10;
 	pixel_y = -25
 	},
-/obj/machinery/door/window{
-	base_state = "rightsecure";
-	dir = 4;
-	icon_state = "rightsecure";
-	layer = 4.1;
-	name = "Secondary AI Core Access";
-	pixel_x = 4;
-	req_access_txt = "16"
-	},
-/obj/effect/landmark/start/ai/secondary,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bEg" = (
@@ -17912,6 +17664,16 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bEm" = (
+/obj/machinery/door/window{
+	base_state = "leftsecure";
+	dir = 8;
+	icon_state = "leftsecure";
+	layer = 4.1;
+	name = "Tertiary AI Core Access";
+	pixel_x = -3;
+	req_access_txt = "16"
+	},
+/obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
 	freerange = 1;
 	listening = 0;
@@ -17931,16 +17693,6 @@
 	pixel_x = 10;
 	pixel_y = -25
 	},
-/obj/machinery/door/window{
-	base_state = "leftsecure";
-	dir = 8;
-	icon_state = "leftsecure";
-	layer = 4.1;
-	name = "Tertiary AI Core Access";
-	pixel_x = -3;
-	req_access_txt = "16"
-	},
-/obj/effect/landmark/start/ai/secondary,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bEP" = (
@@ -18126,12 +17878,10 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "bFQ" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/security/warden)
 "bFR" = (
@@ -18166,6 +17916,21 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "bFT" = (
+/obj/machinery/button/door{
+	id = "aicorewindow";
+	name = "AI Core Shutters";
+	pixel_x = 24;
+	pixel_y = -22;
+	req_access_txt = "16"
+	},
+/obj/machinery/button/door{
+	id = "aicoredoor";
+	name = "AI Chamber Access Control";
+	pixel_x = -23;
+	pixel_y = -23;
+	req_access_txt = "16"
+	},
+/obj/effect/landmark/start/ai,
 /obj/item/radio/intercom{
 	freerange = 1;
 	name = "Common Channel";
@@ -18185,21 +17950,6 @@
 	pixel_x = 27;
 	pixel_y = -7
 	},
-/obj/machinery/button/door{
-	id = "aicorewindow";
-	name = "AI Core Shutters";
-	pixel_x = 24;
-	pixel_y = -22;
-	req_access_txt = "16"
-	},
-/obj/machinery/button/door{
-	id = "aicoredoor";
-	name = "AI Chamber Access Control";
-	pixel_x = -23;
-	pixel_y = -23;
-	req_access_txt = "16"
-	},
-/obj/effect/landmark/start/ai,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bFU" = (
@@ -18602,15 +18352,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bIG" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bIK" = (
@@ -18936,11 +18683,9 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "bJy" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "bJz" = (
@@ -19018,9 +18763,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "bJH" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -19034,6 +18776,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "bJI" = (
@@ -19152,11 +18895,6 @@
 /turf/open/floor/iron,
 /area/medical/morgue)
 "bKh" = (
-/obj/item/radio/intercom{
-	frequency = 1423;
-	name = "Interrogation Intercom";
-	pixel_y = -58
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19251,14 +18989,12 @@
 /area/science/research)
 "bKV" = (
 /obj/structure/disposalpipe/segment,
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bKW" = (
@@ -19288,10 +19024,6 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "bKZ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 32
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19302,6 +19034,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26;
+	pixel_y = 32
 	},
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
@@ -19611,11 +19347,9 @@
 /area/tcommsat/computer)
 "bMy" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/item/folder/blue,
 /obj/item/pen,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/grimy,
 /area/tcommsat/computer)
 "bMz" = (
@@ -19648,21 +19382,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bMD" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/item/kirbyplants/random,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/grimy,
 /area/tcommsat/computer)
 "bME" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/item/book/manual/wiki/tcomms,
 /obj/item/radio{
 	pixel_y = 5
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/grimy,
 /area/tcommsat/computer)
 "bMF" = (
@@ -19690,9 +19420,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
-	},
 /obj/machinery/camera{
 	c_tag = "Detective's Office";
 	dir = 4
@@ -19707,6 +19434,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "bMY" = (
@@ -19797,14 +19525,11 @@
 /area/security/detectives_office)
 "bNh" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bNi" = (
@@ -19885,9 +19610,6 @@
 /turf/open/floor/iron,
 /area/security/warden)
 "bNo" = (
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/structure/bed/dogbed/mcgriff,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -19897,6 +19619,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/pet/dog/pug/mcgriff,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/security/warden)
 "bNp" = (
@@ -19928,9 +19651,6 @@
 	pixel_y = -2
 	},
 /obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -19941,6 +19661,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "bNr" = (
@@ -19952,9 +19673,6 @@
 	},
 /obj/item/storage/lockbox/loyalty,
 /obj/structure/table/reinforced,
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -19965,6 +19683,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "bNs" = (
@@ -20024,10 +19743,6 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "bNw" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -20038,6 +19753,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "bNx" = (
@@ -20111,9 +19827,7 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_y = -24
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "bOf" = (
@@ -20581,13 +20295,6 @@
 	id = "AI";
 	pixel_x = -26
 	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "AI Intercom";
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -20600,6 +20307,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "AI Intercom";
+	pixel_x = 28
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bPH" = (
@@ -20646,13 +20360,10 @@
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/engineering)
 "bQh" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bQi" = (
@@ -20715,9 +20426,6 @@
 /obj/machinery/computer/message_monitor{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/item/paper/monitorkey,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20729,6 +20437,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "bQI" = (
@@ -20752,9 +20461,6 @@
 /obj/machinery/computer/telecomms/server{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -20765,6 +20471,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "bQX" = (
@@ -20803,10 +20510,6 @@
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "bRf" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20818,13 +20521,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "bRg" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -20838,6 +20538,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "bRh" = (
@@ -21081,14 +20782,12 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRz" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRA" = (
@@ -21198,12 +20897,10 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRK" = (
 /obj/machinery/teleport/hub,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRL" = (
@@ -21347,10 +21044,6 @@
 /area/tcommsat/computer)
 "bSK" = (
 /obj/structure/table/wood,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/item/phone{
 	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
 	pixel_x = -3;
@@ -21369,6 +21062,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "bSX" = (
@@ -21401,14 +21095,11 @@
 /area/security/detectives_office)
 "bTa" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bTb" = (
@@ -21448,10 +21139,6 @@
 /area/security/brig)
 "bTf" = (
 /obj/structure/table/reinforced,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/item/clipboard,
 /obj/item/toy/figure/warden,
 /obj/machinery/light{
@@ -21463,6 +21150,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/security/warden)
 "bTg" = (
@@ -21510,10 +21198,6 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -21524,6 +21208,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "bTj" = (
@@ -21776,9 +21461,6 @@
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/machinery/camera{
 	c_tag = "Security Post - Engineering";
 	dir = 8
@@ -21790,6 +21472,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bUk" = (
@@ -21810,13 +21493,10 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos)
 "bUm" = (
@@ -22045,12 +21725,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bUX" = (
@@ -22159,15 +21837,13 @@
 "bVl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /turf/open/floor/iron,
 /area/security/warden)
 "bVn" = (
@@ -22365,9 +22041,6 @@
 	name = "MiniSat Antechamber";
 	req_access_txt = "16"
 	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -22388,6 +22061,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVC" = (
@@ -22701,16 +22375,13 @@
 /area/security/checkpoint/engineering)
 "bWy" = (
 /obj/structure/table/reinforced,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/radio,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bWz" = (
@@ -23342,10 +23013,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bXY" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -23356,6 +23023,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bYa" = (
@@ -23411,10 +23079,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bYh" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -23425,6 +23089,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bYm" = (
@@ -23437,11 +23102,6 @@
 	pixel_x = -26;
 	pixel_y = -26
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -38;
-	pixel_y = -24
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -23452,6 +23112,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -38;
+	pixel_y = -24
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bYE" = (
@@ -23469,9 +23134,6 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bYF" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/machinery/light,
 /obj/machinery/computer/security{
 	dir = 1
@@ -23480,6 +23142,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bYG" = (
@@ -23498,10 +23161,6 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -32
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = -32
-	},
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
@@ -23512,6 +23171,10 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26;
+	pixel_y = -32
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
@@ -23549,12 +23212,10 @@
 /area/hallway/primary/port)
 "bYP" = (
 /obj/machinery/light,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bYQ" = (
@@ -23719,15 +23380,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bZw" = (
@@ -23793,9 +23451,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -23803,6 +23458,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bZC" = (
@@ -24114,15 +23770,15 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/item/radio/intercom{
 	broadcasting = 1;
 	frequency = 1447;
 	listening = 0;
 	name = "AI Intercom";
 	pixel_y = -26
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -24198,10 +23854,6 @@
 "cai" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -24212,13 +23864,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "caj" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -24230,6 +23879,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cak" = (
@@ -24273,13 +23923,6 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/borg,
 /obj/machinery/light,
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "AI Intercom";
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -24289,6 +23932,13 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "AI Intercom";
+	pixel_y = -26
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -24317,9 +23967,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "cao" = (
 /obj/item/kirbyplants/random,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/structure/sign/poster/official/ian{
 	pixel_y = -32
 	},
@@ -24333,6 +23980,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cap" = (
@@ -24668,14 +24316,14 @@
 	pixel_x = -38;
 	pixel_y = -26
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_x = -26;
 	pixel_y = -26
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/warden)
@@ -24882,23 +24530,18 @@
 /area/tcommsat/server)
 "ccT" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ccU" = (
 /obj/effect/spawner/randomsnackvend,
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -24910,6 +24553,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "ccV" = (
@@ -24984,15 +24628,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "cdb" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -25000,18 +24639,17 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "cdc" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "cdd" = (
@@ -25086,10 +24724,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "cdn" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -25100,6 +24734,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/security/brig)
 "cdo" = (
@@ -25120,10 +24755,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "cdp" = (
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = -7
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Security - Brig Aft";
@@ -25131,6 +24762,10 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_x = 26;
+	pixel_y = -7
 	},
 /turf/open/floor/iron,
 /area/security/brig)
@@ -25238,9 +24873,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cdA" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -25252,6 +24884,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cdY" = (
@@ -25343,9 +24976,6 @@
 	pixel_x = -2;
 	pixel_y = 5
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -25356,6 +24986,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "ceO" = (
@@ -25481,10 +25112,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/security/brig)
 "cfc" = (
@@ -25626,9 +25254,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "cfn" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -25638,6 +25263,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
 "cfo" = (
@@ -25957,13 +25583,13 @@
 /area/security/courtroom)
 "cgE" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/item/radio/intercom,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "cgF" = (
@@ -26001,9 +25627,6 @@
 /area/security/courtroom)
 "cgP" = (
 /obj/structure/table/reinforced,
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
-	},
 /obj/item/clipboard,
 /obj/item/toy/figure/secofficer,
 /obj/effect/turf_decal/tile/red{
@@ -26012,6 +25635,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /turf/open/floor/iron,
 /area/security/brig)
 "cgQ" = (
@@ -26117,10 +25741,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "cha" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32;
-	pixel_y = -64
-	},
 /obj/effect/landmark/start/security_officer,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -26132,6 +25752,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32;
+	pixel_y = -64
 	},
 /turf/open/floor/iron,
 /area/security/brig)
@@ -26193,10 +25817,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "chg" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32;
-	pixel_y = -32
-	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32;
 	pixel_y = 32
@@ -26205,6 +25825,10 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32;
+	pixel_y = -32
 	},
 /turf/open/floor/iron,
 /area/security/brig)
@@ -26479,13 +26103,10 @@
 /area/maintenance/central/secondary)
 "cik" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cim" = (
@@ -26584,9 +26205,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "ciB" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -26601,6 +26219,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/security/brig)
 "ciC" = (
@@ -26692,10 +26311,6 @@
 /area/security/brig)
 "ciI" = (
 /obj/structure/table/reinforced,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/item/radio{
 	pixel_x = 5;
 	pixel_y = 5
@@ -26717,6 +26332,7 @@
 	pixel_x = -26;
 	pixel_y = -26
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/security/brig)
 "ciJ" = (
@@ -27206,9 +26822,6 @@
 /area/security/courtroom)
 "ckb" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
 /obj/item/folder/yellow{
 	pixel_x = 3;
 	pixel_y = 3
@@ -27225,6 +26838,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
@@ -27269,9 +26885,6 @@
 "ckn" = (
 /obj/structure/table/reinforced,
 /obj/item/ai_module/reset,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -27282,6 +26895,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cko" = (
@@ -27334,13 +26948,6 @@
 "ckt" = (
 /obj/structure/table/reinforced,
 /obj/item/ai_module/supplied/quarantine,
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "AI Intercom";
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -27351,6 +26958,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "ckJ" = (
@@ -27376,9 +26984,7 @@
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "ckN" = (
@@ -27848,12 +27454,10 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "cmw" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cmA" = (
@@ -27964,11 +27568,11 @@
 /area/security/courtroom)
 "cmU" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "cmV" = (
@@ -28004,9 +27608,6 @@
 	dir = 8;
 	name = "Judge"
 	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -28017,6 +27618,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "cmZ" = (
@@ -28364,10 +27966,6 @@
 "cny" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -28378,6 +27976,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cnI" = (
@@ -28470,9 +28069,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cot" = (
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/warrant{
 	dir = 4
@@ -28487,6 +28083,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "cov" = (
@@ -28553,13 +28150,11 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "coA" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "coB" = (
@@ -28647,10 +28242,6 @@
 /area/security/range)
 "coP" = (
 /obj/structure/table/reinforced,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/item/gun/energy/laser/practice{
 	pixel_x = 3;
 	pixel_y = -3
@@ -28662,6 +28253,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/security/range)
 "coQ" = (
@@ -28724,11 +28316,9 @@
 "cpo" = (
 /obj/structure/tank_dispenser,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/maintenance/port)
 "cpp" = (
@@ -28749,16 +28339,13 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "cpI" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/structure/tank_holder/oxygen/red,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/tcommsat/server)
 "cpJ" = (
@@ -28782,20 +28369,14 @@
 /turf/open/floor/iron,
 /area/tcommsat/server)
 "cpL" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/tcommsat/server)
 "cpM" = (
 /obj/structure/table,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/book/manual/wiki/tcomms,
 /obj/item/wrench,
@@ -28803,6 +28384,7 @@
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/tcommsat/server)
 "cpV" = (
@@ -29019,10 +28601,6 @@
 /area/hallway/secondary/command)
 "crh" = (
 /obj/structure/table,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -29034,6 +28612,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "crj" = (
@@ -29082,7 +28661,6 @@
 /area/security/courtroom)
 "crm" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -29093,6 +28671,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "crn" = (
@@ -29394,9 +28973,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "csw" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -29406,6 +28982,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "csx" = (
@@ -29449,9 +29026,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "csA" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -29461,6 +29035,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "csB" = (
@@ -29560,10 +29135,6 @@
 /area/hallway/primary/central)
 "csK" = (
 /obj/machinery/vending/coffee,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = -32
 	},
@@ -29577,6 +29148,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "csL" = (
@@ -29822,13 +29394,10 @@
 /area/maintenance/starboard)
 "ctE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/maintenance/port)
 "ctF" = (
@@ -29899,14 +29468,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ctU" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ctV" = (
@@ -30016,10 +29582,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "cup" = (
@@ -30037,12 +29600,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "cuq" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "cur" = (
@@ -30130,14 +29690,12 @@
 /area/maintenance/port)
 "cvf" = (
 /obj/structure/table/reinforced,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/item/clipboard,
 /obj/item/folder/blue,
 /obj/item/electronics/firelock,
 /obj/item/stack/sheet/glass,
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/maintenance/port)
 "cvg" = (
@@ -30371,9 +29929,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -30383,6 +29938,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cvV" = (
@@ -30417,15 +29973,12 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cwL" = (
@@ -30469,13 +30022,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cwY" = (
@@ -30925,15 +30475,12 @@
 	},
 /area/maintenance/port)
 "czP" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cAW" = (
@@ -30971,19 +30518,15 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "cBG" = (
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cCv" = (
 /obj/structure/dresser,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hos)
 "cCC" = (
@@ -31047,10 +30590,8 @@
 "cEj" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/maintenance/port)
 "cEk" = (
@@ -31160,12 +30701,12 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden/abandoned)
 "cFL" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/machinery/airalarm/unlocked{
 	dir = 4;
 	pixel_x = -23
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -31179,10 +30720,7 @@
 "cGa" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cGb" = (
@@ -31349,9 +30887,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cIB" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -31361,6 +30896,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cIC" = (
@@ -31427,9 +30963,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cII" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -31439,6 +30972,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cIJ" = (
@@ -31516,9 +31050,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cIQ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -31528,6 +31059,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cIR" = (
@@ -33091,24 +32623,20 @@
 /area/medical/storage)
 "cNM" = (
 /obj/structure/closet/secure_closet/medical3,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/medical/storage)
 "cNN" = (
 /obj/structure/closet/secure_closet/medical3,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/medical/storage)
 "cNO" = (
@@ -33122,16 +32650,13 @@
 "cNP" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/requests_console{
 	department = "Medbay Storage";
 	name = "Medbay Storage RC";
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/medical/storage)
 "cNQ" = (
@@ -33271,24 +32796,20 @@
 /area/maintenance/department/electrical)
 "cOt" = (
 /obj/structure/table/reinforced,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
 /obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "cOu" = (
 /obj/structure/table/reinforced,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/item/electronics/apc{
 	pixel_x = 3;
 	pixel_y = 3
 	},
 /obj/item/electronics/apc,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "cOv" = (
@@ -33340,9 +32861,6 @@
 /area/maintenance/department/electrical)
 "cOA" = (
 /obj/structure/table/reinforced,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/item/stack/cable_coil{
 	pixel_x = 3;
 	pixel_y = 3
@@ -33350,6 +32868,7 @@
 /obj/item/stack/cable_coil,
 /obj/item/multitool,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "cOB" = (
@@ -33771,13 +33290,10 @@
 "cPx" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cPy" = (
@@ -34023,15 +33539,12 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "cQe" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/valve,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "cQf" = (
@@ -34234,9 +33747,6 @@
 /turf/open/floor/iron,
 /area/science/research)
 "cQA" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -34246,6 +33756,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science/research)
 "cQB" = (
@@ -34276,15 +33787,7 @@
 /area/security/checkpoint/science/research)
 "cQE" = (
 /obj/structure/closet/secure_closet/security/science,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/red{
@@ -34296,6 +33799,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26;
+	pixel_y = 32
+	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "cQF" = (
@@ -34304,15 +33812,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "cQG" = (
@@ -34932,12 +34438,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "cRW" = (
@@ -35383,33 +34887,23 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "cSO" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light_switch{
 	pixel_x = 38
 	},
 /obj/structure/closet/secure_closet/security/med,
-/obj/machinery/airalarm{
-	pixel_x = 32;
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -35417,6 +34911,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/airalarm{
+	pixel_x = 32;
+	pixel_y = 23
+	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "cSS" = (
@@ -35799,10 +35298,8 @@
 /area/science/xenobiology)
 "cTQ" = (
 /obj/machinery/monkey_recycler,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "cTR" = (
@@ -35840,15 +35337,11 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/syringes,
-/obj/item/radio/intercom{
-	pixel_y = 32
-	},
 /obj/item/extinguisher/mini,
 /obj/item/storage/box/monkeycubes,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/delivery,
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "cTW" = (
@@ -36424,9 +35917,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -36434,6 +35924,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -36674,10 +36165,10 @@
 	pixel_y = -3;
 	req_access_txt = "55"
 	},
+/obj/effect/turf_decal/bot,
 /obj/item/radio/intercom{
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "cVE" = (
@@ -37133,14 +36624,14 @@
 	pixel_x = -8;
 	pixel_y = -24
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_x = 32;
 	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
@@ -37550,10 +37041,6 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "cXq" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -37571,6 +37058,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "cXr" = (
@@ -37579,17 +37067,11 @@
 /obj/item/electronics/airlock,
 /obj/item/stack/sheet/glass,
 /obj/item/assembly/signaler,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/science/research)
 "cXs" = (
@@ -37718,13 +37200,10 @@
 /area/medical/medbay/central)
 "cXK" = (
 /obj/structure/bed/roller,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cXL" = (
@@ -37862,9 +37341,6 @@
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -37872,6 +37348,7 @@
 	dir = 4
 	},
 /obj/structure/tank_holder/oxygen,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "cYd" = (
@@ -38028,13 +37505,11 @@
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "cYB" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/structure/closet/toolcloset,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "cYC" = (
@@ -38409,17 +37884,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"cZs" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "cZt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -38486,16 +37950,13 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "cZA" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cZB" = (
@@ -38510,10 +37971,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cZC" = (
@@ -38559,10 +38017,6 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "cZE" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -38576,6 +38030,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26;
+	pixel_y = -32
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "cZJ" = (
@@ -38588,15 +38046,13 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cZL" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "cZM" = (
@@ -38887,10 +38343,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "dav" = (
@@ -39167,12 +38620,10 @@
 	pixel_x = 3
 	},
 /obj/item/reagent_containers/dropper,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "dbc" = (
@@ -39334,10 +38785,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "dbw" = (
@@ -39653,15 +39101,12 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dcd" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "dce" = (
@@ -39932,13 +39377,10 @@
 	},
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/micro_laser,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/science/lab)
 "dcF" = (
@@ -40089,15 +39531,13 @@
 /obj/machinery/computer/crew{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dcV" = (
@@ -40261,10 +39701,8 @@
 /area/medical/medbay/central)
 "ddk" = (
 /obj/machinery/vending/cigarette,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "ddl" = (
@@ -40385,12 +39823,9 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ddS" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/secure_closet/cytology,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "ddT" = (
@@ -40427,24 +39862,17 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "ddW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/science/research)
 "ddY" = (
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
 /obj/structure/closet/emcloset,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/science/research)
 "ddZ" = (
@@ -40495,12 +39923,10 @@
 /obj/item/stock_parts/capacitor,
 /obj/item/stock_parts/manipulator,
 /obj/item/stock_parts/manipulator,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/science/lab)
 "dee" = (
@@ -40682,10 +40108,7 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/light/small,
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dex" = (
@@ -40747,10 +40170,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/command/heads_quarters/cmo)
 "deG" = (
@@ -40805,14 +40225,11 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "deN" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
 	pixel_y = 4
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "deO" = (
@@ -41168,10 +40585,6 @@
 	},
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/item/reagent_containers/dropper,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -41182,6 +40595,7 @@
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "dfB" = (
@@ -41442,9 +40856,6 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "dgy" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/machinery/camera{
 	c_tag = "Science - Port";
 	name = "science camera";
@@ -41459,6 +40870,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/science/research)
 "dgz" = (
@@ -41869,15 +41281,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dhf" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/wood,
+/area/command/meeting_room/council)
 "dhg" = (
 /obj/structure/table,
 /obj/item/storage/secure/briefcase,
@@ -42858,16 +42264,13 @@
 /turf/closed/wall,
 /area/science/nanite)
 "djL" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/science/research)
 "djM" = (
@@ -42930,10 +42333,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /obj/machinery/cell_charger,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/machinery/light_switch{
 	pixel_x = -26;
 	pixel_y = -26
@@ -42941,6 +42340,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/science/lab)
 "djZ" = (
@@ -42980,12 +42380,10 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/dropper,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/science/lab)
 "dkd" = (
@@ -43046,14 +42444,12 @@
 /area/hallway/primary/aft)
 "dkg" = (
 /obj/machinery/chem_master,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -32;
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/medical/pharmacy)
 "dkh" = (
@@ -43083,10 +42479,6 @@
 /obj/structure/table/glass,
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -43094,6 +42486,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "dkk" = (
@@ -43111,10 +42504,6 @@
 	pixel_x = 10;
 	pixel_y = -26
 	},
-/obj/item/radio/intercom{
-	pixel_x = -4;
-	pixel_y = -26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -43122,6 +42511,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -4;
+	pixel_y = -26
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
@@ -43411,10 +42804,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "dkM" = (
@@ -43689,12 +43079,10 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "dlL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/science/research)
 "dlM" = (
@@ -43843,13 +43231,6 @@
 "dmt" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/med_data/laptop,
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -43860,6 +43241,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26;
+	pixel_y = -32
+	},
+/obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "dmu" = (
@@ -43916,14 +43302,11 @@
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "dmE" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "dmF" = (
@@ -44024,11 +43407,8 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/science/research)
 "dmY" = (
@@ -44045,14 +43425,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "dna" = (
@@ -44155,15 +43530,13 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "dnn" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "dno" = (
@@ -44212,10 +43585,6 @@
 /area/medical/chemistry)
 "dnr" = (
 /obj/machinery/chem_heater/withbuffer,
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -44226,6 +43595,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "dnt" = (
@@ -44404,9 +43774,6 @@
 /area/medical/surgery)
 "dnK" = (
 /obj/structure/chair,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -44417,9 +43784,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "dnL" = (
@@ -45130,10 +44496,8 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "dpA" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dpB" = (
@@ -45148,10 +44512,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "dpC" = (
@@ -45216,13 +44577,10 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction)
 "dpJ" = (
@@ -45409,10 +44767,6 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45424,6 +44778,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "dqq" = (
@@ -45535,10 +44890,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/science/research)
 "dqL" = (
@@ -45755,11 +45107,8 @@
 /obj/machinery/light_switch{
 	pixel_x = 36
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/vending/assist,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "drG" = (
@@ -45796,10 +45145,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "drJ" = (
@@ -45850,9 +45196,6 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45864,6 +45207,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "drN" = (
@@ -46057,13 +45401,10 @@
 /area/hallway/primary/aft)
 "dsn" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "dsq" = (
@@ -46162,13 +45503,10 @@
 "dsJ" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dsK" = (
@@ -46184,12 +45522,10 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/machinery/iv_drip,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dsM" = (
@@ -46346,13 +45682,10 @@
 /area/science/nanite)
 "dti" = (
 /obj/structure/closet/bombcloset,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/science/mixing)
 "dtj" = (
@@ -46434,12 +45767,10 @@
 /area/science/robotics/mechbay)
 "dtz" = (
 /obj/structure/disposalpipe/segment,
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "dtG" = (
@@ -46508,16 +45839,13 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dtQ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dtR" = (
@@ -46562,10 +45890,6 @@
 /turf/open/floor/iron,
 /area/medical/surgery)
 "dtU" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/structure/mirror{
 	pixel_x = 26;
 	pixel_y = 32
@@ -46573,6 +45897,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dtV" = (
@@ -46756,7 +46081,6 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "duz" = (
-/obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -46768,6 +46092,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "duB" = (
@@ -46817,14 +46142,11 @@
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "duF" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/science/mixing)
 "duG" = (
@@ -46897,16 +46219,16 @@
 /area/science/robotics/mechbay)
 "duZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24;
-	pixel_y = -26
-	},
 /obj/machinery/light_switch{
 	pixel_x = 26;
 	pixel_y = -38
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24;
+	pixel_y = -26
+	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "dva" = (
@@ -47568,10 +46890,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/blue,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dxq" = (
@@ -47769,16 +47089,13 @@
 "dyb" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/science/research)
 "dyc" = (
@@ -47845,13 +47162,11 @@
 /obj/machinery/computer/med_data{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dyE" = (
@@ -48347,10 +47662,8 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos/upper)
 "dAg" = (
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/blue,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dAh" = (
@@ -48393,13 +47706,11 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
 "dAl" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "dAm" = (
@@ -48537,11 +47848,8 @@
 	},
 /obj/item/clothing/glasses/welding,
 /obj/structure/table/reinforced,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "dAK" = (
@@ -48601,9 +47909,6 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "dAV" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -48618,6 +47923,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "dBc" = (
@@ -48945,12 +48251,10 @@
 	pixel_x = -6;
 	pixel_y = -6
 	},
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/science/mixing)
 "dCb" = (
@@ -48979,9 +48283,6 @@
 /area/science/mixing)
 "dCh" = (
 /obj/effect/spawner/randomcolavend,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -48992,6 +48293,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "dCn" = (
@@ -49273,14 +48575,11 @@
 	id = "aftstarboard";
 	name = "Starboard Quarter Solar Control"
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "dDg" = (
@@ -49313,10 +48612,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/science/research/abandoned)
 "dDk" = (
@@ -49411,12 +48707,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/science/research)
 "dDx" = (
@@ -49522,12 +48816,10 @@
 /area/science/robotics/lab)
 "dDH" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "dDI" = (
@@ -49592,9 +48884,6 @@
 	dir = 1
 	},
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -49605,6 +48894,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "dDR" = (
@@ -49866,19 +49156,15 @@
 /area/science/storage)
 "dEx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/science/storage)
 "dEy" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/science/storage)
 "dEz" = (
@@ -49890,24 +49176,15 @@
 /obj/item/crowbar,
 /obj/item/wrench,
 /obj/item/clothing/mask/gas,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/science/storage)
 "dEA" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
 "dEB" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/structure/table,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/item/clipboard,
 /obj/item/wrench,
 /obj/effect/turf_decal/tile/neutral{
@@ -49920,6 +49197,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "dEC" = (
@@ -50071,9 +49350,6 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/machinery/requests_console{
 	department = "Chemistry Lab";
 	name = "Chemistry RC";
@@ -50087,6 +49363,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "dES" = (
@@ -50095,13 +49372,11 @@
 /obj/item/stack/sheet/mineral/plasma{
 	pixel_y = 10
 	},
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "dET" = (
@@ -50111,9 +49386,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "dEV" = (
@@ -50205,10 +49478,6 @@
 /turf/open/floor/iron,
 /area/medical/morgue)
 "dFi" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -50221,6 +49490,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dFt" = (
@@ -50325,17 +49595,12 @@
 /turf/open/floor/iron,
 /area/science/misc_lab)
 "dFE" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/science/misc_lab)
 "dFG" = (
@@ -50409,15 +49674,13 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "dFM" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/science/storage)
 "dFN" = (
@@ -50444,13 +49707,10 @@
 /turf/open/floor/iron,
 /area/science/storage)
 "dFQ" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/science/storage)
 "dFR" = (
@@ -50615,12 +49875,9 @@
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "dGe" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "dGf" = (
@@ -50769,10 +50026,6 @@
 	pixel_x = 26;
 	pixel_y = 26
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -50783,6 +50036,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/medical/morgue)
 "dGA" = (
@@ -50828,10 +50082,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/item/kirbyplants/random,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plating,
 /area/security/detectives_office/private_investigators_office)
 "dGM" = (
@@ -51097,10 +50349,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "dHv" = (
@@ -51277,12 +50527,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/science/misc_lab)
 "dIk" = (
@@ -51609,9 +50857,6 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/science/server)
 "dII" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/machinery/camera{
 	c_tag = "Science - Aft";
 	dir = 4;
@@ -51621,6 +50866,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/science/research)
 "dIJ" = (
@@ -51656,10 +50902,8 @@
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/cell_charger,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "dIM" = (
@@ -51705,13 +50949,11 @@
 /obj/machinery/computer/operating{
 	dir = 1
 	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "dIR" = (
@@ -51893,10 +51135,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dJo" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/green,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dJp" = (
@@ -51985,12 +51225,12 @@
 /obj/machinery/doppler_array/research/science{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26;
 	pixel_y = -32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
 	},
 /turf/open/floor/iron,
 /area/science/misc_lab)
@@ -52020,11 +51260,8 @@
 /area/science/misc_lab)
 "dJO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/science/misc_lab)
 "dJQ" = (
@@ -52064,14 +51301,12 @@
 /area/science/mixing)
 "dJU" = (
 /obj/structure/rack,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/item/clothing/suit/fire/firefighter,
 /obj/item/clothing/head/hardhat/red,
 /obj/item/clothing/mask/gas,
 /obj/machinery/light,
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/science/mixing)
 "dJV" = (
@@ -52084,13 +51319,11 @@
 "dJW" = (
 /obj/machinery/disposal/bin,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/science/mixing)
 "dJX" = (
@@ -52244,10 +51477,7 @@
 "dKs" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office/private_investigators_office)
 "dKt" = (
@@ -52273,10 +51503,6 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/storage/box/evidence,
 /obj/item/taperecorder,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -52287,6 +51513,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/detectives_office/private_investigators_office)
 "dKw" = (
@@ -52965,9 +52192,6 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -52977,6 +52201,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/science/research)
 "dMd" = (
@@ -52994,15 +52219,13 @@
 /turf/open/floor/iron,
 /area/science/research)
 "dMe" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/science/research)
 "dMf" = (
@@ -53027,10 +52250,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/science/research)
 "dMh" = (
@@ -53791,14 +53011,11 @@
 /area/science/research)
 "dNI" = (
 /obj/structure/chair/stool,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/science/research)
 "dNK" = (
@@ -54193,15 +53410,8 @@
 /area/maintenance/port/aft)
 "dOz" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -54212,6 +53422,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs/auxiliary)
 "dOA" = (
@@ -54246,10 +53458,6 @@
 /area/security/checkpoint/customs/auxiliary)
 "dOC" = (
 /obj/structure/filingcabinet/medical,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -54257,6 +53465,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs/auxiliary)
 "dOD" = (
@@ -54272,10 +53481,7 @@
 	icon_state = "plant-21"
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "dOE" = (
@@ -54308,18 +53514,14 @@
 /area/hallway/primary/aft)
 "dOH" = (
 /obj/structure/table,
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "dOI" = (
@@ -54453,15 +53655,13 @@
 /area/science/research)
 "dOZ" = (
 /obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/item/clipboard,
 /obj/item/folder,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/science/research)
 "dPb" = (
@@ -54680,9 +53880,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -54693,6 +53890,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/science/research)
 "dPO" = (
@@ -54895,14 +54093,11 @@
 	dir = 8;
 	name = "emergency shower"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/medical/virology)
 "dQf" = (
@@ -54963,13 +54158,7 @@
 /area/medical/virology)
 "dQm" = (
 /obj/structure/table/glass,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/item/paper_bin,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32;
 	pixel_y = 32
@@ -54977,6 +54166,8 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dQn" = (
@@ -55003,13 +54194,11 @@
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dQr" = (
@@ -55147,10 +54336,6 @@
 /area/security/checkpoint/customs/auxiliary)
 "dQN" = (
 /obj/structure/table/reinforced,
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = -32
-	},
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/tile/blue{
@@ -55159,6 +54344,10 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	pixel_y = -32
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/customs/auxiliary)
@@ -55295,10 +54484,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/medical/virology)
 "dQZ" = (
@@ -55420,9 +54606,6 @@
 /turf/closed/wall,
 /area/medical/virology)
 "dRl" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/structure/table/glass,
 /obj/item/flashlight/lamp,
 /obj/effect/turf_decal/tile/neutral{
@@ -55435,6 +54618,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "dRm" = (
@@ -55459,9 +54643,6 @@
 	dir = 8;
 	pixel_y = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
 	},
@@ -55475,6 +54656,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "dRx" = (
@@ -55793,10 +54975,8 @@
 "dSa" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/light/small,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/medical/virology)
 "dSb" = (
@@ -55808,10 +54988,6 @@
 /turf/open/floor/iron,
 /area/medical/virology)
 "dSd" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -55819,6 +54995,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dSe" = (
@@ -56251,12 +55428,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "dTE" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "dTF" = (
@@ -56334,26 +55509,21 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "dTR" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dTS" = (
 /obj/structure/chair/wood,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/camera{
 	c_tag = "Chapel - Starboard";
 	dir = 8;
 	name = "chapel camera"
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron{
 	icon_state = "chapel"
 	},
@@ -56369,10 +55539,6 @@
 "dTU" = (
 /obj/machinery/light/small{
 	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
 	},
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = -32
@@ -56390,6 +55556,7 @@
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "dTV" = (
@@ -56432,10 +55599,6 @@
 /area/medical/virology)
 "dTX" = (
 /obj/structure/table,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/microwave{
 	desc = "Cooks and boils stuff, somehow.";
 	pixel_x = -3;
@@ -56451,6 +55614,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "dTY" = (
@@ -56711,15 +55875,13 @@
 /area/medical/virology)
 "dVz" = (
 /obj/structure/closet/crate/freezer/blood,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/machinery/camera{
 	c_tag = "Virology - Lab";
 	name = "virology camera";
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/medical/virology)
 "dVA" = (
@@ -56733,9 +55895,6 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dVC" = (
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/machinery/camera{
 	c_tag = "Virology - Hallway";
 	dir = 8;
@@ -56748,6 +55907,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dVD" = (
@@ -57371,10 +56531,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dXU" = (
 /obj/structure/table/glass,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/item/book/manual/wiki/infections,
 /obj/item/reagent_containers/syringe/antiviral,
 /obj/item/reagent_containers/dropper,
@@ -57389,6 +56545,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/medical/virology)
 "dXV" = (
@@ -57462,12 +56619,10 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dYf" = (
@@ -57490,17 +56645,13 @@
 /area/medical/virology)
 "dYi" = (
 /obj/structure/table/glass,
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dYu" = (
@@ -57626,19 +56777,14 @@
 /turf/open/floor/iron,
 /area/medical/virology)
 "dYV" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/light_switch{
 	pixel_x = 26;
 	pixel_y = -26
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/east,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/medical/virology)
 "dYW" = (
@@ -57818,9 +56964,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dZu" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/item/storage/photo_album/bar{
 	pixel_x = -6;
 	pixel_y = 6
@@ -57839,6 +56982,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "dZx" = (
@@ -57901,15 +57045,12 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dZE" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dZF" = (
@@ -57921,9 +57062,6 @@
 /area/medical/virology)
 "dZG" = (
 /obj/structure/table/glass,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/item/paper_bin,
 /obj/machinery/camera{
 	c_tag = "Virology - Cells";
@@ -57932,6 +57070,7 @@
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/green,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dZH" = (
@@ -58287,9 +57426,6 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "eaR" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/structure/cable,
 /obj/machinery/power/terminal{
 	dir = 4
@@ -58297,6 +57433,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "eaS" = (
@@ -58741,11 +57878,8 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "ecm" = (
@@ -58762,10 +57896,6 @@
 /area/maintenance/solars/port/aft)
 "eco" = (
 /obj/structure/table/reinforced,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/item/multitool,
@@ -58780,6 +57910,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/maintenance/port/aft)
 "ecp" = (
@@ -58819,9 +57950,6 @@
 /area/maintenance/port/aft)
 "ecu" = (
 /obj/structure/table/reinforced,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/gloves/color/black,
@@ -58841,6 +57969,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/maintenance/port/aft)
 "ecv" = (
@@ -59218,10 +58347,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "edB" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/camera{
 	c_tag = "Departures - Aft";
 	dir = 1;
@@ -59234,6 +58359,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "edC" = (
@@ -59303,11 +58429,9 @@
 /area/maintenance/port/aft)
 "edR" = (
 /obj/structure/table/reinforced,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/flashlight,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "edX" = (
@@ -59467,10 +58591,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "eeH" = (
 /obj/structure/filingcabinet/security,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/machinery/light_switch{
 	pixel_x = -26;
 	pixel_y = 26
@@ -59487,6 +58607,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "eeI" = (
@@ -59863,9 +58984,6 @@
 "egh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -59873,6 +58991,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "egi" = (
@@ -59931,10 +59050,6 @@
 /area/security/checkpoint/escape)
 "egm" = (
 /obj/structure/closet/secure_closet/security,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -59943,6 +59058,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "egn" = (
@@ -59989,10 +59105,6 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Security - Departures Starboard";
@@ -60005,6 +59117,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "egw" = (
@@ -60084,14 +59197,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ehG" = (
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/effect/turf_decal/stripes/box,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "ehH" = (
@@ -60104,9 +59215,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "ehI" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/stack/package_wrap,
@@ -60114,6 +59222,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "ehL" = (
@@ -60276,15 +59385,13 @@
 /obj/structure/table/glass,
 /obj/item/folder/blue,
 /obj/item/clothing/glasses/hud/health,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -60341,17 +59448,6 @@
 /obj/structure/filingcabinet/security,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
-"emJ" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "emM" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -60385,10 +59481,8 @@
 /obj/machinery/door/window/eastright{
 	name = "Theater Stage"
 	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/grimy,
 /area/service/bar/atrium)
 "enq" = (
@@ -60932,11 +60026,8 @@
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
 /obj/item/radio,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/command/teleporter)
 "eyL" = (
@@ -61119,9 +60210,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "eAP" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/structure/sign/painting/library_private{
 	pixel_x = 32;
 	pixel_y = 32
@@ -61139,6 +60227,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "eBv" = (
@@ -61348,13 +60437,11 @@
 "eHP" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "eIe" = (
@@ -61460,10 +60547,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "eJG" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/light/small,
 /obj/structure/closet/crate/goldcrate,
 /obj/effect/turf_decal/tile/neutral{
@@ -61476,6 +60559,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "eJR" = (
@@ -61483,10 +60567,7 @@
 	pixel_x = -26;
 	pixel_y = 26
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "eJS" = (
@@ -61517,10 +60598,8 @@
 /area/cargo/sorting)
 "eKo" = (
 /obj/structure/kitchenspike,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "eKq" = (
@@ -61555,13 +60634,10 @@
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "eLv" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "eLC" = (
@@ -61600,10 +60676,8 @@
 "eLV" = (
 /obj/structure/table/wood,
 /obj/item/folder,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/item/razor,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "eLY" = (
@@ -61960,14 +61034,12 @@
 /obj/item/wrench,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/tank/internals/emergency_oxygen/engi,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/item/stock_parts/cell/emproof{
 	pixel_x = 4;
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eSH" = (
@@ -62043,9 +61115,6 @@
 	},
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/micro_laser,
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -62056,6 +61125,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "eTV" = (
@@ -62086,10 +61156,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/effect/mapping_helpers/ianbirthday,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "eUy" = (
@@ -62202,10 +61270,6 @@
 /area/hallway/primary/port)
 "eWx" = (
 /obj/structure/window/reinforced,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -62219,6 +61283,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "eWR" = (
@@ -62517,9 +61582,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "faN" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Aft";
 	name = "atmospherics camera"
@@ -62533,6 +61595,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -62560,13 +61623,6 @@
 "fbr" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1423;
-	listening = 0;
-	name = "Interrogation Intercom";
-	pixel_y = -24
-	},
 /obj/machinery/camera{
 	c_tag = "Security - Interrogation";
 	dir = 1
@@ -62580,6 +61636,13 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1423;
+	listening = 0;
+	name = "Interrogation Intercom";
+	pixel_y = -24
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -62710,13 +61773,10 @@
 /area/engineering/main)
 "fdT" = (
 /obj/machinery/suit_storage_unit/ce,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "fec" = (
@@ -62765,10 +61825,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "feJ" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_y = -27
-	},
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -62780,13 +61836,11 @@
 	dir = 10
 	},
 /obj/machinery/light/small,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos/upper)
 "feM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Gravity Generator Foyer";
 	dir = 4;
@@ -62795,13 +61849,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "ffh" = (
 /obj/machinery/light/small,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plating,
 /area/commons/toilet/auxiliary)
 "ffo" = (
@@ -62933,12 +61986,6 @@
 "fhW" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -62949,6 +61996,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "fiz" = (
@@ -62963,9 +62012,6 @@
 /area/command/bridge)
 "fiJ" = (
 /obj/structure/dresser,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
@@ -62979,6 +62025,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/service/theater)
 "fiN" = (
@@ -62992,10 +62039,6 @@
 /area/engineering/main)
 "fjo" = (
 /obj/structure/table/wood,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/machinery/light_switch{
 	pixel_y = -26
 	},
@@ -63004,16 +62047,15 @@
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/glass,
 /obj/item/circuitboard/machine/microwave,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/electronic_marketing_den)
 "fjp" = (
 /obj/structure/closet/secure_closet/quartermaster,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "fjr" = (
@@ -63067,10 +62109,7 @@
 /area/service/kitchen)
 "fjU" = (
 /obj/machinery/vending/wardrobe/law_wardrobe,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "fkq" = (
@@ -63139,9 +62178,6 @@
 /area/service/abandoned_gambling_den)
 "fno" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/mixingchamber{
-	pixel_y = 24
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -63155,6 +62191,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/airalarm/mixingchamber{
+	pixel_y = 24
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing/chamber)
@@ -63340,9 +62379,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "fqv" = (
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -63353,6 +62389,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "fqA" = (
@@ -63527,14 +62564,12 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ftB" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/structure/closet/emcloset/anchored,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "ftP" = (
@@ -63640,11 +62675,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/stripes/line,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/engineering/storage)
 "fwF" = (
@@ -63826,9 +62859,6 @@
 "fAl" = (
 /obj/structure/rack,
 /obj/item/storage/secure/briefcase,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -63839,6 +62869,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "fAt" = (
@@ -63922,13 +62953,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "fBM" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/checker,
 /area/engineering/break_room)
 "fBQ" = (
@@ -64537,10 +63565,7 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "fNp" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron{
 	dir = 4;
 	icon_state = "chapel"
@@ -65031,10 +64056,6 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "fUl" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light_switch{
 	pixel_x = 26;
 	pixel_y = -26
@@ -65049,6 +64070,7 @@
 	name = "service camera"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/service/theater)
 "fUK" = (
@@ -65067,11 +64089,9 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "fUL" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fVr" = (
@@ -65165,12 +64185,9 @@
 /obj/item/radio,
 /obj/item/radio,
 /obj/item/radio,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/command/gateway)
 "fWW" = (
@@ -65597,9 +64614,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/engineering/main)
 "ggq" = (
@@ -65966,13 +64981,11 @@
 /area/engineering/atmos)
 "gmF" = (
 /obj/machinery/light,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "gmN" = (
@@ -65980,14 +64993,6 @@
 /area/engineering/atmos)
 "gmP" = (
 /obj/structure/table/reinforced,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -65995,6 +65000,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "gni" = (
@@ -66112,12 +65119,10 @@
 /obj/structure/closet/toolcloset,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "gpr" = (
@@ -66179,12 +65184,10 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
 /obj/item/pen,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos)
 "gqN" = (
@@ -66302,9 +65305,6 @@
 "gvx" = (
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
 	c_tag = "Bridge - E.V.A. Fore";
@@ -66320,6 +65320,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "gvH" = (
@@ -66428,13 +65429,11 @@
 /turf/open/floor/carpet,
 /area/service/library)
 "gxL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "gyd" = (
@@ -66460,10 +65459,8 @@
 	desc = "A replica beret resembling that of a special operations officer under Nanotrasen.";
 	name = "replica officer's beret"
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/structure/cable,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/grimy,
 /area/command/corporate_showroom)
 "gyV" = (
@@ -67269,10 +66266,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gNw" = (
@@ -67422,10 +66416,7 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "gQS" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "gRl" = (
@@ -67478,10 +66469,6 @@
 "gSw" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -67492,6 +66479,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "gSF" = (
@@ -67780,10 +66768,12 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "gXJ" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/grimy,
 /area/service/library)
 "gXU" = (
 /obj/structure/table/reinforced,
@@ -68046,9 +67036,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -68059,6 +67046,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "hcO" = (
@@ -68104,6 +67092,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "hdq" = (
@@ -68164,10 +67153,7 @@
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
 "heQ" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "heR" = (
@@ -68192,14 +67178,14 @@
 /area/commons/vacant_room/commissary)
 "hft" = (
 /obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/flask/gold,
+/obj/item/razor,
 /obj/item/radio/intercom{
 	dir = 8;
 	freerange = 1;
 	name = "Captain's Intercom";
 	pixel_x = -26
 	},
-/obj/item/reagent_containers/food/drinks/flask/gold,
-/obj/item/razor,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain/private)
 "hfC" = (
@@ -68222,10 +67208,6 @@
 /area/security/prison)
 "hfV" = (
 /obj/structure/table/reinforced,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/item/clothing/gloves/color/yellow,
 /obj/machinery/light{
 	dir = 8
@@ -68235,6 +67217,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "hgm" = (
@@ -68270,10 +67253,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/science/research)
 "hgT" = (
@@ -68510,10 +67490,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "hjY" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -68523,6 +67499,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/commons/toilet/auxiliary)
 "hkj" = (
@@ -68651,9 +67628,7 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "hlW" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood,
 /area/service/theater/abandoned)
 "hmo" = (
@@ -68801,10 +67776,8 @@
 /area/service/abandoned_gambling_den)
 "hoS" = (
 /obj/machinery/vending/tool,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/delivery,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "hoW" = (
@@ -68952,10 +67925,6 @@
 /area/service/abandoned_gambling_den)
 "hra" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light_switch{
 	pixel_y = 26
 	},
@@ -68969,6 +67938,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "hrf" = (
@@ -69241,10 +68211,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "hxL" = (
@@ -69278,10 +68245,6 @@
 "hyF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -69289,18 +68252,16 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "hyQ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "hzc" = (
@@ -69419,10 +68380,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "hBy" = (
@@ -69515,6 +68473,7 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/south,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "hCQ" = (
@@ -69935,9 +68894,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -69946,6 +68902,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/cargo/office)
 "hJG" = (
@@ -70138,14 +69095,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -70259,16 +69213,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "hQM" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/office)
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "hQO" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -70529,10 +69479,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "hUv" = (
@@ -71186,13 +70133,11 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "igW" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "ihg" = (
@@ -71200,10 +70145,8 @@
 /obj/item/storage/belt/utility,
 /obj/item/weldingtool,
 /obj/item/clothing/head/welding,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "ihj" = (
@@ -71219,9 +70162,6 @@
 /turf/open/floor/iron/white,
 /area/service/janitor)
 "ihy" = (
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -71237,6 +70177,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "ihB" = (
@@ -71270,9 +70211,6 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -71283,15 +70221,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "iiL" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/grimy,
 /area/command/corporate_showroom)
 "iiN" = (
@@ -71907,9 +70843,6 @@
 /area/engineering/main)
 "isC" = (
 /obj/structure/cable,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -71917,6 +70850,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "isJ" = (
@@ -71954,16 +70888,16 @@
 /turf/open/floor/iron,
 /area/engineering/storage)
 "isY" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig - Workroom";
+	dir = 4;
+	network = list("ss13","prison")
+	},
 /obj/item/radio/intercom{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
 	name = "Prison Intercom (General)";
 	pixel_x = -30;
 	prison_radio = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig - Workroom";
-	dir = 4;
-	network = list("ss13","prison")
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -71998,12 +70932,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "itE" = (
@@ -72049,13 +70981,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "iuI" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/effect/turf_decal/arrows{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "iuR" = (
@@ -72430,12 +71359,10 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "iDb" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "iDp" = (
@@ -72486,11 +71413,8 @@
 /area/hallway/primary/fore)
 "iED" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "iEK" = (
@@ -72731,10 +71655,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "iKO" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -72752,6 +71672,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "iKS" = (
@@ -72857,10 +71778,6 @@
 	name = "trenchcoat"
 	},
 /obj/item/clothing/suit/toggle/lawyer/purple,
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/item/clothing/head/fedora{
 	icon_state = "detective"
 	},
@@ -72873,9 +71790,11 @@
 	icon_state = "curator"
 	},
 /obj/item/clothing/under/rank/civilian/curator/treasure_hunter,
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/item/radio/intercom{
+	pixel_x = 26;
+	pixel_y = 26
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "iMR" = (
@@ -72989,9 +71908,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -73001,14 +71917,12 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "iOz" = (
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -73117,13 +72031,11 @@
 /area/engineering/gravity_generator)
 "iSa" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -73229,14 +72141,11 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "iUx" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "iUJ" = (
@@ -73656,9 +72565,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/engineering/main)
 "jet" = (
@@ -73668,10 +72575,6 @@
 /area/security/prison)
 "jfc" = (
 /obj/structure/bodycontainer/morgue,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -73682,6 +72585,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "jfz" = (
@@ -73749,10 +72653,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "jgR" = (
@@ -73804,6 +72705,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "jhY" = (
@@ -73829,9 +72731,6 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/machinery/light/small,
 /obj/effect/turf_decal/bot,
 /obj/machinery/button/door{
@@ -73842,6 +72741,7 @@
 	specialfunctions = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/commons/toilet/auxiliary)
 "jiT" = (
@@ -73950,21 +72850,15 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/science/research)
 "jli" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
 "jlw" = (
@@ -74235,11 +73129,6 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "jsg" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 32
-	},
 /obj/machinery/light_switch{
 	pixel_x = -7;
 	pixel_y = 26
@@ -74247,6 +73136,11 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 32
 	},
 /turf/open/floor/iron,
 /area/service/kitchen)
@@ -74424,9 +73318,6 @@
 /obj/item/stack/package_wrap,
 /obj/item/crowbar,
 /obj/item/hand_labeler,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -74437,6 +73328,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/service/janitor)
 "jwg" = (
@@ -74496,9 +73388,6 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/machinery/light/small,
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/bot,
@@ -74510,6 +73399,7 @@
 	specialfunctions = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
 "jxq" = (
@@ -74550,11 +73440,6 @@
 /area/service/chapel/office)
 "jyl" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -24;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -74564,6 +73449,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = -24;
+	pixel_y = -24
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
@@ -74714,9 +73604,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/secure/briefcase,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -74727,13 +73614,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "jCg" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/button/door{
 	id = "ceblast";
 	name = "Lockdown Control";
@@ -74754,6 +73639,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "jCw" = (
@@ -74870,11 +73756,8 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "jDJ" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
 "jEc" = (
@@ -74943,14 +73826,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = 32
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -74958,6 +73833,11 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26;
+	pixel_y = 32
+	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "jEV" = (
@@ -75030,9 +73910,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -75040,6 +73917,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jGf" = (
@@ -75056,9 +73934,6 @@
 "jGr" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/donkpockets,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -75069,16 +73944,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "jGD" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -75092,6 +73964,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "jGJ" = (
@@ -75366,11 +74239,8 @@
 /area/engineering/atmos)
 "jKg" = (
 /obj/machinery/vending/autodrobe,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/light,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/service/theater)
 "jKu" = (
@@ -75533,9 +74403,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/commons/locker)
 "jMX" = (
@@ -75787,14 +74655,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "jSd" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/closet/secure_closet/personal,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -75802,6 +74663,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/airalarm/directional/south,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "jSe" = (
@@ -75907,9 +74770,6 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "jVE" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -75920,6 +74780,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/main)
 "jVO" = (
@@ -76034,11 +74895,9 @@
 /area/service/chapel/office)
 "jXt" = (
 /obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/item/folder/red,
 /obj/item/lighter,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood,
 /area/service/electronic_marketing_den)
 "jXQ" = (
@@ -76062,9 +74921,6 @@
 	},
 /area/service/library/abandoned)
 "jYF" = (
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/machinery/meter/atmos/atmos_waste_loop,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -76075,16 +74931,17 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos)
 "jYG" = (
 /obj/structure/dresser,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /obj/item/radio/intercom{
 	pixel_x = 26;
 	pixel_y = 26
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
@@ -76155,9 +75012,6 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "kaB" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/light_switch{
 	pixel_x = 26;
 	pixel_y = 26
@@ -76172,6 +75026,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "kaF" = (
@@ -76236,9 +75091,6 @@
 /area/service/chapel/main)
 "kbN" = (
 /obj/structure/table,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/item/stack/sheet/iron/five,
 /obj/item/circuitboard/machine/paystand,
 /obj/effect/turf_decal/tile/brown{
@@ -76247,6 +75099,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -76330,9 +75183,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "kep" = (
@@ -76408,9 +75259,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "kfz" = (
@@ -76544,10 +75393,6 @@
 /area/commons/toilet/restrooms)
 "khK" = (
 /obj/structure/table/wood,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/item/camera,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -76560,6 +75405,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "khQ" = (
@@ -76579,10 +75425,6 @@
 /area/commons/dorms)
 "kip" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch{
 	pixel_x = -10;
@@ -76591,14 +75433,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
 "kiw" = (
 /obj/machinery/disposal/bin,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/light,
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32;
@@ -76617,6 +75456,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "kiz" = (
@@ -76683,28 +75523,19 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
 	pixel_x = -32;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "kjm" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
 "kjo" = (
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -76714,6 +75545,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = 26;
+	pixel_y = 26
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -76902,14 +75737,11 @@
 /area/service/hydroponics/garden/abandoned)
 "knd" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "knk" = (
@@ -77009,9 +75841,6 @@
 	pixel_x = -38;
 	pixel_y = 7
 	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/machinery/button/door{
 	id = "hopline";
 	name = "Queue Shutters Control";
@@ -77045,6 +75874,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hop)
 "kpy" = (
@@ -77061,12 +75891,10 @@
 /area/security/prison)
 "kqi" = (
 /obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
 "kqB" = (
@@ -77477,9 +76305,7 @@
 	pixel_x = 3
 	},
 /obj/item/clothing/glasses/sunglasses,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "kzf" = (
@@ -77536,15 +76362,12 @@
 "kzo" = (
 /obj/structure/table,
 /obj/item/folder,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "kzu" = (
@@ -77553,10 +76376,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "kzH" = (
@@ -77642,13 +76462,8 @@
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/toy/figure/curator,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "kCy" = (
@@ -77840,15 +76655,15 @@
 /obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = 26;
+	pixel_y = -26
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/hos)
@@ -77974,20 +76789,13 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/ce)
 "kJd" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/item/kirbyplants/random,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "kJx" = (
 /obj/item/stack/rods{
 	amount = 25
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
 	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -78000,6 +76808,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "kJB" = (
@@ -78108,9 +76917,6 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "kLu" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/structure/table,
 /obj/item/raw_anomaly_core/random{
 	pixel_y = 9
@@ -78128,6 +76934,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "kLO" = (
@@ -78318,9 +77125,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/masks,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -78332,6 +77136,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "kQh" = (
@@ -78351,11 +77156,8 @@
 /area/security/office)
 "kQF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "kQG" = (
@@ -78643,9 +77445,6 @@
 /area/engineering/main)
 "kWN" = (
 /obj/item/kirbyplants/random,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -78656,6 +77455,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
 "kWO" = (
@@ -78723,10 +77523,8 @@
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "kYo" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "kYA" = (
@@ -78782,10 +77580,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "laj" = (
@@ -78837,12 +77632,10 @@
 	pixel_x = 7;
 	pixel_y = 3
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -79028,13 +77821,9 @@
 "lfn" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/purple,
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "lfq" = (
@@ -79218,10 +78007,6 @@
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "lij" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -79231,6 +78016,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/command/gateway)
 "liT" = (
@@ -79251,16 +78037,11 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "ljt" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -79271,6 +78052,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "lkh" = (
@@ -79524,13 +78306,11 @@
 /area/service/electronic_marketing_den)
 "loW" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/command/heads_quarters/cmo)
 "loX" = (
@@ -79901,10 +78681,8 @@
 /area/commons/dorms)
 "lvY" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/item/flashlight/lamp/green,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hop)
 "lwc" = (
@@ -80052,9 +78830,6 @@
 /turf/open/floor/iron/checker,
 /area/engineering/atmos)
 "lyx" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -80065,6 +78840,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "lyz" = (
@@ -80127,15 +78903,13 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "lze" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/security/office)
 "lzx" = (
@@ -80564,9 +79338,6 @@
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "lHI" = (
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Auxiliary Tool Storage";
@@ -80577,6 +79348,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "lHN" = (
@@ -80664,16 +79436,16 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_x = 32
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = -26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = 26;
+	pixel_y = -26
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -80734,9 +79506,7 @@
 "lKp" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/bookmanagement,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "lKq" = (
@@ -80798,14 +79568,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"lMf" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
-	},
-/turf/open/floor/iron/grimy,
-/area/command/heads_quarters/hos)
 "lMm" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -80983,9 +79745,6 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "lQc" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/machinery/light/small,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -80997,6 +79756,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/electronic_marketing_den)
 "lQg" = (
@@ -81092,11 +79852,6 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "lRM" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -81111,6 +79866,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 32
 	},
 /turf/open/floor/iron,
 /area/service/bar)
@@ -81275,16 +80035,13 @@
 /area/security/prison)
 "lUw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "lUx" = (
@@ -81326,10 +80083,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
 /area/service/library/abandoned)
 "lWi" = (
@@ -81342,9 +80096,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "lWJ" = (
@@ -81550,11 +80302,6 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "lZk" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
-	},
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
@@ -81575,6 +80322,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = -32
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
@@ -81650,10 +80402,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "mam" = (
@@ -81738,10 +80487,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
-"mbg" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/r_wall,
-/area/engineering/storage/tech)
 "mbF" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -81790,12 +80535,10 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/wrench,
 /obj/item/clothing/glasses/welding,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/science/lab)
 "mcF" = (
@@ -82081,16 +80824,10 @@
 /area/engineering/atmos)
 "mgF" = (
 /obj/structure/table/wood,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/item/storage/crayons,
 /obj/item/storage/crayons,
 /obj/item/flashlight/lamp/bananalamp{
 	pixel_y = 5
-	},
-/obj/item/radio/intercom{
-	pixel_y = 26
 	},
 /obj/item/toy/figure/clown,
 /obj/item/clipboard,
@@ -82104,6 +80841,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/service/theater)
 "mgW" = (
@@ -82152,12 +80891,12 @@
 /obj/item/weldingtool,
 /obj/item/clothing/head/welding,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/storage)
 "mhQ" = (
@@ -82182,17 +80921,11 @@
 	c_tag = "Art Gallery";
 	name = "library camera"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/wood,
 /area/service/library)
 "mif" = (
 /obj/structure/table/reinforced,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/item/storage/box/lights/mixed{
 	pixel_x = 3;
 	pixel_y = 3
@@ -82211,6 +80944,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/service/janitor)
 "mio" = (
@@ -82525,10 +81259,7 @@
 /obj/item/clothing/suit/toggle/lawyer,
 /obj/item/clothing/under/costume/maid,
 /obj/item/clothing/head/kitty,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "moT" = (
@@ -82577,9 +81308,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron{
 	icon_state = "chapel"
 	},
@@ -82640,15 +81369,12 @@
 /area/service/electronic_marketing_den)
 "mqR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/light/small,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
 "mrc" = (
@@ -82965,9 +81691,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "mxR" = (
@@ -83210,6 +81934,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "mBW" = (
@@ -83371,9 +82096,6 @@
 /turf/open/floor/iron,
 /area/engineering/storage)
 "mFt" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -83381,6 +82103,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron,
 /area/security/office)
 "mFE" = (
@@ -83475,15 +82198,12 @@
 "mIl" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "mIv" = (
@@ -83542,10 +82262,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/machinery/iv_drip,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -83553,6 +82269,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "mJo" = (
@@ -83657,9 +82374,7 @@
 "mKq" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "mKA" = (
@@ -83745,10 +82460,6 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/captain/private)
 "mMT" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -83762,6 +82473,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "mMY" = (
@@ -84025,9 +82737,7 @@
 "mQO" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "mQQ" = (
@@ -84062,10 +82772,6 @@
 /area/service/bar)
 "mRf" = (
 /obj/structure/bed/dogbed/runtime,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -84074,6 +82780,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/pet/cat/runtime,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/command/heads_quarters/cmo)
 "mRh" = (
@@ -84195,15 +82902,12 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /obj/effect/turf_decal/bot,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "mTl" = (
@@ -84410,9 +83114,6 @@
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/multitool,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -84422,6 +83123,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "mXC" = (
@@ -84507,14 +83209,12 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "nad" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/commons/locker)
 "naG" = (
@@ -84685,9 +83385,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ncP" = (
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
 /obj/machinery/camera{
 	c_tag = "Genetics Lab";
 	dir = 1;
@@ -84701,6 +83398,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "ncQ" = (
@@ -84879,9 +83577,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "ngE" = (
@@ -85126,10 +83822,8 @@
 /obj/structure/table,
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/command/teleporter)
 "nll" = (
@@ -85555,10 +84249,6 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "ntV" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -85566,6 +84256,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "nuA" = (
@@ -85607,9 +84298,6 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "nvi" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -85623,6 +84311,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "nvt" = (
@@ -85764,9 +84453,6 @@
 /turf/open/floor/iron/grimy,
 /area/command/corporate_showroom)
 "nxG" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/terminal{
 	dir = 4
@@ -85775,6 +84461,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "nyC" = (
@@ -85939,9 +84626,6 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "nAL" = (
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -85949,6 +84633,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "nAP" = (
@@ -86014,10 +84699,8 @@
 /area/service/library/abandoned)
 "nBD" = (
 /obj/machinery/icecream_vat,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "nBR" = (
@@ -86190,9 +84873,7 @@
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
 "nEv" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/service/library)
 "nEy" = (
@@ -87019,9 +85700,6 @@
 /area/commons/dorms)
 "nSr" = (
 /obj/structure/rack,
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
 /obj/item/stack/cable_coil/five,
 /obj/item/wrench,
 /obj/item/screwdriver,
@@ -87041,6 +85719,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "nSt" = (
@@ -87048,12 +85727,10 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "nTb" = (
@@ -87352,17 +86029,8 @@
 /area/ai_monitored/command/storage/eva)
 "nXD" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
-	},
 /obj/machinery/light_switch{
 	pixel_x = -26
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -87371,6 +86039,12 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = -32
+	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "nXM" = (
@@ -87402,17 +86076,17 @@
 /area/command/meeting_room/council)
 "nYU" = (
 /obj/machinery/photocopier,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = -32
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
@@ -87457,9 +86131,6 @@
 	dir = 8
 	},
 /obj/machinery/light/small,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -87473,6 +86144,7 @@
 /obj/item/radio/intercom/chapel{
 	pixel_y = -27
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "oad" = (
@@ -87682,10 +86354,6 @@
 /area/command/heads_quarters/ce)
 "odU" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/button/door{
 	id = "transitlock";
 	name = "Transit Tube Lockdown Control";
@@ -87702,6 +86370,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
 "oep" = (
@@ -87788,9 +86457,7 @@
 /area/service/abandoned_gambling_den)
 "ogs" = (
 /obj/item/kirbyplants/random,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "ogE" = (
@@ -87911,9 +86578,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron{
 	dir = 8;
 	icon_state = "chapel"
@@ -88021,9 +86686,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/bodybags,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -88034,6 +86696,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "olH" = (
@@ -88050,16 +86713,13 @@
 	pixel_x = 11
 	},
 /obj/item/trash/sosjerky,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = 32
 	},
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/security/prison/safe)
 "olS" = (
@@ -88229,9 +86889,6 @@
 /turf/open/floor/wood,
 /area/service/library/abandoned)
 "oqN" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -88245,6 +86902,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "oqS" = (
@@ -88355,16 +87013,16 @@
 	pixel_x = -7;
 	pixel_y = -26
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = -26
-	},
 /obj/machinery/keycard_auth{
 	pixel_x = -7;
 	pixel_y = -38
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = 26;
+	pixel_y = -26
 	},
 /turf/open/floor/carpet,
 /area/command/bridge)
@@ -88650,10 +87308,6 @@
 /obj/item/cartridge/atmos,
 /obj/item/cartridge/atmos,
 /obj/item/cartridge/atmos,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/item/stamp/ce,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -88665,6 +87319,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "oyh" = (
@@ -88700,13 +87355,11 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ozp" = (
@@ -88717,10 +87370,6 @@
 	pixel_y = -2
 	},
 /obj/item/crowbar,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -88732,6 +87381,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "ozy" = (
@@ -88862,16 +87512,11 @@
 /area/commons/fitness/recreation)
 "oCs" = (
 /obj/structure/bed,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/item/bedsheet/hop,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hop)
 "oCQ" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -88882,6 +87527,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
 "oCS" = (
@@ -89546,15 +88192,9 @@
 "oNl" = (
 /obj/structure/closet/radiation,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "oNC" = (
@@ -89587,16 +88227,13 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/engineering/atmos)
 "oNS" = (
@@ -89677,15 +88314,15 @@
 	name = "Atmospherics RC";
 	pixel_x = 30
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26;
+	pixel_y = -32
 	},
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos)
@@ -89843,14 +88480,12 @@
 	pixel_y = 3
 	},
 /obj/item/storage/toolbox/emergency,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/item/shovel,
 /obj/item/shovel,
 /obj/item/pickaxe,
 /obj/item/pickaxe,
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "oRu" = (
@@ -90197,10 +88832,6 @@
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
 "oWZ" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light_switch{
 	pixel_y = -26
 	},
@@ -90208,6 +88839,7 @@
 /obj/item/stack/sheet/plasteel/twenty,
 /obj/item/wrench,
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "oXg" = (
@@ -90252,14 +88884,11 @@
 /turf/open/floor/iron,
 /area/security/office)
 "oXG" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/engineering/main)
 "oXH" = (
@@ -90333,23 +88962,18 @@
 	pixel_x = 2;
 	pixel_y = -2
 	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/item/stock_parts/cell/emproof{
 	pixel_x = 1;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/engineering/storage)
 "oYy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -90360,9 +88984,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/cargo/office)
 "oYF" = (
@@ -90418,9 +89041,7 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "oZY" = (
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
 /area/command/meeting_room/council)
 "paB" = (
@@ -90473,10 +89094,6 @@
 /area/command/heads_quarters/captain)
 "pbj" = (
 /obj/structure/table/wood,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = -32
-	},
 /obj/item/staff/broom,
 /obj/item/clothing/head/witchwig,
 /obj/effect/turf_decal/tile/neutral{
@@ -90488,6 +89105,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26;
+	pixel_y = -32
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
@@ -90625,10 +89246,8 @@
 	pixel_y = 32;
 	receive_ore_updates = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "pei" = (
@@ -90888,10 +89507,7 @@
 	pixel_y = 3
 	},
 /obj/item/camera_film,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "pje" = (
@@ -90996,14 +89612,11 @@
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "pkM" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_y = -27
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "pkQ" = (
@@ -91056,9 +89669,7 @@
 	c_tag = "Atmospherics - HFR Main Room";
 	name = "atmospherics camera"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "plu" = (
@@ -91088,10 +89699,6 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -91105,6 +89712,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "pmJ" = (
@@ -91307,9 +89915,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -91321,6 +89926,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "pqQ" = (
@@ -91509,12 +90115,10 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ptO" = (
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "ptQ" = (
@@ -91646,13 +90250,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/command/gateway)
-"pvI" = (
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/open/floor/wood,
-/area/command/meeting_room/council)
 "pwf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -91807,10 +90404,7 @@
 /area/service/library)
 "pAm" = (
 /obj/structure/filingcabinet,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "pAC" = (
@@ -91845,10 +90439,7 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "pAO" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
 "pBl" = (
@@ -92127,10 +90718,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "pHc" = (
@@ -92143,9 +90731,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet,
 /area/service/chapel/office)
 "pHg" = (
@@ -92183,12 +90769,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
-"pHv" = (
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
-/turf/closed/wall,
-/area/security/checkpoint/science/research)
 "pHy" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -92226,10 +90806,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "pIW" = (
@@ -92390,13 +90967,11 @@
 /area/commons/fitness/recreation)
 "pNB" = (
 /obj/machinery/hydroponics/constructable,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "pND" = (
@@ -92430,9 +91005,6 @@
 /area/service/hydroponics)
 "pOd" = (
 /obj/machinery/disposal/bin,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /obj/structure/disposalpipe/trunk{
@@ -92449,18 +91021,16 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/service/janitor)
 "pOJ" = (
 /obj/structure/closet/wardrobe/miner,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_y = -26
-	},
 /obj/item/storage/backpack/satchel/explorer,
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "pPh" = (
@@ -93090,9 +91660,6 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/machinery/light/small,
 /obj/machinery/button/door{
 	id = "Toilet1";
@@ -93102,6 +91669,7 @@
 	specialfunctions = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plating,
 /area/commons/toilet/restrooms)
 "qbH" = (
@@ -93142,11 +91710,8 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "qbV" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/item/kirbyplants/random,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
@@ -93211,10 +91776,8 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
 "qdh" = (
@@ -93369,9 +91932,6 @@
 /obj/structure/table/glass,
 /obj/item/folder/white,
 /obj/item/storage/secure/briefcase,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32;
 	pixel_y = -32
@@ -93380,6 +91940,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/command/heads_quarters/cmo)
 "qfv" = (
@@ -93430,10 +91991,8 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "qfT" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "qgk" = (
@@ -93949,10 +92508,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "qnV" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/machinery/light,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -93964,6 +92519,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "qob" = (
@@ -93985,12 +92541,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "qpf" = (
@@ -94133,9 +92687,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -94147,6 +92698,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "qsK" = (
@@ -94336,9 +92888,6 @@
 /turf/open/floor/wood,
 /area/service/library)
 "qwg" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/machinery/stasis,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -94350,6 +92899,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "qwu" = (
@@ -94418,9 +92968,6 @@
 "qya" = (
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/beerkeg,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -94431,6 +92978,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "qyc" = (
@@ -94488,11 +93036,9 @@
 	pixel_x = 26;
 	pixel_y = 26
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/item/storage/box/beanbag,
 /obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "qzf" = (
@@ -94926,11 +93472,9 @@
 /area/command/heads_quarters/hop)
 "qFn" = (
 /obj/structure/cable,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "qFt" = (
@@ -95008,9 +93552,7 @@
 /area/service/library)
 "qGI" = (
 /obj/structure/chair/wood,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron{
 	dir = 1;
 	icon_state = "chapel"
@@ -95085,11 +93627,8 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "qIn" = (
@@ -95106,13 +93645,11 @@
 "qIO" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "qJk" = (
@@ -95254,11 +93791,8 @@
 /obj/item/stack/sheet/glass{
 	amount = 30
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "qLr" = (
@@ -95328,10 +93862,8 @@
 /obj/item/food/grown/wheat,
 /obj/item/food/grown/corn,
 /obj/item/food/grown/apple,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden/abandoned)
 "qMo" = (
@@ -95374,9 +93906,6 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/office)
 "qMY" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -95390,6 +93919,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "qNh" = (
@@ -95462,10 +93992,8 @@
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "qNT" = (
-/obj/item/radio/intercom{
-	pixel_y = -24
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "qOd" = (
@@ -95515,9 +94043,6 @@
 /area/command/heads_quarters/cmo)
 "qOp" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = -32
 	},
@@ -95527,6 +94052,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white/corner,
 /area/engineering/atmos)
 "qOr" = (
@@ -95557,9 +94083,6 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/machinery/light/small,
 /obj/effect/turf_decal/bot,
 /obj/machinery/button/door{
@@ -95570,6 +94093,7 @@
 	specialfunctions = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
 "qPd" = (
@@ -95722,10 +94246,6 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/main)
 "qSg" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Distro Loop";
 	dir = 1;
@@ -95735,6 +94255,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/visible,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos)
 "qSs" = (
@@ -95798,10 +94319,8 @@
 /obj/item/wrench,
 /obj/item/crowbar,
 /obj/item/paicard,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "qTt" = (
@@ -95849,10 +94368,8 @@
 /area/service/library/abandoned)
 "qTW" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "qUc" = (
@@ -96149,10 +94666,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "qYu" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "qYB" = (
@@ -96259,13 +94773,11 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "rcm" = (
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/landmark/start/hangover,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "rcv" = (
@@ -96288,9 +94800,6 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -96330,11 +94839,8 @@
 /area/hallway/primary/fore)
 "rdR" = (
 /obj/structure/bed/dogbed/ian,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /mob/living/simple_animal/pet/dog/corgi/ian,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "rdS" = (
@@ -96395,15 +94901,13 @@
 /area/security/prison)
 "reS" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/item/clipboard,
 /obj/item/toy/figure/hop{
 	pixel_x = 3;
 	pixel_y = 3
 	},
 /obj/item/toy/figure/ian,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "rfb" = (
@@ -96459,23 +94963,19 @@
 /area/commons/fitness/recreation)
 "rfO" = (
 /obj/machinery/vending/assist,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/machinery/camera{
 	c_tag = "Primary Tool Storage";
 	dir = 4;
 	name = "engineering camera"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "rga" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "rgd" = (
@@ -96580,16 +95080,16 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "rhs" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig - Central";
+	dir = 4;
+	network = list("ss13","prison")
+	},
 /obj/item/radio/intercom{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
 	name = "Prison Intercom (General)";
 	pixel_x = -30;
 	prison_radio = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig - Central";
-	dir = 4;
-	network = list("ss13","prison")
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -96620,10 +95120,8 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/landmark/start/captain,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "rih" = (
@@ -96657,9 +95155,7 @@
 "riv" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/service/library)
 "riS" = (
@@ -96833,23 +95329,17 @@
 /area/command/gateway)
 "rmA" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "rmG" = (
 /turf/closed/wall,
 /area/command/heads_quarters/hos)
 "rmH" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "rmR" = (
@@ -96928,9 +95418,6 @@
 /obj/structure/table,
 /obj/item/wrench,
 /obj/item/crowbar,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/item/clothing/under/misc/burial,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -96942,6 +95429,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "rpy" = (
@@ -97032,10 +95520,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "rtd" = (
@@ -97102,26 +95587,19 @@
 /area/maintenance/solars/port/fore)
 "ruK" = (
 /obj/machinery/light,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/command/teleporter)
 "ruZ" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -97136,6 +95614,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "rvg" = (
@@ -97300,15 +95779,13 @@
 "ryL" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/lights/mixed,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ryN" = (
@@ -97376,10 +95853,7 @@
 /obj/item/food/grown/poppy/lily,
 /obj/item/food/grown/poppy/lily,
 /obj/item/food/grown/poppy/lily,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
 "rzS" = (
@@ -97410,12 +95884,10 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = 32
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "rAb" = (
@@ -97537,9 +96009,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/engineering/main)
 "rBy" = (
@@ -97555,9 +96025,6 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/vomit,
 /obj/machinery/button/door{
@@ -97568,6 +96035,7 @@
 	specialfunctions = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plating,
 /area/commons/toilet/auxiliary)
 "rBY" = (
@@ -97593,11 +96061,8 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "rCt" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
 /area/service/library/abandoned)
 "rCv" = (
@@ -97753,10 +96218,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rFn" = (
-/obj/item/radio/intercom{
-	pixel_x = -26;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -97766,6 +96227,10 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -26;
+	pixel_y = -26
 	},
 /turf/open/floor/iron,
 /area/service/bar/atrium)
@@ -98043,10 +96508,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
 "rJj" = (
@@ -98169,9 +96631,7 @@
 	network = list("ss13","medbay")
 	},
 /obj/structure/closet/secure_closet/medical2,
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "rLP" = (
@@ -98218,15 +96678,13 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "rMk" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/machinery/portable_atmospherics/canister/bz,
 /obj/machinery/light,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "rMx" = (
@@ -98426,9 +96884,6 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -98439,6 +96894,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "rQb" = (
@@ -98449,9 +96905,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "rQl" = (
@@ -98534,14 +96988,6 @@
 /area/service/theater/abandoned)
 "rRw" = (
 /obj/machinery/autolathe,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -33
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -98555,15 +97001,15 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/cargo/office)
 "rRR" = (
 /obj/structure/table/wood,
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "rSG" = (
@@ -98686,9 +97132,6 @@
 /area/science/mixing)
 "rUO" = (
 /obj/item/kirbyplants/random,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -98705,6 +97148,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "rVj" = (
@@ -99066,6 +97510,7 @@
 	c_tag = "Chapel Quarters";
 	name = "chapel camera"
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "saS" = (
@@ -99350,10 +97795,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "shH" = (
@@ -99429,10 +97871,8 @@
 /area/service/abandoned_gambling_den)
 "sjo" = (
 /obj/structure/closet/secure_closet/hydroponics,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "sjz" = (
@@ -99596,9 +98036,7 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "snN" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "soj" = (
@@ -99711,10 +98149,6 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "sqW" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 23
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
 	},
@@ -99722,6 +98156,7 @@
 	dir = 10
 	},
 /obj/item/kirbyplants/random,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/engineering/main)
 "srq" = (
@@ -99817,12 +98252,10 @@
 /turf/closed/wall,
 /area/cargo/warehouse)
 "ssC" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "ssD" = (
@@ -99852,10 +98285,8 @@
 /obj/machinery/computer/security/mining{
 	dir = 1
 	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "suJ" = (
@@ -99921,9 +98352,6 @@
 /area/engineering/atmos/upper)
 "swj" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -99934,6 +98362,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "swM" = (
@@ -100042,10 +98471,6 @@
 "syV" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/light/small,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Engine Foyer";
 	dir = 1;
@@ -100054,6 +98479,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/engineering/main)
 "syY" = (
@@ -100076,15 +98502,13 @@
 	dir = 1;
 	pixel_y = 4
 	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "szF" = (
@@ -100104,9 +98528,6 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/machinery/light/small,
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/bot,
@@ -100118,6 +98539,7 @@
 	specialfunctions = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/commons/toilet/auxiliary)
 "sAj" = (
@@ -100163,10 +98585,6 @@
 /area/security/office)
 "sAx" = (
 /obj/structure/bodycontainer/morgue,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -100177,19 +98595,18 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "sAB" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "sAD" = (
@@ -100226,13 +98643,11 @@
 /area/commons/locker)
 "sBb" = (
 /obj/machinery/vending/assist,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
 "sBl" = (
@@ -100305,10 +98720,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "sDp" = (
@@ -100387,9 +98799,7 @@
 "sEL" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den/secondary)
 "sFf" = (
@@ -100472,14 +98882,12 @@
 /obj/machinery/light,
 /obj/item/storage/secure/briefcase,
 /obj/item/taperecorder,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
+/obj/effect/turf_decal/bot,
 /obj/item/radio/intercom{
 	pixel_x = -26;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
 "sGU" = (
@@ -100561,17 +98969,12 @@
 /turf/open/floor/iron,
 /area/security/office)
 "sIl" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/chem_master/condimaster{
 	name = "BrewMaster 3000"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "sIm" = (
@@ -100615,13 +99018,11 @@
 	},
 /area/service/chapel/main)
 "sJv" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "sJx" = (
@@ -100655,9 +99056,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "sKa" = (
@@ -100674,9 +99073,6 @@
 /area/service/library/abandoned)
 "sKy" = (
 /obj/structure/table/glass,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/item/storage/box/beakers{
 	pixel_x = 3;
 	pixel_y = 3
@@ -100686,6 +99082,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "sKJ" = (
@@ -100812,10 +99209,6 @@
 /obj/item/cartridge/signal/toxins{
 	pixel_y = 6
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/camera{
 	c_tag = "Science - Research Director's Office";
 	dir = 8;
@@ -100823,6 +99216,7 @@
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
 "sNC" = (
@@ -100901,11 +99295,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/command/gateway)
 "sPJ" = (
@@ -100938,21 +99330,16 @@
 /area/engineering/main)
 "sQV" = (
 /obj/structure/closet/radiation,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/engineering/main)
 "sRg" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -100963,6 +99350,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "sRV" = (
@@ -101443,15 +99831,12 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "sYO" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Council Chamber";
 	dir = 1;
 	name = "command camera"
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/command/meeting_room/council)
 "sYS" = (
@@ -101520,10 +99905,8 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "tak" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "taQ" = (
@@ -102005,6 +100388,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/security/office)
 "tkx" = (
@@ -102050,10 +100434,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "tlv" = (
@@ -102179,14 +100560,11 @@
 "tnh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -102264,9 +100642,6 @@
 "tpD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -102277,6 +100652,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/medical/morgue)
 "tpQ" = (
@@ -102292,10 +100668,7 @@
 /area/engineering/break_room)
 "tpS" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "tpW" = (
@@ -102438,9 +100811,6 @@
 /area/commons/storage/primary)
 "tsB" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Pumps";
 	dir = 1;
@@ -102452,6 +100822,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/engineering/atmos)
 "tsY" = (
@@ -102484,14 +100855,12 @@
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 20
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/south,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ttg" = (
@@ -102663,10 +101032,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "tyz" = (
@@ -103116,9 +101482,6 @@
 /area/service/chapel/office)
 "tFA" = (
 /obj/machinery/disposal/bin,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -103132,6 +101495,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "tFK" = (
@@ -103139,10 +101503,7 @@
 /area/engineering/storage)
 "tFO" = (
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "tFT" = (
@@ -103210,10 +101571,6 @@
 /obj/structure/table,
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -103223,6 +101580,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "tHq" = (
@@ -103297,10 +101655,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "tIV" = (
@@ -103383,10 +101738,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/machinery/light_switch{
 	pixel_x = -38;
 	pixel_y = -8
@@ -103397,6 +101748,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tJS" = (
@@ -103895,21 +102247,16 @@
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos)
 "tSY" = (
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain)
 "tTW" = (
 /obj/structure/musician/piano{
 	icon_state = "piano"
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/light,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/grimy,
 /area/service/bar/atrium)
 "tUe" = (
@@ -103949,14 +102296,9 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
 /obj/item/paicard,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/west,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
 "tUW" = (
@@ -103974,9 +102316,6 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/wrench,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/structure/table/reinforced,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/effect/turf_decal/tile/neutral{
@@ -103989,6 +102328,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "tVq" = (
@@ -104025,11 +102365,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/engineering/main)
 "tVL" = (
@@ -104123,10 +102461,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tWY" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_y = -27
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -104136,6 +102470,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "tXh" = (
@@ -104247,10 +102582,6 @@
 /obj/item/stock_parts/capacitor,
 /obj/item/stock_parts/manipulator,
 /obj/item/stock_parts/manipulator,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -104261,6 +102592,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "tYr" = (
@@ -104314,13 +102646,10 @@
 /turf/open/floor/wood,
 /area/command/meeting_room/council)
 "uap" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "uau" = (
@@ -104362,10 +102691,6 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "ubx" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Fore";
 	dir = 1;
@@ -104377,6 +102702,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos)
 "ubz" = (
@@ -104439,10 +102765,6 @@
 	pixel_y = 3
 	},
 /obj/item/camera_film,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
@@ -104456,6 +102778,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "ucu" = (
@@ -104575,11 +102898,8 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
 "uhr" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/machinery/photocopier,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
 /area/service/library)
 "uhs" = (
@@ -104618,9 +102938,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "uhI" = (
@@ -104745,10 +103063,6 @@
 /area/engineering/atmos)
 "ujV" = (
 /obj/structure/table/wood,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/item/clipboard,
 /obj/item/toy/figure/chaplain,
 /obj/structure/sign/poster/official/bless_this_spess{
@@ -104764,6 +103078,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "uki" = (
@@ -105222,10 +103537,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/prison_contraband,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
 "urL" = (
@@ -105360,9 +103672,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "utt" = (
@@ -105508,20 +103818,15 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos)
 "uvi" = (
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uvq" = (
@@ -105625,10 +103930,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "uyh" = (
@@ -105708,9 +104010,6 @@
 /area/security/prison/safe)
 "uAm" = (
 /obj/structure/dresser,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
 	},
@@ -105724,6 +104023,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "uAo" = (
@@ -105763,9 +104063,7 @@
 "uAP" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/engineering/main)
 "uAX" = (
@@ -106120,10 +104418,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "uGw" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -106131,6 +104425,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "uGB" = (
@@ -106344,10 +104639,6 @@
 	pixel_y = 5
 	},
 /obj/item/radio,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/machinery/light_switch{
 	pixel_x = 26
 	},
@@ -106355,6 +104646,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "uKa" = (
@@ -106435,11 +104727,9 @@
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood,
 /area/command/meeting_room/council)
 "uLp" = (
@@ -106540,9 +104830,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -106553,6 +104840,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "uNP" = (
@@ -106850,9 +105138,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "uTq" = (
@@ -107012,10 +105298,6 @@
 /turf/open/floor/iron/grimy,
 /area/command/corporate_showroom)
 "uWL" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_y = -27
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -107025,6 +105307,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "uWU" = (
@@ -107038,13 +105321,11 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "uXz" = (
-/obj/machinery/firealarm{
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "uXJ" = (
@@ -107107,10 +105388,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "uYe" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 32
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/structure/cable,
@@ -107243,10 +105520,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/science/research)
 "vaT" = (
@@ -107844,12 +106118,10 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "vmj" = (
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/structure/sign/painting/library{
 	pixel_y = -32
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
 /area/service/library)
 "vmn" = (
@@ -107925,12 +106197,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vnW" = (
@@ -108117,9 +106386,7 @@
 /obj/structure/table/wood,
 /obj/item/pinpointer/nuke,
 /obj/item/disk/nuclear,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain/private)
 "vtB" = (
@@ -108164,10 +106431,8 @@
 /obj/structure/table/glass,
 /obj/item/wrench,
 /obj/item/clothing/suit/apron,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "vuE" = (
@@ -108252,9 +106517,6 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -108262,6 +106524,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/engineering/main)
 "vvP" = (
@@ -108405,9 +106668,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "vyz" = (
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chief Medical Officer's Quarters";
 	dir = 1;
@@ -108420,6 +106680,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "vyP" = (
@@ -108509,9 +106770,7 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "vAo" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "vAK" = (
@@ -108596,12 +106855,10 @@
 /area/security/office)
 "vCJ" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "vCX" = (
@@ -108627,9 +106884,7 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain/private)
 "vDu" = (
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "vDy" = (
@@ -108903,12 +107158,10 @@
 /area/service/library)
 "vHp" = (
 /obj/structure/table/glass,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/item/clipboard,
 /obj/item/toy/figure/botanist,
 /obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "vHu" = (
@@ -108959,9 +107212,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "vHN" = (
@@ -109035,9 +107286,6 @@
 /obj/item/gps/engineering{
 	gpstag = "CE0"
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -109051,13 +107299,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "vIJ" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -109072,6 +107317,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "vJu" = (
@@ -109122,10 +107368,8 @@
 	pixel_x = -26;
 	pixel_y = -26
 	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
 /obj/structure/bookcase/random,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/wood,
 /area/command/meeting_room/council)
 "vKx" = (
@@ -109350,28 +107594,24 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "vPq" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "vPC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -109431,11 +107671,9 @@
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/flashlight,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/command/gateway)
 "vSn" = (
@@ -109500,10 +107738,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "vTy" = (
@@ -109524,13 +107759,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -109538,6 +107766,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/cargo/office)
 "vUp" = (
@@ -109654,9 +107884,7 @@
 	icon_state = "plant-21"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "vWL" = (
@@ -109701,9 +107929,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "vXy" = (
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "vXz" = (
@@ -110058,9 +108284,7 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "wei" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "weo" = (
@@ -110266,10 +108490,8 @@
 "wic" = (
 /obj/structure/closet/radiation,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "wiy" = (
@@ -110440,9 +108662,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "wlp" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "wlq" = (
@@ -110838,10 +109058,7 @@
 	icon_state = "detective"
 	},
 /obj/item/clothing/under/rank/civilian/lawyer/female,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "wva" = (
@@ -111126,15 +109343,13 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/suit/jacket/letterman_nanotrasen,
 /obj/item/clothing/suit/toggle/lawyer,
+/obj/item/clothing/under/costume/kilt,
+/obj/item/clothing/head/beret,
 /obj/item/radio/intercom{
 	pixel_x = 26;
 	pixel_y = 26
 	},
-/obj/item/clothing/under/costume/kilt,
-/obj/item/clothing/head/beret,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "wzW" = (
@@ -111724,10 +109939,7 @@
 /area/commons/fitness/recreation)
 "wMD" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "wMG" = (
@@ -111900,10 +110112,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clipboard,
 /obj/item/toy/figure/miner,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -111911,6 +110119,7 @@
 	pixel_x = -38
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "wQo" = (
@@ -111932,10 +110141,6 @@
 /area/security/prison)
 "wQx" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/machinery/flasher{
 	id = "AI";
 	pixel_x = -26;
@@ -111951,6 +110156,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
 "wQC" = (
@@ -111965,11 +110171,8 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/shoes/magboots,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/engineering/storage)
 "wQK" = (
@@ -112043,12 +110246,10 @@
 /area/commons/vacant_room/office)
 "wSe" = (
 /obj/effect/spawner/randomsnackvend,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "wSj" = (
@@ -112186,16 +110387,9 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/lights/mixed,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/machinery/light_switch{
 	pixel_x = -26;
 	pixel_y = -26
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -112204,16 +110398,18 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "wTY" = (
 /obj/structure/table/wood,
+/obj/item/folder/blue,
+/obj/item/pen,
 /obj/machinery/newscaster{
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/obj/item/folder/blue,
-/obj/item/pen,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "wUz" = (
@@ -112555,10 +110751,8 @@
 /area/engineering/gravity_generator)
 "xaP" = (
 /obj/machinery/hydroponics/constructable,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/delivery,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "xaQ" = (
@@ -112615,9 +110809,7 @@
 /area/commons/storage/primary)
 "xcV" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "xdx" = (
@@ -112658,11 +110850,9 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "xev" = (
@@ -112985,16 +111175,13 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "xlE" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -113260,10 +111447,6 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "xpT" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -113278,6 +111461,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "xpW" = (
@@ -113408,14 +111592,12 @@
 /obj/item/electronics/airlock,
 /obj/item/electronics/airlock,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/item/stock_parts/cell/emproof{
 	pixel_x = -3;
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/engineering/storage)
 "xty" = (
@@ -113453,9 +111635,7 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "xud" = (
@@ -113600,9 +111780,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -113613,14 +111790,13 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "xwZ" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "xxb" = (
@@ -113676,10 +111852,6 @@
 /turf/closed/wall,
 /area/engineering/atmos)
 "xyb" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Quartermaster's Office";
 	dir = 1;
@@ -113692,6 +111864,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "xyI" = (
@@ -113781,10 +111954,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "xzZ" = (
@@ -113847,13 +112017,11 @@
 /area/security/office)
 "xBe" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "xBf" = (
@@ -113893,10 +112061,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -113907,6 +112071,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
 "xCZ" = (
@@ -114001,10 +112166,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "xFa" = (
@@ -114069,15 +112231,13 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/cmo)
 "xFP" = (
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "xGe" = (
@@ -114185,9 +112345,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/mop,
 /obj/item/mop,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
 /obj/machinery/light/small,
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = -32
@@ -114203,6 +112360,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/service/janitor)
 "xJJ" = (
@@ -114271,10 +112429,7 @@
 /area/ai_monitored/command/nuke_storage)
 "xKt" = (
 /obj/structure/filingcabinet/employment,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "xKE" = (
@@ -114426,9 +112581,7 @@
 /obj/item/laser_pointer{
 	pixel_x = 3
 	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "xNR" = (
@@ -114459,9 +112612,6 @@
 /area/science/xenobiology)
 "xOe" = (
 /obj/structure/rack,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/item/stack/sheet/iron{
 	amount = 30
 	},
@@ -114471,6 +112621,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction)
 "xOo" = (
@@ -114649,10 +112800,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "xSu" = (
@@ -114661,15 +112809,12 @@
 /area/engineering/gravity_generator)
 "xSB" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Captain's Quarters";
 	dir = 1;
 	name = "command camera"
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "xSS" = (
@@ -114768,19 +112913,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "xUH" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -114794,6 +112934,7 @@
 /obj/structure/chair/stool/bar{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "xUM" = (
@@ -114964,12 +113105,12 @@
 "xYc" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /obj/item/radio/intercom{
 	pixel_x = 26;
 	pixel_y = 26
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
@@ -115002,6 +113143,7 @@
 /obj/structure/table,
 /obj/item/wirecutters,
 /obj/item/screwdriver,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/security/office)
 "xYI" = (
@@ -115099,10 +113241,8 @@
 	pixel_y = 3
 	},
 /obj/item/storage/briefcase,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/item/cane,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "yaE" = (
@@ -115188,10 +113328,6 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -115200,16 +113336,20 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/security/office)
-"ycm" = (
-/obj/item/kirbyplants/random,
 /obj/item/radio/intercom{
 	pixel_x = 26;
 	pixel_y = 26
 	},
+/turf/open/floor/iron,
+/area/security/office)
+"ycm" = (
+/obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = 26;
+	pixel_y = 26
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -115477,14 +113617,12 @@
 /area/engineering/main)
 "ygx" = (
 /obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance/two,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
 "ygX" = (
@@ -115806,11 +113944,9 @@
 /area/commons/vacant_room/office)
 "ylX" = (
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/machinery/light/small,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/engineering/main)
 
@@ -146511,7 +144647,7 @@ aaa
 aad
 aaa
 aad
-mbg
+vqp
 jhN
 uHf
 hia
@@ -148329,7 +146465,7 @@ mhX
 mFG
 ycz
 nJo
-wbw
+gXJ
 pAj
 ybZ
 vcW
@@ -148585,7 +146721,7 @@ nJo
 rhJ
 mFG
 mfh
-gXJ
+lxk
 mNk
 pAj
 ybZ
@@ -149351,7 +147487,7 @@ uJM
 tst
 bUm
 bWD
-aaJ
+uxO
 nJo
 gNK
 wFy
@@ -150672,7 +148808,7 @@ cOV
 cOV
 cSl
 dcy
-pHv
+cQD
 dfm
 dgF
 did
@@ -152688,7 +150824,7 @@ hML
 nYj
 nYj
 gqP
-pvI
+nYj
 nYj
 wpW
 tRR
@@ -152945,7 +151081,7 @@ hML
 rDv
 mtj
 nYj
-nYj
+dhf
 lRN
 wpW
 wpW
@@ -153017,7 +151153,7 @@ dPV
 dQK
 dRP
 dNL
-dTE
+dTF
 dUx
 dUx
 dVZ
@@ -155038,7 +153174,7 @@ cSB
 cUq
 cWg
 dGf
-cZs
+dDH
 daZ
 dcL
 dek
@@ -157566,7 +155702,7 @@ fFy
 jqu
 nzz
 veC
-emJ
+rsZ
 glH
 vDu
 gaN
@@ -159154,8 +157290,8 @@ cZA
 cPo
 cPo
 cPo
+hQM
 cPo
-dhf
 diB
 iLU
 cNA
@@ -167838,7 +165974,7 @@ ils
 ktc
 xWK
 oXg
-hQM
+mau
 xYt
 tuZ
 wTx
@@ -170407,7 +168543,7 @@ xnI
 ybi
 mCK
 ybi
-lMf
+ybi
 hCK
 frV
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This replaces most of the wall mounts with their subtypes on Delta, where applicable. I have **not** converted any diagonal or otherwise var-edited wall mounts with these subtypes. I could easily do so if requested but I felt like the diagonals would look strange without their own subtype and otherwise edited things are a bit more complicated than pixel displacement, so I left them as-is. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Var edits are bad, subtypes are good. Compresses the map code quite a bit.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
