### PR TITLE
Adds seeds to tramstation permabrig

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -48951,10 +48951,18 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "nQS" = (
-/obj/structure/sink{
-	pixel_y = 20
-	},
 /obj/structure/closet/crate/hydroponics,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/item/seeds/onion,
+/obj/item/seeds/garlic,
+/obj/item/seeds/potato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/carrot,
+/obj/item/seeds/grass,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron,
 /area/security/prison)


### PR DESCRIPTION
## About The Pull Request

fixes: #58017

I got rid of a sink to make room for the crate but it shouldn't be an issue.

## Why It's Good For The Game

seeds are a need

## Changelog
:cl:
fix: Tramstation permabrig has seeds in its garden now
/:cl: