### PR TITLE
Fixes a way of obtaining metal on the CTF map downtown

### DIFF
--- a/_maps/map_files/CTF/downtown.dmm
+++ b/_maps/map_files/CTF/downtown.dmm
@@ -76,10 +76,11 @@
 /turf/open/floor/iron/dark,
 /area/ctf)
 "bO" = (
+/obj/effect/turf_decal/siding/wood/corner,
 /obj/structure/chair/stool/bar{
+	item_chair = null;
 	resistance_flags = 64
 	},
-/obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
 /area/ctf)
 "bR" = (
@@ -252,6 +253,7 @@
 /area/ctf)
 "fJ" = (
 /obj/structure/chair/stool/bar{
+	item_chair = null;
 	resistance_flags = 64
 	},
 /turf/open/floor/wood,
@@ -578,6 +580,7 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/chair/stool/bar{
+	item_chair = null;
 	resistance_flags = 64
 	},
 /turf/open/floor/iron,
@@ -920,6 +923,7 @@
 "rT" = (
 /obj/structure/chair{
 	dir = 4;
+	item_chair = null;
 	resistance_flags = 64
 	},
 /turf/open/floor/plating/grass,
@@ -1446,6 +1450,7 @@
 "BL" = (
 /obj/structure/chair{
 	dir = 8;
+	item_chair = null;
 	resistance_flags = 64
 	},
 /turf/open/floor/plating/grass,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fikou managed to find a way to obtain metal sheets and block off the flag on this CTF map, this fixes it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Walling off the flag in CTF is no fun.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: CTF map downtown's chairs/stools are now stuck to the floor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
