### PR TITLE
Speeds up drink reactions bringing them back to near instant.

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -1,13 +1,13 @@
 //////////////////////////////////////// DRINK RECIPE BASE ////////////////////////////////
 
 /datum/chemical_reaction/drink
-	optimal_temp = 200
+	optimal_temp = 250
 	temp_exponent_factor = 1
 	optimal_ph_min = 2
 	optimal_ph_max = 10
 	thermic_constant = 0
 	H_ion_release = 0
-	rate_up_lim = 50
+	rate_up_lim = 60
 	purity_min = 0
 	reaction_tags = REACTION_TAG_DRINK | REACTION_TAG_EASY
 

--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -1,7 +1,7 @@
 //////////////////////////////////////// DRINK RECIPE BASE ////////////////////////////////
 
 /datum/chemical_reaction/drink
-	optimal_temp = 400
+	optimal_temp = 200
 	temp_exponent_factor = 1
 	optimal_ph_min = 2
 	optimal_ph_max = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There was a recent change to the drinks dispense that made the dispensed drinks chilled - but this also slowed down reactions to drinks unintendedly. Someone pointed out that people are having issues with drink mixing being slow - so this should speed them back up again!

## Why It's Good For The Game

Slow drinks isn't intentional. This should make it so 60u is reacted per second in game, so hopefully this will help!

## Changelog
:cl:
qol: restores drink mixing speeds back to what it was (or slightly faster)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
