### PR TITLE
[s] Fixing an infinite loop exception with Move()

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -472,8 +472,8 @@
 			stop_pulling()
 		else
 			var/pull_dir = get_dir(src, pulling)
-			//puller and pullee more than one tile away or in diagonal position
-			if(get_dist(src, pulling) > 1 || (moving_diagonally != SECOND_DIAG_STEP && ((pull_dir - 1) & pull_dir)))
+			//puller and pullee more than one tile away or in diagonal position and whatever the pullee is pulling isn't already moving from a pull as it'll most likely result in an infinite loop a la ouroborus.
+			if(!pulling.pulling?.moving_from_pull && (get_dist(src, pulling) > 1 || (moving_diagonally != SECOND_DIAG_STEP && ((pull_dir - 1) & pull_dir))))
 				pulling.moving_from_pull = src
 				pulling.Move(T, get_dir(pulling, T), glide_size) //the pullee tries to reach our previous position
 				pulling.moving_from_pull = null


### PR DESCRIPTION
## About The Pull Request
A bug that I found out while stress testing the z movement refactor I'm working on and that happens whenever a piece of a series composed by at least three movables with each one pulling one other like some sort of conga circle is displaced one tile away by an outside force (not client movement as it calls mob.resist_grab() first) in a way that grabs are not broken, thus setting off an infinite loop of Move() calls because everyone is pulling something.

## Why It's Good For The Game
Be careful around recursions.

## Changelog
N/A.
