### PR TITLE
Adds logging / admin messages to midround syndicate sleeper agent

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -210,6 +210,8 @@
 	living_players -= M
 	var/datum/antagonist/traitor/newTraitor = new
 	M.mind.add_antag_datum(newTraitor)
+	message_admins("[ADMIN_LOOKUPFLW(M)] was selected by the [rule.name] ruleset and was made into a midround traitor.")
+	log_game("DYNAMIC: [key_name(M)] was selected by the [rule.name] ruleset and was made into a midround traitor.")
 	return TRUE
 
 //////////////////////////////////////////////

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -210,8 +210,8 @@
 	living_players -= M
 	var/datum/antagonist/traitor/newTraitor = new
 	M.mind.add_antag_datum(newTraitor)
-	message_admins("[ADMIN_LOOKUPFLW(M)] was selected by the [rule.name] ruleset and was made into a midround traitor.")
-	log_game("DYNAMIC: [key_name(M)] was selected by the [rule.name] ruleset and was made into a midround traitor.")
+	message_admins("[ADMIN_LOOKUPFLW(M)] was selected by the [name] ruleset and has been made into a midround traitor.")
+	log_game("DYNAMIC: [key_name(M)] was selected by the [name] ruleset and has been made into a midround traitor.")
 	return TRUE
 
 //////////////////////////////////////////////


### PR DESCRIPTION
## About The Pull Request

This PR adds a log and an admin message to the syndicate sleeper agent.

## Why It's Good For The Game

All the other midround rulesets make themselves known when they trigger and execute. Even latejoin syndicate infiltrator messages admins when it fires. This makes midround traitors more obvious when they spawn to admins, which is useful.

## Changelog
:cl: Melbert
admin: Midround Syndicate Sleeper Agent is now logged and messages admins when triggered.
/:cl:

