### PR TITLE
Improves status bar coverage

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -158,6 +158,7 @@
 	. += hidden ? show_appearance : hide_appearance
 
 /atom/movable/screen/movable/action_button/MouseEntered(location,control,params)
+	. = ..()
 	if(!QDELETED(src))
 		openToolTip(usr,src,params,title = name,content = desc,theme = actiontooltipstyle)
 

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -107,6 +107,7 @@
 
 
 /atom/movable/screen/alert/MouseEntered(location,control,params)
+	. = ..()
 	if(!QDELETED(src))
 		openToolTip(usr,src,params,title = name,content = desc,theme = alerttooltipstyle)
 

--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/hud/blob.dmi'
 
 /atom/movable/screen/blob/MouseEntered(location,control,params)
+	. = ..()
 	openToolTip(usr,src,params,title = name,content = desc, theme = "blob")
 
 /atom/movable/screen/blob/MouseExited()
@@ -42,7 +43,7 @@
 		else
 			name = initial(name)
 			desc = initial(desc)
-	..()
+	return ..()
 
 /atom/movable/screen/blob/jump_to_core/Click()
 	if(isovermind(usr))
@@ -130,7 +131,7 @@
 		else
 			name = "[initial(name)] ([BLOB_POWER_REROLL_COST])"
 			desc = "Allows you to choose a new strain from [BLOB_POWER_REROLL_CHOICES] random choices for [BLOB_POWER_REROLL_COST] resources."
-	..()
+	return ..()
 
 /atom/movable/screen/blob/readapt_strain/Click()
 	if(isovermind(usr))

--- a/code/_onclick/hud/families.dm
+++ b/code/_onclick/hud/families.dm
@@ -18,6 +18,7 @@
 	update_appearance()
 
 /atom/movable/screen/wanted/MouseEntered(location,control,params)
+	. = ..()
 	openToolTip(usr,src,params,title = name,content = desc, theme = "alerttooltipstyle")
 
 /atom/movable/screen/wanted/MouseExited()

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -1,7 +1,8 @@
 /atom/movable/screen/ghost
 	icon = 'icons/hud/screen_ghost.dmi'
 
-/atom/movable/screen/ghost/MouseEntered()
+/atom/movable/screen/ghost/MouseEntered(location, control, params)
+	. = ..()
 	flick(icon_state + "_anim", src)
 
 /atom/movable/screen/ghost/spawners_menu

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -149,7 +149,7 @@
 		usr.update_inv_hands()
 	return TRUE
 
-/atom/movable/screen/inventory/MouseEntered()
+/atom/movable/screen/inventory/MouseEntered(location, control, params)
 	..()
 	add_overlays()
 
@@ -500,6 +500,7 @@
 	return set_selected_zone(choice, usr)
 
 /atom/movable/screen/zone_sel/MouseEntered(location, control, params)
+	. = ..()
 	MouseMove(location, control, params)
 
 /atom/movable/screen/zone_sel/MouseMove(location, control, params)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -150,7 +150,7 @@
 	return TRUE
 
 /atom/movable/screen/inventory/MouseEntered(location, control, params)
-	..()
+	. = ..()
 	add_overlays()
 
 /atom/movable/screen/inventory/MouseExited()

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -19,7 +19,7 @@
 	desc += "<br><font size=3><b>Current Bloodthirst: [HG.bloodlust]</b></font>\
 	<br>Becomes undroppable at <b>[HIS_GRACE_FAMISHED]</b>\
 	<br>Will consume you at <b>[HIS_GRACE_CONSUME_OWNER]</b>"
-	..()
+	return ..()
 
 /datum/status_effect/his_grace/on_apply()
 	owner.log_message("gained His Grace's stun immunity", LOG_ATTACK)

--- a/code/game/objects/effects/info.dm
+++ b/code/game/objects/effects/info.dm
@@ -17,7 +17,7 @@
 	. = ..()
 	to_chat(usr, info_text)
 
-/obj/effect/abstract/info/MouseEntered()
+/obj/effect/abstract/info/MouseEntered(location, control, params)
 	. = ..()
 	icon_state = "info_hovered"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR makes sure all MouseEntered() procs call their parent, which handles the status bar. This fixes instances where the status bar was missing, for example when you hovered over the ghost buttons, you would not be shown a name of the button, but completely different object, like "space", which was very misleading. This also means that the new status bar should have better parity the with the old status bar, which also showed these things.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Better status bar coverage.

## Changelog
:cl: Arkatos
qol: Added new status bar support for more objects that were previously visible in the old status bar, like action buttons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
