### PR TITLE
Sec officers now only get PDA'd if the new member is of the same department

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -133,7 +133,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	var/list/partners = list()
 	for (var/officer_ref in distribution)
 		var/mob/partner = locate(officer_ref)
-		if (!istype(partner))
+		if (!istype(partner) || distribution[officer_ref] != department)
 			continue
 		partners += partner.real_name
 
@@ -141,6 +141,9 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 		for (var/obj/item/pda/pda as anything in GLOB.PDAs)
 			if (pda.owner in partners)
 				targets += "[pda.owner] ([pda.ownjob])"
+
+	if (!targets.len)
+		continue
 
 	var/datum/signal/subspace/messaging/pda/signal = new(announcement_system, list(
 		"name" = "Security Department Update",

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -143,7 +143,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 				targets += "[pda.owner] ([pda.ownjob])"
 
 	if (!targets.len)
-		continue
+		return
 
 	var/datum/signal/subspace/messaging/pda/signal = new(announcement_system, list(
 		"name" = "Security Department Update",


### PR DESCRIPTION
Fixes #57869.

## Changelog
:cl:
fix: Security officers now only get PDA'd if the new member is of the same department.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
