### PR TITLE
CTF players are no longer 13 year olds

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -92,7 +92,7 @@
 	/// Linked paystand.
 	var/obj/machinery/paystand/my_store
 	/// Registered owner's age.
-	var/registered_age = 13
+	var/registered_age = 30
 
 	/// The job name registered on the card (for example: Assistant).
 	var/assignment
@@ -1155,24 +1155,20 @@
 	name = "Red Team identification card"
 	desc = "A card used to identify members of the red team for CTF"
 	icon_state = "ctf_red"
-	registered_age = 30
 
 /obj/item/card/id/blue
 	name = "Blue Team identification card"
 	desc = "A card used to identify members of the blue team for CTF"
 	icon_state = "ctf_blue"
-	registered_age = 30
 
 /obj/item/card/id/yellow
 	name = "Yellow Team identification card"
 	desc = "A card used to identify members of the yellow team for CTF"
 	icon_state = "ctf_yellow"
-	registered_age = 30
 
 /obj/item/card/id/green
 	name = "Green Team identification card"
 	desc = "A card used to identify members of the green team for CTF"
 	icon_state = "ctf_green"
-	registered_age = 30
 
 #undef ID_ICON_BORDERS

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1155,20 +1155,24 @@
 	name = "Red Team identification card"
 	desc = "A card used to identify members of the red team for CTF"
 	icon_state = "ctf_red"
+	registered_age = 30
 
 /obj/item/card/id/blue
 	name = "Blue Team identification card"
 	desc = "A card used to identify members of the blue team for CTF"
 	icon_state = "ctf_blue"
+	registered_age = 30
 
 /obj/item/card/id/yellow
 	name = "Yellow Team identification card"
 	desc = "A card used to identify members of the yellow team for CTF"
 	icon_state = "ctf_yellow"
+	registered_age = 30
 
 /obj/item/card/id/green
 	name = "Green Team identification card"
 	desc = "A card used to identify members of the green team for CTF"
 	icon_state = "ctf_green"
+	registered_age = 30
 
 #undef ID_ICON_BORDERS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

CTF ids now have registered_age = 30 so they won't show a large flashing message about players being underaged for drinking which is pretty annoying

## Why It's Good For The Game

CTF IDs no longer show an annoying message, which is good

## Changelog
:cl:
fix: CTF IDs no longer show message about holder being underage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
