### PR TITLE
Fixes cargo gas canisters not being purchaseable

### DIFF
--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -190,9 +190,11 @@
 		if("add")
 			if(is_express)
 				return
-			var/id = text2path(params["id"])
+			var/id = params["id"]
+			id = text2path(id) || id
 			var/datum/supply_pack/pack = SSshuttle.supply_packs[id]
 			if(!istype(pack))
+				stack_trace("Unknown supply pack id given by order console ui. ID: [params["id"]]")
 				return
 			if((pack.hidden && !(obj_flags & EMAGGED)) || (pack.contraband && !contraband) || pack.DropPodOnly)
 				return

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -194,8 +194,7 @@
 			id = text2path(id) || id
 			var/datum/supply_pack/pack = SSshuttle.supply_packs[id]
 			if(!istype(pack))
-				stack_trace("Unknown supply pack id given by order console ui. ID: [params["id"]]")
-				return
+				CRASH("Unknown supply pack id given by order console ui. ID: [params["id"]]")
 			if((pack.hidden && !(obj_flags & EMAGGED)) || (pack.contraband && !contraband) || pack.DropPodOnly)
 				return
 


### PR DESCRIPTION
Forgot to make a change in the ui to handle the different kind of id for generated supply packs.

fixes #58026

## Changelog
:cl:
fix: Cargo gas canisters can be purchased
/:cl: