### PR TITLE
Internal Affairs actually works as intended now

### DIFF
--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -13,6 +13,9 @@
 	var/last_man_standing = FALSE
 	var/list/datum/mind/targets_stolen
 
+/datum/antagonist/traitor/internal_affairs/New()
+	. = ..()
+	targets_stolen = list()
 
 /datum/antagonist/traitor/internal_affairs/proc/give_pinpointer()
 	if(!owner)
@@ -116,7 +119,7 @@
 	if(!objectives.len)
 		return
 	for (var/objective_ in objectives)
-		if(!(istype(objective_, /datum/objective/escape)||istype(objective_, /datum/objective/survive)))
+		if(!(istype(objective_, /datum/objective/escape)||istype(objective_, /datum/objective/survive/malf)))
 			continue
 		remove_objective(objective_)
 
@@ -136,7 +139,7 @@
 
 /datum/antagonist/traitor/internal_affairs/reinstate_escape_objective()
 	..()
-	var/objtype = traitor_kind == TRAITOR_HUMAN ? /datum/objective/escape : /datum/objective/survive
+	var/objtype = traitor_kind == TRAITOR_HUMAN ? /datum/objective/escape : /datum/objective/survive/malf
 	var/datum/objective/escape_objective = new objtype
 	escape_objective.owner = owner
 	add_objective(escape_objective)
@@ -244,7 +247,7 @@
 /datum/antagonist/traitor/internal_affairs/forge_traitor_objectives()
 	forge_iaa_objectives()
 
-	var/objtype = traitor_kind == TRAITOR_HUMAN ? /datum/objective/escape : /datum/objective/survive
+	var/objtype = traitor_kind == TRAITOR_HUMAN ? /datum/objective/escape : /datum/objective/survive/malf
 	var/datum/objective/escape_objective = new objtype
 	escape_objective.owner = owner
 	add_objective(escape_objective)

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -11,7 +11,11 @@
 	antagpanel_category = "IAA"
 	var/syndicate = FALSE
 	var/last_man_standing = FALSE
-	var/list/datum/mind/targets_stolen = list()
+	var/list/datum/mind/targets_stolen
+
+/datum/antagonist/traitor/internal_affairs/New()
+	. = ..()
+	LAZYADD(targets_stolen, src)
 
 /datum/antagonist/traitor/internal_affairs/proc/give_pinpointer()
 	if(!owner)

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -11,11 +11,7 @@
 	antagpanel_category = "IAA"
 	var/syndicate = FALSE
 	var/last_man_standing = FALSE
-	var/list/datum/mind/targets_stolen
-
-/datum/antagonist/traitor/internal_affairs/New()
-	. = ..()
-	targets_stolen = list()
+	var/list/datum/mind/targets_stolen = list()
 
 /datum/antagonist/traitor/internal_affairs/proc/give_pinpointer()
 	if(!owner)


### PR DESCRIPTION
## About The Pull Request

Hey you. Yes you. Did you know that IAA (Internal Affairs Agent) has been BROKEN this entire time? That's right. This gamemode has been BROKEN. It DIDN'T WORK. You never got assigned a target past your initial one, even though the code intended to. Instead, you were left with your initial target AAAAND if somehow, by miracle, all the fellow IAAs died, you'd get DAGD.
Oh, and to top it off, the malf AI had the wrong survive objective, so they always redtexted no matter what.

tl;dr Ports the IAA fix from https://github.com/BeeStation/BeeStation-Hornet/pull/3623 and AI fix from https://github.com/BeeStation/BeeStation-Hornet/pull/2376
Closes https://github.com/tgstation/tgstation/issues/53404

## Was this tested?

Yes, it was. Tested on a live 90+ pop server (since you can't test IAA on local by yourself.)

![image](https://user-images.githubusercontent.com/68669754/112770177-d4854880-8ffb-11eb-9ac1-cb53bdd0b436.png)
![image](https://user-images.githubusercontent.com/68669754/112770178-d7803900-8ffb-11eb-9068-f16dba3a8a78.png)
![image](https://user-images.githubusercontent.com/68669754/112770181-db13c000-8ffb-11eb-95a2-ad68e2d0eaba.png)
![image](https://user-images.githubusercontent.com/68669754/112770183-dd761a00-8ffb-11eb-89b7-36258224eaa0.png)


## Changelog
:cl:
fix: The Internal Affairs gamemode now actually works as intended, getting the target of the agent they just assassinated. Get to work, agents.
fix: IAA AIs will no longer always redtext their survive objective.
/:cl: