### PR TITLE
RPDs can install the unwrench upgrade by interacting with the disk

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -259,6 +259,12 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /obj/item/pipe_dispenser/attack_self(mob/user)
 	ui_interact(user)
 
+/obj/item/pipe_dispenser/pre_attack(atom/target, mob/user, params)
+	if(istype(target, /obj/item/rpd_upgrade/unwrench))
+		install_upgrade(target, user)
+		return TRUE
+	return ..()
+
 /obj/item/pipe_dispenser/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/rpd_upgrade))
 		install_upgrade(W, user)


### PR DESCRIPTION
## About The Pull Request
Adds the functionality to upgrade the RPD by 'slapping' the unwrench upgrade disk with the RPD itself

## Why It's Good For The Game
It doesn't exactly revolutionize gameplay and at most allows engineering cyborg players to at least upgrade their RPD to unwrench saving them a headache and a module slot when doing their thing I suppose

## Changelog
:cl:
add: RPDs can now apply the unwrench upgrade by interacting with the upgrade disk
/:cl: