### PR TITLE
player-controlled gorillas can now choose to punch windows down instead of politely knocking on them

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -203,11 +203,11 @@
 /mob/living/simple_animal/UnarmedAttack(atom/A, proximity_flag, list/modifiers)
 	if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		return
-	if(!dextrous)
-		return ..()
-	if(!ismob(A))
+	if(dextrous && (isitem(A) || !combat_mode))
 		A.attack_hand(src, modifiers)
 		update_inv_hands()
+	else
+		return ..()
 
 
 /*
@@ -218,7 +218,7 @@
 	if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		return
 	target = A
-	if(dextrous && !ismob(A))
+	if(dextrous && (isitem(A) || !combat_mode))
 		..()
 	else
 		AttackingTarget(A)


### PR DESCRIPTION
## About The Pull Request

The logic for the unarmed attacks of dextrous mobs has been changed. Now, if a dextrous mob attacks something with a bare hand while on combat mode, they'll go ape on it, but if they attack it with a bare hand while not on combat mode, they'll interact with it like a human would. Items are an exception to this, and clicking on an item should cause you to pick it up regardless of whether or not you're on combat mode.

This means that gorillas can now break down normal walls (but not rwalls) with their bare hands instead of checking them for secret walls, if they so choose.

This also applies to dextrous holoparasites, but not to drones, since drones have their own override for UnarmedAttack().

## Why It's Good For The Game

Gorillas are VERY CLEARLY supposed to be able to break down normal walls:
`	environment_smash = ENVIRONMENT_SMASH_WALLS`
```
/mob/living/simple_animal/hostile/gorilla/CanSmashTurfs(turf/T)
	return iswallturf(T)
```

It also takes away from the fantasy of being a strong ape that can rip people's arms off with its bare hands if you can get stymied by a mere non-reinforced window unless you have some pathetic hoo-man tools to help you get past it. It also causes a disconnect between yourself and your character when your character starts politely knocking on the window that you're trying to smash, despite being on combat mode.

Also, gorillas who click on someone on help intent thinking that they can hug them will no longer accidentally beat the person they were trying to hug.

This PR has been tested, but I've noticed some oddities with it so far:
* Hitting a window as a gorilla plays a smashing animation, but doesn't play a smashing sound.
* Clicking on a human while not on combat mode as a gorilla does nothing. While still better than punching them, I feel like there has to be some way that I can make it look like a hug or something. Gee, if only my Robots, Hugs, and Fires PR, which refactored hug code so that any mob, not just carbons, could call help_shake_act() on a carbon didn't get closed...
* Gorillas seem to do a really underwhelming amount of damage to structures. Like, normal airlocks don't appear to take any damage, lockers take quite a few hits before popping open due to damage, and reinforced windows take aaaaages to break. If a maintainer permits me to, I'd like to bump the object damage of gorillas up from 20 to 30, or maybe even 50. They can break down walls with a single punch, so they shouldn't be stymied by a door. Not addressing this could make the Lunk issue (https://youtu.be/p4qMbBLEotk?t=145) even worse for gorillas than it is for humans.
* I forgot to test clicking on an item on the ground in and out of combat mode during my testing session. I know that you CAN still pick up a baton as a gorilla, I just forgot which combat state(s) I tested that with. I know that you can still toggle a stun baton with "z" on both intents now, though.
* I still need to test how that one dextrous, handless clown simplemob interacts with this PR's changes.

Proof of testing:
![image](https://user-images.githubusercontent.com/42606352/111065154-4438f680-8486-11eb-98d2-a303c883aa50.png)

## Changelog
:cl:
fix: Gorillas (and dextrous holoparasites) can now SMASH walls, windows, tables, etc. while in combat mode, as they were intended be able to.
/:cl:
