### PR TITLE
cyborg lollipop launchers can no longer spam timers

### DIFF
--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -515,7 +515,7 @@
 	throwforce = 0
 
 /obj/item/food/chewable/lollipop/cyborg
-	food_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/iron = 10, /datum/reagent/consumable/sugar = 5, /datum/reagent/medicine/omnizine = 1) //less omnizine than a normal lollipop
+	food_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/iron = 10, /datum/reagent/consumable/sugar = 5, /datum/reagent/medicine/psicodine = 2) //psicodine instead of omnizine, because the latter was making coders freak out
 
 /obj/item/food/chewable/bubblegum
 	name = "bubblegum"

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -515,19 +515,7 @@
 	throwforce = 0
 
 /obj/item/food/chewable/lollipop/cyborg
-	var/spamchecking = TRUE
-
-/obj/item/food/chewable/lollipop/cyborg/Initialize()
-	. = ..()
-	addtimer(CALLBACK(src, .proc/spamcheck), 1200)
-
-/obj/item/food/chewable/lollipop/cyborg/equipped(mob/living/user, slot)
-	. = ..(user, slot)
-	spamchecking = FALSE
-
-/obj/item/food/chewable/lollipop/cyborg/proc/spamcheck()
-	if(spamchecking)
-		qdel(src)
+	food_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/iron = 10, /datum/reagent/consumable/sugar = 5, /datum/reagent/medicine/omnizine = 1) //less omnizine than a normal lollipop
 
 /obj/item/food/chewable/bubblegum
 	name = "bubblegum"
@@ -608,21 +596,6 @@
 /obj/item/food/chewable/gumball/Initialize()
 	. = ..()
 	color = rgb(rand(0, 255), rand(0, 255), rand(0, 255))
-
-/obj/item/food/chewable/gumball/cyborg
-	var/spamchecking = TRUE
-
-/obj/item/food/chewable/gumball/cyborg/Initialize()
-	. = ..()
-	addtimer(CALLBACK(src, .proc/spamcheck), 1200)
-
-/obj/item/food/chewable/gumball/cyborg/equipped(mob/living/user, slot)
-	. = ..(user, slot)
-	spamchecking = FALSE
-
-/obj/item/food/chewable/gumball/cyborg/proc/spamcheck()
-	if(spamchecking)
-		qdel(src)
 
 /obj/item/food/taco
 	name = "classic taco"

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -345,9 +345,9 @@
 	name = "treat fabricator"
 	desc = "Reward humans with various treats. Toggle in-module to switch between dispensing and high velocity ejection modes."
 	icon_state = "lollipop"
-	var/candy = 30
-	var/candymax = 30
-	var/charge_delay = 10
+	var/candy = 5
+	var/candymax = 5
+	var/charge_delay = 10 SECONDS
 	var/charging = FALSE
 	var/mode = DISPENSE_LOLLIPOP_MODE
 
@@ -365,9 +365,7 @@
 	check_amount()
 
 /obj/item/borg/lollipop/proc/check_amount() //Doesn't even use processing ticks.
-	if(charging)
-		return
-	if(candy < candymax)
+	if(!charging && candy < candymax)
 		addtimer(CALLBACK(src, .proc/charge_lollipops), charge_delay)
 		charging = TRUE
 
@@ -502,15 +500,14 @@
 	name = "gumball"
 	desc = "Oh noes! A fast-moving gumball!"
 	icon_state = "gumball"
-	ammo_type = /obj/item/food/chewable/gumball/cyborg
+	ammo_type = /obj/item/food/chewable/gumball
 	nodamage = TRUE
 	damage = 0
 	speed = 0.5
 
 /obj/projectile/bullet/reusable/gumball/harmful
-	ammo_type = /obj/item/food/chewable/gumball/cyborg
 	nodamage = FALSE
-	damage = 3
+	damage = 10 //mediborgs get 5 shots before needing to reload at a rate of 1 shot/10 seconds, so they can do 50 damage from range max before needing to close the distance or retreat
 
 /obj/projectile/bullet/reusable/gumball/handle_drop()
 	if(!dropped)
@@ -541,7 +538,7 @@
 
 /obj/projectile/bullet/reusable/lollipop/harmful
 	embedding = list(embed_chance=35, fall_chance=2, jostle_chance=0, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.5, pain_mult=3, rip_time=10)
-	damage = 3
+	damage = 10
 	nodamage = FALSE
 	embed_falloff_tile = 0
 


### PR DESCRIPTION
## About The Pull Request

Cyborg treat dispensers now have a maximum treat storage capacity of 5 treats instead of 30 treats, and recharge their treats at a rate of one treat per 10 seconds instead of one treat per second.

To compensate for this, the damage of gumballs and lollipops that have been launched from an emagged cyborg has been increased from 3 to 10.

Launched gumballs and lollipops will no longer delete themselves after 2 minutes (if not equipped).

The 2u of omnizine in each cyborg lollipop has been replaced by 2u of psicodine. The contents of normal lollipops have not been modified.

Cyborg cookie dispensers can now only dispense a cookie once every 10 seconds (instead of once per second). Non-cyborg cookie dispensers no longer self-recharge, but can now accept compressed matter cartirdges for reloading purposes. Support has been added for other types of RSFs to have use cooldowns.

## Why It's Good For The Game

The self-deletion mechanism was apparently causing timer spam, so I reduced the amount of treats that cyborgs could spam out (and the rate of that spamming) so that the mechanism would no longer be necessary. I increased the damage of launched treats to compensate to keep the emagged treat launcher from becoming a very sad joke of a weapon.

Floyd threw a fit when he learned that cyborgs could freely dispense lollipops that contained omnizine, so I replaced the omnizine with psicodine, a chem that is perhaps more appropriate for lollipops (it calms people down), doesn't do much of importance, and can't react to form any rare or interesting chems.

The cookie dispenser thing is also an attempt to appease Floyd, since he doesn't like cyborgs being able to spam food everywhere.

## Changelog
:cl: ATHATH
balance: Cyborg treat dispensers now have a maximum treat storage capacity of 5 treats instead of 30 treats, and recharge their treats at a rate of one treat per 10 seconds instead of one treat per second. To compensate for this, the damage of gumballs and lollipops that have been launched from an emagged cyborg has been increased from 3 to 10.
del: Launched gumballs and lollipops will no longer delete themselves after 2 minutes (if not equipped).
balance: The 2u of omnizine in each cyborg lollipop has been replaced by 2u of psicodine. The contents of normal lollipops have not been modified.
balance: Cyborg cookie dispensers can now only dispense a cookie once every 10 seconds (instead of once per second). Non-cyborg cookie dispensers no longer self-recharge, but can now accept compressed matter cartirdges for reloading purposes. Support has been added for other types of RSFs to have use cooldowns.
/:cl: