### PR TITLE
Fix CI/build failure on master following removal of tourist nationalities with addition of new tourists.

### DIFF
--- a/code/modules/food_and_drinks/restaurant/customers/_customer.dm
+++ b/code/modules/food_and_drinks/restaurant/customers/_customer.dm
@@ -280,7 +280,6 @@
 	self_defense_line = "Time for you to find out what kind of robot I am, eh?"
 
 /datum/customer_data/british
-	nationality = "Space-British"
 	base_icon = "british"
 	prefix_file = "strings/names/british_prefix.txt"
 	speech_sound = 'sound/creatures/tourist/tourist_talk_british.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://github.com/tgstation/tgstation/pull/57860 passed CI at the time of its last commit, but was made after https://github.com/tgstation/tgstation/pull/57542 was merged, which added a new tourist bot type. This means that #57860 didn't remove the Brit tourist nationality var and has caused a CI failure.

```
DM compiler version 513.1536
loading tgstation.dme
loading interface\skin.dmf
code\modules\food_and_drinks\restaurant\customers\_customer.dm:283:error: nationality: undefined var
tgstation.dmb - 1 error, 0 warnings (3/21/21 9:57 pm)
```

This build failure is visible on https://github.com/tgstation/tgstation/runs/2161577585 and is present on master.