### PR TITLE
Fixed the name of the burger that turns you into a cyborg.

### DIFF
--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -86,8 +86,8 @@
 	foodtypes = GRAIN | VEGETABLES
 	venue_value = FOOD_PRICE_CHEAP
 
-/obj/item/food/burger/roburger
-	name = "roburger"
+/obj/item/food/burger/borger
+	name = "borger"
 	desc = "The lettuce is the only organic component. Beep."
 	icon_state = "roburger"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 8, /datum/reagent/cyborg_mutation_nanomachines = 6, /datum/reagent/consumable/nutriment/vitamin = 6)
@@ -95,8 +95,8 @@
 	foodtypes = GRAIN | TOXIC
 	venue_value = FOOD_PRICE_EXOTIC
 
-/obj/item/food/burger/roburgerbig
-	name = "roburger"
+/obj/item/food/burger/borgerbig
+	name = "big borger"
 	desc = "This massive patty looks like poison. Beep."
 	icon_state = "roburger"
 	max_volume = 120


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The roburger is now named borger, as it always should have been.

## Why It's Good For The Game

Borger is a way better name.

## Changelog
:cl:
fix: Nanotrasen has rebranded their horrifying mechanical burger filled with nanites that turns you into a glorified metal slave ! Roburgers are now named borgers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
