### PR TITLE
Mansus grasp now can ignite cigars

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -47,6 +47,10 @@
 	inhand_icon_state = "mansus"
 	catchphrase = "R'CH T'H TR'TH"
 
+/obj/item/melee/touch_attack/mansus_fist/ignition_effect(atom/A, mob/user)
+	. = "<span class='notice'>[user] effortlessly snaps [user.p_their()] fingers near [A], igniting it with eldritch energies. Fucking badass!</span>"
+	qdel(src)
+
 /obj/item/melee/touch_attack/mansus_fist/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 
 	if(!proximity_flag || target == user)


### PR DESCRIPTION
## About The Pull Request

You can now use mansus grasp to ignite things

## Why It's Good For The Game

Green hang goes brrr.

## Changelog
:cl:
add: Mansus grasp can now be used to ignite cigars like a fucking badass.
/:cl:
