### PR TITLE
Voluntary scream sounds (but with spam prevention)

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -73,7 +73,7 @@
 	var/dchatmsg = "<b>[user]</b> [msg]"
 
 	var/tmp_sound = get_sound(user)
-	if(tmp_sound && (!only_forced_audio || !intentional) && user.check_audio_cooldown(user, intentional))
+	if(tmp_sound && (!only_forced_audio || !intentional) && check_audio_cooldown(user, intentional))
 		playsound(user, tmp_sound, 50, vary)
 
 	for(var/mob/M in GLOB.dead_mob_list)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -40,16 +40,6 @@
 		mob_type_allowed_typecache = typecacheof(mob_type_allowed_typecache)
 	mob_type_blacklist_typecache = typecacheof(mob_type_blacklist_typecache)
 	mob_type_ignore_stat_typecache = typecacheof(mob_type_ignore_stat_typecache)
-	
-/datum/emote/proc/check_audio_cooldown(mob/user, intentional)
-	if(!intentional)
-		return TRUE
-	if(user.emotes_used && user.emotes_used[src] + audio_cooldown > world.time)
-		return FALSE
-	if(!user.emotes_used)
-		user.emotes_used = list() //add it to the same area as the rest of the emotes, they did emote after all.
-	user.emotes_used[src] = world.time
-	return TRUE
 
 /datum/emote/proc/run_emote(mob/user, params, type_override, intentional = FALSE)
 	. = TRUE
@@ -104,6 +94,16 @@
 
 /datum/emote/proc/get_sound(mob/living/user)
 	return sound //by default just return this var.
+	
+/datum/emote/proc/check_audio_cooldown(mob/user, intentional)
+	if(!intentional)
+		return TRUE
+	if(user.audio_emotes_used && user.audio_emotes_used[src] + audio_cooldown > world.time)
+		return FALSE
+	if(!user.audio_emotes_used)
+		user.audio_emotes_used = list() //add it to the same area as the rest of the emotes, they did emote after all.
+	user.audio_emotes_used[src] = world.time
+	return TRUE
 
 /datum/emote/proc/replace_pronoun(mob/user, message)
 	if(findtext(message, "their"))

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -50,7 +50,7 @@
 	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_AUDIBLE
-	cooldown = 5.0
+	cooldown = 5 SECONDS
 	vary = TRUE
 
 /datum/emote/living/carbon/human/scream/get_sound(mob/living/user)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -50,7 +50,7 @@
 	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_AUDIBLE
-	cooldown = 5 SECONDS
+	audio_cooldown = 5 SECONDS
 	vary = TRUE
 
 /datum/emote/living/carbon/human/scream/get_sound(mob/living/user)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -50,7 +50,7 @@
 	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_AUDIBLE
-	only_forced_audio = TRUE
+	cooldown = 5.0
 	vary = TRUE
 
 /datum/emote/living/carbon/human/scream/get_sound(mob/living/user)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -219,6 +219,9 @@
 
 	/// Used for tracking last uses of emotes for cooldown purposes
 	var/list/emotes_used
+	
+	/// Same as above except this one is for auditory emote tracking
+	var/list/audio_emotes_used
 
 	///Whether the mob is updating glide size when movespeed updates or not
 	var/updating_glide_size = TRUE


### PR DESCRIPTION
Lets voluntary screams make sound again, but tacks on a 5 second cooldown (now only for the audio, not the emote itself) for spam prevention.
5 seconds is an arbitrary number I came up with in about that much time, I'm more than willing to listen to suggestions of other cooldown lengths if you feel 5 seconds is too long/too short.

## Why is this good for the game

Because having a cooldown seems to work to prevent similar noise or hand-object making emotes (like blowing kisses or deathgasps), so this should be able to return scream sounds without the spamming.

I considered the alternative of merging the oxyloss screams (20 oxygen damage per scream, no screaming if you are 20 health or fewer away from crit), but this seems like a better option and cooldowns are already implemented in emote code so no need to create a new var just to check if something is voluntary in mob/living/carbon/human/emote or if something is a scream in datums/emotes.

## Changelog
:cl:
add: Voluntary screams can now produce sound, with a cooldown.
/:cl: