### PR TITLE
Immovable Rod code cleanup, signal listening and improvement.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -119,6 +119,8 @@
 #define COMSIG_ATOM_UPDATED_ICON "atom_updated_icon"
 ///from base of atom/Entered(): (atom/movable/entering, /atom)
 #define COMSIG_ATOM_ENTERED "atom_entered"
+/// Sent from the atom that just Entered src. From base of atom/Entered(): (/atom/entered_atom, /atom/oldLoc)
+#define COMSIG_ATOM_ENTERING "atom_entering"
 ///from base of atom/Exit(): (/atom/movable/exiting, /atom/newloc)
 #define COMSIG_ATOM_EXIT "atom_exit"
 	#define COMPONENT_ATOM_BLOCK_EXIT (1<<0)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1276,6 +1276,7 @@
  */
 /atom/Entered(atom/movable/AM, atom/oldLoc)
 	SEND_SIGNAL(src, COMSIG_ATOM_ENTERED, AM, oldLoc)
+	SEND_SIGNAL(AM, COMSIG_ATOM_ENTERING, src, oldLoc)
 
 /**
  * An atom is attempting to exit this atom's contents

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -89,6 +89,16 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 
 	walk_towards(src, destination, 1)
 
+	RegisterSignal(src, COMSIG_MOVABLE_CROSSED_OVER, .proc/on_crossed_over_movable)
+	RegisterSignal(src, COMSIG_ATOM_ENTERING, .proc/on_entering_atom)
+
+/obj/effect/immovablerod/Destroy(force)
+	UnregisterSignal(src, COMSIG_MOVABLE_CROSSED_OVER, COMSIG_ATOM_ENTERING)
+	RemoveElement(/datum/element/point_of_interest)
+	SSaugury.unregister_doom(src)
+
+	return ..()
+
 /obj/effect/immovablerod/examine(mob/user)
 	. = ..()
 	if(!isobserver(user))
@@ -109,20 +119,17 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		if(istype(ghost))
 			ghost.ManualFollow(src)
 
+/obj/effect/immovablerod/proc/on_crossed_over_movable(datum/source, atom/movable/atom_crossed_over)
+	SIGNAL_HANDLER
+	if((atom_crossed_over.density || isliving(atom_crossed_over)) && !QDELETED(atom_crossed_over))
+		Bump(atom_crossed_over)
+
+/obj/effect/immovablerod/proc/on_entering_atom(datum/source, atom/atom_entered)
+	SIGNAL_HANDLER
+	if(atom_entered.density && isturf(atom_entered))
+		Bump(atom_entered)
+
 /obj/effect/immovablerod/Moved()
-	// If our loc is dense, noogie it.
-	if(loc.density)
-		Bump(loc)
-
-	// So, we're phasing and will harmlessly glide through things. Let's noogie everything in our loc's contents.
-	for(var/clong in loc.contents)
-		if(clong == src)
-			continue
-
-		var/atom/clong_atom = clong
-		if(clong_atom.density || isliving(clong_atom) && !QDELETED(clong_atom))
-			Bump(clong_atom)
-
 	// If we have a special target, we should definitely make an effort to go find them.
 	if(special_target)
 		var/turf/target_turf = get_turf(special_target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Following on from the recently merged #57378 I've discovered the almighty power of "deductive reasoning". If Atom X has been crossed over by Atom Y, then Atom Y has crossed over Atom X.

This has officially elevated my thinking capacity to that of a young infant.

Leveraging the same deductive reasoning, we can tell when an Immovable Rod has entered a turf as well as tell when an Immovable Rod has crossed over an atom without having to loop the loc's contents on Moved(). Signals get sent. The world is a happier place.
 
I also took the time to unregister the rod from SSaugury and remove the POI element on its destruction. I genuinely don't know if I need to do this, but it seems like a good idea to avoid hard dels.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More consistent rod behaviour, better code, uses signals which is neat I suppose.

No CL as no gameplay-facing changes.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
