### PR TITLE
Makes illegal technology harder to get

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -994,7 +994,7 @@
 	boost_item_paths = list()
 	for(var/path in GLOB.uplink_items)
 		var/datum/uplink_item/UI = new path
-		if(!UI.item || !UI.illegal_tech)
+		if(!UI.item || !UI.illegal_tech || ispath(UI.item, /obj/item/storage/box) || ispath(UI.item, /obj/item/storage/backpack))
 			continue
 		boost_item_paths |= UI.item //allows deconning to unlock.
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -187,6 +187,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/briefcase/sniperbundle
 	cost = 20 // normally 26
 	include_modes = list(/datum/game_mode/nuclear)
+	illegal_tech = FALSE
 
 /datum/uplink_item/bundles_tc/firestarter
 	name = "Spetsnaz Pyro bundle"


### PR DESCRIPTION
## About The Pull Request
Illegal technology can currently be researched from syndicate duffel bags and boxes that contain kits of items. These items should be researchable for illegal technology, not the useless box/backpack/duffelbag the items come in.

- purposefully does not affect Briefcase Launchpad, which has a path of `/obj/item/storage/briefcase/launchpad`
- excludes the only other uplink item that starts in a briefcase

This PR should be followed by another that allows the illegal tech research to look "inside" of the storage for additional items to tag as illegal technology.

## Why It's Good For The Game
Illegal technology should require effort to get, not finding traitor trash in maint. There's also a certain level of 'meta' that this prevents, where players can tell whether an item/backpack was created from an uplink vs roundstart (getting a nukie duffel bag from the vending machine vs purchasing a bundle from an uplink which comes in a duffel bag).

## Changelog
:cl:
balance: Illegal Technology cannot be researched from storage items
/:cl:

