### PR TITLE
Items now properly unset the IN_STORAGE flag when removed from storage.

### DIFF
--- a/code/datums/components/storage/concrete/_concrete.dm
+++ b/code/datums/components/storage/concrete/_concrete.dm
@@ -123,8 +123,8 @@
 	for(var/mob/M in seeing_mobs)
 		M.client.screen -= AM
 	if(isitem(AM))
-		removed_item.item_flags &= ~IN_STORAGE
 		var/obj/item/removed_item = AM
+		removed_item.item_flags &= ~IN_STORAGE
 		if(ismob(parent.loc))
 			var/mob/carrying_mob = parent.loc
 			removed_item.dropped(carrying_mob, TRUE)

--- a/code/datums/components/storage/concrete/_concrete.dm
+++ b/code/datums/components/storage/concrete/_concrete.dm
@@ -122,11 +122,12 @@
 	var/list/seeing_mobs = can_see_contents()
 	for(var/mob/M in seeing_mobs)
 		M.client.screen -= AM
-	if(ismob(parent.loc) && isitem(AM))
-		var/obj/item/I = AM
-		var/mob/M = parent.loc
-		I.dropped(M, TRUE)
-		I.item_flags &= ~IN_STORAGE
+	if(isitem(AM))
+		removed_item.item_flags &= ~IN_STORAGE
+		var/obj/item/removed_item = AM
+		if(ismob(parent.loc))
+			var/mob/carrying_mob = parent.loc
+			removed_item.dropped(carrying_mob, TRUE)
 	if(new_location)
 		//Reset the items values
 		_removal_reset(AM)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The IN_STORAGE flag is applied to all items that enter storage item, but is only removed from items that leave storage when that storage item's loc is a mob.

This clears the flag in all cases as long as the thing removed was an item.

![image](https://user-images.githubusercontent.com/24975989/110895894-6bf75580-82f2-11eb-8ea0-8a78ac973c01.png)

This item was sat on the floor - Still had IN_STORAGE flag.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes incorrect flags on items.

No player-facing changes, no changelog.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
