### PR TITLE
the rsf now uses base icon state instead of initial(icon_state), doesnt delete stacks instantly

### DIFF
--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -63,7 +63,10 @@ RSF
 		if(tempMatter > max_matter)
 			to_chat(user, "<span class='warning'>\The [src] can't hold any more [discriptor]!</span>")
 			return
-		qdel(W)
+		if(isstack(W))
+			W.use(1)
+		else
+			qdel(W)
 		matter = tempMatter //We add its value
 		playsound(src.loc, 'sound/machines/click.ogg', 10, TRUE)
 		to_chat(user, "<span class='notice'>\The [src] now holds [matter]/[max_matter] [discriptor].</span>")

--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -64,7 +64,8 @@ RSF
 			to_chat(user, "<span class='warning'>\The [src] can't hold any more [discriptor]!</span>")
 			return
 		if(isstack(W))
-			W.use(1)
+			var/obj/item/stack/stack = W
+			stack.use(1)
 		else
 			qdel(W)
 		matter = tempMatter //We add its value

--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -10,6 +10,7 @@ RSF
 	desc = "A device used to rapidly deploy service items."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rsf"
+	base_icon_state = "rsf"
 	///The icon state to revert to when the tool is empty
 	var/spent_icon_state = "rsf_empty"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
@@ -66,7 +67,7 @@ RSF
 		matter = tempMatter //We add its value
 		playsound(src.loc, 'sound/machines/click.ogg', 10, TRUE)
 		to_chat(user, "<span class='notice'>\The [src] now holds [matter]/[max_matter] [discriptor].</span>")
-		icon_state = initial(icon_state)//and set the icon state to the initial value it had
+		icon_state = base_icon_state//and set the icon state to the base state
 	else
 		return ..()
 
@@ -147,6 +148,7 @@ RSF
 	name = "Cookie Synthesizer"
 	desc = "A self-recharging device used to rapidly deploy cookies."
 	icon_state = "rcd"
+	base_icon_state = "rcd"
 	spent_icon_state = "rcd"
 	max_matter = 10
 	cost_by_item = list(/obj/item/food/cookie = 100)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
the rsf now uses base icon state instead of initial(icon_state)
it uses stacks instead of deleting them

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
lets you customize the icon with admin tools or in a map or something, this item is almost a fully modular printer thingy so this will be great

## Changelog
:cl:
code: rsf can now have a custom icon, no longer deletes stacks instantly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
