### PR TITLE
Fix back slot not respecting internals for tgui strip panel

### DIFF
--- a/code/modules/mob/living/carbon/carbon_stripping.dm
+++ b/code/modules/mob/living/carbon/carbon_stripping.dm
@@ -6,6 +6,12 @@
 	key = STRIPPABLE_ITEM_BACK
 	item_slot = ITEM_SLOT_BACK
 
+/datum/strippable_item/mob_item_slot/back/get_alternate_action(atom/source, mob/user)
+	return get_strippable_alternate_action_internals(get_item(source), source)
+
+/datum/strippable_item/mob_item_slot/back/alternate_action(atom/source, mob/user)
+	return strippable_alternate_action_internals(get_item(source), source, user)
+
 /datum/strippable_item/mob_item_slot/mask
 	key = STRIPPABLE_ITEM_MASK
 	item_slot = ITEM_SLOT_MASK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #57999. I do eventually want this to be handled in a better manner, but only one alternate action is currently supported at a time, so it's better to just handle it individually.

## Changelog
:cl:
fix: Fixed not being able to turn on internals when stripping someone if it was on their back.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
