### PR TITLE
Fixes items in toilet cisterns being deleted / null'd on deconstruction

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -84,8 +84,8 @@
 
 /obj/structure/toilet/deconstruct()
 	if(!(flags_1 & NODECONSTRUCT_1))
-		for(var/obj/item as anything in contents)
-			item.forceMove(loc)
+		for(var/obj/toilet_item in contents)
+			toilet_item.forceMove(drop_location())
 		if(buildstacktype)
 			new buildstacktype(loc,buildstackamount)
 		else

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -84,6 +84,8 @@
 
 /obj/structure/toilet/deconstruct()
 	if(!(flags_1 & NODECONSTRUCT_1))
+		for(var/obj/item as anything in contents)
+			item.forceMove(loc)
 		if(buildstacktype)
 			new buildstacktype(loc,buildstackamount)
 		else


### PR DESCRIPTION
## About The Pull Request

Prior, deconstructing a toilet with items inside would just vanish the items. Now, it drops them to the ground.

## Why It's Good For The Game

The toilet realm is a place of mystic and wonder. Mere mortals should not tread there. 
(We shouldn't have stuff be deleted out of thin air.)

## Changelog
:cl: Melbert
fix: Toilets now drop their cistern contents on deconstruction.
/:cl: