### PR TITLE
Autodocs the slippery component + changes the hardcoded slot whitelist to a variable

### DIFF
--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -1,17 +1,27 @@
+/// Slippery component, for making anything slippery. Of course.
 /datum/component/slippery
+	/// If the slip forces you to drop held items.
 	var/force_drop_items = FALSE
+	/// How long the slip keeps you knocked down.
 	var/knockdown_time = 0
+	/// How long the slip paralyzes for.
 	var/paralyze_time = 0
+	/// Flags for how slippery the parent is.
 	var/lube_flags
+	/// A proc callback to call on slip.
 	var/datum/callback/callback
+	/// If parent is an item, this is the person currently holding/wearing the parent (or the parent if no one is holding it)
 	var/mob/living/holder
+	/// Whitelist of item slots the parent can be equipped in that make the holder slippery. If null or empty, it will always make the holder slippery.
+	var/list/slot_whitelist
 
-/datum/component/slippery/Initialize(_knockdown, _lube_flags = NONE, datum/callback/_callback, _paralyze, _force_drop = FALSE)
+/datum/component/slippery/Initialize(_knockdown, _lube_flags = NONE, datum/callback/_callback, _paralyze, _force_drop = FALSE, _slot_whitelist)
 	knockdown_time = max(_knockdown, 0)
 	paralyze_time = max(_paralyze, 0)
 	force_drop_items = _force_drop
 	lube_flags = _lube_flags
 	callback = _callback
+	slot_whitelist = _slot_whitelist
 	RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/Slip)
 	if(isitem(parent))
 		holder = parent
@@ -31,7 +41,7 @@
 /datum/component/slippery/proc/on_equip(datum/source, mob/equipper, slot)
 	SIGNAL_HANDLER
 
-	if((slot in list(ITEM_SLOT_ID, ITEM_SLOT_BELT)) && isliving(equipper))
+	if((!LAZYLEN(slot_whitelist) || (slot in slot_whitelist)) && isliving(equipper))
 		holder = equipper
 		RegisterSignal(holder, COMSIG_MOVABLE_CROSSED, .proc/Slip_on_wearer)
 		RegisterSignal(holder, COMSIG_PARENT_PREQDELETED, .proc/holder_deleted)

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -6,7 +6,7 @@
 	var/knockdown_time = 0
 	/// How long the slip paralyzes for.
 	var/paralyze_time = 0
-	/// Flags for how slippery the parent is.
+	/// Flags for how slippery the parent is. See [__DEFINES/mobs.dm]
 	var/lube_flags
 	/// A proc callback to call on slip.
 	var/datum/callback/callback
@@ -15,13 +15,13 @@
 	/// Whitelist of item slots the parent can be equipped in that make the holder slippery. If null or empty, it will always make the holder slippery.
 	var/list/slot_whitelist
 
-/datum/component/slippery/Initialize(_knockdown, _lube_flags = NONE, datum/callback/_callback, _paralyze, _force_drop = FALSE, _slot_whitelist)
-	knockdown_time = max(_knockdown, 0)
-	paralyze_time = max(_paralyze, 0)
-	force_drop_items = _force_drop
-	lube_flags = _lube_flags
-	callback = _callback
-	slot_whitelist = _slot_whitelist
+/datum/component/slippery/Initialize(knockdown, lube_flags = NONE, datum/callback/callback, paralyze, force_drop = FALSE, slot_whitelist)
+	src.knockdown_time = max(knockdown, 0)
+	src.paralyze_time = max(paralyze, 0)
+	src.force_drop_items = force_drop
+	src.lube_flags = lube_flags
+	src.callback = callback
+	src.slot_whitelist = slot_whitelist
 	RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/Slip)
 	if(isitem(parent))
 		holder = parent

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -9,7 +9,7 @@
 
 /obj/item/pda/clown/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/slippery/clowning, 120, NO_SLIP_WHEN_WALKING, CALLBACK(src, .proc/AfterSlip), _slot_whitelist = list(ITEM_SLOT_ID, ITEM_SLOT_BELT))
+	AddComponent(/datum/component/slippery/clowning, 120, NO_SLIP_WHEN_WALKING, CALLBACK(src, .proc/AfterSlip), slot_whitelist = list(ITEM_SLOT_ID, ITEM_SLOT_BELT))
 	AddComponent(/datum/component/wearertargeting/sitcomlaughter, CALLBACK(src, .proc/after_sitcom_laugh))
 
 /obj/item/pda/clown/proc/AfterSlip(mob/living/carbon/human/M)

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -9,7 +9,7 @@
 
 /obj/item/pda/clown/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/slippery/clowning, 120, NO_SLIP_WHEN_WALKING, CALLBACK(src, .proc/AfterSlip))
+	AddComponent(/datum/component/slippery/clowning, 120, NO_SLIP_WHEN_WALKING, CALLBACK(src, .proc/AfterSlip), _slot_whitelist = list(ITEM_SLOT_ID, ITEM_SLOT_BELT))
 	AddComponent(/datum/component/wearertargeting/sitcomlaughter, CALLBACK(src, .proc/after_sitcom_laugh))
 
 /obj/item/pda/clown/proc/AfterSlip(mob/living/carbon/human/M)


### PR DESCRIPTION
## About The Pull Request

Autodocs the slippery component, its variables, and its procs.

Changes the hardcoded slots (`ITEM_SLOT_ID`, `ITEM_SLOT_BELT`) that is solely intended for use with the clown's PDA to be a list passed on initialization. #56820 made a few things that used to slip you when worn no longer slip you, so this PR fixes that.

## Why It's Good For The Game

Docs good.

Hardcoded blacklists bad. Does not let me badmin effectively. A few things that used to be slippery in clothing slots were made unslippery which is unfun. They now slip again, which is fun.

## Changelog
:cl: Melbert
fix: Some worn things that previously used to be slippery are now properly slippery again.
code: Slip component can be given a whitelist of valid worn slots. (B)Admins can now make anything worn slippery, again.
/:cl:

