### PR TITLE
Washing machine now uses right click to start a wash cycle

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -336,16 +336,16 @@ GLOBAL_LIST_INIT(dye_registry, list(
 
 /obj/machinery/washing_machine/attack_hand_secondary(mob/user, modifiers)
 	if(!user.canUseTopic(src, !issilicon(user)))
-		return
+		return SECONDARY_ATTACK_CONTINUE_CHAIN
 	if(busy)
 		to_chat(user, "<span class='warning'>[src] is busy!</span>")
-		return
+		return SECONDARY_ATTACK_CONTINUE_CHAIN
 	if(state_open)
 		to_chat(user, "<span class='warning'>Close the door first!</span>")
-		return
+		return SECONDARY_ATTACK_CONTINUE_CHAIN
 	if(bloody_mess)
 		to_chat(user, "<span class='warning'>[src] must be cleaned up first!</span>")
-		return
+		return SECONDARY_ATTACK_CONTINUE_CHAIN
 	busy = TRUE
 	update_appearance()
 	addtimer(CALLBACK(src, .proc/wash_cycle), 20 SECONDS)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -148,24 +148,7 @@ GLOBAL_LIST_INIT(dye_registry, list(
 /obj/machinery/washing_machine/examine(mob/user)
 	. = ..()
 	if(!busy)
-		. += "<span class='notice'><b>Alt-click</b> it to start a wash cycle.</span>"
-
-/obj/machinery/washing_machine/AltClick(mob/user)
-	if(!user.canUseTopic(src, !issilicon(user)))
-		return
-	if(busy)
-		return
-	if(state_open)
-		to_chat(user, "<span class='warning'>Close the door first!</span>")
-		return
-	if(bloody_mess)
-		to_chat(user, "<span class='warning'>[src] must be cleaned up first!</span>")
-		return
-	busy = TRUE
-	update_appearance()
-	addtimer(CALLBACK(src, .proc/wash_cycle), 200)
-
-	START_PROCESSING(SSfastprocess, src)
+		. += "<span class='notice'><b>Right-click</b> with an empty hand to start a wash cycle.</span>"
 
 /obj/machinery/washing_machine/process(delta_time)
 	if(!busy)
@@ -350,6 +333,24 @@ GLOBAL_LIST_INIT(dye_registry, list(
 	else
 		state_open = FALSE //close the door
 		update_appearance()
+
+/obj/machinery/washing_machine/attack_hand_secondary(mob/user, modifiers)
+	if(!user.canUseTopic(src, !issilicon(user)))
+		return
+	if(busy)
+		to_chat(user, "<span class='warning'>[src] is busy!</span>")
+		return
+	if(state_open)
+		to_chat(user, "<span class='warning'>Close the door first!</span>")
+		return
+	if(bloody_mess)
+		to_chat(user, "<span class='warning'>[src] must be cleaned up first!</span>")
+		return
+	busy = TRUE
+	update_appearance()
+	addtimer(CALLBACK(src, .proc/wash_cycle), 20 SECONDS)
+	START_PROCESSING(SSfastprocess, src)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/washing_machine/deconstruct(disassembled = TRUE)
 	if (!(flags_1 & NODECONSTRUCT_1))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR changes washing machine controls - instead of having to alt-click the machine to start a wash cycle, you will now use right click. This is much more handy, and frees alt-click for tile content viewing, or potentional future interactions, like machine rotation.

Also cleans up relevant code a little bit, adds feedback for when machine is busy and moves relevant proc below regular attack_hand.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Easier machine control.

## Changelog
:cl: Arkatos
qol: Washing machine now uses right click to start a wash cycle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
