### PR TITLE
Lights up the alien chambers on the CTF map Cruiser

### DIFF
--- a/_maps/map_files/CTF/cruiser.dmm
+++ b/_maps/map_files/CTF/cruiser.dmm
@@ -134,10 +134,18 @@
 /area/ctf)
 "fj" = (
 /obj/structure/table/abductor,
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
 /turf/open/floor/plating/abductor2,
 /area/ctf)
 "fl" = (
 /obj/structure/table/abductor,
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
 /turf/open/floor/plating/abductor,
 /area/ctf)
 "fS" = (
@@ -247,6 +255,10 @@
 "mb" = (
 /obj/effect/mob_spawn/human/abductor,
 /obj/structure/table/optable/abductor,
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
 /turf/open/floor/plating/abductor2,
 /area/space/nearstation)
 "me" = (
@@ -477,6 +489,10 @@
 /turf/open/floor/iron,
 /area/ctf)
 "zx" = (
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
 /turf/open/floor/plating/abductor2,
 /area/space/nearstation)
 "zF" = (
@@ -576,6 +592,10 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/ctf)
 "Gx" = (
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
 /turf/open/floor/plating/abductor,
 /area/space/nearstation)
 "GF" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
These were supposed to be lit from the get go but I forgot

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The dark voids give the illusion that theres walls in a location that can be shot through

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: CTF map Cruiser alien rooms are nolonger dark voids
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
