### PR TITLE
Fixing the undoable experisci arcade experiment.

### DIFF
--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -77,7 +77,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	Reset()
 
 /obj/machinery/computer/arcade/proc/prizevend(mob/user, prizes = 1)
-	SEND_SIGNAL(user, COMSIG_ARCADE_PRIZEVEND, user, prizes)
+	SEND_SIGNAL(src, COMSIG_ARCADE_PRIZEVEND, user, prizes)
 	if(user.mind?.get_skill_level(/datum/skill/gaming) >= SKILL_LEVEL_LEGENDARY && HAS_TRAIT(user, TRAIT_GAMERGOD))
 		visible_message("<span class='notice'>[user] inputs an intense cheat code!",\
 		"<span class='notice'>You hear a flurry of buttons being pressed.</span>")

--- a/code/modules/experisci/experiment/physical_experiments.dm
+++ b/code/modules/experisci/experiment/physical_experiments.dm
@@ -22,6 +22,7 @@
 	. += EXPERIMENT_PROG_BOOL("Fire an emitter at a tracked meat wall", is_complete())
 
 /datum/experiment/physical/meat_wall_explosion/proc/check_experiment(datum/source, obj/projectile/Proj)
+	SIGNAL_HANDLER
 	if(istype(Proj, /obj/projectile/beam/emitter))
 		finish_experiment(linked_experiment_handler)
 
@@ -53,4 +54,5 @@
 	. += EXPERIMENT_PROG_BOOL("Win an arcade game at a tracked arcade cabinet.", is_complete())
 
 /datum/experiment/physical/arcade_winner/proc/win_arcade(datum/source)
+	SIGNAL_HANDLER
 	finish_experiment(linked_experiment_handler)


### PR DESCRIPTION
## About The Pull Request
It was sending the signal to the user, not src. Also adding SIGNAL_HANDLER to two experisci-related comsig procs.

## Why It's Good For The Game
Fixing a bug that hasn't been reported yet.

## Changelog
:cl:
fix: The experisi arcade experiment is now doable.
/:cl:
