### PR TITLE
Reopen Roundstart Roles on Sui

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -55,18 +55,18 @@ HUMANS_NEED_SURNAMES
 #FORCE_RANDOM_NAMES
 
 ## Unhash this to turn on automatic reopening of a player's job if they suicide at roundstart
-#REOPEN_ROUNDSTART_SUICIDE_ROLES
+REOPEN_ROUNDSTART_SUICIDE_ROLES
 
 ## Unhash to enable reopening of command level positions
-#REOPEN_ROUNDSTART_SUICIDE_ROLES_COMMAND_POSITIONS
+REOPEN_ROUNDSTART_SUICIDE_ROLES_COMMAND_POSITIONS
 
 ## Define the delay for roles to be reopened after the round starts in seconds.
 ## Has a minimum delay of 30 seconds, though it's suggested to keep over 1 min
 ## If undefined, the delay defaults to 4 minutes.
-#REOPEN_ROUNDSTART_SUICIDE_ROLES_DELAY 240
+REOPEN_ROUNDSTART_SUICIDE_ROLES_DELAY 240
 
 ## Unhash to enable a printed command report for reopened roles listing what roles were reopened.
-#REOPEN_ROUNDSTART_SUICIDE_ROLES_COMMAND_REPORT
+REOPEN_ROUNDSTART_SUICIDE_ROLES_COMMAND_REPORT
 
 
 ## ALERT LEVELS ###


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reopens jobs if they suicide after 4 minutes into the shift. 
This was originally going to be a port of cryopods - machines that do the same function, but after some discussion, 
![Imgur img](https://i.imgur.com/5xJQTpt.png)
this seemed a better option. I am inclined to agree. 

### Why not Cryopods?
Cryopods would have required considerable overhead, mapping, and always seemed to be buggy with objectives. Just to log out, you'd have to run across the map to find them (RL often doesn't give you that time), and that's IF they weren't destroyed by the random workplace hazard.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- A mildly entertaining and thematic alternative to cryopods
- Players don't have to run across the map to log out
- Players can offer up job slots to arrivals easily
- Considerably less overhead needed to maintain
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Recent Vacancies: CentCom now reopens job slots for crew members that suicide after the four minute mark. 
config: Turned on reopen roundstart jobs upon suicide
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
