### PR TITLE
Updates TramStation atmospherics to be of a higher quality.

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -12294,6 +12294,26 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"ayU" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Atmospherics South-East";
+	dir = 1;
+	network = list("ss13","engineering")
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ayV" = (
 /obj/machinery/door/airlock{
 	id_tag = "private_g";
@@ -20952,6 +20972,19 @@
 	dir = 8
 	},
 /area/service/bar)
+"aXl" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "aXn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
@@ -21012,6 +21045,16 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"aXI" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "aXK" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/iron/showroomfloor,
@@ -23131,16 +23174,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bUp" = (
-/obj/machinery/computer/atmos_control/tank/air_tank{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bUu" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/trimline/brown/filled/corner,
@@ -23662,6 +23695,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
+"cff" = (
+/obj/machinery/atmospherics/components/trinary/mixer/airmix{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "cfh" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -29480,6 +29520,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"eDF" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "O2 Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "eEo" = (
 /obj/structure/railing{
 	dir = 1
@@ -31125,6 +31181,10 @@
 "fnk" = (
 /turf/open/floor/iron,
 /area/security/prison)
+"fnx" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "fnX" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Medical Maintenance";
@@ -32646,6 +32706,12 @@
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"fWL" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "fWR" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -32934,20 +33000,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
-"geo" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ger" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -33176,9 +33228,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"glb" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 5
+"glg" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -34790,12 +34845,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"gRw" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "gRP" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/decal/cleanable/dirt,
@@ -35004,12 +35053,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"gVz" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "gVN" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium"
@@ -35119,6 +35162,21 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
+"hbL" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hbZ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -38382,19 +38440,6 @@
 /obj/machinery/atmospherics/pipe/multiz/layer2,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
-"iFE" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "O2 Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "iFH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -38824,13 +38869,6 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"iPg" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "iPj" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -40012,18 +40050,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"jvG" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "jvO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -44049,26 +44075,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"lnm" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Atmospherics South-East";
-	dir = 1;
-	network = list("ss13","engineering")
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lnB" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -47797,12 +47803,6 @@
 	},
 /turf/closed/wall,
 /area/cargo/sorting)
-"ncP" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ndn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -50953,13 +50953,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"oGc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "oGX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -51654,15 +51647,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"oWh" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "oWl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -53261,6 +53245,11 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"pEn" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "pEo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57458,6 +57447,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"rzA" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "rzK" = (
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
@@ -60583,13 +60578,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain/private)
-"tau" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "taS" = (
 /obj/structure/chair{
 	dir = 1
@@ -65183,16 +65171,6 @@
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"vab" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vas" = (
 /obj/effect/turf_decal/sand,
 /obj/item/chair,
@@ -65683,17 +65661,6 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
-"vlz" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vlJ" = (
 /obj/machinery/camera{
 	c_tag = "Security - Interrogation Main";
@@ -65856,6 +65823,14 @@
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"vrq" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vrN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
@@ -66161,13 +66136,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"vAm" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vAt" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -66557,13 +66525,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"vHA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vHH" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/disposalpipe/segment{
@@ -66826,6 +66787,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"vNm" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vNK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -67532,11 +67503,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
-"whV" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "wic" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -67622,6 +67588,20 @@
 "wld" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/exit)
+"wll" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wlr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -69177,6 +69157,10 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/left)
+"wVc" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wVu" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
@@ -70596,16 +70580,6 @@
 /mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"xBw" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xBC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -72076,6 +72050,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"ygC" = (
+/obj/machinery/computer/atmos_control/tank/air_tank{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ygD" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -107147,11 +107134,11 @@ tnL
 pnF
 iky
 cmE
-glb
-gVz
-tau
-whV
-iFE
+wVc
+cff
+vrq
+fWL
+eDF
 gFR
 gED
 eaY
@@ -107404,11 +107391,11 @@ qyQ
 iZX
 uPi
 ljs
-iPg
+fnx
 kCj
 uiE
 rfq
-jvG
+hbL
 one
 jwD
 iCR
@@ -107661,11 +107648,11 @@ oTZ
 ntR
 pIu
 spz
-ncP
+tnL
 gUE
 iVY
 thl
-vab
+aXl
 mgz
 jPQ
 xIt
@@ -107918,11 +107905,11 @@ bkn
 bkn
 bkn
 rqG
-vHA
+wsP
 wsP
 psJ
 lNO
-bUp
+ygC
 tOl
 jwD
 ntZ
@@ -108175,11 +108162,11 @@ iVY
 nBs
 qKp
 bhe
-vAm
-gRw
-vlz
-oGc
-geo
+iVY
+pEn
+aXI
+rzA
+wll
 gFR
 gED
 eip
@@ -108434,9 +108421,9 @@ vOX
 luc
 mxE
 gMk
-oWh
-xBw
-lnm
+glg
+vNm
+ayU
 one
 jwD
 iCR

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -24072,7 +24072,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cmN" = (
@@ -32424,6 +32424,9 @@
 "fQc" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/reagent_dispensers/foamtank,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fQd" = (
@@ -37571,9 +37574,7 @@
 	dir = 8;
 	name = "Port to Filter"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Incinerator"
-	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ikD" = (
@@ -39265,7 +39266,9 @@
 /area/commons/vacant_room/office)
 "iZX" = (
 /obj/machinery/meter/atmos/atmos_waste_loop,
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jad" = (
@@ -45692,6 +45695,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
+"mgx" = (
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "mgz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -51722,6 +51729,12 @@
 "oYl" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/radshelter/civil)
+"oYp" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Port to Incinerator"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "oYD" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -52450,9 +52463,7 @@
 /area/maintenance/starboard/secondary)
 "pnF" = (
 /obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "pnN" = (
@@ -107130,7 +107141,7 @@ woj
 tnL
 dGY
 fQc
-tnL
+oYp
 pnF
 iky
 cmE
@@ -107386,7 +107397,7 @@ lsZ
 wIq
 oBQ
 qyQ
-qyQ
+mgx
 qyQ
 iZX
 uPi

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6664,6 +6664,14 @@
 /obj/structure/railing,
 /turf/open/floor/glass,
 /area/commons/dorms)
+"anN" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "anO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
@@ -12216,6 +12224,23 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/engine,
 /area/engineering/main)
+"ayN" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Testing Room";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/engineering/atmospherics_engine)
 "ayO" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -12310,6 +12335,34 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"ayZ" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Turbine Access";
+	req_access_txt = "24"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"aza" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "azb" = (
 /obj/structure/chair{
 	dir = 4
@@ -12331,6 +12384,25 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"aze" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Turbine Access";
+	req_access_txt = "24"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "azf" = (
 /obj/effect/turf_decal/bot,
 /obj/vehicle/ridden/janicart,
@@ -16942,6 +17014,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
+"aIr" = (
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "aIs" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -21461,6 +21540,21 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"bfA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/robot_debris/limb,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "bfR" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Office";
@@ -21502,6 +21596,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"bhe" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "bhi" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -21767,6 +21871,18 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
+"bnA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "bnB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -21866,18 +21982,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
-"brz" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "brA" = (
 /obj/machinery/smartfridge/chemistry,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -21998,6 +22102,18 @@
 	},
 /turf/open/floor/plating,
 /area/science/nanite)
+"bup" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "buy" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
@@ -22587,6 +22703,13 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"bJW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "bJX" = (
 /obj/structure/chair{
 	dir = 4
@@ -22674,6 +22797,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"bLI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "bLV" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -22866,6 +23004,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"bPZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "bQN" = (
 /obj/machinery/door/window/southleft{
 	name = "Maximum Security Test Chamber";
@@ -22983,6 +23131,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"bUp" = (
+/obj/machinery/computer/atmos_control/tank/air_tank{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "bUu" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/trimline/brown/filled/corner,
@@ -23030,6 +23188,17 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"bVO" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "bVX" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -23351,6 +23520,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
+"ccj" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "cct" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -23845,6 +24028,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/starboard/central)
+"cmE" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "cmN" = (
 /obj/structure/chair{
 	dir = 4
@@ -24352,6 +24542,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/break_room)
+"cAP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "External to Filter"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "cAW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -24373,6 +24575,11 @@
 	},
 /turf/open/floor/plating,
 /area/command/bridge)
+"cBq" = (
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "cBt" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/trimline/white/filled/line{
@@ -24603,6 +24810,32 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
+"cHa" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer";
+	req_access_txt = "56"
+	},
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "cHo" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/iron/dark/telecomms,
@@ -25762,20 +25995,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"dfK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "dfT" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/disposaloutlet,
@@ -26471,13 +26690,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"dvK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "dvQ" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -26765,12 +26977,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
-"dCA" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "dCC" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -27385,14 +27591,6 @@
 "dOL" = (
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
-"dOR" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "dOU" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
@@ -27918,6 +28116,12 @@
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"dYM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "dYR" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock"
@@ -28336,13 +28540,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/medical/coldroom)
-"eiT" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "eiX" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /turf/open/floor/iron,
@@ -28703,16 +28900,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
-"erh" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "erl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -28939,16 +29126,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"ewE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "ewH" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -29112,6 +29289,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"eAx" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "eAy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
@@ -29655,6 +29840,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"eOp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmospherics_engine)
 "eOy" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -29743,13 +29938,6 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
-"ePE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmospherics_engine)
 "ePI" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -30114,6 +30302,11 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"eWy" = (
+/obj/machinery/meter/atmos/distro_loop,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "eWI" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -30126,12 +30319,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"eWM" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/neutral/corner,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "eWR" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/light,
@@ -30709,14 +30896,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"fhP" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Air to Distro"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "fhR" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
@@ -30824,6 +31003,16 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"flU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
 "fmd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -30944,6 +31133,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"foh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmospherics_engine)
 "fom" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -31188,16 +31389,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
-"fug" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/atmospherics_engine)
 "fuv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -31574,6 +31765,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
+"fBv" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "fBx" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/escape)
@@ -32052,6 +32252,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"fOh" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "fOm" = (
 /obj/structure/chair/plastic,
 /obj/effect/decal/cleanable/dirt,
@@ -32319,6 +32528,16 @@
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/security/prison)
+"fTg" = (
+/obj/machinery/computer/atmos_control/tank/toxin_tank{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "fTk" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -32372,6 +32591,13 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
+"fTV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "fTY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -32652,14 +32878,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/qm)
-"gcR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "gcW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
@@ -32716,6 +32934,20 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
+"geo" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ger" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -32756,11 +32988,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"geV" = (
-/obj/machinery/meter/atmos/atmos_waste_loop,
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "geY" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -32847,6 +33074,18 @@
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"ghw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "ghY" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/machinery/light/small{
@@ -32937,6 +33176,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"glb" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "glj" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -34364,6 +34609,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice)
+"gMk" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gMr" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/tcomms,
@@ -34402,11 +34656,6 @@
 "gNM" = (
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"gNX" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "gNY" = (
 /obj/structure/lattice,
 /turf/open/openspace/airless/planetary,
@@ -34540,6 +34789,12 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
+/area/engineering/atmos)
+"gRw" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "gRP" = (
 /obj/effect/turf_decal/caution/stand_clear,
@@ -34805,17 +35060,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating/airless,
 /area/engineering/main)
-"gYY" = (
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "gYZ" = (
 /obj/machinery/ntnet_relay,
 /obj/structure/sign/warning/nosmoking{
@@ -35108,6 +35352,24 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"hhn" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hhp" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -35516,11 +35778,6 @@
 /obj/item/stack/sheet/iron,
 /turf/open/floor/plating/asteroid,
 /area/mine/explored)
-"hpc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "hpp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -35542,25 +35799,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/center)
-"hqf" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Turbine Access";
-	req_access_txt = "24"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "hqm" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/prison_contraband,
@@ -35874,16 +36112,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"hyu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "hzh" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -36069,12 +36297,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/processing)
-"hDm" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "hDp" = (
 /obj/item/shovel,
 /obj/item/storage/bag/ore,
@@ -36513,16 +36735,6 @@
 /obj/structure/closet/secure_closet/hop,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
-"hOV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmospherics_engine)
 "hPc" = (
 /obj/machinery/computer/security{
 	dir = 8
@@ -36849,6 +37061,16 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"hXD" = (
+/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hXR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -36900,13 +37122,6 @@
 "hZq" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"hZz" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -37146,26 +37361,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/cargo/miningdock)
-"ign" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Atmospherics South-East";
-	dir = 1;
-	network = list("ss13","engineering")
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "igu" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
@@ -37211,13 +37406,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"ihP" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ihX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/multiz/layer4{
@@ -37320,6 +37508,30 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
+"iky" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Port to Filter"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Port to Incinerator"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"ikD" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Distribution Loop";
+	req_access_txt = "24"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ikF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37548,14 +37760,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/brig)
-"ipU" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ipX" = (
 /obj/machinery/light,
 /turf/open/floor/iron/dark,
@@ -37572,6 +37776,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"iqe" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "iqm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -37615,24 +37826,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"isy" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "isH" = (
 /obj/machinery/holopad/secure,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -38177,12 +38370,31 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
+"iFm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
 "iFq" = (
 /obj/structure/ladder,
 /obj/machinery/atmospherics/pipe/multiz/layer4,
 /obj/machinery/atmospherics/pipe/multiz/layer2,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
+"iFE" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "O2 Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "iFH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -38612,6 +38824,13 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"iPg" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "iPj" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -38771,18 +38990,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"iRR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "External to Filter"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "iRW" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -39018,6 +39225,11 @@
 "iZO" = (
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
+"iZX" = (
+/obj/machinery/meter/atmos/atmos_waste_loop,
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "jad" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -39088,6 +39300,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"jbt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "jbA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/power/apc/auto_name/south,
@@ -39160,6 +39380,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/lab)
+"jeh" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Distro to Waste"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "jek" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -39180,20 +39407,6 @@
 "jfy" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"jfQ" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Distribution Loop";
-	req_access_txt = "24"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -39403,16 +39616,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"jlc" = (
-/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "jld" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice,
@@ -39452,6 +39655,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"jmu" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "jmC" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
@@ -39639,16 +39851,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/research)
-"jrO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "jrY" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -39810,6 +40012,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"jvG" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "jvO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -39983,12 +40197,13 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
-"jzl" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
+"jyY" = (
+/obj/machinery/computer/atmos_control/tank/oxygen_tank{
+	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -40411,15 +40626,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"jLa" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Waste In"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "jLP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -40506,13 +40712,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"jOr" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "jOR" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
@@ -40630,17 +40829,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/center)
-"jRZ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "jTb" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -41254,16 +41442,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"kdK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/iron/dark,
-/area/engineering/atmospherics_engine)
 "kdT" = (
 /obj/machinery/door/airlock/research{
 	name = "Research and Development Lab";
@@ -41508,6 +41686,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
+"kjL" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "kjQ" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
@@ -41626,15 +41816,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
-"klV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Atmospherics Maintenance";
-	req_one_access_txt = "24"
-	},
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
 "kml" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -41883,18 +42064,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
-"ktx" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ktC" = (
 /turf/closed/wall/r_wall,
 /area/security/brig)
@@ -41999,6 +42168,20 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"kwc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kwg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -42079,29 +42262,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
-"kwY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"kxa" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kxn" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
@@ -42291,13 +42451,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"kBz" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kBI" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/status_display/evac{
@@ -42538,15 +42691,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/mine/explored)
-"kHE" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kIt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
@@ -42806,13 +42950,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"kNq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "kNz" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
@@ -42831,6 +42968,20 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"kNF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "kOv" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
@@ -42949,22 +43100,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"kRg" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kRh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -43100,13 +43235,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
-"kUP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kUQ" = (
 /obj/structure/chair,
 /obj/structure/sign/poster/official/random{
@@ -43643,6 +43771,13 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
+"led" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
 "lee" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -43665,6 +43800,17 @@
 "leZ" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"lfe" = (
+/obj/structure/cable,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "lfi" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -43710,6 +43856,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
+"lgz" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "lgR" = (
 /turf/open/floor/plating/asteroid,
 /area/maintenance/central)
@@ -43772,17 +43928,6 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"lju" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 6
-	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ljx" = (
@@ -43904,6 +44049,26 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"lnm" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Atmospherics South-East";
+	dir = 1;
+	network = list("ss13","engineering")
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "lnB" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -44176,6 +44341,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"luc" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "CO2 Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "luw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -44271,6 +44447,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"lwa" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "lwr" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/machinery/airalarm/directional/south,
@@ -44489,16 +44673,6 @@
 "lBO" = (
 /turf/open/floor/wood,
 /area/maintenance/central)
-"lBY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmospherics_engine)
 "lCc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -44593,11 +44767,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
-"lFW" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lGe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44789,6 +44958,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
+"lKd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "lKt" = (
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Upper External North";
@@ -44879,6 +45064,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/virology)
+"lNO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "lOd" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/ce)
@@ -44933,32 +45123,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
-"lQe" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/door/airlock/command{
-	name = "Chief Engineer";
-	req_access_txt = "56"
-	},
-/turf/open/floor/iron,
-/area/command/heads_quarters/ce)
 "lQy" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
 	dir = 8
@@ -45133,18 +45297,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"lUt" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "lUE" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/navbeacon/wayfinding/med,
@@ -45289,6 +45441,14 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"lYg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "lYu" = (
 /obj/structure/grille,
 /obj/machinery/meter,
@@ -45312,6 +45472,18 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"lZC" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "lZG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -45549,16 +45721,6 @@
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /turf/open/floor/engine,
 /area/science/mixing)
-"mhG" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "mhI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -46168,6 +46330,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
+"mxE" = (
+/obj/machinery/computer/atmos_control/tank/carbon_tank{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "mxF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -46270,20 +46442,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"mzE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "mzF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -46336,17 +46494,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"mAZ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "mBn" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/chaplain,
@@ -46920,26 +47067,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"mOH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "mOK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"mOL" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "mON" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -47059,17 +47192,6 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit)
-"mQU" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "mRa" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -47168,6 +47290,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"mTt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
 "mTV" = (
 /obj/machinery/light{
 	dir = 1
@@ -47665,6 +47797,12 @@
 	},
 /turf/closed/wall,
 /area/cargo/sorting)
+"ncP" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ndn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -48022,18 +48160,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
-"nnG" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "nnZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -48551,6 +48677,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"nBs" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "nBB" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "pharmacy_shutters_2";
@@ -48915,15 +49046,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"nKG" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "nKR" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -48952,6 +49074,26 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/cargo/office)
+"nLE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/bonfire,
+/obj/item/reagent_containers/food/drinks/bottle/orangejuice{
+	desc = "For the weary spacemen on their quest to rekindle the first plasma fire.";
+	name = "Carton of Estus"
+	},
+/obj/item/melee/moonlight_greatsword,
+/obj/effect/decal/remains/human,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "nLJ" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = 32
@@ -48994,6 +49136,15 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
+"nNs" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "nNw" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/pump,
@@ -49068,20 +49219,6 @@
 /obj/structure/stairs/north,
 /turf/open/floor/iron/stairs/medium,
 /area/science/research)
-"nOv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "nOF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
@@ -49198,6 +49335,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"nQR" = (
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "nQS" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -49306,11 +49452,6 @@
 /obj/item/stamp/cmo,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
-"nUU" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "nUW" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -49361,6 +49502,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"nVQ" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/corner,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "nWb" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/effect/turf_decal/siding/thinplating/corner,
@@ -49957,19 +50104,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/lab)
-"okz" = (
-/obj/machinery/computer/atmos_control/tank/nitrous_tank{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "okC" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron,
@@ -50328,18 +50462,6 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"otQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "otY" = (
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -50480,16 +50602,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/sorting)
-"owO" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Filter"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Incinerator"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "oxe" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
@@ -50596,13 +50708,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"oAq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "oAv" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
@@ -50848,6 +50953,13 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"oGc" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "oGX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -50858,13 +50970,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"oHe" = (
-/obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "oHn" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
@@ -51142,16 +51247,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"oLQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "oLR" = (
 /obj/machinery/gateway/centerstation,
 /obj/effect/turf_decal/bot_white/left,
@@ -51306,16 +51401,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"oQx" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "oQH" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -51569,6 +51654,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"oWh" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "oWl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -51826,6 +51920,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"pcg" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "pch" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -52055,15 +52157,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"pil" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Plasma Outlet Pump"
+"pik" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "piI" = (
@@ -52172,19 +52272,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"plt" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "plu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -52377,6 +52464,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"pnF" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "pnN" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Lab";
@@ -52590,6 +52684,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"psJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "psM" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/loot_site_spawner,
@@ -53281,16 +53382,6 @@
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/left)
-"pGI" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "pGY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -53315,6 +53406,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
+"pHm" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "pHp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -53492,14 +53588,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"pLk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "pLR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -53584,13 +53672,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"pOb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "pOw" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -54256,6 +54337,15 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
+"qfl" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qfo" = (
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating/asteroid,
@@ -54297,19 +54387,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/service/theater)
-"qgl" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "qgs" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating/asteroid/airless,
@@ -55538,6 +55615,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"qHo" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qHD" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -55630,6 +55713,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
+"qKp" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qLb" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "plating"
@@ -55856,13 +55947,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"qTe" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Distro to Waste"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "qTm" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium_blue"
@@ -56350,24 +56434,10 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
-"rfe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+"rfq" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"rfv" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -56517,19 +56587,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"riI" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "riU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -56713,14 +56770,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
-"rll" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "rlv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -56978,6 +57027,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"rqy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "rqz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -57658,15 +57714,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
-"rIL" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "rIQ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -57961,12 +58008,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"rPS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmospherics_engine)
 "rPX" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -58052,15 +58093,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"rTI" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "rTL" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
@@ -58322,6 +58354,16 @@
 /mob/living/simple_animal/hostile/cockroach,
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
+"sbv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "sby" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -58487,20 +58529,6 @@
 "seV" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"sfg" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sfm" = (
@@ -59043,6 +59071,16 @@
 	},
 /turf/open/openspace,
 /area/science/xenobiology)
+"sqo" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "sqS" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
@@ -59363,12 +59401,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"sxW" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "syc" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -59705,17 +59737,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"sES" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "sFj" = (
 /obj/structure/cable,
 /obj/machinery/flasher{
@@ -59846,27 +59867,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"sIp" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "N2 Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"sID" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "sJm" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -60096,30 +60096,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"sOa" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"sOc" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"sOd" = (
-/obj/effect/turf_decal/arrows/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmospherics_engine)
 "sOn" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -60363,6 +60339,16 @@
 	dir = 5
 	},
 /area/command/heads_quarters/rd)
+"sUS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "sVe" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -60448,6 +60434,19 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"sWu" = (
+/obj/machinery/computer/atmos_control/tank/nitrous_tank{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "sWC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -60569,20 +60568,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"taa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "tab" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -60758,6 +60743,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"ter" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "teO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -60826,6 +60823,17 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
+"tgv" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Plasma Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tgK" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -60872,6 +60880,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"thl" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "thz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -61013,6 +61028,14 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
+"tjx" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Air to Distro"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tjD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -61164,6 +61187,17 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"tnm" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tnu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61186,6 +61220,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
+"tnH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "tnL" = (
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -61210,18 +61256,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"tnO" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "tom" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/railing/corner{
@@ -61293,20 +61327,6 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/iron/white,
 /area/security/brig)
-"toU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "toV" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -61523,6 +61543,16 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
+"ttp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/iron/dark,
+/area/engineering/atmospherics_engine)
 "ttH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
@@ -61781,26 +61811,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
-"txV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/bonfire,
-/obj/item/reagent_containers/food/drinks/bottle/orangejuice{
-	desc = "For the weary spacemen on their quest to rekindle the first plasma fire.";
-	name = "Carton of Estus"
-	},
-/obj/item/melee/moonlight_greatsword,
-/obj/effect/decal/remains/human,
-/turf/open/floor/iron/dark,
-/area/engineering/atmos)
 "txZ" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/light/small{
@@ -61864,18 +61874,6 @@
 "tAh" = (
 /turf/closed/wall/r_wall,
 /area/engineering/storage/tech)
-"tAm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/atmospherics_engine)
 "tAn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -62038,6 +62036,19 @@
 /obj/item/wallframe/apc,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"tEe" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tEA" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -62194,16 +62205,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"tJg" = (
-/obj/machinery/computer/atmos_control/tank/toxin_tank{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "tJq" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -62228,11 +62229,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit)
-"tJH" = (
-/obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "tJL" = (
 /obj/machinery/camera{
 	c_tag = "Secure - Gateway North";
@@ -62278,13 +62274,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
-"tKz" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "tKC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -62310,19 +62299,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"tLB" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "O2 Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "tLQ" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -62456,16 +62432,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/brig)
-"tPZ" = (
-/obj/machinery/computer/atmos_control/tank/air_tank{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "tQc" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -62521,6 +62487,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"tQN" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/meter/atmos/atmos_waste_loop,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tRy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -62531,15 +62507,6 @@
 	},
 /turf/open/floor/carpet,
 /area/service/library)
-"tRA" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "tRD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -62762,6 +62729,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"tWH" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tWP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -63283,18 +63259,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/service/bar)
-"ugx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "ugF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -64080,6 +64044,15 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
+"uzY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Atmospherics Maintenance";
+	req_one_access_txt = "24"
+	},
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "uAe" = (
 /obj/structure/transit_tube,
 /obj/effect/turf_decal/sand/plating,
@@ -64229,12 +64202,6 @@
 "uEX" = (
 /turf/closed/wall,
 /area/security/checkpoint/escape)
-"uFv" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "uFL" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -64472,6 +64439,19 @@
 	dir = 5
 	},
 /area/science/breakroom)
+"uKH" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "N2 Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "uKN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -64847,18 +64827,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"uQN" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "uQZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -65154,23 +65122,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"uYy" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "N2O Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Unfiltered to Mix"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "uYP" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	dir = 4;
@@ -65232,6 +65183,16 @@
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"vab" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vas" = (
 /obj/effect/turf_decal/sand,
 /obj/item/chair,
@@ -65247,17 +65208,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"vaO" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "CO2 Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vbr" = (
 /obj/effect/turf_decal/tile{
 	dir = 1
@@ -65733,6 +65683,17 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
+"vlz" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vlJ" = (
 /obj/machinery/camera{
 	c_tag = "Security - Interrogation Main";
@@ -65757,6 +65718,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"vlY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vlZ" = (
 /obj/machinery/porta_turret/ai,
 /obj/machinery/light{
@@ -65974,22 +65943,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"vsX" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Turbine Access";
-	req_access_txt = "24"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vtm" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -66013,6 +65966,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"vtJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "vtT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -66194,6 +66161,13 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"vAm" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vAt" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -66224,16 +66198,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"vBc" = (
-/obj/machinery/computer/atmos_control/tank/carbon_tank{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vBi" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/riot{
@@ -66401,6 +66365,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
+"vEh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vEm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -66486,10 +66464,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"vGd" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "vGu" = (
 /turf/closed/wall/r_wall,
 /area/command/bridge)
@@ -66583,6 +66557,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"vHA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vHH" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/disposalpipe/segment{
@@ -66900,6 +66881,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"vOX" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vPp" = (
 /turf/open/floor/iron/white,
 /area/security/prison)
@@ -67108,6 +67099,16 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"vTG" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vUi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -67142,12 +67143,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"vVh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "vVs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -67264,16 +67259,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"vYu" = (
-/obj/machinery/computer/atmos_control/tank/oxygen_tank{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vYV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/red/filled/warning,
@@ -67287,6 +67272,15 @@
 /obj/item/paicard,
 /turf/open/floor/iron/white,
 /area/science/research)
+"was" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste In"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "waG" = (
 /obj/item/beacon,
 /obj/effect/turf_decal/stripes/line{
@@ -67538,6 +67532,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
+"whV" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wic" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -67772,6 +67771,20 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
+"wpf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "wpl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -67923,21 +67936,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
-"wts" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/robot_debris/limb,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "wtt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -68296,6 +68294,15 @@
 "wAL" = (
 /turf/open/floor/iron/dark,
 /area/command/gateway)
+"wAR" = (
+/obj/effect/turf_decal/arrows/white{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
 "wBg" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -68446,22 +68453,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/lab)
-"wEw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "wEN" = (
 /obj/structure/girder,
 /obj/effect/turf_decal/sand/plating,
@@ -68797,15 +68788,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
-"wNk" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "wNp" = (
 /obj/machinery/door/airlock/command{
 	name = "Research Director's Office";
@@ -69201,6 +69183,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
+"wVY" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "wWd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -69479,11 +69465,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/security/brig)
-"xbL" = (
-/obj/machinery/meter/atmos/distro_loop,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xbT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -69528,16 +69509,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"xcU" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xdg" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2,
 /turf/open/floor/iron,
@@ -69583,6 +69554,19 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"xdZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xej" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
@@ -69951,6 +69935,17 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
+"xlb" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xlj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -70236,6 +70231,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"xsu" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "N2O Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Unfiltered to Mix"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xsv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -70335,15 +70347,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"xvc" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xvf" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -70593,6 +70596,16 @@
 /mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"xBw" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xBC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -70759,6 +70772,22 @@
 /obj/item/screwdriver,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"xFM" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xFN" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -71463,6 +71492,14 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
+"xTI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xTU" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/item/stack/sheet/iron,
@@ -71587,23 +71624,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
-"xWy" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Testing Room";
-	req_access_txt = "24"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/engineering/atmospherics_engine)
 "xWQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -72154,16 +72174,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
-"yiY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/meter/atmos/atmos_waste_loop,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "yje" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -72266,18 +72276,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/science/research)
-"ylT" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 
 (1,1,1) = {"
 ajc
@@ -104841,7 +104839,7 @@ ijR
 jZf
 eOc
 one
-txV
+nLE
 one
 aae
 aae
@@ -105085,7 +105083,7 @@ gUn
 uYT
 lOd
 wPP
-lQe
+cHa
 wPP
 lOd
 lOd
@@ -105335,7 +105333,7 @@ sss
 geu
 bhR
 bhR
-vGd
+wVY
 npx
 cyF
 kgc
@@ -105345,7 +105343,7 @@ bKd
 fFZ
 juv
 sud
-ipU
+anN
 gIc
 uaf
 lmk
@@ -105589,9 +105587,9 @@ dCC
 owd
 aOl
 iWU
-kwY
+bLI
 jfy
-sID
+eAx
 one
 njO
 fqJ
@@ -105610,7 +105608,7 @@ beL
 tUF
 tnL
 tnL
-jzl
+pik
 wFO
 okn
 xQi
@@ -105846,14 +105844,14 @@ jXu
 one
 dxE
 sKW
-nnG
-sOc
-plt
-isy
-taa
-mOH
-iRR
-pLk
+lZC
+pcg
+xdZ
+hhn
+vEh
+xTI
+cAP
+lYg
 qBb
 xPR
 qhD
@@ -105868,7 +105866,7 @@ vdg
 beL
 beL
 xdg
-jlc
+hXD
 tOl
 jwD
 ntZ
@@ -106124,8 +106122,8 @@ tnL
 pch
 lGS
 iVY
-lFW
-sIp
+pHm
+uKH
 gFR
 gED
 eaY
@@ -106367,7 +106365,7 @@ one
 qOl
 xZW
 xZW
-oQx
+lgz
 eBS
 qmC
 sJT
@@ -106381,8 +106379,8 @@ tnL
 vdg
 bRF
 ttH
-rll
-dfK
+vlY
+kwc
 ger
 cTH
 iCR
@@ -106624,7 +106622,7 @@ one
 tOl
 tOl
 tOl
-jfQ
+ikD
 rsm
 xiD
 snR
@@ -106638,8 +106636,8 @@ beL
 bUh
 kEG
 fqJ
-hDm
-rfv
+qHo
+fBv
 okn
 xQi
 eaY
@@ -106878,10 +106876,10 @@ akU
 one
 aLB
 vwX
-rIL
-jLa
-yiY
-ylT
+nNs
+was
+tQN
+bup
 tFX
 uLB
 ezn
@@ -106896,7 +106894,7 @@ bjv
 rUe
 tnL
 tnL
-vYu
+jyY
 tOl
 jwD
 ntZ
@@ -107133,9 +107131,9 @@ sOA
 uQI
 bIu
 one
-hyu
+bPZ
 one
-qTe
+jeh
 tnL
 xEr
 oAx
@@ -107146,14 +107144,14 @@ tnL
 dGY
 fQc
 tnL
-jOr
-owO
-tKz
-dCA
+pnF
+iky
+cmE
+glb
 gVz
 tau
-nUU
-tLB
+whV
+iFE
 gFR
 gED
 eaY
@@ -107390,9 +107388,9 @@ khK
 mGV
 xXg
 one
-jrO
+sUS
 vwX
-xbL
+eWy
 ktD
 otx
 hZT
@@ -107403,14 +107401,14 @@ oBQ
 qyQ
 qyQ
 qyQ
-geV
+iZX
 uPi
 ljs
-eiT
+iPg
 kCj
 uiE
-sOa
-brz
+rfq
+jvG
 one
 jwD
 iCR
@@ -107663,11 +107661,11 @@ oTZ
 ntR
 pIu
 spz
-sxW
+ncP
 gUE
 iVY
-ihP
-xcU
+thl
+vab
 mgz
 jPQ
 xIt
@@ -107906,7 +107904,7 @@ phM
 wzB
 kWk
 one
-fhP
+tjx
 nTs
 hZq
 bxw
@@ -107920,11 +107918,11 @@ bkn
 bkn
 bkn
 rqG
-kUP
+vHA
 wsP
-pOb
-hpc
-tPZ
+psJ
+lNO
+bUp
 tOl
 jwD
 ntZ
@@ -108163,25 +108161,25 @@ aJo
 fVf
 rqz
 one
-oHe
-pGI
-hZz
-tJH
-kNq
-riI
+aIr
+vTG
+iqe
+cBq
+rqy
+tEe
 iVY
-eWM
-mQU
-mhG
+nVQ
+bVO
+sqo
 iVY
-gNX
-dOR
-erh
-kBz
-uFv
-qgl
-mOL
-lju
+nBs
+qKp
+bhe
+vAm
+gRw
+vlz
+oGc
+geo
 gFR
 gED
 eip
@@ -108420,25 +108418,25 @@ aJo
 dkh
 rqz
 one
-kHE
-nKG
+nQR
+tWH
 cvS
-xvc
+qfl
 okn
-uYy
-okz
-ktx
-kRg
-pil
-tJg
-wNk
-oLQ
-vaO
-vBc
-rTI
-tnO
-jRZ
-ign
+xsu
+sWu
+ter
+xFM
+tgv
+fTg
+fOh
+vOX
+luc
+mxE
+gMk
+oWh
+xBw
+lnm
 one
 jwD
 iCR
@@ -108678,24 +108676,24 @@ vDX
 rqz
 one
 one
-oAq
+bJW
 tOl
-dvK
+fTV
 one
-oAq
+bJW
 tOl
-dvK
+fTV
 one
-oAq
+bJW
 tOl
-dvK
+fTV
 one
-oAq
+bJW
 tOl
-dvK
+fTV
 one
 one
-vsX
+ayZ
 one
 jwD
 one
@@ -108952,7 +108950,7 @@ jwD
 eui
 jwD
 tOl
-mAZ
+xlb
 tOl
 jwD
 one
@@ -109189,7 +109187,7 @@ cix
 wBD
 aJo
 iVs
-rfe
+ghw
 aJo
 one
 lYu
@@ -109209,7 +109207,7 @@ ntZ
 lYu
 one
 dGP
-uQN
+aza
 dGP
 one
 one
@@ -109466,7 +109464,7 @@ nfp
 hUe
 one
 kZV
-sES
+tnm
 dGP
 aae
 aae
@@ -109723,7 +109721,7 @@ xFX
 vKh
 one
 mWF
-kxa
+lwa
 dGP
 ajc
 aBM
@@ -109980,7 +109978,7 @@ sxN
 vKh
 one
 xap
-gYY
+lfe
 dGP
 dGP
 dGP
@@ -110217,7 +110215,7 @@ aae
 aae
 aJo
 aJM
-otQ
+bnA
 aJo
 one
 one
@@ -110237,7 +110235,7 @@ diU
 diU
 diU
 kGx
-sfg
+ccj
 jMf
 byD
 oCp
@@ -110494,7 +110492,7 @@ nWL
 tVq
 diU
 dOL
-hqf
+aze
 hTg
 hTg
 qFu
@@ -110730,7 +110728,7 @@ aJz
 aJz
 aJz
 aJz
-ewE
+sbv
 vDX
 aJo
 ify
@@ -110751,7 +110749,7 @@ tWb
 jbA
 diU
 ayT
-wEw
+lKd
 bNe
 eDs
 bZx
@@ -111008,7 +111006,7 @@ syF
 eLR
 diU
 aoo
-gcR
+jbt
 bGf
 poj
 mep
@@ -111261,11 +111259,11 @@ peZ
 udR
 jXF
 tZl
-tAm
-kdK
-xWy
-nOv
-ugx
+foh
+ttp
+ayN
+wpf
+tnH
 pmO
 pNC
 kPz
@@ -111501,14 +111499,14 @@ nlQ
 gfq
 dJk
 wGY
-mzE
+vtJ
 aJz
-lUt
-aJz
-aJz
+kjL
 aJz
 aJz
-wts
+aJz
+aJz
+bfA
 aJo
 ijL
 sod
@@ -111517,8 +111515,8 @@ rzp
 wNL
 tiG
 caj
-lBY
-fug
+flU
+eOp
 nET
 diU
 bid
@@ -111765,16 +111763,16 @@ aJy
 aJy
 aJo
 aJo
-toU
-tRA
-vVh
-vVh
-klV
-rPS
-ePE
-sOd
-rPS
-hOV
+kNF
+jmu
+dYM
+dYM
+uzY
+iFm
+led
+wAR
+iFm
+mTt
 tuo
 rkS
 diU

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -67,6 +67,27 @@
 "aak" = (
 /turf/closed/wall,
 /area/hallway/primary/port)
+"aal" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/kirbyplants,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/port)
 "aam" = (
 /turf/open/floor/iron/stairs/medium{
 	dir = 4
@@ -1048,6 +1069,30 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
+"acj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/motion{
+	c_tag = "Security - Armory";
+	network = list("ss13","Security")
+	},
+/obj/structure/ladder,
+/obj/machinery/atmospherics/pipe/multiz/layer4,
+/obj/machinery/atmospherics/pipe/multiz/layer2,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "ack" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -1126,6 +1171,17 @@
 "acr" = (
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"acs" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/chair/comfy/beige{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 10
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "act" = (
 /obj/effect/turf_decal/siding/thinplating/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -1463,6 +1519,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"adh" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/service/bar)
 "adi" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1511,6 +1577,17 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/bar)
+"ado" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "adp" = (
 /obj/machinery/door/airlock{
 	name = "Hydroponics-Kitchen Access";
@@ -1519,6 +1596,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/service/kitchen)
+"adq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "adr" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
@@ -1591,6 +1682,11 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"adA" = (
+/obj/structure/ladder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "adB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -1668,6 +1764,19 @@
 	dir = 4
 	},
 /area/service/chapel)
+"adK" = (
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 6
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "adL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -2342,6 +2451,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"afh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "afi" = (
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
@@ -2527,6 +2642,19 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"afF" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
+/area/commons/locker)
 "afG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -3358,6 +3486,15 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/service/hydroponics)
+"ahm" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/east,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/service/bar)
 "ahn" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -3581,6 +3718,17 @@
 /obj/item/clothing/glasses/hud/health,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"ahO" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "ahP" = (
 /obj/structure/chair{
 	dir = 4
@@ -3606,12 +3754,29 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/security/courtroom)
+"ahS" = (
+/obj/structure/chair/comfy/black,
+/obj/item/radio/intercom/directional/north,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/service/library)
 "ahT" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/virologist,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"ahU" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/service/bar)
 "ahV" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -3675,6 +3840,15 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/port)
+"aic" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "aid" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 4
@@ -3736,6 +3910,17 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/science/mixing)
+"ail" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/grimy,
+/area/service/chapel/office)
 "aim" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/turf_decal/trimline/yellow/corner,
@@ -3945,6 +4130,18 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"aiM" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
+/area/commons/locker)
 "aiN" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -4187,6 +4384,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"ajp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen,
+/turf/open/floor/plating,
+/area/command/heads_quarters/hos)
 "ajq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
@@ -4509,6 +4712,27 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"ajT" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/port)
 "ajU" = (
 /obj/structure/railing/corner,
 /turf/open/floor/glass,
@@ -4570,6 +4794,22 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"akb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
+"akc" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "akd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -4606,6 +4846,19 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"aki" = (
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet/restrooms)
 "akj" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -4891,6 +5144,20 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/science/lab)
+"akL" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/obj/machinery/button/door{
+	id = "private_b";
+	name = "Privacy Bolts";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = -8;
+	specialfunctions = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "akM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -5034,6 +5301,20 @@
 	dir = 5
 	},
 /area/command/heads_quarters/rd)
+"alf" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutter";
+	name = "Vacant Commissary Shutter"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "alg" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -5044,6 +5325,24 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/dorms)
+"alh" = (
+/obj/structure/table/reinforced,
+/obj/structure/noticeboard{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutter";
+	name = "Vacant Commissary Shutter"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "ali" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -5335,6 +5634,16 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/science/research)
+"alL" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "alM" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
@@ -5657,6 +5966,13 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/wood,
 /area/service/theater)
+"amp" = (
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/grimy,
+/area/service/chapel/office)
 "amq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -5664,6 +5980,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/brig)
+"amr" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/obj/machinery/button/door{
+	id = "private_l";
+	name = "Privacy Bolts";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	pixel_y = -8;
+	specialfunctions = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "ams" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -5857,6 +6187,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"amM" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/service/hydroponics)
 "amN" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -6174,6 +6514,16 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/wood,
 /area/service/library)
+"anx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/service/hydroponics)
 "any" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -6314,18 +6664,6 @@
 /obj/structure/railing,
 /turf/open/floor/glass,
 /area/commons/dorms)
-"anN" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "External to Filter"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "anO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
@@ -6384,6 +6722,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"anV" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/service/bar)
 "anW" = (
 /obj/machinery/computer/security{
 	dir = 1
@@ -6643,6 +6995,23 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"aoz" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/seccarts{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/storage/box/deputy,
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/button/door{
+	id = "HOSOffice";
+	name = "Emergency Blast Doors";
+	pixel_x = -24;
+	pixel_y = -8;
+	req_access_txt = "3"
+	},
+/turf/open/floor/carpet,
+/area/command/heads_quarters/hos)
 "aoA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -6666,6 +7035,23 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"aoC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "aoD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -6931,6 +7317,14 @@
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
+"apf" = (
+/obj/structure/toilet{
+	dir = 8;
+	pixel_y = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/service/bar)
 "apg" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -7082,6 +7476,24 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
+"apt" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/entry)
 "apu" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -7126,6 +7538,14 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"apy" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white,
+/area/security/brig)
 "apz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -7492,6 +7912,15 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"aqg" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/tram/left)
 "aqh" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -7708,6 +8137,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
+"aqC" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/left)
 "aqD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -7874,6 +8313,20 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
+"aqU" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 9
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "aqV" = (
 /obj/structure/ladder,
 /turf/open/floor/iron/white,
@@ -7969,6 +8422,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"arg" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "arh" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -8005,6 +8470,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"arl" = (
+/obj/item/bikehorn/rubberducky,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet/restrooms)
 "arm" = (
 /obj/structure/filingcabinet,
 /obj/machinery/status_display/ai{
@@ -8847,6 +9324,15 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"asR" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/tram/center)
 "asS" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -8998,6 +9484,18 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
+"atj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 6
+	},
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/maintenance/tram/mid)
 "atk" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -9241,6 +9739,17 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/right)
+"atF" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/service/bar)
 "atG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -9375,6 +9884,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
+"atS" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/right)
 "atT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -9469,6 +9995,14 @@
 	dir = 8
 	},
 /area/service/chapel)
+"aua" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet/restrooms)
 "aub" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral{
@@ -9885,6 +10419,16 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"auS" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Power Access Hatch";
+	req_one_access_txt = "19"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/command/bridge)
 "auU" = (
 /obj/machinery/light/small,
 /turf/open/openspace,
@@ -10207,6 +10751,13 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
+"avC" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/tram/center)
 "avD" = (
 /obj/structure/chair{
 	dir = 4
@@ -10496,6 +11047,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
+"awi" = (
+/obj/structure/chair/sofa/corner,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "awj" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -10736,6 +11292,15 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
+"awJ" = (
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/firealarm/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria{
+	dir = 5
+	},
+/area/science/breakroom)
 "awK" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/structure/railing,
@@ -10940,6 +11505,20 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/science/explab)
+"axl" = (
+/obj/structure/chair/sofa/left,
+/obj/effect/turf_decal/siding/thinplating/corner,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
+"axm" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/service/library)
 "axn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11236,10 +11815,33 @@
 "axR" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/tram/right)
+"axS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "axT" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"axU" = (
+/obj/structure/disposalpipe/trunk/multiz/down,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
 "axV" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -11521,6 +12123,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"ayE" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
 "ayF" = (
 /obj/structure/chair{
 	dir = 8;
@@ -11549,6 +12159,20 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/engineering/main)
+"ayH" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/obj/machinery/button/door{
+	id = "private_j";
+	name = "Privacy Bolts";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = -8;
+	specialfunctions = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "ayI" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -11645,23 +12269,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"ayU" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Atmospherics South-East";
-	dir = 1;
-	network = list("ss13","engineering")
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ayV" = (
 /obj/machinery/door/airlock{
 	id_tag = "private_g";
@@ -11703,28 +12310,6 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"ayZ" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Turbine Access";
-	req_access_txt = "24"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"aza" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "azb" = (
 /obj/structure/chair{
 	dir = 4
@@ -11857,6 +12442,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"azt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "azu" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Emitter Room East";
@@ -12356,6 +12950,19 @@
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
+"aAv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "aAw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -12570,6 +13177,15 @@
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/right)
+"aAS" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/right)
 "aAT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -12601,6 +13217,19 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"aAX" = (
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
+"aAY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
 "aAZ" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -12641,6 +13270,16 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"aBe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/tram/right)
 "aBf" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -12760,6 +13399,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"aBq" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "aBr" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -13218,6 +13865,13 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/command/gateway)
+"aCn" = (
+/obj/structure/chair,
+/obj/machinery/airalarm/directional/north,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/maintenance/radshelter/service)
 "aCo" = (
 /obj/machinery/chem_master/condimaster,
 /obj/item/radio/intercom/directional/west,
@@ -13362,6 +14016,14 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"aCG" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/obj/structure/closet/toolcloset,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron,
+/area/commons/storage/tools)
 "aCH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -13537,6 +14199,20 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
+"aDa" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/obj/machinery/button/door{
+	id = "private_f";
+	name = "Privacy Bolts";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	pixel_y = -8;
+	specialfunctions = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "aDb" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
@@ -13568,6 +14244,35 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"aDd" = (
+/obj/structure/sign/directions/supply{
+	dir = 4;
+	pixel_y = 28
+	},
+/obj/structure/sign/directions/security{
+	dir = 4;
+	pixel_y = 34
+	},
+/obj/structure/sign/directions/command{
+	dir = 4;
+	pixel_y = 40
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/arrow_cw{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/sign/directions/vault{
+	dir = 4;
+	pixel_y = 22
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/left)
 "aDe" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -13662,6 +14367,16 @@
 /obj/effect/turf_decal/trimline/neutral/corner,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"aDj" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/left)
 "aDk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -13977,6 +14692,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
+"aDM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aDN" = (
 /obj/structure/closet/crate,
 /obj/item/crowbar,
@@ -14365,6 +15091,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
+"aEA" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron/cafeteria,
+/area/commons/locker)
 "aEB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron,
@@ -14700,6 +15437,14 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
+"aFk" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/center)
 "aFl" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -14864,6 +15609,13 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"aFB" = (
+/obj/structure/chair/comfy/beige{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/grimy,
+/area/hallway/secondary/entry)
 "aFC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
@@ -15162,6 +15914,35 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"aGm" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = -32
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/white,
+/area/science/research)
+"aGn" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool,
+/obj/structure/noticeboard{
+	pixel_y = -27
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/service/bar)
 "aGo" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -15297,6 +16078,14 @@
 /obj/machinery/light,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"aGC" = (
+/obj/structure/cable/multilayer/multiz,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
 "aGD" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -15414,6 +16203,14 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
+"aGO" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "aGP" = (
 /obj/structure/chair{
 	dir = 8;
@@ -15508,6 +16305,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
+"aHa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
 "aHb" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -15551,6 +16354,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"aHg" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
 "aHh" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -16132,13 +16942,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
-"aIr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "aIs" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -16214,6 +17017,15 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/maintenance/tram/left)
+"aIB" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/plastic,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "aIC" = (
@@ -16837,6 +17649,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"aKe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "aKf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -16860,6 +17682,13 @@
 "aKl" = (
 /turf/closed/wall,
 /area/maintenance/port/aft)
+"aKm" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/service/bar)
 "aKo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -16916,6 +17745,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"aKD" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/corner{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/service/bar)
 "aKE" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet,
@@ -17096,6 +17940,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"aLu" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "aLx" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -17135,6 +17992,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"aLF" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/service/bar)
 "aLG" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -17181,6 +18045,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"aLL" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/service/bar)
 "aLM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron/dark,
@@ -17519,6 +18394,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
+"aNv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/tram/left)
 "aNw" = (
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
@@ -17530,6 +18415,16 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"aNB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/tram/right)
 "aNC" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -17656,6 +18551,15 @@
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
+"aNP" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/service/bar)
 "aNR" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
@@ -17825,6 +18729,27 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
+"aOF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/service/theater)
+"aOG" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Tunnel Access";
+	req_one_access_txt = "12"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/maintenance/tram/left)
 "aOH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
@@ -17999,6 +18924,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"aPv" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "aPw" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -18331,6 +19264,18 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"aQr" = (
+/obj/structure/cable,
+/obj/structure/ladder,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/commons/lounge)
 "aQt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -18890,6 +19835,16 @@
 /obj/item/clothing/shoes/jackboots,
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
+"aRJ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/commons/lounge)
 "aRL" = (
 /turf/closed/wall,
 /area/maintenance/starboard/secondary)
@@ -18944,6 +19899,18 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"aRV" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/commons/lounge)
 "aRW" = (
 /turf/closed/wall,
 /area/commons/locker)
@@ -18953,6 +19920,15 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"aRY" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/commons/lounge)
 "aRZ" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 4
@@ -18965,6 +19941,20 @@
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
+"aSa" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/obj/machinery/button/door{
+	id = "private_h";
+	name = "Privacy Bolts";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = -8;
+	specialfunctions = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "aSb" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -18974,6 +19964,16 @@
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
+"aSc" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -32
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/service/library)
 "aSd" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -19062,6 +20062,22 @@
 /area/commons/lounge)
 "aSo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/lounge)
+"aSp" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -19358,11 +20374,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"aTs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "aTu" = (
 /obj/structure/chair/sofa{
 	dir = 8
@@ -19408,6 +20419,14 @@
 /obj/effect/turf_decal/siding/thinplating,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
+"aTT" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "aTU" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
@@ -19431,6 +20450,22 @@
 "aUb" = (
 /turf/closed/wall/r_wall,
 /area/engineering/engine_smes)
+"aUc" = (
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
+"aUe" = (
+/obj/structure/sign/poster/official/bless_this_spess{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/grimy,
+/area/service/chapel/office)
 "aUf" = (
 /obj/structure/table/glass,
 /obj/machinery/airalarm/directional/north,
@@ -19456,6 +20491,20 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"aUv" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/obj/machinery/button/door{
+	id = "private_n";
+	name = "Privacy Bolts";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	pixel_y = -8;
+	specialfunctions = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "aUy" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/blue{
@@ -19676,12 +20725,6 @@
 	},
 /turf/open/floor/glass,
 /area/commons/dorms)
-"aWq" = (
-/obj/machinery/light/small,
-/obj/structure/closet/firecloset,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/center)
 "aWs" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -19927,6 +20970,15 @@
 /obj/item/stack/spacecash/c10,
 /turf/open/floor/wood,
 /area/service/bar)
+"aYd" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet/restrooms)
 "aYi" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/neutral{
@@ -20020,6 +21072,17 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"aYM" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/closet/wardrobe/green,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron/cafeteria,
+/area/commons/locker)
 "aYR" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -20262,6 +21325,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"bbP" = (
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/science/research)
 "bbT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -20370,6 +21445,16 @@
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
+"beS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Power Access Hatch";
+	req_one_access_txt = "19"
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "bfg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner,
@@ -20417,16 +21502,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
-"bhe" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bhi" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -20510,11 +21585,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"bil" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/command/bridge)
 "biz" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium_white"
@@ -20535,15 +21605,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"biR" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/center)
 "bjv" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -20606,23 +21667,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bkx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "bkV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -20697,20 +21741,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/cytology)
-"bmL" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "bnl" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/holosign/barrier/atmos/sturdy,
@@ -20737,6 +21767,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
+"bnB" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "bnF" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -20798,18 +21835,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"bpX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "bqf" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -20841,6 +21866,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
+"brz" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "brA" = (
 /obj/machinery/smartfridge/chemistry,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -20896,6 +21933,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"bsM" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "bsR" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -20953,15 +21998,21 @@
 	},
 /turf/open/floor/plating,
 /area/science/nanite)
-"bup" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
+"buy" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/machinery/camera{
+	c_tag = "Science - Lobby";
+	dir = 9;
+	network = list("ss13","science")
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/white,
+/area/science/research)
 "buL" = (
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/bot{
@@ -20972,6 +22023,24 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
+"buP" = (
+/obj/machinery/shower{
+	pixel_y = 24
+	},
+/obj/structure/curtain,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet/restrooms)
+"buT" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "bvw" = (
 /obj/machinery/suit_storage_unit/captain,
 /turf/open/floor/wood,
@@ -21244,6 +22313,14 @@
 /obj/effect/decal/cleanable/robot_debris,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"bBj" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/commons/lounge)
 "bBA" = (
 /turf/closed/wall,
 /area/maintenance/disposal)
@@ -21252,18 +22329,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
-"bBV" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+"bCy" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
 	},
-/obj/item/pen,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/break_room)
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "bCZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -21303,39 +22382,11 @@
 	dir = 4
 	},
 /area/service/theater)
-"bEi" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 6
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/machinery/camera{
-	c_tag = "Science - Lobby";
-	dir = 9;
-	network = list("ss13","science")
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white,
-/area/science/research)
 "bEj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/wirecutters,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"bEq" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "bEs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -21449,12 +22500,6 @@
 /obj/effect/spawner/lootdrop/food_packaging,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"bGm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen,
-/turf/open/floor/plating,
-/area/command/heads_quarters/hos)
 "bGK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -21533,14 +22578,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
-"bJW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+"bJI" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
+/turf/open/floor/iron,
+/area/cargo/storage)
 "bJX" = (
 /obj/structure/chair{
 	dir = 4
@@ -21579,12 +22625,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bKh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/freezer,
-/area/science/research)
 "bKz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -21621,25 +22661,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/science/mixing)
+"bKT" = (
+/obj/machinery/door/airlock/security{
+	name = "Prison Sanitarium";
+	req_access_txt = "2"
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "bLs" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"bLI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bLV" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -21711,6 +22745,33 @@
 	},
 /turf/open/floor/circuit/green,
 /area/science/nanite)
+"bMJ" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1;
+	name = "sorting disposal pipe (Head of Personnel's Office)";
+	sortType = 15
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
+"bMN" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "bNe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
@@ -21792,18 +22853,6 @@
 /obj/item/mmi,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
-"bPp" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/command/bridge)
 "bPy" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -21817,32 +22866,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"bPK" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Turbine Access";
-	req_access_txt = "24"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
-"bPZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "bQN" = (
 /obj/machinery/door/window/southleft{
 	name = "Maximum Security Test Chamber";
@@ -21960,13 +22983,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bUp" = (
-/obj/machinery/computer/atmos_control/tank/air_tank{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bUu" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/trimline/brown/filled/corner,
@@ -22014,17 +23030,6 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"bVO" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bVX" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -22264,6 +23269,18 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"caR" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/maintenance/tram/left)
 "caY" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -22380,6 +23397,23 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
+"cdB" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "cdF" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -22820,6 +23854,16 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"cmQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/item/assembly/mousetrap/armed,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/maintenance/tram/mid)
 "cni" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
@@ -23029,16 +24073,6 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"crK" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "crW" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -23077,6 +24111,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"csY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron/freezer,
+/area/science/research)
 "ctf" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -23119,27 +24159,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"cuo" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/obj/structure/closet/toolcloset,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/commons/storage/tools)
-"cus" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/service/chapel/office)
 "cuB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -23262,13 +24281,6 @@
 /obj/structure/transit_tube,
 /turf/open/floor/plating,
 /area/science/research)
-"czM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/tram/center)
 "czP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23340,15 +24352,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/break_room)
-"cAP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cAW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -23370,14 +24373,6 @@
 	},
 /turf/open/floor/plating,
 /area/command/bridge)
-"cBq" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Unfiltered to Mix"
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cBt" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/trimline/white/filled/line{
@@ -23392,10 +24387,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/cytology)
-"cBD" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "cBF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/light,
@@ -23421,15 +24412,6 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"cCf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/maintenance/tram/mid)
 "cCp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -23453,13 +24435,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
-"cDh" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 9
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "cDx" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -23502,6 +24477,14 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
+"cEi" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "cEk" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
@@ -23536,6 +24519,19 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"cEN" = (
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "cFF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -23607,33 +24603,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
-"cHa" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/door/airlock/command{
-	name = "Chief Engineer";
-	req_access_txt = "56"
-	},
-/turf/open/floor/iron,
-/area/command/heads_quarters/ce)
 "cHo" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/iron/dark/telecomms,
@@ -23810,6 +24779,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"cKT" = (
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria{
+	dir = 5
+	},
+/area/science/breakroom)
 "cLh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -23861,17 +24836,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
-"cMf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "cMo" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -23895,6 +24859,12 @@
 	},
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
+"cMH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "cMP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -23921,10 +24891,6 @@
 "cNT" = (
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/civil)
-"cNV" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/service/library)
 "cNX" = (
 /obj/machinery/air_sensor/atmos/mix_tank,
 /turf/open/floor/engine/vacuum,
@@ -23940,16 +24906,6 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"cPe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Atmospherics Maintenance";
-	req_one_access_txt = "24"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
 "cPj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -23977,41 +24933,34 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"cPU" = (
+/obj/machinery/door/airlock{
+	name = "Bathroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron/freezer,
+/area/science/research)
 "cQd" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/white,
 /area/science/explab)
-"cQu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+"cQr" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/engineering/main)
-"cQL" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/chair/comfy{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 6
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/command)
+"cQG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/security/checkpoint/escape)
 "cQM" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/cytology{
@@ -24120,6 +25069,19 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"cRH" = (
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet/restrooms)
 "cRK" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -24188,12 +25150,26 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"cSV" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+"cSO" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
+"cTb" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/hallway/secondary/entry)
 "cTp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall,
@@ -24266,6 +25242,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"cTR" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/corner,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "cTX" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -24396,6 +25387,19 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"cXC" = (
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
 "cXF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -24462,6 +25466,26 @@
 "cYt" = (
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"cYH" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/comfy{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit)
 "cZd" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -24509,6 +25533,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"cZO" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "cZR" = (
 /obj/structure/rack,
 /obj/item/latexballon,
@@ -24518,22 +25546,6 @@
 /obj/item/screwdriver,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"cZY" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/cargo/office)
-"dac" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/tram/right)
 "daf" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/duct,
@@ -24572,19 +25584,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"daN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "daS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -24604,6 +25603,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
+"dbr" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "dby" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -24748,6 +25762,20 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"dfK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "dfT" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/disposaloutlet,
@@ -24771,17 +25799,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"dgv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "dgP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -24843,13 +25860,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
-"dhX" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/bar)
 "did" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
@@ -24982,23 +25992,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"dml" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/tram/right)
 "dmu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -25075,12 +26068,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/research)
-"doo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/command/heads_quarters/ce)
 "dot" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 4"
@@ -25274,24 +26261,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"drI" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
-	},
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron/dark,
-/area/hallway/secondary/entry)
 "drK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/weldingtool,
@@ -25390,15 +26359,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
-"dtt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "dtL" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -25467,10 +26427,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
-"duB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/security/checkpoint/escape)
 "duJ" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -25508,14 +26464,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"dvs" = (
+"dvg" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/commons/lounge)
+/area/hallway/secondary/command)
+"dvK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "dvQ" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -25539,18 +26501,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"dwH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/yellow/warning,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+"dwi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
-/area/maintenance/tram/left)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/service/bar)
 "dxx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -25581,16 +26542,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"dyb" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+"dxK" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/service/hydroponics)
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/service/theater)
 "dyg" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
@@ -25635,20 +26594,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
-"dzl" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/construction/engineering)
 "dzy" = (
 /turf/closed/wall/r_wall,
 /area/cargo/miningdock)
@@ -25691,6 +26636,20 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/science/server)
+"dzX" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/security/brig)
+"dAd" = (
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
 "dAk" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -25786,6 +26745,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"dCn" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/science/research)
 "dCv" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
@@ -25799,6 +26765,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
+"dCA" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "dCC" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -25812,6 +26784,18 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
+"dCV" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/tram/left)
 "dDn" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -25828,17 +26812,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
-"dDp" = (
-/obj/effect/turf_decal/stripes,
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/structure/industrial_lift/tram{
-	icon_state = "titanium"
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/vault,
-/area/hallway/primary/tram/center)
 "dDB" = (
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Upper External West";
@@ -25878,6 +26851,15 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"dDU" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
 "dDY" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -25901,19 +26883,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
-"dEF" = (
-/obj/structure/urinal{
-	pixel_y = 32
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "dFh" = (
 /obj/structure/chair/plastic,
 /obj/effect/decal/cleanable/dirt,
@@ -25946,6 +26915,29 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"dFR" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1;
+	name = "sorting disposal pipe (Detective's Office)";
+	sortType = 30
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "dFW" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
@@ -26084,21 +27076,6 @@
 /obj/item/food/meat/rawcutlet/plain,
 /turf/open/floor/iron/white,
 /area/security/prison)
-"dIl" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Treatment Center";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "dIs" = (
 /obj/effect/turf_decal/siding/thinplating,
 /turf/open/floor/iron,
@@ -26196,22 +27173,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"dJM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "dJT" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -26274,13 +27235,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
-"dKZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/security/checkpoint/escape)
 "dLb" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -26296,6 +27250,15 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics/lab)
+"dLp" = (
+/obj/structure/chair/pew/right{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/service/chapel)
 "dLs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -26366,12 +27329,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"dNz" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/security/prison)
 "dOc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -26428,6 +27385,14 @@
 "dOL" = (
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
+"dOR" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "dOU" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
@@ -26673,23 +27638,6 @@
 /obj/item/construction/plumbing,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"dUr" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Treatment Center";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "dUE" = (
 /obj/effect/mapping_helpers/ianbirthday,
 /obj/structure/disposalpipe/segment{
@@ -26718,20 +27666,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"dUR" = (
-/obj/structure/bed,
-/obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
-	id = "private_l";
-	name = "Privacy Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -8;
-	specialfunctions = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/commons/dorms)
 "dUU" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Lab";
@@ -26984,14 +27918,6 @@
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"dYH" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood,
-/area/service/library)
 "dYR" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock"
@@ -27178,6 +28104,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"edA" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/left)
 "edC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -27202,6 +28133,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"efe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/maintenance/tram/left)
 "efq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27366,16 +28306,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"ehS" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "eip" = (
 /obj/structure/grille,
 /obj/machinery/meter{
@@ -27406,6 +28336,13 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/medical/coldroom)
+"eiT" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "eiX" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /turf/open/floor/iron,
@@ -27484,6 +28421,16 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
+"ekF" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/grimy,
+/area/service/library)
 "ekZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -27509,6 +28456,11 @@
 /obj/item/plunger,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"emk" = (
+/obj/structure/ladder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/cargo/storage)
 "emw" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -27545,6 +28497,11 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"emU" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/construction/engineering)
 "ena" = (
 /obj/structure/fluff/tram_rail/end{
 	dir = 1
@@ -27614,13 +28571,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"eoe" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/cargo/storage)
 "eog" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced,
@@ -27693,12 +28643,6 @@
 	},
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
-"epy" = (
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria{
-	dir = 5
-	},
-/area/science/breakroom)
 "epT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -27759,6 +28703,31 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
+"erh" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"erl" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "eru" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/corner{
@@ -27833,24 +28802,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"esM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
 "etc" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -27873,12 +28824,13 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine,
 /area/science/cytology)
-"etJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+"etL" = (
+/obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/engineering/main)
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/glass,
+/area/commons/dorms)
 "etT" = (
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 1
@@ -27987,6 +28939,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"ewE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "ewH" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -28135,19 +29097,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"ezW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "eAa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -28163,15 +29112,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"eAx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "eAy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
@@ -28201,6 +29141,13 @@
 /obj/effect/turf_decal/trimline/blue/corner,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"eAL" = (
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/right)
 "eAP" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/iron/dark/telecomms,
@@ -28303,6 +29250,16 @@
 "eCU" = (
 /turf/open/floor/plating/asteroid,
 /area/maintenance/port/fore)
+"eDr" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "eDs" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1
@@ -28438,6 +29395,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/civil)
+"eGY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "eHk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -28504,31 +29472,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"eIU" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/ai_monitored/security/armory)
 "eJf" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/airalarm/directional/north,
@@ -28644,6 +29587,16 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/openspace/airless/planetary,
 /area/space)
+"eMU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor{
+	id = "right_tram_lower";
+	name = "tunnel access blast door"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/maintenance/tram/mid)
 "eNw" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -28692,20 +29645,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"eOk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "eOn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
@@ -28804,6 +29743,13 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
+"ePE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
 "ePI" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -28888,6 +29834,13 @@
 	},
 /turf/open/floor/plating,
 /area/command/teleporter)
+"eRF" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "eRW" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29029,6 +29982,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"eUu" = (
+/obj/structure/mirror{
+	pixel_y = 28
+	},
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet/restrooms)
 "eUx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -29080,19 +30043,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"eVG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmospherics_engine)
 "eVK" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -29113,15 +30063,6 @@
 "eVQ" = (
 /turf/closed/wall,
 /area/medical/morgue)
-"eVU" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria{
-	dir = 5
-	},
-/area/science/breakroom)
 "eVY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -29173,12 +30114,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"eWy" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "eWI" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -29191,6 +30126,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"eWM" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/corner,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "eWR" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/light,
@@ -29203,13 +30144,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"eXc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "eXj" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -29236,12 +30170,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"eXy" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/server)
 "eYk" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -29535,13 +30463,6 @@
 /obj/item/pen,
 /turf/open/floor/iron/white,
 /area/science/explab)
-"fch" = (
-/obj/structure/cable/multilayer/multiz,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai)
 "fck" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -29582,6 +30503,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"fdh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/light_switch{
+	pixel_x = 12;
+	pixel_y = 25
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "fdy" = (
 /obj/structure/ladder,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -29771,6 +30709,14 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
+"fhP" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Air to Distro"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "fhR" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
@@ -29811,17 +30757,6 @@
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"fjq" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/closet/masks,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron/cafeteria,
-/area/commons/locker)
 "fjs" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -29847,6 +30782,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"fjE" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/security/prison)
 "fkL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -29928,6 +30867,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"fmm" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/construction/engineering)
 "fmq" = (
 /obj/structure/table,
 /turf/open/floor/carpet,
@@ -30223,13 +31176,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"ftl" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/center)
 "ftr" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -30242,15 +31188,16 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
-"fuf" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+"fug" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/plastic,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/maintenance/tram/left)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmospherics_engine)
 "fuv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -30300,11 +31247,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"fvG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "fvH" = (
 /obj/structure/transit_tube/crossing,
 /turf/open/floor/plating/airless,
@@ -30349,6 +31291,31 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"fwA" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/gun/energy/laser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/ai_monitored/security/armory)
 "fwL" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/purple/end{
@@ -30550,18 +31517,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/brig)
-"fAz" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/lounge)
 "fAE" = (
 /obj/item/stack/ore/iron,
 /obj/item/stack/ore/iron,
@@ -30619,31 +31574,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
-"fBv" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "fBx" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/escape)
-"fBy" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "fBQ" = (
 /obj/structure/chair{
 	dir = 4
@@ -30751,11 +31684,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"fDR" = (
-/obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "fEk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -30775,6 +31703,11 @@
 	dir = 5
 	},
 /area/command/heads_quarters/rd)
+"fET" = (
+/obj/structure/ladder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "fFP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -30904,6 +31837,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"fIj" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/service/chapel/office)
 "fIp" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -30919,16 +31865,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/command/gateway)
-"fIz" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Power Access Hatch";
-	req_one_access_txt = "19"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/command/bridge)
 "fIK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -30946,24 +31882,6 @@
 /obj/machinery/air_sensor/atmos/nitrogen_tank,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
-"fJz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "fJW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -31019,6 +31937,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
+"fLc" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
+"fLg" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/secondary/construction/engineering)
 "fLy" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -31040,10 +31978,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"fLH" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "fLP" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
@@ -31118,15 +32052,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"fOh" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "fOm" = (
 /obj/structure/chair/plastic,
 /obj/effect/decal/cleanable/dirt,
@@ -31145,18 +32070,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain/private)
-"fOQ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
-/area/commons/locker)
 "fOX" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/structure/railing/corner{
@@ -31174,6 +32087,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
+"fOZ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "fPc" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -31182,19 +32103,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"fPe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/iron,
-/area/ai_monitored/command/storage/eva)
 "fPm" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 9
@@ -31264,6 +32172,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"fQS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/maintenance/tram/right)
 "fQY" = (
 /obj/machinery/vending/cola/red,
 /obj/effect/turf_decal/tile/neutral{
@@ -31344,6 +32264,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
+"fSd" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/glass,
+/area/commons/dorms)
 "fSg" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -31386,15 +32313,12 @@
 "fSF" = (
 /turf/open/floor/iron/elevatorshaft,
 /area/security/prison)
-"fTg" = (
-/obj/machinery/computer/atmos_control/tank/toxin_tank{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
+"fSR" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/light,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/security/prison)
 "fTk" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -31448,14 +32372,14 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
-"fTV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+"fTY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 6
 	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/maintenance/tram/mid)
 "fUf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -31552,12 +32476,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/office)
-"fXT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron/freezer,
-/area/science/research)
 "fYx" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
@@ -31591,6 +32509,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
+"fZj" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Post - Cargo";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "fZp" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -31643,6 +32578,19 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
 /area/mine/explored)
+"gaD" = (
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/tram/right)
 "gbB" = (
 /obj/machinery/computer/camera_advanced/xenobio,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -31704,6 +32652,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"gcR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "gcW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
@@ -31730,12 +32686,36 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
-"gdC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+"gdp" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Hallway - Bar West";
+	dir = 6
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/service/bar)
+"gea" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/structure/chair/office,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
-/area/hallway/secondary/command)
+/area/security/checkpoint/escape)
 "ger" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -31776,6 +32756,11 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"geV" = (
+/obj/machinery/meter/atmos/atmos_waste_loop,
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "geY" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -31845,6 +32830,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"ggP" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/break_room)
 "ggQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
@@ -31902,6 +32899,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"gki" = (
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "gkF" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -31927,12 +32937,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"glg" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+"glj" = (
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "gls" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -31997,6 +33011,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"gnn" = (
+/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron/freezer,
+/area/science/research)
 "gnC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -32236,22 +33255,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"gsw" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "gsJ" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
@@ -32350,6 +33353,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/science/nanite)
+"guh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/shower{
+	pixel_y = 24
+	},
+/obj/structure/curtain,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet/restrooms)
 "gui" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -32761,17 +33773,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
-"gBR" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/structure/chair/comfy/beige{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "gBW" = (
 /obj/machinery/conveyor{
 	id = "packageSort2"
@@ -32791,17 +33792,6 @@
 "gBY" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
-"gCb" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron/cafeteria,
-/area/commons/locker)
 "gCm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/reagent_dispensers/peppertank{
@@ -33035,20 +34025,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"gFS" = (
-/obj/structure/bed,
-/obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
-	id = "private_f";
-	name = "Privacy Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -8;
-	specialfunctions = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/commons/dorms)
 "gFV" = (
 /obj/structure/railing{
 	dir = 1
@@ -33184,18 +34160,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"gHZ" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai)
 "gIc" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -33278,26 +34242,6 @@
 	dir = 5
 	},
 /area/science/breakroom)
-"gJF" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/chair/comfy{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 10
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
 "gJG" = (
 /obj/vehicle/sealed/mecha/working/ripley,
 /turf/open/floor/mech_bay_recharge_floor,
@@ -33353,19 +34297,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"gKD" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "gKQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -33433,15 +34364,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice)
-"gMk" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "gMr" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/tcomms,
@@ -33480,6 +34402,11 @@
 "gNM" = (
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"gNX" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gNY" = (
 /obj/structure/lattice,
 /turf/open/openspace/airless/planetary,
@@ -33499,6 +34426,17 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"gOg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/main)
 "gOj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -33531,15 +34469,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/prison)
-"gOG" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "gPa" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -33556,17 +34485,6 @@
 /obj/structure/railing,
 /turf/open/space/basic,
 /area/space/nearstation)
-"gPM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "gPR" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -33579,6 +34497,13 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"gPW" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "gQb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -33615,13 +34540,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engineering/atmos)
-"gRw" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/turf/open/floor/iron,
 /area/engineering/atmos)
 "gRP" = (
 /obj/effect/turf_decal/caution/stand_clear,
@@ -33701,11 +34619,6 @@
 /obj/item/wrench/medical,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
-"gTo" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/tram/left)
 "gTp" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -33803,6 +34716,11 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"gUL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/plating,
+/area/maintenance/tram/left)
 "gUT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -33837,21 +34755,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"gVB" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/chair/sofa/corp/corner{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/service/bar)
 "gVN" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium"
@@ -33902,6 +34805,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating/airless,
 /area/engineering/main)
+"gYY" = (
+/obj/structure/cable,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gYZ" = (
 /obj/machinery/ntnet_relay,
 /obj/structure/sign/warning/nosmoking{
@@ -33909,20 +34823,6 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"gZz" = (
-/obj/structure/bed,
-/obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
-	id = "private_h";
-	name = "Privacy Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = -8;
-	specialfunctions = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/commons/dorms)
 "hag" = (
 /turf/closed/wall,
 /area/medical/psychology)
@@ -34085,18 +34985,6 @@
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
-"hdY" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/left)
 "hed" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -34220,23 +35108,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"hhn" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "hhp" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -34267,10 +35138,33 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"hhI" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "hhJ" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"hhU" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "him" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -34310,6 +35204,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"hjB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
 "hjC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
@@ -34323,9 +35224,6 @@
 	},
 /turf/open/floor/carpet,
 /area/service/chapel)
-"hjE" = (
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "hjI" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -34454,6 +35352,18 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
+"hlq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/maintenance/tram/mid)
 "hlz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -34606,6 +35516,11 @@
 /obj/item/stack/sheet/iron,
 /turf/open/floor/plating/asteroid,
 /area/mine/explored)
+"hpc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hpp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -34627,6 +35542,25 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/center)
+"hqf" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Turbine Access";
+	req_access_txt = "24"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "hqm" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/prison_contraband,
@@ -34716,6 +35650,31 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
+"hrI" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria{
+	dir = 5
+	},
+/area/science/breakroom)
+"hrP" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/dropper,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "hrY" = (
 /obj/structure/displaycase/captain{
 	pixel_y = 5
@@ -34762,18 +35721,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"htx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/blobstart,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
 "htC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -34807,6 +35754,12 @@
 	},
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
+"huk" = (
+/obj/structure/chair,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/maintenance/radshelter/civil)
 "hut" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -34868,21 +35821,6 @@
 	dir = 5
 	},
 /area/science/breakroom)
-"hvK" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "hvU" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -34936,25 +35874,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"hyW" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Treatment Center";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+"hyu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "hzh" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -35051,16 +35980,6 @@
 "hAW" = (
 /turf/closed/wall/r_wall,
 /area/commons/storage/tools)
-"hAX" = (
-/obj/structure/ladder,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"hBF" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "hBI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -35150,6 +36069,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/processing)
+"hDm" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hDp" = (
 /obj/item/shovel,
 /obj/item/storage/bag/ore,
@@ -35259,17 +36184,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
-"hFo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/navbeacon/wayfinding/aiupload,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/command/bridge)
 "hFq" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
@@ -35301,14 +36215,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"hFN" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/vault,
-/area/hallway/primary/tram/left)
 "hGh" = (
 /turf/closed/wall,
 /area/science/robotics/mechbay)
@@ -35331,11 +36237,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"hGU" = (
-/obj/structure/ladder,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+"hGz" = (
+/obj/structure/railing,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/glass,
+/area/commons/dorms)
 "hHe" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/door/firedoor/border_only{
@@ -35383,10 +36289,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/security/prison)
-"hIh" = (
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/prison)
 "hIw" = (
@@ -35437,6 +36339,18 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"hJG" = (
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/command/bridge)
 "hJL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -35459,17 +36373,22 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
-"hJQ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
+"hJM" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center";
+	req_access_txt = "5"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/service/bar)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "hKa" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -35522,16 +36441,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"hLa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "hLr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -35575,13 +36484,6 @@
 "hNf" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
-"hNw" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "hNG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -35611,6 +36513,16 @@
 /obj/structure/closet/secure_closet/hop,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"hOV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
 "hPc" = (
 /obj/machinery/computer/security{
 	dir = 8
@@ -35837,30 +36749,6 @@
 	},
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
-"hUs" = (
-/obj/structure/mirror{
-	pixel_y = 28
-	},
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
-"hUw" = (
-/obj/structure/bed,
-/obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
-	id = "private_n";
-	name = "Privacy Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -8;
-	specialfunctions = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/commons/dorms)
 "hUF" = (
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
@@ -35887,16 +36775,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"hVa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "hVw" = (
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 1
@@ -35971,24 +36849,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"hXj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"hXD" = (
-/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "hXR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -36043,6 +36903,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"hZz" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hZH" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -36082,23 +36949,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
-"iap" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "ias" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -36176,18 +37026,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"ien" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 6
-	},
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/maintenance/tram/mid)
 "ieo" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -36308,6 +37146,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/cargo/miningdock)
+"ign" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Atmospherics South-East";
+	dir = 1;
+	network = list("ss13","engineering")
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "igu" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
@@ -36353,25 +37211,30 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"ihP" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"ihX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/cargo/storage)
 "iic" = (
 /turf/open/floor/iron/dark,
 /area/engineering/main)
-"iid" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Treatment Center";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "iij" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
@@ -36418,16 +37281,6 @@
 /obj/machinery/medical_kiosk,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"ijD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Power Access Hatch";
-	req_one_access_txt = "19"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "ijL" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -36467,27 +37320,6 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
-"iky" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Filter"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"ikD" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Distribution Loop";
-	req_access_txt = "24"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ikF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36505,11 +37337,38 @@
 "ikR" = (
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"ild" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "ili" = (
 /obj/effect/landmark/start/captain,
 /obj/structure/chair/office,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
+"ilI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/maintenance/tram/left)
 "ilN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -36542,6 +37401,23 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/science/lab)
+"imU" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/service/bar)
 "imW" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -36557,15 +37433,6 @@
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
-"ing" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/obj/machinery/piratepad/civilian,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/cargo/office)
 "inn" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -36634,16 +37501,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"ioU" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "ipa" = (
 /obj/machinery/light{
 	dir = 8
@@ -36691,6 +37548,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/brig)
+"ipU" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ipX" = (
 /obj/machinery/light,
 /turf/open/floor/iron/dark,
@@ -36707,10 +37572,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"iqe" = (
-/obj/machinery/atmospherics/pipe/manifold4w/green/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "iqm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -36754,6 +37615,24 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"isy" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "isH" = (
 /obj/machinery/holopad/secure,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -36765,20 +37644,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"itc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "itk" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall,
@@ -36816,12 +37681,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"itH" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "itJ" = (
 /obj/effect/turf_decal/tile/bar,
@@ -36906,6 +37765,19 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
+"ivk" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/bed/roller,
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Medical - Lobby";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "ivo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -36943,31 +37815,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
-"ivR" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Tunnel Access";
-	req_one_access_txt = "12"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/maintenance/tram/left)
-"ivU" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/escape)
 "iwb" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
@@ -37010,14 +37857,6 @@
 /obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"iwI" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "iwZ" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/virology{
@@ -37067,6 +37906,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"iyu" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/construction/engineering)
 "iyw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
@@ -37145,6 +37993,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
+"iAF" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/escape)
 "iAL" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Office";
@@ -37302,15 +38160,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit)
-"iEC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "iEV" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -37328,16 +38177,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
-"iFE" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "O2 Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+"iFq" = (
+/obj/structure/ladder,
+/obj/machinery/atmospherics/pipe/multiz/layer4,
+/obj/machinery/atmospherics/pipe/multiz/layer2,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
 "iFH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -37347,6 +38192,11 @@
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
+/area/hallway/secondary/entry)
+"iFI" = (
+/obj/structure/closet/emcloset,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "iFO" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -37420,6 +38270,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/bar)
+"iGJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/navbeacon/wayfinding/aiupload,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/command/bridge)
 "iHK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -37479,30 +38340,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"iJm" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/camera/motion{
-	c_tag = "Security - Armory";
-	network = list("ss13","Security")
-	},
-/obj/structure/ladder,
-/obj/machinery/atmospherics/pipe/multiz/layer4,
-/obj/machinery/atmospherics/pipe/multiz/layer2,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
 "iJx" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/noticeboard{
@@ -37599,6 +38436,13 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"iLL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "iMa" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -37693,16 +38537,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"iNf" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+"iNk" = (
+/obj/structure/chair/comfy/beige,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/tram/left)
+/turf/open/floor/iron/grimy,
+/area/hallway/secondary/entry)
 "iNm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_large{
@@ -37773,10 +38612,6 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"iPg" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "iPj" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -37852,6 +38687,19 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
+"iQi" = (
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/tram/left)
 "iQl" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -37880,12 +38728,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"iQz" = (
-/obj/structure/chair/sofa/left,
-/obj/effect/turf_decal/siding/thinplating/corner,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "iQO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -37903,18 +38745,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"iRp" = (
-/obj/structure/cable,
-/obj/structure/ladder,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/commons/lounge)
 "iRv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -37941,6 +38771,18 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"iRR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "External to Filter"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "iRW" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -37993,51 +38835,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron,
 /area/security/prison)
-"iSO" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
-"iTD" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/service/bar)
-"iTE" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
-"iUg" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "iUt" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
@@ -38180,14 +38977,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/miningdock)
-"iXh" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
 "iXt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -38229,13 +39018,6 @@
 "iZO" = (
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
-"iZX" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/machinery/meter/atmos/atmos_waste_loop,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "jad" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -38341,6 +39123,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"jdw" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Break Room";
+	req_access_txt = "47"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "jdK" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/girder,
@@ -38360,11 +39160,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/lab)
-"jeh" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible,
-/obj/machinery/meter/atmos/atmos_waste_loop,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "jek" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -38372,6 +39167,10 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
+"jeE" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/construction/engineering)
 "jeL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -38384,31 +39183,20 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"jfI" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Post - Cargo";
-	req_access_txt = "63"
+"jfQ" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Distribution Loop";
+	req_access_txt = "24"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/security/checkpoint/supply)
-"jga" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/item/kirbyplants/random,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
+/area/engineering/atmos)
 "jgd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -38426,11 +39214,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"jgw" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/construction/engineering)
 "jgS" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -38445,27 +39228,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"jgZ" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/facid{
-	name = "fluorosulfuric acid bottle";
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/glass/bottle/toxin{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/syringe{
-	pixel_y = 5
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "jhj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
@@ -38502,23 +39264,6 @@
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"jir" = (
-/obj/structure/cable/multilayer/multiz,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/cargo/storage)
-"jiu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/service/theater)
 "jiv" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -38580,26 +39325,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"jjR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 6
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/hallway/secondary/exit/departure_lounge)
 "jkk" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -38678,6 +39403,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"jlc" = (
+/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "jld" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice,
@@ -38883,6 +39618,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"jrz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor{
+	id = "right_tram_lower";
+	name = "tunnel access blast door"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/maintenance/tram/right)
 "jrC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -38894,6 +39639,16 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/research)
+"jrO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "jrY" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -38911,12 +39666,45 @@
 /obj/effect/spawner/lootdrop/food_packaging,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"jsj" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 10
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "jst" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"jsJ" = (
+/obj/machinery/door/airlock/research{
+	name = "Research and Development Lab";
+	req_one_access_txt = "7"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rndlab1";
+	name = "Research and Development Shutter"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/lab)
 "jtb" = (
 /obj/machinery/light/small,
 /obj/structure/closet/emcloset,
@@ -38938,25 +39726,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/mine/explored)
-"jtH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "jtI" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -39041,15 +39810,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"jvG" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "jvO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -39223,11 +39983,13 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
-"jyY" = (
-/obj/machinery/computer/atmos_control/tank/oxygen_tank{
-	dir = 1
+"jzl" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jzs" = (
@@ -39274,6 +40036,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
+"jAw" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/closet/secure_closet/brig,
+/turf/open/floor/iron,
+/area/security/prison)
 "jAA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -39286,35 +40053,12 @@
 	},
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
-"jBa" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/turf/open/floor/iron,
-/area/security/processing)
 "jBc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"jBs" = (
-/obj/effect/turf_decal/stripes,
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/structure/industrial_lift/tram{
-	icon_state = "titanium"
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/vault,
-/area/hallway/primary/tram/center)
 "jBw" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -39386,13 +40130,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"jEx" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "jEz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -39404,14 +40141,6 @@
 "jED" = (
 /turf/open/floor/iron,
 /area/engineering/main)
-"jFb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "jFc" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -39517,6 +40246,16 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
+/area/science/research)
+"jHM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/science/research)
 "jIg" = (
 /obj/machinery/light/small{
@@ -39650,11 +40389,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"jKw" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/hallway/secondary/entry)
 "jKG" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -39677,6 +40411,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"jLa" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste In"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "jLP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -39695,23 +40438,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"jMn" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 10
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white,
-/area/science/research)
 "jMF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -39780,6 +40506,13 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"jOr" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "jOR" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
@@ -39898,15 +40631,16 @@
 /turf/open/floor/plating,
 /area/hallway/primary/tram/center)
 "jRZ" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/engineering/atmos)
 "jTb" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -40285,10 +41019,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"kal" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/security/checkpoint/engineering)
 "kam" = (
 /obj/machinery/telecomms/server/presets/medical,
 /turf/open/floor/iron/dark/telecomms,
@@ -40313,6 +41043,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"kaD" = (
+/obj/machinery/hydroponics/soil,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/grass,
+/area/service/hydroponics/garden)
 "kbb" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -40431,6 +41166,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"kcA" = (
+/obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/plating,
+/area/maintenance/tram/mid)
 "kcB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -40460,6 +41201,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
+"kcH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/maintenance/tram/right)
 "kdx" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/tile/neutral{
@@ -40485,6 +41235,35 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
+"kdB" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
+"kdK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/iron/dark,
+/area/engineering/atmospherics_engine)
 "kdT" = (
 /obj/machinery/door/airlock/research{
 	name = "Research and Development Lab";
@@ -40705,16 +41484,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
-"kit" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "kiv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
@@ -40777,6 +41546,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"kkq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "kkx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -40848,23 +41626,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
-"klx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+"klV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Atmospherics Maintenance";
+	req_one_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/light_switch{
-	pixel_x = 12;
-	pixel_y = 25
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "kml" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -40879,6 +41649,28 @@
 "kmO" = (
 /turf/open/floor/iron/stairs/medium,
 /area/hallway/secondary/construction/engineering)
+"kmR" = (
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "kmX" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -40955,6 +41747,18 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"koO" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/commons/lounge)
 "koV" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
@@ -40979,25 +41783,6 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
-"kpx" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/commons/dorms)
-"kpK" = (
-/obj/item/bikehorn/rubberducky,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "kqy" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -41098,6 +41883,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
+"ktx" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ktC" = (
 /turf/closed/wall/r_wall,
 /area/security/brig)
@@ -41165,6 +41962,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"kuY" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "kvg" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
@@ -41195,17 +41999,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"kwc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kwg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -41265,6 +42058,50 @@
 "kwQ" = (
 /turf/closed/wall,
 /area/security/checkpoint/medical)
+"kwU" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/bottle/facid{
+	name = "fluorosulfuric acid bottle";
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/glass/bottle/toxin{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/syringe{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
+"kwY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"kxa" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kxn" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
@@ -41396,6 +42233,18 @@
 "kAu" = (
 /turf/open/floor/iron/stairs/medium,
 /area/science/research)
+"kAA" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "kAI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -41442,6 +42291,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"kBz" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kBI" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/status_display/evac{
@@ -41449,15 +42305,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
-"kBU" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/construction/engineering)
 "kBV" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -41487,19 +42334,6 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
-"kDe" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "kDj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -41509,6 +42343,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"kDm" = (
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "kDG" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/glass/bowl,
@@ -41569,22 +42410,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"kDU" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/lounge)
 "kEf" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
@@ -41672,6 +42497,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
+"kGx" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kGR" = (
 /obj/structure/disposalpipe/trunk/multiz,
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -41707,6 +42538,15 @@
 	},
 /turf/open/floor/plating/airless,
 /area/mine/explored)
+"kHE" = (
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kIt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
@@ -41743,16 +42583,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"kIU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/service/hydroponics)
 "kIX" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/iron/white,
@@ -41862,11 +42692,21 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"kLb" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
+"kLi" = (
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "kLl" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/tile/neutral{
@@ -41891,6 +42731,23 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
+"kLo" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "kLG" = (
 /obj/machinery/button/door{
 	id = "rdoffice";
@@ -41903,12 +42760,6 @@
 	dir = 5
 	},
 /area/command/heads_quarters/rd)
-"kLK" = (
-/obj/structure/chair/comfy/black,
-/obj/item/radio/intercom/directional/north,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood,
-/area/service/library)
 "kMb" = (
 /obj/machinery/computer/upload/ai{
 	dir = 8
@@ -41955,6 +42806,13 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"kNq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "kNz" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
@@ -42026,13 +42884,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"kPC" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "kPK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
@@ -42070,6 +42921,10 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"kQF" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/service/library)
 "kQP" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/tile/brown{
@@ -42094,6 +42949,22 @@
 /obj/structure/table/glass,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"kRg" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kRh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -42104,19 +42975,6 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
-"kRo" = (
-/obj/structure/disposalpipe/trunk/multiz/down,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
-"kRR" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood,
-/area/service/theater)
 "kSk" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
@@ -42173,6 +43031,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"kSR" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/center)
 "kSX" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -42215,12 +43083,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/service/library)
-"kUF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "kUL" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 2
@@ -42238,6 +43100,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
+"kUP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kUQ" = (
 /obj/structure/chair,
 /obj/structure/sign/poster/official/random{
@@ -42337,13 +43206,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/mine/explored)
-"kWs" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/glass,
-/area/commons/dorms)
 "kWz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -42382,16 +43244,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"kXh" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/grimy,
-/area/service/library)
 "kXk" = (
 /obj/structure/bodycontainer/morgue,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -42536,14 +43388,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"kZA" = (
-/obj/effect/turf_decal/siding/thinplating,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "kZD" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -42570,6 +43414,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"kZY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "lap" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
@@ -42653,15 +43507,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"lcc" = (
-/obj/structure/toilet,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/freezer,
-/area/science/research)
 "lce" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42731,14 +43576,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/right)
-"ldt" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "ldA" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -42754,6 +43591,25 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/science/research)
+"ldE" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "ldG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/structure/disposalpipe/segment{
@@ -42768,14 +43624,17 @@
 /obj/structure/railing,
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
-"ldT" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/neutral/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/tram/center)
+"ldQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "lec" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -42806,14 +43665,6 @@
 "leZ" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"lfe" = (
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lfi" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -42823,20 +43674,6 @@
 	},
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/aisat_interior)
-"lfX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "lgb" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -42873,17 +43710,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
-"lgz" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Waste In"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lgR" = (
 /turf/open/floor/plating/asteroid,
 /area/maintenance/central)
@@ -42985,13 +43811,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"lkR" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "lkS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
@@ -43020,6 +43839,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
+"lma" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "lmk" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -43071,11 +43895,6 @@
 	},
 /turf/open/floor/carpet,
 /area/service/chapel)
-"lmW" = (
-/obj/structure/chair/sofa/corner,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "lni" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -43118,6 +43937,14 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
+"lnR" = (
+/obj/effect/turf_decal/siding/thinplating,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "lnV" = (
 /obj/machinery/pdapainter{
 	pixel_y = 2
@@ -43152,15 +43979,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
-"loP" = (
-/obj/structure/chair/pew/left{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/chapel{
-	dir = 8
-	},
-/area/service/chapel)
 "lpd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -43358,16 +44176,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"luc" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "CO2 Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "luw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -43413,22 +44221,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"luX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "lva" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -43479,11 +44271,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"lwa" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lwr" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/machinery/airalarm/directional/south,
@@ -43543,15 +44330,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"lys" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/center)
 "lyN" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/tile/neutral{
@@ -43654,16 +44432,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"lAr" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood,
-/area/service/library)
 "lAC" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -43721,6 +44489,24 @@
 "lBO" = (
 /turf/open/floor/wood,
 /area/maintenance/central)
+"lBY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
+"lCc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 9
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/maintenance/tram/right)
 "lCr" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
@@ -43807,6 +44593,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
+"lFW" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "lGe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43823,20 +44614,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
-"lGk" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/tram/center)
-"lGz" = (
-/obj/structure/ladder,
-/turf/open/floor/plating,
-/area/command/bridge)
 "lGB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -44012,27 +44789,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
-"lJZ" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility,
-/obj/item/clothing/head/welding,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue,
-/obj/machinery/camera{
-	c_tag = "Secure - EVA Main";
-	dir = 6
-	},
-/obj/machinery/requests_console{
-	department = "EVA";
-	pixel_y = 32
-	},
-/turf/open/floor/iron,
-/area/ai_monitored/command/storage/eva)
 "lKt" = (
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Upper External North";
@@ -44077,6 +44833,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"lMz" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet/restrooms)
 "lMH" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
@@ -44115,13 +44879,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/virology)
-"lNO" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lOd" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/ce)
@@ -44145,6 +44902,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"lOR" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "lPd" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -44166,6 +44933,32 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
+"lQe" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer";
+	req_access_txt = "56"
+	},
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "lQy" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
 	dir = 8
@@ -44193,16 +44986,6 @@
 "lQG" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
-"lRc" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
 "lRL" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -44313,6 +45096,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
+"lTu" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/turf/open/floor/iron,
+/area/security/processing)
 "lTF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -44341,6 +45133,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"lUt" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "lUE" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/navbeacon/wayfinding/med,
@@ -44479,35 +45283,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"lYa" = (
-/obj/structure/urinal{
-	pixel_y = 32
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "lYb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
-"lYg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lYu" = (
 /obj/structure/grille,
 /obj/machinery/meter,
@@ -44525,28 +45306,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
-"lYN" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
-/obj/machinery/meter/atmos/atmos_waste_loop,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "lZo" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"lZC" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lZG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -44599,69 +45364,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"maB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/tram/left)
-"maD" = (
-/obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 5
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
-"maE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
-"mbk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/command/bridge)
-"mbr" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/corner,
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "mbt" = (
 /obj/machinery/conveyor{
 	id = "packageSort2"
@@ -44684,12 +45386,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"mbS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "mcB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -44731,6 +45427,12 @@
 /obj/machinery/navbeacon/wayfinding/teleporter,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
+"mdk" = (
+/obj/machinery/light/small,
+/obj/structure/closet/firecloset,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/center)
 "mdv" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -44847,6 +45549,16 @@
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /turf/open/floor/engine,
 /area/science/mixing)
+"mhG" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "mhI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -44924,13 +45636,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/science/lab)
-"mjb" = (
-/obj/structure/chair/comfy/beige{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/grimy,
-/area/hallway/secondary/entry)
 "mjd" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/holosign/barrier/atmos/sturdy,
@@ -44944,6 +45649,20 @@
 	},
 /turf/open/openspace,
 /area/security/prison)
+"mjK" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
+"mjQ" = (
+/obj/structure/toilet{
+	dir = 8;
+	pixel_y = 8
+	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet/restrooms)
 "mke" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -45120,17 +45839,6 @@
 "mnj" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
-"mnz" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/grimy,
-/area/service/chapel/office)
 "mnK" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/effect/turf_decal/stripes/corner{
@@ -45178,19 +45886,6 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"mpK" = (
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 6
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "mqd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45473,22 +46168,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
-"mxo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
-"mxE" = (
-/obj/machinery/computer/atmos_control/tank/carbon_tank{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "mxF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -45591,6 +46270,20 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"mzE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "mzF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -45628,17 +46321,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/engine,
 /area/engineering/main)
-"mAq" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
 "mAT" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -45654,6 +46336,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"mAZ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "mBn" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/chaplain,
@@ -45826,16 +46519,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
-"mFz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "mGe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45905,14 +46588,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
-"mHm" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/break_room)
 "mHo" = (
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 2
@@ -45951,14 +46626,6 @@
 /obj/structure/ore_box,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"mIf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "mIG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -46043,17 +46710,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"mKf" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/service/bar)
 "mKh" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -46107,49 +46763,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
-"mLI" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/hallway/primary/port)
-"mMf" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/glass,
-/area/commons/dorms)
-"mMj" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/neutral/corner,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "mMz" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 6
@@ -46272,6 +46885,22 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"mNY" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/departments/restroom{
+	pixel_y = 32
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/service/bar)
 "mOj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -46280,16 +46909,37 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"mOo" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "mOF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"mOH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "mOK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"mOL" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "mON" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -46391,37 +47041,35 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
-"mQE" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+"mQS" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit)
+"mQU" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/iron,
-/area/hallway/primary/tram/left)
-"mQJ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	name = "sorting disposal pipe (Head of Personnel's Office)";
-	sortType = 15
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
+/area/engineering/atmos)
 "mRa" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -46461,22 +47109,31 @@
 "mSi" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"mSF" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Treatment Center";
-	req_access_txt = "5"
+"mSz" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/commons/lounge)
+"mSE" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit)
 "mSH" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -46511,14 +47168,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"mTg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/iron,
-/area/engineering/atmospherics_engine)
 "mTV" = (
 /obj/machinery/light{
 	dir = 1
@@ -46681,12 +47330,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
-"mWu" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ai_monitored/security/armory)
 "mWF" = (
 /obj/machinery/light{
 	dir = 1
@@ -46714,11 +47357,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"mXl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/plating,
-/area/maintenance/tram/left)
 "mXp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -46976,6 +47614,19 @@
 "nbz" = (
 /turf/closed/wall,
 /area/medical/medbay/central)
+"nbD" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/effect/landmark/xeno_spawn,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/service/bar)
 "nbR" = (
 /obj/structure/table,
 /obj/item/electronics/apc,
@@ -47014,16 +47665,6 @@
 	},
 /turf/closed/wall,
 /area/cargo/sorting)
-"ncU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/command/heads_quarters/ce)
 "ndn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -47108,13 +47749,6 @@
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
-"nfr" = (
-/obj/structure/closet/secure_closet/injection{
-	name = "educational injections";
-	pixel_x = 2
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "nfv" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -47218,15 +47852,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"ngY" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/closet/firecloset,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "nhn" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
@@ -47252,23 +47877,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"niq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 6
-	},
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/structure/closet,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/maintenance/tram/right)
-"niF" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "niW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -47297,13 +47905,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"njr" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/right)
 "nju" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -47336,16 +47937,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
-"nkN" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "nlo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -47365,6 +47956,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"nlx" = (
+/obj/machinery/recharge_station,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet/restrooms)
 "nlL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -47415,13 +48011,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"nmr" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/maintenance/radshelter/civil)
 "nmW" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
@@ -47433,6 +48022,18 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"nnG" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "nnZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -47456,10 +48057,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain/private)
-"noT" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "npx" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -47546,16 +48143,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"nrf" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/structure/chair/stool/bar{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "nrs" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -47576,11 +48163,6 @@
 /obj/item/extinguisher,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"nsh" = (
-/obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/freezer,
-/area/science/research)
 "nsk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods,
@@ -47725,13 +48307,6 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating/icemoon,
 /area/engineering/atmos)
-"nul" = (
-/obj/structure/bed,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/security/brig)
 "nur" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/item/crowbar,
@@ -47785,15 +48360,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
-"nvx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "nvY" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/sign/warning/electricshock{
@@ -47814,6 +48380,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
+"nwV" = (
+/obj/structure/chair/pew{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
+/area/service/chapel)
 "nxj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -47824,10 +48399,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
-"nxl" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "nyb" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -47880,14 +48451,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"nzj" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Atmospherics Plasma Chamber";
-	dir = 6;
-	network = list("ss13","engineering")
-	},
-/turf/open/floor/engine/plasma,
-/area/engineering/atmos)
+"nzo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/plating,
+/area/maintenance/tram/mid)
 "nzq" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -47958,6 +48526,10 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"nAU" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "nAX" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/medical)
@@ -47979,13 +48551,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"nBs" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "nBB" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "pharmacy_shutters_2";
@@ -48072,6 +48637,16 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"nDF" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/cargo,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "nDT" = (
 /obj/item/ammo_casing/spent,
 /turf/open/floor/plating/airless,
@@ -48151,13 +48726,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
-"nFj" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/bar)
 "nFL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -48220,6 +48788,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"nGJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "nGS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -48265,16 +48842,6 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
-"nIE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "nIG" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -48348,35 +48915,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"nKx" = (
-/obj/structure/sign/directions/supply{
-	dir = 4;
-	pixel_y = 28
+"nKG" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
 	},
-/obj/structure/sign/directions/security{
-	dir = 4;
-	pixel_y = 34
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
 	},
-/obj/structure/sign/directions/command{
-	dir = 4;
-	pixel_y = 40
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/arrow_cw{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/sign/directions/vault{
-	dir = 4;
-	pixel_y = 22
-	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/hallway/primary/tram/left)
+/area/engineering/atmos)
 "nKR" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -48447,16 +48994,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
-"nNs" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Distro to Waste"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "nNw" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/pump,
@@ -48470,13 +49007,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
-"nNB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "nNC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -48538,6 +49068,20 @@
 /obj/structure/stairs/north,
 /turf/open/floor/iron/stairs/medium,
 /area/science/research)
+"nOv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "nOF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
@@ -48566,6 +49110,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
+"nOU" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "nOV" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Recharge Bay";
@@ -48574,20 +49125,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"nOW" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "commissaryshutter";
-	name = "Vacant Commissary Shutter"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
 "nOZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -48621,19 +49158,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
-"nPP" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/effect/landmark/xeno_spawn,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/service/bar)
 "nPQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -48665,23 +49189,6 @@
 "nQj" = (
 /turf/closed/wall,
 /area/tcommsat/server)
-"nQw" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Foyer";
-	req_one_access_txt = "32;19"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/break_room)
 "nQP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -48691,19 +49198,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"nQR" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix to Incinerator"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "nQS" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -48724,20 +49218,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"nSm" = (
-/obj/structure/bed,
-/obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
-	id = "private_b";
-	name = "Privacy Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = -8;
-	specialfunctions = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/commons/dorms)
 "nSw" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -48751,18 +49231,20 @@
 /obj/machinery/power/supermatter_crystal/engine,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"nSO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "nTd" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"nTl" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Atmospherics Plasma Chamber";
+	dir = 6;
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/engine/plasma,
+/area/engineering/atmos)
 "nTn" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
@@ -48824,6 +49306,11 @@
 /obj/item/stamp/cmo,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
+"nUU" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "nUW" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -48874,14 +49361,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"nVQ" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/neutral/corner,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "nWb" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/effect/turf_decal/siding/thinplating/corner,
@@ -48938,16 +49417,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"nXq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor{
-	id = "right_tram_lower";
-	name = "tunnel access blast door"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/maintenance/tram/right)
 "nXu" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/bot{
@@ -49188,6 +49657,20 @@
 /obj/structure/railing,
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
+"ocV" = (
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "ocW" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -49248,21 +49731,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"ofu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/shard,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
+"oeT" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "ofx" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -49308,6 +49780,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"ogJ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/closet/masks,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron/cafeteria,
+/area/commons/locker)
 "ohl" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/holosign/barrier/atmos/sturdy,
@@ -49353,6 +49836,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"ohZ" = (
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "oim" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
@@ -49400,6 +49897,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"ojb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 6
+	},
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/structure/closet,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron,
+/area/maintenance/tram/right)
 "oju" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/light,
@@ -49411,27 +49918,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"ojU" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/item/kirbyplants,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/hallway/primary/port)
 "okd" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -49463,11 +49949,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"okv" = (
-/obj/structure/ladder,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/cargo/storage)
 "oky" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -49476,6 +49957,19 @@
 	},
 /turf/open/floor/plating,
 /area/science/lab)
+"okz" = (
+/obj/machinery/computer/atmos_control/tank/nitrous_tank{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "okC" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron,
@@ -49567,19 +50061,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"olx" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/center)
 "oly" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -49646,6 +50127,27 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"onb" = (
+/obj/structure/rack,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/head/welding,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue,
+/obj/machinery/camera{
+	c_tag = "Secure - EVA Main";
+	dir = 6
+	},
+/obj/machinery/requests_console{
+	department = "EVA";
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
 "one" = (
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
@@ -49757,13 +50259,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"oqJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "oqM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -49812,6 +50307,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"osQ" = (
+/obj/structure/bed,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/mask/muzzle,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "osV" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
@@ -49826,6 +50328,18 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"otQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "otY" = (
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -49879,12 +50393,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
-"ovu" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "ovv" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -49972,6 +50480,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/sorting)
+"owO" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Port to Filter"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Port to Incinerator"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "oxe" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
@@ -49987,18 +50505,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"oxt" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/maintenance/tram/right)
 "oxX" = (
 /obj/machinery/light/small,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
+"oyj" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/plating,
+/area/maintenance/tram/left)
 "oyE" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -50080,6 +50596,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"oAq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "oAv" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
@@ -50096,14 +50619,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"oBf" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "oBl" = (
 /obj/machinery/light{
 	dir = 8
@@ -50130,6 +50645,14 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"oCq" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/cargo/office)
 "oCw" = (
 /obj/structure/fluff/tram_rail/end,
 /turf/open/openspace,
@@ -50205,13 +50728,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"oDx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "oDy" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
@@ -50342,6 +50858,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"oHe" = (
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "oHn" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
@@ -50356,6 +50879,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"oHI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/cargo/storage)
 "oHS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -50446,19 +50973,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/science/mixing)
-"oJL" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
-/area/commons/locker)
 "oJO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
@@ -50469,6 +50983,16 @@
 /obj/item/stack/ore/glass,
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
+"oJS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/service/hydroponics)
 "oJW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50521,12 +51045,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"oKp" = (
-/obj/machinery/atmospherics/pipe/multiz/layer4,
-/obj/effect/turf_decal/stripes/end,
-/obj/machinery/atmospherics/pipe/multiz/layer2,
-/turf/open/floor/plating,
-/area/service/hydroponics)
 "oKI" = (
 /obj/structure/closet/emcloset,
 /obj/item/flashlight,
@@ -50624,6 +51142,16 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"oLQ" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "oLR" = (
 /obj/machinery/gateway/centerstation,
 /obj/effect/turf_decal/bot_white/left,
@@ -50662,16 +51190,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/cytology)
-"oMT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "oNe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -50772,23 +51290,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"oPJ" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/structure/chair/stool/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/service/bar)
 "oPY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -50805,6 +51306,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"oQx" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "oQH" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -50895,13 +51406,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
-"oTf" = (
-/obj/structure/chair,
-/obj/machinery/airalarm/directional/north,
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/maintenance/radshelter/service)
 "oTo" = (
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -50914,19 +51418,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
-"oTA" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "oTL" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
@@ -50983,14 +51474,6 @@
 	sortType = 19
 	},
 /turf/open/floor/iron,
-/area/service/bar)
-"oUU" = (
-/obj/structure/toilet{
-	dir = 8;
-	pixel_y = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
 /area/service/bar)
 "oUW" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -51063,30 +51546,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"oVB" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/cargo/storage)
-"oVI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/event_spawn,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "oVS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -51098,6 +51557,18 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"oVZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/blobstart,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "oWl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -51130,13 +51601,6 @@
 /obj/item/electronics/apc,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/department/medical)
-"oXh" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/freezer,
-/area/science/research)
 "oXi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -51152,10 +51616,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/research)
-"oXu" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/cargo/storage)
 "oXC" = (
 /turf/open/floor/plating/asteroid,
 /area/mine/explored)
@@ -51181,15 +51641,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"oYf" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_y = 8
-	},
-/obj/effect/landmark/start/assistant,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "oYl" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/radshelter/civil)
@@ -51241,13 +51692,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
-"oZw" = (
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/grimy,
-/area/service/chapel/office)
 "oZB" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Secure Pen";
@@ -51280,6 +51724,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/cargo/office)
+"pas" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/right)
 "paw" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -51415,15 +51866,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
-"pcN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "pcR" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -51444,6 +51886,16 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"per" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/grimy,
+/area/service/library)
 "pex" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -51542,15 +51994,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/office)
-"pgV" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/tram/right)
 "phl" = (
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/window/plasma/reinforced{
@@ -51596,24 +52039,33 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"pik" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+"pib" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
+/area/engineering/main)
+"pil" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Plasma Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
 /area/engineering/atmos)
-"piw" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
-/area/commons/locker)
 "piI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -51624,15 +52076,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"pjd" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/lounge)
 "pjl" = (
 /obj/structure/table,
 /obj/item/assembly/flash/handheld,
@@ -51652,23 +52095,6 @@
 /obj/machinery/navbeacon/wayfinding/bar,
 /turf/open/floor/iron,
 /area/service/bar)
-"pjn" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/seccarts{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/storage/box/deputy,
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/button/door{
-	id = "HOSOffice";
-	name = "Emergency Blast Doors";
-	pixel_x = -24;
-	pixel_y = -8;
-	req_access_txt = "3"
-	},
-/turf/open/floor/carpet,
-/area/command/heads_quarters/hos)
 "pjt" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -51701,6 +52127,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"pjY" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "pkd" = (
 /obj/effect/turf_decal/tile{
 	dir = 1
@@ -51713,6 +52143,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"pkw" = (
+/obj/machinery/atmospherics/pipe/multiz/layer4,
+/obj/effect/turf_decal/stripes/end,
+/obj/machinery/atmospherics/pipe/multiz/layer2,
+/turf/open/floor/plating,
+/area/service/hydroponics)
 "pkI" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -51736,6 +52172,19 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"plt" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "plu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -51896,16 +52345,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
-"pnc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/tram/right)
 "pnd" = (
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
@@ -52000,6 +52439,19 @@
 /obj/item/radio,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
+"por" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
 "pov" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
@@ -52068,19 +52520,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/main)
-"prf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "prw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52093,10 +52532,6 @@
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
-"prV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "prX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
@@ -52155,13 +52590,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"psJ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "psM" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/loot_site_spawner,
@@ -52178,14 +52606,9 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"ptp" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_y = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
+"pto" = (
+/turf/open/floor/plating,
+/area/science/research)
 "ptv" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -52206,6 +52629,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"puf" = (
+/obj/structure/table,
+/obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/engineering,
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_guide{
+	pixel_x = -2
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/break_room)
 "pug" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -52267,6 +52705,17 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"pvq" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "pwc" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -52317,13 +52766,6 @@
 /obj/item/storage/bag/ore,
 /turf/open/floor/plating/asteroid,
 /area/mine/explored)
-"pwo" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/science/research)
 "pws" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
@@ -52415,6 +52857,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"pyh" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "pyr" = (
 /obj/structure/showcase/cyborg/old{
 	dir = 4;
@@ -52478,6 +52929,16 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"pzR" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/right)
 "pAe" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -52596,14 +53057,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"pCn" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "pCt" = (
 /obj/structure/window/reinforced{
 	pixel_y = 2
@@ -52687,19 +53140,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/art)
-"pDD" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "pDN" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/command)
@@ -52841,6 +53281,16 @@
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/left)
+"pGI" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "pGY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -52865,14 +53315,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"pHm" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "pHp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -52914,11 +53356,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"pIw" = (
-/obj/structure/railing/corner,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/glass,
-/area/commons/dorms)
 "pII" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/eva)
@@ -53020,11 +53457,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"pKA" = (
-/obj/machinery/recharge_station,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "pKF" = (
 /obj/machinery/button/door{
 	id = "ceprivacy";
@@ -53033,6 +53465,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
+"pKK" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/break_room)
 "pKS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -53048,12 +53492,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"pLL" = (
-/obj/structure/closet/firecloset,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
-/area/maintenance/tram/mid)
+"pLk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "pLR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -53138,6 +53584,13 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"pOb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "pOw" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -53152,6 +53605,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
+"pOF" = (
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/tram/right)
 "pOP" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -53212,6 +53678,16 @@
 /obj/structure/girder,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"pQj" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "pQm" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -53255,6 +53731,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"pRH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 10
+	},
+/obj/structure/closet,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron,
+/area/maintenance/tram/mid)
 "pRU" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -53309,6 +53796,24 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"pSL" = (
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"pSS" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "pTe" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw{
@@ -53610,10 +54115,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
-"qaA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/command/heads_quarters/ce)
 "qbg" = (
 /obj/structure/fluff/tram_rail{
 	dir = 1
@@ -53679,31 +54180,28 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/office)
-"qcD" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 8
-	},
-/obj/structure/cable,
+"qcC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/command)
+/area/engineering/main)
 "qcS" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
@@ -53758,15 +54256,6 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
-"qfl" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "qfo" = (
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating/asteroid,
@@ -53808,6 +54297,19 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/service/theater)
+"qgl" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qgs" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating/asteroid/airless,
@@ -53916,6 +54418,20 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"qio" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/service/bar)
 "qix" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/disposalpipe/segment,
@@ -54101,20 +54617,6 @@
 /obj/item/stock_parts/micro_laser,
 /turf/open/floor/iron/white,
 /area/science/lab)
-"qnI" = (
-/obj/structure/bed,
-/obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
-	id = "private_j";
-	name = "Privacy Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = -8;
-	specialfunctions = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/commons/dorms)
 "qnL" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -54216,11 +54718,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron/white,
 /area/security/brig)
-"qqr" = (
-/obj/structure/ladder,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "qqw" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -54245,25 +54742,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"qrs" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Testing Room";
-	req_access_txt = "24"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/iron/dark,
-/area/engineering/atmospherics_engine)
 "qru" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -54276,13 +54754,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"qrO" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "qrV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -54291,13 +54762,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
-"qsn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "qtb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -54363,6 +54827,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"qtX" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "quf" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -54392,18 +54871,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"qvi" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/chair/stool,
-/obj/structure/noticeboard{
-	pixel_y = -27
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/service/bar)
 "qvj" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -54424,12 +54891,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
-"qvA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/security/checkpoint/engineering)
 "qvF" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/iron/dark/telecomms,
@@ -54583,29 +55044,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"qyA" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	name = "sorting disposal pipe (Detective's Office)";
-	sortType = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "qyE" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -54781,6 +55219,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"qBr" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "qBv" = (
 /obj/machinery/light{
 	dir = 4
@@ -54804,6 +55252,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/command)
+"qBH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "qBS" = (
 /obj/docking_port/stationary/random{
 	dir = 8;
@@ -54958,13 +55416,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/security/prison)
-"qFs" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/science/research)
 "qFu" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/r_wall,
@@ -55087,15 +55538,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"qHo" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "qHD" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -55188,29 +55630,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
-"qJW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/cable_coil/cut,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"qKp" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "qLb" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "plating"
@@ -55296,15 +55715,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"qOx" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "qOM" = (
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/iron/dark/telecomms,
@@ -55327,19 +55737,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
-"qQc" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "qQj" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -55375,15 +55772,6 @@
 /obj/structure/railing,
 /turf/open/openspace,
 /area/science/xenobiology)
-"qRP" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/item/radio/intercom/directional/east,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/service/bar)
 "qRS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -55408,6 +55796,25 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"qSd" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
+/area/commons/locker)
+"qSf" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/machinery/piratepad/civilian,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/cargo/office)
 "qSj" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -55449,6 +55856,13 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"qTe" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Distro to Waste"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qTm" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium_blue"
@@ -55472,25 +55886,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"qTP" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "EVA Storage";
-	req_access_txt = "18"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron,
-/area/ai_monitored/command/storage/eva)
 "qUb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -55579,6 +55974,11 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
+"qVF" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/command/bridge)
 "qVK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -55627,17 +56027,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron,
 /area/security/brig)
-"qXz" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "qXE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -55669,6 +56058,14 @@
 /obj/effect/spawner/lootdrop/food_packaging,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"qYM" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/maintenance/tram/right)
 "qYR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -55687,14 +56084,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"qZc" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/processing)
 "qZf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -55820,6 +56209,25 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
+"rci" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/sign/departments/restroom{
+	pixel_y = 32
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/service/bar)
 "rcj" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
@@ -55942,24 +56350,24 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
-"rfk" = (
+"rfe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"rfv" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
 	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"rfq" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -56070,6 +56478,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"rhL" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/center)
 "rhN" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -56099,6 +56517,19 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"riI" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "riU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -56282,6 +56713,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
+"rll" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "rlv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -56392,16 +56831,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"rnN" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "rnP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
@@ -56446,16 +56875,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"roo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor{
-	id = "left_tram_lower";
-	name = "tunnel access blast door"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/maintenance/tram/left)
 "rou" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
@@ -56533,11 +56952,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"rpL" = (
-/obj/structure/railing,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/glass,
-/area/commons/dorms)
 "rqf" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/warning,
@@ -56564,14 +56978,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"rqy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "rqz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -56600,14 +57006,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"rrg" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "rrm" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -56617,17 +57015,6 @@
 /obj/item/pen/blue,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
-"rrt" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "rru" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
@@ -56671,14 +57058,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"rsa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 6
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/maintenance/tram/mid)
 "rsm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -56686,24 +57065,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"rst" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/hallway/secondary/exit/departure_lounge)
 "rsN" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/decal/cleanable/ash,
@@ -56950,13 +57311,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
-"ryl" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/glasses/blindfold,
-/obj/item/clothing/mask/muzzle,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "ryt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -56964,27 +57318,25 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
-"ryv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor{
-	id = "left_tram_lower";
-	name = "tunnel access blast door"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/maintenance/tram/mid)
 "ryA" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"ryJ" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/right)
 "ryX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"ryY" = (
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/service/hydroponics)
 "rzc" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -57102,6 +57454,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"rAE" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "rCB" = (
 /obj/effect/spawner/lootdrop/garbage_spawner,
 /obj/effect/decal/cleanable/dirt,
@@ -57198,16 +57555,6 @@
 /obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"rFn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor{
-	id = "right_tram_lower";
-	name = "tunnel access blast door"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/maintenance/tram/mid)
 "rFo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -57235,17 +57582,6 @@
 /obj/item/relic,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
-"rGu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
-	},
-/obj/structure/closet,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/maintenance/tram/mid)
 "rGJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -57322,6 +57658,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
+"rIL" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "rIQ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -57377,6 +57722,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
+"rJE" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/maintenance/radshelter/service)
 "rJF" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -57384,6 +57736,12 @@
 	},
 /turf/open/openspace,
 /area/security/prison)
+"rJM" = (
+/obj/item/bikehorn,
+/obj/item/grown/bananapeel,
+/obj/item/food/spaghetti/copypasta,
+/turf/open/floor/plating,
+/area/engineering/main)
 "rKk" = (
 /obj/machinery/navbeacon/wayfinding/chapel,
 /turf/open/floor/carpet,
@@ -57521,12 +57879,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"rMU" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "rMZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -57540,18 +57892,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"rNl" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "rNY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/crowbar,
@@ -57602,18 +57942,6 @@
 /obj/structure/curtain,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain/private)
-"rOR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/yellow/warning,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
-/area/maintenance/tram/right)
 "rOW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -57633,14 +57961,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"rPN" = (
-/obj/machinery/shower{
-	pixel_y = 24
-	},
-/obj/structure/curtain,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
+"rPS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
 "rPX" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -57667,6 +57993,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"rQJ" = (
+/obj/structure/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/grimy,
+/area/hallway/secondary/entry)
 "rQP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -57702,6 +58035,32 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"rSi" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Foyer";
+	req_one_access_txt = "32;19"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/break_room)
+"rTI" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "rTL" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
@@ -57727,6 +58086,10 @@
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"rUD" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "rUN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -57842,16 +58205,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"rYl" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "rYZ" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prisoner Processing";
@@ -57924,13 +58277,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/processing)
-"rZD" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "rZI" = (
 /obj/machinery/shower{
 	dir = 1
@@ -57976,15 +58322,6 @@
 /mob/living/simple_animal/hostile/cockroach,
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
-"sbu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "sby" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -58030,13 +58367,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/processing)
-"scl" = (
-/obj/structure/chair/plastic{
-	dir = 1
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "scw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -58098,12 +58428,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"sdE" = (
-/obj/structure/sign/poster/official/bless_this_spess{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/grimy,
-/area/service/chapel/office)
 "sdS" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/light/small{
@@ -58163,6 +58487,20 @@
 "seV" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"sfg" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sfm" = (
@@ -58288,10 +58626,6 @@
 "siu" = (
 /turf/closed/wall,
 /area/tcommsat/computer)
-"siN" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/tram/right)
 "siP" = (
 /obj/structure/cable,
 /obj/machinery/camera{
@@ -58313,16 +58647,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"siU" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/navbeacon/wayfinding/cargo,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "siX" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -58455,13 +58779,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"slJ" = (
-/obj/structure/chair{
-	dir = 4
+"slM" = (
+/obj/structure/closet/secure_closet/injection{
+	name = "educational injections";
+	pixel_x = 2
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/maintenance/radshelter/service)
+/turf/open/floor/iron/white,
+/area/security/prison)
 "slR" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -58539,20 +58863,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"smn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/cargo/storage)
 "smu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58733,16 +59043,6 @@
 	},
 /turf/open/openspace,
 /area/science/xenobiology)
-"sqo" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "sqS" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
@@ -58778,6 +59078,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
+"src" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/maintenance/radshelter/civil)
 "srj" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
@@ -58833,10 +59140,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/kitchen)
-"ssm" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "ssn" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -58897,6 +59200,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
+"stq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "stG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58941,28 +59250,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"suh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/navbeacon/wayfinding/vault,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/ai_monitored/security/armory)
-"suW" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/tram/right)
 "sva" = (
 /obj/machinery/suit_storage_unit/cmo,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -59009,16 +59296,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
-"svI" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/service/bar)
 "svU" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/light/small{
@@ -59072,6 +59349,11 @@
 	},
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
+"sxO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
 "sxR" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
@@ -59081,6 +59363,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"sxW" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "syc" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -59129,17 +59417,6 @@
 /obj/effect/turf_decal/trimline/white/filled/line,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"szn" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/service/bar)
 "szq" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -59228,6 +59505,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron/airless/solarpanel,
 /area/space/nearstation)
+"sBJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "sBU" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -59287,12 +59582,6 @@
 /obj/item/wheelchair/gold,
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
-"sCP" = (
-/obj/structure/ladder,
-/obj/machinery/atmospherics/pipe/multiz/layer4,
-/obj/machinery/atmospherics/pipe/multiz/layer2,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "sCR" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -59354,6 +59643,24 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"sDF" = (
+/obj/structure/cable/multilayer/multiz,
+/obj/structure/sign/warning/electricshock{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/cargo/storage)
+"sEo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/security/checkpoint/escape)
 "sEs" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -59398,6 +59705,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"sES" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "sFj" = (
 /obj/structure/cable,
 /obj/machinery/flasher{
@@ -59449,27 +59767,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"sGf" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/commons/dorms)
-"sGs" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
-"sGy" = (
-/obj/structure/toilet{
-	dir = 8;
-	pixel_y = 8
-	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "sHa" = (
 /turf/closed/wall/r_wall,
 /area/science/genetics)
@@ -59549,11 +59846,27 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"sJl" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
+"sIp" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "N2 Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/hallway/secondary/entry)
+/area/engineering/atmos)
+"sID" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "sJm" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -59635,6 +59948,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"sLw" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/center)
 "sLz" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -59649,26 +59969,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/mine/explored)
-"sLJ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"sMl" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "sMm" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -59796,6 +60096,37 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"sOa" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"sOc" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"sOd" = (
+/obj/effect/turf_decal/arrows/white{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
+"sOn" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/science/research)
 "sOA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -59818,11 +60149,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
-"sOM" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/grass,
-/area/service/hydroponics/garden)
 "sOX" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -59895,14 +60221,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
-"sQF" = (
-/obj/structure/cable/multilayer/multiz,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/end,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "sRy" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/crayon{
@@ -60008,42 +60326,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/chapel,
 /area/service/chapel)
-"sTz" = (
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "sTF" = (
 /turf/open/floor/glass,
 /area/cargo/storage)
-"sUi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "sUt" = (
 /obj/structure/filingcabinet,
 /obj/structure/cable,
@@ -60149,12 +60434,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"sWi" = (
-/obj/structure/chair,
-/obj/machinery/airalarm/directional/north,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/maintenance/radshelter/civil)
 "sWs" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
@@ -60169,18 +60448,6 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"sWu" = (
-/obj/machinery/computer/atmos_control/tank/nitrous_tank{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "sWC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -60302,6 +60569,20 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"taa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tab" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -60310,13 +60591,6 @@
 	dir = 5
 	},
 /area/command/heads_quarters/rd)
-"taj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "taq" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -60404,10 +60678,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"tcI" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "tcP" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -60421,33 +60691,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"tdv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "tdx" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"tdH" = (
+/obj/structure/cable/multilayer/multiz,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai)
 "tdP" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -60482,6 +60737,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"tej" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron/freezer,
+/area/science/research)
 "tep" = (
 /obj/machinery/door/airlock/security{
 	name = "Permanent Cell 1"
@@ -60497,18 +60758,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"ter" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "teO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -60577,16 +60826,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
-"tgv" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Plasma Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "tgK" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -60597,16 +60836,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/lab)
-"tgN" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/tram/center)
 "tgV" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -60643,24 +60872,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"thg" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
-"thl" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "thz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -60802,37 +61013,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
-"tjv" = (
-/obj/structure/chair/pew/right{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/chapel{
-	dir = 1
-	},
-/area/service/chapel)
-"tjx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"tjB" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Treatment Center";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "tjD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -60881,6 +61061,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
+"tkL" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/comfy{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit)
 "tkN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -60907,14 +61107,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"tlm" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "tlq" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "plating"
@@ -60931,29 +61123,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"tlA" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/closet/wardrobe/green,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron/cafeteria,
-/area/commons/locker)
-"tlG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/break_room)
 "tlX" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -60979,14 +61148,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"tnm" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+"tmH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/main)
 "tnu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61033,18 +61210,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"tnY" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
+"tnO" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
 	},
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
+	dir = 10
+	},
 /turf/open/floor/iron,
-/area/maintenance/tram/left)
+/area/engineering/atmos)
 "tom" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/railing/corner{
@@ -61097,24 +61274,13 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron,
 /area/cargo/office)
-"toN" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+"toM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "toQ" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -61127,6 +61293,20 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/iron/white,
 /area/security/brig)
+"toU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "toV" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -61176,15 +61356,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
-"tpM" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/maintenance/tram/right)
 "tqj" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/closet,
@@ -61201,6 +61372,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"tqs" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "tqt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -61341,23 +61523,6 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
-"ttc" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
 "ttH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
@@ -61481,6 +61646,16 @@
 /mob/living/simple_animal/pet/cat/jerry,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
+"tvr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "tvB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
@@ -61606,6 +61781,35 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"txV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/bonfire,
+/obj/item/reagent_containers/food/drinks/bottle/orangejuice{
+	desc = "For the weary spacemen on their quest to rekindle the first plasma fire.";
+	name = "Carton of Estus"
+	},
+/obj/item/melee/moonlight_greatsword,
+/obj/effect/decal/remains/human,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
+"txZ" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "tyF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -61625,6 +61829,12 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/eva)
+"tzk" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ai_monitored/security/armory)
 "tzr" = (
 /obj/structure/chair{
 	dir = 1
@@ -61646,16 +61856,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"tAa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "tAe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -61664,6 +61864,18 @@
 "tAh" = (
 /turf/closed/wall/r_wall,
 /area/engineering/storage/tech)
+"tAm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmospherics_engine)
 "tAn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -61679,11 +61891,6 @@
 /obj/item/crowbar,
 /turf/open/floor/plating,
 /area/mine/explored)
-"tAs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/plating,
-/area/maintenance/tram/mid)
 "tAu" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/sand/plating,
@@ -61722,21 +61929,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"tBd" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/structure/chair/stool/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/service/bar)
 "tBe" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -61773,11 +61965,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"tCg" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "tCk" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -61851,40 +62038,6 @@
 /obj/item/wallframe/apc,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"tEe" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"tEo" = (
-/obj/machinery/door/airlock/security{
-	name = "Prison Sanitarium";
-	req_access_txt = "2"
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
-"tEz" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/service/bar)
 "tEA" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -61991,18 +62144,6 @@
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
-"tGK" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/commons/lounge)
 "tHv" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
@@ -62029,6 +62170,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
+"tHN" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "tIj" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating/asteroid,
@@ -62044,12 +62194,45 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"tJg" = (
+/obj/machinery/computer/atmos_control/tank/toxin_tank{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tJq" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
+"tJC" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit)
+"tJH" = (
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tJL" = (
 /obj/machinery/camera{
 	c_tag = "Secure - Gateway North";
@@ -62073,18 +62256,6 @@
 /obj/machinery/computer/security/telescreen/cmo,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
-"tKm" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/science/research)
 "tKp" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -62107,19 +62278,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
-"tKK" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/bed/roller,
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Medical - Lobby";
-	dir = 1;
-	network = list("ss13","medbay")
+"tKz" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"tKC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "tKT" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/palebush,
@@ -62137,14 +62310,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"tLE" = (
-/obj/structure/bed,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
+"tLB" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "O2 Outlet Pump"
 	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/white,
-/area/security/brig)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tLQ" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -62234,6 +62412,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"tNL" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/commons/lounge)
 "tOl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -62271,6 +62456,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/brig)
+"tPZ" = (
+/obj/machinery/computer/atmos_control/tank/air_tank{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tQc" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -62326,16 +62521,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"tQN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/meter/atmos/atmos_waste_loop,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "tRy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -62346,6 +62531,15 @@
 	},
 /turf/open/floor/carpet,
 /area/service/library)
+"tRA" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "tRD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -62355,6 +62549,27 @@
 "tRH" = (
 /turf/closed/wall,
 /area/medical/coldroom)
+"tRV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
+"tRW" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/break_room)
 "tRZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -62421,16 +62636,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/security/brig)
-"tTq" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/construction/engineering)
 "tTu" = (
 /obj/structure/table,
 /obj/item/multitool,
@@ -62448,18 +62653,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
-"tTT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/yellow/warning,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
-/area/maintenance/tram/mid)
 "tTU" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -62535,16 +62728,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
-"tVI" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "tWb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -62574,13 +62757,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"tWH" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+"tWl" = (
+/obj/structure/ladder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "tWP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -62672,6 +62853,21 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"tYk" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "tYB" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -62728,6 +62924,31 @@
 /obj/item/stack/cable_coil/cut,
 /turf/closed/mineral/random/stationside/asteroid,
 /area/mine/explored)
+"tZE" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "uad" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -62800,28 +63021,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"ubl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/item/assembly/mousetrap/armed,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/maintenance/tram/mid)
 "ubz" = (
 /turf/closed/wall/r_wall,
 /area/science/cytology)
-"ubR" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
 "uce" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -62833,6 +63035,16 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"ucp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor{
+	id = "left_tram_lower";
+	name = "tunnel access blast door"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/maintenance/tram/left)
 "udf" = (
 /obj/item/target,
 /obj/structure/window/reinforced,
@@ -63071,6 +63283,18 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/service/bar)
+"ugx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "ugF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -63083,14 +63307,6 @@
 /obj/item/assembly/mousetrap/armed,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"ugM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 9
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/maintenance/tram/right)
 "ugZ" = (
 /obj/effect/turf_decal/stripes,
 /obj/effect/turf_decal/stripes{
@@ -63273,6 +63489,19 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/right)
+"ukc" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "ukl" = (
 /obj/structure/railing{
 	dir = 4
@@ -63368,16 +63597,6 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
-"umY" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/tram/left)
 "unm" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/box,
@@ -63425,19 +63644,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"unW" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "uom" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing,
@@ -63504,13 +63710,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice)
-"upG" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/tram/right)
 "upI" = (
 /obj/structure/table,
 /obj/machinery/computer/bookmanagement,
@@ -63526,22 +63725,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"upS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
-"upT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/engineering{
-	name = "Power Access Hatch";
-	req_access_txt = "11"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "uqp" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/bot,
@@ -63555,6 +63738,13 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"uqw" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
 "uqD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -63619,15 +63809,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/gateway)
-"urH" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
 "urN" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -63784,11 +63965,6 @@
 "uwx" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"uwR" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "uxd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -63857,11 +64033,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/mixing)
-"uxZ" = (
-/obj/structure/chair/comfy/beige,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/grimy,
-/area/hallway/secondary/entry)
 "uya" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/structure/railing/corner,
@@ -63879,21 +64050,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
-"uyj" = (
-/obj/structure/table,
-/obj/structure/cable,
-/obj/machinery/navbeacon/wayfinding/engineering,
-/obj/item/book/manual/wiki/engineering_hacking{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/book/manual/wiki/engineering_guide{
-	pixel_x = -2
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/break_room)
 "uyS" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = -32
@@ -63903,6 +64059,11 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/center)
+"uyV" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/service/hydroponics/garden)
 "uzd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -63915,16 +64076,6 @@
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/security/prison)
-"uzn" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/closet/firecloset,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/right)
 "uzN" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
@@ -64017,13 +64168,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/disposal)
-"uDd" = (
-/obj/structure/chair/comfy/beige{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/grimy,
-/area/hallway/secondary/entry)
 "uDi" = (
 /obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/iron/dark/telecomms,
@@ -64085,6 +64229,12 @@
 "uEX" = (
 /turf/closed/wall,
 /area/security/checkpoint/escape)
+"uFv" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "uFL" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -64098,6 +64248,25 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/security/processing)
+"uGS" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "EVA Storage";
+	req_access_txt = "18"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
 "uGV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -64206,12 +64375,43 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"uIW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/engineering{
+	name = "Power Access Hatch";
+	req_access_txt = "11"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
+"uJd" = (
+/obj/structure/cable/multilayer/multiz,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "uJg" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
 /area/science/breakroom)
+"uJk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor{
+	id = "left_tram_lower";
+	name = "tunnel access blast door"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/maintenance/tram/mid)
 "uJu" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -64244,17 +64444,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"uKb" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+"uKg" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center";
+	req_access_txt = "5"
 	},
-/obj/structure/chair/stool/bar{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/service/bar)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "uKl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
@@ -64267,16 +64472,6 @@
 	dir = 5
 	},
 /area/science/breakroom)
-"uKH" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "N2 Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "uKN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -64343,17 +64538,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
-"uMj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/iron/dark,
-/area/engineering/atmospherics_engine)
 "uMm" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -64663,6 +64847,34 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"uQN" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"uQZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
+"uRd" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "uRv" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room";
@@ -64723,25 +64935,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"uSb" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/sign/departments/restroom{
-	pixel_y = 32
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/bar)
 "uSn" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/decal/cleanable/dirt,
@@ -64767,6 +64960,16 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"uSM" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "uSP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -64859,6 +65062,18 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
+"uWm" = (
+/obj/effect/landmark/event_spawn,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/cargo/storage)
 "uWz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -64876,15 +65091,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"uWN" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/firealarm/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria{
-	dir = 5
-	},
-/area/science/breakroom)
 "uXd" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -64908,11 +65114,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
-"uXG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plating,
-/area/engineering/atmos)
+"uXA" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/tram/center)
 "uXX" = (
 /obj/structure/table,
 /obj/item/clothing/head/welding{
@@ -64940,6 +65154,23 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"uYy" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "N2O Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Unfiltered to Mix"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "uYP" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	dir = 4;
@@ -64960,12 +65191,6 @@
 "uYT" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/engineering)
-"uZa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "uZq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -64999,24 +65224,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"uZE" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
 "uZJ" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/iron,
@@ -65025,23 +65232,6 @@
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"vab" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"vah" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/tram/right)
 "vas" = (
 /obj/effect/turf_decal/sand,
 /obj/item/chair,
@@ -65057,6 +65247,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"vaO" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "CO2 Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vbr" = (
 /obj/effect/turf_decal/tile{
 	dir = 1
@@ -65302,18 +65503,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/science/nanite)
-"vfn" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw,
-/obj/effect/turf_decal/caution,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/tram/center)
 "vfx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -65505,33 +65694,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"vkO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"vkV" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
-/area/commons/locker)
 "vlt" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
@@ -65595,17 +65757,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"vlY" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vlZ" = (
 /obj/machinery/porta_turret/ai,
 /obj/machinery/light{
@@ -65823,6 +65974,22 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"vsX" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Turbine Access";
+	req_access_txt = "24"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vtm" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -65880,24 +66047,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
-"vuM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Hallway - Bar West";
-	dir = 6
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/service/bar)
 "vvo" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -65919,24 +66068,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"vwS" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 9
+"vwc" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
 	},
-/obj/structure/chair{
+/obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw,
+/obj/effect/turf_decal/caution,
+/obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/corner{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
+/area/hallway/primary/tram/center)
 "vwX" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"vxz" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "vxX" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 6
@@ -66011,26 +66163,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"vzA" = (
-/obj/machinery/light/small{
+"vzt" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
-"vzF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "vAc" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -66046,10 +66194,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"vAm" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vAt" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -66080,6 +66224,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"vBc" = (
+/obj/machinery/computer/atmos_control/tank/carbon_tank{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vBi" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/riot{
@@ -66138,11 +66292,17 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hallway/secondary/command)
-"vBO" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/iron,
-/area/security/prison)
+"vBI" = (
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/structure/industrial_lift/tram{
+	icon_state = "titanium"
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/vault,
+/area/hallway/primary/tram/center)
 "vCk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -66151,19 +66311,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/service)
-"vCA" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/tram/left)
 "vCD" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -66202,15 +66349,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"vDl" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/landmark/event_spawn,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "vDn" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -66263,19 +66401,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
-"vEh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vEm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -66283,12 +66408,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"vEp" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
-/area/maintenance/tram/left)
 "vEx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -66367,8 +66486,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"vGd" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "vGu" = (
 /turf/closed/wall/r_wall,
+/area/command/bridge)
+"vGB" = (
+/obj/structure/ladder,
+/turf/open/floor/plating,
 /area/command/bridge)
 "vGF" = (
 /obj/machinery/door/airlock/mining{
@@ -66467,15 +66594,6 @@
 /obj/effect/turf_decal/siding/thinplating/end,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"vHN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/maintenance/tram/right)
 "vHQ" = (
 /obj/machinery/computer/atmos_control/toxinsmix{
 	dir = 8
@@ -66629,15 +66747,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"vKI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/maintenance/tram/left)
 "vKS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -66732,19 +66841,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"vNm" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+"vNk" = (
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/commons/dorms)
 "vNK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -66767,12 +66867,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"vOb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "vOt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -66806,15 +66900,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"vOX" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vPp" = (
 /turf/open/floor/iron/white,
 /area/security/prison)
@@ -66851,6 +66936,12 @@
 /obj/structure/railing,
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
+"vQX" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/server)
 "vRc" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -66884,6 +66975,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"vRm" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/cargo/storage)
 "vRA" = (
 /obj/machinery/door/airlock/security{
 	name = "Permanent Cell 3"
@@ -66928,16 +67026,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/research)
-"vSi" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "vSv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -66980,17 +67068,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"vSL" = (
-/obj/structure/cable/multilayer/multiz,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
 "vSS" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -67031,18 +67108,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"vTG" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Air to Mix"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vUi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -67077,6 +67142,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"vVh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "vVs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -67156,22 +67227,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"vXh" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/dropper,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "vXx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -67209,38 +67264,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"vYu" = (
+/obj/machinery/computer/atmos_control/tank/oxygen_tank{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vYV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"vZN" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
-"vZQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "waa" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -67281,9 +67319,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
-"wby" = (
-/turf/open/floor/plating,
-/area/science/research)
 "wbE" = (
 /turf/open/space/basic,
 /area/science/mixing)
@@ -67317,15 +67352,14 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
-"wcw" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+"wcM" = (
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/vault,
+/area/hallway/primary/tram/left)
 "wdc" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -67449,19 +67483,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
-"wfP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "wfQ" = (
 /obj/effect/turf_decal/loading_area,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -67480,11 +67501,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"wgg" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/service/hydroponics/garden)
 "wgo" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -67493,12 +67509,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/engineering/main)
-"wgt" = (
-/obj/machinery/light/small,
-/obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "wgS" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -67528,28 +67538,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
-"whV" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"whY" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
 "wic" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -67614,19 +67602,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"wko" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/atmospherics_engine)
 "wkx" = (
 /obj/structure/chair{
 	dir = 1
@@ -67636,6 +67611,15 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"wkz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/navbeacon/wayfinding/vault,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ai_monitored/security/armory)
 "wld" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/exit)
@@ -67704,21 +67688,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"wns" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "wnM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -67783,6 +67752,14 @@
 /obj/effect/turf_decal/caution,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
+"woW" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/processing)
 "wpe" = (
 /obj/machinery/light{
 	dir = 1
@@ -67802,24 +67779,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
-"wpn" = (
-/obj/structure/table/reinforced,
-/obj/structure/noticeboard{
-	dir = 8;
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "commissaryshutter";
-	name = "Vacant Commissary Shutter"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
 "wpq" = (
 /obj/machinery/shower{
 	dir = 4
@@ -67864,6 +67823,11 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
+"wpP" = (
+/obj/structure/railing/corner,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/glass,
+/area/commons/dorms)
 "wpS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -67873,24 +67837,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
-"wqG" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Break Room";
-	req_access_txt = "47"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/breakroom)
 "wrn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -67951,10 +67897,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"wsB" = (
-/obj/structure/ladder,
+"wsA" = (
+/obj/machinery/light/small,
+/obj/structure/closet/emcloset,
+/obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/plating,
-/area/service/hydroponics)
+/area/hallway/primary/tram/left)
 "wsM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -67975,6 +67923,21 @@
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
+"wts" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/robot_debris/limb,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "wtt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -68081,6 +68044,11 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"wvM" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "wvZ" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -68255,18 +68223,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
-"wzp" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "wzB" = (
 /obj/item/clothing/head/cone{
 	pixel_y = 8
@@ -68309,16 +68265,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"wAn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/service/hydroponics)
+"wAj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "wAx" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Checkpoint";
@@ -68346,21 +68296,6 @@
 "wAL" = (
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"wBe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/atmospherics_engine)
 "wBg" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -68511,11 +68446,34 @@
 	},
 /turf/open/floor/iron,
 /area/science/lab)
+"wEw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "wEN" = (
 /obj/structure/girder,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"wFb" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "wFd" = (
 /obj/structure/chair,
 /obj/structure/sign/poster/official/random{
@@ -68523,16 +68481,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/service)
-"wFk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/science/research)
 "wFn" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -68540,15 +68488,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"wFs" = (
-/obj/structure/chair/pew{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/chapel{
-	dir = 8
-	},
-/area/service/chapel)
 "wFB" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -68611,6 +68550,17 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
 /area/engineering/main)
+"wGT" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
+/area/commons/locker)
 "wGY" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
@@ -68659,6 +68609,21 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
+"wIh" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
+"wIj" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/center)
 "wIq" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -68832,6 +68797,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
+"wNk" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wNp" = (
 /obj/machinery/door/airlock/command{
 	name = "Research Director's Office";
@@ -68877,11 +68851,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
-"wOw" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "wOB" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -68942,13 +68911,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"wPD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ai_monitored/command/storage/eva)
 "wPE" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -68956,16 +68918,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
-"wPJ" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/grimy,
-/area/service/library)
 "wPL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -68995,19 +68947,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/maintenance/tram/right)
-"wQh" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
 /area/maintenance/tram/right)
 "wQG" = (
 /obj/machinery/door/airlock/external{
@@ -69155,6 +69094,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"wTL" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/right)
 "wTO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -69172,29 +69119,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
-"wTT" = (
-/obj/machinery/door/airlock/research{
-	name = "Research and Development Lab";
-	req_one_access_txt = "7"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rndlab1";
-	name = "Research and Development Shutter"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/lab)
 "wUd" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 8
@@ -69217,6 +69141,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/cytology)
+"wUi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "wUq" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
 /obj/effect/turf_decal/sand/plating,
@@ -69261,35 +69195,12 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/left)
-"wUZ" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"wVo" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "wVu" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
-"wVY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "wWd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -69512,24 +69423,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"xaA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/robot_debris/limb,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "xaQ" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/cafeteria{
@@ -69586,6 +69479,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/security/brig)
+"xbL" = (
+/obj/machinery/meter/atmos/distro_loop,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xbT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -69630,6 +69528,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"xcU" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xdg" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2,
 /turf/open/floor/iron,
@@ -69675,18 +69583,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"xdZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xej" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
@@ -69823,11 +69719,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"xgV" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "xhe" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
@@ -69879,6 +69770,21 @@
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
+"xim" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/service/bar)
 "xit" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -69924,10 +69830,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/freezer,
 /area/service/bar)
-"xiU" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "xja" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -70002,16 +69904,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"xjT" = (
-/obj/effect/turf_decal/arrows/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/iron,
-/area/engineering/atmospherics_engine)
 "xjU" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
@@ -70059,14 +69951,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
-"xlb" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xlj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -70139,6 +70023,20 @@
 /obj/structure/ladder,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"xnh" = (
+/obj/structure/chair/pew/left{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
+/area/service/chapel)
+"xnt" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "xnD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -70236,22 +70134,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"xqu" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/sign/departments/restroom{
-	pixel_y = 32
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/bar)
 "xqx" = (
 /turf/open/floor/iron/white,
 /area/science/explab)
@@ -70275,18 +70157,6 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/wood,
 /area/maintenance/central)
-"xqX" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/chair/office,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/security/checkpoint/escape)
 "xrB" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
@@ -70366,19 +70236,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"xsu" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "N2O Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xsv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -70478,6 +70335,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"xvc" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xvf" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -70723,10 +70589,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"xAT" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/construction/engineering)
 "xBm" = (
 /mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/iron/dark,
@@ -70754,14 +70616,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"xBS" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "xCs" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/rack,
@@ -70808,22 +70662,24 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"xDw" = (
-/obj/structure/chair/sofa/right{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "xDE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"xEa" = (
+/obj/machinery/atmospherics/pipe/multiz/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/multiz/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai)
 "xEi" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -70860,6 +70716,15 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/lab)
+"xEK" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/maintenance/tram/right)
 "xES" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -70894,21 +70759,6 @@
 /obj/item/screwdriver,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"xFM" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xFN" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -71062,6 +70912,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
+"xHG" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/corner,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "xHR" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/iron/dark/telecomms,
@@ -71133,6 +71002,20 @@
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /turf/open/floor/engine,
 /area/science/mixing)
+"xJA" = (
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/structure/industrial_lift/tram{
+	icon_state = "titanium"
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/vault,
+/area/hallway/primary/tram/center)
 "xJF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -71295,6 +71178,15 @@
 	},
 /turf/open/floor/plating,
 /area/science/research)
+"xMZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/command/bridge)
 "xNa" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -71337,12 +71229,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"xOf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/security/checkpoint/engineering)
 "xOw" = (
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 20
@@ -71386,6 +71272,17 @@
 	dir = 5
 	},
 /area/command/heads_quarters/rd)
+"xPl" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "xPq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/warning,
@@ -71471,15 +71368,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
-"xRG" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/service/bar)
 "xRI" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -71566,6 +71454,15 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"xTe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/maintenance/tram/mid)
 "xTU" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/item/stack/sheet/iron,
@@ -71604,21 +71501,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"xUx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "xUz" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -71634,21 +71516,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
-"xUD" = (
-/obj/item/bikehorn,
-/obj/item/grown/bananapeel,
-/obj/item/food/spaghetti/copypasta,
-/turf/open/floor/plating,
-/area/engineering/main)
-"xUE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/shower{
-	pixel_y = 24
-	},
-/obj/structure/curtain,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "xUJ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -71659,6 +71526,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"xUP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/commons/lounge)
 "xVk" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -71708,6 +71587,43 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
+"xWy" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Testing Room";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/engineering/atmospherics_engine)
+"xWQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "xWS" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -71917,16 +71833,6 @@
 "yak" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"yaS" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "yaU" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -72104,6 +72010,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
+"yfK" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "yfV" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -72176,12 +72091,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/qm)
-"yhr" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "yhw" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -72217,6 +72126,15 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron,
 /area/science/research)
+"yhS" = (
+/obj/structure/toilet,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/freezer,
+/area/science/research)
 "yiH" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/closet/crate,
@@ -72229,13 +72147,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"yiS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/iron,
-/area/engineering/atmospherics_engine)
 "yiT" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/port/central)
@@ -72243,6 +72154,16 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
+"yiY" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/meter/atmos/atmos_waste_loop,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "yje" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -72279,19 +72200,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"yjv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmospherics_engine)
 "ykx" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
@@ -72318,6 +72226,16 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
+/area/security/prison)
+"ylu" = (
+/obj/structure/table/glass,
+/obj/item/storage/backpack/duffelbag/sec/surgery{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 5
+	},
+/turf/open/floor/iron/white,
 /area/security/prison)
 "ylJ" = (
 /obj/machinery/door/window/westleft{
@@ -72348,6 +72266,18 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/science/research)
+"ylT" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 
 (1,1,1) = {"
 ajc
@@ -87921,7 +87851,7 @@ uxf
 gxB
 xIc
 aSJ
-kXh
+per
 gxB
 bqf
 aAb
@@ -88433,7 +88363,7 @@ aJn
 aeM
 nAC
 awc
-wPJ
+ekF
 agy
 afM
 aiC
@@ -89200,7 +89130,7 @@ ahI
 aIY
 aCa
 aFN
-cNV
+kQF
 aFN
 pbb
 aCa
@@ -90238,7 +90168,7 @@ aYz
 arj
 dQU
 aOi
-lAr
+aSc
 aCa
 kni
 aKJ
@@ -91005,7 +90935,7 @@ kAc
 aFN
 aFN
 aZO
-cNV
+kQF
 aFN
 kAc
 aiV
@@ -91248,7 +91178,7 @@ aJt
 aMK
 aNe
 aNe
-maB
+aNv
 sFv
 aJt
 aIq
@@ -91505,7 +91435,7 @@ aJt
 cKo
 nvY
 aIq
-vCA
+iQi
 aMK
 aJt
 rMi
@@ -91751,7 +91681,7 @@ aej
 aej
 aej
 aej
-vuM
+gdp
 asK
 aej
 aae
@@ -91770,7 +91700,7 @@ aEc
 aEc
 aae
 aCa
-kLK
+ahS
 aGV
 agL
 aCa
@@ -91780,7 +91710,7 @@ vTa
 aCa
 abK
 aGV
-dYH
+axm
 aCa
 aHL
 aMJ
@@ -92005,7 +91935,7 @@ aDy
 afq
 aEl
 aej
-nPP
+nbD
 kKz
 aej
 alN
@@ -92265,7 +92195,7 @@ aZh
 ibN
 nyf
 dsq
-tEz
+qio
 aLM
 aej
 aae
@@ -92289,7 +92219,7 @@ aPW
 aPW
 tpB
 aQO
-sLJ
+tNL
 aQY
 oNg
 aPW
@@ -92522,8 +92452,8 @@ aej
 aej
 aej
 aej
-uSb
-nFj
+rci
+aKm
 aej
 aEc
 aEc
@@ -92557,8 +92487,8 @@ qgE
 aRp
 aRA
 aRp
-nkN
-fAz
+aRJ
+aRV
 aSn
 aRW
 aRW
@@ -92788,7 +92718,7 @@ tUc
 cqY
 maa
 lpd
-mXl
+gUL
 aMK
 aMK
 gwU
@@ -92815,13 +92745,13 @@ aRx
 aRx
 aRx
 aRx
-pjd
+aRY
 aSo
 aRW
 arH
 aqS
 afH
-fjq
+ogJ
 ayp
 aRW
 aRW
@@ -93027,13 +92957,13 @@ eCU
 fyx
 afq
 mTV
-kRR
+dxK
 akg
 aeK
 abX
-xRG
+aNP
 ahG
-qvi
+aGn
 aej
 aej
 waP
@@ -93075,7 +93005,7 @@ aOP
 aRZ
 aSo
 aRW
-oJL
+afF
 aUD
 aUD
 aAh
@@ -93284,7 +93214,7 @@ fyx
 fyx
 afq
 pwj
-jiu
+aOF
 akf
 aeK
 abX
@@ -93296,7 +93226,7 @@ aGg
 pwc
 ahV
 ayW
-gVB
+aKD
 aej
 aej
 aEc
@@ -93323,7 +93253,7 @@ aII
 aII
 aII
 aQy
-rZD
+mSz
 aQb
 aOP
 aRD
@@ -93337,7 +93267,7 @@ aDH
 aDH
 aDH
 aUD
-piw
+wGT
 aRW
 aLO
 aKl
@@ -93546,7 +93476,7 @@ akf
 aeK
 abX
 ahV
-svI
+adh
 ahV
 ahV
 ahV
@@ -93587,7 +93517,7 @@ aRD
 aRE
 aRE
 aSd
-kDU
+aSp
 aBx
 azW
 aDH
@@ -93803,8 +93733,8 @@ tvB
 xbF
 xjU
 iOd
-oPJ
-tBd
+imU
+xim
 lRL
 lRL
 pmm
@@ -93813,7 +93743,7 @@ ahV
 axf
 aVH
 amZ
-fuf
+aIB
 aLT
 lpd
 aMK
@@ -93849,7 +93779,7 @@ gEv
 dxx
 nlL
 jXW
-fOQ
+aiM
 aiN
 ajR
 aRW
@@ -94041,7 +93971,7 @@ aae
 aaB
 aaX
 oDC
-dgv
+ldQ
 vsn
 aPh
 agV
@@ -94068,7 +93998,7 @@ itJ
 ayk
 aWC
 apZ
-szn
+aLL
 amZ
 aIC
 aLT
@@ -94078,7 +94008,7 @@ aMM
 aMM
 aMM
 aNJ
-ivR
+aOG
 aOY
 aPN
 auE
@@ -94298,8 +94228,8 @@ aae
 aaB
 fNH
 yiT
-vzA
-gKD
+cSO
+ukc
 aPh
 ahb
 agV
@@ -94320,21 +94250,21 @@ ack
 ahV
 ahV
 ayI
-uKb
+atF
 pwc
 ahV
 ahV
-mKf
+ahU
 aTa
 amZ
-fuf
+aIB
 aLW
 lpd
 aMK
 aMK
 aMK
 gwU
-tnY
+caR
 aOP
 aOW
 aPM
@@ -94365,7 +94295,7 @@ aUD
 aUD
 aUD
 adY
-tlA
+aYM
 aRW
 aLO
 aKl
@@ -94837,7 +94767,7 @@ szq
 hzh
 oUJ
 ahV
-iTD
+anV
 adH
 aej
 aej
@@ -94851,7 +94781,7 @@ kSJ
 aNM
 vdH
 aOZ
-oVI
+xUP
 aQb
 aQy
 aII
@@ -95132,7 +95062,7 @@ aSj
 aSt
 aRW
 aya
-vkV
+qSd
 aUD
 aAh
 aUL
@@ -95392,7 +95322,7 @@ aDF
 aqS
 azn
 anE
-gCb
+aEA
 aRW
 aRW
 aLO
@@ -95606,8 +95536,8 @@ aej
 aej
 aej
 aej
-xqu
-dhX
+mNY
+aLF
 aej
 aEc
 aEc
@@ -95642,7 +95572,7 @@ dRm
 aQG
 aQG
 aQG
-dvs
+bBj
 aSy
 aRW
 aRW
@@ -95863,7 +95793,7 @@ aZh
 xiS
 vuu
 dsq
-hJQ
+dwi
 aLM
 aej
 uoK
@@ -96115,7 +96045,7 @@ aae
 aae
 aae
 aej
-oUU
+apf
 aej
 qGs
 ugs
@@ -96394,7 +96324,7 @@ qrV
 asY
 aOP
 aPT
-tGK
+koO
 aXA
 avP
 avP
@@ -96644,14 +96574,14 @@ aEc
 rKF
 lpd
 aMK
-mXl
+gUL
 aMK
 gwU
 tMs
 aEc
 aEc
 aPT
-iRp
+aQr
 aXA
 avP
 avP
@@ -96913,12 +96843,12 @@ aXA
 aeV
 aui
 aTE
-loP
+xnh
 lmE
 avP
 avP
 aeV
-wFs
+nwV
 aTE
 atZ
 aiU
@@ -97403,7 +97333,7 @@ aae
 aej
 aMx
 aHj
-qRP
+ahm
 iGH
 iuh
 anO
@@ -97431,7 +97361,7 @@ aCv
 lmE
 rKk
 avP
-tjv
+dLp
 aui
 aTE
 pFx
@@ -97695,8 +97625,8 @@ anX
 aiU
 anP
 ahP
-mnz
-oZw
+ail
+amp
 aiU
 rqz
 uCO
@@ -97939,7 +97869,7 @@ axc
 aQZ
 axc
 adZ
-wFs
+nwV
 aTE
 aCv
 lmE
@@ -97952,8 +97882,8 @@ aCv
 aiU
 bwG
 adV
-cus
-sdE
+fIj
+aUe
 aiU
 rqz
 sXN
@@ -98405,9 +98335,9 @@ aae
 aae
 aae
 nTn
-jgZ
-vXh
-maD
+kwU
+hrP
+ylu
 nTn
 aae
 aae
@@ -98440,13 +98370,13 @@ aae
 aEc
 aEc
 aEc
-dwH
+ilI
 lpd
 aMK
 aMK
 aMK
 gwU
-vKI
+efe
 aEc
 aEc
 axc
@@ -98662,9 +98592,9 @@ aae
 aae
 aae
 nTn
-ryl
+osQ
 vPp
-ryl
+osQ
 nTn
 aae
 aae
@@ -98919,9 +98849,9 @@ aae
 aae
 aae
 nTn
-uwR
+lma
 vPp
-nfr
+slM
 nTn
 aae
 aae
@@ -98955,11 +98885,11 @@ aEc
 qJQ
 aEc
 aEc
-roo
-roo
-roo
-roo
-roo
+ucp
+ucp
+ucp
+ucp
+ucp
 aEc
 aEc
 aMK
@@ -99177,7 +99107,7 @@ aae
 aae
 nTn
 nTn
-tEo
+bKT
 nTn
 nTn
 nTn
@@ -99210,7 +99140,7 @@ aGF
 aGF
 aEc
 yhw
-vEp
+oyj
 aEc
 rOW
 rOW
@@ -99435,7 +99365,7 @@ aae
 nTn
 sXa
 nUW
-wUZ
+uRd
 nTn
 afz
 fJq
@@ -99469,11 +99399,11 @@ aEc
 qJQ
 aEc
 aHH
-ryv
-ryv
-ryv
-ryv
-ryv
+uJk
+uJk
+uJk
+uJk
+uJk
 aHH
 aEc
 aMK
@@ -99486,7 +99416,7 @@ aae
 aJy
 ckL
 aJK
-oTA
+gki
 aJy
 aJI
 hjw
@@ -99743,7 +99673,7 @@ tAh
 tAh
 aQS
 aJM
-tAa
+aKe
 aJy
 aJQ
 aUb
@@ -99982,13 +99912,13 @@ aGF
 aEc
 aEc
 aHH
-tTT
+hlq
 wiA
 aMP
 bnz
 aMP
 vQt
-ubl
+cmQ
 aHH
 aEc
 aEc
@@ -100784,8 +100714,8 @@ agA
 prw
 aPb
 aIG
-tdv
-sbu
+qcC
+pyh
 aUj
 lpV
 nXu
@@ -101041,7 +100971,7 @@ cMo
 lvS
 azk
 aJS
-luX
+tmH
 jED
 cni
 wMp
@@ -101555,7 +101485,7 @@ aov
 aXg
 mkS
 aJS
-dJM
+pib
 jED
 cni
 wMp
@@ -101783,7 +101713,7 @@ aHH
 aHH
 hZa
 wiA
-tAs
+nzo
 aMP
 aMP
 vQt
@@ -101812,8 +101742,8 @@ jFL
 oaQ
 axN
 aIG
-fJz
-qOx
+axS
+yfK
 eiE
 lpV
 anL
@@ -102045,7 +101975,7 @@ aMP
 aMP
 vQt
 xvs
-rGu
+pRH
 aHH
 gHd
 gHd
@@ -102302,7 +102232,7 @@ aMP
 aMP
 vQt
 qYU
-rsa
+fTY
 aHH
 aae
 gHd
@@ -102822,12 +102752,12 @@ aae
 aae
 aae
 gut
-kBU
+iyu
 lIp
 iXO
 qYR
 mnj
-jgw
+emU
 pAW
 gtx
 uKN
@@ -102846,7 +102776,7 @@ sqS
 pre
 wgo
 tfO
-cQu
+gOg
 uSP
 sBU
 jQx
@@ -103103,7 +103033,7 @@ jcG
 jED
 jED
 jED
-etJ
+uQZ
 jED
 dqP
 wMp
@@ -104093,7 +104023,7 @@ aiF
 aiW
 ajO
 akO
-nOW
+alf
 alR
 wiA
 aMP
@@ -104133,7 +104063,7 @@ cWe
 bJt
 kcC
 lOd
-xUD
+rJM
 pAW
 bYA
 fbj
@@ -104338,7 +104268,7 @@ cfh
 aGF
 agd
 abS
-ijD
+beS
 rwZ
 ivx
 aac
@@ -104350,7 +104280,7 @@ aiF
 ahF
 aka
 akQ
-nOW
+alf
 alT
 uXw
 uXw
@@ -104367,13 +104297,13 @@ fBn
 gdl
 wBg
 cAf
-dzl
-tTq
-nQw
-tlG
-mHm
-bBV
-uyj
+fmm
+fLg
+rSi
+pKK
+tRW
+ggP
+puf
 out
 mfj
 pBL
@@ -104596,8 +104526,8 @@ aGF
 agc
 vLw
 aac
-pcN
-wns
+kkq
+kLi
 aac
 aae
 aBM
@@ -104607,7 +104537,7 @@ aiF
 ajj
 akd
 akO
-wpn
+alh
 alY
 wiA
 aMP
@@ -104911,8 +104841,8 @@ ijR
 jZf
 eOc
 one
-aae
-aae
+txV
+one
 aae
 aae
 aae
@@ -105148,17 +105078,17 @@ ttP
 him
 alr
 bhR
-qvA
-xOf
-xOf
-xOf
-kal
-qaA
-ncU
-cHa
-ncU
-qaA
-doo
+uYT
+gUn
+gUn
+gUn
+uYT
+lOd
+wPP
+lQe
+wPP
+lOd
+lOd
 xsr
 fbm
 uXX
@@ -105405,7 +105335,7 @@ sss
 geu
 bhR
 bhR
-wVY
+vGd
 npx
 cyF
 kgc
@@ -105415,7 +105345,7 @@ bKd
 fFZ
 juv
 sud
-anN
+ipU
 gIc
 uaf
 lmk
@@ -105639,7 +105569,7 @@ aHH
 amB
 wiA
 aMP
-tAs
+nzo
 aMP
 vQt
 nbr
@@ -105659,10 +105589,10 @@ dCC
 owd
 aOl
 iWU
-bLI
-nNB
-eAx
-kUF
+kwY
+jfy
+sID
+one
 njO
 fqJ
 rhf
@@ -105672,15 +105602,15 @@ beL
 xVQ
 beL
 beL
-mbS
+beL
 beL
 beL
 beL
 beL
 tUF
 tnL
-hZq
-pik
+tnL
+jzl
 wFO
 okn
 xQi
@@ -105909,21 +105839,21 @@ kmO
 ltr
 ctZ
 pTG
-xAT
+jeE
 mnj
 mnj
 jXu
 one
 dxE
 sKW
-lZC
-mmq
-xdZ
-hhn
-vEh
-xPR
-cAP
-lYg
+nnG
+sOc
+plt
+isy
+taa
+mOH
+iRR
+pLk
 qBb
 xPR
 qhD
@@ -105936,9 +105866,9 @@ xME
 tnL
 vdg
 beL
+beL
 xdg
-rMU
-hXD
+jlc
 tOl
 jwD
 ntZ
@@ -106194,8 +106124,8 @@ tnL
 pch
 lGS
 iVY
-pHm
-uKH
+lFW
+sIp
 gFR
 gED
 eaY
@@ -106437,7 +106367,7 @@ one
 qOl
 xZW
 xZW
-lgz
+oQx
 eBS
 qmC
 sJT
@@ -106451,8 +106381,8 @@ tnL
 vdg
 bRF
 ttH
-vlY
-kwc
+rll
+dfK
 ger
 cTH
 iCR
@@ -106671,7 +106601,7 @@ aMP
 aMP
 vQt
 fze
-ien
+atj
 aHH
 aae
 aae
@@ -106690,11 +106620,11 @@ iWT
 loB
 hgo
 cqx
-vwX
-oDx
-uXG
-oDx
-ikD
+one
+tOl
+tOl
+tOl
+jfQ
 rsm
 xiD
 snR
@@ -106708,8 +106638,8 @@ beL
 bUh
 kEG
 fqJ
-qHo
-fBv
+hDm
+rfv
 okn
 xQi
 eaY
@@ -106947,11 +106877,11 @@ lce
 akU
 one
 aLB
-one
-nNs
-jfy
-tQN
-bup
+vwX
+rIL
+jLa
+yiY
+ylT
 tFX
 uLB
 ezn
@@ -106965,8 +106895,8 @@ oAx
 bjv
 rUe
 tnL
-cSV
-jyY
+tnL
+vYu
 tOl
 jwD
 ntZ
@@ -107203,9 +107133,9 @@ sOA
 uQI
 bIu
 one
-bPZ
-vwX
-jeh
+hyu
+one
+qTe
 tnL
 xEr
 oAx
@@ -107216,14 +107146,14 @@ tnL
 dGY
 fQc
 tnL
-dGY
-iky
-spz
-tnL
+jOr
+owO
+tKz
+dCA
 gVz
 tau
-whV
-iFE
+nUU
+tLB
 gFR
 gED
 eaY
@@ -107460,9 +107390,9 @@ khK
 mGV
 xXg
 one
-aLB
-one
-eWy
+jrO
+vwX
+xbL
 ktD
 otx
 hZT
@@ -107473,14 +107403,14 @@ oBQ
 qyQ
 qyQ
 qyQ
-iZX
+geV
 uPi
 ljs
-iPg
+eiT
 kCj
 uiE
-rfq
-jvG
+sOa
+brz
 one
 jwD
 iCR
@@ -107733,11 +107663,11 @@ oTZ
 ntR
 pIu
 spz
-tnL
+sxW
 gUE
 iVY
-thl
-vab
+ihP
+xcU
 mgz
 jPQ
 xIt
@@ -107976,7 +107906,7 @@ phM
 wzB
 kWk
 one
-tjx
+fhP
 nTs
 hZq
 bxw
@@ -107990,11 +107920,11 @@ bkn
 bkn
 bkn
 rqG
+kUP
 wsP
-wsP
-psJ
-lNO
-bUp
+pOb
+hpc
+tPZ
 tOl
 jwD
 ntZ
@@ -108184,7 +108114,7 @@ aae
 aae
 aae
 aac
-bmL
+ocV
 rlQ
 aac
 aae
@@ -108233,24 +108163,24 @@ aJo
 fVf
 rqz
 one
-aIr
-vTG
-iqe
-cBq
-rqy
-tEe
-vAm
-nVQ
-bVO
-sqo
-vAm
-nBs
-qKp
-bhe
-vAm
-gRw
-gOG
-iwI
+oHe
+pGI
+hZz
+tJH
+kNq
+riI
+iVY
+eWM
+mQU
+mhG
+iVY
+gNX
+dOR
+erh
+kBz
+uFv
+qgl
+mOL
 lju
 gFR
 gED
@@ -108441,8 +108371,8 @@ aae
 aae
 aae
 aac
-sUi
-qqr
+ado
+adA
 aac
 aae
 aae
@@ -108488,27 +108418,27 @@ vRc
 lMb
 aJo
 dkh
-vZQ
-ssm
-nQR
-tWH
+rqz
+one
+kHE
+nKG
 cvS
-qfl
-gQQ
-xsu
-sWu
-ter
-xFM
-tgv
-fTg
-fOh
-vOX
-luc
-mxE
-gMk
-glg
-vNm
-ayU
+xvc
+okn
+uYy
+okz
+ktx
+kRg
+pil
+tJg
+wNk
+oLQ
+vaO
+vBc
+rTI
+tnO
+jRZ
+ign
 one
 jwD
 iCR
@@ -108698,7 +108628,7 @@ aae
 aae
 aae
 aac
-itc
+adq
 cjW
 aac
 aae
@@ -108720,13 +108650,13 @@ aBM
 aHH
 aHH
 aHH
-tTT
+hlq
 wiA
 aMP
 aMP
 aMP
 vQt
-cCf
+xTe
 aHH
 aHH
 aHH
@@ -108745,27 +108675,27 @@ tPz
 aJH
 phM
 vDX
-eOk
+rqz
 one
-lYN
-ldt
-mgz
-jFb
-yhr
-bJW
-mgz
-fTV
-noT
-bJW
-mgz
-fTV
-noT
-bJW
-mgz
-fTV
-noT
-ovu
-ayZ
+one
+oAq
+tOl
+dvK
+one
+oAq
+tOl
+dvK
+one
+oAq
+tOl
+dvK
+one
+oAq
+tOl
+dvK
+one
+one
+vsX
 one
 jwD
 one
@@ -108999,10 +108929,10 @@ aae
 aae
 aJo
 msT
-scl
+kDm
 aJo
 ijL
-eOk
+rqz
 aJo
 jwD
 kvR
@@ -109022,7 +108952,7 @@ jwD
 eui
 jwD
 tOl
-xlb
+mAZ
 tOl
 jwD
 one
@@ -109235,11 +109165,11 @@ aHH
 iBD
 aHH
 aHH
-rFn
-rFn
-rFn
-rFn
-rFn
+eMU
+eMU
+eMU
+eMU
+eMU
 aHH
 aHH
 aMP
@@ -109259,7 +109189,7 @@ cix
 wBD
 aJo
 iVs
-ofu
+rfe
 aJo
 one
 lYu
@@ -109279,7 +109209,7 @@ ntZ
 lYu
 one
 dGP
-aza
+uQN
 dGP
 one
 one
@@ -109498,7 +109428,7 @@ gqu
 gqu
 gqu
 aHH
-pLL
+kcA
 cRs
 aHH
 aBM
@@ -109516,7 +109446,7 @@ aJo
 aJo
 aJo
 fkV
-eOk
+rqz
 neO
 one
 wux
@@ -109536,7 +109466,7 @@ nfp
 hUe
 one
 kZV
-tnm
+sES
 dGP
 aae
 aae
@@ -109749,11 +109679,11 @@ aHH
 vXF
 aHH
 aHI
-nXq
-nXq
-nXq
-nXq
-nXq
+jrz
+jrz
+jrz
+jrz
+jrz
 aHI
 aHH
 aMP
@@ -109773,7 +109703,7 @@ cAL
 xjM
 rxe
 neO
-eOk
+rqz
 neO
 one
 dTm
@@ -109793,7 +109723,7 @@ xFX
 vKh
 one
 mWF
-lwa
+kxa
 dGP
 ajc
 aBM
@@ -110030,7 +109960,7 @@ aJo
 aJo
 aJo
 ofx
-eOk
+rqz
 neO
 one
 kEz
@@ -110041,7 +109971,7 @@ pPr
 xev
 jhk
 iCR
-nzj
+nTl
 eRW
 xyk
 iCR
@@ -110050,7 +109980,7 @@ sxN
 vKh
 one
 xap
-lfe
+gYY
 dGP
 dGP
 dGP
@@ -110262,13 +110192,13 @@ aBM
 aHH
 aHH
 aHI
-rOR
+fQS
 pmY
 aMY
 rvc
 aMY
 uom
-vHN
+kcH
 aHI
 aHH
 aHH
@@ -110286,8 +110216,8 @@ aae
 aae
 aae
 aJo
-lfX
-qJW
+aJM
+otQ
 aJo
 one
 one
@@ -110306,8 +110236,8 @@ diU
 diU
 diU
 diU
-wVo
-rfk
+kGx
+sfg
 jMf
 byD
 oCp
@@ -110525,7 +110455,7 @@ aMY
 aMY
 aMY
 uom
-tpM
+xEK
 aHI
 aae
 aae
@@ -110543,7 +110473,7 @@ aJo
 aJo
 aJo
 aJo
-eOk
+rqz
 sAK
 aJo
 fwy
@@ -110564,7 +110494,7 @@ nWL
 tVq
 diU
 dOL
-bPK
+hqf
 hTg
 hTg
 qFu
@@ -110800,7 +110730,7 @@ aJz
 aJz
 aJz
 aJz
-wfP
+ewE
 vDX
 aJo
 ify
@@ -110821,7 +110751,7 @@ tWb
 jbA
 diU
 ayT
-daN
+wEw
 bNe
 eDs
 bZx
@@ -111057,7 +110987,7 @@ wGY
 wGY
 wGY
 wGY
-eOk
+rqz
 rgO
 aJo
 fwy
@@ -111078,7 +111008,7 @@ syF
 eLR
 diU
 aoo
-aTs
+gcR
 bGf
 poj
 mep
@@ -111314,7 +111244,7 @@ iSp
 aiE
 rJa
 wGY
-eOk
+rqz
 tyF
 aJo
 aJo
@@ -111331,11 +111261,11 @@ peZ
 udR
 jXF
 tZl
-wBe
-uMj
-qrs
-xUx
-bpX
+tAm
+kdK
+xWy
+nOv
+ugx
 pmO
 pNC
 kPz
@@ -111571,14 +111501,14 @@ nlQ
 gfq
 dJk
 wGY
-vkO
-nvx
-pDD
-nvx
-nvx
-nvx
-nvx
-xaA
+mzE
+aJz
+lUt
+aJz
+aJz
+aJz
+aJz
+wts
 aJo
 ijL
 sod
@@ -111587,8 +111517,8 @@ rzp
 wNL
 tiG
 caj
-eVG
-wko
+lBY
+fug
 nET
 diU
 bid
@@ -111835,16 +111765,16 @@ aJy
 aJy
 aJo
 aJo
-bkx
-crK
-oqJ
-oqJ
-cPe
-yiS
-mTg
-xjT
-yiS
-yjv
+toU
+tRA
+vVh
+vVh
+klV
+rPS
+ePE
+sOd
+rPS
+hOV
 tuo
 rkS
 diU
@@ -112046,7 +111976,7 @@ wwj
 fmq
 dzy
 aet
-ezW
+tRV
 aeu
 aGf
 adS
@@ -112087,7 +112017,7 @@ myW
 gGO
 wGY
 jcZ
-hXj
+eGY
 neO
 aJy
 aae
@@ -112344,8 +112274,8 @@ dXc
 vFI
 wGY
 aJK
-kDe
-sMl
+aLu
+pSL
 aJy
 aae
 aJo
@@ -112574,7 +112504,7 @@ eLU
 xCF
 aae
 aHI
-oxt
+qYM
 koj
 pmY
 aMY
@@ -112582,7 +112512,7 @@ aMY
 aMY
 uom
 wdc
-niq
+ojb
 aHI
 qtG
 tzc
@@ -114133,7 +114063,7 @@ xaQ
 fat
 uJg
 gJC
-uWN
+awJ
 bJc
 luP
 awR
@@ -114380,7 +114310,7 @@ aMY
 aMY
 aMY
 uom
-tpM
+xEK
 aHI
 aet
 adS
@@ -114390,7 +114320,7 @@ avu
 lwI
 wQW
 dVI
-epy
+cKT
 fhu
 mVK
 eGj
@@ -114411,7 +114341,7 @@ aRL
 aRO
 aRO
 lQG
-cDh
+mOo
 klo
 lXy
 pfC
@@ -114647,8 +114577,8 @@ aij
 apV
 gAY
 ngy
-eVU
-wqG
+hrI
+jdw
 jkA
 wlZ
 dIs
@@ -115192,7 +115122,7 @@ lQG
 lQG
 lQG
 lQG
-iEC
+azt
 vul
 kcc
 dZR
@@ -115675,9 +115605,9 @@ aae
 aae
 der
 kbY
-bKh
-oXh
-ioU
+tej
+cPU
+eDr
 frM
 mgV
 mgV
@@ -115932,7 +115862,7 @@ der
 der
 der
 kbY
-qFs
+sOn
 der
 der
 der
@@ -116186,10 +116116,10 @@ adS
 aGf
 adS
 der
-lcc
-oXh
-nsh
-fXT
+yhS
+cPU
+gnn
+csY
 qSj
 oab
 der
@@ -116520,7 +116450,7 @@ ucf
 pDk
 pDk
 pDk
-itH
+wIh
 cRL
 eYL
 eYL
@@ -116686,7 +116616,7 @@ adS
 aFC
 aHJ
 aHI
-ugM
+lCc
 iij
 pmY
 aMY
@@ -117205,7 +117135,7 @@ aMG
 nIg
 iJW
 aJf
-wQh
+pOF
 aMY
 aMG
 aMY
@@ -117462,7 +117392,7 @@ aMG
 fKQ
 aNi
 bxp
-vah
+aNB
 aMY
 aMG
 aJf
@@ -148572,7 +148502,7 @@ aYr
 aYr
 aYr
 aMg
-fDR
+iFI
 aVR
 aiR
 aGH
@@ -149832,7 +149762,7 @@ aGH
 aBV
 vdY
 azs
-rrg
+aTT
 awZ
 aYr
 aYr
@@ -150087,7 +150017,7 @@ aae
 aae
 aGH
 apU
-nxl
+nAU
 aBa
 agf
 awZ
@@ -150613,7 +150543,7 @@ aYr
 aYr
 aYr
 awZ
-pCn
+aPv
 aOv
 fWU
 gtp
@@ -150629,7 +150559,7 @@ aYr
 aYr
 awZ
 pkd
-kLb
+xnt
 awZ
 aYr
 aYr
@@ -151643,7 +151573,7 @@ aYr
 aYr
 awZ
 arv
-hNw
+eRF
 gtp
 awZ
 aYr
@@ -152404,7 +152334,7 @@ avV
 awS
 awS
 awS
-qXz
+pvq
 awS
 awS
 fzB
@@ -152414,7 +152344,7 @@ aAw
 avU
 aBa
 ldi
-sJl
+pSS
 aOw
 aBa
 aIJ
@@ -152422,7 +152352,7 @@ tgW
 dpB
 bYl
 bYl
-dtt
+nGJ
 bYl
 odE
 bYl
@@ -152671,8 +152601,8 @@ ajz
 aAy
 azr
 azr
-lkR
-oMT
+cTb
+qBH
 bYl
 iCv
 aCS
@@ -153186,7 +153116,7 @@ aAC
 bhZ
 awC
 aLR
-mjb
+rQJ
 arT
 aGq
 akM
@@ -153440,7 +153370,7 @@ aBU
 oev
 adX
 aAE
-uxZ
+iNk
 awt
 aox
 awt
@@ -153451,7 +153381,7 @@ aSD
 abG
 aFw
 iRZ
-wgg
+uyV
 atM
 abG
 aae
@@ -153700,7 +153630,7 @@ aAC
 awt
 aiZ
 mqN
-jKw
+rAE
 awt
 aGq
 aBa
@@ -153951,7 +153881,7 @@ amy
 prX
 azV
 aAm
-prf
+aAv
 aAw
 aAH
 awt
@@ -154212,7 +154142,7 @@ oev
 aBa
 aAC
 awt
-jKw
+rAE
 avy
 aiZ
 awt
@@ -154728,7 +154658,7 @@ aAC
 tjo
 aDp
 tpy
-uDd
+aFB
 tjo
 aBp
 aEF
@@ -154994,7 +154924,7 @@ abG
 aTU
 arr
 akp
-sOM
+kaD
 abG
 cFH
 vvI
@@ -155486,7 +155416,7 @@ aae
 jPI
 guo
 wZN
-slJ
+rJE
 xMg
 jPI
 ajg
@@ -155521,7 +155451,7 @@ mKk
 nkC
 vUC
 aOb
-rPN
+buP
 jpX
 oKb
 svk
@@ -155781,7 +155711,7 @@ aOb
 hwy
 aGx
 aCQ
-kpK
+arl
 aOb
 aae
 aae
@@ -155998,13 +155928,13 @@ aae
 aae
 aae
 jPI
-oTf
+aCn
 aCw
 guy
 saV
 jPI
 gpL
-mFz
+wUi
 amL
 anF
 apr
@@ -156264,7 +156194,7 @@ akz
 alV
 amS
 aGH
-drI
+apt
 auM
 awF
 awF
@@ -156524,8 +156454,8 @@ anG
 anG
 anG
 awF
-kRo
-tlm
+axU
+ayE
 azv
 meV
 apv
@@ -156540,7 +156470,7 @@ akE
 aeb
 wPL
 akE
-nSm
+akL
 apQ
 akE
 aZk
@@ -156549,7 +156479,7 @@ akE
 aGa
 apQ
 aOb
-dEF
+cRH
 hKK
 aYu
 vhE
@@ -156773,7 +156703,7 @@ ahu
 ahu
 ahu
 aak
-mLI
+ajT
 akz
 alV
 aDA
@@ -156781,10 +156711,10 @@ anG
 apv
 lJR
 awF
-vzF
-fvG
-fvG
-hLa
+hjB
+sxO
+sxO
+aAY
 apv
 awF
 lJR
@@ -156792,7 +156722,7 @@ apv
 anG
 aFA
 aMH
-gBR
+acs
 akE
 akE
 aNO
@@ -157024,7 +156954,7 @@ aLo
 aoD
 atu
 aAc
-cuo
+aCG
 alW
 ahu
 ahu
@@ -157041,10 +156971,10 @@ awF
 apv
 pXQ
 lJR
-vZN
+cXC
 apv
 awF
-ngY
+dDU
 apv
 anG
 eON
@@ -157066,7 +156996,7 @@ aOb
 akZ
 kcw
 aOb
-oYf
+aYd
 aOb
 aae
 aae
@@ -157308,14 +157238,14 @@ hUH
 aSq
 aSq
 aOB
-pIw
+wpP
 aWe
 aWe
 aWe
 aWe
 aWe
 aWe
-kWs
+fSd
 aWe
 aoa
 aDu
@@ -157577,7 +157507,7 @@ aIg
 aoT
 aAI
 aOb
-hUs
+eUu
 hKK
 aOb
 aOb
@@ -157781,7 +157711,7 @@ aae
 aae
 aae
 aak
-ojU
+aal
 abb
 ach
 acR
@@ -157799,19 +157729,19 @@ aeE
 aeE
 aeN
 aeN
-hBF
+vxz
 aeN
-taj
+bnB
 aeN
 amh
 ank
 anH
-hdY
+dCV
 auY
 eCj
 axW
 axW
-hFN
+wcM
 axW
 axW
 eSx
@@ -157837,7 +157767,7 @@ aOb
 aKk
 pWq
 aOb
-ptp
+aua
 aOb
 aae
 aae
@@ -158063,7 +157993,7 @@ acr
 acr
 amH
 anT
-mQE
+aqg
 avc
 awK
 axX
@@ -158076,13 +158006,13 @@ aCX
 aEB
 aoN
 aGj
-sGf
+vNk
 aSq
 aPY
 aFt
 aoG
 aoG
-mMf
+etL
 aoG
 aoG
 aoG
@@ -158299,7 +158229,7 @@ aak
 abe
 act
 adf
-mpK
+adK
 amK
 aMp
 kyw
@@ -158843,7 +158773,7 @@ azB
 qbg
 axX
 anG
-nKx
+aDd
 aEH
 aJV
 asq
@@ -158856,10 +158786,10 @@ akE
 atG
 apQ
 akE
-gFS
+aDa
 apQ
 akE
-kpx
+gPW
 aGM
 thB
 aIg
@@ -159085,11 +159015,11 @@ avo
 aTJ
 awv
 abq
-nrf
-iQz
+glj
+axl
 ayx
 aWs
-xDw
+aUc
 afy
 aqB
 avc
@@ -159322,7 +159252,7 @@ aae
 aae
 aPh
 usX
-kIU
+anx
 kkx
 aou
 aoK
@@ -159349,7 +159279,7 @@ aUE
 aOx
 aid
 aqB
-gTo
+edA
 kUi
 axX
 vUA
@@ -159578,8 +159508,8 @@ aae
 aae
 aae
 aPh
-wsB
-dyb
+ryY
+amM
 aPh
 aAo
 aoL
@@ -159835,8 +159765,8 @@ aae
 aae
 aae
 aPh
-oKp
-wAn
+pkw
+oJS
 aPh
 aCk
 aNK
@@ -160146,7 +160076,7 @@ apz
 akE
 xAk
 aGW
-kZA
+lnR
 aIg
 aIg
 auU
@@ -160370,13 +160300,13 @@ yft
 aPF
 aPk
 xzj
-nrf
-lmW
+glj
+awi
 aTu
 aTu
 aGA
 aCp
-umY
+aqC
 avf
 anG
 axX
@@ -160392,13 +160322,13 @@ arq
 aCf
 qHD
 aJV
-gZz
+aSa
 bzV
 akE
 axB
 agT
 akE
-qnI
+ayH
 agT
 akE
 jpq
@@ -161125,7 +161055,7 @@ aak
 aaw
 abn
 acr
-xiU
+oeT
 adO
 tAT
 ael
@@ -161142,7 +161072,7 @@ ahc
 qHN
 ahc
 ajn
-uZa
+akb
 acr
 acr
 amH
@@ -161156,7 +161086,7 @@ pGF
 qbg
 axX
 aBH
-iNf
+aDj
 wdO
 aoN
 xAk
@@ -161171,7 +161101,7 @@ aWe
 aWe
 aWe
 aWe
-kWs
+fSd
 aoa
 aHo
 aHv
@@ -161399,8 +161329,8 @@ aeN
 aeN
 aeN
 ajq
-rYl
-kit
+akc
+alL
 amj
 any
 aob
@@ -161420,7 +161350,7 @@ vlS
 bdp
 bdp
 hqz
-rpL
+hGz
 aIg
 aIg
 aIg
@@ -161649,7 +161579,7 @@ afg
 aBh
 agE
 agU
-kPC
+nOU
 acJ
 aCe
 ahJ
@@ -161930,12 +161860,12 @@ anG
 anG
 nDc
 awF
-hjE
-hjE
+aAX
+aAX
 awF
 aCM
 aFt
-mMf
+etL
 aoG
 aoG
 aoG
@@ -161946,7 +161876,7 @@ aoG
 aYv
 aRB
 aOb
-hUs
+eUu
 asw
 loK
 emS
@@ -162156,7 +162086,7 @@ aWO
 apl
 ajW
 apx
-ubR
+aic
 aAF
 abw
 aIL
@@ -162176,7 +162106,7 @@ sJV
 azf
 aZQ
 dmZ
-wgt
+wsA
 anG
 axX
 vUA
@@ -162187,9 +162117,9 @@ anG
 aCP
 wlr
 awF
-sCP
-nSO
-upT
+iFq
+aHa
+uIW
 aFY
 aTB
 ams
@@ -162197,7 +162127,7 @@ aTB
 vAc
 ams
 aTB
-rNl
+kAA
 ams
 aTB
 aTB
@@ -162206,7 +162136,7 @@ aOb
 ald
 asD
 aOb
-sGy
+mjQ
 aOb
 aae
 aae
@@ -162408,15 +162338,15 @@ aae
 aae
 aae
 aFF
-mAq
+ahO
 azb
-iSO
+wFb
 acI
 pXr
 acI
 azb
 azb
-iXh
+aGO
 aFF
 aBA
 oKX
@@ -162444,8 +162374,8 @@ anG
 auN
 wlr
 awF
-sQF
-qrO
+aGC
+aHg
 awF
 akE
 akE
@@ -162667,12 +162597,12 @@ aae
 aFF
 aoQ
 cNx
-lRc
+fLc
 fLB
 apB
 aKd
 aYA
-lRc
+fLc
 avD
 aFF
 aVz
@@ -162708,16 +162638,16 @@ akE
 avM
 apQ
 akE
-dUR
+amr
 apQ
 akE
 aZL
 apQ
 akE
-hUw
+aUv
 apQ
 aOb
-lYa
+aki
 asw
 lef
 crg
@@ -162977,7 +162907,7 @@ aOb
 asd
 asw
 aOb
-pKA
+nlx
 aOb
 aae
 aae
@@ -163488,7 +163418,7 @@ akE
 akE
 akE
 aOb
-xUE
+guh
 axx
 agv
 aKz
@@ -164002,10 +163932,10 @@ aae
 aae
 aae
 aOb
-rPN
+buP
 jpX
 aZo
-oBf
+lMz
 aOb
 aBM
 kWq
@@ -164496,7 +164426,7 @@ cuD
 azC
 jaz
 mhj
-niF
+dAd
 eFB
 aRN
 aBM
@@ -165021,8 +164951,8 @@ aae
 aae
 hce
 tZx
-hAX
-qQc
+fET
+cEN
 hce
 aae
 tRH
@@ -165278,8 +165208,8 @@ aae
 aae
 hce
 kpe
-cMf
-nIE
+aDM
+tvr
 hce
 aae
 tRH
@@ -165486,7 +165416,7 @@ mNk
 bcB
 fnk
 dIZ
-vBO
+jAw
 nTn
 aae
 aae
@@ -165743,7 +165673,7 @@ mZf
 fnk
 fnk
 dIZ
-dNz
+fSR
 nTn
 aae
 aae
@@ -166010,7 +165940,7 @@ pII
 cVf
 vUi
 lHB
-wPD
+uqw
 tze
 aAW
 hlO
@@ -166265,7 +166195,7 @@ aae
 aae
 pII
 pII
-fPe
+por
 coO
 rfR
 aqN
@@ -166512,7 +166442,7 @@ aoR
 azR
 dOV
 hzL
-hIh
+fjE
 dIZ
 wMv
 ktC
@@ -166522,7 +166452,7 @@ xkv
 xkv
 xkv
 pII
-lJZ
+onb
 dOc
 eYE
 sRY
@@ -167026,7 +166956,7 @@ orQ
 kbc
 mQy
 uad
-prV
+wAj
 cuB
 wMq
 ktC
@@ -167287,17 +167217,17 @@ oOW
 gBp
 utu
 ktC
-tLE
+apy
 oDZ
 xbH
 qqh
-nul
+dzX
 pII
 aaI
 aoV
 wul
 pII
-qTP
+uGS
 fsa
 ieT
 ieT
@@ -167316,7 +167246,7 @@ azG
 ajJ
 hkC
 asE
-aWq
+mdk
 avn
 ayd
 xds
@@ -167815,7 +167745,7 @@ lSJ
 vcC
 oDv
 oDv
-mIf
+tKC
 oDv
 oDv
 puM
@@ -168051,7 +167981,7 @@ sck
 bCZ
 gQF
 hDi
-jBa
+lTu
 dOV
 mUB
 lap
@@ -168067,7 +167997,7 @@ amT
 anz
 amn
 apL
-xgV
+bMN
 arU
 jyB
 pmi
@@ -168080,14 +168010,14 @@ ffq
 awa
 ffq
 mZk
-hvK
-tVI
-tVI
+erl
+uSM
+uSM
 mFg
 lkU
 aaC
-olx
-ftl
+uXA
+avC
 usd
 ayg
 ayg
@@ -168308,7 +168238,7 @@ qZI
 ovz
 iHP
 gAz
-qZc
+woW
 dOV
 xsF
 anz
@@ -168333,17 +168263,17 @@ vGu
 vGu
 vGu
 vFT
-yaS
+qBr
 awb
 xfZ
 lIK
-gdC
+stq
 ffq
 ffq
 ffq
 cwJ
 vBA
-lys
+asR
 avR
 axj
 ayd
@@ -168596,11 +168526,11 @@ vGu
 uDD
 pmi
 iob
-jEx
+kuY
 pmi
 aDU
 aaQ
-lGk
+rhL
 avK
 axj
 ayd
@@ -168613,7 +168543,7 @@ czP
 aFe
 aGe
 aGe
-tgN
+kSR
 qQj
 aHh
 nbz
@@ -168625,9 +168555,9 @@ eCF
 uht
 uht
 uht
-tjB
+dbr
 tDm
-tjB
+dbr
 uht
 uht
 uht
@@ -169119,7 +169049,7 @@ avQ
 avn
 tlq
 cXZ
-jBs
+xJA
 kpr
 tlq
 avn
@@ -169128,7 +169058,7 @@ aFf
 aGi
 aFD
 rMQ
-ehS
+lOR
 dFl
 knj
 bhn
@@ -169369,7 +169299,7 @@ uMP
 gSw
 lnV
 azO
-wOw
+wvM
 qBE
 atg
 avR
@@ -169618,7 +169548,7 @@ qFy
 pKj
 jVH
 vGu
-bil
+qVF
 cBf
 vGu
 cFP
@@ -169636,7 +169566,7 @@ gVN
 knD
 eDw
 vjI
-vfn
+vwc
 aDz
 aFg
 aGo
@@ -169649,7 +169579,7 @@ bhn
 xGC
 eLP
 rlv
-iid
+hJM
 hqL
 htq
 xnR
@@ -169659,7 +169589,7 @@ jek
 aHW
 gKY
 tNb
-dUr
+kLo
 krG
 hRj
 aJL
@@ -169845,9 +169775,9 @@ kZi
 eLx
 yfG
 hNf
-iJm
-suh
-eIU
+acj
+wkz
+fwA
 lUT
 jZX
 duo
@@ -169874,9 +169804,9 @@ oAm
 mJm
 gxl
 auq
-fIz
-hFo
-lGz
+auS
+iGJ
+vGB
 vGu
 arA
 eFD
@@ -169898,10 +169828,10 @@ aDB
 eed
 aGp
 eLP
-fLH
+rUD
 lUE
 eLP
-tKK
+ivk
 nbz
 nFd
 rXO
@@ -170102,9 +170032,9 @@ bZi
 eLx
 yfG
 hNf
-ttc
+aoC
 qan
-mWu
+tzk
 eog
 ssX
 ekE
@@ -170132,8 +170062,8 @@ cfJ
 pKj
 apE
 vGu
-mbk
-bPp
+xMZ
+hJG
 vGu
 jKG
 dUE
@@ -170147,12 +170077,12 @@ avR
 qDY
 qeN
 gVN
-dDp
+vBI
 eDw
 biz
 mRN
 aDD
-ldT
+aFk
 aGr
 jaK
 quA
@@ -170163,7 +170093,7 @@ bhn
 xGC
 eLP
 vtm
-mSF
+uKg
 iIX
 sLq
 asM
@@ -170173,7 +170103,7 @@ tvR
 aHW
 tGb
 xDr
-hyW
+kdB
 cSq
 rvT
 uDs
@@ -170397,7 +170327,7 @@ kqN
 kuw
 nFe
 xsf
-tCg
+mjK
 qBE
 atg
 avO
@@ -170669,7 +170599,7 @@ aDJ
 aFf
 aGi
 asz
-vSi
+pQj
 xgB
 nQP
 fqw
@@ -170914,7 +170844,7 @@ iMZ
 hYr
 hYr
 atr
-czM
+sLw
 axr
 lIu
 bWo
@@ -171163,10 +171093,10 @@ vGu
 lOg
 mXM
 vGu
-maE
-qcD
+ild
+tZE
 vhe
-eXc
+dvg
 sjf
 aDY
 aaQ
@@ -171195,9 +171125,9 @@ kaB
 uht
 uht
 uht
-dIl
+tYk
 tDm
-dIl
+tYk
 uht
 uht
 uht
@@ -171408,7 +171338,7 @@ xWS
 dYC
 doZ
 apR
-eXc
+dvg
 xfD
 vGu
 vGu
@@ -171420,8 +171350,8 @@ kIT
 vem
 wXQ
 iXt
-fBy
-iTE
+qtX
+hhU
 ffq
 ffq
 ffq
@@ -171640,11 +171570,11 @@ aae
 aae
 cso
 agn
-pjn
+aoz
 mNh
 aot
 vWh
-bGm
+ajp
 ajx
 snY
 nuZ
@@ -171677,11 +171607,11 @@ eVL
 ffq
 rMC
 ffq
-mMj
-mQJ
-bEq
-unW
-qyA
+cTR
+bMJ
+cQr
+hhI
+dFR
 puy
 aba
 nyE
@@ -171921,7 +171851,7 @@ jIZ
 rVM
 tPS
 bjY
-mbr
+xHG
 xUJ
 wGH
 pWG
@@ -171933,8 +171863,8 @@ juc
 sQj
 iNe
 grF
-sTz
-jtH
+kmR
+ldE
 aLX
 asl
 asl
@@ -172183,7 +172113,7 @@ pDN
 uDD
 pmi
 pmi
-sGs
+aBq
 pmi
 pmi
 pmi
@@ -172464,7 +172394,7 @@ azT
 bgI
 ayd
 avn
-biR
+wIj
 aEZ
 avn
 wWF
@@ -172672,7 +172602,7 @@ ves
 fAM
 roQ
 dPO
-bGm
+ajp
 ajx
 nBV
 dgU
@@ -173720,8 +173650,8 @@ ktC
 ktC
 lTF
 fsi
-whY
-vSL
+ohZ
+uJd
 fsi
 aae
 ezo
@@ -173977,8 +173907,8 @@ eQx
 eQx
 eQx
 csS
-htx
-hGU
+oVZ
+tWl
 fsi
 aae
 ezo
@@ -174234,7 +174164,7 @@ bae
 bae
 ggA
 fsi
-urH
+txZ
 lTF
 fsi
 aae
@@ -175284,7 +175214,7 @@ aBM
 aBM
 dOi
 xMC
-njr
+eAL
 dlR
 xSI
 aAO
@@ -177323,9 +177253,9 @@ oOP
 oOP
 kuX
 uIG
-oXu
-okv
-jir
+oHI
+emk
+sDF
 uIG
 fGX
 oOP
@@ -177580,9 +177510,9 @@ oOP
 kuX
 kuX
 uIG
-eoe
-oVB
-smn
+vRm
+uWm
+ihX
 uIG
 mlE
 fGX
@@ -177604,7 +177534,7 @@ aAQ
 ujT
 ayt
 aod
-uzn
+pzR
 aux
 axR
 uHz
@@ -177623,8 +177553,8 @@ aPX
 bPl
 dyg
 bwc
-pwo
-wby
+dCn
+pto
 ayQ
 asL
 bsR
@@ -177880,8 +177810,8 @@ aHT
 aHZ
 dyg
 lSU
-wFk
-tKm
+jHM
+bbP
 ayQ
 aIs
 rbD
@@ -178399,7 +178329,7 @@ mHl
 mHl
 mHl
 mHl
-iUg
+bCy
 mLA
 qUb
 czV
@@ -178608,8 +178538,8 @@ jIS
 xHg
 bAl
 tiq
-qsn
-jRZ
+toM
+buT
 mZS
 bDC
 eHk
@@ -178622,7 +178552,7 @@ vKE
 dDP
 hEO
 svw
-jfI
+fZj
 atR
 awh
 axw
@@ -178635,7 +178565,7 @@ aCs
 aur
 aFO
 aEb
-siN
+ryJ
 mON
 aHu
 lar
@@ -178865,8 +178795,8 @@ aqF
 xHg
 uUN
 nRC
-mxo
-wcw
+iLL
+bJI
 bSv
 apI
 rkv
@@ -178880,7 +178810,7 @@ tUg
 dhQ
 tTU
 veF
-dml
+atS
 awk
 axw
 ayt
@@ -179157,7 +179087,7 @@ der
 kvg
 kvg
 oky
-wTT
+jsJ
 oky
 wwC
 wwC
@@ -179390,7 +179320,7 @@ dse
 arN
 pXz
 epb
-ing
+qSf
 toG
 tzr
 xtb
@@ -179409,7 +179339,7 @@ pmr
 big
 dqE
 waa
-jMn
+aGm
 bJd
 kvg
 akF
@@ -179917,7 +179847,7 @@ aAQ
 ujT
 ayt
 lgw
-upG
+pas
 aFV
 swz
 lMH
@@ -179950,7 +179880,7 @@ ufT
 uZr
 fwn
 qhx
-klx
+fdh
 cTz
 gbB
 xcN
@@ -180157,7 +180087,7 @@ pXz
 adv
 pXR
 oZV
-siU
+nDF
 yaf
 sML
 hFq
@@ -180412,9 +180342,9 @@ ttN
 ttN
 pXz
 adE
-hVa
+kZY
 qzJ
-upS
+afh
 afW
 pXz
 ene
@@ -180677,7 +180607,7 @@ iHK
 ukX
 uAF
 aqy
-cZY
+oCq
 nLs
 auh
 awf
@@ -180695,7 +180625,7 @@ msN
 kPK
 iCV
 ngB
-bEi
+buy
 kvg
 uLU
 vLU
@@ -181702,13 +181632,13 @@ ovH
 gOu
 bUu
 vfS
-gsw
+vzt
 uwx
 eSS
 uJw
 aok
 aus
-dac
+wTL
 axM
 ayt
 oCw
@@ -181720,7 +181650,7 @@ aEd
 fIK
 aGw
 ops
-cBD
+pjY
 rqf
 lar
 hRI
@@ -182226,7 +182156,7 @@ ash
 aEL
 ayA
 ayA
-pgV
+aAS
 ayA
 ayA
 aFi
@@ -182493,7 +182423,7 @@ aod
 gmv
 uwx
 kuT
-gJF
+cYH
 cVT
 aGQ
 qCt
@@ -182730,7 +182660,7 @@ jJo
 nZR
 jmg
 jJo
-esM
+tJC
 fxf
 uIa
 jkZ
@@ -182741,7 +182671,7 @@ axR
 aux
 lds
 avY
-suW
+gaD
 aux
 axR
 aDX
@@ -182824,7 +182754,7 @@ xIh
 dFA
 tJd
 hKU
-gHZ
+xEa
 hOe
 jTv
 xwN
@@ -182998,7 +182928,7 @@ axR
 aux
 rWR
 rWR
-pnc
+aBe
 aux
 axR
 avY
@@ -183007,7 +182937,7 @@ aod
 gmv
 uwx
 tCx
-cQL
+tkL
 cVT
 vgd
 mEE
@@ -183017,7 +182947,7 @@ uNO
 xjn
 sby
 dzG
-eXy
+vQX
 xjn
 aIi
 tei
@@ -183506,7 +183436,7 @@ fxf
 uIa
 wfb
 aod
-uZE
+mQS
 iDO
 axR
 axR
@@ -183515,11 +183445,11 @@ mcB
 axR
 axR
 axR
-toN
+mSE
 eoj
 aod
 aSP
-cBD
+pjY
 tCx
 qze
 aae
@@ -183756,7 +183686,7 @@ aae
 oYl
 jDb
 vhP
-nmr
+src
 oKN
 wld
 gAS
@@ -183852,7 +183782,7 @@ tiC
 dtL
 myx
 ciO
-fch
+tdH
 xKb
 myx
 gsu
@@ -184025,7 +183955,7 @@ bTr
 lUm
 fQJ
 fQJ
-vDl
+tHN
 xGB
 eSn
 aTm
@@ -184268,7 +184198,7 @@ aae
 aae
 aae
 oYl
-sWi
+huk
 ary
 rhN
 cNT
@@ -184791,9 +184721,9 @@ exL
 aqA
 aqR
 uEX
-vwS
+aqU
 qHU
-rnN
+jsj
 gBY
 rzP
 cTX
@@ -184801,7 +184731,7 @@ jOk
 gBY
 pYX
 qHU
-rnN
+jsj
 gBY
 gBY
 aae
@@ -185559,8 +185489,8 @@ aYr
 aBM
 uEX
 xAj
-dKZ
-xqX
+sEo
+gea
 gIh
 wBO
 eHH
@@ -185570,10 +185500,10 @@ ujA
 aXR
 arf
 eHH
-tcI
+cZO
 eHH
 jbm
-rst
+sBJ
 gBY
 aae
 aae
@@ -185816,16 +185746,16 @@ aYr
 aYr
 uEX
 mUX
-duB
-ivU
+cQG
+iAF
 oNe
 nXw
 eHH
 eHH
 nQb
-xBS
+bsM
 loN
-wzp
+arg
 eHH
 eHH
 eHH
@@ -186076,10 +186006,10 @@ kkE
 aDt
 ajL
 wAx
-iap
-gPM
-thg
-vOb
+cdB
+xPl
+cEi
+cMH
 taS
 loN
 arh
@@ -186337,7 +186267,7 @@ gBY
 gBY
 aEN
 nQb
-xBS
+bsM
 loN
 ffk
 eHH
@@ -186853,7 +186783,7 @@ uOC
 hux
 ujA
 qlJ
-rrt
+tqs
 eHH
 qnL
 eHH
@@ -187115,7 +187045,7 @@ eHH
 eHH
 eHH
 jbm
-jjR
+xWQ
 gBY
 aae
 aae
@@ -187367,7 +187297,7 @@ mZd
 wmH
 vSz
 wmH
-jga
+fOZ
 wmH
 uiK
 wmH


### PR DESCRIPTION
i PRed this because a fortune cookie told me to

## About The Pull Request

This PR updates TramStation atmospherics to be more of its own unique layout, which prevents many issues the map had.

![https://i.imgur.com/W2AnlCA.png](https://i.imgur.com/W2AnlCA.png)

## Why It's Good For The Game

Half of tram atmos's pipes were inside the walls, alongside other questionable design decisions. Pipes under walls and windows are should be avoided as much as possible for important piping.

## Changelog
:cl:
qol: TramStation's atmospherics pipes are no longer mostly in walls. In addition, the incinerator pipe no longer goes in maintenance.
/:cl: