### PR TITLE
Nondextrous mobs can't use hotkeys on atmos machineries

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -345,7 +345,7 @@
 		if(!(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON))
 			return FALSE
 
-	else if(ishuman(user)) // If we are a living human
+	else if(user.can_hold_items()) // If we are a living mob with hand slots.
 		var/mob/living/L = user
 
 		if(interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SILICON) // First make sure the machine doesn't require silicon interaction

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -333,7 +333,6 @@
 
 
 /obj/machinery/can_interact(mob/user)
-	var/dextrous_cache = FALSE
 	if((machine_stat & (NOPOWER|BROKEN)) && !(interaction_flags_machine & INTERACT_MACHINE_OFFLINE)) // Check if the machine is broken, and if we can still interact with it if so
 		return FALSE
 
@@ -346,12 +345,13 @@
 		if(!(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON))
 			return FALSE
 
-	if(istype(user, /mob/living/simple_animal))
-		var/mob/living/simple_animal/SA = user
-		if (SA.dextrous)
-			dextrous_cache = TRUE
+	var/is_dextrous = FALSE
+	if(isanimal(user))
+		var/mob/living/simple_animal/user_as_animal = user
+		if (user_as_animal.dextrous)
+			is_dextrous = TRUE
 
-	if(dextrous_cache || user.can_hold_items()) // If we are a living mob with hand slots or a dextrous simple animal.
+	if(is_dextrous || user.can_hold_items()) // If we are a living mob with hand slots or a dextrous simple animal.
 		var/mob/living/L = user
 
 		if(interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SILICON) // First make sure the machine doesn't require silicon interaction

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -333,6 +333,7 @@
 
 
 /obj/machinery/can_interact(mob/user)
+	var/dextrous_cache = FALSE
 	if((machine_stat & (NOPOWER|BROKEN)) && !(interaction_flags_machine & INTERACT_MACHINE_OFFLINE)) // Check if the machine is broken, and if we can still interact with it if so
 		return FALSE
 
@@ -345,7 +346,12 @@
 		if(!(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON))
 			return FALSE
 
-	else if(user.can_hold_items()) // If we are a living mob with hand slots.
+	if(istype(user, /mob/living/simple_animal))
+		var/mob/living/simple_animal/SA = user
+		if (SA.dextrous)
+			dextrous_cache = TRUE
+
+	else if(user.can_hold_items() || dextrous_cache) // If we are a living mob with hand slots or a dextrous simple animal.
 		var/mob/living/L = user
 
 		if(interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SILICON) // First make sure the machine doesn't require silicon interaction

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -345,7 +345,7 @@
 		if(!(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON))
 			return FALSE
 
-	else if(isliving(user)) // If we are a living human
+	else if(ishuman(user)) // If we are a living human
 		var/mob/living/L = user
 
 		if(interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SILICON) // First make sure the machine doesn't require silicon interaction

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -351,7 +351,7 @@
 		if (SA.dextrous)
 			dextrous_cache = TRUE
 
-	else if(user.can_hold_items() || dextrous_cache) // If we are a living mob with hand slots or a dextrous simple animal.
+	if(dextrous_cache || user.can_hold_items()) // If we are a living mob with hand slots or a dextrous simple animal.
 		var/mob/living/L = user
 
 		if(interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SILICON) // First make sure the machine doesn't require silicon interaction


### PR DESCRIPTION
## About The Pull Request
Lemon asked me to atomize.


OUTDATED:
`can_interact` now does what the comment thinks its doing. It checks if something is human rather than if something is alive. This does not exclude monkeys, but let me know if i should add a separate check for them. Omitted doing that since it is a parent proc to many other machineries, not just atmospheric ones.


Nondextrous mobs can now no longer use hotkeys on atmospheric machineries. dextrous simplemobs, and mobs that can hold objects are allowed (drone springs to mind.)
Many thanks to the reviewers!

## Why It's Good For The Game
No more wannabe atmostech spiders flooding the station with funny gases.

## Changelog
:cl:
fix: Nondextrous simplemobs can no longer interact with atmos machineries using hotkeys.
/:cl: