### PR TITLE
Block topics on round restart in stat browser

### DIFF
--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -81,7 +81,9 @@ SUBSYSTEM_DEF(server_maint)
 		if(!thing)
 			continue
 		var/client/C = thing
-		C?.tgui_panel?.send_roundrestart()
+		if (!isnull(C))
+			C.tgui_panel?.send_roundrestart()
+			C << output(null, "statbrowser:round_is_restarting")
 		if(server) //if you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
 			C << link("byond://[server]")
 	var/datum/tgs_version/tgsversion = world.TgsVersion()

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -226,6 +226,13 @@
 <div id="under_menu"></div>
 <div id="statcontent"></div>
 <script>
+var roundRestarting = false;
+
+function round_is_restarting() {
+	roundRestarting = true;
+}
+
+
 // Polyfills and compatibility ------------------------------------------------
 var decoder = decodeURIComponent || unescape;
 var addEventListenerKey = (document.addEventListener ? 'addEventListener' : 'attachEvent'); // IE8 handling for Wine users
@@ -304,7 +311,8 @@ if (window.location) {
 				var y = event.y || event.clientY;
 				if(x || y ) // if either of these exist this is happening after a click
 					return;
-				window.location.href = "byond://winset?command=keyDown " + e.key;
+				if (!roundRestarting)
+					window.location.href = "byond://winset?command=keyDown " + e.key;
 			}
 		}
 	});
@@ -321,7 +329,8 @@ if (window.location) {
 			if( x || y ) // if either of these exist this is happening after a click
 				return;
 
-			window.location.href = "byond://winset?command=keyUp " + e.key;
+			if (!roundRestarting)
+				window.location.href = "byond://winset?command=keyUp " + e.key;
 		}
 	});
 }
@@ -556,11 +565,13 @@ function SendTabsToByond(){
 }
 
 function SendTabToByond(tab) {
+	if (roundRestarting) return;
 	window.location.href = "byond://winset?command=Send-Tabs " + tab;
 }
 
 //Byond can't have this tab anymore since we're removing it
 function TakeTabFromByond(tab) {
+	if (roundRestarting) return;
 	window.location.href = "byond://winset?command=Remove-Tabs " + tab;
 }
 
@@ -674,10 +685,12 @@ function tab_change(tab) {
 	} else {
 		statcontentdiv[textContentKey] = "Loading...";
 	}
+	if (roundRestarting) return;
 	window.location.href = "byond://winset?statbrowser.is-visible=true";
 }
 
 function set_byond_tab(tab){
+	if (roundRestarting) return;
 	window.location.href = "byond://winset?command=Set-Tab " + tab;
 }
 function draw_debug() {
@@ -755,6 +768,7 @@ function draw_status() {
 	}
 	if(verb_tabs.length == 0 || !verbs)
 	{
+		if (roundRestarting) return;
 		window.location.href = "byond://winset?command=Fix-Stat-Panel";
 	}
 }
@@ -1138,6 +1152,7 @@ function set_style_sheet(sheet) {
 }
 
 document[addEventListenerKey]("click", function(e) {
+	if (roundRestarting) return;
 	window.location.href = "byond://winset?map.focus=true";
 });
 
@@ -1151,6 +1166,7 @@ window.onload = function() {
 };
 
 function NotifyByondOnload() {
+	if (roundRestarting) return;
 	window.location.href = "byond://winset?command=Panel-Ready";
 }
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Blocks (nearly, not the verb buttons) every topic call in the statbrowser when the round is restarting.

The reconnect bug is caused when a topic is sent while the round is restarting. I used Cheat Engine to log every topic I/O, and on Bagil I received a crap ton of stat panel updates at the end of the round that I didn't receive on local (where I can't reproduce this bug).

A lot of things are potentially causing this bug, but this is one of them.

## Changelog
:cl:
fix: Fixed another source of the bug that prevents reconnection.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
