### PR TITLE
Fixes not being able to open inactive ticket browser on admin ticket tab.

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -25,8 +25,6 @@
 
 
 /client/MouseDown(datum/object, location, control, params)
-	if(!control)
-		return
 	if(QDELETED(object)) //Yep, you can click on qdeleted things before they have time to nullspace. Fun.
 		return
 	SEND_SIGNAL(src, COMSIG_CLIENT_MOUSEDOWN, object, location, control, params)
@@ -44,8 +42,6 @@
 		active_mousedown_item.onMouseDown(object, location, params, mob)
 
 /client/MouseUp(object, location, control, params)
-	if(!control)
-		return
 	if(SEND_SIGNAL(src, COMSIG_CLIENT_MOUSEUP, object, location, control, params) & COMPONENT_CLIENT_MOUSEUP_INTERCEPT)
 		click_intercept_time = world.time
 	if(mouse_up_icon)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -811,8 +811,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		ip_intel = res.intel
 
 /client/Click(atom/object, atom/location, control, params)
-	if(!control)
-		return
 	if(click_intercept_time)
 		if(click_intercept_time >= world.time)
 			click_intercept_time = 0 //Reset and return. Next click should work, but not this one.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently admins can't access the ticket logs for Resolved, Disconnected, Closed and Active tickets due to an early return that will block these from being opened in 100% of circumstances.

Clicking on the Active/Disconnected/Closed/Resolved tickets would have behaviour handled by `/datum/admin_help_tickets/proc/BrowseTickets()` which was reached through Click() calls.

![image](https://user-images.githubusercontent.com/24975989/111919336-68499880-8a81-11eb-807c-4f33bdfafa7d.png)

When we call `.Click()` from topic calls, we provide a `null` var for the `control` parameter.

This then leads through to `/client/Click()` where #57084 added a bunch of if(!control) checks supposedly ported from TGMC (or at least Fikou couldn't explain why we changed that).

I can't find a single instance of us using this locally, it appears it's always passed through to Byond. Byond docs at http://www.byond.com/docs/ref/#/client/proc/Click describe it as `control - the name of the skin control involved`

I can't see any reason to early return if `control` is a FALSE-y value. This check is what was blocking access to the admin_help_tickets datum.

In testing, removing these checks restored previous functionality.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Admins less triggered.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Admins can once again open the stat panels to look at active, disconnected, closed and resolved tickets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
