### PR TITLE
Fixes Orion bad messages

### DIFF
--- a/code/game/machinery/computer/arcade/orion_event.dm
+++ b/code/game/machinery/computer/arcade/orion_event.dm
@@ -8,8 +8,8 @@
 	///buttons to pick in response to the event. Don't worry, orion js will handle the rest
 	var/list/event_responses = list()
 	///default emag effect of events is to play an audible message and sound
-	var/emag_message = "<span class='userdanger'>Coders forgot to set this!</span>"
-	var/emag_sound = 'sound/effects/bamf.ogg'
+	var/emag_message
+	var/emag_sound
 	///gaming skill level of the player
 	var/gamer_skill_level = 0
 	///gaming skill of the player


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically, Orion is checking to see if emag messages exist and sending if they do but the default emag message is something

## Changelog
:cl:
fix: orion emag no longer produces... weeeeird messages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
