### PR TITLE
PK borgs now have pepperspray

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -404,7 +404,8 @@
 		/obj/item/holosign_creator/cyborg,
 		/obj/item/borg/cyborghug/peacekeeper,
 		/obj/item/extinguisher,
-		/obj/item/borg/projectile_dampen)
+		/obj/item/borg/projectile_dampen,
+		/obj/item/reagent_containers/spray/pepper)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/peace/hacked)
 	cyborg_base_icon = "peace"
 	model_select_icon = "standard"


### PR DESCRIPTION
## About The Pull Request

This PR adds a can of pepperspray to the peacekeeper model's list of modules.

## Why It's Good For The Game

<img width="412" alt="pkpepperaccurate1" src="https://user-images.githubusercontent.com/42606352/112590348-b687d000-8dd0-11eb-86b1-0e67d1c9ba6b.PNG">
<img width="309" alt="pkpepperaccurate2" src="https://user-images.githubusercontent.com/42606352/112590362-bbe51a80-8dd0-11eb-9efb-9aa33d9e36c4.PNG">

I may or may not have spent like 1.5-2 hours making that comic in MS Paint.

## Changelog
:cl: ATHATH
add: A can of pepperspray has been added to the peacekeeper model's list of modules.
/:cl: