### PR TITLE
Repairs broken ice cream recipes

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_frozen.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_frozen.dm
@@ -8,7 +8,7 @@
 	reqs = list(
 		/datum/reagent/consumable/cream = 5,
 		/datum/reagent/consumable/ice = 5,
-		/obj/item/food = 1
+		/obj/item/food/icecream = 1
 	)
 	result = /obj/item/food/icecreamsandwich
 	subcategory = CAT_ICE
@@ -19,6 +19,7 @@
 		/datum/reagent/consumable/cream = 5,
 		/datum/reagent/consumable/ice = 5,
 		/obj/item/food/grown/berries = 2,
+		/obj/item/food/icecream = 1
 	)
 	result = /obj/item/food/strawberryicecreamsandwich
 	subcategory = CAT_ICE
@@ -28,7 +29,7 @@
 	reqs = list(
 		/datum/reagent/consumable/bluecherryjelly = 5,
 		/datum/reagent/consumable/spacemountainwind = 15,
-		/obj/item/food = 1
+		/obj/item/food/icecream = 1
 	)
 	result = /obj/item/food/spacefreezy
 	subcategory = CAT_ICE
@@ -39,7 +40,7 @@
 		/datum/reagent/consumable/cream = 5,
 		/obj/item/food/grown/cherries = 1,
 		/obj/item/food/grown/banana = 1,
-		/obj/item/food = 1
+		/obj/item/food/icecream = 1
 	)
 	result = /obj/item/food/sundae
 	subcategory = CAT_ICE
@@ -51,7 +52,7 @@
 		/obj/item/clothing/mask/gas/clown_hat = 1,
 		/obj/item/food/grown/cherries = 1,
 		/obj/item/food/grown/banana = 2,
-		/obj/item/food = 1
+		/obj/item/food/icecream = 1
 	)
 	result = /obj/item/food/honkdae
 	subcategory = CAT_ICE
@@ -59,11 +60,11 @@
 /datum/crafting_recipe/food/cornuto
 	name = "Cornuto"
 	reqs = list(
-		/obj/item/food/pastrybase = 1,
 		/obj/item/food/chocolatebar = 1,
 		/datum/reagent/consumable/cream = 4,
 		/datum/reagent/consumable/ice = 2,
-		/datum/reagent/consumable/sugar = 4
+		/datum/reagent/consumable/sugar = 4,
+		/obj/item/food/icecream = 1
 	)
 	result = /obj/item/food/cornuto
 	subcategory = CAT_ICE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The recipes were broken for ice cream sandwich, space freezy, sundae, honkdae and cornuto. They consumed _any food_ to craft. This replaces the /obj/item/food that was being used with /obj/item/food/icecream - or the ice cream cone from the ice cream machine. The berry ice cream sandwich and cornuto were also updated to require an ice cream cone for consistency with the other recipes.

## Why It's Good For The Game

Makes broken things not broken. Amazing. Fixes a part of _but does not close_ https://github.com/tgstation/tgstation/issues/57671

## Changelog
:cl:
qol: changed berry ice cream sandwich and cornuto to use ice cream cone for consistency
fix: fixed broken ice cream recipes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
