### PR TITLE
lazy station fix

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -35058,7 +35058,6 @@
 /area/hallway/primary/tram/center)
 "gWm" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "gXl" = (
@@ -59457,10 +59456,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"swR" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/engine/air,
-/area/engineering/atmos)
 "swZ" = (
 /obj/machinery/disposal/bin{
 	pixel_x = -2;
@@ -107742,7 +107737,7 @@ mgz
 jPQ
 xIt
 moi
-swR
+che
 che
 iCR
 ajc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fix an already fixed issue with xenos and other mid-round antags from spawning inside atmos chambers.
Copy-paste very bad
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
map fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: remove xeno and mid-round antags spawn from atmos tanks from tramstation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
