### PR TITLE
reverts map_format changes

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -19,7 +19,6 @@
 	hub_password = "kMZy3U5jJHSiBQjr"
 	name = "/tg/ Station 13"
 	fps = 20
-	map_format = SIDE_MAP
 #ifdef FIND_REF_NO_CHECK_TICK
 	loop_checks = FALSE
 #endif


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
reverts map_format changes done in #57915

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
this change was unmentioned in the pr, it broke stuff like library paintings and a bunch of other stuff
here is the ORANGE TEST, an extremely scientific test of me spamming the same orange themed supplypod on the 2 map_formats
VIDEO OF SIDE MAP ON THE ORANGE TEST: BREAKS INTO TEARS AFTER 10 SECONDS OF ADMIN GRIEF, LAYERING LATER IN THE ROUND GETS AWFUL
https://streamable.com/3mptai
VIDEO OF TOPDOWN MAP ON THE ORANGE TEST: NEVER SHEDS A TEAR, GOOD OLD MAP FORMAT THATS BEEN USED FOR AGES WITHOUT PROBLEMS
https://streamable.com/de7rgn


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
