### PR TITLE
Fixes mech projectiles hitting the mech that fires them

### DIFF
--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -38,6 +38,7 @@
 
 		var/obj/projectile/A = new projectile(get_turf(src))
 		var/modifiers = params2list(params)
+		A.firer = chassis
 		A.preparePixelProjectile(target, source, modifiers, spread)
 
 		A.fire()


### PR DESCRIPTION
## About The Pull Request
What if you had a phazon , but god said "All mech guns act like hilarious firing pin lasers" and you shot yourself to death?
## Why It's Good For The Game
Bug fix
Also closes #55641

## Changelog
:cl:
fix: fixed mech bullets hitting the mechs they're fired from
/:cl:
