### PR TITLE
Replaces 9x19mm with 9mm, makes the PP-95 use a damage multiplier

### DIFF
--- a/code/__DEFINES/projectiles.dm
+++ b/code/__DEFINES/projectiles.dm
@@ -13,9 +13,7 @@
 #define CALIBER_712X82MM "mm71282"
 /// The caliber used by the [security auto-rifle][/obj/item/gun/ballistic/automatic/wt550].
 #define CALIBER_46X30MM "4.6x30mm"
-/// The caliber used by the [plastikov SMG][/obj/item/gun/ballistic/automatic/plastikov].
-#define CALIBER_9X19MM "9x19mm"
-/// The caliber used by the Nanotrasen Saber SMG, and Type U3 Uzi. Also used as the default caliber for pistols but only the stechkin APS machine pistol doesn't override it.
+/// The caliber used by the Nanotrasen Saber SMG, PP-95 SMG and Type U3 Uzi. Also used as the default caliber for pistols but only the stechkin APS machine pistol doesn't override it.
 #define CALIBER_9MM "9mm"
 /// The caliber used as the default for ballistic guns. Only not overridden for the [surplus rifle][/obj/item/gun/ballistic/automatic/surplus].
 #define CALIBER_10MM "10mm"

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -21,7 +21,7 @@
 	desc = "A 10mm incendiary bullet casing."
 	projectile_type = /obj/projectile/bullet/incendiary/c10mm
 
-// 9mm (Makarov and Stechkin APS)
+// 9mm (Makarov, Stechkin APS, PP-95)
 
 /obj/item/ammo_casing/c9mm
 	name = "9mm bullet casing"

--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -33,11 +33,3 @@
 	name = ".45 incendiary bullet casing"
 	desc = "A .45 bullet casing."
 	projectile_type = /obj/projectile/bullet/incendiary/c45
-
-// 9x19mm (PP-95)
-
-/obj/item/ammo_casing/c9x19mm
-	name = "9x19mm bullet casing"
-	desc = "A 9.19mm bullet casing."
-	caliber = CALIBER_9X19MM
-	projectile_type = /obj/projectile/bullet/c9x19mm

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -31,11 +31,11 @@
 	icon_state = "[base_icon_state]-[round(ammo_count(), 4)]"
 
 /obj/item/ammo_box/magazine/plastikov9mm
-	name = "PP-95 magazine (9x19mm)"
+	name = "PP-95 magazine (9mm)"
 	icon_state = "9x19-50"
 	base_icon_state = "9x19"
-	ammo_type = /obj/item/ammo_casing/c9x19mm
-	caliber = CALIBER_9X19MM
+	ammo_type = /obj/item/ammo_casing/c9mm
+	caliber = CALIBER_9MM
 	max_ammo = 50
 
 /obj/item/ammo_box/magazine/plastikov9mm/update_icon_state()

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -120,7 +120,7 @@
 	spread = 25
 	can_suppress = FALSE
 	actions_types = list()
-	projectile_damage_multiplier = 0.33 //It's like 9.9 damage per bullet, it's close enough to 10
+	projectile_damage_multiplier = 0.35 //It's like 10.5 damage per bullet, it's close enough to 10 shots
 	mag_display = TRUE
 	empty_indicator = TRUE
 	fire_sound = 'sound/weapons/gun/smg/shot_alt.ogg'

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -112,7 +112,7 @@
 
 /obj/item/gun/ballistic/automatic/plastikov
 	name = "\improper PP-95 SMG"
-	desc = "An ancient 9x19mm submachine gun pattern updated and simplified to lower costs, though perhaps simplified too much."
+	desc = "An ancient 9mm submachine gun pattern updated and simplified to lower costs, though perhaps simplified too much."
 	icon_state = "plastikov"
 	inhand_icon_state = "plastikov"
 	mag_type = /obj/item/ammo_box/magazine/plastikov9mm
@@ -120,6 +120,7 @@
 	spread = 25
 	can_suppress = FALSE
 	actions_types = list()
+	projectile_damage_multiplier = 0.33 //It's like 9.9 damage per bullet, it's close enough to 10
 	mag_display = TRUE
 	empty_indicator = TRUE
 	fire_sound = 'sound/weapons/gun/smg/shot_alt.ogg'

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -35,9 +35,3 @@
 	name = "4.6x30mm incendiary bullet"
 	damage = 10
 	fire_stacks = 1
-
-// 9x19mm (PP-95)
-
-/obj/projectile/bullet/c9x19mm
-	name = "9x19mm bullet"
-	damage = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the special snowflake bullet with just generic 9mm in the PP-95's mag. 

PP-95's now have a .35 damage multiplier, resulting in all 9mm bullets they fire to instead deal 10.5.

## Why It's Good For The Game

I know gun nuts are gonna scream at me but we should probably not be adding completely new ammo types just for one gun to use, and push towards more generic ammo definitions.

I guess they embed now? What implication that has on the angry bees gun is beyond me but you're spraying people with a tickle gun, you are already not taking this particularly seriously.

## Changelog
:cl:
del: Removes 9x19mm as an ammo type.
balance: PP-95's (the surplus gun for nukies) now use 9mm. They also have a .35 damage multiplier, resulting in standard 9mm doing only 10.5 (9x19mm did 10, so not really much of a difference).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
