### PR TITLE
partially reverts reaction chamber

### DIFF
--- a/code/datums/components/plumbing/reaction_chamber.dm
+++ b/code/datums/components/plumbing/reaction_chamber.dm
@@ -9,34 +9,34 @@
 
 /datum/component/plumbing/reaction_chamber/can_give(amount, reagent, datum/ductnet/net)
 	. = ..()
-	var/obj/machinery/plumbing/reaction_chamber/RC = parent
-	if(!. || !RC.emptying || reagents.is_reacting == TRUE)
+	var/obj/machinery/plumbing/reaction_chamber/reaction_chamber = parent
+	if(!. || !reaction_chamber.emptying || reagents.is_reacting == TRUE)
 		return FALSE
 
 /datum/component/plumbing/reaction_chamber/send_request(dir)
-	var/obj/machinery/plumbing/reaction_chamber/RC = parent
-	if(RC.emptying)
+	var/obj/machinery/plumbing/reaction_chamber/chamber = parent
+	if(chamber.emptying)
 		return
 
-	for(var/RT in RC.required_reagents)
+	for(var/required_reagent in chamber.required_reagents)
 		var/has_reagent = FALSE
-		for(var/A in reagents.reagent_list)
-			var/datum/reagent/RD = A
-			if(RT == RD.type)
+		for(var/containing_reagent_but_not_typecasted_yet in reagents.reagent_list)
+			var/datum/reagent/containg_reagent = containing_reagent_but_not_typecasted_yet as anything
+			if(required_reagent == containg_reagent.type)
 				has_reagent = TRUE
-				if(RD.volume < RC.required_reagents[RT])
-					process_request(min(RC.required_reagents[RT] - RD.volume, MACHINE_REAGENT_TRANSFER) , RT, dir)
+				if(containg_reagent.volume < chamber.required_reagents[required_reagent])
+					process_request(min(chamber.required_reagents[required_reagent] - containg_reagent.volume, MACHINE_REAGENT_TRANSFER) , required_reagent, dir)
 					return
 		if(!has_reagent)
-			process_request(min(RC.required_reagents[RT], MACHINE_REAGENT_TRANSFER), RT, dir)
+			process_request(min(chamber.required_reagents[required_reagent], MACHINE_REAGENT_TRANSFER), required_reagent, dir)
 			return
 
 	reagents.flags &= ~NO_REACT
 	reagents.handle_reactions()
 
-	RC.emptying = TRUE //If we move this up, it'll instantly get turned off since any reaction always sets the reagent_total to zero. Other option is make the reaction update
+	chamber.emptying = TRUE //If we move this up, it'll instantly get turned off since any reaction always sets the reagent_total to zero. Other option is make the reaction update
 	//everything for every chemical removed, wich isn't a good option either.
-	RC.on_reagent_change(reagents) //We need to check it now, because some reactions leave nothing left.
+	chamber.on_reagent_change(reagents) //We need to check it now, because some reactions leave nothing left.
 
 ///Special connect that we currently use for reaction chambers. Being used so we can keep certain inputs seperate, like into a special internal acid container
 /datum/component/plumbing/acidic_input

--- a/code/datums/components/plumbing/reaction_chamber.dm
+++ b/code/datums/components/plumbing/reaction_chamber.dm
@@ -20,8 +20,7 @@
 
 	for(var/required_reagent in chamber.required_reagents)
 		var/has_reagent = FALSE
-		for(var/containing_reagent_but_not_typecasted_yet in reagents.reagent_list)
-			var/datum/reagent/containg_reagent = containing_reagent_but_not_typecasted_yet as anything
+		for(var/datum/reagent/containg_reagent as anything in reagents.reagent_list)
 			if(required_reagent == containg_reagent.type)
 				has_reagent = TRUE
 				if(containg_reagent.volume < chamber.required_reagents[required_reagent])

--- a/code/datums/components/plumbing/reaction_chamber.dm
+++ b/code/datums/components/plumbing/reaction_chamber.dm
@@ -18,10 +18,18 @@
 	if(RC.emptying)
 		return
 
-	process_request(amount = min(MACHINE_REAGENT_TRANSFER, RC.target_volume - reagents.total_volume), dir = dir)
-
-	if(RC.target_volume > round(reagents.total_volume, CHEMICAL_VOLUME_ROUNDING)) //not enough yet
-		return
+	for(var/RT in RC.required_reagents)
+		var/has_reagent = FALSE
+		for(var/A in reagents.reagent_list)
+			var/datum/reagent/RD = A
+			if(RT == RD.type)
+				has_reagent = TRUE
+				if(RD.volume < RC.required_reagents[RT])
+					process_request(min(RC.required_reagents[RT] - RD.volume, MACHINE_REAGENT_TRANSFER) , RT, dir)
+					return
+		if(!has_reagent)
+			process_request(min(RC.required_reagents[RT], MACHINE_REAGENT_TRANSFER), RT, dir)
+			return
 
 	reagents.flags &= ~NO_REACT
 	reagents.handle_reactions()

--- a/code/modules/plumbing/plumbers/reaction_chamber.dm
+++ b/code/modules/plumbing/plumbers/reaction_chamber.dm
@@ -84,8 +84,7 @@
 	var/list/data = list()
 
 	var/list/text_reagents = list()
-	for(var/required_reagent_but_not_typecasted_yet in required_reagents) //make a list where the key is text, because that looks alot better in the ui than a typepath
-		var/datum/reagent/required_reagent = required_reagent_but_not_typecasted_yet as anything
+	for(var/datum/reagent/required_reagent as anything in required_reagents) //make a list where the key is text, because that looks alot better in the ui than a typepath
 		text_reagents[initial(required_reagent.name)] = required_reagents[required_reagent]
 
 	data["reagents"] = text_reagents

--- a/code/modules/plumbing/plumbers/reaction_chamber.dm
+++ b/code/modules/plumbing/plumbers/reaction_chamber.dm
@@ -6,7 +6,8 @@
 	buffer = 200
 	reagent_flags = TRANSPARENT | NO_REACT
 
-	/**list of set reagents that the reaction_chamber allows in, and must all be present before mixing is enabled.
+	/**
+	* list of set reagents that the reaction_chamber allows in, and must all be present before mixing is enabled.
 	* example: list(/datum/reagent/water = 20, /datum/reagent/fuel/oil = 50)
 	*/
 	var/list/required_reagents = list()
@@ -83,9 +84,9 @@
 	var/list/data = list()
 
 	var/list/text_reagents = list()
-	for(var/A in required_reagents) //make a list where the key is text, because that looks alot better in the ui than a typepath
-		var/datum/reagent/R = A
-		text_reagents[initial(R.name)] = required_reagents[R]
+	for(var/required_reagent_but_not_typecasted_yet in required_reagents) //make a list where the key is text, because that looks alot better in the ui than a typepath
+		var/datum/reagent/required_reagent = required_reagent_but_not_typecasted_yet as anything
+		text_reagents[initial(required_reagent.name)] = required_reagents[required_reagent]
 
 	data["reagents"] = text_reagents
 	data["emptying"] = emptying

--- a/code/modules/plumbing/plumbers/reaction_chamber.dm
+++ b/code/modules/plumbing/plumbers/reaction_chamber.dm
@@ -6,8 +6,10 @@
 	buffer = 200
 	reagent_flags = TRANSPARENT | NO_REACT
 
-	///At what volume do we start reacting?
-	var/target_volume = 200
+	/**list of set reagents that the reaction_chamber allows in, and must all be present before mixing is enabled.
+	* example: list(/datum/reagent/water = 20, /datum/reagent/fuel/oil = 50)
+	*/
+	var/list/required_reagents = list()
 	///If above this pH, we start dumping buffer into it
 	var/acidic_limit = 9
 	///If below this pH, we start dumping buffer into it
@@ -80,12 +82,17 @@
 /obj/machinery/plumbing/reaction_chamber/ui_data(mob/user)
 	var/list/data = list()
 
+	var/list/text_reagents = list()
+	for(var/A in required_reagents) //make a list where the key is text, because that looks alot better in the ui than a typepath
+		var/datum/reagent/R = A
+		text_reagents[initial(R.name)] = required_reagents[R]
+
+	data["reagents"] = text_reagents
 	data["emptying"] = emptying
 	data["temperature"] = round(reagents.chem_temp, 0.1)
 	data["ph"] = round(reagents.ph, 0.01)
 	data["targetTemp"] = target_temperature
 	data["isReacting"] = reagents.is_reacting
-	data["reagentQuantity"] = target_volume
 	data["reagentAcidic"] = acidic_limit
 	data["reagentAlkaline"] = alkaline_limit
 	return data
@@ -96,6 +103,16 @@
 		return
 	. = TRUE
 	switch(action)
+		if("remove")
+			var/reagent = get_chem_id(params["chem"])
+			if(reagent)
+				required_reagents.Remove(reagent)
+		if("add")
+			var/input_reagent = get_chem_id(params["chem"])
+			if(input_reagent && !required_reagents.Find(input_reagent))
+				var/input_amount = text2num(params["amount"])
+				if(input_amount)
+					required_reagents[input_reagent] = input_amount
 		if("temperature")
 			var/target = params["target"]
 			if(text2num(target) != null)
@@ -103,8 +120,6 @@
 				. = TRUE
 			if(.)
 				target_temperature = clamp(target, 0, 1000)
-		if("volume")
-			target_volume = round(text2num(params["target"]))
 		if("acidic")
 			acidic_limit = round(text2num(params["target"]))
 		if("alkaline")

--- a/tgui/packages/tgui/interfaces/ChemReactionChamber.js
+++ b/tgui/packages/tgui/interfaces/ChemReactionChamber.js
@@ -8,19 +8,28 @@ import { round, toFixed } from 'common/math';
 export const ChemReactionChamber = (props, context) => {
   const { act, data } = useBackend(context);
 
+  const [
+    reagentName,
+    setReagentName,
+  ] = useLocalState(context, 'reagentName', '');
+  const [
+    reagentQuantity,
+    setReagentQuantity,
+  ] = useLocalState(context, 'reagentQuantity', 1);
+
   const {
     emptying,
     temperature,
     ph,
     targetTemp,
     isReacting,
-    reagentQuantity,
     reagentAcidic,
     reagentAlkaline,
   } = data;
+  const reagents = data.reagents || [];
   return (
     <Window
-      width={250}
+      width={290}
       height={280}>
       <Window.Content scrollable>
         <Section
@@ -106,28 +115,6 @@ export const ChemReactionChamber = (props, context) => {
           )}>
           <LabeledList>
             <tr className="LabledList__row">
-              <LabeledList.Item label="Reaction Volume">
-                <td
-                  className={classes([
-                    "LabeledList__buttons",
-                    "LabeledList__cell",
-                  ])}>
-                  <NumberInput
-                    value={reagentQuantity}
-                    minValue={1}
-                    maxValue={200}
-                    step={1}
-                    stepPixelSize={3}
-                    width="39px"
-                    onDrag={(e, value) => act('volume', {
-                      target: value,
-                    })} />
-
-                  <Box inline mr={1} />
-                </td>
-              </LabeledList.Item>
-            </tr>
-            <tr className="LabledList__row">
               <LabeledList.Item label="Acidic pH limit">
                 <td
                   className={classes([
@@ -169,6 +156,53 @@ export const ChemReactionChamber = (props, context) => {
                 </td>
               </LabeledList.Item>
             </tr>
+            <tr className="LabledList__row">
+              <td
+                  colSpan="2"
+                  className="LabeledList__cell">
+                  <Input
+                    fluid
+                    value=""
+                    placeholder="Reagent Name"
+                    onInput={(e, value) => setReagentName(value)} />
+                </td>
+                <td
+                  className={classes([
+                    "LabeledList__buttons",
+                    "LabeledList__cell",
+                  ])}>
+                  <NumberInput
+                    value={reagentQuantity}
+                    minValue={1}
+                    maxValue={100}
+                    step={1}
+                    stepPixelSize={3}
+                    width="39px"
+                    onDrag={(e, value) => setReagentQuantity(value)} />
+                  <Box inline mr={1} />
+                  <Button
+                    icon="plus"
+                    onClick={() => act('add', {
+                      chem: reagentName,
+                      amount: reagentQuantity,
+                    })} />
+                </td>
+              </tr>
+              {map((amount, reagent) => (
+              <LabeledList.Item
+                key={reagent}
+                label={reagent}
+                buttons={(
+                  <Button
+                    icon="minus"
+                    color="bad"
+                    onClick={() => act('remove', {
+                      chem: reagent,
+                    })} />
+                )}>
+                {amount}
+              </LabeledList.Item>
+            ))(reagents)}
           </LabeledList>
         </Section>
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/ChemReactionChamber.js
+++ b/tgui/packages/tgui/interfaces/ChemReactionChamber.js
@@ -188,11 +188,11 @@ export const ChemReactionChamber = (props, context) => {
                   })} />
               </td>
             </tr>
-            {map((amount, reagent) => (
-            <LabeledList.Item
-                key={reagent}
-                label={reagent}
-                buttons={(
+          {map((amount, reagent) => (
+          <LabeledList.Item
+              key={reagent}
+              label={reagent}
+              buttons={(
                   <Button
                     icon="minus"
                     color="bad"
@@ -200,8 +200,8 @@ export const ChemReactionChamber = (props, context) => {
                       chem: reagent,
                     })} />
                 )}>
-                {amount}
-              </LabeledList.Item>
+              {amount}
+            </LabeledList.Item>
             ))(reagents)}
           </LabeledList>
         </Section>

--- a/tgui/packages/tgui/interfaces/ChemReactionChamber.js
+++ b/tgui/packages/tgui/interfaces/ChemReactionChamber.js
@@ -188,7 +188,7 @@ export const ChemReactionChamber = (props, context) => {
                   })} />
               </td>
             </tr>
-          {map((amount, reagent) => (
+            {map((amount, reagent) => (
           <LabeledList.Item
               key={reagent}
               label={reagent}

--- a/tgui/packages/tgui/interfaces/ChemReactionChamber.js
+++ b/tgui/packages/tgui/interfaces/ChemReactionChamber.js
@@ -158,38 +158,38 @@ export const ChemReactionChamber = (props, context) => {
             </tr>
             <tr className="LabledList__row">
               <td
-                  colSpan="2"
-                  className="LabeledList__cell">
-                  <Input
-                    fluid
-                    value=""
-                    placeholder="Reagent Name"
-                    onInput={(e, value) => setReagentName(value)} />
-                </td>
-                <td
-                  className={classes([
-                    "LabeledList__buttons",
-                    "LabeledList__cell",
-                  ])}>
-                  <NumberInput
-                    value={reagentQuantity}
-                    minValue={1}
-                    maxValue={100}
-                    step={1}
-                    stepPixelSize={3}
-                    width="39px"
-                    onDrag={(e, value) => setReagentQuantity(value)} />
-                  <Box inline mr={1} />
-                  <Button
-                    icon="plus"
-                    onClick={() => act('add', {
-                      chem: reagentName,
-                      amount: reagentQuantity,
-                    })} />
-                </td>
-              </tr>
-              {map((amount, reagent) => (
-              <LabeledList.Item
+                colSpan="2"
+                className="LabeledList__cell">
+                <Input
+                  fluid
+                  value=""
+                  placeholder="Reagent Name"
+                  onInput={(e, value) => setReagentName(value)} />
+              </td>
+              <td
+                className={classes([
+                  "LabeledList__buttons",
+                  "LabeledList__cell",
+                ])}>
+                <NumberInput
+                  value={reagentQuantity}
+                  minValue={1}
+                  maxValue={100}
+                  step={1}
+                  stepPixelSize={3}
+                  width="39px"
+                  onDrag={(e, value) => setReagentQuantity(value)} />
+                <Box inline mr={1} />
+                <Button
+                  icon="plus"
+                  onClick={() => act('add', {
+                    chem: reagentName,
+                    amount: reagentQuantity,
+                  })} />
+              </td>
+            </tr>
+            {map((amount, reagent) => (
+            <LabeledList.Item
                 key={reagent}
                 label={reagent}
                 buttons={(

--- a/tgui/packages/tgui/interfaces/ChemReactionChamber.js
+++ b/tgui/packages/tgui/interfaces/ChemReactionChamber.js
@@ -189,10 +189,10 @@ export const ChemReactionChamber = (props, context) => {
               </td>
             </tr>
             {map((amount, reagent) => (
-          <LabeledList.Item
-              key={reagent}
-              label={reagent}
-              buttons={(
+              <LabeledList.Item
+                key={reagent}
+                label={reagent}
+                buttons={(
                   <Button
                     icon="minus"
                     color="bad"
@@ -200,8 +200,8 @@ export const ChemReactionChamber = (props, context) => {
                       chem: reagent,
                     })} />
                 )}>
-              {amount}
-            </LabeledList.Item>
+                {amount}
+              </LabeledList.Item>
             ))(reagents)}
           </LabeledList>
         </Section>


### PR DESCRIPTION
Partially reverts #57071 

## Changelog
:cl:
balance: Temporarily reverts the changes made to the plumbing reaction chamber untill minichem gets added (never)
/:cl:

Why:
I simply underestimated how big this change would be. You could do everything you normally could, but the space limitations were just absolutely massive. At least until minichem gets added, it's better to leave it a little broken

Yes, I could make some other way to controle reactions that would be less broken and cost less space, but I'm just so fucking tired of dealing with the balance implications of plumbing. I just wanna add stupid shit and pat myself on the back
