### PR TITLE
Thermomachine have full temperature range on both modes

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
@@ -135,7 +135,7 @@
 	var/thermal_heat_capacity = thermal_exchange_port.heat_capacity()
 	var/temperature_delta = main_port.temperature - target_temperature
 	if(auto_thermal_regulator)
-		cooling = temperature_delta > 0 ? TRUE : FALSE
+		cooling = temperature_delta > 0
 	else
 		temperature_delta = cooling ? max(temperature_delta, 0) : min(temperature_delta, 0) //no cheesy strats
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
@@ -72,16 +72,12 @@
 	heat_capacity = 7500 * ((calculated_bin_rating - 1) ** 2)
 	min_temperature = T20C
 	max_temperature = T20C
-	if(cooling)
-		var/calculated_laser_rating
-		for(var/obj/item/stock_parts/micro_laser/laser in component_parts)
-			calculated_laser_rating += laser.rating
-		min_temperature = max(T0C - (base_cooling + calculated_laser_rating * 15), TCMB) //73.15K with T1 stock parts
-	else
-		var/calculated_laser_rating
-		for(var/obj/item/stock_parts/micro_laser/laser in component_parts)
-			calculated_laser_rating += laser.rating
-		max_temperature = T20C + (base_heating * calculated_laser_rating) //573.15K with T1 stock parts
+	var/calculated_laser_rating
+	for(var/obj/item/stock_parts/micro_laser/laser in component_parts)
+		calculated_laser_rating += laser.rating
+	min_temperature = max(T0C - (base_cooling + calculated_laser_rating * 15), TCMB) //73.15K with T1 stock parts
+	max_temperature = T20C + (base_heating * calculated_laser_rating) //573.15K with T1 stock parts
+
 
 /obj/machinery/atmospherics/components/binary/thermomachine/update_icon_state()
 	if(panel_open)

--- a/tgui/packages/tgui/interfaces/ThermoMachine.js
+++ b/tgui/packages/tgui/interfaces/ThermoMachine.js
@@ -67,9 +67,14 @@ export const ThermoMachine = (props, context) => {
                 selected={data.use_env_heat}
                 onClick={() => act('use_env_heat')} />
             </LabeledList.Item>
-            <LabeledList.Item label="Setting">
+            <LabeledList.Item label="Thermal setting">
+              <Button
+                content={data.auto_thermal_regulator ? 'Auto' : 'Off'}
+                selected={data.auto_thermal_regulator}
+                onClick={() => act('auto_thermal_regulator')} />
               <Button
                 content={data.cooling ? 'Cooling' : 'Heating'}
+                disabled={data.auto_thermal_regulator}
                 selected={data.cooling}
                 onClick={() => act('cooling')} />
             </LabeledList.Item>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title, 
both cooler and heater will have both ranges on min and max temperature (on t1 they can both go from 73 K to 573 K)
The thermomachine have a new function, the automatic thermal regulation where it will try to keep the temperature to the set one by automatically switching between heater and cooler; it won't change between using enviroment heat
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Quality of life for players
Thermomachines are now able to sustain a temperature on their own; this will help with the new rework so that the already placed machines will automatically reach the best temperature even if the pipenet's temperature changes. Also players are able to create automatic gas production setups where the temperature may change too much due to the energy released by the gas created
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Thermomachine have full temperature range on both modes, plus new automatic thermal regulator function.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
