### PR TITLE
Some minor atmos cleanup

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -54,6 +54,13 @@
 /// Amount of air to take a from a tile
 #define BREATH_PERCENTAGE (BREATH_VOLUME/CELL_VOLUME)
 
+//Defines for N2O and Healium euphoria moodlets
+#define EUPHORIA_INACTIVE 0
+#define EUPHORIA_ACTIVE 1
+#define EUPHORIA_LAST_FLAG 2
+
+#define MIASMA_CORPSE_MOLES 0.02
+#define MIASMA_GIBS_MOLES 0.005
 
 //EXCITED GROUPS
 /**
@@ -473,7 +480,30 @@
 /// north/south east/west doesn't matter, auto normalize on build.
 #define PIPING_CARDINAL_AUTONORMALIZE (1<<3)
 
-//Piping helpers
+// Ventcrawling bitflags, handled in var/vent_movement
+///Allows for ventcrawling to occur. All atmospheric machines have this flag on by default. Cryo is the exception
+#define VENTCRAWL_ALLOWED	(1<<0)
+///Allows mobs to enter or leave from atmospheric machines. On for passive, unary, and scrubber vents.
+#define VENTCRAWL_ENTRANCE_ALLOWED (1<<1)
+///Used to check if a machinery is visible. Called by update_pipe_vision(). On by default for all except cryo.
+#define VENTCRAWL_CAN_SEE	(1<<2)
+
+GLOBAL_LIST_INIT(pipe_paint_colors, sortList(list(
+		"amethyst" = rgb(130,43,255), //supplymain
+		"blue" = rgb(0,0,255),
+		"brown" = rgb(178,100,56),
+		"cyan" = rgb(0,255,249),
+		"dark" = rgb(69,69,69),
+		"green" = rgb(30,255,0),
+		"grey" = rgb(255,255,255),
+		"orange" = rgb(255,129,25),
+		"purple" = rgb(128,0,182),
+		"red" = rgb(255,0,0),
+		"violet" = rgb(64,0,128),
+		"yellow" = rgb(255,198,0)
+)))
+
+//Helpers
 #define PIPING_LAYER_SHIFT(T, PipingLayer) \
 	if(T.dir & (NORTH|SOUTH)) { \
 		T.pixel_x = (PipingLayer - PIPING_LAYER_DEFAULT) * PIPING_LAYER_P_X;\
@@ -514,12 +544,6 @@
 		out_var = cached_gases[gas_id][MOLES];\
 	}
 
-//Adjacent turf related defines, they dictate what to do with a turf once it's been recalculated
-//Used as "state" in CALCULATE_ADJACENT_TURFS
-#define NORMAL_TURF 1
-#define MAKE_ACTIVE 2
-#define KILL_EXCITED 3
-
 #ifdef TESTING
 GLOBAL_LIST_INIT(atmos_adjacent_savings, list(0,0))
 #define CALCULATE_ADJACENT_TURFS(T, state) if (SSadjacent_air.queue[T]) { GLOB.atmos_adjacent_savings[1] += 1 } else { GLOB.atmos_adjacent_savings[2] += 1; SSadjacent_air.queue[T] = state}
@@ -527,38 +551,13 @@ GLOBAL_LIST_INIT(atmos_adjacent_savings, list(0,0))
 #define CALCULATE_ADJACENT_TURFS(T, state) SSadjacent_air.queue[T] = state
 #endif
 
+//Adjacent turf related defines, they dictate what to do with a turf once it's been recalculated
+//Used as "state" in CALCULATE_ADJACENT_TURFS
+#define NORMAL_TURF 1
+#define MAKE_ACTIVE 2
+#define KILL_EXCITED 3
+
 //If you're doing spreading things related to atmos, DO NOT USE CANATMOSPASS, IT IS NOT CHEAP. use this instead, the info is cached after all. it's tweaked just a bit to allow for circular checks
 #define TURFS_CAN_SHARE(T1, T2) (LAZYACCESS(T2.atmos_adjacent_turfs, T1) || LAZYLEN(T1.atmos_adjacent_turfs & T2.atmos_adjacent_turfs))
 //Use this to see if a turf is fully blocked or not, think windows or firelocks. Fails with 1x1 non full tile windows, but it's not worth the cost.
 #define TURF_SHARES(T) (LAZYLEN(T.atmos_adjacent_turfs))
-
-GLOBAL_LIST_INIT(pipe_paint_colors, sortList(list(
-		"amethyst" = rgb(130,43,255), //supplymain
-		"blue" = rgb(0,0,255),
-		"brown" = rgb(178,100,56),
-		"cyan" = rgb(0,255,249),
-		"dark" = rgb(69,69,69),
-		"green" = rgb(30,255,0),
-		"grey" = rgb(255,255,255),
-		"orange" = rgb(255,129,25),
-		"purple" = rgb(128,0,182),
-		"red" = rgb(255,0,0),
-		"violet" = rgb(64,0,128),
-		"yellow" = rgb(255,198,0)
-)))
-
-#define MIASMA_CORPSE_MOLES 0.02
-#define MIASMA_GIBS_MOLES 0.005
-
-//Defines for N2O and Healium euphoria moodlets
-#define EUPHORIA_INACTIVE 0
-#define EUPHORIA_ACTIVE 1
-#define EUPHORIA_LAST_FLAG 2
-
-// Ventcrawling bitflags, handled in var/vent_movement
-///Allows for ventcrawling to occur. All atmospheric machines have this flag on by default. Cryo is the exception
-#define VENTCRAWL_ALLOWED	(1<<0)
-///Allows mobs to enter or leave from atmospheric machines. On for passive, unary, and scrubber vents.
-#define VENTCRAWL_ENTRANCE_ALLOWED (1<<1)
-///Used to check if a machinery is visible. Called by update_pipe_vision(). On by default for all except cryo.
-#define VENTCRAWL_CAN_SEE	(1<<2)

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -473,7 +473,7 @@
 /// north/south east/west doesn't matter, auto normalize on build.
 #define PIPING_CARDINAL_AUTONORMALIZE (1<<3)
 
-//HELPERS
+//Piping helpers
 #define PIPING_LAYER_SHIFT(T, PipingLayer) \
 	if(T.dir & (NORTH|SOUTH)) { \
 		T.pixel_x = (PipingLayer - PIPING_LAYER_DEFAULT) * PIPING_LAYER_P_X;\
@@ -507,16 +507,19 @@
 	for(var/total_moles_id in cached_gases){\
 		out_var += cached_gases[total_moles_id][MOLES];\
 	}
+
 #define TOTAL_MOLES_SPECIFIC(cached_gases, gas_id, out_var)\
 	out_var = 0;\
-	for(var/total_moles_id in cached_gases){\
-		if(total_moles_id == gas_id){\
-			out_var += cached_gases[total_moles_id][MOLES];\
-		}\
+	if(cached_gases[gas_id]){\
+		out_var = cached_gases[gas_id][MOLES];\
 	}
+
+//Adjacent turf related defines, they dictate what to do with a turf once it's been recalculated
+//Used as "state" in CALCULATE_ADJACENT_TURFS
 #define NORMAL_TURF 1
 #define MAKE_ACTIVE 2
 #define KILL_EXCITED 3
+
 #ifdef TESTING
 GLOBAL_LIST_INIT(atmos_adjacent_savings, list(0,0))
 #define CALCULATE_ADJACENT_TURFS(T, state) if (SSadjacent_air.queue[T]) { GLOB.atmos_adjacent_savings[1] += 1 } else { GLOB.atmos_adjacent_savings[2] += 1; SSadjacent_air.queue[T] = state}

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -115,10 +115,11 @@
 	for(var/obj/effect/temp_visual/mining_overlay/M in src)
 		qdel(M)
 	var/flags = NONE
+	var/old_type = type
 	if(defer_change) // TODO: make the defer change var a var for any changeturf flag
 		flags = CHANGETURF_DEFER_CHANGE
 	var/turf/open/mined = ScrapeAway(null, flags)
-	addtimer(CALLBACK(src, .proc/AfterChange), 1, TIMER_UNIQUE)
+	addtimer(CALLBACK(src, .proc/AfterChange, old_type), 1, TIMER_UNIQUE)
 	playsound(src, 'sound/effects/break_stone.ogg', 50, TRUE) //beautiful destruction
 	mined.update_visuals()
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -108,10 +108,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	TOTAL_MOLES(cached_gases, .)
 
 /// Calculate moles for a specific gas in the mixture
-/datum/gas_mixture/proc/total_moles_specific(gas_id = null)
+/datum/gas_mixture/proc/total_moles_specific(gas_id)
 	var/cached_gases = gases
-	if(!gas_id)
-		return null
 	TOTAL_MOLES_SPECIFIC(cached_gases, gas_id, .)
 
 /// Checks to see if gas amount exists in mixture.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes mining not making turfs active, I forgot to add a type arg when I added one to AfterChange(). This isn't the only source of the issue, but it's the most prevalent one

Cleans up total_moles_specific() slightly, there's no point iterating a list if you already have the gas id. Removes a null assignment and if check, they don't catch anything as things are now, and if someone passes null to the proc I want a runtime

Oh and I reordered a bit of atmospherics.dm to make a comment make sense. Don't worry about it

## Why It's Good For The Game
sweep sweep sweep

## Changelog
:cl:
fix: Fixes mined out turfs not sharing gas with their neighbors in a rare case, this most likely only effected one room on tramstation 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
