### PR TITLE
Fixes smoker addiction, reworks addiction system a bit.

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -105,11 +105,13 @@
 #define MAX_ADDICTION_POINTS 1000
 
 ///Addiction start/ends
-#define WITHDRAWAL_STAGE1_START_CYCLE 1
-#define WITHDRAWAL_STAGE1_END_CYCLE 60
-#define WITHDRAWAL_STAGE2_START_CYCLE 61
-#define WITHDRAWAL_STAGE2_END_CYCLE 120
-#define WITHDRAWAL_STAGE3_START_CYCLE 121
+#define WITHDRAWAL_STAGE0_START_CYCLE 1
+#define WITHDRAWAL_STAGE0_END_CYCLE 60
+#define WITHDRAWAL_STAGE1_START_CYCLE 61
+#define WITHDRAWAL_STAGE1_END_CYCLE 120
+#define WITHDRAWAL_STAGE2_START_CYCLE 121
+#define WITHDRAWAL_STAGE2_END_CYCLE 180
+#define WITHDRAWAL_STAGE3_START_CYCLE 181
 
 ///reagent tags - used to look up reagents for specific effects. Feel free to add to but comment it
 /// This reagent does brute effects (BOTH damaging and healing)

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -102,8 +102,6 @@
 ////Used to force an equlibrium to end a reaction in reaction_step() (i.e. in a reaction_step() proc return END_REACTION to end it)
 #define END_REACTION "end_reaction"
 
-///Minimum requirement for addiction buzz to be met
-#define MIN_ADDICTION_REAGENT_AMOUNT 2
 #define MAX_ADDICTION_POINTS 1000
 
 ///Addiction start/ends

--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -49,6 +49,7 @@
 
 /datum/mood_event/addiction_satiated/add_effects(drug_name)
 	description = "<span class='nicegreen'>I've had some [drug_name] recently!</span>\n"
+
 /datum/mood_event/happiness_drug
 	description = "<span class='nicegreen'>Can't feel a thing...</span>\n"
 	mood_change = 50

--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -43,6 +43,12 @@
 /datum/mood_event/withdrawal_critical/add_effects(drug_name)
 	description = "<span class='boldwarning'>[drug_name]! [drug_name]! [drug_name]!</span>\n"
 
+/datum/mood_event/addiction_satiated
+	mood_change = 1
+	timeout = 1 MINUTES
+
+/datum/mood_event/addiction_satiated/add_effects(drug_name)
+	description = "<span class='nicegreen'>I've had some [drug_name] recently!</span>\n"
 /datum/mood_event/happiness_drug
 	description = "<span class='nicegreen'>Can't feel a thing...</span>\n"
 	mood_change = 50

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -509,7 +509,7 @@
 		reagent_type = pick(drug_list)
 	reagent_instance = new reagent_type()
 	for(var/addiction in reagent_instance.addiction_types)
-		H.mind.add_addiction_points(addiction, 1000) ///Max that shit out
+		H.mind?.add_addiction_points(addiction, 1000) ///Max that shit out
 	var/current_turf = get_turf(quirk_holder)
 	if (!drug_container_type)
 		drug_container_type = /obj/item/storage/pill_bottle
@@ -542,7 +542,7 @@
 /datum/quirk/junkie/remove()
 	if(quirk_holder && reagent_instance)
 		for(var/addiction_type in subtypesof(/datum/addiction))
-			quirk_holder.mind.remove_addiction_points(addiction_type, MAX_ADDICTION_POINTS) //chat feedback here. No need of lose_text.
+			quirk_holder.mind?.remove_addiction_points(addiction_type, MAX_ADDICTION_POINTS) //chat feedback here. No need of lose_text.
 
 /datum/quirk/junkie/proc/announce_drugs()
 	to_chat(quirk_holder, "<span class='boldnotice'>There is a [initial(drug_container_type.name)] of [initial(reagent_type.name)] [where_drug]. Better hope you don't run out...</span>")
@@ -556,14 +556,14 @@
 		var/deleted = QDELETED(reagent_instance)
 		var/missing_addiction = FALSE
 		for(var/addiction_type in reagent_instance.addiction_types)
-			if(!LAZYACCESS(H.mind.active_addictions, addiction_type))
+			if(!LAZYACCESS(H.mind?.active_addictions, addiction_type))
 				missing_addiction = TRUE
 		if(deleted || missing_addiction)
 			if(deleted)
 				reagent_instance = new reagent_type()
 			to_chat(quirk_holder, "<span class='danger'>You thought you kicked it, but you feel like you're falling back onto bad habits..</span>")
 			for(var/addiction in reagent_instance.addiction_types)
-				H.mind.add_addiction_points(addiction, 1000) ///Max that shit out
+				H.mind?.add_addiction_points(addiction, 1000) ///Max that shit out
 
 
 /datum/quirk/junkie/smoker

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -519,7 +519,7 @@
 		for(var/i in 1 to 7)
 			var/obj/item/reagent_containers/pill/P = new(drug_instance)
 			P.icon_state = pill_state
-			P.reagents.add_reagent(reagent_type, 1)
+			P.reagents.add_reagent(reagent_type, 2)
 
 	var/obj/item/accessory_instance
 	if (accessory_type)

--- a/code/modules/reagents/withdrawal/_addiction.dm
+++ b/code/modules/reagents/withdrawal/_addiction.dm
@@ -93,7 +93,6 @@
 			withdrawal_enters_stage_1(affected_carbon)
 		if(WITHDRAWAL_STAGE2_START_CYCLE)
 			withdrawal_enters_stage_2(affected_carbon)
-			addiction_satiated = FALSE //reset so they can get the addiction satiation enter after getting their fix
 		if(WITHDRAWAL_STAGE3_START_CYCLE)
 			withdrawal_enters_stage_3(affected_carbon)
 
@@ -124,6 +123,7 @@
 /// Called when addiction enters stage 2
 /datum/addiction/proc/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
 	SEND_SIGNAL(affected_carbon, COMSIG_ADD_MOOD_EVENT, "[type]_addiction", /datum/mood_event/withdrawal_medium, name)
+	addiction_satiated = FALSE //reset so they can get the addiction satiation enter after getting their fix
 
 /// Called when addiction enters stage 3
 /datum/addiction/proc/withdrawal_enters_stage_3(mob/living/carbon/affected_carbon)

--- a/code/modules/reagents/withdrawal/_addiction.dm
+++ b/code/modules/reagents/withdrawal/_addiction.dm
@@ -1,4 +1,6 @@
 ///base class for addiction, handles when you become addicted and what the effects of that are. By default you become addicted when you hit a certain threshold, and stop being addicted once you go below another one.
+
+#define ADDICTION_SATIETY_TICKS 8
 /datum/addiction
 	///Name of this addiction
 	var/name = "cringe code"
@@ -12,6 +14,10 @@
 	var/addiction_loss_per_stage = list(0.5, 0.5, 1, 1.5)
 	///Rate at which high sanity helps addiction loss
 	var/high_sanity_addiction_loss = 2
+	///Time since last addiction dose was taken
+	var/time_since_dose_began = 0
+	///Addiction has been satiated from a higher withdrawal state
+	var/addiction_satiated = FALSE
 
 ///Called when you gain addiction points somehow. Takes a mind as argument and sees if you gained the addiction
 /datum/addiction/proc/on_gain_addiction_points(datum/mind/victim_mind)
@@ -47,12 +53,18 @@
 /datum/addiction/proc/process_addiction(mob/living/carbon/affected_carbon, delta_time, times_fired)
 	var/current_addiction_cycle = LAZYACCESS(affected_carbon.mind.active_addictions, type) //If this is null, we're not addicted
 	var/on_drug_of_this_addiction = FALSE
+	message_admins("[time_since_dose_began]")
 	for(var/datum/reagent/possible_drug as anything in affected_carbon.reagents.reagent_list) //Go through the drugs in our system
 		for(var/addiction in possible_drug.addiction_types) //And check all of their addiction types
-			if(addiction == type && possible_drug.volume >= MIN_ADDICTION_REAGENT_AMOUNT) //If one of them matches, and we have enough of it in our system, we're not losing addiction
-				if(current_addiction_cycle)
-					LAZYSET(affected_carbon.mind.active_addictions, type, 1) //Keeps withdrawal at first cycle.
-				on_drug_of_this_addiction = TRUE
+			if(addiction == type && possible_drug.volume > 0) //If addiction drug is in system
+				if(time_since_dose_began >= ADDICTION_SATIETY_TICKS) // and it's been in their body for more than 8 consecutive seconds, they're satisfying their addiction
+					if(!addiction_satiated && current_addiction_cycle > WITHDRAWAL_STAGE2_START_CYCLE) //only give the bonus if they've come down from a higher level
+						addiction_satiated = TRUE
+						addiction_satiated_enter(affected_carbon)
+					if(current_addiction_cycle)
+						LAZYSET(affected_carbon.mind.active_addictions, type, 1) //Keeps withdrawal at first cycle.
+					on_drug_of_this_addiction = TRUE
+				time_since_dose_began += delta_time
 				return
 
 	var/withdrawal_stage
@@ -68,6 +80,7 @@
 			withdrawal_stage = 0
 
 	if(!on_drug_of_this_addiction)
+		time_since_dose_began = 0
 		if(affected_carbon.mind.remove_addiction_points(type, addiction_loss_per_stage[withdrawal_stage + 1] * delta_time)) //If true was returned, we lost the addiction!
 			return
 
@@ -79,6 +92,7 @@
 			withdrawal_enters_stage_1(affected_carbon)
 		if(WITHDRAWAL_STAGE2_START_CYCLE)
 			withdrawal_enters_stage_2(affected_carbon)
+			addiction_satiated = FALSE //reset so they can get the addiction satiation enter after getting their fix
 		if(WITHDRAWAL_STAGE3_START_CYCLE)
 			withdrawal_enters_stage_3(affected_carbon)
 
@@ -105,6 +119,9 @@
 /datum/addiction/proc/withdrawal_enters_stage_3(mob/living/carbon/affected_carbon)
 	SEND_SIGNAL(affected_carbon, COMSIG_ADD_MOOD_EVENT, "[type]_addiction", /datum/mood_event/withdrawal_severe, name)
 
+/// Called when addiction is first satiated from a withdrawal stage
+/datum/addiction/proc/addiction_satiated_enter(mob/living/carbon/affected_carbon)
+	SEND_SIGNAL(affected_carbon, COMSIG_ADD_MOOD_EVENT, "[type]_addiction_satiated", /datum/mood_event/addiction_satiated, name)
 
 /// Called when addiction is in stage 1 every process
 /datum/addiction/proc/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
@@ -116,8 +133,9 @@
 	if(DT_PROB(10, delta_time) )
 		to_chat(affected_carbon, "<span class='danger'>[withdrawal_stage_messages[2]]</span>")
 
-
 /// Called when addiction is in stage 3 every process
 /datum/addiction/proc/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
 	if(DT_PROB(15, delta_time))
 		to_chat(affected_carbon, "<span class='danger'>[withdrawal_stage_messages[3]]</span>")
+
+#undef ADDICTION_SATIETY_TICKS

--- a/code/modules/reagents/withdrawal/_addiction.dm
+++ b/code/modules/reagents/withdrawal/_addiction.dm
@@ -1,6 +1,6 @@
 ///base class for addiction, handles when you become addicted and what the effects of that are. By default you become addicted when you hit a certain threshold, and stop being addicted once you go below another one.
 
-#define ADDICTION_SATIETY_TICKS 8
+#define ADDICTION_SATIETY_TICKS 6
 /datum/addiction
 	///Name of this addiction
 	var/name = "cringe code"
@@ -35,7 +35,7 @@
 	log_game("[key_name(victim_mind.current)] has become addicted to [name].")
 
 
-///Called when you lose addiction poitns somehow. Takes a mind as argument and sees if you lost the addiction
+///Called when you lose addiction points somehow. Takes a mind as argument and sees if you lost the addiction
 /datum/addiction/proc/on_lose_addiction_points(datum/mind/victim_mind)
 	var/current_addiction_point_amount = victim_mind.addiction_points[type]
 	if(!LAZYACCESS(victim_mind.active_addictions, type)) //Not addicted
@@ -56,12 +56,12 @@
 	for(var/datum/reagent/possible_drug as anything in affected_carbon.reagents.reagent_list) //Go through the drugs in our system
 		for(var/addiction in possible_drug.addiction_types) //And check all of their addiction types
 			if(addiction == type && possible_drug.volume > 0) //If addiction drug is in system
-				if(time_since_dose_began >= ADDICTION_SATIETY_TICKS) // and it's been in their body for more than 8 consecutive seconds, they're satisfying their addiction
+				if(time_since_dose_began >= ADDICTION_SATIETY_TICKS) // and it's been in their body for more than 6 consecutive seconds, they're satisfying their addiction
 					if(!addiction_satiated && current_addiction_cycle > WITHDRAWAL_STAGE2_START_CYCLE) //only give the bonus if they've come down from a higher level
 						addiction_satiated = TRUE
 						addiction_satiated_enter(affected_carbon)
 					if(current_addiction_cycle)
-						LAZYSET(affected_carbon.mind.active_addictions, type, 1) //Keeps withdrawal at first cycle.
+						LAZYSET(affected_carbon.mind.active_addictions, type, 0) //Keeps withdrawal at first cycle.
 					on_drug_of_this_addiction = TRUE
 				time_since_dose_began += delta_time
 				return
@@ -69,14 +69,14 @@
 	var/withdrawal_stage
 
 	switch(current_addiction_cycle)
+		if(WITHDRAWAL_STAGE0_START_CYCLE to WITHDRAWAL_STAGE0_END_CYCLE)
+			withdrawal_stage = 0
 		if(WITHDRAWAL_STAGE1_START_CYCLE to WITHDRAWAL_STAGE1_END_CYCLE)
 			withdrawal_stage = 1
 		if(WITHDRAWAL_STAGE2_START_CYCLE to WITHDRAWAL_STAGE2_END_CYCLE)
 			withdrawal_stage = 2
 		if(WITHDRAWAL_STAGE3_START_CYCLE to INFINITY)
 			withdrawal_stage = 3
-		else
-			withdrawal_stage = 0
 
 	if(!on_drug_of_this_addiction)
 		time_since_dose_began = 0
@@ -87,6 +87,8 @@
 		return FALSE
 
 	switch(current_addiction_cycle)
+		if(WITHDRAWAL_STAGE0_START_CYCLE)
+			withdrawal_enters_stage_0(affected_carbon)
 		if(WITHDRAWAL_STAGE1_START_CYCLE)
 			withdrawal_enters_stage_1(affected_carbon)
 		if(WITHDRAWAL_STAGE2_START_CYCLE)
@@ -97,6 +99,8 @@
 
 	///One cycle is 2 seconds
 	switch(withdrawal_stage)
+		if(0)
+			withdrawal_stage_0_process(affected_carbon, delta_time)
 		if(1)
 			withdrawal_stage_1_process(affected_carbon, delta_time)
 		if(2)
@@ -105,6 +109,13 @@
 			withdrawal_stage_3_process(affected_carbon, delta_time)
 
 	LAZYADDASSOC(affected_carbon.mind.active_addictions, type, 1 * delta_time) //Next cycle!
+
+/// Called when addiciton enters stage 0
+/datum/addiction/proc/withdrawal_enters_stage_0(mob/living/carbon/affected_carbon)
+	/// Clear all withdrawal mood effects
+	SEND_SIGNAL(affected_carbon, COMSIG_CLEAR_MOOD_EVENT, "[type]_addiction", /datum/mood_event/withdrawal_light, name)
+	SEND_SIGNAL(affected_carbon, COMSIG_CLEAR_MOOD_EVENT, "[type]_addiction", /datum/mood_event/withdrawal_medium, name)
+	SEND_SIGNAL(affected_carbon, COMSIG_CLEAR_MOOD_EVENT, "[type]_addiction", /datum/mood_event/withdrawal_severe, name)
 
 /// Called when addiction enters stage 1
 /datum/addiction/proc/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
@@ -121,6 +132,9 @@
 /// Called when addiction is first satiated from a withdrawal stage
 /datum/addiction/proc/addiction_satiated_enter(mob/living/carbon/affected_carbon)
 	SEND_SIGNAL(affected_carbon, COMSIG_ADD_MOOD_EVENT, "[type]_addiction_satiated", /datum/mood_event/addiction_satiated, name)
+
+/// Called when addiction is in stage 0 every process, empty by default. Override in addiction procs
+/datum/addiction/proc/withdrawal_stage_0_process(mob/living/carbon/affected_carbon, delta_time)
 
 /// Called when addiction is in stage 1 every process
 /datum/addiction/proc/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)

--- a/code/modules/reagents/withdrawal/_addiction.dm
+++ b/code/modules/reagents/withdrawal/_addiction.dm
@@ -53,7 +53,6 @@
 /datum/addiction/proc/process_addiction(mob/living/carbon/affected_carbon, delta_time, times_fired)
 	var/current_addiction_cycle = LAZYACCESS(affected_carbon.mind.active_addictions, type) //If this is null, we're not addicted
 	var/on_drug_of_this_addiction = FALSE
-	message_admins("[time_since_dose_began]")
 	for(var/datum/reagent/possible_drug as anything in affected_carbon.reagents.reagent_list) //Go through the drugs in our system
 		for(var/addiction in possible_drug.addiction_types) //And check all of their addiction types
 			if(addiction == type && possible_drug.volume > 0) //If addiction drug is in system

--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -3,6 +3,10 @@
 	name = "opiod"
 	withdrawal_stage_messages = list("I feel aches in my bodies..", "I need some pain relief...", "It aches all over...I need some opiods!")
 
+/datum/addiction/opiods/withdrawal_enters_stage_0(mob/living/carbon/affected_carbon)
+	. = ..()
+	lose_addiction(affected_carbon.mind)
+
 /datum/addiction/opiods/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
 	if(DT_PROB(10, delta_time))
@@ -30,8 +34,7 @@
 
 /datum/addiction/stimulants/withdrawal_enters_stage_0(mob/living/carbon/affected_carbon)
 	. = ..()
-	affected_carbon.remove_actionspeed_modifier(/datum/actionspeed_modifier/stimulants)
-	affected_carbon.remove_movespeed_modifier(/datum/movespeed_modifier/stimulants)
+	lose_addiction(affected_carbon.mind)
 
 /datum/addiction/stimulants/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
 	. = ..()
@@ -77,6 +80,10 @@
 	name = "hallucinogen"
 	withdrawal_stage_messages = list("I feel so empty...", "I wonder what the machine elves are up to?..", "I need to see the beautiful colors again!!")
 
+/datum/addiction/hallucinogens/withdrawal_enters_stage_0(mob/living/carbon/affected_carbon)
+	. = ..()
+	lose_addiction(affected_carbon.mind)
+
 /datum/addiction/hallucinogens/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
 	. = ..()
 	var/atom/movable/plane_master_controller/game_plane_master_controller = affected_carbon.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
@@ -97,6 +104,10 @@
 
 /datum/addiction/maintenance_drugs
 	name = "maintenance drug"
+
+/datum/addiction/maintenance_drugs/withdrawal_enters_stage_0(mob/living/carbon/affected_carbon)
+	. = ..()
+	lose_addiction(affected_carbon.mind)
 
 /datum/addiction/maintenance_drugs/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
 	. = ..()
@@ -166,6 +177,10 @@
 	withdrawal_stage_messages = list("", "", "")
 	var/datum/hallucination/fake_alert/hallucination
 	var/datum/hallucination/fake_health_doll/hallucination2
+
+/datum/addiction/medicine/withdrawal_enters_stage_0(mob/living/carbon/affected_carbon)
+	. = ..()
+	lose_addiction(affected_carbon.mind)
 
 /datum/addiction/medicine/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
 	. = ..()
@@ -239,6 +254,10 @@
 	name = "nicotine"
 	withdrawal_stage_messages = list("Feel like having a smoke...", "Getting antsy. Really need a smoke now.", "I can't take it! Need a smoke NOW!")
 
+/datum/addiction/nicotine/withdrawal_enters_stage_0(mob/living/carbon/affected_carbon)
+	. = ..()
+	lose_addiction(affected_carbon.mind)
+
 /datum/addiction/nicotine/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
 	if(DT_PROB(5, delta_time))
@@ -259,7 +278,8 @@
 	if(DT_PROB(15, delta_time))
 		affected_carbon.emote("cough")
 
-/datum/addiction/nicotine/addiction_satiated_enter(mob/living/carbon/affected_carbon)
+/datum/addiction/nicotine/lose_addiction(datum/mind/victim_mind)
 	. = ..()
+	var/mob/living/carbon/human/affected_carbon = victim_mind.current
 	SEND_SIGNAL(affected_carbon, COMSIG_CLEAR_MOOD_EVENT, "nicotine_withdrawal_moderate", /datum/mood_event/nicotine_withdrawal_moderate)
 	SEND_SIGNAL(affected_carbon, COMSIG_CLEAR_MOOD_EVENT, "nicotine_withdrawal_severe", /datum/mood_event/nicotine_withdrawal_severe)

--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -5,7 +5,7 @@
 
 /datum/addiction/opiods/withdrawal_enters_stage_0(mob/living/carbon/affected_carbon)
 	. = ..()
-	lose_addiction(affected_carbon.mind)
+	affected_carbon.remove_status_effect(STATUS_EFFECT_HIGHBLOODPRESSURE)
 
 /datum/addiction/opiods/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
@@ -34,7 +34,9 @@
 
 /datum/addiction/stimulants/withdrawal_enters_stage_0(mob/living/carbon/affected_carbon)
 	. = ..()
-	lose_addiction(affected_carbon.mind)
+	affected_carbon.remove_actionspeed_modifier(ACTIONSPEED_ID_STIMULANTS)
+	affected_carbon.remove_status_effect(STATUS_EFFECT_WOOZY)
+	affected_carbon.remove_movespeed_modifier(MOVESPEED_ID_STIMULANTS)
 
 /datum/addiction/stimulants/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
 	. = ..()
@@ -82,7 +84,10 @@
 
 /datum/addiction/hallucinogens/withdrawal_enters_stage_0(mob/living/carbon/affected_carbon)
 	. = ..()
-	lose_addiction(affected_carbon.mind)
+	var/atom/movable/plane_master_controller/game_plane_master_controller = affected_carbon.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	game_plane_master_controller.remove_filter("hallucinogen_blur")
+	game_plane_master_controller.remove_filter("hallucinogen_wave")
+	affected_carbon.remove_status_effect(/datum/status_effect/trance, 40 SECONDS, TRUE)
 
 /datum/addiction/hallucinogens/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
 	. = ..()
@@ -107,7 +112,16 @@
 
 /datum/addiction/maintenance_drugs/withdrawal_enters_stage_0(mob/living/carbon/affected_carbon)
 	. = ..()
-	lose_addiction(affected_carbon.mind)
+	affected_carbon.hal_screwyhud = SCREWYHUD_NONE
+	if(!ishuman(affected_carbon))
+		return
+	var/mob/living/carbon/human/affected_human = affected_carbon
+	affected_human.dna?.species.liked_food = initial(affected_human.dna?.species.liked_food)
+	affected_human.dna?.species.disliked_food = initial(affected_human.dna?.species.disliked_food)
+	affected_human.dna?.species.toxic_food = initial(affected_human.dna?.species.toxic_food)
+	REMOVE_TRAIT(affected_human, TRAIT_NIGHT_VISION, type)
+	var/obj/item/organ/eyes/eyes = affected_human.getorgan(/obj/item/organ/eyes)
+	eyes.refresh()
 
 /datum/addiction/maintenance_drugs/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
 	. = ..()
@@ -180,7 +194,9 @@
 
 /datum/addiction/medicine/withdrawal_enters_stage_0(mob/living/carbon/affected_carbon)
 	. = ..()
-	lose_addiction(affected_carbon.mind)
+	affected_carbon.hal_screwyhud = SCREWYHUD_NONE
+	hallucination.cleanup()
+	QDEL_NULL(hallucination2)
 
 /datum/addiction/medicine/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
 	. = ..()
@@ -256,7 +272,8 @@
 
 /datum/addiction/nicotine/withdrawal_enters_stage_0(mob/living/carbon/affected_carbon)
 	. = ..()
-	lose_addiction(affected_carbon.mind)
+	SEND_SIGNAL(affected_carbon, COMSIG_CLEAR_MOOD_EVENT, "nicotine_withdrawal_moderate", /datum/mood_event/nicotine_withdrawal_moderate)
+	SEND_SIGNAL(affected_carbon, COMSIG_CLEAR_MOOD_EVENT, "nicotine_withdrawal_severe", /datum/mood_event/nicotine_withdrawal_severe)
 
 /datum/addiction/nicotine/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()

--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -28,6 +28,11 @@
 	name = "stimulant"
 	withdrawal_stage_messages = list("You feel a bit tired...You could really use a pick me up.", "You are getting a bit woozy...", "So...Tired...")
 
+/datum/addiction/stimulants/withdrawal_enters_stage_0(mob/living/carbon/affected_carbon)
+	. = ..()
+	affected_carbon.remove_actionspeed_modifier(/datum/actionspeed_modifier/stimulants)
+	affected_carbon.remove_movespeed_modifier(/datum/movespeed_modifier/stimulants)
+
 /datum/addiction/stimulants/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)
 	. = ..()
 	affected_carbon.add_actionspeed_modifier(/datum/actionspeed_modifier/stimulants)
@@ -234,9 +239,10 @@
 	name = "nicotine"
 	withdrawal_stage_messages = list("Feel like having a smoke...", "Getting antsy. Really need a smoke now.", "I can't take it! Need a smoke NOW!")
 
-/datum/addiction/nicotine/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/nicotine/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
-	affected_carbon.Jitter(5 * delta_time)
+	if(DT_PROB(5, delta_time))
+		affected_carbon.Jitter(5 * delta_time)
 
 /datum/addiction/nicotine/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()

--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -248,6 +248,12 @@
 /datum/addiction/nicotine/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
 	affected_carbon.Jitter(15 * delta_time)
+	SEND_SIGNAL(affected_carbon, COMSIG_CLEAR_MOOD_EVENT, "nicotine_withdrawal_moderate", /datum/mood_event/nicotine_withdrawal_moderate)
 	SEND_SIGNAL(affected_carbon, COMSIG_ADD_MOOD_EVENT, "nicotine_withdrawal_severe", /datum/mood_event/nicotine_withdrawal_severe)
 	if(DT_PROB(15, delta_time))
 		affected_carbon.emote("cough")
+
+/datum/addiction/nicotine/addiction_satiated_enter(mob/living/carbon/affected_carbon)
+	. = ..()
+	SEND_SIGNAL(affected_carbon, COMSIG_CLEAR_MOOD_EVENT, "nicotine_withdrawal_moderate", /datum/mood_event/nicotine_withdrawal_moderate)
+	SEND_SIGNAL(affected_carbon, COMSIG_CLEAR_MOOD_EVENT, "nicotine_withdrawal_severe", /datum/mood_event/nicotine_withdrawal_severe)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #57705, fixes #57168

Please don't kill me, Floyd.

OK, so the problem was that with the recent addiction rework, it only considered an addiction satisfied if you had more than 2u of the chem in your body. Smokers would never reach 2u in any normal circumstance, so this kinda ruined them.

This PR changes this to instead check if the mob has the chem in their body for 6 seconds consecutively (with a bit of leeway, since it checks once every 2 seconds), and if so, the addiction is satisfied.

Also adds a slight positive moodlet for if the addiction is satisfied from stage 2 or higher withdrawal level. Proc can also be extended to have addiction specific benefits if desired, although none is included in this PR.

Stage 0 withdrawal level has also been added, which should allow addicts to function normally as long as they constantly satisfy their addictions since some of the addictions had pretty bad effects even at stage 1 withdrawal.

Starting pills for junkies is also increased from 1u to 2u, so that they are more reliably able to satisfy their urges with 1 pill.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Makes the addiction system a bit less tedious to deal with for most people, giving them an option to keep operating normally if they can keep their addiction in check.

Smoking addiction should no longer be a mental death spiral.

Me burning all of my GBP. 😢 

## Changelog
:cl:
balance: Addictions can now be satisfied by having the chem in your body for 6 seconds consecutively.
balance: Roundstart junkie pills increased from 1u to 2u to more likely be able to satisfy addictions.
balance: Slight positive moodlet from satisfying addiction from a stage 2 or higher withdrawal level.
balance: Stage 0 withdrawal symptoms allows addicts to operate normally as long as they keep their addictions in check
fix: Addicts no longer constantly have a "I need x" moodlet debuff even if they're currently on the drug.
fix: Smokers should no longer be trapped in a jitter and depression spiral.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
