### PR TITLE
Fix infinite recursive loop in cyborg beaker icon updates

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -812,7 +812,7 @@
 
 /obj/item/borg/apparatus/Exited(atom/A)
 	if(A == stored) //sanity check
-		UnregisterSignal(stored, COMSIG_ATOM_UPDATE_ICON)
+		UnregisterSignal(stored, COMSIG_ATOM_UPDATED_ICON)
 		stored = null
 	update_appearance()
 	. = ..()
@@ -846,7 +846,7 @@
 			var/obj/item/O = A
 			O.forceMove(src)
 			stored = O
-			RegisterSignal(stored, COMSIG_ATOM_UPDATE_ICON, .proc/on_update_icon)
+			RegisterSignal(stored, COMSIG_ATOM_UPDATED_ICON, .proc/on_stored_updated_icon)
 			update_appearance()
 			return
 	else
@@ -854,10 +854,16 @@
 		return
 	. = ..()
 
-/// Exists to eat signal args
-/obj/item/borg/apparatus/proc/on_update_icon(datum/source, updates)
+/**
+ * Updates the appearance of the apparatus when the stored object's icon gets updated.
+ *
+ * Returns NONE as we have not done anything tothe stored object itself,
+ * which is where this signal that this handler intercepts is sent from.
+ */
+/obj/item/borg/apparatus/proc/on_stored_updated_icon(datum/source, updates)
 	SIGNAL_HANDLER
-	return on_update_icon(updates)
+	update_appearance()
+	return NONE
 
 /obj/item/borg/apparatus/attackby(obj/item/W, mob/user, params)
 	if(stored)
@@ -879,7 +885,7 @@
 /obj/item/borg/apparatus/beaker/Initialize()
 	. = ..()
 	stored = new /obj/item/reagent_containers/glass/beaker/large(src)
-	RegisterSignal(stored, COMSIG_ATOM_UPDATE_ICON, .proc/on_update_icon)
+	RegisterSignal(stored, COMSIG_ATOM_UPDATED_ICON, .proc/on_stored_updated_icon)
 	update_appearance()
 
 /obj/item/borg/apparatus/beaker/Destroy()
@@ -939,7 +945,7 @@
 /obj/item/borg/apparatus/beaker/service/Initialize()
 	. = ..()
 	stored = new /obj/item/reagent_containers/food/drinks/drinkingglass(src)
-	RegisterSignal(stored, COMSIG_ATOM_UPDATE_ICON, .proc/on_update_icon)
+	RegisterSignal(stored, COMSIG_ATOM_UPDATED_ICON, .proc/on_stored_updated_icon)
 	update_appearance()
 
 /////////////////////

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -857,7 +857,7 @@
 /**
  * Updates the appearance of the apparatus when the stored object's icon gets updated.
  *
- * Returns NONE as we have not done anything tothe stored object itself,
+ * Returns NONE as we have not done anything to the stored object itself,
  * which is where this signal that this handler intercepts is sent from.
  */
 /obj/item/borg/apparatus/proc/on_stored_updated_icon(datum/source, updates)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implements proper logic for updating the apparatus' appearance after its stored beaker's icon is updated (and not before).

Solves a code oversight where a proc could call itself endlessly.

Documents the proc properly.

![JPBRlzHazm](https://user-images.githubusercontent.com/24975989/111018048-bb9b5700-83ae-11eb-92a1-877e4db84f37.gif)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/24975989/111018016-868f0480-83ae-11eb-9171-60a598047d21.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed various issues with the cyborg beaker apparatus code. These fixes mean it should now properly update its own icon when reagents are transferred to any beaker it is holding.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
