### PR TITLE
Makes cargo canister listings get automatically generated at runtime

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -44,10 +44,19 @@ SUBSYSTEM_DEF(shuttle)
 	var/centcom_message = "" //Remarks from CentCom on how well you checked the last order.
 	var/list/discoveredPlants = list() //Typepaths for unusual plants we've already sent CentCom, associated with their potencies
 
+	/// All of the possible supply packs that can be purchased by cargo
 	var/list/supply_packs = list()
+
+	/// Queued supplies to be purchased for the chef
 	var/list/chef_groceries = list()
+
+	/// Queued supply packs to be purchased
 	var/list/shoppinglist = list()
+
+	/// Wishlist items made by crew for cargo to purchase at their leisure
 	var/list/requestlist = list()
+
+	/// A listing of previously delivered supply packs
 	var/list/orderhistory = list()
 
 	var/list/hidden_shuttle_turfs = list() //all turfs hidden from navigation computers associated with a list containing the image hiding them and the type of the turf they are pretending to be
@@ -76,11 +85,22 @@ SUBSYSTEM_DEF(shuttle)
 /datum/controller/subsystem/shuttle/Initialize(timeofday)
 	ordernum = rand(1, 9000)
 
-	for(var/pack in subtypesof(/datum/supply_pack))
-		var/datum/supply_pack/P = new pack()
-		if(!P.contains)
+	var/list/pack_processing = subtypesof(/datum/supply_pack)
+	while(length(pack_processing))
+		var/datum/supply_pack/pack = pack_processing[length(pack_processing)]
+		pack_processing.len--
+		if(ispath(pack, /datum/supply_pack))
+			pack = new pack
+
+		var/list/generated_packs = pack.generate_supply_packs()
+		if(generated_packs)
+			pack_processing += generated_packs
 			continue
-		supply_packs[P.type] = P
+
+		if(!pack.contains)
+			continue
+
+		supply_packs[pack.id] = pack
 
 	initial_load()
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -17,7 +17,7 @@ This prevents race conditions that arise based on the order of tile processing.
  *Any other attempts to fix it just killed atmos. I leave this to a greater man then I
  */
 #define QUANTIZE(variable) (round((variable), (MOLAR_ACCURACY)))
-GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
+GLOBAL_LIST_INIT_TYPED(meta_gas_info, /datum/gas, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 /proc/init_gaslist_cache()

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -17,7 +17,7 @@ This prevents race conditions that arise based on the order of tile processing.
  *Any other attempts to fix it just killed atmos. I leave this to a greater man then I
  */
 #define QUANTIZE(variable) (round((variable), (MOLAR_ACCURACY)))
-GLOBAL_LIST_INIT_TYPED(meta_gas_info, /datum/gas, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
+GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 /proc/init_gaslist_cache()

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -49,24 +49,32 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	var/dangerous = FALSE //currently used by canisters
 	var/fusion_power = 0 //How much the gas accelerates a fusion reaction
 	var/rarity = 0 // relative rarity compared to other gases, used when setting up the reactions list.
+	var/purchaseable = FALSE
+	var/base_value = 0
 
 /datum/gas/oxygen
 	id = "o2"
 	specific_heat = 20
 	name = "Oxygen"
 	rarity = 900
+	purchaseable = TRUE
+	base_value = 0.2
 
 /datum/gas/nitrogen
 	id = "n2"
 	specific_heat = 20
 	name = "Nitrogen"
 	rarity = 1000
+	purchaseable = TRUE
+	base_value = 0.1
 
 /datum/gas/carbon_dioxide //what the fuck is this?
 	id = "co2"
 	specific_heat = 30
 	name = "Carbon Dioxide"
 	rarity = 700
+	purchaseable = TRUE
+	base_value = 0.2
 
 /datum/gas/plasma
 	id = "plasma"
@@ -76,6 +84,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	moles_visible = MOLES_GAS_VISIBLE
 	dangerous = TRUE
 	rarity = 800
+	base_value = 2
 
 /datum/gas/water_vapor
 	id = "water_vapor"
@@ -85,6 +94,8 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	moles_visible = MOLES_GAS_VISIBLE
 	fusion_power = 8
 	rarity = 500
+	purchaseable = TRUE
+	base_value = 0.5
 
 /datum/gas/hypernoblium
 	id = "nob"
@@ -95,6 +106,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	dangerous = TRUE
 	fusion_power = 10
 	rarity = 50
+	base_value = 5
 
 /datum/gas/nitrous_oxide
 	id = "n2o"
@@ -105,6 +117,8 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	fusion_power = 10
 	dangerous = TRUE
 	rarity = 600
+	purchaseable = TRUE
+	base_value = 3
 
 /datum/gas/nitryl
 	id = "no2"
@@ -114,6 +128,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	moles_visible = MOLES_GAS_VISIBLE
 	dangerous = TRUE
 	rarity = 100
+	base_value = 5
 
 /datum/gas/tritium
 	id = "tritium"
@@ -124,6 +139,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	dangerous = TRUE
 	fusion_power = 5
 	rarity = 300
+	base_value = 5
 
 /datum/gas/bz
 	id = "bz"
@@ -132,6 +148,8 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	dangerous = TRUE
 	fusion_power = 8
 	rarity = 400
+	purchaseable = TRUE
+	base_value = 2
 
 /datum/gas/stimulum
 	id = "stim"
@@ -139,6 +157,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	name = "Stimulum"
 	fusion_power = 7
 	rarity = 1
+	base_value = 100
 
 /datum/gas/pluoxium
 	id = "pluox"
@@ -146,6 +165,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	name = "Pluoxium"
 	fusion_power = -10
 	rarity = 200
+	base_value = 5
 
 /datum/gas/miasma
 	id = "miasma"
@@ -154,6 +174,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	gas_overlay = "miasma"
 	moles_visible = MOLES_GAS_VISIBLE * 60
 	rarity = 250
+	base_value = 2
 
 /datum/gas/freon
 	id = "freon"
@@ -163,6 +184,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	moles_visible = MOLES_GAS_VISIBLE *30
 	fusion_power = -5
 	rarity = 10
+	base_value = 15
 
 /datum/gas/hydrogen
 	id = "hydrogen"
@@ -171,6 +193,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	dangerous = TRUE
 	fusion_power = 2
 	rarity = 600
+	base_value = 1
 
 /datum/gas/healium
 	id = "healium"
@@ -180,6 +203,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	gas_overlay = "healium"
 	moles_visible = MOLES_GAS_VISIBLE
 	rarity = 300
+	base_value = 19
 
 /datum/gas/proto_nitrate
 	id = "proto_nitrate"
@@ -189,6 +213,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	gas_overlay = "proto_nitrate"
 	moles_visible = MOLES_GAS_VISIBLE
 	rarity = 200
+	base_value = 5
 
 /datum/gas/zauker
 	id = "zauker"
@@ -198,6 +223,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	gas_overlay = "zauker"
 	moles_visible = MOLES_GAS_VISIBLE
 	rarity = 1
+	base_value = 100
 
 /datum/gas/halon
 	id = "halon"
@@ -207,6 +233,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	gas_overlay = "halon"
 	moles_visible = MOLES_GAS_VISIBLE
 	rarity = 300
+	base_value = 9
 
 /datum/gas/helium
 	id = "helium"
@@ -214,6 +241,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	name = "Helium"
 	fusion_power = 7
 	rarity = 50
+	base_value = 6
 
 /datum/gas/antinoblium
 	id = "antinoblium"
@@ -224,6 +252,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	moles_visible = MOLES_GAS_VISIBLE
 	fusion_power = 20
 	rarity = 1
+	base_value = 10
 
 /obj/effect/overlay/gas
 	icon = 'icons/effects/atmospherics.dmi'

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -5,6 +5,36 @@
 #define CANISTER_TIER_2 2
 #define CANISTER_TIER_3 3
 
+///List of all the gases, used in labelling the canisters
+GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
+
+/proc/init_gas_id_to_canister()
+	return sortList(list(
+		"n2" = /obj/machinery/portable_atmospherics/canister/nitrogen,
+		"o2" = /obj/machinery/portable_atmospherics/canister/oxygen,
+		"co2" = /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+		"plasma" = /obj/machinery/portable_atmospherics/canister/toxins,
+		"n2o" = /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+		"no2" = /obj/machinery/portable_atmospherics/canister/nitryl,
+		"bz" = /obj/machinery/portable_atmospherics/canister/bz,
+		"air" = /obj/machinery/portable_atmospherics/canister/air,
+		"water vapor" = /obj/machinery/portable_atmospherics/canister/water_vapor,
+		"tritium" = /obj/machinery/portable_atmospherics/canister/tritium,
+		"hyper-noblium" = /obj/machinery/portable_atmospherics/canister/nob,
+		"stimulum" = /obj/machinery/portable_atmospherics/canister/stimulum,
+		"pluoxium" = /obj/machinery/portable_atmospherics/canister/pluoxium,
+		"caution" = /obj/machinery/portable_atmospherics/canister,
+		"miasma" = /obj/machinery/portable_atmospherics/canister/miasma,
+		"freon" = /obj/machinery/portable_atmospherics/canister/freon,
+		"hydrogen" = /obj/machinery/portable_atmospherics/canister/hydrogen,
+		"healium" = /obj/machinery/portable_atmospherics/canister/healium,
+		"proto_nitrate" = /obj/machinery/portable_atmospherics/canister/proto_nitrate,
+		"zauker" = /obj/machinery/portable_atmospherics/canister/zauker,
+		"helium" = /obj/machinery/portable_atmospherics/canister/helium,
+		"antinoblium" = /obj/machinery/portable_atmospherics/canister/antinoblium,
+		"halon" = /obj/machinery/portable_atmospherics/canister/halon
+	))
+
 /obj/machinery/portable_atmospherics/canister
 	name = "canister"
 	desc = "A canister for the storage of gas."
@@ -56,32 +86,6 @@
 	var/restricted = FALSE
 	///Set the tier of the canister and overlay used
 	var/mode = CANISTER_TIER_1
-	///List of all the gases, used in labelling the canisters
-	var/static/list/label2types = list(
-		"n2" = /obj/machinery/portable_atmospherics/canister/nitrogen,
-		"o2" = /obj/machinery/portable_atmospherics/canister/oxygen,
-		"co2" = /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-		"plasma" = /obj/machinery/portable_atmospherics/canister/toxins,
-		"n2o" = /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-		"no2" = /obj/machinery/portable_atmospherics/canister/nitryl,
-		"bz" = /obj/machinery/portable_atmospherics/canister/bz,
-		"air" = /obj/machinery/portable_atmospherics/canister/air,
-		"water vapor" = /obj/machinery/portable_atmospherics/canister/water_vapor,
-		"tritium" = /obj/machinery/portable_atmospherics/canister/tritium,
-		"hyper-noblium" = /obj/machinery/portable_atmospherics/canister/nob,
-		"stimulum" = /obj/machinery/portable_atmospherics/canister/stimulum,
-		"pluoxium" = /obj/machinery/portable_atmospherics/canister/pluoxium,
-		"caution" = /obj/machinery/portable_atmospherics/canister,
-		"miasma" = /obj/machinery/portable_atmospherics/canister/miasma,
-		"freon" = /obj/machinery/portable_atmospherics/canister/freon,
-		"hydrogen" = /obj/machinery/portable_atmospherics/canister/hydrogen,
-		"healium" = /obj/machinery/portable_atmospherics/canister/healium,
-		"proto_nitrate" = /obj/machinery/portable_atmospherics/canister/proto_nitrate,
-		"zauker" = /obj/machinery/portable_atmospherics/canister/zauker,
-		"helium" = /obj/machinery/portable_atmospherics/canister/helium,
-		"antinoblium" = /obj/machinery/portable_atmospherics/canister/antinoblium,
-		"halon" = /obj/machinery/portable_atmospherics/canister/halon
-	)
 
 /obj/machinery/portable_atmospherics/canister/Initialize(mapload, datum/gas_mixture/existing_mixture)
 	. = ..()
@@ -552,9 +556,9 @@
 		return
 	switch(action)
 		if("relabel")
-			var/label = input("New canister label:", name) as null|anything in sortList(label2types)
+			var/label = input("New canister label:", name) as null|anything in GLOB.gas_id_to_canister
 			if(label && !..())
-				var/newtype = label2types[label]
+				var/newtype = GLOB.gas_id_to_canister[label]
 				if(newtype)
 					var/obj/machinery/portable_atmospherics/canister/replacement = newtype
 					investigate_log("was relabelled to [initial(replacement.name)] by [key_name(usr)].", INVESTIGATE_ATMOS)

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -109,9 +109,10 @@
 
 /datum/export/large/gas_canister/get_cost(obj/O)
 	var/obj/machinery/portable_atmospherics/canister/C = O
-	var/worth = 10
+	var/worth = cost
 	var/canister_mix = C.air_contents.gases
-	var/list/gases_to_check = list(/datum/gas/bz,
+	var/list/gases_to_check = list(
+								/datum/gas/bz,
 								/datum/gas/stimulum,
 								/datum/gas/hypernoblium,
 								/datum/gas/miasma,
@@ -124,29 +125,17 @@
 								/datum/gas/zauker,
 								/datum/gas/helium,
 								/datum/gas/antinoblium,
-								/datum/gas/halon
-								)
-
-	var/list/gas_prices = list(/datum/gas/bz = 2,
-								/datum/gas/stimulum = 100,
-								/datum/gas/hypernoblium = 5,
-								/datum/gas/miasma = 2,
-								/datum/gas/tritium = 5,
-								/datum/gas/pluoxium = 5,
-								/datum/gas/freon = 15,
-								/datum/gas/hydrogen = 1,
-								/datum/gas/healium = 19,
-								/datum/gas/proto_nitrate = 5,
-								/datum/gas/zauker = 100,
-								/datum/gas/helium = 6,
-								/datum/gas/antinoblium = 10,
-								/datum/gas/halon = 9
+								/datum/gas/halon,
 								)
 
 	for(var/gasID in gases_to_check)
 		C.air_contents.assert_gas(gasID)
 		if(canister_mix[gasID][MOLES] > 0)
-			worth += round((gas_prices[gasID]/k_elasticity) * (1 - NUM_E**(-1 * k_elasticity * canister_mix[gasID][MOLES])))
+			worth += get_gas_value(gasID, canister_mix[gasID][MOLES])
 
 	C.air_contents.garbage_collect()
 	return worth
+
+/datum/export/large/gas_canister/proc/get_gas_value(gasType, moles)
+	var/baseValue = GLOB.meta_gas_info[gasType].base_value
+	return round((baseValue/k_elasticity) * 1 - NUM_E**(-1 * k_elasticity * moles))

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -136,6 +136,6 @@
 	C.air_contents.garbage_collect()
 	return worth
 
-/datum/export/large/gas_canister/proc/get_gas_value(gasType, moles)
-	var/baseValue = GLOB.meta_gas_info[gasType].base_value
+/datum/export/large/gas_canister/proc/get_gas_value(datum/gas/gasType, moles)
+	var/baseValue = initial(gasType.base_value)
 	return round((baseValue/k_elasticity) * 1 - NUM_E**(-1 * k_elasticity * moles))

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1109,12 +1109,10 @@
 	var/obj/machinery/portable_atmospherics/canister/fakeCanister = /obj/machinery/portable_atmospherics/canister
 	// This is the amount of moles in a default canister
 	var/moleCount = (initial(fakeCanister.maximum_pressure) * initial(fakeCanister.filled)) * initial(fakeCanister.volume) / (R_IDEAL_GAS_EQUATION * T20C)
-	to_chat(world, "Test [moleCount]")
 
 	for(var/gasType in GLOB.meta_gas_info)
 		var/datum/gas/gas = gasType
 		var/name = initial(gas.name)
-		to_chat(world, "Processing pack for [gasType]([name])([initial(gas.purchaseable)])")
 		if(!initial(gas.purchaseable))
 			continue
 		var/datum/supply_pack/materials/pack = new

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -10,6 +10,7 @@
 	var/access_any = FALSE
 	var/list/contains = null
 	var/crate_name = "crate"
+	var/id
 	var/desc = ""//no desc by default
 	var/crate_type = /obj/structure/closet/crate
 	var/dangerous = FALSE // Should we message admins?
@@ -19,6 +20,9 @@
 	var/special_pod //If this pack comes shipped in a specific pod when launched from the express console
 	var/admin_spawned = FALSE
 	var/goody = FALSE //Goodies can only be purchased by private accounts and can have coupons apply to them. They also come in a lockbox instead of a full crate, so the 700 min doesn't apply
+
+/datum/supply_pack/New()
+	id = type
 
 /datum/supply_pack/proc/generate(atom/A, datum/bank_account/paying_account)
 	var/obj/structure/closet/crate/C
@@ -48,6 +52,10 @@
 	else
 		for(var/item in contains)
 			new item(C)
+
+/// For generating supply packs at runtime. Returns a list of supply packs to use instead of this one.
+/datum/supply_pack/proc/generate_supply_packs()
+	return
 
 // If you add something to this list, please group it by type and sort it alphabetically instead of just jamming it in like an animal
 
@@ -1049,25 +1057,6 @@
 	contains = list(/obj/item/stack/sheet/mineral/wood/fifty)
 	crate_name = "wood planks crate"
 
-/datum/supply_pack/materials/bz
-	name = "BZ Canister Crate"
-	desc = "Contains a canister of BZ. Requires Toxins access to open."
-	cost = CARGO_CRATE_VALUE * 16
-	access = ACCESS_TOXINS
-	access_view = ACCESS_ATMOSPHERICS
-	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
-	crate_name = "BZ canister crate"
-	crate_type = /obj/structure/closet/crate/secure/science
-
-/datum/supply_pack/materials/carbon_dio
-	name = "Carbon Dioxide Canister"
-	desc = "Contains a canister of Carbon Dioxide."
-	cost = CARGO_CRATE_VALUE * 6
-	access_view = ACCESS_ATMOSPHERICS
-	contains = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
-	crate_name = "carbon dioxide canister crate"
-	crate_type = /obj/structure/closet/crate/large
-
 /datum/supply_pack/materials/foamtank
 	name = "Firefighting Foam Tank Crate"
 	desc = "Contains a tank of firefighting foam. Also known as \"plasmaman's bane\"."
@@ -1101,32 +1090,6 @@
 	crate_name = "high-capacity fuel tank crate"
 	crate_type = /obj/structure/closet/crate/large
 
-/datum/supply_pack/materials/nitrogen
-	name = "Nitrogen Canister"
-	desc = "Contains a canister of Nitrogen."
-	cost = CARGO_CRATE_VALUE * 4
-	contains = list(/obj/machinery/portable_atmospherics/canister/nitrogen)
-	crate_name = "nitrogen canister crate"
-	crate_type = /obj/structure/closet/crate/large
-
-/datum/supply_pack/materials/nitrous_oxide_canister
-	name = "Nitrous Oxide Canister"
-	desc = "Contains a canister of Nitrous Oxide. Requires Atmospherics access to open."
-	cost = CARGO_CRATE_VALUE * 6
-	access = ACCESS_ATMOSPHERICS
-	access_view = ACCESS_ATMOSPHERICS
-	contains = list(/obj/machinery/portable_atmospherics/canister/nitrous_oxide)
-	crate_name = "nitrous oxide canister crate"
-	crate_type = /obj/structure/closet/crate/secure
-
-/datum/supply_pack/materials/oxygen
-	name = "Oxygen Canister"
-	desc = "Contains a canister of Oxygen. Canned in Druidia."
-	cost = CARGO_CRATE_VALUE * 3
-	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
-	crate_name = "oxygen canister crate"
-	crate_type = /obj/structure/closet/crate/large
-
 /datum/supply_pack/materials/watertank
 	name = "Water Tank Crate"
 	desc = "Contains a tank of dihydrogen monoxide... sounds dangerous."
@@ -1135,13 +1098,43 @@
 	crate_name = "water tank crate"
 	crate_type = /obj/structure/closet/crate/large
 
-/datum/supply_pack/materials/water_vapor
-	name = "Water Vapor Canister"
-	desc = "Contains a canister of Water Vapor. I swear to god if you open this in the halls..."
-	cost = CARGO_CRATE_VALUE * 4
-	contains = list(/obj/machinery/portable_atmospherics/canister/water_vapor)
-	crate_name = "water vapor canister crate"
+/datum/supply_pack/materials/gas_canisters
+	cost = CARGO_CRATE_VALUE * 0.05
+	contains = list(/obj/machinery/portable_atmospherics/canister)
 	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/materials/gas_canisters/generate_supply_packs()
+	var/list/canister_packs = list()
+
+	var/obj/machinery/portable_atmospherics/canister/fakeCanister = /obj/machinery/portable_atmospherics/canister
+	// This is the amount of moles in a default canister
+	var/moleCount = (initial(fakeCanister.maximum_pressure) * initial(fakeCanister.filled)) * initial(fakeCanister.volume) / (R_IDEAL_GAS_EQUATION * T20C)
+	to_chat(world, "Test [moleCount]")
+
+	for(var/gasType in GLOB.meta_gas_info)
+		var/datum/gas/gas = gasType
+		var/name = initial(gas.name)
+		to_chat(world, "Processing pack for [gasType]([name])([initial(gas.purchaseable)])")
+		if(!initial(gas.purchaseable))
+			continue
+		var/datum/supply_pack/materials/pack = new
+		pack.name = "[name] Canister"
+		pack.desc = "Contains a canister of [name]."
+		if(initial(gas.dangerous))
+			pack.desc = "[pack.desc] Requires Atmospherics access to open."
+			pack.access = ACCESS_ATMOSPHERICS
+			pack.access_view = ACCESS_ATMOSPHERICS
+		pack.crate_name = "[name] canister crate"
+		pack.id = "[type]([name])"
+
+		pack.cost = cost + moleCount * initial(gas.base_value) * 1.6
+		pack.cost = CEILING(pack.cost, 10)
+
+		pack.contains = list(GLOB.gas_id_to_canister[initial(gas.id)])
+
+		canister_packs += pack
+
+	return canister_packs
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Medical /////////////////////////////////////////


### PR DESCRIPTION
## About The Pull Request

This makes it so that selling and purchasing gas are both based on the same base value with modifications. I derived the values by using the sale value as base price so that should remain mostly unchanged. For purchasing gas I based the purchasing markup off of the value of the oxygen canister which results in gas being 1.6x the value of selling that same gas. Other purchase prices went up or down a bit due to this.

This is step one of some other gas supply changes, I need the prices to be standardized like this to continue.

## Changelog
:cl:
balance: All gas prices have been standardized and based on a single base value, this has resulted in some fluctuations in the purchase price of various gases.
/:cl:
