### PR TITLE
Test newest version of gbp-action

### DIFF
--- a/.github/workflows/gbp.yml
+++ b/.github/workflows/gbp.yml
@@ -8,7 +8,22 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: GBP action
-      uses: tgstation/gbp-action@master
+    - name: Setup git
+      run: |
+        git config --global user.name "gbp-action"
+        git config --global user.email "<>"
+    - name: Checkout alternate branch
+      uses: actions/checkout@v2
       with:
+        ref: "gbp-balances" # The branch name
+        path: gbp-balances
+    # This is to ensure we keep the gbp.toml from master
+    # without having to update our separate branch.
+    - name: Copy configuration
+      run: cp ./.github/gbp.toml ./gbp-balances/.github/gbp.toml
+    - name: GBP action
+      uses: Mothblocks/gbp-action@collate-changes
+      with:
+        branch: "gbp-balances"
+        directory: ./gbp-balances
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gbp_collect.yml
+++ b/.github/workflows/gbp_collect.yml
@@ -11,8 +11,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Setup git
       run: |
-        git config --global user.name "gbp-action"
-        git config --global user.email "<>"
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
     - name: Checkout alternate branch
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/gbp_collect.yml
+++ b/.github/workflows/gbp_collect.yml
@@ -1,0 +1,30 @@
+name: GBP Collection
+# Every hour at the :20 minute mark. GitHub tells us to pick odd hours, instead of just using the start.
+on:
+  schedule:
+  - cron: "20 * * * *"
+jobs:
+  gbp_collection:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup git
+      run: |
+        git config --global user.name "gbp-action"
+        git config --global user.email "<>"
+    - name: Checkout alternate branch
+      uses: actions/checkout@v2
+      with:
+        ref: "gbp-balances" # The branch name
+        path: gbp-balances
+    # This is to ensure we keep the gbp.toml from master
+    # without having to update our separate branch.
+    - name: Copy configuration
+      run: cp ./.github/gbp.toml ./gbp-balances/.github/gbp.toml
+    - name: GBP action
+      uses: ./
+      with:
+        collect: "true"
+        directory: ./gbp-balances
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Read about it here: https://github.com/tgstation/gbp-action/pull/28

TLDR: Less race conditions, and all logs are now pushed to a separate branch. The new location of gbp-balances.toml is in the gbp-balances branch. Will most likely be able to delete the one in master so people don't get confused.

This required a workflow update, and so was not directly pushed to master. This currently uses my PR branch directly so that I can make changes for anything that doesn't work. When it is solid, I will push it to master and we will go back to `gbp-actions@master`, or some pinned version.