### PR TITLE
Formaldehyde uses mercury instead of silver

### DIFF
--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -1,7 +1,7 @@
 
 /datum/chemical_reaction/formaldehyde
 	results = list(/datum/reagent/toxin/formaldehyde = 3)
-	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/oxygen = 1, /datum/reagent/silver = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/oxygen = 1, /datum/reagent/mercury = 1)
 	required_temp = 420
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DAMAGING | REACTION_TAG_CHEMICAL | REACTION_TAG_BRUTE | REACTION_TAG_TOXIN
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes formaldehyde use mercury instead of silver in its recipe.

## Why It's Good For The Game

https://github.com/tgstation/tgstation/pull/57306 changed stasis beds to not use operating computers, so patients need to be moved into operating rooms for any major surgery. This causes organ rot in dead patients unless the doctors use their one medipen on the patient first. This will fix the weird artificial scarcity of a basic, three reagent chem that should be seeing a lot more use than it currently is.

## Changelog
:cl:
balance: changed formaldehyde recipe to use mercury in place of silver
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
