### PR TITLE
Fixes admin immovable rods not hitting things

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -83,14 +83,13 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 
 	AddElement(/datum/element/point_of_interest)
 
-	if(special_target)
-		walk_towards(src, special_target, 1)
-		return
-
-	walk_towards(src, destination, 1)
-
 	RegisterSignal(src, COMSIG_MOVABLE_CROSSED_OVER, .proc/on_crossed_over_movable)
 	RegisterSignal(src, COMSIG_ATOM_ENTERING, .proc/on_entering_atom)
+
+	if(special_target)
+		walk_towards(src, special_target, 1)
+	else
+		walk_towards(src, destination, 1)
 
 /obj/effect/immovablerod/Destroy(force)
 	UnregisterSignal(src, COMSIG_MOVABLE_CROSSED_OVER, COMSIG_ATOM_ENTERING)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Timber did an oopsie in #57850 and made it so rods with a specific target (AKA any spawned by admins either through the trigger event button or the admin smite) quit out of their creation before they started listening for clonging things. Possibly this was partly intended, in case you wanted to spawn a rod that would only hit whatever you designated as your target and nothing else, but this current setup doesn't hit the target either soo something needs fixing.

@Timberpoes let me know what you think and if you were intending for a soft rod option that would only hit the target.

Fixes: #57888
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As timber would say, feex
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Immovable rods triggered by admin intervention will no longer miss everything in their path
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
