### PR TITLE
Implements a content freeze on admin-only features.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -670,6 +670,7 @@ Do not add any of the following in a Pull Request or risk getting the PR closed:
 * National Socialist Party of Germany content, National Socialist Party of Germany related content, or National Socialist Party of Germany references
 * Code adding, removing, or updating the availability of alien races/species/human mutants without prior approval. Pull requests attempting to add or remove features from said races/species/mutants require prior approval as well.
 * Code which violates GitHub's [terms of service](https://github.com/site/terms).
+* Code which is only accessible by players with administrative access that is not a development/moderation tool.
 
 Just because something isn't on this list doesn't mean that it's acceptable. Use common sense above all else.
 


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

If your feature isn't going to fit in the regular game, it shouldn't be PR'd to the repository. An exception is made for actual moderation/development tools, but anything other than that is a waste of maintainer review time.

## Changelog
:cl:
code: Added a new section to the banned content section on the CONTRIBUTING.md regarding admin-only features.
/:cl: