### PR TITLE
Chance to mutate into a gorilla is reduced

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -92,7 +92,7 @@
 
 /datum/species/monkey/handle_mutations_and_radiation(mob/living/carbon/human/H)
 	. = ..()
-	if(H.radiation > RAD_MOB_MUTATE * 2 && prob(50))
+	if(H.radiation > RAD_MOB_MUTATE * 2 && prob(0.5))
 		H.gorillize()
 		return
 

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -92,8 +92,8 @@
 
 /datum/species/monkey/handle_mutations_and_radiation(mob/living/carbon/human/source, delta_time, times_fired)
 	. = ..()
-	if(H.radiation > RAD_MOB_MUTATE * 2 && prob(0.5))
-		H.gorillize()
+	if(source.radiation > RAD_MOB_MUTATE * 2 && DT_PROB(0.25, delta_time))
+		source.gorillize()
 		return
 
 /datum/species/monkey/check_roundstart_eligible()

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -90,7 +90,7 @@
 	target.attack_paw(user, modifiers)
 	return TRUE
 
-/datum/species/monkey/handle_mutations_and_radiation(mob/living/carbon/human/H)
+/datum/species/monkey/handle_mutations_and_radiation(mob/living/carbon/human/source, delta_time, times_fired)
 	. = ..()
 	if(H.radiation > RAD_MOB_MUTATE * 2 && prob(0.5))
 		H.gorillize()


### PR DESCRIPTION
Gorillas are a problem, this fixes them without bothering without all
the snowflake of a new weaker type.

If this continues to be a problem the chance will decrease further

:cl: oranges
balance: Chance to mutate a monkey into a gorilla is greatly reduced
/:cl: