### PR TITLE
Adds RangedRightClickOn to Mobs

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -159,7 +159,10 @@
 			else
 				W.afterattack(A,src,0,params)
 		else
-			RangedAttack(A,modifiers)
+			if(LAZYACCESS(modifiers, RIGHT_CLICK))
+				RangedRightClickOn(A, modifiers)
+			else
+				RangedAttack(A,modifiers)
 
 /// Is the atom obscured by a PREVENT_CLICK_UNDER_1 object above it
 /atom/proc/IsObscured()
@@ -285,6 +288,16 @@
 	if(SEND_SIGNAL(src, COMSIG_MOB_ATTACK_RANGED, A, modifiers) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return TRUE
 
+/**
+ * Ranged right click
+ *
+ * If the same conditions are met to trigger RangedAttack but it is
+ * instead initialized via a right click, this will trigger instead.
+ * Useful for mobs that have their abilities mapped to right click.
+ */
+/mob/proc/RangedRightClickOn(atom/A, modifiers)
+	if(SEND_SIGNAL(src, COMSIG_MOB_ATTACK_RANGED, A, modifiers) & COMPONENT_CANCEL_ATTACK_CHAIN)
+		return TRUE
 
 /**
  * Middle click

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -160,7 +160,7 @@
 				W.afterattack(A,src,0,params)
 		else
 			if(LAZYACCESS(modifiers, RIGHT_CLICK))
-				RangedRightClickOn(A, modifiers)
+				ranged_secondary_attack(A, modifiers)
 			else
 				RangedAttack(A,modifiers)
 
@@ -289,15 +289,13 @@
 		return TRUE
 
 /**
- * Ranged right click
+ * Ranged secondary attack
  *
  * If the same conditions are met to trigger RangedAttack but it is
  * instead initialized via a right click, this will trigger instead.
  * Useful for mobs that have their abilities mapped to right click.
  */
-/mob/proc/RangedRightClickOn(atom/A, modifiers)
-	if(SEND_SIGNAL(src, COMSIG_MOB_ATTACK_RANGED, A, modifiers) & COMPONENT_CANCEL_ATTACK_CHAIN)
-		return TRUE
+/mob/proc/ranged_secondary_attack(atom/target, modifiers)
 
 /**
  * Middle click


### PR DESCRIPTION
## About The Pull Request

This PR adds a new method, OnRangedRightClick, to mobs.  This method is used whenever RangedAttack would've been called but the user presses right click instead of left click.  This change allows mob abilities to be easily mapped to right clicks instead of hyjacking RangedAttack for that functionality instead.

## Why It's Good For The Game

Simplifies all code wanting to utilize right clicks that isn't for the purpose of adding tool functionalities going forward, specifically tying simplemob abilities into this system so we can properly utilize right clicks on them without messy copypasta code.

No changelog since this is entirely a backend change.
