### PR TITLE
Makes it so you cant apply component to qdeleted targets

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -395,6 +395,10 @@
 /datum/proc/_AddComponent(list/raw_args)
 	var/new_type = raw_args[1]
 	var/datum/component/nt = new_type
+
+	if(QDELING(src))
+		CRASH("Attempted to add a new component of type \[[nt]\] to a qdeleting parent of type \[[type]\]!")
+
 	var/dm = initial(nt.dupe_mode)
 	var/dt = initial(nt.dupe_type)
 


### PR DESCRIPTION
This shouldn't be happening but it seems it does in at least one case with forensics component being applied to some qdeleted gibs.
