### PR TITLE
Eldritch whetstone nerf

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -395,7 +395,7 @@
 	icon_state = "cult_sharpener"
 	uses = 1
 	increment = 5
-	max = 40
+	max = 30
 	prefix = "darkened"
 
 /obj/item/sharpener/cult/update_icon_state()


### PR DESCRIPTION
## About The Pull Request

I realized that there was a fucking 40 damage cap on the eldritch cult stone and that it is a massive 5 increment instead of the normal 4. When paired with the eldritch longsword, it gets kinda silly.

## Why It's Good For The Game

It's far too dumb when paired up with the 30 damage cult longsword, you can sharpen your daggers and bloodletters at least still boys!

## Changelog
:cl:
balance: Eldritch whetstone damage increase cap lowered to 30.
/:cl: