### PR TITLE
Corrects span and a typo with emagged pAIs

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -332,7 +332,7 @@
 	if(!pai)
 		return
 	to_chat(user, "<span class='notice'>You override [pai]'s directive system, clearing its master string and supplied directive.</span>")
-	to_chat(pai, "<span class='danger'>Warning: System override detected, check directive sub-system for any changes.'</span>")
+	to_chat(pai, "<span class='userdanger'>Warning: System override detected, check directive sub-system for any changes.</span>")
 	log_game("[key_name(user)] emagged [key_name(pai)], wiping their master DNA and supplemental directive.")
 	pai.master = null
 	pai.master_dna = null


### PR DESCRIPTION
## About The Pull Request

Removes a stray apostrophe and changes the span to the intended one (before, danger instead of userdanger was an oversight).

## Why It's Good For The Game

Span fix makes it more consistent with other emag messages, and small typo fixes are always nice.

## Changelog
:cl:
spellcheck: Corrected the span and a typo when a pAI gets emagged.
/:cl: