### PR TITLE
Fixes people being able to remotely eject out ID cards out of the civillian bounty console

### DIFF
--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -138,6 +138,8 @@
 
 /obj/machinery/computer/piratepad_control/civilian/AltClick(mob/user)
 	. = ..()
+	if(!Adjacent(user))
+		return FALSE
 	id_eject(user, inserted_scan_id)
 
 /obj/machinery/computer/piratepad_control/civilian/ui_interact(mob/user, datum/tgui/ui)


### PR DESCRIPTION

## About The Pull Request
Fixes people being able to remotely eject ID cards from the civillian bounty consoles
## Why It's Good For The Game
Bug fix(also telekinesis users can interact with the console and press the eject button, the reason i didn't add a special interaction for it is because telekinesis is meant to  display blue sparks when used on a console)
## Changelog
:cl:
fix: fixed people being able to remotely eject out ID cards from bounty consoles
/:cl:
