### PR TITLE
Sentience fun balloon QoL

### DIFF
--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -49,8 +49,9 @@
 
 /obj/effect/fun_balloon/sentience/effect()
 	var/list/bodies = list()
-	for(var/mob/living/M in range(effect_range, get_turf(src)))
-		bodies += M
+	for(var/mob/living/possessable in range(effect_range, get_turf(src)))
+		if (possessable.stat == CONSCIOUS) // Only assign ghosts to living mobs!
+			bodies += possessable
 
 	var/question = "Would you like to be [group_name]?"
 	var/list/candidates = pollCandidatesForMobs(question, ROLE_PAI, null, FALSE, 100, bodies)

--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -50,7 +50,7 @@
 /obj/effect/fun_balloon/sentience/effect()
 	var/list/bodies = list()
 	for(var/mob/living/possessable in range(effect_range, get_turf(src)))
-		if (possessable.stat == CONSCIOUS) // Only assign ghosts to living mobs!
+		if (!possessable.ckey && possessable.stat == CONSCIOUS) // Only assign ghosts to living, non-occupied mobs!
 			bodies += possessable
 
 	var/question = "Would you like to be [group_name]?"
@@ -59,9 +59,8 @@
 		var/mob/dead/observer/C = pick_n_take(candidates)
 		var/mob/living/body = pick_n_take(bodies)
 
-		to_chat(body, "<span class='warning'>Your mob has been taken over by a ghost!</span>", confidential = TRUE)
 		message_admins("[key_name_admin(C)] has taken control of ([key_name_admin(body)])")
-		body.ghostize(0)
+		body.ghostize(FALSE)
 		body.key = C.key
 		new /obj/effect/temp_visual/gravpush(get_turf(body))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so that only unoccupied conscious/living mobs can be used with the sentience fun balloon.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's no fun for a ghost to click on a prompt, expecting to play, just to find out the mob they were assigned to is already dead.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: sentience fun balloons can no longer assign ghosts to dead mobs
qol: sentience fun balloons only work on mobs without a ckey
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
