### PR TITLE
Swap buttons in ListInput for improved accessibility

### DIFF
--- a/tgui/packages/tgui/interfaces/ListInput.js
+++ b/tgui/packages/tgui/interfaces/ListInput.js
@@ -168,20 +168,20 @@ export const ListInput = (props, context) => {
               <Stack.Item grow basis={0}>
                 <Button
                   fluid
-                  color="bad"
-                  lineHeight={2}
-                  content="Cancel"
-                  onClick={() => act("cancel")}
-                />
-              </Stack.Item>
-              <Stack.Item grow basis={0}>
-                <Button
-                  fluid
                   color="good"
                   lineHeight={2}
                   content="Confirm"
                   disabled={selectedButton === null}
                   onClick={() => act("choose", { choice: selectedButton })}
+                />
+              </Stack.Item>
+              <Stack.Item grow basis={0}>
+                <Button
+                  fluid
+                  color="bad"
+                  lineHeight={2}
+                  content="Cancel"
+                  onClick={() => act("cancel")}
                 />
               </Stack.Item>
             </Stack>


### PR DESCRIPTION
## About The Pull Request

SS13 is predominantly played on Windows machines, and we should therefore follow Windows UI guidelines in how these buttons should be ordered.

I could've done more with this, but I felt lazy, so I just webedited this and swapped the buttons.

## Why It's Good For The Game

Hopefully less players will be annoyed by the wrong order of buttons, and it requires less tabbing to focus the Confirm button. One task less in my tgui roadmap.

## Changelog
:cl:
fix: Swapped OK/Cancel buttons in tgui list input, so that it stays consistent with Windows UI guidelines (was Cancel/OK before).
/:cl:
