### PR TITLE
Makes canister pressure capabilities a bit random and more unstable

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -91,7 +91,7 @@
 	else
 		create_gas()
 
-	var/random_quality = rand(0, 100) / 100
+	var/random_quality = rand()
 	pressure_limit = initial(pressure_limit) * (1 + 0.1 * random_quality)
 
 	update_appearance()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -508,7 +508,7 @@
 		var/leak_chance = (1 - obj_integrity / max_integrity) * 100
 		if(prob(leak_chance))
 			mix_air = TRUE
-			pressure = air_contents.return_pressure()
+			pressure = air_contents.return_pressure() / 10
 			gas_mix = location.return_air()
 			air_update = TRUE
 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -37,7 +37,7 @@
 	///Max amount of heat allowed inside of the canister before it starts to melt (different tiers have different limits)
 	var/heat_limit = 5000
 	///Max amount of pressure allowed inside of the canister before it starts to break (different tiers have different limits)
-	var/pressure_limit = 50000
+	var/pressure_limit = 46000
 	///Maximum amount of heat that the canister can handle before taking damage
 	var/temperature_resistance = 1000 + T0C
 	///Initial temperature gas mixture
@@ -92,7 +92,7 @@
 		create_gas()
 
 	var/random_quality = rand()
-	pressure_limit = initial(pressure_limit) * (1 + 0.1 * random_quality)
+	pressure_limit = initial(pressure_limit) * (1 + 0.2 * random_quality)
 
 	update_appearance()
 
@@ -332,12 +332,12 @@
 
 /obj/machinery/portable_atmospherics/canister/tier_1
 	heat_limit = 5000
-	pressure_limit = 50000
+	pressure_limit = 46000
 	mode = CANISTER_TIER_1
 
 /obj/machinery/portable_atmospherics/canister/tier_2
 	heat_limit = 500000
-	pressure_limit = 5e6
+	pressure_limit = 4600000
 	volume = 3000
 	max_integrity = 300
 	can_max_release_pressure = (ONE_ATMOSPHERE * 30)
@@ -346,7 +346,7 @@
 
 /obj/machinery/portable_atmospherics/canister/tier_3
 	heat_limit = 1e12
-	pressure_limit = 1e14
+	pressure_limit = 9.2e13
 	volume = 5000
 	max_integrity = 500
 	can_max_release_pressure = (ONE_ATMOSPHERE * 30)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -460,13 +460,13 @@
 	var/turf/T = get_turf(src)
 	T.assume_air(expelled_gas)
 	air_update_turf(FALSE, FALSE)
+	obj_break()
 
 	if(expelled_pressure > pressure_limit)
 		var/pressure_dif = expelled_pressure - pressure_limit
 		var/explosion_range = CEILING(min(pressure_dif, 20000) / 1000, 1)
 		explosion(T, 0, 0, explosion_range, 0, smoke = FALSE)
 
-	obj_break()
 	density = FALSE
 	playsound(src.loc, 'sound/effects/spray.ogg', 10, TRUE, -3)
 	investigate_log("was destroyed.", INVESTIGATE_ATMOS)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -505,7 +505,7 @@
 
 	// When at least 10% of integrity is lost it starts checking for leaking
 	if(obj_integrity < max_integrity * 0.9)
-		var/leak_chance = 1 - obj_integrity / max_integrity
+		var/leak_chance = (1 - obj_integrity / max_integrity) * 100
 		if(prob(leak_chance))
 			mix_air = TRUE
 			pressure = air_contents.return_pressure()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -514,7 +514,7 @@
 
 	// Handle gas transfer.
 	if(mix_air)
-		var/datum/gas_mixture/target_air = gas_mix ? gas_mix : location.return_air()
+		var/datum/gas_mixture/target_air = gas_mix || location.return_air()
 
 		if(air_contents.release_gas_to(target_air, pressure) && (!holding || air_update))
 			air_update_turf(FALSE, FALSE)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -464,7 +464,8 @@
 
 	if(expelled_pressure > pressure_limit)
 		var/pressure_dif = expelled_pressure - pressure_limit
-		var/explosion_range = CEILING(min(pressure_dif, 20000) / 1000, 1)
+		var/max_pressure_difference = 20000
+		var/explosion_range = CEILING(min(pressure_dif, max_pressure_difference) / 1000, 1)
 		explosion(T, 0, 0, explosion_range, 0, smoke = FALSE)
 
 	density = FALSE

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -85,10 +85,15 @@
 
 /obj/machinery/portable_atmospherics/canister/Initialize(mapload, datum/gas_mixture/existing_mixture)
 	. = ..()
+
 	if(existing_mixture)
 		air_contents.copy_from(existing_mixture)
 	else
 		create_gas()
+
+	var/random_quality = rand(0, 100) / 100
+	pressure_limit = initial(pressure_limit) * (1 + 0.1 * random_quality)
+
 	update_appearance()
 
 /obj/machinery/portable_atmospherics/canister/ComponentInitialize()
@@ -105,7 +110,7 @@
 /obj/machinery/portable_atmospherics/canister/examine(user)
 	. = ..()
 	if(mode)
-		. += "<span class='notice'>This canister is Tier [mode]. A sticker on its side says <b>MAX PRESSURE: [siunit_pressure(pressure_limit, 0)]</b>.</span>"
+		. += "<span class='notice'>This canister is Tier [mode]. A sticker on its side says <b>MAX SAFE PRESSURE: [siunit_pressure(initial(pressure_limit), 0)]</b>.</span>"
 
 /obj/machinery/portable_atmospherics/canister/nitrogen
 	name = "Nitrogen canister"
@@ -451,9 +456,15 @@
 /obj/machinery/portable_atmospherics/canister/proc/canister_break()
 	disconnect()
 	var/datum/gas_mixture/expelled_gas = air_contents.remove(air_contents.total_moles())
+	var/expelled_pressure = expelled_gas?.return_pressure()
 	var/turf/T = get_turf(src)
 	T.assume_air(expelled_gas)
 	air_update_turf(FALSE, FALSE)
+
+	if(expelled_pressure > pressure_limit)
+		var/pressure_dif = expelled_pressure - pressure_limit
+		var/explosion_range = CEILING(min(pressure_dif, 20000) / 1000, 1)
+		explosion(T, 0, 0, explosion_range, 0, smoke = FALSE)
 
 	obj_break()
 	density = FALSE
@@ -482,12 +493,30 @@
 		valve_open = !valve_open
 		timing = FALSE
 
-	// Handle gas transfer.
-	if(valve_open)
-		var/turf/T = get_turf(src)
-		var/datum/gas_mixture/target_air = holding ? holding.air_contents : T.return_air()
+	var/turf/location = get_turf(src)
 
-		if(air_contents.release_gas_to(target_air, release_pressure) && !holding)
+	var/mix_air = FALSE
+	var/pressure = release_pressure
+	var/gas_mix = holding?.air_contents
+	var/air_update = FALSE
+
+	if(valve_open)
+		mix_air = TRUE
+
+	// When at least 10% of integrity is lost it starts checking for leaking
+	if(obj_integrity < max_integrity * 0.9)
+		var/leak_chance = 1 - obj_integrity / max_integrity
+		if(prob(leak_chance))
+			mix_air = TRUE
+			pressure = air_contents.return_pressure()
+			gas_mix = location.return_air()
+			air_update = TRUE
+
+	// Handle gas transfer.
+	if(mix_air)
+		var/datum/gas_mixture/target_air = gas_mix ? gas_mix : location.return_air()
+
+		if(air_contents.release_gas_to(target_air, pressure) && (!holding || air_update))
 			air_update_turf(FALSE, FALSE)
 
 	var/our_pressure = air_contents.return_pressure()


### PR DESCRIPTION
## About The Pull Request

This is mainly to make bomb making just a little bit less of a formulaic activity. Canister base capacity is 8% lower but is increased by up to 20% from that amount, roughly resulting in the same average capacity. You can experiment to figure out each one's individual limit or just stick to safe minimum pressures.

To counter balance this somewhat, canister failure is a bit more violent. Damaged canisters will slowly leak gas, and a canister that breaks with internal pressure greater than it's capability will explode.

## Changelog
:cl:
add: Canisters will leak when damaged.
add: Canisters that break while highly pressured will explode.
balance: Canister base pressure capacity has been reduced by 8%.
balance: Canisters have a hidden pressure capacity that is up to 20% larger than the base labeled max.
/:cl:
