### PR TITLE
Reworks thermal mutation.

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -57,7 +57,7 @@
 #define UNINTELLIGIBLE /datum/mutation/human/unintelligible
 #define VOID /datum/mutation/human/void
 #define WACKY /datum/mutation/human/wacky
-#define XRAY /datum/mutation/human/thermal/x_ray
+#define XRAY /datum/mutation/human/xray
 
 #define BURDENED /datum/mutation/human/burdened
 #define HONORBOUND /datum/mutation/human/honorbound

--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -20,6 +20,7 @@
 /datum/generecipe/mindread
 	required = "/datum/mutation/human/antenna; /datum/mutation/human/paranoia"
 	result = MINDREAD
+
 /datum/generecipe/shock
 	required = "/datum/mutation/human/insulated; /datum/mutation/human/radioactive"
 	result = SHOCKTOUCH

--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -21,6 +21,10 @@
 	required = "/datum/mutation/human/antenna; /datum/mutation/human/paranoia"
 	result = MINDREAD
 
+/datum/generecipe/x_ray
+	required = "/datum/mutation/human/thermal; /datum/mutation/human/radioactive"
+	result = XRAY
+
 /datum/generecipe/shock
 	required = "/datum/mutation/human/insulated; /datum/mutation/human/radioactive"
 	result = SHOCKTOUCH

--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -20,11 +20,6 @@
 /datum/generecipe/mindread
 	required = "/datum/mutation/human/antenna; /datum/mutation/human/paranoia"
 	result = MINDREAD
-
-/datum/generecipe/x_ray
-	required = "/datum/mutation/human/thermal; /datum/mutation/human/radioactive"
-	result = XRAY
-
 /datum/generecipe/shock
 	required = "/datum/mutation/human/insulated; /datum/mutation/human/radioactive"
 	result = SHOCKTOUCH

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -71,7 +71,7 @@
 	if(!istype(user_mob))
 		return
 
-	user_mob.adjustOrganLoss(ORGAN_SLOT_EYES, 20)
+	user_mob.adjustOrganLoss(ORGAN_SLOT_EYES, 10)
 
 ///X-ray Vision lets you see through walls.
 /datum/mutation/human/thermal/x_ray

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -42,29 +42,76 @@
 	text_gain_indication = "<span class='notice'>You can see the heat rising off of your skin...</span>"
 	time_coeff = 2
 	instability = 25
-	var/visionflag = TRAIT_THERMAL_VISION
+	power = /obj/effect/proc_holder/spell/self/thermal_vision_activate
 
-/datum/mutation/human/thermal/on_acquiring(mob/living/carbon/human/owner)
-	if(..())
+/obj/effect/proc_holder/spell/self/thermal_vision_activate
+	name = "Activate thermal vision"
+	desc = "You can see thermal signatures, at the cost of your eyesight."
+	charge_max = 15 SECONDS
+	clothes_req = FALSE
+
+/obj/effect/proc_holder/spell/self/thermal_vision_activate/cast(list/targets, mob/user = usr)
+	. = ..()
+
+	if(HAS_TRAIT(user,TRAIT_THERMAL_VISION))
 		return
 
-	ADD_TRAIT(owner, visionflag, GENETIC_MUTATION)
-	owner.update_sight()
+	ADD_TRAIT(user, TRAIT_THERMAL_VISION, GENETIC_MUTATION)
+	user.update_sight()
+	to_chat(user, text("You focus your eyes intensely, as your vision becomes filled with heat signatures."))
 
-/datum/mutation/human/thermal/on_losing(mob/living/carbon/human/owner)
-	if(..())
+	addtimer(CALLBACK(src, .proc/thermal_vision_deactivate), 10 SECONDS)
+
+/obj/effect/proc_holder/spell/self/thermal_vision_activate/proc/thermal_vision_deactivate(mob/user = usr)
+	REMOVE_TRAIT(user, TRAIT_THERMAL_VISION, GENETIC_MUTATION)
+	user.update_sight()
+	to_chat(user, text("You blink a few times, your vision returning to normal as a dull pain settles in your eyes."))
+
+	var/mob/living/carbon/user_mob = user
+	if(!istype(user_mob))
 		return
-	REMOVE_TRAIT(owner, visionflag, GENETIC_MUTATION)
-	owner.update_sight()
+
+	user_mob.adjustOrganLoss(ORGAN_SLOT_EYES, 10)
 
 ///X-ray Vision lets you see through walls.
 /datum/mutation/human/thermal/x_ray
 	name = "X Ray Vision"
 	desc = "A strange genome that allows the user to see between the spaces of walls." //actual x-ray would mean you'd constantly be blasting rads, wich might be fun for later //hmb
-	text_gain_indication = "<span class='notice'>The walls suddenly disappear!</span>"
+	text_gain_indication = "<span class='notice'>The walls suddenly disappear! You blink, and they're back.</span>"
 	instability = 35
+	power = /obj/effect/proc_holder/spell/self/xray_vision_activate
 	locked = TRUE
-	visionflag = TRAIT_XRAY_VISION
+
+/obj/effect/proc_holder/spell/self/xray_vision_activate
+	name = "Activate xray vision"
+	desc = "You can see through walls, at the cost of your brain's health."
+	charge_max = 15 SECONDS
+	clothes_req = FALSE
+
+/obj/effect/proc_holder/spell/self/xray_vision_activate/cast(list/targets, mob/user = usr)
+	. = ..()
+
+	if(HAS_TRAIT(user,TRAIT_XRAY_VISION))
+		return
+
+	ADD_TRAIT(user, TRAIT_XRAY_VISION, GENETIC_MUTATION)
+	user.update_sight()
+	to_chat(user, text("You focus your eyes intensely, as your vision pierces everything around you."))
+
+	addtimer(CALLBACK(src, .proc/xray_vision_deactivate), 10 SECONDS)
+
+/obj/effect/proc_holder/spell/self/xray_vision_activate/proc/xray_vision_deactivate(mob/user = usr)
+	REMOVE_TRAIT(user, TRAIT_XRAY_VISION, GENETIC_MUTATION)
+	user.update_sight()
+	to_chat(user, text("You blink a few times, your vision returning to normal as a dull pain settles in your head."))
+
+	var/mob/living/carbon/user_mob = user
+	if(!istype(user_mob))
+		return
+
+	user_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 20)
+
+
 
 ///Laser Eyes lets you shoot lasers from your eyes!
 /datum/mutation/human/laser_eyes

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -42,12 +42,27 @@
 	text_gain_indication = "<span class='notice'>You can see the heat rising off of your skin...</span>"
 	time_coeff = 2
 	instability = 25
+	synchronizer_coeff = 1
+	power_coeff = 1
+	energy_coeff = 1
 	power = /obj/effect/proc_holder/spell/self/thermal_vision_activate
+
+
+/datum/mutation/human/thermal/modify()
+	if(!power)
+		return FALSE
+	var/obj/effect/proc_holder/spell/self/thermal_vision_activate/Modified_power = power
+	Modified_power.eye_damage = 10 * GET_MUTATION_SYNCHRONIZER(src)
+	Modified_power.thermal_duration = 10 * GET_MUTATION_POWER(src)
+	Modified_power.charge_max = 25 * GET_MUTATION_ENERGY(src) SECONDS
+
 
 /obj/effect/proc_holder/spell/self/thermal_vision_activate
 	name = "Activate Thermal Vision"
 	desc = "You can see thermal signatures, at the cost of your eyesight."
-	charge_max = 20 SECONDS
+	charge_max = 25 SECONDS
+	var/eye_damage = 10
+	var/thermal_duration = 10
 	clothes_req = FALSE
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "augmented_eyesight"
@@ -62,7 +77,7 @@
 	user.update_sight()
 	to_chat(user, text("You focus your eyes intensely, as your vision becomes filled with heat signatures."))
 
-	addtimer(CALLBACK(src, .proc/thermal_vision_deactivate), 10 SECONDS)
+	addtimer(CALLBACK(src, .proc/thermal_vision_deactivate), thermal_duration SECONDS)
 
 /obj/effect/proc_holder/spell/self/thermal_vision_activate/proc/thermal_vision_deactivate(mob/user = usr)
 
@@ -78,7 +93,7 @@
 	if(!istype(user_mob))
 		return
 
-	user_mob.adjustOrganLoss(ORGAN_SLOT_EYES, 10)
+	user_mob.adjustOrganLoss(ORGAN_SLOT_EYES, eye_damage)
 
 ///X-ray Vision lets you see through walls.
 /datum/mutation/human/thermal/x_ray

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -77,40 +77,21 @@
 /datum/mutation/human/thermal/x_ray
 	name = "X Ray Vision"
 	desc = "A strange genome that allows the user to see between the spaces of walls." //actual x-ray would mean you'd constantly be blasting rads, wich might be fun for later //hmb
-	text_gain_indication = "<span class='notice'>The walls suddenly disappear! You blink, and they're back.</span>"
+	text_gain_indication = "<span class='notice'>The walls suddenly disappear!</span>"
 	instability = 35
-	power = /obj/effect/proc_holder/spell/self/xray_vision_activate
 	locked = TRUE
 
-/obj/effect/proc_holder/spell/self/xray_vision_activate
-	name = "Activate xray vision"
-	desc = "You can see through walls, at the cost of your brain's health."
-	charge_max = 30 SECONDS
-	clothes_req = FALSE
-
-/obj/effect/proc_holder/spell/self/xray_vision_activate/cast(list/targets, mob/user = usr)
-	. = ..()
-
-	if(HAS_TRAIT(user,TRAIT_XRAY_VISION))
+/datum/mutation/human/thermal/xray/on_acquiring(mob/living/carbon/human/owner)
+	if(..())
 		return
+	ADD_TRAIT(owner, TRAIT_XRAY_VISION, GENETIC_MUTATION)
+	owner.update_sight()
 
-	ADD_TRAIT(user, TRAIT_XRAY_VISION, GENETIC_MUTATION)
-	user.update_sight()
-	to_chat(user, text("You focus your eyes intensely, as your vision pierces everything around you."))
-
-	addtimer(CALLBACK(src, .proc/xray_vision_deactivate), 10 SECONDS)
-
-/obj/effect/proc_holder/spell/self/xray_vision_activate/proc/xray_vision_deactivate(mob/user = usr)
-	REMOVE_TRAIT(user, TRAIT_XRAY_VISION, GENETIC_MUTATION)
-	user.update_sight()
-	to_chat(user, text("You blink a few times, your vision returning to normal as a dull pain settles in your head."))
-
-	var/mob/living/carbon/user_mob = user
-	if(!istype(user_mob))
+/datum/mutation/human/thermal/xray/on_losing(mob/living/carbon/human/owner)
+	if(..())
 		return
-
-	user_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 50)
-
+	REMOVE_TRAIT(owner, TRAIT_XRAY_VISION, GENETIC_MUTATION)
+	owner.update_sight()
 
 
 ///Laser Eyes lets you shoot lasers from your eyes!

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -71,7 +71,7 @@
 	if(!istype(user_mob))
 		return
 
-	user_mob.adjustOrganLoss(ORGAN_SLOT_EYES, 10)
+	user_mob.adjustOrganLoss(ORGAN_SLOT_EYES, 20)
 
 ///X-ray Vision lets you see through walls.
 /datum/mutation/human/thermal/x_ray
@@ -109,7 +109,7 @@
 	if(!istype(user_mob))
 		return
 
-	user_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 20)
+	user_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 50)
 
 
 

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -47,7 +47,7 @@
 /obj/effect/proc_holder/spell/self/thermal_vision_activate
 	name = "Activate thermal vision"
 	desc = "You can see thermal signatures, at the cost of your eyesight."
-	charge_max = 15 SECONDS
+	charge_max = 20 SECONDS
 	clothes_req = FALSE
 
 /obj/effect/proc_holder/spell/self/thermal_vision_activate/cast(list/targets, mob/user = usr)
@@ -85,7 +85,7 @@
 /obj/effect/proc_holder/spell/self/xray_vision_activate
 	name = "Activate xray vision"
 	desc = "You can see through walls, at the cost of your brain's health."
-	charge_max = 15 SECONDS
+	charge_max = 30 SECONDS
 	clothes_req = FALSE
 
 /obj/effect/proc_holder/spell/self/xray_vision_activate/cast(list/targets, mob/user = usr)

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -96,20 +96,20 @@
 	user_mob.adjustOrganLoss(ORGAN_SLOT_EYES, eye_damage)
 
 ///X-ray Vision lets you see through walls.
-/datum/mutation/human/thermal/x_ray
+/datum/mutation/human/xray
 	name = "X Ray Vision"
 	desc = "A strange genome that allows the user to see between the spaces of walls." //actual x-ray would mean you'd constantly be blasting rads, wich might be fun for later //hmb
 	text_gain_indication = "<span class='notice'>The walls suddenly disappear!</span>"
 	instability = 35
 	locked = TRUE
 
-/datum/mutation/human/thermal/xray/on_acquiring(mob/living/carbon/human/owner)
+/datum/mutation/human/xray/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
 	ADD_TRAIT(owner, TRAIT_XRAY_VISION, GENETIC_MUTATION)
 	owner.update_sight()
 
-/datum/mutation/human/thermal/xray/on_losing(mob/living/carbon/human/owner)
+/datum/mutation/human/xray/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
 	REMOVE_TRAIT(owner, TRAIT_XRAY_VISION, GENETIC_MUTATION)

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -51,10 +51,10 @@
 /datum/mutation/human/thermal/modify()
 	if(!power)
 		return FALSE
-	var/obj/effect/proc_holder/spell/self/thermal_vision_activate/Modified_power = power
-	Modified_power.eye_damage = 10 * GET_MUTATION_SYNCHRONIZER(src)
-	Modified_power.thermal_duration = 10 * GET_MUTATION_POWER(src)
-	Modified_power.charge_max = 25 * GET_MUTATION_ENERGY(src) SECONDS
+	var/obj/effect/proc_holder/spell/self/thermal_vision_activate/modified_power = power
+	modified_power.eye_damage = 10 * GET_MUTATION_SYNCHRONIZER(src)
+	modified_power.thermal_duration = 10 * GET_MUTATION_POWER(src)
+	modified_power.charge_max = (25 * GET_MUTATION_ENERGY(src)) SECONDS
 
 
 /obj/effect/proc_holder/spell/self/thermal_vision_activate

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -45,10 +45,12 @@
 	power = /obj/effect/proc_holder/spell/self/thermal_vision_activate
 
 /obj/effect/proc_holder/spell/self/thermal_vision_activate
-	name = "Activate thermal vision"
+	name = "Activate Thermal Vision"
 	desc = "You can see thermal signatures, at the cost of your eyesight."
 	charge_max = 20 SECONDS
 	clothes_req = FALSE
+	action_icon = 'icons/mob/actions/actions_changeling.dmi'
+	action_icon_state = "augmented_eyesight"
 
 /obj/effect/proc_holder/spell/self/thermal_vision_activate/cast(list/targets, mob/user = usr)
 	. = ..()
@@ -63,6 +65,11 @@
 	addtimer(CALLBACK(src, .proc/thermal_vision_deactivate), 10 SECONDS)
 
 /obj/effect/proc_holder/spell/self/thermal_vision_activate/proc/thermal_vision_deactivate(mob/user = usr)
+
+
+	if(!HAS_TRAIT_FROM(user,TRAIT_THERMAL_VISION, GENETIC_MUTATION))
+		return
+
 	REMOVE_TRAIT(user, TRAIT_THERMAL_VISION, GENETIC_MUTATION)
 	user.update_sight()
 	to_chat(user, text("You blink a few times, your vision returning to normal as a dull pain settles in your eyes."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR reworks the thermal mutation to be a spell that deals eye damage on use.

Edit : Now with chromosomes support.

## Why It's Good For The Game

Offers trade-offs for using thermal, promote inter-departmental cooperations (medical can produce chems to help deal with the after effects of using the mutation).
## TODO

- [x] Icons for the spell
- [x] Chromosomes

## Changelog
:cl:
balance: Thermal is now an active mutation, that has a cooldown and deals damage to your eyes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
