### PR TITLE
Thermomachine can be dragged around now

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
@@ -11,6 +11,8 @@
 	layer = OBJ_LAYER
 	circuit = /obj/item/circuitboard/machine/thermomachine
 
+	move_resist = MOVE_RESIST_DEFAULT
+
 	pipe_flags = PIPING_ONE_PER_TURF
 
 	var/icon_state_off = "freezer"
@@ -33,6 +35,11 @@
 	. = ..()
 	RefreshParts()
 	update_appearance()
+
+/obj/machinery/atmospherics/components/binary/thermomachine/isConnectable()
+	if(!anchored || panel_open)
+		return FALSE
+	. = ..()
 
 /obj/machinery/atmospherics/components/binary/thermomachine/getNodeConnects()
 	return list(dir, turn(dir, 180))
@@ -100,8 +107,6 @@
 	if(holding)
 		var/mutable_appearance/holding = mutable_appearance(icon, "holding")
 		. += holding
-	if(showpipe)
-		. += getpipeimage(icon, "scrub_cap", initialize_directions)
 	if(skipping_work && on)
 		var/mutable_appearance/skipping = mutable_appearance(icon, "blinking")
 		. += skipping
@@ -193,7 +198,11 @@
 
 /obj/machinery/atmospherics/components/binary/thermomachine/attackby(obj/item/item, mob/user, params)
 	if(!on && !holding)
+		if(!anchored)
+			to_chat(user, "<span class='notice'>Anchor [src] first!</span>")
+			return
 		if(default_deconstruction_screwdriver(user, icon_state_open, icon_state_off, item))
+			change_pipe_connection(panel_open)
 			return
 	if(default_change_direction_wrench(user, item))
 		return
@@ -215,31 +224,17 @@
 	if(!..())
 		return FALSE
 	SetInitDirections()
-	var/turf/local_turf = get_turf(src)
-	var/datum/gas_mixture/enviroment = local_turf.return_air()
+	return TRUE
+
+/obj/machinery/atmospherics/components/binary/thermomachine/proc/change_pipe_connection(disconnect)
+	if(disconnect)
+		disconnect_pipes()
+		return
+	connect_pipes()
+
+/obj/machinery/atmospherics/components/binary/thermomachine/proc/connect_pipes()
 	var/obj/machinery/atmospherics/node1 = nodes[1]
 	var/obj/machinery/atmospherics/node2 = nodes[2]
-	if(airs[1].total_moles())
-		var/datum/gas_mixture/remove = airs[1].remove(airs[1].total_moles())
-		enviroment.merge(remove)
-	if(airs[2].total_moles())
-		var/datum/gas_mixture/remove = airs[2].remove(airs[2].total_moles())
-		enviroment.merge(remove)
-	air_update_turf(FALSE, FALSE)
-	if(node1)
-		if(src in node1.nodes) //Only if it's actually connected. On-pipe version would is one-sided.
-			node1.disconnect(src)
-		nodes[1] = null
-	if(node2)
-		if(src in node2.nodes) //Only if it's actually connected. On-pipe version would is one-sided.
-			node2.disconnect(src)
-		nodes[2] = null
-
-	if(parents[1])
-		nullifyPipenet(parents[1])
-	if(parents[2])
-		nullifyPipenet(parents[2])
-
 	atmosinit()
 	node1 = nodes[1]
 	if(node1)
@@ -250,7 +245,27 @@
 		node2.atmosinit()
 		node2.addMember(src)
 	SSair.add_to_rebuild_queue(src)
-	return TRUE
+
+/obj/machinery/atmospherics/components/binary/thermomachine/proc/disconnect_pipes()
+	var/obj/machinery/atmospherics/node1 = nodes[1]
+	var/obj/machinery/atmospherics/node2 = nodes[2]
+	if(node1)
+		if(src in node1.nodes) //Only if it's actually connected. On-pipe version would is one-sided.
+			node1.disconnect(src)
+		nodes[1] = null
+	if(node2)
+		if(src in node2.nodes) //Only if it's actually connected. On-pipe version would is one-sided.
+			node2.disconnect(src)
+		nodes[2] = null
+	if(parents[1])
+		nullifyPipenet(parents[1])
+	if(parents[2])
+		nullifyPipenet(parents[2])
+
+/obj/machinery/atmospherics/components/binary/thermomachine/attackby_secondary(obj/item/item, mob/user, params)
+	. = ..()
+	if(panel_open && default_unfasten_wrench(user, item))
+		return SECONDARY_ATTACK_CONTINUE_CHAIN
 
 /obj/machinery/atmospherics/components/binary/thermomachine/proc/replace_tank(mob/living/user, obj/item/tank/new_tank)
 	if(!user)
@@ -269,6 +284,8 @@
 	return UI_CLOSE
 
 /obj/machinery/atmospherics/components/binary/thermomachine/ui_interact(mob/user, datum/tgui/ui)
+	if(panel_open)
+		return
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "ThermoMachine", name)
@@ -344,11 +361,14 @@
 	update_appearance()
 
 /obj/machinery/atmospherics/components/binary/thermomachine/CtrlClick(mob/living/user)
-	if(!can_interact(user))
+	if(!panel_open)
+		if(!can_interact(user))
+			return
+		on = !on
+		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
+		update_appearance()
 		return
-	on = !on
-	investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
-	update_appearance()
+	. = ..()
 
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer
 	icon_state = "freezer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Thermomachines can now be moved around.
To do this, open up the panel with a screwdriver, then Right-Click on the machine with a wrench, after a delay the machine will be un-anchored; use ctrl-click to move the machine around. Then set the rotation of the machine by Left-Click with a wrench, screwdriver to close the panel, and the machine is functional again.

thermomachines can change the piping layer while constructed by hitting them when un-anchored with a multitool
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More thermomachine QOL
being able to move the thermomachine around without having to deconstruct/rebuild it each time, helps player and will haste the construction of the various pipenets required to produce different gases, it is also much more needed since the rework due to the slightly increase in piping required
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Thermomachines can now be moved around. To do this, open up the panel with a screwdriver, then Right-Click on the machine with a wrench, after a delay the machine will be un-anchored; use ctrl-click to move the machine around. Then set the rotation of the machine by Left-Click with a wrench, screwdriver to close the panel, and the machine is functional again.
qol: thermomachines can change the piping layer while constructed by hitting them when un-anchored with a multitool
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
