### PR TITLE
Reduces the export cost of Zauker to something more sane

### DIFF
--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -137,7 +137,7 @@
 								/datum/gas/hydrogen = 1,
 								/datum/gas/healium = 19,
 								/datum/gas/proto_nitrate = 5,
-								/datum/gas/zauker = 1050,
+								/datum/gas/zauker = 100,
 								/datum/gas/helium = 6,
 								/datum/gas/antinoblium = 10,
 								/datum/gas/halon = 9


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'm not entirely sure why someone thought 1050cr/mol was a good price, but turns out you can make Zauker pretty easily using the HFR once you know what you're doing.  tl;dr it's Hydrogen all over again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Economy no break please

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Centcom is now only paying 100cr/mol for Zauker, down from 1050.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
