### PR TITLE
Fixes simple bots wrongfully failing to path

### DIFF
--- a/code/__HELPERS/path.dm
+++ b/code/__HELPERS/path.dm
@@ -126,7 +126,12 @@
 	src.simulated_only = simulated_only
 	src.avoid = avoid
 
-/// The proc you use to run the search, returns a list with the steps to the destination if one is available, or nothing if one couldn't be found
+/**
+ * search() is the proc you call to kick off and handle the actual pathfinding, and kills the pathfind datum instance when it's done.
+ *
+ * If a valid path was found, it's returned as a list. If invalid or cross-z-level params are entered, returns FALSE.
+ * If no valid path is found, returns an empty list, which is important for simple bot mobs who rely on an empty list meaning no path found.
+ */
 /datum/pathfind/proc/search()
 	start = get_turf(caller)
 	if(!start || !end)
@@ -135,7 +140,7 @@
 	if(start.z != end.z || start == end ) //no pathfinding between z levels
 		return FALSE
 	if(max_distance && (max_distance < get_dist(start, end))) //if start turf is farther than max_distance from end turf, no need to do anything
-		return FALSE
+		return list()
 
 	//initialization
 	var/datum/jps_node/current_processed_node = new (start, -1, 0, end)

--- a/code/__HELPERS/path.dm
+++ b/code/__HELPERS/path.dm
@@ -163,6 +163,8 @@
 	if(path)
 		for(var/i = 1 to round(0.5 * length(path)))
 			path.Swap(i, length(path) - i + 1)
+	else
+		path = new()
 	sources = null
 	qdel(open)
 	return path


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In #56780 I thought it'd be fine to change the get_path function to return null if there was no path found instead of an empty list, but apparently quite a lot of code in simple bots expects empty lists and freaks out if path is just null, causing simple bots to occasionally fail to respond to summoning even if a path is clearly found and briefly assigned

This undoes that
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Takes Inspector Johnson earpods out so he has to listen to you again
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Simple bots should no longer randomly fail to respond to summons even when a path is available
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
