### PR TITLE
Makes deadchat control's examine only shows up for ghosts

### DIFF
--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -157,6 +157,9 @@
 /datum/component/deadchat_control/proc/on_examine(atom/A, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
+	if(!isobserver(user))
+		return
+
 	examine_list += "<span class='notice'>[A.p_theyre(TRUE)] currently under deadchat control using the [deadchat_mode] ruleset!</span>"
 
 	if(deadchat_mode == DEMOCRACY_MODE)


### PR DESCRIPTION
## About The Pull Request

This PR early returns the `on_examine` proc for deadchat control if the examiner is not an observer.
So, only ghosts (deadchat) are allowed to see if something is under deadchat control. Humans don't need to know (or shouldn't know) if deadchat is expanding its reach into the physical realm.

## Why It's Good For The Game

Alive players shouldn't be able to see if something is under control by the spirits, and Timberpoes confirmed this was unintentional behavior. 

## Changelog
:cl: Melbert
fix: Only ghosts can see if something is deadchat controlled. Humans are no longer clairvoyant. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
