### PR TITLE
Adds jade lanterns to the black market uplink

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -11,6 +11,16 @@
 	stock_max = 2
 	availability_prob = 50
 
+/datum/blackmarket_item/misc/Extra_Bright_Lantern
+	name = "Suspicious Lantern"
+	desc = "Found in a box labeled "Danger: Radioactive". Probably safe."
+	item = /obj/item/flashlight/lantern/syndicate
+
+	price_min = 300
+	price_max = 700
+	stock_max = 2
+	availability_prob = 25
+
 /datum/blackmarket_item/misc/cap_gun
 	name = "Cap Gun"
 	desc = "Prank your friends with this harmless gun! Harmlessness guranteed."

--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -13,7 +13,7 @@
 
 /datum/blackmarket_item/misc/Extra_Bright_Lantern
 	name = "Suspicious Lantern"
-	desc = "Found in a box labeled "Danger: Radioactive". Probably safe."
+	desc = "Found in a box labeled 'Danger: Radioactive'. Probably safe."
 	item = /obj/item/flashlight/lantern/syndicate
 
 	price_min = 300

--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -11,15 +11,15 @@
 	stock_max = 2
 	availability_prob = 50
 
-/datum/blackmarket_item/misc/Extra_Bright_Lantern
-	name = "Suspicious Lantern"
+/datum/blackmarket_item/misc/jade_Lantern
+	name = "Jade Lantern"
 	desc = "Found in a box labeled 'Danger: Radioactive'. Probably safe."
-	item = /obj/item/flashlight/lantern/syndicate
+	item = /obj/item/flashlight/lantern/jade
 
-	price_min = 300
-	price_max = 700
+	price_min = 150
+	price_max = 500
 	stock_max = 2
-	availability_prob = 25
+	availability_prob = 45
 
 /datum/blackmarket_item/misc/cap_gun
 	name = "Cap Gun"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
PR 2 of hopefully many that add more unique or fun things to the black market uplink. This one adds those jade lanters from lavaland, uncommonly appearing for sale and costing 150-300 credits. Up to two can appear, in case security confiscates the first!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More things in the black market uplink to make it used more.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Jade lanterns can now be found in the black market uplink
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
