### PR TITLE
Refactors pellet_cloud/create_cassing_pellets to not sleep

### DIFF
--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -101,7 +101,7 @@
 	SIGNAL_HANDLER
 
 	shooter = user
-	var/turf/targloc = get_turf(target)
+	var/turf/target_loc = get_turf(target)
 	if(!zone_override)
 		zone_override = shooter.zone_selected
 
@@ -124,10 +124,10 @@
 		shell.loaded_projectile.wound_bonus = original_wb
 		shell.loaded_projectile.bare_wound_bonus = original_bwb
 		pellets += shell.loaded_projectile
-		var/turf/curloc = get_turf(user)
-		if (!istype(targloc) || !istype(curloc) || !(shell.loaded_projectile))
+		var/turf/current_loc = get_turf(user)
+		if (!istype(target_loc) || !istype(current_loc) || !(shell.loaded_projectile))
 			return
-		INVOKE_ASYNC(shell, /obj/item/ammo_casing.proc/throw_proj, target, targloc, shooter, params, spread)
+		INVOKE_ASYNC(shell, /obj/item/ammo_casing.proc/throw_proj, target, target_loc, shooter, params, spread)
 
 		if(i != num_pellets)
 			shell.newshot()

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -98,10 +98,10 @@
  * The arguments really don't matter, this proc is triggered by COMSIG_PELLET_CLOUD_INIT which is only for this really, it's just a big mess of the state vars we need for doing the stuff over here.
  */
 /datum/component/pellet_cloud/proc/create_casing_pellets(obj/item/ammo_casing/shell, atom/target, mob/living/user, fired_from, randomspread, spread, zone_override, params, distro)
-	SIGNAL_HANDLER_DOES_SLEEP
+	SIGNAL_HANDLER
 
 	shooter = user
-	var/targloc = get_turf(target)
+	var/turf/targloc = get_turf(target)
 	if(!zone_override)
 		zone_override = shooter.zone_selected
 
@@ -124,8 +124,11 @@
 		shell.loaded_projectile.wound_bonus = original_wb
 		shell.loaded_projectile.bare_wound_bonus = original_bwb
 		pellets += shell.loaded_projectile
-		if(!shell.throw_proj(target, targloc, shooter, params, spread))
+		var/turf/curloc = get_turf(user)
+		if (!istype(targloc) || !istype(curloc) || !(shell.loaded_projectile))
 			return
+		INVOKE_ASYNC(shell, /obj/item/ammo_casing.proc/throw_proj, target, targloc, shooter, params, spread)
+
 		if(i != num_pellets)
 			shell.newshot()
 


### PR DESCRIPTION

## About The Pull Request

Refactors create_Casing_pellets in pellet_cloud component to not use SIGNAL_HANDLER_DOES_SLEEP and STOP_LAG

## Why It's Good For The Game
At high TiDi , casing are cucked by stop_lag and makes shotguns fire like a L6 saw instead of all its bullet at once

## Changelog
:cl:
refactor: refactored create_casing_pellets to not sleep
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
