### PR TITLE
Removes leftover stat() call

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -180,12 +180,6 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 			return 1
 	return 0
 
-/datum/cameranet/proc/stat_entry()
-	if(!statclick)
-		statclick = new/obj/effect/statclick/debug(null, "Initializing...", src)
-
-	stat(name, statclick.update("Cameras: [GLOB.cameranet.cameras.len] | Chunks: [GLOB.cameranet.chunks.len]"))
-
 /obj/effect/overlay/camera_static
 	name = "static"
 	icon = null


### PR DESCRIPTION
Shouldn't be there since browser statpanel. Entry already handled here https://github.com/tgstation/tgstation/blob/245bae466c1b46fa6b9b0df3280c4996be80472f/code/controllers/subsystem/statpanel.dm#L166