### PR TITLE
Pay stands reject transactions from departmental budget cards

### DIFF
--- a/code/modules/economy/pay_stand.dm
+++ b/code/modules/economy/pay_stand.dm
@@ -49,6 +49,9 @@
 			return
 		var/obj/item/card/id/pay_card = W
 		if(pay_card.registered_account)
+			if(!pay_card.registered_account.account_job)//Departmental budget cards like cargo's fall under this
+				to_chat(user, "<span class='warning'>ERROR: Personal use of department budgets is not authorized.</span>")
+				return
 			var/credit_amount = 0
 			if(!force_fee)
 				credit_amount = input(user, "How much would you like to deposit?", "Money Deposit") as null|num


### PR DESCRIPTION
## About The Pull Request
Follows the train of thought in https://github.com/tgstation/tgstation/pull/57640 and https://github.com/tgstation/tgstation/pull/57610 in preventing players from transferring funds from departmental budgets to personal accounts

## Why It's Good For The Game
Makes it harder to buy things from personal accounts and avoid dealing with access requirement mechanics 

## Changelog
:cl:
fix: Pay stands won't accept funds from the cargo budget.
/:cl:
