### PR TITLE
Fixes mech HUD's not being properly removed

### DIFF
--- a/code/modules/vehicles/mecha/medical/odysseus.dm
+++ b/code/modules/vehicles/mecha/medical/odysseus.dm
@@ -18,12 +18,13 @@
 	if(. && !HAS_TRAIT(H, TRAIT_MEDICAL_HUD))
 		var/datum/atom_hud/hud = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
 		hud.add_hud_to(H)
+		ADD_TRAIT(H, TRAIT_MEDICAL_HUD, VEHICLE_TRAIT)
 
-/obj/vehicle/sealed/mecha/medical/odysseus/remove_occupant(mob/M)
-	if(isliving(M) && HAS_TRAIT_FROM(M, TRAIT_MEDICAL_HUD, src))
-		var/mob/living/L = M
+/obj/vehicle/sealed/mecha/medical/odysseus/remove_occupant(mob/living/carbon/human/H)
+	if(isliving(H) && HAS_TRAIT_FROM(H, TRAIT_MEDICAL_HUD, VEHICLE_TRAIT))
 		var/datum/atom_hud/hud = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
-		hud.remove_hud_from(L)
+		hud.remove_hud_from(H)
+		REMOVE_TRAIT(H, TRAIT_MEDICAL_HUD, VEHICLE_TRAIT)
 	return ..()
 
 /obj/vehicle/sealed/mecha/medical/odysseus/mmi_moved_inside(obj/item/mmi/M, mob/user)

--- a/code/modules/vehicles/mecha/working/clarke.dm
+++ b/code/modules/vehicles/mecha/working/clarke.dm
@@ -33,12 +33,13 @@
 	if(. && !HAS_TRAIT(H, TRAIT_DIAGNOSTIC_HUD))
 		var/datum/atom_hud/hud = GLOB.huds[DATA_HUD_DIAGNOSTIC_ADVANCED]
 		hud.add_hud_to(H)
+		ADD_TRAIT(H, TRAIT_DIAGNOSTIC_HUD, VEHICLE_TRAIT)
 
-/obj/vehicle/sealed/mecha/working/clarke/remove_occupant(mob/M)
-	if(isliving(M) && HAS_TRAIT_FROM(M, TRAIT_DIAGNOSTIC_HUD, src))
-		var/mob/living/L = M
+/obj/vehicle/sealed/mecha/working/clarke/remove_occupant(mob/living/carbon/H)
+	if(isliving(H) && HAS_TRAIT_FROM(H, TRAIT_DIAGNOSTIC_HUD, VEHICLE_TRAIT))
 		var/datum/atom_hud/hud = GLOB.huds[DATA_HUD_DIAGNOSTIC_ADVANCED]
-		hud.remove_hud_from(L)
+		hud.remove_hud_from(H)
+		REMOVE_TRAIT(H, TRAIT_DIAGNOSTIC_HUD, VEHICLE_TRAIT)
 	return ..()
 
 /obj/vehicle/sealed/mecha/working/clarke/mmi_moved_inside(obj/item/mmi/M, mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes mech hud's not being removed when leaving the odysseus or clarke
## Why It's Good For The Game
Because unremoveable huds bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed mech hud's not being removed when leaving the mech.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
