### PR TITLE
Fixes flying damage slowdown applying to the floating movetype instead.

### DIFF
--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -24,7 +24,7 @@
 	variable = TRUE
 
 /datum/movespeed_modifier/damage_slowdown_flying
-	movetypes = FLOATING
+	movetypes = FLYING
 	variable = TRUE
 
 /datum/movespeed_modifier/equipment_speedmod


### PR DESCRIPTION
## About The Pull Request
Title. This issue has been around for some time now that people might have grown accustomed to it, but the flying slowdown should affects mobs with the FLYING movetype, not FLOATING (hence the title). Also, since I refactored movetypes a while ago, having a FLYING movetype no longer applies the FLOATING type too, which means having wings makes you de facto immune to damage slowdown.

## Why It's Good For The Game
See above.

## Changelog
:cl:
fix: The flying damage slowdown movetype no longer affects floating humanoids rather than flying ones.
/:cl:
