### PR TITLE
Turns off cache on docker publish action

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -20,4 +20,3 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: Dockerfile
           tags: "latest"
-          cache: true


### PR DESCRIPTION
Maybe it will stop it screaming in pain about missing dependencies.
Publish action suggests alternative of running this as cronjob to update cached version so if this works but is too slow we can change to that.