### PR TITLE
You can now print cable coils and welding helmets from scilathes and engilathes

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -145,15 +145,16 @@
 /datum/design/welding_helmet
 	name = "Welding Helmet"
 	id = "welding_helmet"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 1750, /datum/material/glass = 400)
 	build_path = /obj/item/clothing/head/welding
-	category = list("initial","Tools")
+	category = list("initial","Tools","Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/cable_coil
 	name = "Cable Coil"
 	id = "cable_coil"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 10, /datum/material/glass = 5)
 	build_path = /obj/item/stack/cable_coil
 	category = list("initial","Tools","Tool Designs")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -48,7 +48,7 @@
 	starting_node = TRUE
 	display_name = "Basic Tools"
 	description = "Basic mechanical, electronic, surgical and botanical tools."
-	design_ids = list("screwdriver", "wrench", "wirecutters", "crowbar", "multitool", "welding_tool", "tscanner", "analyzer", "cable_coil", "pipe_painter", "airlock_painter", "decal_painter",
+	design_ids = list("screwdriver", "wrench", "wirecutters", "crowbar", "multitool", "cable_coil", "welding_tool", "welding_helmet", "tscanner", "analyzer", "cable_coil", "pipe_painter", "airlock_painter", "decal_painter",
 					"cultivator", "plant_analyzer", "shovel", "spade", "hatchet", "secateurs", "mop", "pushbroom", "plunger", "spraycan", "swab", "petri_dish", "normtrash")
 
 /datum/techweb_node/basic_medical


### PR DESCRIPTION
## About The Pull Request

See the title (and add ghost role protolathes to that list as well). They're both a part of the Basic Tools tech node now.

## Why It's Good For The Game

I honestly believe that cable coils not being able to be printed by science and engineering protolathes was an oversight; their design has the DEPARTMENTAL_FLAG_ENGINEERING and DEPARTMENTAL_FLAG_SCIENCE departmental_flags, like the other tools, but for some reason doesn't have the PROTOLATHE build_type to use them with. Cable coils are also used to construct machine frames and computer frames, which engineers and scientists should be doing pretty regularly.

I've thrown welding helmets into that node as well. Science and engi lathes get to print welding goggles and welding gas masks after the Industrial Engineering and Advanced Engineering nodes are researched, respectively, but they never get the ability to build the basic welding masks that autolathes can make. Since they're printable from a roundstart autolathe (unlike welding goggles and welding gas masks) and take up a more inconvenient slot than welding goggles do, I put them in a roundstart node instead of in Industral Engineering.

I considered adding proximity sensors to the protolathe and/or mechanical fabricator as well, but I'm worried that that could get this PR shot down for "balance reasons" (and there might be some other sensors that I should move over as well), so I'm saving that for a follow-up PR that I'll make if this one gets merged. If the maintainers are okay with it, I could certainly just bundle that change with this PR.

## Changelog
:cl: ATHATH
qol: You can now print cable coils and welding helmets from science protolathes, engineering protolathes, and ghost role protolathes.
/:cl: