### PR TITLE
Mind magnification helmets once again fall off monkeys when they are humanized

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -414,7 +414,9 @@
 
 /obj/item/clothing/head/helmet/monkey_sentience/equipped(mob/user, slot)
 	. = ..()
-	if(slot != ITEM_SLOT_HEAD || istype(user, /mob/living/carbon/human/dummy))
+	if(slot != ITEM_SLOT_HEAD)
+		return
+	if(istype(user, /mob/living/carbon/human/dummy)) //Prevents ghosts from being polled when the helmet is put on a dummy.
 		return
 	if(!ismonkey(user) || user.ckey)
 		var/mob/living/something = user


### PR DESCRIPTION
## About The Pull Request

Refactoring monkeys into a human subtype meant that mind magnification helmets no longer fell off of them when they got humanized. This corrects that oversight along with fixing some runtimes and performance-hindering edge cases.

Note that monkeys mind magnified with a `NODROP` helmet will keep it on when they get humanized, but I don't see any situation outside of adminbus where that would happen. If this is undesirable, I can make `make_fall_off` call `dropItemToGround` with `forced=TRUE`

## Why It's Good For The Game

The codebase discourages features or interactions that allow the crew of the station to be replenished with proper humans.

Fixes #57814 

## Changelog
:cl:
fix: Corrected a manufacturing defect in mind magnification helmets that allowed them to remain on the subject's head after humanization.
/:cl:
