### PR TITLE
Fixes the oversight that allows DNA Consoles to massively irradiate things.

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -209,6 +209,7 @@
 	injectorready = world.time + INJECTOR_TIMEOUT
 	scrambleready = world.time + SCRAMBLE_TIMEOUT
 	jokerready = world.time + JOKER_TIMEOUT
+	COOLDOWN_START(src, enzyme_copy_timer, ENZYME_COPY_BASE_COOLDOWN)
 
 	// Set the default tgui state
 	set_default_state()

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -34,6 +34,9 @@
 /// Flag for the mutation ref search system. Search will include advanced injector mutations
 #define SEARCH_ADV_INJ 8
 
+/// The base cooldown of the ability to copy enzymes and genetic makeup to people.
+#define ENZYME_COPY_BASE_COOLDOWN (60 SECONDS)
+
 /obj/machinery/computer/scan_consolenew
 	name = "DNA Console"
 	desc = "Scan DNA."
@@ -85,6 +88,8 @@
 	var/rad_pulse_index = 0
 	/// World time when the enzyme pulse should complete
 	var/rad_pulse_timer = 0
+	/// Cooldown for the genetic makeup transfer actions.
+	COOLDOWN_DECLARE(enzyme_copy_timer)
 
 	/// Used for setting tgui data - Whether the connected DNA Scanner is usable
 	var/can_use_scanner = FALSE
@@ -328,6 +333,7 @@
 	data["injectorSeconds"] = time_to_injector
 	data["isPulsingRads"] = is_pulsing_rads
 	data["radPulseSeconds"] = time_to_pulse
+	data["geneticMakeupCooldown"] = COOLDOWN_TIMELEFT(src, enzyme_copy_timer) / 10
 
 	if(diskette != null)
 		data["hasDisk"] = TRUE
@@ -1198,6 +1204,8 @@
 		//  "ui" - Unique Identity, changes looks
 		//  "mixed" - Combination of both ue and ui
 		if("makeup_injector")
+			if(!COOLDOWN_FINISHED(src, enzyme_copy_timer))
+				return
 			// Convert the index to a number and clamp within the array range, then
 			//  copy the data from the disk to that buffer
 			var/buffer_index = text2num(params["index"])
@@ -1280,6 +1288,9 @@
 			// GUARD CHECK - Can we genetically modify the occupant? Includes scanner
 			//  operational guard checks.
 			if(!can_modify_occupant())
+				return
+
+			if(!COOLDOWN_FINISHED(src, enzyme_copy_timer))
 				return
 
 			// Convert the index to a number and clamp within the array range, then
@@ -1570,6 +1581,7 @@
 			if(!buffer_slot["UI"])
 				to_chat(usr,"<span class='warning'>Genetic data corrupted, unable to apply genetic data.</span>")
 				return FALSE
+			COOLDOWN_START(src, enzyme_copy_timer, ENZYME_COPY_BASE_COOLDOWN)
 			scanner_occupant.dna.uni_identity = buffer_slot["UI"]
 			scanner_occupant.updateappearance(mutations_overlay_update=1)
 			scanner_occupant.radiation += rad_increase
@@ -1582,6 +1594,7 @@
 			if(!buffer_slot["name"] || !buffer_slot["UE"] || !buffer_slot["blood_type"])
 				to_chat(usr,"<span class='warning'>Genetic data corrupted, unable to apply genetic data.</span>")
 				return FALSE
+			COOLDOWN_START(src, enzyme_copy_timer, ENZYME_COPY_BASE_COOLDOWN)
 			scanner_occupant.real_name = buffer_slot["name"]
 			scanner_occupant.name = buffer_slot["name"]
 			scanner_occupant.dna.unique_enzymes = buffer_slot["UE"]
@@ -1596,6 +1609,7 @@
 			if(!buffer_slot["UI"] || !buffer_slot["name"] || !buffer_slot["UE"] || !buffer_slot["blood_type"])
 				to_chat(usr,"<span class='warning'>Genetic data corrupted, unable to apply genetic data.</span>")
 				return FALSE
+			COOLDOWN_START(src, enzyme_copy_timer, ENZYME_COPY_BASE_COOLDOWN)
 			scanner_occupant.dna.uni_identity = buffer_slot["UI"]
 			scanner_occupant.updateappearance(mutations_overlay_update=1)
 			scanner_occupant.real_name = buffer_slot["name"]
@@ -1692,7 +1706,7 @@
 	//  we want to perform it.
 	// GUARD CHECK - Make sure we can modify the occupant, apply_genetic_makeup()
 	//  assumes we've already done this.
-	if(delayed_action && can_modify_occupant())
+	if(delayed_action && can_modify_occupant() && COOLDOWN_FINISHED(src, enzyme_copy_timer))
 		var/type = delayed_action["type"]
 		var/buffer_slot = delayed_action["buffer_slot"]
 		if(apply_genetic_makeup(type, buffer_slot))

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -2151,6 +2151,7 @@
 		diskette.forceMove(drop_location())
 	diskette = null
 
+#undef ENZYME_COPY_BASE_COOLDOWN
 #undef INJECTOR_TIMEOUT
 #undef NUMBER_OF_BUFFERS
 #undef SCRAMBLE_TIMEOUT

--- a/tgui/packages/tgui/interfaces/DnaConsole.js
+++ b/tgui/packages/tgui/interfaces/DnaConsole.js
@@ -1186,11 +1186,11 @@ const GeneticMakeupBuffers = (props, context) => {
   const { data, act } = useBackend(context);
   const {
     diskHasMakeup,
+    geneticMakeupCooldown,
     hasDisk,
     isViableSubject,
     makeupCapacity = 3,
     makeupStorage,
-    geneticMakeupCooldown,
   } = data;
   const elements = [];
   for (let i = 1; i <= makeupCapacity; i++) {

--- a/tgui/packages/tgui/interfaces/DnaConsole.js
+++ b/tgui/packages/tgui/interfaces/DnaConsole.js
@@ -1190,6 +1190,7 @@ const GeneticMakeupBuffers = (props, context) => {
     isViableSubject,
     makeupCapacity = 3,
     makeupStorage,
+    geneticMakeupCooldown,
   } = data;
   const elements = [];
   for (let i = 1; i <= makeupCapacity; i++) {
@@ -1235,6 +1236,19 @@ const GeneticMakeupBuffers = (props, context) => {
   }
   return (
     <Section title="Genetic Makeup Buffers">
+      {!!geneticMakeupCooldown && (
+        <Dimmer
+          fontSize="14px"
+          textAlign="center">
+          <Icon
+            mr={1}
+            name="spinner"
+            spin />
+          Genetic makeup transfer ready in...
+          <Box mt={1} />
+          {geneticMakeupCooldown}s
+        </Dimmer>
+      )}
       {elements}
     </Section>
   );


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a cooldown timer to the Genetic Makeup sub-section of the DNA Console.

This cooldown timer is 1 minute.

![image](https://user-images.githubusercontent.com/24975989/111109083-f5f12980-8551-11eb-9302-7dbb3dd82c29.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

As the coder of the tgui interface for genetics consoles, this was originally an oversight.

I became aware of it fairly quickly (since before I even became a maintainer) and considered it a quirky little fun thing that geneticists could do to make Gorillas. It seemed roughly thematic as well, since they work with monkeys and radiation.

As long as it was fairly niche knowledge and not being abused, I was not mindful to fix it. Every so often a new player would pop up, use it for a couple of shifts and then vanish off again, never to be seen in a genetics lab.

It has finally become a The Thing Everyone Does Now enough that it's getting too much attention. This is why we can't have fun things. It's time to take this oversight behind the back of the shed and Ol' Yeller it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes oversight in DNA Consoles where doing a transfer from the Genetic Makeup tab had no cooldown and could be spammed to massively irradiate things.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
