### PR TITLE
More harddel fixes + Tram sanity check

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -101,11 +101,10 @@
 		user.unset_machine()
 
 /obj/machinery/computer/camera_advanced/Destroy()
-	if(current_user)
-		current_user.unset_machine()
 	if(eyeobj)
-		qdel(eyeobj)
+		QDEL_NULL(eyeobj)
 	QDEL_LIST(actions)
+	current_user = null
 	return ..()
 
 /obj/machinery/computer/camera_advanced/on_unset_machine(mob/M)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -190,9 +190,11 @@
 	ui_interact(user)
 
 /mob/proc/unset_machine()
-	if(machine)
-		machine.on_unset_machine(src)
-		machine = null
+	if(!machine)
+		return
+	UnregisterSignal(O, COMSIG_PARENT_QDELETING)
+	machine.on_unset_machine(src)
+	machine = null
 
 //called when the user unsets the machine.
 /atom/movable/proc/on_unset_machine(mob/user)
@@ -202,6 +204,7 @@
 	if(src.machine)
 		unset_machine()
 	src.machine = O
+	RegisterSignal(O, COMSIG_PARENT_QDELETING, .proc/unset_machine)
 	if(istype(O))
 		O.obj_flags |= IN_USE
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -192,7 +192,7 @@
 /mob/proc/unset_machine()
 	if(!machine)
 		return
-	UnregisterSignal(O, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(machine, COMSIG_PARENT_QDELETING)
 	machine.on_unset_machine(src)
 	machine = null
 
@@ -201,9 +201,9 @@
 	return
 
 /mob/proc/set_machine(obj/O)
-	if(src.machine)
+	if(machine)
 		unset_machine()
-	src.machine = O
+	machine = O
 	RegisterSignal(O, COMSIG_PARENT_QDELETING, .proc/unset_machine)
 	if(istype(O))
 		O.obj_flags |= IN_USE

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -297,7 +297,6 @@
 
 /obj/effect/chronos_cam/check_eye(mob/user)
 	if(user != holder)
-		user.unset_machine()
 		qdel(src)
 
 /obj/effect/chronos_cam/on_unset_machine(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

 Fixes a tram related harddel, the proc that removed things from the riders list worked on stuff passed in by Uncrossed, but failed with the qdeleting signal. I've made a wrapper proc to better support these things, added signal handlers, and removed an if check that hid nulls (If it's breaking I need to know)

Also fixes a harddel caused by the fucking machine var, shoot me why does this exist
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Tramstation should lag a bit less when you drive the trolley around for fun and profit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
