### PR TITLE
Create explicit warning if not building with CBT

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -82,7 +82,7 @@
 #define MAX_ATOM_OVERLAYS 100
 
 #if !defined(CBT) && !defined(SPACEMAN_DMM)
-#warn "Building with Dream Maker is no longer supported."
+#warn "Building with Dream Maker is no longer supported and may result in errors."
 #warn "In order to build, run BUILD.bat in the root directory."
-#warn "Consider using Visual Studio Code instead, where you can Ctrl+Shift+B to build."
+#warn "Consider switching to VSCode editor instead, where you can press Ctrl+Shift+B to build."
 #endif

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -72,6 +72,11 @@
 #define TESTING
 #endif
 
+#ifdef TGS
+// TGS performs its own build of dm.exe, but includes a prepended TGS define.
+#define CBT
+#endif
+
 // A reasonable number of maximum overlays an object needs
 // If you think you need more, rethink it
 #define MAX_ATOM_OVERLAYS 100

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -82,7 +82,7 @@
 #define MAX_ATOM_OVERLAYS 100
 
 #if !defined(CBT) && !defined(SPACEMAN_DMM)
-#error "Building with Dream Maker is no longer supported."
-#error "In order to build, run BUILD.bat in the root directory."
-#error "Consider using Visual Studio Code instead, where you can Ctrl+Shift+B to build."
+#warn "Building with Dream Maker is no longer supported."
+#warn "In order to build, run BUILD.bat in the root directory."
+#warn "Consider using Visual Studio Code instead, where you can Ctrl+Shift+B to build."
 #endif

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -75,3 +75,9 @@
 // A reasonable number of maximum overlays an object needs
 // If you think you need more, rethink it
 #define MAX_ATOM_OVERLAYS 100
+
+#if !defined(CBT) && !defined(SPACEMAN_DMM)
+#error "Building with Dream Maker is no longer supported."
+#error "In order to build, run BUILD.bat in the root directory."
+#error "Consider using Visual Studio Code instead, where you can Ctrl+Shift+B to build."
+#endif

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -93,6 +93,17 @@ const taskTgui = new Task('tgui')
     await yarn(['run', 'webpack-cli', '--mode=production']);
   });
 
+/// Prepends the defines to the .dme.
+/// Does not clean them up, as this is intended for TGS which
+/// clones new copies anyway.
+const taskPrependDefines = (...defines) => new Task('prepend defines')
+  .depends(`${DME_NAME}.dme`)
+  .build(async () => {
+    const dmeContents = fs.readFileSync(`${DME_NAME}.dme`);
+    const textToWrite = defines.map(define => `#define ${define}\n`);
+    fs.writeFileSync(`${DME_NAME}.dme`, `${textToWrite}\n${dmeContents}`);
+  });
+
 const taskDm = (...injectedDefines) => new Task('dm')
   .depends('_maps/map_files/generic/**')
   .depends('code/**')
@@ -187,7 +198,8 @@ switch (BUILD_MODE) {
     tasksToRun = [
       taskYarn,
       taskTgfont,
-      taskTgui
+      taskTgui,
+      taskPrependDefines('TGS'),
     ]
     break;
   case ALL_MAPS_BUILD:

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -165,7 +165,7 @@ const taskDm = (...injectedDefines) => new Task('dm')
         // Rename rsc
         fs.renameSync(`${DME_NAME}.mdme.rsc`, `${DME_NAME}.rsc`)
         // Remove mdme
-        fs.rmSync(`${DME_NAME}.mdme`)
+        fs.unlinkSync(`${DME_NAME}.mdme`)
     }
     else {
       await exec(dmPath, [`${DME_NAME}.dme`]);
@@ -180,7 +180,7 @@ switch (BUILD_MODE) {
       taskYarn,
       taskTgfont,
       taskTgui,
-      taskDm(),
+      taskDm('CBT'),
     ]
     break;
   case TGS_BUILD:
@@ -195,7 +195,7 @@ switch (BUILD_MODE) {
       taskYarn,
       taskTgfont,
       taskTgui,
-      taskDm('CIBUILDING','CITESTING','ALL_MAPS')
+      taskDm('CBT','CIBUILDING','CITESTING','ALL_MAPS')
     ];
     break;
   case TEST_RUN_BUILD:
@@ -203,7 +203,7 @@ switch (BUILD_MODE) {
       taskYarn,
       taskTgfont,
       taskTgui,
-      taskDm('CIBUILDING')
+      taskDm('CBT','CIBUILDING')
     ];
     break;
   default:

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -96,8 +96,7 @@ const taskTgui = new Task('tgui')
 /// Prepends the defines to the .dme.
 /// Does not clean them up, as this is intended for TGS which
 /// clones new copies anyway.
-const taskPrependDefines = (...defines) => new Task('prepend defines')
-  .depends(`${DME_NAME}.dme`)
+const taskPrependDefines = (...defines) => new Task('prepend-defines')
   .build(async () => {
     const dmeContents = fs.readFileSync(`${DME_NAME}.dme`);
     const textToWrite = defines.map(define => `#define ${define}\n`);


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new `CBT` define which is automatically created when building. If this define is absent, the build will fail.

This is what @Cyberboss tried to do with USE_BUILD_BAT_INSTEAD_OF_DREAM_MAKER.dm, but couldn't. See https://github.com/tgstation/tgstation/pull/56470.

The reasoning behind this is CBT is already a requirement to build a fresh project, otherwise the tgui bundle files won't exist. This gives a readable error to go along with that. However, you can currently build once then just use Dream Maker. This is a footgun--not only are we already adding new things to CBT like tgfont which will fail later on, but also it will create weird scenarios when we add tasks to CBT that don't immediately fail if not ran, or otherwise create out of sync builds.

Also replaces `rmSync` with `unlinkSync`, which works on older Node versions.