### PR TITLE
Replaces a bunch of action buttons from crew gear with rmb toggles

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -675,7 +675,7 @@
 	desc = "Activates the jump boot's internal propulsion system, allowing the user to dash over 4-wide gaps."
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "jetboot"
-	
+
 /datum/action/item_action/bhop/brocket
 	name = "Activate Rocket Boots"
 	desc = "Activates the boot's rocket propulsion system, allowing the user to hurl themselves great distances."

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -23,7 +23,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 	item_flags = NOBLUDGEON
 	w_class = WEIGHT_CLASS_TINY
 	slot_flags = ITEM_SLOT_ID | ITEM_SLOT_BELT
-	actions_types = list(/datum/action/item_action/toggle_light)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	light_system = MOVABLE_LIGHT_DIRECTIONAL
@@ -106,6 +105,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	if((!isnull(cartridge)))
 		. += "<span class='notice'>Ctrl+Shift-click to remove the cartridge.</span>" //won't name cart on examine in case it's Detomatix
+	. += "<span class='notice'>Right click on it with an empty active hand to toggle its light.</span>"
 
 /obj/item/pda/Initialize()
 	. = ..()
@@ -856,13 +856,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 	..()
 	eject_cart(user)
 
-/obj/item/pda/verb/verb_toggle_light()
-	set name = "Toggle light"
-	set category = "Object"
-	set src in oview(1)
-
-	toggle_light(usr)
-
 /obj/item/pda/verb/verb_remove_id()
 	set category = "Object"
 	set name = "Eject ID"
@@ -886,6 +879,12 @@ GLOBAL_LIST_EMPTY(PDAs)
 	set src in usr
 
 	eject_cart(usr)
+
+/obj/item/pda/attack_hand_secondary(mob/user, params)
+	toggle_light(user)
+	if(!silent)
+		playsound(src, 'sound/machines/terminal_select.ogg', 15, TRUE)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/pda/proc/toggle_light(mob/user)
 	if(issilicon(user) || !user.canUseTopic(src, BE_CLOSE))

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -12,7 +12,6 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
 	custom_materials = list(/datum/material/iron=50, /datum/material/glass=20)
-	actions_types = list(/datum/action/item_action/toggle_light)
 	light_system = MOVABLE_LIGHT_DIRECTIONAL
 	light_range = 4
 	light_power = 1
@@ -36,14 +35,15 @@
 		update_light()
 
 
-/obj/item/flashlight/attack_self(mob/user)
+/obj/item/flashlight/attack_hand_secondary(mob/user, params)
 	on = !on
 	playsound(user, on ? 'sound/weapons/magin.ogg' : 'sound/weapons/magout.ogg', 40, TRUE)
 	update_brightness(user)
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.UpdateButtonIcon()
-	return 1
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/flashlight/examine(mob/living/user)
+	. = ..()
+	. += "<span class='notice'>Right click on it with an empty active hand to toggle its light.</span>"
 
 /obj/item/flashlight/suicide_act(mob/living/carbon/human/user)
 	if (user.is_blind())

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -28,6 +28,15 @@
 	STR.display_numerical_stacking = TRUE
 	STR.click_gather = TRUE
 
+/obj/item/storage/bag/attack_hand_secondary(mob/user, params)
+	var/datum/component/storage/storage_component = GetComponent(/datum/component/storage)
+	storage_component.gather_mode_switch(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/storage/bag/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Right click with an empty active hand to change its gathering mode.</span>"
+
 // -----------------------------
 //          Trash bag
 // -----------------------------

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -23,7 +23,6 @@
 	throw_speed = 1
 	throw_range = 4
 	custom_materials = list(/datum/material/iron = 500)
-	actions_types = list(/datum/action/item_action/set_internals)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 0, RAD = 0, FIRE = 80, ACID = 30)
 	integrity_failure = 0.5
 	/// The gases this tank contains.
@@ -37,8 +36,12 @@
 	/// Icon state when in a tank holder. Null makes it incompatible with tank holder.
 	var/tank_holder_icon_state = "holder_generic"
 
-/obj/item/tank/ui_action_click(mob/user)
+/obj/item/tank/attack_hand_secondary(mob/user, params)
+	if(src.loc != user)
+		to_chat(user, "<span class='warning'>You can't open [src] valve from there!</span>")
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	toggle_internals(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/tank/proc/toggle_internals(mob/user)
 	var/mob/living/carbon/human/H = user
@@ -106,6 +109,7 @@
 		return
 
 	. += "<span class='notice'>The pressure gauge reads [round(src.air_contents.return_pressure(),0.01)] kPa.</span>"
+	. += "<span class='notice'>Right click on it with an empty active hand to open the valve.</span>"
 
 	var/celsius_temperature = src.air_contents.temperature-T0C
 	var/descriptive

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -131,14 +131,33 @@
 	icon_state = "purple"
 	inhand_icon_state = "glasses"
 	clothing_flags = SCAN_REAGENTS //You can see reagents while wearing science goggles
-	actions_types = list(/datum/action/item_action/toggle_research_scanner)
 	glass_colour_type = /datum/client_colour/glass_colour/purple
 	resistance_flags = ACID_PROOF
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 80, ACID = 100)
+	///Used to determine if additional information is displayed when examining things
+	var/active = FALSE
 
-/obj/item/clothing/glasses/science/item_action_slot_check(slot)
-	if(slot == ITEM_SLOT_EYES)
-		return 1
+/obj/item/clothing/glasses/science/attack_hand_secondary(mob/user, params)
+	if(user.get_item_by_slot(ITEM_SLOT_EYES) != src)
+		to_chat(user, "<span class='notice'>You must wear [src] to toggle its research scanner.</span>")
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	active = !active
+	if(active)
+		user.research_scanner = TRUE
+	else
+		user.research_scanner = FALSE
+	to_chat(user, "<span class='notice'>[src] research scanner has been [active ? "activated" : "deactivated"].</span>")
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/clothing/glasses/science/dropped(mob/user)
+	. = ..()
+	if(user.get_item_by_slot(ITEM_SLOT_EYES) == src && active)
+		active = FALSE
+		user.research_scanner = FALSE
+
+/obj/item/clothing/glasses/science/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Right click with an empty active hand to toggle its research scanner while worn.</span>"
 
 /obj/item/clothing/glasses/night
 	name = "night vision goggles"
@@ -295,7 +314,6 @@
 	desc = "Protects the eyes from bright flashes; approved by the mad scientist association."
 	icon_state = "welding-g"
 	inhand_icon_state = "welding-g"
-	actions_types = list(/datum/action/item_action/toggle)
 	flash_protect = FLASH_PROTECTION_WELDER
 	custom_materials = list(/datum/material/iron = 250)
 	tint = 2
@@ -303,9 +321,13 @@
 	flags_cover = GLASSESCOVERSEYES
 	glass_colour_type = /datum/client_colour/glass_colour/gray
 
-/obj/item/clothing/glasses/welding/attack_self(mob/user)
+/obj/item/clothing/glasses/welding/attack_hand_secondary(mob/user, params)
 	weldingvisortoggle(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
+/obj/item/clothing/glasses/welding/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Right click with an empty active hand to adjust it.</span>"
 
 /obj/item/clothing/glasses/blindfold
 	name = "blindfold"

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -5,7 +5,6 @@
 	inhand_icon_state = "hardhat0_yellow"
 	armor = list(MELEE = 15, BULLET = 5, LASER = 20, ENERGY = 10, BOMB = 20, BIO = 10, RAD = 20, FIRE = 100, ACID = 50, WOUND = 10) // surprisingly robust against head trauma
 	flags_inv = 0
-	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	clothing_flags = SNUG_FIT
 	resistance_flags = FIRE_PROOF
 	dynamic_hair_suffix = "+generic"
@@ -25,8 +24,13 @@
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 
-/obj/item/clothing/head/hardhat/attack_self(mob/living/user)
+/obj/item/clothing/head/hardhat/attack_hand_secondary(mob/user, params)
 	toggle_helmet_light(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/clothing/head/hardhat/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Right click on it with an empty active hand to toggle its light.</span>"
 
 /obj/item/clothing/head/hardhat/proc/toggle_helmet_light(mob/living/user)
 	on = !on

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -115,7 +115,7 @@
 	desc = "A piece of headgear used in dangerous working conditions to protect the head. Comes with a built-in flashlight AND welding shield! The bulb seems a little smaller though."
 	light_range = 3 //Needs a little bit of tradeoff
 	dog_fashion = null
-	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_screen)
+	actions_types = list(/datum/action/item_action/toggle_welding_screen)
 	flash_protect = FLASH_PROTECTION_WELDER
 	tint = 2
 	flags_inv = HIDEEYES | HIDEFACE | HIDESNOUT

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -24,15 +24,18 @@
 	tint = 2
 	armor = list(MELEE = 10, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 60)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDESNOUT
-	actions_types = list(/datum/action/item_action/toggle)
 	visor_flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDESNOUT
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = FIRE_PROOF
 	clothing_flags = SNUG_FIT
 
-/obj/item/clothing/head/welding/attack_self(mob/user)
+/obj/item/clothing/head/welding/attack_hand_secondary(mob/user, params)
 	weldingvisortoggle(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
+/obj/item/clothing/head/welding/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Right click with an empty active hand to adjust it.</span>"
 /*
  * Cakehat
  */

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -9,7 +9,6 @@
 	w_class = WEIGHT_CLASS_SMALL
 	gas_transfer_coefficient = 0.1
 	permeability_coefficient = 0.5
-	actions_types = list(/datum/action/item_action/adjust)
 	flags_cover = MASKCOVERSMOUTH
 	visor_flags_cover = MASKCOVERSMOUTH
 	resistance_flags = NONE
@@ -21,14 +20,14 @@
 /obj/item/clothing/mask/breath/attack_self(mob/user)
 	adjustmask(user)
 
-/obj/item/clothing/mask/breath/AltClick(mob/user)
-	..()
+/obj/item/clothing/mask/breath/attack_hand_secondary(mob/user, params)
 	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
 		adjustmask(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/clothing/mask/breath/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>Alt-click [src] to adjust it.</span>"
+	. += "<span class='notice'>Right click on it with an empty active hand to adjust it.</span>"
 
 /obj/item/clothing/mask/breath/medical
 	desc = "A close-fitting sterile mask that can be connected to an air supply."

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -39,15 +39,19 @@
 	custom_materials = list(/datum/material/iron=4000, /datum/material/glass=2000)
 	tint = 2
 	armor = list(MELEE = 10, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 55)
-	actions_types = list(/datum/action/item_action/toggle)
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDESNOUT
 	flags_cover = MASKCOVERSEYES
 	visor_flags_inv = HIDEEYES
 	visor_flags_cover = MASKCOVERSEYES
 	resistance_flags = FIRE_PROOF
 
-/obj/item/clothing/mask/gas/welding/attack_self(mob/user)
+/obj/item/clothing/mask/gas/welding/attack_hand_secondary(mob/user, params)
 	weldingvisortoggle(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/clothing/mask/gas/welding/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Right click with an empty active hand to adjust its visor.</span>"
 
 /obj/item/clothing/mask/gas/welding/up
 
@@ -82,7 +86,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
-	actions_types = list(/datum/action/item_action/adjust)
+
 	dog_fashion = /datum/dog_fashion/head/clown
 	species_exception = list(/datum/species/golem/bananium)
 	var/list/clownmask_designs = list()
@@ -98,9 +102,7 @@
 		)
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_CLOWN, CELL_VIRUS_TABLE_GENERIC, rand(2,3), 0)
 
-/obj/item/clothing/mask/gas/clown_hat/ui_action_click(mob/user)
-	if(!istype(user) || user.incapacitated())
-		return
+/obj/item/clothing/mask/gas/clown_hat/attack_hand_secondary(mob/user, params)
 
 	var/list/options = list()
 	options["True Form"] = "clown"
@@ -111,7 +113,7 @@
 
 	var/choice = show_radial_menu(user,src, clownmask_designs, custom_check = FALSE, radius = 36, require_near = TRUE)
 	if(!choice)
-		return FALSE
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	if(src && choice && !user.incapacitated() && in_range(user,src))
 		icon_state = options[choice]
@@ -120,7 +122,11 @@
 			var/datum/action/A = X
 			A.UpdateButtonIcon()
 		to_chat(user, "<span class='notice'>Your Clown Mask has now morphed into [choice], all praise the Honkmother!</span>")
-		return TRUE
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/clothing/mask/gas/clown_hat/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Right click on it with an empty active hand to adjust it.</span>"
 
 /obj/item/clothing/mask/gas/sexyclown
 	name = "sexy-clown wig and mask"
@@ -141,7 +147,6 @@
 	w_class = WEIGHT_CLASS_SMALL
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
-	actions_types = list(/datum/action/item_action/adjust)
 	species_exception = list(/datum/species/golem)
 	var/list/mimemask_designs = list()
 
@@ -154,9 +159,9 @@
 		"Effrayé" = image(icon = src.icon, icon_state = "scaredmime")
 		)
 
-/obj/item/clothing/mask/gas/mime/ui_action_click(mob/user)
+/obj/item/clothing/mask/gas/mime/attack_hand_secondary(mob/user, params)
 	if(!istype(user) || user.incapacitated())
-		return
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	var/list/options = list()
 	options["Blanc"] = "mime"
@@ -166,7 +171,7 @@
 
 	var/choice = show_radial_menu(user,src, mimemask_designs, custom_check = FALSE, radius = 36, require_near = TRUE)
 	if(!choice)
-		return FALSE
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	if(src && choice && !user.incapacitated() && in_range(user,src))
 		icon_state = options[choice]
@@ -175,7 +180,7 @@
 			var/datum/action/A = X
 			A.UpdateButtonIcon()
 		to_chat(user, "<span class='notice'>Your Mime Mask has now morphed into [choice]!</span>")
-		return TRUE
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/clothing/mask/gas/monkeymask
 	name = "monkey mask"

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -45,7 +45,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 /obj/item/clothing/mask/gas/sechailer
 	name = "security gas mask"
 	desc = "A standard issue Security gas mask with integrated 'Compli-o-nator 3000' device. Plays over a dozen pre-recorded compliance phrases designed to get scumbags to stand still whilst you tase them. Do not tamper with the device."
-	actions_types = list(/datum/action/item_action/halt, /datum/action/item_action/adjust)
+	actions_types = list(/datum/action/item_action/halt)
 	icon_state = "sechailer"
 	inhand_icon_state = "sechailer"
 	clothing_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
@@ -104,11 +104,13 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 		to_chat(user, "<span class='danger'>You broke the restrictor!</span>")
 		aggressiveness = AGGR_BROKEN
 
-/obj/item/clothing/mask/gas/sechailer/ui_action_click(mob/user, action)
-	if(istype(action, /datum/action/item_action/halt))
-		halt()
-	else
-		adjustmask(user)
+/obj/item/clothing/mask/gas/sechailer/attack_hand_secondary(mob/user, params)
+	adjustmask(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/clothing/mask/gas/sechailer/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Right click on it with an empty active hand to adjust it.</span>"
 
 /obj/item/clothing/mask/gas/sechailer/attack_self()
 	halt()

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -29,10 +29,14 @@
 	gas_transfer_coefficient = 0.9
 	permeability_coefficient = 0.01
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 25, RAD = 0, FIRE = 0, ACID = 0)
-	actions_types = list(/datum/action/item_action/adjust)
 
-/obj/item/clothing/mask/surgical/attack_self(mob/user)
+/obj/item/clothing/mask/surgical/attack_hand_secondary(mob/user, params)
 	adjustmask(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/clothing/mask/surgical/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Right click on it with an empty active hand to adjust it.</span>"
 
 /obj/item/clothing/mask/fakemoustache
 	name = "fake moustache"

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -1,7 +1,6 @@
 //Hoods for winter coats and chaplain hoodie etc
 
 /obj/item/clothing/suit/hooded
-	actions_types = list(/datum/action/item_action/toggle_hood)
 	var/obj/item/clothing/head/hooded/hood
 	var/hoodtype = /obj/item/clothing/head/hooded/winterhood //so the chaplain hoodie or other hoodies can override this
 	///Alternative mode for hiding the hood, instead of storing the hood in the suit it qdels it, useful for when you deal with hooded suit with storage.
@@ -23,8 +22,9 @@
 		W.suit = src
 		hood = W
 
-/obj/item/clothing/suit/hooded/ui_action_click()
+/obj/item/clothing/suit/hooded/attack_hand_secondary(mob/user, params)
 	ToggleHood()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/clothing/suit/hooded/item_action_slot_check(slot, mob/user)
 	if(slot == ITEM_SLOT_OCLOTHING)
@@ -84,6 +84,10 @@
 				A.UpdateButtonIcon()
 	else
 		RemoveHood()
+
+/obj/item/clothing/suit/hooded/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Right click with an empty active hand to adjust [hood].</span>"
 
 /obj/item/clothing/head/hooded
 	var/obj/item/clothing/suit/hooded/suit

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -42,12 +42,8 @@
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	visor_flags_inv = HIDEFACIALHAIR
 	visor_flags_cover = MASKCOVERSMOUTH
-	actions_types = list(/datum/action/item_action/adjust)
 	armor = list(MELEE = 10, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 0, BIO = 50, RAD = 0, FIRE = 20, ACID = 40, WOUND = 5)
 	resistance_flags = FIRE_PROOF
-
-/obj/item/clothing/mask/gas/explorer/attack_self(mob/user)
-	adjustmask(user)
 
 /obj/item/clothing/mask/gas/explorer/adjustmask(user)
 	..()
@@ -56,6 +52,14 @@
 /obj/item/clothing/mask/gas/explorer/folded/Initialize()
 	. = ..()
 	adjustmask()
+
+/obj/item/clothing/mask/gas/explorer/attack_hand_secondary(mob/user, params)
+	adjustmask(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/clothing/mask/gas/explorer/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Right click on it with an empty active hand to adjust it.</span>"
 
 /obj/item/clothing/suit/space/hostile_environment
 	name = "H.E.C.K. suit"

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -19,7 +19,6 @@
 	attack_verb_continuous = list("smashes", "crushes", "cleaves", "chops", "pulps")
 	attack_verb_simple = list("smash", "crush", "cleave", "chop", "pulp")
 	sharpness = SHARP_EDGED
-	actions_types = list(/datum/action/item_action/toggle_light)
 	obj_flags = UNIQUE_RENAME
 	light_system = MOVABLE_LIGHT
 	light_range = 5
@@ -60,6 +59,7 @@
 	for(var/t in trophies)
 		var/obj/item/crusher_trophy/T = t
 		. += "<span class='notice'>It has \a [T] attached, which causes [T.effect_desc()].</span>"
+	. += "<span class='notice'>Right click on it with an empty active hand to toggle its light.</span>"
 
 /obj/item/kinetic_crusher/attackby(obj/item/I, mob/living/user)
 	if(I.tool_behaviour == TOOL_CROWBAR)
@@ -150,10 +150,11 @@
 		update_appearance()
 		playsound(src.loc, 'sound/weapons/kenetic_reload.ogg', 60, TRUE)
 
-/obj/item/kinetic_crusher/ui_action_click(mob/user, actiontype)
+/obj/item/kinetic_crusher/attack_hand_secondary(mob/user, params)
 	set_light_on(!light_on)
 	playsound(user, 'sound/weapons/empty.ogg', 100, TRUE)
 	update_appearance()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 
 /obj/item/kinetic_crusher/update_icon_state()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -139,7 +139,7 @@
 	var/datum/component/storage/active_storage
 	/// Active hud
 	var/datum/hud/hud_used = null
-	/// I have no idea tbh
+	/// Used to determine if the mob can see additional research/material information when examining something when wearing science goggles
 	var/research_scanner = FALSE
 
 	/// Is the mob throw intent on

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -57,7 +57,6 @@
 
 	var/can_flashlight = FALSE //if a flashlight can be added or removed if it already has one.
 	var/obj/item/flashlight/seclite/gun_light
-	var/datum/action/item_action/toggle_gunlight/alight
 	var/gunlight_state = "flight"
 
 	var/can_bayonet = FALSE //if a bayonet can be added or removed if it already has one.
@@ -82,8 +81,6 @@
 	. = ..()
 	if(pin)
 		pin = new pin(src)
-	if(gun_light)
-		alight = new(src)
 	build_zooming()
 
 /obj/item/gun/Destroy()
@@ -131,7 +128,7 @@
 		. += "It doesn't have a <b>firing pin</b> installed, and won't fire."
 
 	if(gun_light)
-		. += "It has \a [gun_light] [can_flashlight ? "" : "permanently "]mounted on it."
+		. += "It has \a [gun_light] [can_flashlight ? "" : "permanently "]mounted on it. Right click with an empty active hand to toggle it."
 		if(can_flashlight) //if it has a light and this is false, the light is permanent.
 			. += "<span class='info'>[gun_light] looks like it can be <b>unscrewed</b> from [src].</span>"
 	else if(can_flashlight)
@@ -412,9 +409,6 @@
 			to_chat(user, "<span class='notice'>You click [S] into place on [src].</span>")
 			set_gun_light(S)
 			update_gunlight()
-			alight = new(src)
-			if(loc == user)
-				alight.Grant(user)
 	else if(istype(I, /obj/item/kitchen/knife))
 		var/obj/item/kitchen/knife/K = I
 		if(!can_bayonet || !K.bayonet || bayonet) //ensure the gun has an attachment point available, and that the knife is compatible with it.
@@ -520,7 +514,6 @@
 	set_gun_light(null)
 	update_gunlight()
 	removed_light.update_brightness()
-	QDEL_NULL(alight)
 	return TRUE
 
 
@@ -552,11 +545,9 @@
 
 	gun_light = new_light
 
-/obj/item/gun/ui_action_click(mob/user, actiontype)
-	if(istype(actiontype, alight))
-		toggle_gunlight()
-	else
-		..()
+/obj/item/gun/attack_hand_secondary(mob/user, params)
+	toggle_gunlight()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/gun/proc/toggle_gunlight()
 	if(!gun_light)


### PR DESCRIPTION
## About The Pull Request
Uses `attack_hand_secondary`, being a right click with an empty active hand on the item itself in place of action buttons, allowing for toggling effects from worn equipment without needing to hold them or take up screen space.
These features are described when examining them.

The intent is to remove action buttons that are specifically of little value in a combat scenario, as we have clearly bloated what qualifies for taking up screen space.

A few things I'm aware of that are similar but I'd like to handle separately are hardsuits and chameleon outfits.
- Hardsuits - A lot of functionalities that have varying levels of importance for combat that I'm not certain how I want to address them yet
- Chameleon outfits - Tons of buttons, but I'd like to do a sweep of antag-related items on their own

A few things that I intend to touch on with this pr:
- [x] remove welding hard hat light action button, leaving the visor action, as the helmet has two
- [x] make cake hats light again, as they're a hardhat subtype that I haven't fixed yet
- [x] make wintercoat/survival suit hoods compliant
- [x] make storage/bags compliant

If you can think of similar items please comment below, as I'm sure there's plenty I've missed still.

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/51932756/112784809-c8a38180-900f-11eb-91cd-c804cc135738.png)
Here you can see that the 7 action buttons in a reasonable outfit as a moth virologist easily begins to obscure the screen tips.

![image](https://user-images.githubusercontent.com/51932756/112784540-2daaa780-900f-11eb-8e29-aa098fbd11b6.png)
All functions are preserved with this pr, the only difference is that instead of clicking on an action button you right click on the item you intend to adjust.
The biobag no longer has its action button now either.

![moderate_master](https://user-images.githubusercontent.com/51932756/112892612-c46e7700-9096-11eb-967a-bb4c00b27593.png)
Here an assistant setup that is a little bit of a stretch with two light sources and heelies completely obscures a small screen tip, and starts making a second line.

![image](https://user-images.githubusercontent.com/51932756/112892745-f8e23300-9096-11eb-9f3e-a3751b48256e.png)
And with these changes, only the heelies, being a vehicle that changes your mobility and needs disabled before you collide with anything to avoid crashing remains, allowing you to clearly see a larger screen tip.



## Changelog
:cl:
qol: A large number of action buttons have been replaced by right clicking on the items with an empty active hand. Read below for a list.
qol: Examining an item that has lost its toggle action button will describe how to toggle them
del: Action buttons for PDAs, flashlights, air tanks, science goggles, welding goggles, welding helmets, hardhats, helmets, breath masks, welding masks, welding hardhats, clown masks, mime masks, sec hailers, surgical masks, explorer masks, kinetic crusher lights, clothing with hoods, storage bags like trashbags, and lights attached to guns are gone.
/:cl: