### PR TITLE
Examining people only shows the big picture of their ID if the user has secHUDs

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -91,8 +91,8 @@
 	//ID
 	if(wear_id && !(wear_id.item_flags & EXAMINE_SKIP))
 		. += "[t_He] [t_is] wearing [wear_id.get_examine_string(user)]."
-
-		. += wear_id.get_id_examine_strings(user)
+		if(HAS_TRAIT(user, TRAIT_SECURITY_HUD))
+			. += wear_id.get_id_examine_strings(user)
 		//var/list/extended_id_examine = wear_id.get_id_examine_strings(user)
 
 		//for(var/examine_string in extended_id_examine)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes it so the giant picture of the ID someone is wearing that allows you to see their trim in detail only shows up if the user has secHUDs. You can still see the ID they're wearing as normal without them, you just don't get the big picture.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Unless I'm security, I'm not getting paid to care about what trim someone is rocking on their ID, no need to take up 5 lines of text each time I examine someone because of it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
qol: Examining someone will only show a close-up image of their worn ID if you are wearing secHUDs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
