### PR TITLE
Fix plant trash from grown food not inheriting their proper seeds

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -78,7 +78,7 @@
 /// Callback proc for bonus behavior for generating trash of grown food. Used by [/datum/element/food_trash].
 /obj/item/food/grown/proc/generate_trash()
 	// If this is some type of grown thing, we pass a seed arg into its Inititalize()
-	if(istype(trash_type, /obj/item/grown) || istype(trash_type, /obj/item/food/grown))
+	if(ispath(trash_type, /obj/item/grown) || ispath(trash_type, /obj/item/food/grown))
 		return new trash_type(src, seed)
 
 	return new trash_type(src)


### PR DESCRIPTION
## About The Pull Request

This PR fixes plant trash not getting the seed from their parent.

`trash_type` is a type path, not an instantiated object. `istype` always fails trying to use it on `trash_type`. `ispath` is the correct helper to use here, because it's a type path and not an object.

## Why It's Good For The Game

Botany can now make super banana peels again.

## Changelog
:cl: Melbert
fix: Plant trash from grown foods (banana peels) now inherit their parent plant's traits properly again.
/:cl:

