### PR TITLE
Removes nationality tags from restaurant customer bot names

### DIFF
--- a/code/modules/food_and_drinks/restaurant/customers/_customer.dm
+++ b/code/modules/food_and_drinks/restaurant/customers/_customer.dm
@@ -1,6 +1,4 @@
 /datum/customer_data
-	///Name of the robot's origin
-	var/nationality = "Generic"
 	///The types of food this robot likes in a assoc list of venue type | weighted list. does NOT include subtypes.
 	var/list/orderable_objects = list()
 	///The amount a robot pays for each food he likes in an assoc list type | payment
@@ -63,7 +61,6 @@
 	return
 
 /datum/customer_data/american
-	nationality = "Space-American"
 	orderable_objects = list(
 	/datum/venue/restaurant = list(/obj/item/food/burger/plain = 25, /obj/item/food/burger/cheese = 15, /obj/item/food/burger/superbite = 1, /obj/item/food/fries = 10, /obj/item/food/cheesyfries = 6, /obj/item/food/pie/applepie = 4, /obj/item/food/pie/pumpkinpie = 2, /obj/item/food/hotdog = 8, /obj/item/food/pizza/pineapple = 1, /obj/item/food/burger/baconburger = 10, /obj/item/food/pancakes = 4),
 	/datum/venue/bar = list(/datum/reagent/consumable/ethanol/b52 = 6, /datum/reagent/consumable/ethanol/manhattan = 3, /datum/reagent/consumable/ethanol/atomicbomb = 1, /datum/reagent/consumable/ethanol/beer = 25))
@@ -81,7 +78,6 @@
 
 
 /datum/customer_data/italian
-	nationality = "Space-Italian"
 	prefix_file = "strings/names/italian_prefix.txt"
 	base_icon = "italian"
 	clothing_sets = list("italian_pison", "italian_godfather")
@@ -101,7 +97,6 @@
 
 
 /datum/customer_data/french
-	nationality = "Space-French"
 	prefix_file = "strings/names/french_prefix.txt"
 	base_icon = "french"
 	clothing_sets = list("french_fit")
@@ -128,7 +123,6 @@
 
 
 /datum/customer_data/japanese
-	nationality = "Space-Japanese"
 	prefix_file = "strings/names/japanese_prefix.txt"
 	base_icon = "japanese"
 	clothing_sets = list("japanese_animes")
@@ -172,7 +166,6 @@
 	/datum/venue/bar = list(/datum/reagent/consumable/ethanol/beer = 14, /datum/reagent/consumable/ethanol/sake = 9, /datum/reagent/consumable/cafe_latte = 3, /datum/reagent/consumable/coffee = 3, /datum/reagent/consumable/soy_latte = 3, /datum/reagent/consumable/ethanol/atomicbomb = 1))
 
 /datum/customer_data/moth
-	nationality = "Mothman"
 	prefix_file = "strings/names/moth_prefix.txt"
 	base_icon = "mothbot"
 	found_seat_lines = list("Give me your hat!", "Moth?", "Certainly an... interesting venue.")
@@ -267,7 +260,6 @@
 	return dynamic_order || ..()
 
 /datum/customer_data/mexican
-	nationality = "Space-Mexican"
 	base_icon = "mexican"
 	prefix_file = "strings/names/mexican_prefix.txt"
 	speech_sound = 'sound/creatures/tourist/tourist_talk_mexican.ogg'
@@ -289,7 +281,6 @@
 
 ///MALFUNCTIONING - only shows up once per venue, very rare
 /datum/customer_data/malfunction
-	nationality = "Malfunctioning"
 	base_icon = "defect"
 	prefix_file = "strings/names/malf_prefix.txt"
 	speech_sound = 'sound/effects/clang.ogg'

--- a/code/modules/mob/living/simple_animal/friendly/robot_customer.dm
+++ b/code/modules/mob/living/simple_animal/friendly/robot_customer.dm
@@ -35,7 +35,7 @@
 	ai_controller.blackboard[BB_CUSTOMER_ATTENDING_VENUE] = attending_venue
 	ai_controller.blackboard[BB_CUSTOMER_PATIENCE] = customer_info.total_patience
 	icon_state = customer_info.base_icon
-	name = "[pick(customer_info.name_prefixes)]-bot ([customer_info.nationality])"
+	name = "[pick(customer_info.name_prefixes)]-bot"
 	color = rgb(rand(80,255), rand(80,255), rand(80,255))
 	update_icon()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the "Space-American" and similar tags from customer bot names.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The robots have unique sprites and sounds, and themed names and chat lines. These tags aren't really necessary and pretty much just ruin the joke by telling the punchline.

Also, "Space-\<Earth Country\>" is dumb.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
spellcheck: Restaurant customer bots no longer list imaginary countries in their names
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
