### PR TITLE
Fixes oversight with eigenstasium which teleports you before saving your location (when purity is greater than 90% and ingested)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -37,15 +37,6 @@
 
 /datum/reagent/eigenstate/expose_mob(mob/living/living_mob, methods, reac_volume, show_message, touch_protection)
 	. = ..()
-	if(!(methods & INGEST))
-		return
-	if(creation_purity > 0.9 && location_created) //Teleports you home if it's pure enough
-		do_sparks(5,FALSE,living_mob)
-		do_teleport(living_mob, location_created, 0, asoundin = 'sound/effects/phasein.ogg')
-		do_sparks(5,FALSE,living_mob)
-
-//Main functions
-/datum/reagent/eigenstate/on_mob_add(mob/living/living_mob, amount)
 	//make hologram at return point
 	eigenstate = new (living_mob.loc)
 	eigenstate.appearance = living_mob.appearance
@@ -60,7 +51,14 @@
 	location_return = get_turf(living_mob)	//sets up return point
 	to_chat(living_mob, "<span class='userdanger'>You feel like part of yourself has split off!</span>")
 
-	return ..()
+	if(!(methods & INGEST))
+		return
+	if(creation_purity > 0.9 && location_created) //Teleports you home if it's pure enough
+		do_sparks(5,FALSE,living_mob)
+		do_teleport(living_mob, location_created, 0, asoundin = 'sound/effects/phasein.ogg')
+		do_sparks(5,FALSE,living_mob)
+
+
 
 /datum/reagent/eigenstate/on_mob_life(mob/living/carbon/living_mob)
 	if(prob(20))

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -24,7 +24,7 @@
 	inverse_chem_val = 0
 	failed_chem = /datum/reagent/bluespace //crashes out
 	chemical_flags = REAGENT_DEAD_PROCESS //So if you die with it in your body, you still get teleported back to the location as a corpse
-	data = list("location_created" = null, "location_return" = null, "eigenstate" = null)//So we retain the target location and creator between reagent instances
+	data = list("location_created" = null, "ingested" = FALSE)//So we retain the target location and creator between reagent instances
 	///The creation point assigned during the reaction
 	var/turf/location_created
 	///The return point indicator
@@ -34,14 +34,26 @@
 
 /datum/reagent/eigenstate/on_new(list/data)
 	location_created = data["location_created"]
-	location_return = data["location_return"]
-	eigenstate = data["eigenstate"]
 
 /datum/reagent/eigenstate/expose_mob(mob/living/living_mob, methods, reac_volume, show_message, touch_protection)
 	. = ..()
-	data["exposure_type"] = methods
+	if(!(methods & INGEST) || !iscarbon(living_mob))
+		return
+	//This looks rediculous, but expose is usually called from the donor reagents datum - we want to edit the post exposure version present in the mob.
+	var/mob/living/carbon/carby = living_mob
+	//But because carbon mobs have stomachs we have to search in there because we're ingested
+	var/obj/item/organ/stomach/stomach = carby.getorganslot(ORGAN_SLOT_STOMACH)
+	var/datum/reagent/eigenstate/eigen
+	if(stomach)
+		eigen = stomach.reagents.has_reagent(/datum/reagent/eigenstate)
+	if(!eigen)//But what if they have no stomach! I want to get off expose_mob's wild ride
+		eigen = carby.reagents.has_reagent(/datum/reagent/eigenstate)
+	//Because expose_mob and on_mob_add() across all of the different things call them in different orders, so I want to make sure whatever is the first one to call it sets up the location correctly.
+	eigen.data["ingested"] = TRUE
 
-	//make hologram at return point
+//Main functions
+/datum/reagent/eigenstate/on_mob_add(mob/living/living_mob, amount)
+	//make hologram at return point to indicate where someone will go back to
 	eigenstate = new (living_mob.loc)
 	eigenstate.appearance = living_mob.appearance
 	eigenstate.alpha = 170
@@ -51,20 +63,18 @@
 	eigenstate.anchored = 1//So space wind cannot drag it.
 	eigenstate.name = "[living_mob.name]'s eigenstate"//If someone decides to right click.
 	eigenstate.set_light(2)	//hologram lighting
-	data["eigenstate"] = eigenstate
 
-	location_return = get_turf(living_mob)	//sets up return point
-	data["location_return"] = location_return
+	if(!location_return)
+		location_return = get_turf(living_mob)	//sets up return point
 	to_chat(living_mob, "<span class='userdanger'>You feel like part of yourself has split off!</span>")
 
-	if(!(data["exposure_type"] & INGEST))
-		return ..()
-	if(creation_purity > 0.9 && location_created) //Teleports you home if it's pure enough
+	//Teleports you home if it's pure enough
+	if(creation_purity > 0.9 && location_created && data["ingested"])
 		do_sparks(5,FALSE,living_mob)
 		do_teleport(living_mob, location_created, 0, asoundin = 'sound/effects/phasein.ogg')
 		do_sparks(5,FALSE,living_mob)
-	..()
 
+	return ..()
 
 /datum/reagent/eigenstate/on_mob_life(mob/living/carbon/living_mob)
 	if(prob(20))

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -24,7 +24,7 @@
 	inverse_chem_val = 0
 	failed_chem = /datum/reagent/bluespace //crashes out
 	chemical_flags = REAGENT_DEAD_PROCESS //So if you die with it in your body, you still get teleported back to the location as a corpse
-	data = list("location_created" = null, "exposure_type" = null)//So we retain the target location and creator between reagent instances
+	data = list("location_created" = null, "location_return" = null, "eigenstate" = null)//So we retain the target location and creator between reagent instances
 	///The creation point assigned during the reaction
 	var/turf/location_created
 	///The return point indicator
@@ -34,12 +34,12 @@
 
 /datum/reagent/eigenstate/on_new(list/data)
 	location_created = data["location_created"]
+	location_return = data["location_return"]
+	eigenstate = data["eigenstate"]
 
 /datum/reagent/eigenstate/expose_mob(mob/living/living_mob, methods, reac_volume, show_message, touch_protection)
 	. = ..()
 	data["exposure_type"] = methods
-
-/datum/reagent/eigenstate/on_mob_add(mob/living/living_mob, amount)
 
 	//make hologram at return point
 	eigenstate = new (living_mob.loc)
@@ -51,11 +51,13 @@
 	eigenstate.anchored = 1//So space wind cannot drag it.
 	eigenstate.name = "[living_mob.name]'s eigenstate"//If someone decides to right click.
 	eigenstate.set_light(2)	//hologram lighting
+	data["eigenstate"] = eigenstate
 
 	location_return = get_turf(living_mob)	//sets up return point
+	data["location_return"] = location_return
 	to_chat(living_mob, "<span class='userdanger'>You feel like part of yourself has split off!</span>")
 
-	if(data["exposure_type"] & INGEST)
+	if(!(data["exposure_type"] & INGEST))
 		return ..()
 	if(creation_purity > 0.9 && location_created) //Teleports you home if it's pure enough
 		do_sparks(5,FALSE,living_mob)

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -24,7 +24,7 @@
 	inverse_chem_val = 0
 	failed_chem = /datum/reagent/bluespace //crashes out
 	chemical_flags = REAGENT_DEAD_PROCESS //So if you die with it in your body, you still get teleported back to the location as a corpse
-	data = list("location_created" = null)//So we retain the target location and creator between reagent instances
+	data = list("location_created" = null, "exposure_type" = null)//So we retain the target location and creator between reagent instances
 	///The creation point assigned during the reaction
 	var/turf/location_created
 	///The return point indicator
@@ -37,6 +37,10 @@
 
 /datum/reagent/eigenstate/expose_mob(mob/living/living_mob, methods, reac_volume, show_message, touch_protection)
 	. = ..()
+	data["exposure_type"] = methods
+
+/datum/reagent/eigenstate/on_mob_add(mob/living/living_mob, amount)
+
 	//make hologram at return point
 	eigenstate = new (living_mob.loc)
 	eigenstate.appearance = living_mob.appearance
@@ -51,13 +55,13 @@
 	location_return = get_turf(living_mob)	//sets up return point
 	to_chat(living_mob, "<span class='userdanger'>You feel like part of yourself has split off!</span>")
 
-	if(!(methods & INGEST))
-		return
+	if(!(data["exposure_type"] & INGEST))
+		return ..()
 	if(creation_purity > 0.9 && location_created) //Teleports you home if it's pure enough
 		do_sparks(5,FALSE,living_mob)
 		do_teleport(living_mob, location_created, 0, asoundin = 'sound/effects/phasein.ogg')
 		do_sparks(5,FALSE,living_mob)
-
+	..()
 
 
 /datum/reagent/eigenstate/on_mob_life(mob/living/carbon/living_mob)

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -55,7 +55,7 @@
 	location_return = get_turf(living_mob)	//sets up return point
 	to_chat(living_mob, "<span class='userdanger'>You feel like part of yourself has split off!</span>")
 
-	if(!(data["exposure_type"] & INGEST))
+	if(data["exposure_type"] & INGEST)
 		return ..()
 	if(creation_purity > 0.9 && location_created) //Teleports you home if it's pure enough
 		do_sparks(5,FALSE,living_mob)

--- a/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/unique/eigenstasium.dm
@@ -64,8 +64,7 @@
 	eigenstate.name = "[living_mob.name]'s eigenstate"//If someone decides to right click.
 	eigenstate.set_light(2)	//hologram lighting
 
-	if(!location_return)
-		location_return = get_turf(living_mob)	//sets up return point
+	location_return = get_turf(living_mob)	//sets up return point
 	to_chat(living_mob, "<span class='userdanger'>You feel like part of yourself has split off!</span>")
 
 	//Teleports you home if it's pure enough


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I didn't quite realise in testing that expose_mob() is called before on_mob_add() so when I stood in the same spot as I took it so I ended up not realising it resolved like this. Since reagents don't transfer information about their consumption type and I need to ensure that a specific ordering occurs I solve this by adding the consumption type to data - which is kept between reagent datums. 

It's supposed to return you to where you took it - then teleport you away. This fixes the ordering so it works as indended.

## Why It's Good For The Game

Fixes an oversight in proc ordering for a very specific case. Restores eigenstasium to intended function!

## Changelog
:cl:
fix: Fixes oversight with eigenstasium which teleports you before saving your location (when purity is greater than 90% and ingested)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
