### PR TITLE
Removes the foam finger rocket launcher

### DIFF
--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -246,18 +246,4 @@
 	desc = "It's not just a stick, it's a MAGIC stick?"
 	ammo_type = /obj/item/ammo_casing/magic/nothing
 
-/////////////////////////////////////
-//foam finger that shoots rockets??
-/////////////////////////////////////
 
-/obj/item/gun/magic/wand/foamfinger
-	name = "foam finger"
-	desc = "Pull my finger- unless, like, it blew off your hand."
-	icon_state = "foamfinger"
-	inhand_icon_state = "foamfinger"
-	fire_sound = 'sound/weapons/gun/general/rocket_launch.ogg'
-	w_class = WEIGHT_CLASS_NORMAL
-	max_charges = 5000
-	variable_charges = FALSE
-	checks_antimagic = FALSE
-	ammo_type = /obj/item/ammo_casing/caseless/rocket


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It's _baaaaad_. Very bad. There are way better ways to do this but I don't honestly have the capacity to do them. The sprite states are all fucked up, it's an odd case of something not being snowflake enough in the right places, the goddamn thing breaks if you *drop it*... For fuck's sake, Ryll tried to fix it and even they couldn't. No, fuck it, get rid of it, we'll rewrite it later.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's good for the game because I'm not removing the toy version.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed the admin snowflake rocket launcher foam finger. The toy one is still around.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
