### PR TITLE
emissive blockers are now just an overlay to lower maptick (proof in comments)

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -75,13 +75,7 @@
 
 /atom/movable/Initialize(mapload)
 	. = ..()
-	switch(blocks_emissive)
-		if(EMISSIVE_BLOCK_GENERIC)
-			update_emissive_block()
-		if(EMISSIVE_BLOCK_UNIQUE)
-			render_target = ref(src)
-			em_block = new(src, render_target)
-			vis_contents += em_block
+	update_appearance()
 	if(opacity)
 		AddElement(/datum/element/light_blocking)
 	switch(light_system)
@@ -131,15 +125,24 @@
 
 	vis_contents.Cut()
 
-
 /atom/movable/proc/update_emissive_block()
-	if(blocks_emissive != EMISSIVE_BLOCK_GENERIC)
+	if(!blocks_emissive)
 		return
-	var/mutable_appearance/gen_emissive_blocker = mutable_appearance(icon, icon_state, EMISSIVE_BLOCKER_LAYER, EMISSIVE_BLOCKER_PLANE)
-	gen_emissive_blocker.dir = dir
-	gen_emissive_blocker.alpha = alpha
-	gen_emissive_blocker.appearance_flags |= appearance_flags
-	add_overlay(list(gen_emissive_blocker))
+	else if (blocks_emissive == EMISSIVE_BLOCK_GENERIC)
+		var/mutable_appearance/gen_emissive_blocker = mutable_appearance(icon, icon_state, EMISSIVE_BLOCKER_LAYER, EMISSIVE_BLOCKER_PLANE)
+		gen_emissive_blocker.dir = dir
+		gen_emissive_blocker.alpha = alpha
+		gen_emissive_blocker.appearance_flags |= appearance_flags
+		return gen_emissive_blocker
+	else if(blocks_emissive == EMISSIVE_BLOCK_UNIQUE)
+		if(!em_block)
+			render_target = ref(src)
+			em_block = new(src, render_target)
+		return em_block
+
+/atom/movable/update_overlays()
+	. = ..()
+	. += update_emissive_block()
 
 /atom/movable/proc/can_zFall(turf/source, levels = 1, turf/target, direction)
 	if(!direction)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -135,13 +135,11 @@
 /atom/movable/proc/update_emissive_block()
 	if(blocks_emissive != EMISSIVE_BLOCK_GENERIC)
 		return
-	if(length(managed_vis_overlays))
-		for(var/a in managed_vis_overlays)
-			var/obj/effect/overlay/vis/vs
-			if(vs.plane == EMISSIVE_BLOCKER_PLANE)
-				SSvis_overlays.remove_vis_overlay(src, list(vs))
-				break
-	SSvis_overlays.add_vis_overlay(src, icon, icon_state, EMISSIVE_BLOCKER_LAYER, EMISSIVE_BLOCKER_PLANE, dir)
+	var/mutable_appearance/gen_emissive_blocker = mutable_appearance(icon, icon_state, EMISSIVE_BLOCKER_LAYER, EMISSIVE_BLOCKER_PLANE)
+	gen_emissive_blocker.dir = dir
+	gen_emissive_blocker.alpha = alpha
+	gen_emissive_blocker.appearance_flags |= appearance_flags
+	add_overlay(list(gen_emissive_blocker))
 
 /atom/movable/proc/can_zFall(turf/source, levels = 1, turf/target, direction)
 	if(!direction)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -75,7 +75,17 @@
 
 /atom/movable/Initialize(mapload)
 	. = ..()
-	update_appearance()
+	switch(blocks_emissive)
+		if(EMISSIVE_BLOCK_GENERIC)
+			var/mutable_appearance/gen_emissive_blocker = mutable_appearance(icon, icon_state, EMISSIVE_BLOCKER_LAYER, EMISSIVE_BLOCKER_PLANE)
+			gen_emissive_blocker.dir = dir
+			gen_emissive_blocker.alpha = alpha
+			gen_emissive_blocker.appearance_flags |= appearance_flags
+			add_overlay(list(gen_emissive_blocker))
+		if(EMISSIVE_BLOCK_UNIQUE)
+			render_target = ref(src)
+			em_block = new(src, render_target)
+			add_overlay(list(em_block))
 	if(opacity)
 		AddElement(/datum/element/light_blocking)
 	switch(light_system)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
currently emissive blockers are objects added to the vis_contents of every item. however mutable appearances as overlays can serve this role perfectly well and according to my tests should cause less maptick per item. for mobs mutable appearances dont work for reasons i dont understand so instead this adds the em_block object to overlays instead of vis_contents. these both use atom/movable/update_icon() now

graphed test results below 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
LESS MAPTICK. by some amount at least. i dont know how much of a contribution to maptick the emissive blockers on items + mobs make specifically for a live round. the only downsides to this that i know of (assuming there arent weird bugs) are that init probably takes slightly longer and each item takes more memory (probably) because overlays are value-copied appearances instead of references like vis_contents are
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


