### PR TITLE
Adds right-click support to AIs/Cyborgs

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -103,6 +103,13 @@
 /atom/proc/attack_ai(mob/user)
 	return
 
+/**
+ * What happens when the AI holds right-click on an item. Returns a SECONDARY_ATTACK_* value.
+ *
+ * Arguments:
+ * * user The mob holding the right click
+ * * modifiers The list of the custom click modifiers
+ */
 /atom/proc/attack_ai_secondary(mob/user, list/modifiers)
 	return SECONDARY_ATTACK_CALL_NORMAL
 

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -67,6 +67,12 @@
 	if(LAZYACCESS(modifiers, MIDDLE_CLICK))
 		MiddleClickOn(A, params)
 		return
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
+		var/secondary_result = A.attack_ai_secondary(src, modifiers)
+		if(secondary_result == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN || secondary_result == SECONDARY_ATTACK_CONTINUE_CHAIN)
+			return
+		else if(secondary_result != SECONDARY_ATTACK_CALL_NORMAL)
+			CRASH("attack_ai_secondary did not return a SECONDARY_ATTACK_* define.")
 
 	if(world.time <= next_move)
 		return
@@ -90,11 +96,15 @@
 */
 /mob/living/silicon/ai/UnarmedAttack(atom/A, proximity_flag, list/modifiers)
 	A.attack_ai(src)
+
 /mob/living/silicon/ai/RangedAttack(atom/A)
 	A.attack_ai(src)
 
 /atom/proc/attack_ai(mob/user)
 	return
+
+/atom/proc/attack_ai_secondary(mob/user, list/modifiers)
+	return SECONDARY_ATTACK_CALL_NORMAL
 
 /*
 	Since the AI handles shift, ctrl, and alt-click differently

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -185,4 +185,4 @@
  * * modifiers The list of the custom click modifiers
  */
 /atom/proc/attack_robot_secondary(mob/user, list/modifiers)
-	. = attack_ai_secondary(user, modifiers)
+	return attack_ai_secondary(user, modifiers)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -36,6 +36,12 @@
 	if(LAZYACCESS(modifiers, CTRL_CLICK))
 		CtrlClickOn(A)
 		return
+	if(LAZYACCESS(modifiers, RIGHT_CLICK) && !module_active)
+		var/secondary_result = A.attack_robot_secondary(src, modifiers)
+		if(secondary_result == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN || secondary_result == SECONDARY_ATTACK_CONTINUE_CHAIN)
+			return
+		else if (secondary_result != SECONDARY_ATTACK_CALL_NORMAL)
+			CRASH("attack_robot_secondary did not return a SECONDARY_ATTACK_* define.")
 
 	if(next_move >= world.time)
 		return
@@ -170,3 +176,13 @@
 /atom/proc/attack_robot(mob/user)
 	attack_ai(user)
 	return
+
+/**
+ * What happens when the cyborg without active module holds right-click on an item. Returns a SECONDARY_ATTACK_* value.
+ *
+ * Arguments:
+ * * user The mob holding the right click
+ * * modifiers The list of the custom click modifiers
+ */
+/atom/proc/attack_robot_secondary(mob/user, list/modifiers)
+	. = attack_ai_secondary(user, modifiers)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -335,8 +335,6 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		update_appearance()
 
 /obj/machinery/washing_machine/attack_hand_secondary(mob/user, modifiers)
-	if(!user.canUseTopic(src, !issilicon(user)))
-		return SECONDARY_ATTACK_CONTINUE_CHAIN
 	if(busy)
 		to_chat(user, "<span class='warning'>[src] is busy!</span>")
 		return SECONDARY_ATTACK_CONTINUE_CHAIN
@@ -351,6 +349,9 @@ GLOBAL_LIST_INIT(dye_registry, list(
 	addtimer(CALLBACK(src, .proc/wash_cycle), 20 SECONDS)
 	START_PROCESSING(SSfastprocess, src)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/machinery/washing_machine/attack_ai_secondary(mob/user, modifiers)
+	. = attack_hand_secondary(user, modifiers)
 
 /obj/machinery/washing_machine/deconstruct(disassembled = TRUE)
 	if (!(flags_1 & NODECONSTRUCT_1))

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -335,6 +335,8 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		update_appearance()
 
 /obj/machinery/washing_machine/attack_hand_secondary(mob/user, modifiers)
+	if(!user.canUseTopic(src, !issilicon(user)))
+		return SECONDARY_ATTACK_CONTINUE_CHAIN
 	if(busy)
 		to_chat(user, "<span class='warning'>[src] is busy!</span>")
 		return SECONDARY_ATTACK_CONTINUE_CHAIN

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -353,7 +353,7 @@ GLOBAL_LIST_INIT(dye_registry, list(
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/washing_machine/attack_ai_secondary(mob/user, modifiers)
-	. = attack_hand_secondary(user, modifiers)
+	return attack_hand_secondary(user, modifiers)
 
 /obj/machinery/washing_machine/deconstruct(disassembled = TRUE)
 	if (!(flags_1 & NODECONSTRUCT_1))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR adds right-click support to silicons, namely AIs and cyborgs and with it fixes an issue where silicons were not able to start a wash cycle on the washing machine. Cyborgs can activate right-click actions only if they do not have any active module (tool) selected, as to not conflict with the right click use of the item itself, e.g. syringes. AIs do not have such restrictions, as they never hold any items.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugfix, right click support for silicons.

## Changelog
:cl: Arkatos
code: Added right-click support to AIs and cyborgs. Cyborgs can use right click actions only if they do not have any tool selected, as to not conflict with the right click actions of the items themselves, like syringes.
fix: Silicons are now once again able to start a wash cycle due to newly added right click support.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
