### PR TITLE
TGUI Limbgrower + Limbgrower refactoring and design expansion

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -138,6 +138,7 @@
 	result = /obj/item/tailclub
 	reqs = list(/obj/item/organ/tail/lizard = 1,
 				/obj/item/stack/sheet/iron = 1)
+	blacklist = list(/obj/item/organ/tail/lizard/fake)
 	time = 40
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
@@ -147,6 +148,7 @@
 	result = /obj/item/melee/chainofcommand/tailwhip
 	reqs = list(/obj/item/organ/tail/lizard = 1,
 				/obj/item/stack/cable_coil = 1)
+	blacklist = list(/obj/item/organ/tail/lizard/fake)
 	time = 40
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -83,7 +83,7 @@
 				var/datum/reagent/reagent_id = find_reagent_object_from_type(reagent_typepath)
 				var/list/reagent_data = list(
 					name = reagent_id.name,
-					amount = found_design.reagents_list[reagent_typepath],
+					amount = (found_design.reagents_list[reagent_typepath] * production_coefficient),
 				)
 				all_reagents += list(reagent_data)
 
@@ -122,7 +122,7 @@
 		return
 
 	if(default_deconstruction_screwdriver(user, "limbgrower_panelopen", "limbgrower_idleoff", user_item))
-		ui_close()
+		ui_close(user)
 		return
 
 	if(panel_open && default_deconstruction_crowbar(user_item))

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -12,7 +12,7 @@
 	circuit = /obj/item/circuitboard/machine/limbgrower
 
 	/// The category of limbs we're browing in our UI.
-	var/selected_category
+	var/selected_category = "human"
 	/// If we're currently printing something.
 	var/busy = FALSE
 	/// How efficient our machine is. Better parts = less chemicals used and less power used. Range of 1 to 0.25.
@@ -193,10 +193,13 @@
 			break
 
 		reagents.remove_reagent(reagent_id, modified_consumed_reagents_list[reagent_id])
-	if(ispath(being_built.build_path, /obj/item/bodypart))
-		build_limb(being_built.build_path)
+
+	var/built_typepath = being_built.build_path
+	// If we have a bodypart, we need to initialize the limb on its own. Otherwise we can build it here.
+	if(ispath(built_typepath, /obj/item/bodypart))
+		build_limb(built_typepath)
 	else
-		new being_built.build_path(loc)
+		new built_typepath(loc)
 
 	busy = FALSE
 	flick("limbgrower_unfill", src)

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -80,12 +80,11 @@
 		for(var/datum/design/found_design in species_categories[category])
 			var/list/all_reagents = list()
 			for(var/reagent_typepath in found_design.reagents_list)
-				var/datum/reagent/reagent_id = new reagent_typepath()
+				var/datum/reagent/reagent_id = find_reagent_object_from_type(reagent_typepath)
 				var/list/reagent_data = list(
 					name = reagent_id.name,
 					amount = found_design.reagents_list[reagent_typepath],
 				)
-				qdel(reagent_id)
 				all_reagents += list(reagent_data)
 
 			category_data["designs"] += list(list(

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -1,9 +1,5 @@
-#define LIMBGROWER_MAIN_MENU       1
-#define LIMBGROWER_CATEGORY_MENU   2
-#define LIMBGROWER_CHEMICAL_MENU   3
-//use these for the menu system
-
-
+/// The limbgrower. Makes organd and limbs with synthflesh and chems.
+/// See [limbgrower_designs.dm] for everything we can make.
 /obj/machinery/limbgrower
 	name = "limb grower"
 	desc = "It grows new limbs using Synthflesh."
@@ -15,27 +11,26 @@
 	active_power_usage = 100
 	circuit = /obj/item/circuitboard/machine/limbgrower
 
-	var/operating = FALSE
-	var/disabled = FALSE
-	var/busy = FALSE
-	var/prod_coeff = 1
-	var/datum/design/being_built
-	var/datum/techweb/stored_research
+	/// The category of limbs we're browing in our UI.
 	var/selected_category
-	var/screen = 1
-	var/list/categories = list(
-							"human",
-							"lizard",
-							"moth",
-							"plasmaman",
-							"ethereal",
-							"other"
-							)
+	/// If we're currently printing something.
+	var/busy = FALSE
+	/// How efficient our machine is. Better parts = less chemicals used and less power used. Range of 1 to 0.25.
+	var/production_coefficient = 1
+	/// How long it takes for us to print a limb. Affected by production_coefficient.
+	var/production_speed = 3 SECONDS
+	/// The design we're printing currently.
+	var/datum/design/being_built
+	/// Our internal techweb for limbgrower designs.
+	var/datum/techweb/stored_research
+	/// All the categories of organs we can print.
+	var/list/categories = list("human", "lizard", "moth", "plasmaman", "ethereal", "other")
 
 /obj/machinery/limbgrower/Initialize()
+	. = ..()
 	create_reagents(100, OPENCONTAINER)
 	stored_research = new /datum/techweb/specialized/autounlocking/limbgrower
-	. = ..()
+	AddComponent(/datum/component/plumbing/simple_demand)
 
 /obj/machinery/limbgrower/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()
@@ -44,75 +39,119 @@
 		ui = new(user, src, "Limbgrower")
 		ui.open()
 
+/obj/machinery/limbgrower/ui_state(mob/user)
+	return GLOB.physical_state
+
 /obj/machinery/limbgrower/ui_data(mob/user)
 	var/list/data = list()
-
 
 	for(var/datum/reagent/reagent_id in reagents.reagent_list)
 		var/list/reagent_data = list(
 			reagent_name = reagent_id.name,
 			reagent_amount = reagent_id.volume,
+			reagent_type = reagent_id
 		)
 		data["reagents"] += list(reagent_data)
 
 	data["total_reagents"] = reagents.total_volume
 	data["max_reagents"] = reagents.maximum_volume
-	data["categories"] = categories
+
+	return data
+
+/obj/machinery/limbgrower/ui_static_data(mob/user)
+	var/list/data = list()
+	data["categories"] = list()
+
+	var/species_categories = categories.Copy()
+	for(var/species in species_categories)
+		species_categories[species] = list()
 	for(var/design_id in stored_research.researched_designs)
 		var/datum/design/limb_design = SSresearch.techweb_design_by_id(design_id)
-		var/list/design_data = list(
-			ref = REF(limb_design),
-			name = limb_design.name,
-		)
-		var/list/design_categories = list()
-		for(var/limb_category in limb_design.category)
-			if(limb_category in categories)
-				design_categories += limb_category
+		for(var/found_category in species_categories)
+			if(found_category in limb_design.category)
+				species_categories[found_category] += limb_design
 
-		design_data["categories"] list(design_categories)
-		data["designs"] += list(design_data)
+	for(var/all_category in species_categories)
+		var/list/category_data = list(
+			name = all_category,
+			designs = list(),
+		)
+		for(var/datum/design/found_design in species_categories[all_category])
+			var/list/all_reagents = list()
+			for(var/reagent_typepath in found_design.reagents_list)
+				var/datum/reagent/reagent_id = new reagent_typepath()
+				var/list/reagent_data = list(
+					name = reagent_id.name,
+					amount = found_design.reagents_list[reagent_typepath],
+				)
+				qdel(reagent_id)
+				all_reagents += list(reagent_data)
+
+			category_data["designs"] += list(list(
+				name = found_design.name,
+				id = found_design.id,
+				needed_reagents = all_reagents,
+			))
+
+		data["categories"] += list(category_data)
+
 	return data
 
 /obj/machinery/limbgrower/on_deconstruction()
-	for(var/obj/item/reagent_containers/glass/G in component_parts)
-		reagents.trans_to(G, G.reagents.maximum_volume)
+	for(var/obj/item/reagent_containers/glass/our_beaker in component_parts)
+		reagents.trans_to(our_beaker, our_beaker.reagents.maximum_volume)
 	..()
 
-/obj/machinery/limbgrower/attackby(obj/item/O, mob/living/user, params)
+/obj/machinery/limbgrower/attackby(obj/item/user_item, mob/living/user, params)
 	if (busy)
 		to_chat(user, "<span class=\"alert\">The Limb Grower is busy. Please wait for completion of previous operation.</span>")
 		return
 
-	if(default_deconstruction_screwdriver(user, "limbgrower_panelopen", "limbgrower_idleoff", O))
-		updateUsrDialog()
+	if(istype(user_item, /obj/item/disk/design_disk/limbs))
+		user.visible_message("<span class='notice'>[user] begins to load \the [user_item] in \the [src]...</span>",
+			"<span class='notice'>You begin to load designs from \the [user_item]...</span>",
+			"<span class='hear'>You hear the clatter of a floppy drive.</span>")
+		busy = TRUE
+		var/obj/item/disk/design_disk/limbs/limb_design_disk = user_item
+		if(do_after(user, 2 SECONDS, target = src))
+			for(var/datum/design/found_design in limb_design_disk.blueprints)
+				stored_research.add_design(found_design)
+			update_static_data(user)
+		busy = FALSE
 		return
 
-	if(panel_open && default_deconstruction_crowbar(O))
+	if(default_deconstruction_screwdriver(user, "limbgrower_panelopen", "limbgrower_idleoff", user_item))
+		ui_close()
+		return
+
+	if(panel_open && default_deconstruction_crowbar(user_item))
 		return
 
 	if(user.combat_mode) //so we can hit the machine
 		return ..()
 
-/obj/machinery/limbgrower/Topic(href, href_list)
-	if(..())
+/obj/machinery/limbgrower/ui_act(action, list/params)
+	. = ..()
+	if(.)
 		return
-	if (!busy)
-		if(href_list["menu"])
-			screen = text2num(href_list["menu"])
 
-		if(href_list["category"] in categories) //Don't let people send invalid categories, selected_category is displayed to anyone who looks at the machine in several places
-			selected_category = href_list["category"]
+	if (busy)
+		to_chat(usr, "<span class=\"alert\">The limb grower is busy. Please wait for completion of previous operation.</span>")
+		return
 
-		if(href_list["disposeI"])  //Get rid of a reagent incase you add the wrong one by mistake
-			reagents.del_reagent(text2path(href_list["disposeI"]))
+	switch(action)
 
-		if(href_list["make"])
+		if("update_active_tab")
+			selected_category = params["active_tab"]
 
-			/////////////////
-			//href protection
-			being_built = stored_research.isDesignResearchedID(href_list["make"]) //check if it's a valid design
+		if("empty_reagent")
+			reagents.del_reagent(text2path(params["reagent_type"]))
+			. = TRUE
+
+		if("make_limb")
+			being_built = stored_research.isDesignResearchedID(params["design_id"])
 			if(!being_built)
-				return
+				CRASH("[src] was passed an invalid design id!")
 
 			/// All the reagents we're using to make our organ.
 			var/list/consumed_reagents_list = being_built.reagents_list.Copy()
@@ -120,9 +159,9 @@
 			var/power = 0
 
 			for(var/datum/reagent/reagent_id in consumed_reagents_list)
-				consumed_reagents_list[reagent_id] *= prod_coeff
+				consumed_reagents_list[reagent_id] *= production_coefficient
 				if(!reagents.has_reagent(reagent_id, consumed_reagents_list[reagent_id]))
-					audible_message("<span class='notice'>The [src] buzzes. It does not have enough materials to complete the task.")
+					audible_message("<span class='notice'>The [src] buzzes.</span>")
 					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
 					return
 
@@ -132,18 +171,24 @@
 			use_power(power)
 			flick("limbgrower_fill",src)
 			icon_state = "limbgrower_idleon"
-			addtimer(CALLBACK(src, .proc/build_item, consumed_reagents_list), 32 * prod_coeff)
+			addtimer(CALLBACK(src, .proc/build_item, consumed_reagents_list), production_speed * production_coefficient)
+			. = TRUE
 
-	else
-		to_chat(usr, "<span class=\"alert\">The limb grower is busy. Please wait for completion of previous operation.</span>")
-
-	updateUsrDialog()
 	return
 
+/*
+ * The process of beginning to build a limb or organ.
+ * Goes through and sanity checks that we actually have enough reagent to build our item.
+ * Then, remove those reagents from our reagents datum.
+ *
+ * After the reagents are handled, we can proceede with making the limb or organ. (Limbs are handled in a separate proc)
+ *
+ * modified_consumed_reagents_list - the list of reagents we will consume on build, modified by the production coefficient.
+ */
 /obj/machinery/limbgrower/proc/build_item(list/modified_consumed_reagents_list)
 	for(var/datum/reagent/reagent_id in modified_consumed_reagents_list)
 		if(!reagents.has_reagent(reagent_id, modified_consumed_reagents_list[reagent_id]))
-			audible_message("<span class='notice'>The [src] buzzes.")
+			audible_message("<span class='notice'>The [src] buzzes.</span>")
 			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
 			break
 
@@ -156,22 +201,30 @@
 	busy = FALSE
 	flick("limbgrower_unfill", src)
 	icon_state = "limbgrower_idleoff"
-	updateUsrDialog()
 
+/*
+ * The process of putting together a limb.
+ * This is called from after we remove the reagents, so this proc is just initializing the limb type.
+ *
+ * This proc handles skin / mutant color, greyscaling, names and descriptions, and various other limb creation steps.
+ *
+ * buildpath - the path of the bodypart we're building.
+ */
 /obj/machinery/limbgrower/proc/build_limb(buildpath)
-	//i need to create a body part manually using a set icon (otherwise it doesnt appear)
-	var/obj/item/bodypart/limb
-	limb = new buildpath(loc)
-	if(selected_category == "human" || selected_category == "lizard" || selected_category == "ethereal") //Species with greyscale parts should be included here
+	/// The limb we're making with our buildpath, so we can edit it.
+	var/obj/item/bodypart/limb = new buildpath(loc)
+	/// Species with greyscale limbs.
+	var/list/greyscale_species = list("human", "lizard", "ethereal")
+	if(selected_category in greyscale_species) //Species with greyscale parts should be included here
 		if(selected_category == "human") //humans don't use the full colour spectrum, they use random_skin_tone
 			limb.skin_tone = random_skin_tone()
 		else
 			limb.species_color = random_short_color()
-
 		limb.icon = 'icons/mob/human_parts_greyscale.dmi'
 		limb.should_draw_greyscale = TRUE
 	else
 		limb.icon = 'icons/mob/human_parts.dmi'
+
 	// Set this limb up using the species name and body zone
 	limb.icon_state = "[selected_category]_[limb.body_zone]"
 	limb.name = "\improper biosynthetic [selected_category] [parse_zone(limb.body_zone)]"
@@ -182,87 +235,40 @@
 
 /obj/machinery/limbgrower/RefreshParts()
 	reagents.maximum_volume = 0
-	for(var/obj/item/reagent_containers/glass/G in component_parts)
-		reagents.maximum_volume += G.volume
-		G.reagents.trans_to(src, G.reagents.total_volume)
-	var/T=1.2
-	for(var/obj/item/stock_parts/manipulator/M in component_parts)
-		T -= M.rating*0.2
-	prod_coeff = min(1,max(0,T)) // Coeff going 1 -> 0,8 -> 0,6 -> 0,4
+	for(var/obj/item/reagent_containers/glass/our_beaker in component_parts)
+		reagents.maximum_volume += our_beaker.volume
+		our_beaker.reagents.trans_to(src, our_beaker.reagents.total_volume)
+	production_coefficient = 1.25
+	for(var/obj/item/stock_parts/manipulator/our_manipulator in component_parts)
+		production_coefficient -= our_manipulator.rating * 0.25
+	production_coefficient = clamp(production_coefficient, 0, 1) // coefficient goes from 1 -> 0.75 -> 0.5 -> 0.25
 
 /obj/machinery/limbgrower/examine(mob/user)
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
-		. += "<span class='notice'>The status display reads: Storing up to <b>[reagents.maximum_volume]u</b> of reagents.<br>Reagent consumption at <b>[prod_coeff * 100]%</b>.</span>"
+		. += "<span class='notice'>The status display reads: Storing up to <b>[reagents.maximum_volume]u</b> of reagents.<br>Reagent consumption rate at <b>[production_coefficient * 100]%</b>.</span>"
 
-/obj/machinery/limbgrower/proc/main_win(mob/user)
-	var/dat = "<div class='statusDisplay'><h3>Limb Grower Menu:</h3><br>"
-	dat += "<A href='?src=[REF(src)];menu=[LIMBGROWER_CHEMICAL_MENU]'>Chemical Storage</A>"
-	dat += materials_printout()
-	dat += "<table style='width:100%' align='center'><tr>"
-
-	for(var/C in categories)
-		dat += "<td><A href='?src=[REF(src)];category=[C];menu=[LIMBGROWER_CATEGORY_MENU]'>[C]</A></td>"
-		dat += "</tr><tr>"
-		//one category per line
-
-	dat += "</tr></table></div>"
-	return dat
-
-/obj/machinery/limbgrower/proc/category_win(mob/user,selected_category)
-	var/dat = "<A href='?src=[REF(src)];menu=[LIMBGROWER_MAIN_MENU]'>Return to main menu</A>"
-	dat += "<div class='statusDisplay'><h3>Browsing [selected_category]:</h3><br>"
-	dat += materials_printout()
-
-	for(var/v in stored_research.researched_designs)
-		var/datum/design/D = SSresearch.techweb_design_by_id(v)
-		if(!(selected_category in D.category))
-			continue
-		if(disabled || !can_build(D))
-			dat += "<span class='linkOff'>[D.name]</span>"
-		else
-			dat += "<a href='?src=[REF(src)];make=[D.id];multiplier=1'>[D.name]</a>"
-		dat += "[get_design_cost(D)]<br>"
-
-	dat += "</div>"
-	return dat
-
-
-/obj/machinery/limbgrower/proc/chemical_win(mob/user)
-	var/dat = "<A href='?src=[REF(src)];menu=[LIMBGROWER_MAIN_MENU]'>Return to main menu</A>"
-	dat += "<div class='statusDisplay'><h3>Browsing Chemical Storage:</h3><br>"
-	dat += materials_printout()
-
-	for(var/datum/reagent/R in reagents.reagent_list)
-		dat += "[R.name]: [R.volume]"
-		dat += "<A href='?src=[REF(src)];disposeI=[R]'>Purge</A><BR>"
-
-	dat += "</div>"
-	return dat
-
-/obj/machinery/limbgrower/proc/materials_printout()
-	var/dat = "<b>Total amount:></b> [reagents.total_volume] / [reagents.maximum_volume] cm<sup>3</sup><br>"
-	return dat
-
+/*
+ * Checks our reagent list to see if a design can be built.
+ *
+ * limb_design - the design we're checking for buildability.
+ *
+ * returns TRUE if we have enough reagent to build it. Returns FALSE if we do not.
+ */
 /obj/machinery/limbgrower/proc/can_build(datum/design/limb_design)
 	for(var/datum/reagent/reagent_id in limb_design.reagents_list)
-		if(!reagents.has_reagent(reagent_id, limb_design.reagents_list[reagent_id] * prod_coeff))
+		if(!reagents.has_reagent(reagent_id, limb_design.reagents_list[reagent_id] * production_coefficient))
 			return FALSE
-
 	return TRUE
 
-/obj/machinery/limbgrower/proc/get_design_cost(datum/design/limb_design)
-	var/dat
-	for(var/datum/reagent/reagent_id in limb_design.reagents_list)
-		dat += "[limb_design.reagents_list[reagent_id] * prod_coeff] [reagent_id.name]"
-	return dat
-
+/// Emagging a limbgrower allows you to build synthetic armblades.
 /obj/machinery/limbgrower/emag_act(mob/user)
 	if(obj_flags & EMAGGED)
 		return
-	for(var/id in SSresearch.techweb_designs)
-		var/datum/design/D = SSresearch.techweb_design_by_id(id)
-		if((D.build_type & LIMBGROWER) && ("emagged" in D.category))
-			stored_research.add_design(D)
+	for(var/design_id in SSresearch.techweb_designs)
+		var/datum/design/found_design = SSresearch.techweb_design_by_id(design_id)
+		if((found_design.build_type & LIMBGROWER) && ("emagged" in found_design.category))
+			stored_research.add_design(found_design)
 	to_chat(user, "<span class='warning'>A warning flashes onto the screen, stating that safety overrides have been deactivated!</span>")
 	obj_flags |= EMAGGED
+	update_static_data(user)

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
@@ -10,6 +10,7 @@
 		/obj/item/organ/tail/lizard = 1,
 		/datum/reagent/consumable/ethanol = 100
 	)
+	blacklist = list(/obj/item/organ/tail/lizard/fake)
 	result = /obj/item/reagent_containers/food/drinks/bottle/lizardwine
 	category = CAT_DRINK
 

--- a/code/modules/research/designs/limbgrower_designs.dm
+++ b/code/modules/research/designs/limbgrower_designs.dm
@@ -26,6 +26,22 @@
 	build_path = /obj/item/bodypart/l_leg
 	category = list("initial","human","lizard","moth","plasmaman","ethereal")
 
+/datum/design/digi_leftleg
+	name = "Digitigrade Left Leg"
+	id = "digi_leftleg"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 30)
+	build_path = /obj/item/bodypart/l_leg/digitigrade
+	category = list("initial","lizard")
+
+/datum/design/digi_rightleg
+	name = "Digitigrade Right Leg"
+	id = "digi_rightleg"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 30)
+	build_path = /obj/item/bodypart/r_leg/digitigrade
+	category = list("initial","lizard")
+
 /datum/design/rightleg
 	name = "Right Leg"
 	id = "rightleg"
@@ -99,6 +115,94 @@
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10)
 	build_path = /obj/item/organ/tongue
 	category = list("other","initial")
+
+/datum/design/lizard_tail
+	name = "Lizard Tail"
+	id = "liztail"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 20)
+	build_path = /obj/item/organ/tail/lizard/fake
+	category = list("other","lizard")
+
+/datum/design/cat_tail
+	name = "Monkey Tail"
+	id = "monkeytail"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 20)
+	build_path = /obj/item/organ/tail/monkey
+	category = list("other","human")
+
+/datum/design/cat_tail
+	name = "Cat Tail"
+	id = "cattail"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 20)
+	build_path = /obj/item/organ/tail/cat
+	category = list("other","human")
+
+/datum/design/cat_ears
+	name = "Cat Ears"
+	id = "catears"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10)
+	build_path = /obj/item/organ/ears/cat
+	category = list("other","human")
+
+/datum/design/plasmaman_lungs
+	name = "Plasma Filter"
+	id = "plasmamanlungs"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/toxin/plasma = 20)
+	build_path = /obj/item/organ/lungs/plasmaman
+	category = list("other","plasmaman")
+
+/datum/design/plasmaman_tongue
+	name = "Plasma Bone Tongue"
+	id = "plasmamantongue"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/toxin/plasma = 20)
+	build_path = /obj/item/organ/tongue/bone/plasmaman
+	category = list("other","plasmaman")
+
+/datum/design/plasmaman_liver
+	name = "Reagent Processing Crystal"
+	id = "plasmamanliver"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/toxin/plasma = 20)
+	build_path = /obj/item/organ/liver/plasmaman
+	category = list("other","plasmaman")
+
+/datum/design/plasmaman_stomach
+	name = "Digestive Crystal"
+	id = "plasmamanstomach"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/toxin/plasma = 20)
+	build_path = /obj/item/organ/stomach/bone/plasmaman
+	category = list("other","plasmaman")
+
+/datum/design/ethereal_stomach
+	name = "Biological Battery"
+	id = "etherealstomach"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/consumable/liquidelectricity = 20)
+	build_path = /obj/item/organ/stomach/ethereal
+	category = list("other","ethereal")
+
+/datum/design/ethereal_tongue
+	name = "Electrical Discharger"
+	id = "etherealtongue"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/consumable/liquidelectricity = 20)
+	build_path = /obj/item/organ/tongue/ethereal
+	category = list("other","ethereal")
+
+/datum/design/ethereal_heart
+	name = "Crystal Core"
+	id = "etherealtongue"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/consumable/liquidelectricity = 20)
+	build_path = /obj/item/organ/heart/ethereal
+	category = list("other","ethereal")
 
 /datum/design/armblade
 	name = "Arm Blade"

--- a/code/modules/research/designs/limbgrower_designs.dm
+++ b/code/modules/research/designs/limbgrower_designs.dm
@@ -205,7 +205,7 @@
 	build_path = /obj/item/organ/tongue/ethereal
 	category = list("ethereal")
 
-// Not growable by normal means.
+// Intentionally not growable by normal means - for balance conerns.
 /datum/design/ethereal_heart
 	name = "Crystal Core"
 	id = "etherealheart"
@@ -227,6 +227,7 @@
 	name = "Limb Design Disk"
 	desc = "A disk containing limb and organ designs for a limbgrower."
 	icon_state = "datadisk1"
+	/// List of all limb designs this disk contains.
 	var/list/limb_designs = list()
 
 /obj/item/disk/design_disk/limbs/Initialize()
@@ -238,7 +239,7 @@
 
 /datum/design/limb_disk
 	name = "Limb Design Disk"
-	desc = "Limb designs but you shouldn't see this!"
+	desc = "Contains designs for various limbs."
 	id = "limbdesign_parent"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 300, /datum/material/glass = 100)

--- a/code/modules/research/designs/limbgrower_designs.dm
+++ b/code/modules/research/designs/limbgrower_designs.dm
@@ -26,22 +26,6 @@
 	build_path = /obj/item/bodypart/l_leg
 	category = list("initial","human","lizard","moth","plasmaman","ethereal")
 
-/datum/design/digi_leftleg
-	name = "Digitigrade Left Leg"
-	id = "digi_leftleg"
-	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 30)
-	build_path = /obj/item/bodypart/l_leg/digitigrade
-	category = list("initial","lizard")
-
-/datum/design/digi_rightleg
-	name = "Digitigrade Right Leg"
-	id = "digi_rightleg"
-	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 30)
-	build_path = /obj/item/bodypart/r_leg/digitigrade
-	category = list("initial","lizard")
-
 /datum/design/rightleg
 	name = "Right Leg"
 	id = "rightleg"
@@ -49,6 +33,22 @@
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 25)
 	build_path = /obj/item/bodypart/r_leg
 	category = list("initial","human","lizard","moth","plasmaman","ethereal")
+
+/datum/design/digi_leftleg
+	name = "Digitigrade Left Leg"
+	id = "digi_leftleg"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 30)
+	build_path = /obj/item/bodypart/l_leg/digitigrade
+	category = list("lizard")
+
+/datum/design/digi_rightleg
+	name = "Digitigrade Right Leg"
+	id = "digi_rightleg"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 30)
+	build_path = /obj/item/bodypart/r_leg/digitigrade
+	category = list("lizard")
 
 //Non-limb limb designs
 
@@ -58,7 +58,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 30)
 	build_path = /obj/item/organ/heart
-	category = list("other","initial")
+	category = list("human","initial")
 
 /datum/design/lungs
 	name = "Lungs"
@@ -66,7 +66,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 20)
 	build_path = /obj/item/organ/lungs
-	category = list("other","initial")
+	category = list("human","initial")
 
 /datum/design/liver
 	name = "Liver"
@@ -74,7 +74,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 20)
 	build_path = /obj/item/organ/liver
-	category = list("other","initial")
+	category = list("human","initial")
 
 /datum/design/stomach
 	name = "Stomach"
@@ -82,7 +82,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 15)
 	build_path = /obj/item/organ/stomach
-	category = list("other","initial")
+	category = list("human","initial")
 
 /datum/design/appendix
 	name = "Appendix"
@@ -90,7 +90,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 5) //why would you need this
 	build_path = /obj/item/organ/appendix
-	category = list("other","initial")
+	category = list("human","initial")
 
 /datum/design/eyes
 	name = "Eyes"
@@ -98,7 +98,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10)
 	build_path = /obj/item/organ/eyes
-	category = list("other","initial")
+	category = list("human","initial")
 
 /datum/design/ears
 	name = "Ears"
@@ -106,7 +106,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10)
 	build_path = /obj/item/organ/ears
-	category = list("other","initial")
+	category = list("human","initial")
 
 /datum/design/tongue
 	name = "Tongue"
@@ -114,7 +114,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10)
 	build_path = /obj/item/organ/tongue
-	category = list("other","initial")
+	category = list("human","initial")
 
 /datum/design/lizard_tail
 	name = "Lizard Tail"
@@ -122,15 +122,23 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 20)
 	build_path = /obj/item/organ/tail/lizard/fake
-	category = list("other","lizard")
+	category = list("lizard")
 
-/datum/design/cat_tail
+/datum/design/lizard_tongue
+	name = "Forked Tongue"
+	id = "liztongue"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 20)
+	build_path = /obj/item/organ/tongue/lizard
+	category = list("lizard")
+
+/datum/design/monkey_tail
 	name = "Monkey Tail"
 	id = "monkeytail"
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 20)
 	build_path = /obj/item/organ/tail/monkey
-	category = list("other","human")
+	category = list("other")
 
 /datum/design/cat_tail
 	name = "Cat Tail"
@@ -138,7 +146,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 20)
 	build_path = /obj/item/organ/tail/cat
-	category = list("other","human")
+	category = list("human")
 
 /datum/design/cat_ears
 	name = "Cat Ears"
@@ -146,7 +154,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10)
 	build_path = /obj/item/organ/ears/cat
-	category = list("other","human")
+	category = list("human")
 
 /datum/design/plasmaman_lungs
 	name = "Plasma Filter"
@@ -154,7 +162,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/toxin/plasma = 20)
 	build_path = /obj/item/organ/lungs/plasmaman
-	category = list("other","plasmaman")
+	category = list("plasmaman")
 
 /datum/design/plasmaman_tongue
 	name = "Plasma Bone Tongue"
@@ -162,7 +170,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/toxin/plasma = 20)
 	build_path = /obj/item/organ/tongue/bone/plasmaman
-	category = list("other","plasmaman")
+	category = list("plasmaman")
 
 /datum/design/plasmaman_liver
 	name = "Reagent Processing Crystal"
@@ -170,7 +178,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/toxin/plasma = 20)
 	build_path = /obj/item/organ/liver/plasmaman
-	category = list("other","plasmaman")
+	category = list("plasmaman")
 
 /datum/design/plasmaman_stomach
 	name = "Digestive Crystal"
@@ -178,7 +186,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/toxin/plasma = 20)
 	build_path = /obj/item/organ/stomach/bone/plasmaman
-	category = list("other","plasmaman")
+	category = list("plasmaman")
 
 /datum/design/ethereal_stomach
 	name = "Biological Battery"
@@ -186,7 +194,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/consumable/liquidelectricity = 20)
 	build_path = /obj/item/organ/stomach/ethereal
-	category = list("other","ethereal")
+	category = list("ethereal")
 
 /datum/design/ethereal_tongue
 	name = "Electrical Discharger"
@@ -194,15 +202,15 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/consumable/liquidelectricity = 20)
 	build_path = /obj/item/organ/tongue/ethereal
-	category = list("other","ethereal")
+	category = list("ethereal")
 
 /datum/design/ethereal_heart
 	name = "Crystal Core"
-	id = "etherealtongue"
+	id = "etherealheart"
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/consumable/liquidelectricity = 20)
 	build_path = /obj/item/organ/heart/ethereal
-	category = list("other","ethereal")
+	category = list("ethereal")
 
 /datum/design/armblade
 	name = "Arm Blade"
@@ -211,3 +219,68 @@
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 75)
 	build_path = /obj/item/melee/synthetic_arm_blade
 	category = list("other","emagged")
+
+/// Design disks and designs - for adding limbs and organs to the limbgrower.
+/obj/item/disk/design_disk/limbs
+	name = "Limb Design Disk"
+	desc = "A disk containing limb and organ designs for a limbgrower."
+	icon_state = "datadisk1"
+	var/list/limb_designs = list()
+
+/obj/item/disk/design_disk/limbs/Initialize()
+	. = ..()
+	max_blueprints = limb_designs.len
+	var/blueprint_num = 1
+	for(var/datum/design/design in limb_designs)
+		blueprints[blueprint_num] = new design()
+		blueprint_num++
+
+/datum/design/limb_disk
+	name = "Limb Design Disk"
+	desc = "Limb designs but you shouldn't see this!"
+	id = "limbdesign_parent"
+	build_type = PROTOLATHE
+	custom_materials = list(/datum/material/iron = 300, /datum/material/glass = 100)
+	build_path = /obj/item/disk/design_disk/limbs
+	category = list("Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
+/obj/item/disk/design_disk/limbs/felinid
+	name = "Felinid Limb Design Disk"
+	limb_designs = list(/datum/design/cat_tail, /datum/design/cat_ears)
+
+/datum/design/limb_disk/felinid
+	name = "Felinid Limb Design Disk"
+	desc = "Contains designs for felinid bodyparts for the limbgrower - Felinid ears and tail."
+	id = "limbdesign_felinid"
+	build_path = /obj/item/disk/design_disk/limbs/felinid
+
+/obj/item/disk/design_disk/limbs/lizard
+	name = "Lizard Limb Design Disk"
+	limb_designs = list(/datum/design/lizard_tail, /datum/design/lizard_tongue, /datum/design/digi_leftleg, /datum/design/digi_rightleg)
+
+/datum/design/limb_disk/lizard
+	name = "Lizard Limb Design Disk"
+	desc = "Contains designs for lizard bodyparts for the limbgrower - Lizard tongue, tail, and digitigrade legs."
+	id = "limbdesign_lizard"
+	build_path = /obj/item/disk/design_disk/limbs/lizard
+
+/obj/item/disk/design_disk/limbs/plasmaman
+	name = "Plasmaman Limb Design Disk"
+	limb_designs = list(/datum/design/plasmaman_stomach, /datum/design/plasmaman_liver, /datum/design/plasmaman_lungs, /datum/design/plasmaman_tongue)
+
+/datum/design/limb_disk/plasmaman
+	name = "Plasmaman Limb Design Disk"
+	desc = "Contains designs for plasmaman organs for the limbgrower - Plasmaman tongue, liver, stomach, and lungs."
+	id = "limbdesign_plasmaman"
+	build_path = /obj/item/disk/design_disk/limbs/plasmaman
+
+/obj/item/disk/design_disk/limbs/ethereal
+	name = "Ethereal Limb Design Disk"
+	limb_designs = list(/datum/design/ethereal_heart, /datum/design/ethereal_stomach, /datum/design/ethereal_tongue)
+
+/datum/design/limb_disk/ethereal
+	name = "Ethereal Limb Design Disk"
+	desc = "Contains designs for ethereal organs for the limbgrower - Ethereal tongue, stomach, and heart."
+	id = "limbdesign_ethereal"
+	build_path = /obj/item/disk/design_disk/limbs/ethereal

--- a/code/modules/research/designs/limbgrower_designs.dm
+++ b/code/modules/research/designs/limbgrower_designs.dm
@@ -116,6 +116,7 @@
 	build_path = /obj/item/organ/tongue
 	category = list("human","initial")
 
+// Grows a fake lizard tail - not usable in lizard wine and other similar recipes.
 /datum/design/lizard_tail
 	name = "Lizard Tail"
 	id = "liztail"
@@ -138,7 +139,7 @@
 	build_type = LIMBGROWER
 	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 20)
 	build_path = /obj/item/organ/tail/monkey
-	category = list("other")
+	category = list("other","initial")
 
 /datum/design/cat_tail
 	name = "Cat Tail"
@@ -204,6 +205,7 @@
 	build_path = /obj/item/organ/tongue/ethereal
 	category = list("ethereal")
 
+// Not growable by normal means.
 /datum/design/ethereal_heart
 	name = "Crystal Core"
 	id = "etherealheart"
@@ -231,8 +233,10 @@
 	. = ..()
 	max_blueprints = limb_designs.len
 	var/blueprint_num = 1
-	for(var/datum/design/design in limb_designs)
-		blueprints[blueprint_num] = new design()
+	for(var/design in limb_designs)
+		message_admins("Adding [design] to [blueprint_num]")
+		var/datum/design/new_design = design
+		blueprints[blueprint_num] = new new_design
 		blueprint_num++
 
 /datum/design/limb_disk
@@ -240,7 +244,7 @@
 	desc = "Limb designs but you shouldn't see this!"
 	id = "limbdesign_parent"
 	build_type = PROTOLATHE
-	custom_materials = list(/datum/material/iron = 300, /datum/material/glass = 100)
+	materials = list(/datum/material/iron = 300, /datum/material/glass = 100)
 	build_path = /obj/item/disk/design_disk/limbs
 	category = list("Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
@@ -277,10 +281,10 @@
 
 /obj/item/disk/design_disk/limbs/ethereal
 	name = "Ethereal Limb Design Disk"
-	limb_designs = list(/datum/design/ethereal_heart, /datum/design/ethereal_stomach, /datum/design/ethereal_tongue)
+	limb_designs = list(/datum/design/ethereal_stomach, /datum/design/ethereal_tongue)
 
 /datum/design/limb_disk/ethereal
 	name = "Ethereal Limb Design Disk"
-	desc = "Contains designs for ethereal organs for the limbgrower - Ethereal tongue, stomach, and heart."
+	desc = "Contains designs for ethereal organs for the limbgrower - Ethereal tongue and stomach."
 	id = "limbdesign_ethereal"
 	build_path = /obj/item/disk/design_disk/limbs/ethereal

--- a/code/modules/research/designs/limbgrower_designs.dm
+++ b/code/modules/research/designs/limbgrower_designs.dm
@@ -232,12 +232,9 @@
 /obj/item/disk/design_disk/limbs/Initialize()
 	. = ..()
 	max_blueprints = limb_designs.len
-	var/blueprint_num = 1
 	for(var/design in limb_designs)
-		message_admins("Adding [design] to [blueprint_num]")
 		var/datum/design/new_design = design
-		blueprints[blueprint_num] = new new_design
-		blueprint_num++
+		blueprints += new new_design
 
 /datum/design/limb_disk
 	name = "Limb Design Disk"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -82,14 +82,14 @@
 	required_experiments = list(/datum/experiment/scanning/points/slime/easy)
 	discount_experiments = list(/datum/experiment/scanning/random/material/meat = 4000) //Big discount to reinforce doing it.
 
-/datum/techweb_node/adv_biotech
+/datum/techweb_node/xenoorgan_biotech
 	id = "xenoorgan_bio"
-	display_name = "Xenoorgan Biology"
-	description = "AXenoorgan Biology"
+	display_name = "Xeno-organ Biology"
+	description = "Plasmaman, Ethereals, Lizardpeople... What makes our non-human crewmembers tick?"
 	prereq_ids = list("adv_biotech")
 	design_ids = list("limbdesign_felinid", "limbdesign_lizard", "limbdesign_plasmaman", "limbdesign_ethereal")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
-	discount_experiments = list(/datum/experiment/scanning/random/material/meat = 4000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 6500)
+	discount_experiments = list(/datum/experiment/scanning/random/cytology/easy = 1000, /datum/experiment/scanning/points/slime/expert = 5000)
 
 /datum/techweb_node/bio_process
 	id = "bio_process"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -82,6 +82,15 @@
 	required_experiments = list(/datum/experiment/scanning/points/slime/easy)
 	discount_experiments = list(/datum/experiment/scanning/random/material/meat = 4000) //Big discount to reinforce doing it.
 
+/datum/techweb_node/adv_biotech
+	id = "xenoorgan_bio"
+	display_name = "Xenoorgan Biology"
+	description = "AXenoorgan Biology"
+	prereq_ids = list("adv_biotech")
+	design_ids = list("limbdesign_felinid", "limbdesign_lizard", "limbdesign_plasmaman", "limbdesign_ethereal")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	discount_experiments = list(/datum/experiment/scanning/random/material/meat = 4000)
+
 /datum/techweb_node/bio_process
 	id = "bio_process"
 	display_name = "Biological Processing"

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -81,6 +81,10 @@
 	new_tail.tail_type = tail_type
 	new_tail.spines = spines
 
+/obj/item/organ/tail/lizard/fake
+	name = "fabricated lizard tail"
+	desc = "A fabricated severed lizard tail. This one's made of synthflesh. Probably not usable for lizard wine."
+
 /obj/item/organ/tail/monkey
 	name = "monkey tail"
 	desc = "A severed monkey tail. Does not look like a banana."

--- a/tgui/packages/tgui/interfaces/Limbgrower.js
+++ b/tgui/packages/tgui/interfaces/Limbgrower.js
@@ -33,7 +33,7 @@ export const Limbgrower = (props, context) => {
             </Flex.Item>
             <Flex.Item>
               <LabeledList>
-                {reagents.len && reagents.map(reagent => (
+                { reagents.map(reagent => (
                   <LabeledList.Item
                     label={reagent.reagent_name}
                     buttons={(
@@ -50,9 +50,7 @@ export const Limbgrower = (props, context) => {
             </Flex.Item>
           </Flex>
         </Section>
-
         <Divider/>
-
         <Section title="Designs">
           <Flex direction="column">
             <Flex.Item>

--- a/tgui/packages/tgui/interfaces/Limbgrower.js
+++ b/tgui/packages/tgui/interfaces/Limbgrower.js
@@ -1,5 +1,5 @@
 import { useBackend, useSharedState } from '../backend';
-import { Box, Button, Section, Divider, Tabs, LabeledList, Flex } from '../components';
+import { Box, Button, Section, Divider, Tabs, LabeledList, Flex, Dimmer, Icon } from '../components';
 import { Window } from '../layouts';
 
 export const Limbgrower = (props, context) => {
@@ -9,6 +9,7 @@ export const Limbgrower = (props, context) => {
     total_reagents,
     max_reagents,
     categories = [],
+    busy,
   } = data;
   const [tab, setTab] = useSharedState(context, 'category', categories[0]?.name);
   const designList = categories.find(category => category.name === tab)?.designs
@@ -18,6 +19,12 @@ export const Limbgrower = (props, context) => {
       width={400}
       height={550}
       title="Limb Grower">
+      {!!busy && (
+        <Dimmer fontSize="32px">
+          <Icon name="cog" spin={1} />
+          {' Building limb...'}
+        </Dimmer>
+      )}
       <Window.Content scrollable>
         <Section title="Reagents">
           <Flex direction="column">
@@ -26,11 +33,13 @@ export const Limbgrower = (props, context) => {
             </Flex.Item>
             <Flex.Item>
               <LabeledList>
-                {reagents.map(reagent => (
+                {reagents.len && reagents.map(reagent => (
                   <LabeledList.Item
                     label={reagent.reagent_name}
                     buttons={(
-                      <Button
+                      <Button.Confirm
+                        textAlign="center"
+                        width="120px"
                         content="Remove Reagent"
                         color="bad"
                         onClick={() => act('empty_reagent', {reagent_type: reagent.reagent_type})} />)} >
@@ -52,10 +61,7 @@ export const Limbgrower = (props, context) => {
                   <Tabs.Tab
                     fluid
                     selected={tab === category.name}
-                    onClick={() => {
-                      act("updated_active_tab", {active_tab: category.name});
-                      setTab(category.name);
-                    }}>
+                    onClick={() => setTab(category.name)}>
                     {category.name}
                   </Tabs.Tab>
                 ))}
@@ -70,7 +76,10 @@ export const Limbgrower = (props, context) => {
                         <Button
                           content="Make"
                           color="good"
-                          onClick={() => act('make_limb', {design_id: design.id})}/>
+                          onClick={() => act('make_limb', {
+                            design_id: design.id,
+                            active_tab: design.parent_category,
+                          })}/>
                         )}>
                       {design.needed_reagents.map(reagent => (
                         <Box>

--- a/tgui/packages/tgui/interfaces/Limbgrower.js
+++ b/tgui/packages/tgui/interfaces/Limbgrower.js
@@ -1,5 +1,5 @@
 import { useBackend, useSharedState } from '../backend';
-import { Box, Button, Section, Divider, Tabs, LabeledList, Flex, Dimmer, Icon } from '../components';
+import { Box, Button, Dimmer, Icon, LabeledList, Section, Tabs } from '../components';
 import { Window } from '../layouts';
 
 export const Limbgrower = (props, context) => {

--- a/tgui/packages/tgui/interfaces/Limbgrower.js
+++ b/tgui/packages/tgui/interfaces/Limbgrower.js
@@ -1,0 +1,58 @@
+import { useBackend, useSharedState } from '../backend';
+import { Box, Button, Section, Divider, Tabs, LabeledList, Flex } from '../components';
+import { Window } from '../layouts';
+
+export const Limbgrower = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    reagents = [],
+    categories = [],
+    total_reagents,
+    max_reagents,
+  } = data;
+  const [tab, setTab] = useSharedState(context, 'category', categories[0]);
+
+  return (
+    <Window
+      width={400}
+      height={500}
+      title="Limb Grower">
+      <Window.Content>
+        <Section title="Reagents">
+          <Flex direction="column">
+            <Flex.Item>
+              {total_reagents} / {max_reagents} reagents currently filled.
+            </Flex.Item>
+            <Flex.Item>
+              <LabeledList>
+                {reagents.map(reagent => {
+                  <LabeledList.Item label={reagent.reagent_name}>
+                    {reagent.reagent_amount}
+                  </LabeledList.Item>
+                })}
+              </LabeledList>
+            </Flex.Item>
+          </Flex>
+        </Section>
+
+        <Divider/>
+
+        <Section title="Designs">
+          <Flex direction="column">
+            <Flex.Item>
+              <Tabs>
+                {categories.map(category => {
+                  <Tabs.Tab
+                    selected={tab === category}
+                    onClick={() => setTab(category)}>
+                    Category: {category}
+                  </Tabs.Tab>
+                })}
+              </Tabs>
+            </Flex.Item>
+          </Flex>
+        </Section>
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/Limbgrower.js
+++ b/tgui/packages/tgui/interfaces/Limbgrower.js
@@ -12,7 +12,8 @@ export const Limbgrower = (props, context) => {
     busy,
   } = data;
   const [tab, setTab] = useSharedState(context, 'category', categories[0]?.name);
-  const designList = categories.find(category => category.name === tab)?.designs
+  const designList = categories.find(category =>
+    category.name === tab)?.designs;
 
   return (
     <Window
@@ -35,6 +36,7 @@ export const Limbgrower = (props, context) => {
               <LabeledList>
                 { reagents.map(reagent => (
                   <LabeledList.Item
+                    key={reagent.reagent_name}
                     label={reagent.reagent_name}
                     buttons={(
                       <Button.Confirm
@@ -42,7 +44,7 @@ export const Limbgrower = (props, context) => {
                         width="120px"
                         content="Remove Reagent"
                         color="bad"
-                        onClick={() => act('empty_reagent', {reagent_type: reagent.reagent_type})} />)} >
+                        onClick={() => act('empty_reagent', { reagent_type: reagent.reagent_type })} />)} >
                     {reagent.reagent_amount}u
                   </LabeledList.Item>
                 ))}
@@ -50,7 +52,7 @@ export const Limbgrower = (props, context) => {
             </Flex.Item>
           </Flex>
         </Section>
-        <Divider/>
+        <Divider />
         <Section title="Designs">
           <Flex direction="column">
             <Flex.Item>
@@ -58,6 +60,7 @@ export const Limbgrower = (props, context) => {
                 {categories.map(category => (
                   <Tabs.Tab
                     fluid
+                    key={category.name}
                     selected={tab === category.name}
                     onClick={() => setTab(category.name)}>
                     {category.name}
@@ -67,25 +70,26 @@ export const Limbgrower = (props, context) => {
             </Flex.Item>
             <Flex.Item>
               <LabeledList>
-                  {designList.map(design => (
-                    <LabeledList.Item
-                      label={design.name}
-                      buttons={(
-                        <Button
-                          content="Make"
-                          color="good"
-                          onClick={() => act('make_limb', {
-                            design_id: design.id,
-                            active_tab: design.parent_category,
-                          })}/>
-                        )}>
-                      {design.needed_reagents.map(reagent => (
-                        <Box>
-                          {reagent.name}: {reagent.amount}u
-                        </Box>
-                        ))}
-                    </LabeledList.Item>
-                  ))}
+                {designList.map(design => (
+                  <LabeledList.Item
+                    key={design.name}
+                    label={design.name}
+                    buttons={(
+                      <Button
+                        content="Make"
+                        color="good"
+                        onClick={() => act('make_limb', {
+                          design_id: design.id,
+                          active_tab: design.parent_category,
+                        })} />
+                    )}>
+                    {design.needed_reagents.map(reagent => (
+                      <Box key={reagent.name}>
+                        {reagent.name}: {reagent.amount}u
+                      </Box>
+                    ))}
+                  </LabeledList.Item>
+                ))}
               </LabeledList>
             </Flex.Item>
           </Flex>

--- a/tgui/packages/tgui/interfaces/Limbgrower.js
+++ b/tgui/packages/tgui/interfaces/Limbgrower.js
@@ -6,30 +6,37 @@ export const Limbgrower = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     reagents = [],
-    categories = [],
     total_reagents,
     max_reagents,
+    categories = [],
   } = data;
-  const [tab, setTab] = useSharedState(context, 'category', categories[0]);
+  const [tab, setTab] = useSharedState(context, 'category', categories[0]?.name);
+  const designList = categories.find(category => category.name === tab)?.designs
 
   return (
     <Window
       width={400}
-      height={500}
+      height={550}
       title="Limb Grower">
-      <Window.Content>
+      <Window.Content scrollable>
         <Section title="Reagents">
           <Flex direction="column">
-            <Flex.Item>
-              {total_reagents} / {max_reagents} reagents currently filled.
+            <Flex.Item mb={1}>
+              {total_reagents} / {max_reagents} reagent capacity used.
             </Flex.Item>
             <Flex.Item>
               <LabeledList>
-                {reagents.map(reagent => {
-                  <LabeledList.Item label={reagent.reagent_name}>
-                    {reagent.reagent_amount}
+                {reagents.map(reagent => (
+                  <LabeledList.Item
+                    label={reagent.reagent_name}
+                    buttons={(
+                      <Button
+                        content="Remove Reagent"
+                        color="bad"
+                        onClick={() => act('empty_reagent', {reagent_type: reagent.reagent_type})} />)} >
+                    {reagent.reagent_amount}u
                   </LabeledList.Item>
-                })}
+                ))}
               </LabeledList>
             </Flex.Item>
           </Flex>
@@ -41,14 +48,38 @@ export const Limbgrower = (props, context) => {
           <Flex direction="column">
             <Flex.Item>
               <Tabs>
-                {categories.map(category => {
+                {categories.map(category => (
                   <Tabs.Tab
-                    selected={tab === category}
-                    onClick={() => setTab(category)}>
-                    Category: {category}
+                    fluid
+                    selected={tab === category.name}
+                    onClick={() => {
+                      act("updated_active_tab", {active_tab: category.name});
+                      setTab(category.name);
+                    }}>
+                    {category.name}
                   </Tabs.Tab>
-                })}
+                ))}
               </Tabs>
+            </Flex.Item>
+            <Flex.Item>
+              <LabeledList>
+                  {designList.map(design => (
+                    <LabeledList.Item
+                      label={design.name}
+                      buttons={(
+                        <Button
+                          content="Make"
+                          color="good"
+                          onClick={() => act('make_limb', {design_id: design.id})}/>
+                        )}>
+                      {design.needed_reagents.map(reagent => (
+                        <Box>
+                          {reagent.name}: {reagent.amount}u
+                        </Box>
+                        ))}
+                    </LabeledList.Item>
+                  ))}
+              </LabeledList>
             </Flex.Item>
           </Flex>
         </Section>

--- a/tgui/packages/tgui/interfaces/Limbgrower.js
+++ b/tgui/packages/tgui/interfaces/Limbgrower.js
@@ -11,15 +11,17 @@ export const Limbgrower = (props, context) => {
     categories = [],
     busy,
   } = data;
-  const [tab, setTab] = useSharedState(context, 'category', categories[0]?.name);
-  const designList = categories.find(category =>
-    category.name === tab)?.designs;
+  const [tab, setTab] = useSharedState(
+    context, 'category', categories[0]?.name);
+  const designList = categories
+    .find(category => category.name === tab)
+    ?.designs;
 
   return (
     <Window
+      title="Limb Grower"
       width={400}
-      height={550}
-      title="Limb Grower">
+      height={550}>
       {!!busy && (
         <Dimmer fontSize="32px">
           <Icon name="cog" spin={1} />
@@ -28,71 +30,63 @@ export const Limbgrower = (props, context) => {
       )}
       <Window.Content scrollable>
         <Section title="Reagents">
-          <Flex direction="column">
-            <Flex.Item mb={1}>
-              {total_reagents} / {max_reagents} reagent capacity used.
-            </Flex.Item>
-            <Flex.Item>
-              <LabeledList>
-                { reagents.map(reagent => (
-                  <LabeledList.Item
-                    key={reagent.reagent_name}
-                    label={reagent.reagent_name}
-                    buttons={(
-                      <Button.Confirm
-                        textAlign="center"
-                        width="120px"
-                        content="Remove Reagent"
-                        color="bad"
-                        onClick={() => act('empty_reagent', { reagent_type: reagent.reagent_type })} />)} >
-                    {reagent.reagent_amount}u
-                  </LabeledList.Item>
-                ))}
-              </LabeledList>
-            </Flex.Item>
-          </Flex>
+          <Box mb={1}>
+            {total_reagents} / {max_reagents} reagent capacity used.
+          </Box>
+          <LabeledList>
+            {reagents.map(reagent => (
+              <LabeledList.Item
+                key={reagent.reagent_name}
+                label={reagent.reagent_name}
+                buttons={(
+                  <Button.Confirm
+                    textAlign="center"
+                    width="120px"
+                    content="Remove Reagent"
+                    color="bad"
+                    onClick={() => act('empty_reagent', {
+                      reagent_type: reagent.reagent_type,
+                    })} />
+                )}>
+                {reagent.reagent_amount}u
+              </LabeledList.Item>
+            ))}
+          </LabeledList>
         </Section>
-        <Divider />
         <Section title="Designs">
-          <Flex direction="column">
-            <Flex.Item>
-              <Tabs>
-                {categories.map(category => (
-                  <Tabs.Tab
-                    fluid
-                    key={category.name}
-                    selected={tab === category.name}
-                    onClick={() => setTab(category.name)}>
-                    {category.name}
-                  </Tabs.Tab>
+          <Tabs>
+            {categories.map(category => (
+              <Tabs.Tab
+                fluid
+                key={category.name}
+                selected={tab === category.name}
+                onClick={() => setTab(category.name)}>
+                {category.name}
+              </Tabs.Tab>
+            ))}
+          </Tabs>
+          <LabeledList>
+            {designList.map(design => (
+              <LabeledList.Item
+                key={design.name}
+                label={design.name}
+                buttons={(
+                  <Button
+                    content="Make"
+                    color="good"
+                    onClick={() => act('make_limb', {
+                      design_id: design.id,
+                      active_tab: design.parent_category,
+                    })} />
+                )}>
+                {design.needed_reagents.map(reagent => (
+                  <Box key={reagent.name}>
+                    {reagent.name}: {reagent.amount}u
+                  </Box>
                 ))}
-              </Tabs>
-            </Flex.Item>
-            <Flex.Item>
-              <LabeledList>
-                {designList.map(design => (
-                  <LabeledList.Item
-                    key={design.name}
-                    label={design.name}
-                    buttons={(
-                      <Button
-                        content="Make"
-                        color="good"
-                        onClick={() => act('make_limb', {
-                          design_id: design.id,
-                          active_tab: design.parent_category,
-                        })} />
-                    )}>
-                    {design.needed_reagents.map(reagent => (
-                      <Box key={reagent.name}>
-                        {reagent.name}: {reagent.amount}u
-                      </Box>
-                    ))}
-                  </LabeledList.Item>
-                ))}
-              </LabeledList>
-            </Flex.Item>
-          </Flex>
+              </LabeledList.Item>
+            ))}
+          </LabeledList>
         </Section>
       </Window.Content>
     </Window>

--- a/tgui/packages/tgui/interfaces/Limbgrower.js
+++ b/tgui/packages/tgui/interfaces/Limbgrower.js
@@ -22,7 +22,7 @@ export const Limbgrower = (props, context) => {
       {!!busy && (
         <Dimmer fontSize="32px">
           <Icon name="cog" spin={1} />
-          {' Building limb...'}
+          {' Building...'}
         </Dimmer>
       )}
       <Window.Content scrollable>


### PR DESCRIPTION
## About The Pull Request

- Gives the limbgrower a neat TGUI interface instead of the wonky HTML it used in the past. (This is my first TGUI project so it might be bad.)

![image](https://user-images.githubusercontent.com/51863163/112555298-efef1a00-8d95-11eb-846c-64414741afa2.png)
![image](https://user-images.githubusercontent.com/51863163/112555898-12356780-8d97-11eb-83b5-e6126728dd68.png)

- Refactors the limbgrower to modernize the code. Now, the limbgrower can accept any type of reagent in limbgrower designs.

- Adds simple plumbing demand to the limbgrower, so you can pipe synthflesh into it.

- Adds monkey tails, felinid ears and tails, lizard digitigrade legs, lizard tongues, fake lizard tails (unusable in lizard-wine and similar recipes), plasmaman organs, and ethereal organs (minus the heart) to the limbgrower via limbgrower design disks. These disks can be printed from the medical lathe once the required technology has been researched.

- Adds a technology node to unlock the limbgrower design disks after advanced biotech, xenoorgan biology. In the future, this could have an experiment requirement - maybe to scan multiple types of species.

## Why It's Good For The Game

The limbgrower is very outdated and uses a 5 year old UI. It hardly prints any organs or limbs and it is quite useless. A fresh UI and some additional limb designs can breathe some life in this forgotten machine, and allow medbay to get creative with their frankenstein-ian creations. 

## Changelog
:cl: Melbert
refactor: TGUI Limbgrower
refactor: Refactored the limbgrower to modernize the code and allow for more types of designs.
add: Limbgrower design disks. Science now has a new tech node after advanced biotechnology, "Xenoorgan Biology" which allows medbay to print new designs for the limbgrower, including various felinid, lizard, plasmaman, and ethereal organs.
add: The limbgrower now supports plumbing ducts.
/:cl:
