### PR TITLE
Carbons breath more and faster

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -50,7 +50,7 @@
  * graph the functions that describe how it is used/how it interacts with breath code, and pick something on the upper half of the sawtooth
  *
 **/
-#define BREATH_VOLUME 1.99
+#define BREATH_VOLUME 3.5
 /// Amount of air to take a from a tile
 #define BREATH_PERCENTAGE (BREATH_VOLUME/CELL_VOLUME)
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -50,7 +50,7 @@
 
 //Start of a breath chain, calls breathe()
 /mob/living/carbon/handle_breathing(delta_time, times_fired)
-	var/next_breath = 4
+	var/next_breath = 3
 	var/obj/item/organ/lungs/L = getorganslot(ORGAN_SLOT_LUNGS)
 	var/obj/item/organ/heart/H = getorganslot(ORGAN_SLOT_HEART)
 	if(L)
@@ -61,7 +61,7 @@
 			next_breath--
 
 	if((times_fired % next_breath) == 0 || failed_last_breath)
-		breathe(delta_time, times_fired) //Breathe per 4 ticks if healthy, down to 2 if our lungs or heart are damaged, unless suffocating
+		breathe(delta_time, times_fired) //Breathe per 3 ticks if healthy, down to 1 if our lungs and heart are damaged, unless suffocating
 		if(failed_last_breath)
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "suffocation", /datum/mood_event/suffocation)
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this PR makes all carbons breathe more air in and out (with increased exchange in gases) and a bit faster too.
This will help with:
the current waste loop not being able to keep up with the new thermomachines
emergency internals lasting over 10 minutes (with this is reduced to 5)
breathable air will exchange more often, allowing atmos tech to do more work on the system

sidenote: the amount of air (3.5) has been checked on the [graph](https://www.desmos.com/calculator/5icdlnktus?lang=it) and is on the upper half of the sawtooth
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
balance issues fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: carbons breath more air and a bit faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
