### PR TITLE
Fixes books spawned in the holodeck not disappearing when programs are changed

### DIFF
--- a/_maps/templates/holodeck_lounge.dmm
+++ b/_maps/templates/holodeck_lounge.dmm
@@ -49,7 +49,7 @@
 "h" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/cigarette/pipe,
-/obj/item/book/manual/random,
+/obj/effect/holodeck_effect/random_book,
 /turf/open/floor/holofloor/carpet,
 /area/template_noop)
 "i" = (
@@ -209,7 +209,7 @@
 /area/template_noop)
 "J" = (
 /obj/structure/table/wood,
-/obj/item/book/manual/random,
+/obj/effect/holodeck_effect/random_book,
 /turf/open/floor/holofloor/carpet,
 /area/template_noop)
 "K" = (

--- a/code/modules/holodeck/holo_effect.dm
+++ b/code/modules/holodeck/holo_effect.dm
@@ -64,7 +64,15 @@
 		T.temperature = 5000 //Why? not quite sure to be honest with you
 		T.hotspot_expose(50000,50000,1)
 
+/obj/effect/holodeck_effect/random_book
 
+
+/obj/effect/holodeck_effect/random_book/activate(obj/machinery/computer/holodeck/father_holodeck)
+	var/static/banned_books = list(/obj/item/book/manual/random, /obj/item/book/manual/nuclear, /obj/item/book/manual/wiki)
+	var/newtype = pick(subtypesof(/obj/item/book/manual) - banned_books)
+	var/obj/item/book/manual/to_spawn = new newtype(loc)
+	to_spawn.flags_1 |= (HOLOGRAM_1 | NODECONSTRUCT_1)
+	return to_spawn
 
 /obj/effect/holodeck_effect/mobspawner
 	var/mobtype = /mob/living/simple_animal/hostile/carp/holocarp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
obj/item/book/manual/random deletes itself and spawns a random manual, so the newly created book wasnt being added to the spawned list. now theres a obj/effect/holodeck_effect/random_book that does the same thing but the returns the random book to the holodeck so it can get tracked now.
this is probably a bug i introduced since the original holodeck refactor but i dont remember if i fixed it before, this should future proof it regardless
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
no more free books
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: NanoTrasen & Noble realized that the holodecks ability to replicate books was cutting into its bottom line, so they convinced the branch responsible for the holodeck to patch it out
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
