### PR TITLE
Adds a minor negative station trait: Bot Language Error (+fixes a minor error in another negative trait)

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -81,7 +81,7 @@
 
 /datum/station_trait/slow_shuttle
 	name = "Slow Shuttle"
-	trait_type = STATION_TRAIT_NEUTRAL
+	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 5
 	show_in_report = TRUE
 	report_message = "Due to distance to our supply station, the cargo shuttle will have a slower flight time to your cargo department."
@@ -90,3 +90,24 @@
 /datum/station_trait/slow_shuttle/on_round_start()
 	. = ..()
 	SSshuttle.supply.callTime *= 1.5
+
+/datum/station_trait/bot_languages
+	name = "Bot Language Matrix Malfunction"
+	trait_type = STATION_TRAIT_NEGATIVE
+	weight = 3
+	show_in_report = TRUE
+	report_message = "Your station's friendly bots have had their language matrix fried due to an event, resulting in some strange and unfamiliar speech patterns."
+
+/datum/station_trait/bot_languages/New()
+	. = ..()
+	/// What "caused" our robots to go haywire (fluff)
+	var/event_source = pick("an ion storm", "a syndicate hacking attempt", "a malfunction", "issues with your onboard AI", "an intern's mistakes", "budget cuts")
+	report_message = "Your station's friendly bots have had their language matrix fried due to [event_source], resulting in some strange and unfamiliar speech patterns."
+
+/datum/station_trait/bot_languages/on_round_start()
+	. = ..()
+	//All bots that exist round start have their set language randomized.
+	for(var/mob/living/simple_animal/bot/found_bot in GLOB.alive_mob_list)
+		/// The bot's language holder - so we can randomize and change their language
+		var/datum/language_holder/bot_languages = found_bot.get_language_holder()
+		bot_languages.selected_language = bot_languages.get_random_spoken_language()

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -101,7 +101,7 @@
 /datum/station_trait/bot_languages/New()
 	. = ..()
 	/// What "caused" our robots to go haywire (fluff)
-	var/event_source = pick("an ion storm", "a syndicate hacking attempt", "a malfunction", "issues with your onboard AI", "an intern's mistakes", "budget cuts")
+	var/event_source = pick(list("an ion storm", "a syndicate hacking attempt", "a malfunction", "issues with your onboard AI", "an intern's mistakes", "budget cuts"))
 	report_message = "Your station's friendly bots have had their language matrix fried due to [event_source], resulting in some strange and unfamiliar speech patterns."
 
 /datum/station_trait/bot_languages/on_round_start()


### PR DESCRIPTION
## About The Pull Request

This PR adds a minor negative station trait: Bot Language Matrix Malfunction. At the start of the round, all simplemob bots (medibots, secbots) will have their languages sets to a random language they can speak (mostly playable species languages). Beepsky might start speaking calcic. Inspector Johnson could be speaking moffic. 

This PR also fixes a minor error in which "Slow shuttle" station trait was classified as neutral instead of negative. (It's in the negative file and it's a negative trait, it appears to be an typo that it's neutral.)

## Why It's Good For The Game

While working on another project I accidentally made all medibots speak draconic and it was pretty hilarious to see, so I tossed it into a station trait. Only officers that know the right language know who beepsky is arresting, and only doctors who understand Doc Johnson know who's in crit, and where.

## Changelog
:cl: Melbert
add: Adds a negative station trait: Bot Language Matrix Malfunction. Is Beepsky speaking nekomimetic...?
fix: The "Slow Shuttle" station trait is now properly classified as a negative trait instead of a neutral trait.
/:cl:
