### PR TITLE
The "change everyone's species" button no longer turns everyone into traitors

### DIFF
--- a/tgui/packages/tgui/interfaces/Secrets.js
+++ b/tgui/packages/tgui/interfaces/Secrets.js
@@ -456,7 +456,7 @@ const FunForYouTab = (props, context) => {
             icon="hand-lizard"
             fluid
             content="Change everyone's species"
-            onClick={() => act("traitor_all")} />
+            onClick={() => act("allspecies")} />
         </NoticeBox>
       </Stack.Item>
       <Stack.Item>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Arm goofed and made it so the button in the secrets panel that is supposed to change everyone's species actually activates the "make everyone kill each other" button. This fixes that

Fixes: #57702
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Frankly if you hit the change species button as an admin i think you deserve this, but nothing wrong with correct code I guess
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: The admin button to change everyone's species no longer makes everyone a traitor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
