### PR TITLE
Cleans up bullets to use subtypes for ammo variations

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/lmg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/lmg.dm
@@ -10,12 +10,12 @@
 /obj/item/ammo_casing/mm712x82/ap
 	name = "7.12x82mm armor-piercing bullet casing"
 	desc = "A 7.12x82mm bullet casing designed with a hardened-tipped core to help penetrate armored targets."
-	projectile_type = /obj/projectile/bullet/mm712x82_ap
+	projectile_type = /obj/projectile/bullet/mm712x82/ap
 
 /obj/item/ammo_casing/mm712x82/hollow
 	name = "7.12x82mm hollow-point bullet casing"
 	desc = "A 7.12x82mm bullet casing designed to cause more damage to unarmored targets."
-	projectile_type = /obj/projectile/bullet/mm712x82_hp
+	projectile_type = /obj/projectile/bullet/mm712x82/hp
 
 /obj/item/ammo_casing/mm712x82/incen
 	name = "7.12x82mm incendiary bullet casing"
@@ -25,9 +25,9 @@
 /obj/item/ammo_casing/mm712x82/match
 	name = "7.12x82mm match bullet casing"
 	desc = "A 7.12x82mm bullet casing manufactured to unfailingly high standards, you could pull off some cool trickshots with this."
-	projectile_type = /obj/projectile/bullet/mm712x82_match
+	projectile_type = /obj/projectile/bullet/mm712x82/match
 
 /obj/item/ammo_casing/mm712x82/bouncy
 	name = "7.12x82mm rubber bullet casing"
 	desc = "A 7.12x82mm rubber bullet casing manufactured to unfailingly disastrous standards, you could piss off a lot of people spraying this down a hallway."
-	projectile_type = /obj/projectile/bullet/mm712x82_bouncy
+	projectile_type = /obj/projectile/bullet/mm712x82/bouncy

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -9,12 +9,12 @@
 /obj/item/ammo_casing/c10mm/ap
 	name = "10mm armor-piercing bullet casing"
 	desc = "A 10mm armor-piercing bullet casing."
-	projectile_type = /obj/projectile/bullet/c10mm_ap
+	projectile_type = /obj/projectile/bullet/c10mm/ap
 
 /obj/item/ammo_casing/c10mm/hp
 	name = "10mm hollow-point bullet casing"
 	desc = "A 10mm hollow-point bullet casing."
-	projectile_type = /obj/projectile/bullet/c10mm_hp
+	projectile_type = /obj/projectile/bullet/c10mm/hp
 
 /obj/item/ammo_casing/c10mm/fire
 	name = "10mm incendiary bullet casing"
@@ -32,12 +32,12 @@
 /obj/item/ammo_casing/c9mm/ap
 	name = "9mm armor-piercing bullet casing"
 	desc = "A 9mm armor-piercing bullet casing."
-	projectile_type =/obj/projectile/bullet/c9mm_ap
+	projectile_type =/obj/projectile/bullet/c9mm/ap
 
 /obj/item/ammo_casing/c9mm/hp
 	name = "9mm hollow-point bullet casing"
-	desc = "A 10mm hollow-point bullet casing."
-	projectile_type = /obj/projectile/bullet/c9mm_hp
+	desc = "A 9mm hollow-point bullet casing."
+	projectile_type = /obj/projectile/bullet/c9mm/hp
 
 /obj/item/ammo_casing/c9mm/fire
 	name = "9mm incendiary bullet casing"

--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -8,7 +8,7 @@
 	projectile_type = /obj/projectile/bullet/a762
 
 /obj/item/ammo_casing/a762/enchanted
-	projectile_type = /obj/projectile/bullet/a762_enchanted
+	projectile_type = /obj/projectile/bullet/a762/enchanted
 
 // 5.56mm (M-90gl Carbine)
 

--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -9,7 +9,7 @@
 /obj/item/ammo_casing/c46x30mm/ap
 	name = "4.6x30mm armor-piercing bullet casing"
 	desc = "A 4.6x30mm armor-piercing bullet casing."
-	projectile_type = /obj/projectile/bullet/c46x30mm_ap
+	projectile_type = /obj/projectile/bullet/c46x30mm/ap
 
 /obj/item/ammo_casing/c46x30mm/inc
 	name = "4.6x30mm incendiary bullet casing"
@@ -27,7 +27,7 @@
 /obj/item/ammo_casing/c45/ap
 	name = ".45 armor-piercing bullet casing"
 	desc = "A .45 bullet casing."
-	projectile_type = /obj/projectile/bullet/c45_ap
+	projectile_type = /obj/projectile/bullet/c45/ap
 
 /obj/item/ammo_casing/c45/inc
 	name = ".45 incendiary bullet casing"

--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -32,7 +32,6 @@
 
 /obj/projectile/bullet/mm712x82/ap
 	name = "7.12x82mm armor-piercing bullet"
-	damage = 40
 	armour_penetration = 75
 
 /obj/projectile/bullet/mm712x82/hp
@@ -51,12 +50,10 @@
 
 /obj/projectile/bullet/mm712x82/match
 	name = "7.12x82mm match bullet"
-	damage = 40
 	ricochets_max = 2
 	ricochet_chance = 60
 	ricochet_auto_aim_range = 4
 	ricochet_incidence_leeway = 55
-	wound_bonus = -50
 
 /obj/projectile/bullet/mm712x82/bouncy
 	name = "7.12x82mm rubber bullet"

--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -30,12 +30,12 @@
 	wound_bonus = -50
 	wound_falloff_tile = 0
 
-/obj/projectile/bullet/mm712x82_ap
+/obj/projectile/bullet/mm712x82/ap
 	name = "7.12x82mm armor-piercing bullet"
 	damage = 40
 	armour_penetration = 75
 
-/obj/projectile/bullet/mm712x82_hp
+/obj/projectile/bullet/mm712x82/hp
 	name = "7.12x82mm hollow-point bullet"
 	damage = 50
 	armour_penetration = -60
@@ -49,7 +49,7 @@
 	damage = 20
 	fire_stacks = 3
 
-/obj/projectile/bullet/mm712x82_match
+/obj/projectile/bullet/mm712x82/match
 	name = "7.12x82mm match bullet"
 	damage = 40
 	ricochets_max = 2
@@ -58,7 +58,7 @@
 	ricochet_incidence_leeway = 55
 	wound_bonus = -50
 
-/obj/projectile/bullet/mm712x82_bouncy
+/obj/projectile/bullet/mm712x82/bouncy
 	name = "7.12x82mm rubber bullet"
 	damage = 25
 	ricochets_max = 40

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -5,14 +5,14 @@
 	damage = 30
 	embedding = list(embed_chance=15, fall_chance=3, jostle_chance=4, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=10)
 
-/obj/projectile/bullet/c9mm_ap
+/obj/projectile/bullet/c9mm/ap
 	name = "9mm armor-piercing bullet"
 	damage = 27
 	armour_penetration = 40
 	embedding = null
 	shrapnel_type = null
 
-/obj/projectile/bullet/c9mm_hp
+/obj/projectile/bullet/c9mm/hp
 	name = "9mm hollow-point bullet"
 	damage = 40
 	armour_penetration = -50
@@ -28,12 +28,12 @@
 	name = "10mm bullet"
 	damage = 40
 
-/obj/projectile/bullet/c10mm_ap
+/obj/projectile/bullet/c10mm/ap
 	name = "10mm armor-piercing bullet"
 	damage = 37
 	armour_penetration = 40
 
-/obj/projectile/bullet/c10mm_hp
+/obj/projectile/bullet/c10mm/hp
 	name = "10mm hollow-point bullet"
 	damage = 60
 	armour_penetration = -50

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -22,7 +22,7 @@
 	wound_bonus = -45
 	wound_falloff_tile = 0
 
-/obj/projectile/bullet/a762_enchanted
+/obj/projectile/bullet/a762/enchanted
 	name = "enchanted 7.62 bullet"
 	damage = 20
 	stamina = 80

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -8,7 +8,6 @@
 
 /obj/projectile/bullet/c45/ap
 	name = ".45 armor-piercing bullet"
-	damage = 30
 	armour_penetration = 50
 
 /obj/projectile/bullet/incendiary/c45

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -6,7 +6,7 @@
 	wound_bonus = -10
 	wound_falloff_tile = -10
 
-/obj/projectile/bullet/c45_ap
+/obj/projectile/bullet/c45/ap
 	name = ".45 armor-piercing bullet"
 	damage = 30
 	armour_penetration = 50
@@ -25,7 +25,7 @@
 	bare_wound_bonus = 5
 	embed_falloff_tile = -4
 
-/obj/projectile/bullet/c46x30mm_ap
+/obj/projectile/bullet/c46x30mm/ap
 	name = "4.6x30mm armor-piercing bullet"
 	damage = 15
 	armour_penetration = 40


### PR DESCRIPTION
#57517

## About The Pull Request
We have a bunch of bullets across the code that are **pewpew**mm_ap and **powpow**mm/ap
This switches it to the latter for consistency.
Be warned, this does mean that, for example, the nukie LMG will inherit new stats for their bullet subtypes:
```
/obj/projectile/bullet/mm712x82/ap
	name = "7.12x82mm armor-piercing bullet"
	damage = 40
	armour_penetration = 75
```
This will now inherit these stats from its parent:
```
	wound_bonus = -50
	wound_falloff_tile = 0
```
The stats previously for the AP version of the bullet, as defined by projectile/bullet, were:
```
	wound_bonus = -100
	wound_falloff_tile = -5
```

I'm unsure if bullets affected in this manner were supposed to be doing this or not. If I were to guess, the AP/HP/whatever variants of each bullet should've used the same base stats of the base bullets and modified the stats.

## Why It's Good For The Game
Potential fix..? It's up for interpretation, really. Some of those bullets are inheriting stats from projectile/bullet, and I'm not sure if they should be or if they should be inheriting stats from the version of the bullet they are.
Also, consistency across code. Bullet casings are subtypes, some bullets are subtypes, may as well make more bullets into subtypes.

## also this
![image](https://user-images.githubusercontent.com/53862927/111854686-631d0a00-8918-11eb-8e4b-a6f935870591.png)
