### PR TITLE
nerfs Infective Exo-Locomotion use rate

### DIFF
--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -188,7 +188,7 @@
 	name = "Infective Exo-Locomotion"
 	desc = "The nanites gain the ability to survive for brief periods outside of the human body, as well as the ability to start new colonies without an integration process; \
 			resulting in an extremely infective strain of nanites."
-	use_rate = 1.50
+	use_rate = 5.50
 	rogue_types = list(/datum/nanite_program/aggressive_replication, /datum/nanite_program/necrotic)
 	var/spread_cooldown = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes Infective Exo-Locomotion use 5.5 nanites a second instead of 1.5

## Why It's Good For The Game

a single protocol-virus-food replication lets nanites spread 100% of the time (plus the wiki said 5.5 for ages and apparently its been 1.5 for ages also in the code,) and was ment to be a high resource program  

## Changelog
balance: Infective Exo-Locomotion now uses 5.5 nanites per second (up from 1.5)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
