### PR TITLE
Snappier Firelocks

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -322,6 +322,8 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		firedoors_last_closed_on = world.time
 		for(var/FD in firedoors)
 			var/obj/machinery/door/firedoor/D = FD
+			if (D.being_held_open)
+				continue
 			var/cont = !D.welded
 			if(cont && opening) //don't open if adjacent area is on fire
 				for(var/I in D.affecting_areas)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -222,6 +222,10 @@
 /obj/machinery/door/proc/try_to_crowbar(obj/item/I, mob/user)
 	return
 
+/obj/machinery/door/proc/try_to_crowbar_secondary(obj/item/I, mob/user)
+	try_to_crowbar(I, user)
+	// Only firelocks have a special secondary usage for now, might want to make this simply return in the future.
+
 /obj/machinery/door/attackby(obj/item/I, mob/living/user, params)
 	if(!user.combat_mode && (I.tool_behaviour == TOOL_CROWBAR || istype(I, /obj/item/fireaxe)))
 		var/forced_open = FALSE
@@ -246,7 +250,7 @@
 		if(istype(weapon, /obj/item/crowbar))
 			var/obj/item/crowbar/crowbar = weapon
 			forced_open = crowbar.force_opens
-		try_to_crowbar(weapon, user, forced_open, secondary = TRUE)
+		try_to_crowbar_secondary(weapon, user, forced_open)
 
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -246,7 +246,7 @@
 		if(istype(weapon, /obj/item/crowbar))
 			var/obj/item/crowbar/crowbar = weapon
 			forced_open = crowbar.force_opens
-		try_to_crowbar(weapon, user, forced_open)
+		try_to_crowbar(weapon, user, forced_open, secondary = TRUE)
 
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -223,8 +223,7 @@
 	return
 
 /obj/machinery/door/proc/try_to_crowbar_secondary(obj/item/I, mob/user)
-	try_to_crowbar(I, user)
-	// Only firelocks have a special secondary usage for now, might want to make this simply return in the future.
+	return
 
 /obj/machinery/door/attackby(obj/item/I, mob/living/user, params)
 	if(!user.combat_mode && (I.tool_behaviour == TOOL_CROWBAR || istype(I, /obj/item/fireaxe)))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -219,10 +219,12 @@
 /obj/machinery/door/proc/try_to_weld_secondary(obj/item/weldingtool/tool, mob/user)
 	return
 
-/obj/machinery/door/proc/try_to_crowbar(obj/item/I, mob/user)
+
+/obj/machinery/door/proc/try_to_crowbar(obj/item/acting_object, mob/user)
 	return
 
-/obj/machinery/door/proc/try_to_crowbar_secondary(obj/item/I, mob/user)
+/// Called when the user right-clicks on the door with a crowbar.
+/obj/machinery/door/proc/try_to_crowbar_secondary(obj/item/acting_object, mob/user)
 	return
 
 /obj/machinery/door/attackby(obj/item/I, mob/living/user, params)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -141,7 +141,6 @@
 		open()
 		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
 		RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
-		handle_held_open_adjacency(user)
 	else
 		close()
 
@@ -157,13 +156,13 @@
 
 /obj/machinery/door/firedoor/proc/handle_held_open_adjacency(mob/user)
 	var/mob/living/living_user = user
-	if(!Adjacent(user) || !isliving(user) || !living_user.is_standing())
-		being_held_open = FALSE
-		close()
-		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
-		UnregisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION)
+	if(Adjacent(user) && isliving(user) && living_user.is_standing())
 		return
-
+	being_held_open = FALSE
+	close()
+	UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION)
+	
 /obj/machinery/door/firedoor/attack_ai(mob/user)
 	add_fingerprint(user)
 	if(welded || operating || machine_stat & NOPOWER)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -142,10 +142,12 @@
 	if(density)
 		being_held_open = TRUE
 		open()
-		if(user && !QDELETED(user))
-			RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
-			RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
-			handle_held_open_adjacency(user)
+		if(!user || QDELETED(user))
+			being_held_open = FALSE
+			return
+		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
+		RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
+		handle_held_open_adjacency(user)
 	else
 		close()
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -142,9 +142,10 @@
 	if(density)
 		being_held_open = TRUE
 		open()
-		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
-		RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
-		handle_held_open_adjacency(user)
+		if(user && !QDELETED(user))
+			RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
+			RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
+			handle_held_open_adjacency(user)
 	else
 		close()
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -144,7 +144,7 @@
 		open()
 		if(QDELETED(user))
 			being_held_open = FALSE
-		return
+			return
 		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
 		RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
 		RegisterSignal(user, COMSIG_PARENT_QDELETING, .proc/handle_held_open_adjacency)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -163,8 +163,6 @@
 	
 	being_held_open = FALSE
 	close()
-	return
-
 /obj/machinery/door/firedoor/attack_ai(mob/user)
 	add_fingerprint(user)
 	if(welded || operating || machine_stat & NOPOWER)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -139,6 +139,8 @@
 	if(density)
 		being_held_open = TRUE
 		open()
+		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
+		RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
 		handle_held_open_adjacency(user)
 	else
 		close()
@@ -161,9 +163,6 @@
 		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 		UnregisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION)
 		return
-
-	RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
-	RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
 
 /obj/machinery/door/firedoor/attack_ai(mob/user)
 	add_fingerprint(user)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -131,25 +131,29 @@
 		log_game("[key_name(user)] [welded ? "welded":"unwelded"] firedoor [src] with [W] at [AREACOORD(src)]")
 		update_appearance()
 
-/obj/machinery/door/firedoor/try_to_crowbar(obj/item/I, mob/user, var/secondary = FALSE)
+/obj/machinery/door/firedoor/try_to_crowbar(obj/item/I, mob/user)
 	if(welded || operating)
 		return
 
 	if(density)
-		if(!secondary)
-			being_held_open = TRUE
-			open()
-			handle_held_open_adjacency(user)
-		else
-			open()
-			
+		being_held_open = TRUE
+		open()
+		handle_held_open_adjacency(user)
+	else
+		close()
+
+/obj/machinery/door/firedoor/try_to_crowbar_secondary(obj/item/I, mob/user)
+	if(welded || operating)
+		return
+
+	if(density)
+		open()
 	else
 		close()
 
 /obj/machinery/door/firedoor/proc/handle_held_open_adjacency(mob/user)
-	var/distance = get_dist(user, src)
 	var/mob/living/living_user = isliving(user) ? user : null
-	if(distance>1 || !isliving(user) || !living_user.is_standing())
+	if(!Adjacent(user) || !isliving(user) || !living_user.is_standing())
 		being_held_open = FALSE
 		close()
 		return

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -152,7 +152,7 @@
 		close()
 
 /obj/machinery/door/firedoor/proc/handle_held_open_adjacency(mob/user)
-	var/mob/living/living_user = isliving(user) ? user : null
+	var/mob/living/living_user = user
 	if(!Adjacent(user) || !isliving(user) || !living_user.is_standing())
 		being_held_open = FALSE
 		close()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -131,7 +131,8 @@
 		log_game("[key_name(user)] [welded ? "welded":"unwelded"] firedoor [src] with [W] at [AREACOORD(src)]")
 		update_appearance()
 
-/obj/machinery/door/firedoor/try_to_crowbar(obj/item/I, mob/user)
+/// Closes opened firedoors and 
+/obj/machinery/door/firedoor/try_to_crowbar(obj/item/acting_object, mob/user)
 	if(welded || operating)
 		return
 
@@ -142,7 +143,8 @@
 	else
 		close()
 
-/obj/machinery/door/firedoor/try_to_crowbar_secondary(obj/item/I, mob/user)
+/// A simple toggle for firedoors between on and off
+/obj/machinery/door/firedoor/try_to_crowbar_secondary(obj/item/acting_object, mob/user)
 	if(welded || operating)
 		return
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -142,11 +142,9 @@
 	if(density)
 		being_held_open = TRUE
 		open()
-		if(QDELETED(user))
-			being_held_open = FALSE
-			return
 		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
 		RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
+		RegisterSignal(user, COMSIG_PARENT_QDELETING, .proc/handle_held_open_adjacency)
 		handle_held_open_adjacency(user)
 	else
 		close()
@@ -163,6 +161,15 @@
 
 /obj/machinery/door/firedoor/proc/handle_held_open_adjacency(mob/user)
 	SIGNAL_HANDLER
+
+	//Handle qdeletion here
+	if(QDELETED(user))
+		being_held_open = FALSE
+		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
+		UnregisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION)
+		UnregisterSignal(user, COMSIG_PARENT_QDELETING)
+		return
+
 	var/mob/living/living_user = user
 	if(Adjacent(user) && isliving(user) && (living_user.body_position == STANDING_UP))
 		return
@@ -170,6 +177,7 @@
 	INVOKE_ASYNC(src, .proc/close)
 	UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 	UnregisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION)
+	UnregisterSignal(user, COMSIG_PARENT_QDELETING)
 	
 /obj/machinery/door/firedoor/attack_ai(mob/user)
 	add_fingerprint(user)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -131,7 +131,7 @@
 		log_game("[key_name(user)] [welded ? "welded":"unwelded"] firedoor [src] with [W] at [AREACOORD(src)]")
 		update_appearance()
 
-/// Closes opened firedoors and 
+/// We check for adjacency when using the primary attack.
 /obj/machinery/door/firedoor/try_to_crowbar(obj/item/acting_object, mob/user)
 	if(welded || operating)
 		return

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -131,7 +131,7 @@
 		log_game("[key_name(user)] [welded ? "welded":"unwelded"] firedoor [src] with [W] at [AREACOORD(src)]")
 		update_appearance()
 
-/obj/machinery/door/firedoor/try_to_crowbar(obj/item/I, mob/user, secondary = FALSE)
+/obj/machinery/door/firedoor/try_to_crowbar(obj/item/I, mob/user, var/secondary = FALSE)
 	if(welded || operating)
 		return
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -35,7 +35,10 @@
 	if(!density)
 		. += "<span class='notice'>It is open, but could be <b>pried</b> closed.</span>"
 	else if(!welded)
-		. += "<span class='notice'>It is closed, but could be <i>pried</i> open. Deconstruction would require it to be <b>welded</b> shut.</span>"
+		. += "<span class='notice'>It is closed, but could be <b>pried</b> open.</span>"
+		. += "<span class='notice'>Hold the door open by prying it with <i>left-click</i> and standing next to it.</span>"
+		. += "<span class='notice'>Prying by <i>right-clicking</i> the door will simply open it.</span>"
+		. += "<span class='notice'>Deconstruction would require it to be <b>welded</b> shut.</span>"
 	else if(boltslocked)
 		. += "<span class='notice'>It is <i>welded</i> shut. The floor bolts have been locked by <b>screws</b>.</span>"
 	else
@@ -137,7 +140,11 @@
 		return
 
 	if(density)
+		being_held_open = TRUE
 		open()
+		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
+		RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
+		handle_held_open_adjacency(user)
 	else
 		close()
 
@@ -147,11 +154,7 @@
 		return
 
 	if(density)
-		being_held_open = TRUE
 		open()
-		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
-		RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
-		handle_held_open_adjacency(user)
 	else
 		close()
 
@@ -161,7 +164,7 @@
 	if(Adjacent(user) && isliving(user) && (living_user.body_position == STANDING_UP))
 		return
 	being_held_open = FALSE
-	addtimer(CALLBACK(src, .proc/close), 0.1 SECONDS)
+	INVOKE_ASYNC(src, .proc/close)
 	UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 	UnregisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION)
 	

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -158,13 +158,13 @@
 	if(!Adjacent(user) || !isliving(user) || !living_user.is_standing())
 		being_held_open = FALSE
 		close()
+		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
+		UnregisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION)
 		return
 
-	if (!do_after(living_user, 30 SECONDS, src, progress=FALSE, extra_checks = CALLBACK(living_user, /mob/living/.proc/is_standing)))
-		handle_held_open_adjacency(living_user)
-	
-	being_held_open = FALSE
-	close()
+	RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
+	RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
+
 /obj/machinery/door/firedoor/attack_ai(mob/user)
 	add_fingerprint(user)
 	if(welded || operating || machine_stat & NOPOWER)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -142,7 +142,7 @@
 	if(density)
 		being_held_open = TRUE
 		open()
-		if(!user || QDELETED(user))
+		if(QDELETED(user))
 			being_held_open = FALSE
 			return
 		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -155,6 +155,7 @@
 		close()
 
 /obj/machinery/door/firedoor/proc/handle_held_open_adjacency(mob/user)
+	SIGNAL_HANDLER
 	var/mob/living/living_user = user
 	if(Adjacent(user) && isliving(user) && (living_user.body_position == STANDING_UP))
 		return

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -156,7 +156,7 @@
 
 /obj/machinery/door/firedoor/proc/handle_held_open_adjacency(mob/user)
 	var/mob/living/living_user = user
-	if(Adjacent(user) && isliving(user) && living_user.is_standing())
+	if(Adjacent(user) && isliving(user) && (living_user.body_position == STANDING_UP))
 		return
 	being_held_open = FALSE
 	close()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -142,6 +142,9 @@
 	if(density)
 		being_held_open = TRUE
 		open()
+		if(QDELETED(user))
+			being_held_open = FALSE
+		return
 		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
 		RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
 		RegisterSignal(user, COMSIG_PARENT_QDELETING, .proc/handle_held_open_adjacency)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -151,6 +151,7 @@
 		open()
 		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
 		RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
+		handle_held_open_adjacency(user)
 	else
 		close()
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -137,10 +137,7 @@
 		return
 
 	if(density)
-		being_held_open = TRUE
 		open()
-		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
-		RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
 	else
 		close()
 
@@ -150,7 +147,10 @@
 		return
 
 	if(density)
+		being_held_open = TRUE
 		open()
+		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/handle_held_open_adjacency)
+		RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, .proc/handle_held_open_adjacency)
 	else
 		close()
 
@@ -160,7 +160,7 @@
 	if(Adjacent(user) && isliving(user) && (living_user.body_position == STANDING_UP))
 		return
 	being_held_open = FALSE
-	close()
+	addtimer(CALLBACK(src, .proc/close), 0.1 SECONDS)
 	UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 	UnregisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION)
 	

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -58,3 +58,7 @@
 	if(stat > SOFT_CRIT)
 		return
 	return ..()
+
+/// Used as a callback proc by handle_forced_open_adjacency under firedoor.dm
+/mob/living/proc/is_standing()
+	return (body_position == STANDING_UP)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -58,7 +58,3 @@
 	if(stat > SOFT_CRIT)
 		return
 	return ..()
-
-/// Check whether the mob is standing or not.
-/mob/living/proc/is_standing()
-	return body_position == STANDING_UP

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -61,4 +61,4 @@
 
 /// Used as a callback proc by handle_forced_open_adjacency under firedoor.dm
 /mob/living/proc/is_standing()
-	return (body_position == STANDING_UP)
+	return body_position == STANDING_UP

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -59,6 +59,6 @@
 		return
 	return ..()
 
-/// Used as a callback proc by handle_forced_open_adjacency under firedoor.dm
+/// Check whether the mob is standing or not.
 /mob/living/proc/is_standing()
 	return body_position == STANDING_UP


### PR DESCRIPTION
## About The Pull Request
Firelocks are kind of annoying to open since it relies on a 10 second area based timer that is difficult to predict, this tries to solve that. 

When forced open with the primary attack, the firelock now checks if you are adjacent to it or not. Our dearest Manuel players can think of it as you manually holding the door back. It is also made to close when you are no longer adjacent or went horizontal (resting, etc.)
This sort of made firelocks snappier and close faster too, and I hope this might help it seal off areas better.

The door will be stuck closed when you leave it however, and that's where the old behaviour comes in. Secondary attack is used to toggle the firelock and surrender it to the timer if an alarm is triggered. Primary attack without a fire alarm triggering cannot keep the door open after you walk away. I hope this is intuitive enough.

[in action](https://imgur.com/a/1wpzGRc)

## Why It's Good For The Game
Snappier firelocks, less luck based crushing, hopefully a better experience for all.

## Changelog
:cl:
add: Crowbarring a firelock is changed a bit. Left clicking will let you open a firedoor and hold it in place! It will close again when you move away, though. Old behaviour is still there, you just need to right-click it.
/:cl: