### PR TITLE
Box item spawning rework (and illegal tech introspection)

### DIFF
--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -23,6 +23,7 @@
 	STR.max_combined_w_class = 21
 
 /obj/item/storage/briefcase/PopulateContents()
+	..()
 	new /obj/item/pen(src)
 	var/obj/item/folder/folder = new folder_path(src)
 	for(var/i in 1 to 6)
@@ -38,13 +39,15 @@
 /obj/item/storage/briefcase/sniperbundle
 	desc = "Its label reads \"genuine hardened Captain leather\", but suspiciously has no other tags or branding. Smells like L'Air du Temps."
 	force = 10
+	items_inside = list(
+		/obj/item/gun/ballistic/automatic/sniper_rifle/syndicate = 1,
+		/obj/item/clothing/neck/tie/red = 1,
+		/obj/item/clothing/under/syndicate/sniper = 1,
+		/obj/item/ammo_box/magazine/sniper_rounds/soporific = 1,
+		/obj/item/ammo_box/magazine/sniper_rounds/soporific = 1,
+		/obj/item/suppressor/specialoffer = 1
+	)
 
 /obj/item/storage/briefcase/sniperbundle/PopulateContents()
 	..() // in case you need any paperwork done after your rampage
-	new /obj/item/gun/ballistic/automatic/sniper_rifle/syndicate(src)
-	new /obj/item/clothing/neck/tie/red(src)
-	new /obj/item/clothing/under/syndicate/sniper(src)
-	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
-	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
-	new /obj/item/suppressor/specialoffer(src)
 

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -44,6 +44,8 @@
 //Cyberboss says: "USE THIS TO FILL IT, NOT INITIALIZE OR NEW"
 
 /obj/item/storage/proc/PopulateContents()
+	if(items_inside?.len)
+		generate_items_inside(items_inside,src)
 
 /obj/item/storage/proc/emptyStorage()
 	var/datum/component/storage/ST = GetComponent(/datum/component/storage)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -4,6 +4,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	var/rummage_if_nodrop = TRUE
 	var/component_type = /datum/component/storage/concrete
+	var/list/items_inside //used for illegal tech to look inside of boxes and storage from only the typepath
 
 /obj/item/storage/get_dumping_location(obj/item/storage/source,mob/user)
 	return src

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -381,21 +381,24 @@
 
 /obj/item/storage/box/syndie_kit/imp_freedom
 	name = "freedom implant box"
-
-/obj/item/storage/box/syndie_kit/imp_freedom/PopulateContents()
-	new /obj/item/implanter/freedom(src)
+	items_inside = list(
+		/obj/item/implanter/freedom = 1
+	)
 
 /obj/item/storage/box/syndie_kit/imp_microbomb
 	name = "microbomb implant box"
-
-/obj/item/storage/box/syndie_kit/imp_microbomb/PopulateContents()
-	new /obj/item/implanter/explosive(src)
+	items_inside = list(
+		/obj/item/implanter/explosive = 1
+	)
 
 /obj/item/storage/box/syndie_kit/imp_macrobomb
 	name = "macrobomb implant box"
+	items_inside = list(
+		/obj/item/implanter/explosive_macro
+	)
 
 /obj/item/storage/box/syndie_kit/imp_macrobomb/PopulateContents()
-	new /obj/item/implanter/explosive_macro(src)
+	new (src)
 
 /obj/item/storage/box/syndie_kit/imp_uplink
 	name = "uplink implant box"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -374,11 +374,10 @@
 /obj/item/storage/box/syndie_kit/origami_bundle
 	name = "origami kit"
 	desc = "A box full of a number of rather masterfully engineered paper planes and a manual on \"The Art of Origami\"."
-
-/obj/item/storage/box/syndie_kit/origami_bundle/PopulateContents()
-	new /obj/item/book/granter/action/origami(src)
-	for(var/i in 1 to 5)
-		new /obj/item/paper(src)
+	items_inside = list(
+		/obj/item/book/granter/action/origami = 1,
+		/obj/item/paper = 5
+	)
 
 /obj/item/storage/box/syndie_kit/imp_freedom
 	name = "freedom implant box"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -564,7 +564,7 @@
 
 /obj/item/storage/box/syndie_kit/ez_clean
 	items_inside = list(
-		new/obj/item/grenade/chem_grenade/ez_clean = 3
+		/obj/item/grenade/chem_grenade/ez_clean = 3
 	)
 
 /obj/item/storage/box/hug/reverse_revolver

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -394,49 +394,44 @@
 /obj/item/storage/box/syndie_kit/imp_macrobomb
 	name = "macrobomb implant box"
 	items_inside = list(
-		/obj/item/implanter/explosive_macro
+		/obj/item/implanter/explosive_macro = 1
 	)
-
-/obj/item/storage/box/syndie_kit/imp_macrobomb/PopulateContents()
-	new (src)
 
 /obj/item/storage/box/syndie_kit/imp_uplink
 	name = "uplink implant box"
-
-/obj/item/storage/box/syndie_kit/imp_uplink/PopulateContents()
-	new /obj/item/implanter/uplink(src)
+	items_inside = list(
+		/obj/item/implanter/uplink = 1
+	)
 
 /obj/item/storage/box/syndie_kit/bioterror
 	name = "bioterror syringe box"
-
-/obj/item/storage/box/syndie_kit/bioterror/PopulateContents()
-	for(var/i in 1 to 7)
-		new /obj/item/reagent_containers/syringe/bioterror(src)
+	items_inside = list(
+		/obj/item/reagent_containers/syringe/bioterror = 7
+	)
 
 /obj/item/storage/box/syndie_kit/clownpins
 	name = "ultra hilarious firing pin box"
-
-/obj/item/storage/box/syndie_kit/clownpins/PopulateContents()
-	for(var/i in 1 to 7)
-		new /obj/item/firing_pin/clown/ultra(src)
+	items_inside = list(
+		/obj/item/firing_pin/clown/ultra = 7
+	)
 
 /obj/item/storage/box/syndie_kit/imp_storage
 	name = "storage implant box"
-
-/obj/item/storage/box/syndie_kit/imp_storage/PopulateContents()
-	new /obj/item/implanter/storage(src)
+	items_inside = list(
+		/obj/item/implanter/storage = 1
+	)
 
 /obj/item/storage/box/syndie_kit/imp_stealth
 	name = "stealth implant box"
-
-/obj/item/storage/box/syndie_kit/imp_stealth/PopulateContents()
-	new /obj/item/implanter/stealth(src)
+	items_inside = list(
+		/obj/item/implanter/stealth = 1
+	)
 
 /obj/item/storage/box/syndie_kit/imp_radio
 	name = "syndicate radio implant box"
-
-/obj/item/storage/box/syndie_kit/imp_radio/PopulateContents()
-	new /obj/item/implanter/radio/syndicate(src)
+	items_inside = list(
+		/obj/item/implanter/radio/syndicate = 1
+	)
 
 /obj/item/storage/box/syndie_kit/space
 	name = "boxed space suit and helmet"
@@ -458,55 +453,58 @@
 
 /obj/item/storage/box/syndie_kit/emp
 	name = "EMP kit"
-
-/obj/item/storage/box/syndie_kit/emp/PopulateContents()
-	for(var/i in 1 to 5)
-		new /obj/item/grenade/empgrenade(src)
-	new /obj/item/implanter/emp(src)
+	items_inside = list(
+		/obj/item/grenade/empgrenade = 5,
+		/obj/item/implanter/emp = 1
+	)
 
 /obj/item/storage/box/syndie_kit/chemical
 	name = "chemical kit"
+	items_inside = list(
+		new /obj/item/reagent_containers/glass/bottle/polonium = 1,
+		new /obj/item/reagent_containers/glass/bottle/venom = 1,
+		new /obj/item/reagent_containers/glass/bottle/fentanyl = 1,
+		new /obj/item/reagent_containers/glass/bottle/formaldehyde = 1,
+		new /obj/item/reagent_containers/glass/bottle/spewium = 1,
+		new /obj/item/reagent_containers/glass/bottle/cyanide = 1,
+		new /obj/item/reagent_containers/glass/bottle/histamine = 1,
+		new /obj/item/reagent_containers/glass/bottle/initropidril = 1,
+		new /obj/item/reagent_containers/glass/bottle/pancuronium = 1,
+		new /obj/item/reagent_containers/glass/bottle/sodium_thiopental = 1,
+		new /obj/item/reagent_containers/glass/bottle/coniine = 1,
+		new /obj/item/reagent_containers/glass/bottle/curare = 1,
+		new /obj/item/reagent_containers/glass/bottle/amanitin = 1,
+		new /obj/item/reagent_containers/syringe = 1
+	)
 
 /obj/item/storage/box/syndie_kit/chemical/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 14
 
-/obj/item/storage/box/syndie_kit/chemical/PopulateContents()
-	new /obj/item/reagent_containers/glass/bottle/polonium(src)
-	new /obj/item/reagent_containers/glass/bottle/venom(src)
-	new /obj/item/reagent_containers/glass/bottle/fentanyl(src)
-	new /obj/item/reagent_containers/glass/bottle/formaldehyde(src)
-	new /obj/item/reagent_containers/glass/bottle/spewium(src)
-	new /obj/item/reagent_containers/glass/bottle/cyanide(src)
-	new /obj/item/reagent_containers/glass/bottle/histamine(src)
-	new /obj/item/reagent_containers/glass/bottle/initropidril(src)
-	new /obj/item/reagent_containers/glass/bottle/pancuronium(src)
-	new /obj/item/reagent_containers/glass/bottle/sodium_thiopental(src)
-	new /obj/item/reagent_containers/glass/bottle/coniine(src)
-	new /obj/item/reagent_containers/glass/bottle/curare(src)
-	new /obj/item/reagent_containers/glass/bottle/amanitin(src)
-	new /obj/item/reagent_containers/syringe(src)
-
 /obj/item/storage/box/syndie_kit/nuke
 	name = "box"
-
-/obj/item/storage/box/syndie_kit/nuke/PopulateContents()
-	new /obj/item/screwdriver/nuke(src)
-	new /obj/item/nuke_core_container(src)
-	new /obj/item/paper/guides/antag/nuke_instructions(src)
+	items_inside = list(
+		/obj/item/screwdriver/nuke = 1,
+		/obj/item/nuke_core_container = 1,
+		/obj/item/paper/guides/antag/nuke_instructions = 1
+	)
 
 /obj/item/storage/box/syndie_kit/supermatter
 	name = "box"
+	items_inside = list(
+		/obj/item/scalpel/supermatter = 1,
+		/obj/item/hemostat/supermatter = 1,
+		/obj/item/nuke_core_container/supermatter = 1,
+		/obj/item/paper/guides/antag/supermatter_sliver = 1
+	)
 
-/obj/item/storage/box/syndie_kit/supermatter/PopulateContents()
-	new /obj/item/scalpel/supermatter(src)
-	new /obj/item/hemostat/supermatter(src)
-	new /obj/item/nuke_core_container/supermatter(src)
-	new /obj/item/paper/guides/antag/supermatter_sliver(src)
 
 /obj/item/storage/box/syndie_kit/tuberculosisgrenade
 	name = "virus grenade kit"
+	items_inside = list(
+
+	)
 
 /obj/item/storage/box/syndie_kit/tuberculosisgrenade/PopulateContents()
 	new /obj/item/grenade/chem_grenade/tuberculosis(src)
@@ -517,6 +515,9 @@
 
 /obj/item/storage/box/syndie_kit/chameleon
 	name = "chameleon kit"
+	items_inside = list(
+
+	)
 
 /obj/item/storage/box/syndie_kit/chameleon/PopulateContents()
 	new /obj/item/clothing/under/chameleon(src)
@@ -535,27 +536,31 @@
 
 //5*(2*4) = 5*8 = 45, 45 damage if you hit one person with all 5 stars.
 //Not counting the damage it will do while embedded (2*4 = 8, at 15% chance)
-/obj/item/storage/box/syndie_kit/throwing_weapons/PopulateContents()
-	for(var/i in 1 to 5)
-		new /obj/item/throwing_star(src)
-	for(var/i in 1 to 2)
-		new /obj/item/paperplane/syndicate(src)
-	new /obj/item/restraints/legcuffs/bola/tactical(src)
-	new /obj/item/restraints/legcuffs/bola/tactical(src)
+/obj/item/storage/box/syndie_kit/throwing_weapons
+	items_inside = list(
+		/obj/item/throwing_star = 5,
+		/obj/item/paperplane/syndicate = 2,
+		/obj/item/restraints/legcuffs/bola/tactical = 2
+	)
 
-/obj/item/storage/box/syndie_kit/cutouts/PopulateContents()
-	for(var/i in 1 to 3)
-		new/obj/item/cardboard_cutout/adaptive(src)
-	new/obj/item/toy/crayon/rainbow(src)
+/obj/item/storage/box/syndie_kit/cutouts
+	items_inside = list(
+		/obj/item/cardboard_cutout/adaptive = 3,
+		/obj/item/toy/crayon/rainbow = 1
+	)
 
-/obj/item/storage/box/syndie_kit/romerol/PopulateContents()
-	new /obj/item/reagent_containers/glass/bottle/romerol(src)
-	new /obj/item/reagent_containers/syringe(src)
-	new /obj/item/reagent_containers/dropper(src)
+/obj/item/storage/box/syndie_kit/romerol
+	items_inside = list(
+		/obj/item/reagent_containers/glass/bottle/romerol = 1,
+		/obj/item/reagent_containers/syringe = 1,
+		/obj/item/reagent_containers/dropper = 1
+	)
 
-/obj/item/storage/box/syndie_kit/ez_clean/PopulateContents()
-	for(var/i in 1 to 3)
-		new/obj/item/grenade/chem_grenade/ez_clean(src)
+
+/obj/item/storage/box/syndie_kit/ez_clean
+	items_inside = list(
+		new/obj/item/grenade/chem_grenade/ez_clean = 3
+	)
 
 /obj/item/storage/box/hug/reverse_revolver/PopulateContents()
 	new /obj/item/gun/ballistic/revolver/reverse(src)
@@ -593,10 +598,9 @@
 /obj/item/storage/box/syndie_kit/bee_grenades
 	name = "buzzkill grenade box"
 	desc = "A sleek, sturdy box with a buzzing noise coming from the inside. Uh oh."
-
-/obj/item/storage/box/syndie_kit/bee_grenades/PopulateContents()
-	for(var/i in 1 to 3)
-		new /obj/item/grenade/spawnergrenade/buzzkill(src)
+	items_inside = list(
+		/obj/item/grenade/spawnergrenade/buzzkill = 3
+	)
 
 /obj/item/storage/box/syndie_kit/sleepytime/PopulateContents()
 	new /obj/item/clothing/under/syndicate/bloodred/sleepytime(src)
@@ -606,14 +610,11 @@
 
 ///Subtype for the sabotage bundle. Contains three C4, two X4 and 6 signalers
 /obj/item/storage/backpack/duffelbag/syndie/sabotage
-
-/obj/item/storage/backpack/duffelbag/syndie/sabotage/PopulateContents()
-	new /obj/item/grenade/c4(src)
-	new /obj/item/grenade/c4(src)
-	new /obj/item/grenade/c4(src)
-	new /obj/item/grenade/c4/x4(src)
-	new /obj/item/grenade/c4/x4(src)
-	new /obj/item/storage/box/syndie_kit/signaler(src)
+	items_inside = list(
+		/obj/item/grenade/c4 = 3,
+		/obj/item/grenade/c4/x4 = 2,
+		/obj/item/storage/box/syndie_kit/signaler = 6
+	)
 
 /obj/item/storage/box/syndie_kit/signaler
 	name = "signaler box"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -470,20 +470,20 @@
 /obj/item/storage/box/syndie_kit/chemical
 	name = "chemical kit"
 	items_inside = list(
-		new /obj/item/reagent_containers/glass/bottle/polonium = 1,
-		new /obj/item/reagent_containers/glass/bottle/venom = 1,
-		new /obj/item/reagent_containers/glass/bottle/fentanyl = 1,
-		new /obj/item/reagent_containers/glass/bottle/formaldehyde = 1,
-		new /obj/item/reagent_containers/glass/bottle/spewium = 1,
-		new /obj/item/reagent_containers/glass/bottle/cyanide = 1,
-		new /obj/item/reagent_containers/glass/bottle/histamine = 1,
-		new /obj/item/reagent_containers/glass/bottle/initropidril = 1,
-		new /obj/item/reagent_containers/glass/bottle/pancuronium = 1,
-		new /obj/item/reagent_containers/glass/bottle/sodium_thiopental = 1,
-		new /obj/item/reagent_containers/glass/bottle/coniine = 1,
-		new /obj/item/reagent_containers/glass/bottle/curare = 1,
-		new /obj/item/reagent_containers/glass/bottle/amanitin = 1,
-		new /obj/item/reagent_containers/syringe = 1
+		/obj/item/reagent_containers/glass/bottle/polonium = 1,
+		/obj/item/reagent_containers/glass/bottle/venom = 1,
+		/obj/item/reagent_containers/glass/bottle/fentanyl = 1,
+		/obj/item/reagent_containers/glass/bottle/formaldehyde = 1,
+		/obj/item/reagent_containers/glass/bottle/spewium = 1,
+		/obj/item/reagent_containers/glass/bottle/cyanide = 1,
+		/obj/item/reagent_containers/glass/bottle/histamine = 1,
+		/obj/item/reagent_containers/glass/bottle/initropidril = 1,
+		/obj/item/reagent_containers/glass/bottle/pancuronium = 1,
+		/obj/item/reagent_containers/glass/bottle/sodium_thiopental = 1,
+		/obj/item/reagent_containers/glass/bottle/coniine = 1,
+		/obj/item/reagent_containers/glass/bottle/curare = 1,
+		/obj/item/reagent_containers/glass/bottle/amanitin = 1,
+		/obj/item/reagent_containers/syringe = 1
 	)
 
 /obj/item/storage/box/syndie_kit/chemical/ComponentInitialize()

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -563,11 +563,7 @@
 		new/obj/item/grenade/chem_grenade/ez_clean = 3
 	)
 
-/obj/item/storage/box/syndie_kit/reverse_revolver
-	name = "box of hugs"
-	desc = "A special box for sensitive people."
-	icon_state = "hugbox"
-	illustration = "heart"
+/obj/item/storage/box/hug/reverse_revolver
 	items_inside = list(
 		/obj/item/gun/ballistic/revolver/reverse = 1
 	)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -368,7 +368,6 @@
 
 /obj/item/storage/box/syndie_kit/PopulateContents()
 	if(items_inside?.len)
-		if(items_inside?.len)
 		generate_items_inside(items_inside,src)
 
 /obj/item/storage/box/syndie_kit/origami_bundle
@@ -503,36 +502,32 @@
 /obj/item/storage/box/syndie_kit/tuberculosisgrenade
 	name = "virus grenade kit"
 	items_inside = list(
-
+		/obj/item/grenade/chem_grenade/tuberculosis = 1,
+		/obj/item/reagent_containers/hypospray/medipen/tuberculosiscure = 5,
+		/obj/item/reagent_containers/syringe = 1,
+		/obj/item/reagent_containers/glass/bottle/tuberculosiscure = 1
 	)
-
-/obj/item/storage/box/syndie_kit/tuberculosisgrenade/PopulateContents()
-	new /obj/item/grenade/chem_grenade/tuberculosis(src)
-	for(var/i in 1 to 5)
-		new /obj/item/reagent_containers/hypospray/medipen/tuberculosiscure(src)
-	new /obj/item/reagent_containers/syringe(src)
-	new /obj/item/reagent_containers/glass/bottle/tuberculosiscure(src)
 
 /obj/item/storage/box/syndie_kit/chameleon
 	name = "chameleon kit"
 	items_inside = list(
-
+		/obj/item/clothing/under/chameleon = 1,
+		/obj/item/clothing/suit/chameleon = 1,
+		/obj/item/clothing/gloves/chameleon = 1,
+		/obj/item/clothing/shoes/chameleon = 1,
+		/obj/item/clothing/glasses/chameleon = 1,
+		/obj/item/clothing/head/chameleon = 1,
+		/obj/item/clothing/mask/chameleon = 1,
+		/obj/item/clothing/neck/chameleon = 1,
+		/obj/item/storage/backpack/chameleon = 1,
+		/obj/item/storage/belt/chameleon = 1,
+		/obj/item/radio/headset/chameleon = 1,
+		/obj/item/stamp/chameleon = 1,
+		/obj/item/pda/chameleon = 1
 	)
 
 /obj/item/storage/box/syndie_kit/chameleon/PopulateContents()
-	new /obj/item/clothing/under/chameleon(src)
-	new /obj/item/clothing/suit/chameleon(src)
-	new /obj/item/clothing/gloves/chameleon(src)
-	new /obj/item/clothing/shoes/chameleon(src)
-	new /obj/item/clothing/glasses/chameleon(src)
-	new /obj/item/clothing/head/chameleon(src)
-	new /obj/item/clothing/mask/chameleon(src)
-	new /obj/item/clothing/neck/chameleon(src)
-	new /obj/item/storage/backpack/chameleon(src)
-	new /obj/item/storage/belt/chameleon(src)
-	new /obj/item/radio/headset/chameleon(src)
-	new /obj/item/stamp/chameleon(src)
-	new /obj/item/pda/chameleon(src)
+
 
 //5*(2*4) = 5*8 = 45, 45 damage if you hit one person with all 5 stars.
 //Not counting the damage it will do while embedded (2*4 = 8, at 15% chance)
@@ -609,12 +604,13 @@
 	new /obj/item/bedsheet/syndie(src)
 
 ///Subtype for the sabotage bundle. Contains three C4, two X4 and 6 signalers
-/obj/item/storage/backpack/duffelbag/syndie/sabotage
-	items_inside = list(
-		/obj/item/grenade/c4 = 3,
-		/obj/item/grenade/c4/x4 = 2,
-		/obj/item/storage/box/syndie_kit/signaler = 6
-	)
+/obj/item/storage/backpack/duffelbag/syndie/sabotage/PopulateContents()
+	new /obj/item/grenade/c4(src)
+	new /obj/item/grenade/c4(src)
+	new /obj/item/grenade/c4(src)
+	new /obj/item/grenade/c4/x4(src)
+	new /obj/item/grenade/c4/x4(src)
+	new /obj/item/storage/box/syndie_kit/signaler(src)
 
 /obj/item/storage/box/syndie_kit/signaler
 	name = "signaler box"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -243,14 +243,17 @@
 
 /obj/item/storage/toolbox/emergency/old/ancientbundle/ //So the subtype works
 
-/obj/item/storage/toolbox/emergency/old/ancientbundle/PopulateContents()
-	new /obj/item/card/emag(src)
-	new /obj/item/pen/sleepy(src)
-	new /obj/item/reagent_containers/pill/cyanide(src)
-	new /obj/item/chameleon(src) //its not the original cloaking device, but it will do.
-	new /obj/item/gun/ballistic/revolver(src)
-	new /obj/item/implanter/freedom(src)
-	new /obj/item/stack/telecrystal(src) //The failsafe/self destruct isn't an item we can physically include in the kit, but 1 TC is technically enough to buy the equivalent.
+/obj/item/storage/toolbox/emergency/old/ancientbundle
+	items_inside = list(
+		/obj/item/card/emag = 1,
+		/obj/item/pen/sleepy = 1,
+		/obj/item/reagent_containers/pill/cyanide = 1,
+		/obj/item/chameleon = 1, //its not the original cloaking device, but it will do.
+		/obj/item/gun/ballistic/revolver = 1,
+		/obj/item/implanter/freedom = 1,
+		/obj/item/stack/telecrystal = 1, //The failsafe/self destruct isn't an item we can physically include in the kit, but 1 TC is technically enough to buy the equivalent.
+	)
+
 
 /obj/item/storage/box/syndicate/contract_kit
 	name = "Contract Kit"
@@ -438,6 +441,9 @@
 		/obj/item/clothing/head/helmet/space/syndicate = 1,
 		/obj/item/clothing/suit/space/syndicate = 1
 	)
+	var/set_a = list(
+
+	)
 
 /obj/item/storage/box/syndie_kit/space/ComponentInitialize()
 	. = ..()
@@ -614,21 +620,23 @@
 	new /obj/item/bedsheet/syndie(src)
 
 ///Subtype for the sabotage bundle. Contains three C4, two X4 and 6 signalers
-/obj/item/storage/backpack/duffelbag/syndie/sabotage/PopulateContents()
-	new /obj/item/grenade/c4(src)
-	new /obj/item/grenade/c4(src)
-	new /obj/item/grenade/c4(src)
-	new /obj/item/grenade/c4/x4(src)
-	new /obj/item/grenade/c4/x4(src)
-	new /obj/item/storage/box/syndie_kit/signaler(src)
+/obj/item/storage/backpack/duffelbag/syndie/sabotage
+	items_inside = list(
+		/obj/item/grenade/c4(src) = 1,
+		/obj/item/grenade/c4(src) = 1,
+		/obj/item/grenade/c4(src) = 1,
+		/obj/item/grenade/c4/x4(src) = 1,
+		/obj/item/grenade/c4/x4(src) = 1,
+		/obj/item/storage/box/syndie_kit/signaler(src) = 1
+	)
+
 
 /obj/item/storage/box/syndie_kit/signaler
 	name = "signaler box"
 	desc = "Contains everything an agent would need to remotely detonate their bombs."
-
-/obj/item/storage/box/syndie_kit/signaler/PopulateContents()
-	for(var/i in 1 to 6)
-		new /obj/item/assembly/signaler(src)
+	items_inside = list(
+		/obj/item/assembly/signaler = 6
+	)
 
 /obj/item/storage/box/syndie_kit/imp_deathrattle
 	name = "deathrattle implant box"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -434,6 +434,12 @@
 
 /obj/item/storage/box/syndie_kit/space
 	name = "boxed space suit and helmet"
+	items_inside = list( //won't proc since PopulateContents() overwritten
+		/obj/item/clothing/suit/space/syndicate/black/red = 1,
+		/obj/item/clothing/head/helmet/space/syndicate/black/red = 1,
+		/obj/item/clothing/head/helmet/space/syndicate = 1,
+		/obj/item/clothing/suit/space/syndicate = 1
+	)
 
 /obj/item/storage/box/syndie_kit/space/ComponentInitialize()
 	. = ..()
@@ -557,12 +563,22 @@
 		new/obj/item/grenade/chem_grenade/ez_clean = 3
 	)
 
-/obj/item/storage/box/hug/reverse_revolver/PopulateContents()
-	new /obj/item/gun/ballistic/revolver/reverse(src)
+/obj/item/storage/box/syndie_kit/reverse_revolver
+	name = "box of hugs"
+	desc = "A special box for sensitive people."
+	icon_state = "hugbox"
+	illustration = "heart"
+	items_inside = list(
+		/obj/item/gun/ballistic/revolver/reverse = 1
+	)
 
-/obj/item/storage/box/syndie_kit/mimery/PopulateContents()
-	new /obj/item/book/granter/spell/mimery_blockade(src)
-	new /obj/item/book/granter/spell/mimery_guns(src)
+
+/obj/item/storage/box/syndie_kit/mimery
+	items_inside = list(
+		/obj/item/book/granter/spell/mimery_blockade = 1,
+		/obj/item/book/granter/spell/mimery_guns = 1,
+	)
+
 
 /obj/item/storage/box/syndie_kit/centcom_costume/PopulateContents()
 	new /obj/item/clothing/under/rank/centcom/officer(src)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -310,14 +310,17 @@
 
 	return ..()
 
-/obj/item/storage/box/syndicate/contractor_loadout/PopulateContents()
-	new /obj/item/clothing/head/helmet/space/syndicate/contract(src)
-	new /obj/item/clothing/suit/space/syndicate/contract(src)
-	new /obj/item/clothing/under/chameleon(src)
-	new /obj/item/clothing/mask/chameleon(src)
-	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
-	new /obj/item/card/id/advanced/chameleon(src)
-	new /obj/item/lighter(src)
+/obj/item/storage/box/syndicate/contractor_loadout
+	items_inside = list(
+		/obj/item/clothing/head/helmet/space/syndicate/contract = 1,
+		/obj/item/clothing/suit/space/syndicate/contract = 1,
+		/obj/item/clothing/under/chameleon = 1,
+		/obj/item/clothing/mask/chameleon = 1,
+		/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 1,
+		/obj/item/card/id/advanced/chameleon = 1,
+		/obj/item/lighter = 1
+	)
+
 
 /obj/item/storage/box/syndicate/contract_kit/PopulateContents()
 	new /obj/item/modular_computer/tablet/syndicate_contract_uplink/preset/uplink(src)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -24,16 +24,16 @@
 
 /obj/item/storage/box/syndicate/bundle_a/PopulateContents()
 	switch (pickweight(list(
-		KIT_RECON = 2, 
-		KIT_BLOODY_SPAI = 3, 
-		KIT_STEALTHY = 2, 
-		KIT_SCREWED = 2, 
-		KIT_SABOTAGE = 3, 
-		KIT_GUN = 2, 
-		KIT_MURDER = 2, 
-		KIT_IMPLANTS = 1, 
-		KIT_HACKER = 3, 
-		KIT_SNIPER = 1, 
+		KIT_RECON = 2,
+		KIT_BLOODY_SPAI = 3,
+		KIT_STEALTHY = 2,
+		KIT_SCREWED = 2,
+		KIT_SABOTAGE = 3,
+		KIT_GUN = 2,
+		KIT_MURDER = 2,
+		KIT_IMPLANTS = 1,
+		KIT_HACKER = 3,
+		KIT_SNIPER = 1,
 		KIT_NUKEOPS_METAGAME = 1
 		)))
 		if(KIT_RECON)
@@ -153,14 +153,14 @@
 			new /obj/item/card/emag/doorjack(src) // 3 tc
 
 /obj/item/storage/box/syndicate/bundle_b/PopulateContents()
-	switch (pickweight(list( 
-		KIT_JAMES_BOND = 2, 
-		KIT_NINJA = 1, 
-		KIT_DARK_LORD = 1, 
-		KIT_WHITE_WHALE_HOLY_GRAIL = 2, 
-		KIT_MAD_SCIENTIST = 2, 
-		KIT_BEES = 1, 
-		KIT_MR_FREEZE = 2, 
+	switch (pickweight(list(
+		KIT_JAMES_BOND = 2,
+		KIT_NINJA = 1,
+		KIT_DARK_LORD = 1,
+		KIT_WHITE_WHALE_HOLY_GRAIL = 2,
+		KIT_MAD_SCIENTIST = 2,
+		KIT_BEES = 1,
+		KIT_MR_FREEZE = 2,
 		KIT_TRAITOR_2006 = 1
 		)))
 		if(KIT_JAMES_BOND)
@@ -237,12 +237,12 @@
 			new /obj/item/dnainjector/cryokinesis(src)
 			new /obj/item/gun/energy/temperature/security(src)
 			new /obj/item/melee/transforming/energy/sword/saber/blue(src) //see see it fits the theme bc its blue and ice is blue
-			
+
 		if(KIT_TRAITOR_2006) //A kit so old, it's probably older than you. //This bundle is filled with the entire unlink contents traitors had access to in 2006, from OpenSS13. Notably the esword was not a choice but existed in code.
 			new /obj/item/storage/toolbox/emergency/old/ancientbundle(src) //Items fit neatly into a classic toolbox just to remind you what the theme is.
-		
+
 /obj/item/storage/toolbox/emergency/old/ancientbundle/ //So the subtype works
-		
+
 /obj/item/storage/toolbox/emergency/old/ancientbundle/PopulateContents()
 	new /obj/item/card/emag(src)
 	new /obj/item/pen/sleepy(src)
@@ -364,6 +364,12 @@
 	desc = "A sleek, sturdy box."
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
+	var/list/items_inside //used for illegal tech to look inside of boxes and storage from only the typepath
+
+/obj/item/storage/box/syndie_kit/PopulateContents()
+	if(items_inside?.len)
+		if(items_inside?.len)
+		generate_items_inside(items_inside,src)
 
 /obj/item/storage/box/syndie_kit/origami_bundle
 	name = "origami kit"
@@ -632,7 +638,7 @@
 	for(var/i in implants)
 		group.register(i)
 	desc += " The implants are registered to the \"[group.name]\" group."
-	
+
 #undef KIT_RECON
 #undef KIT_BLOODY_SPAI
 #undef KIT_STEALTHY

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -365,11 +365,6 @@
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
 
-
-/obj/item/storage/box/syndie_kit/PopulateContents()
-	if(items_inside?.len)
-		generate_items_inside(items_inside,src)
-
 /obj/item/storage/box/syndie_kit/origami_bundle
 	name = "origami kit"
 	desc = "A box full of a number of rather masterfully engineered paper planes and a manual on \"The Art of Origami\"."

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -364,7 +364,7 @@
 	desc = "A sleek, sturdy box."
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
-	var/list/items_inside //used for illegal tech to look inside of boxes and storage from only the typepath
+
 
 /obj/item/storage/box/syndie_kit/PopulateContents()
 	if(items_inside?.len)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -622,12 +622,9 @@
 ///Subtype for the sabotage bundle. Contains three C4, two X4 and 6 signalers
 /obj/item/storage/backpack/duffelbag/syndie/sabotage
 	items_inside = list(
-		/obj/item/grenade/c4(src) = 1,
-		/obj/item/grenade/c4(src) = 1,
-		/obj/item/grenade/c4(src) = 1,
-		/obj/item/grenade/c4/x4(src) = 1,
-		/obj/item/grenade/c4/x4(src) = 1,
-		/obj/item/storage/box/syndie_kit/signaler(src) = 1
+		/obj/item/grenade/c4 = 3,
+		/obj/item/grenade/c4/x4 = 2,
+		/obj/item/storage/box/syndie_kit/signaler = 1
 	)
 
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -994,8 +994,18 @@
 	boost_item_paths = list()
 	for(var/path in GLOB.uplink_items)
 		var/datum/uplink_item/UI = new path
-		if(!UI.item || !UI.illegal_tech || ispath(UI.item, /obj/item/storage/box) || ispath(UI.item, /obj/item/storage/backpack))
+		if(!UI.item || !UI.illegal_tech) // if there is no item, or node does not allow illegal_tech
 			continue
+		if(ispath(UI.item, /obj/item/storage/box) || ispath(UI.item, /obj/item/storage/backpack)) //disallow box/item containers
+			continue
+		if(ispath(UI.item, /obj/item/storage/box/syndie_kit)) //if the item awards a syndie kit PATH
+			var/obj/item/storage/box/syndie_kit/my_kit = new UI.item //init that item so I can get the variables from it
+			for(var/each_item in my_kit.items_inside)
+				//TODO: Default off bitflag for items, ILLEGAL_TECH, that is checked here so that when an item is searched this proc can check it for illegal technology
+				//we don't want to give illegal tech for items like paper, since those also spawn in syndicate things
+				//or I change the box definition to major/minor items, but eh
+				// recursive check for contents?
+				boost_item_paths |= each_item
 		boost_item_paths |= UI.item //allows deconning to unlock.
 
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -996,9 +996,9 @@
 		var/datum/uplink_item/UI = new path
 		if(!UI.item || !UI.illegal_tech) // if there is no item, or node does not allow illegal_tech
 			continue
-		if(ispath(UI.item, /obj/item/storage/box/syndie_kit)) //if the item awards a syndie kit PATH
-			var/obj/item/storage/box/syndie_kit/my_kit = new UI.item //init that item so I can get the variables from it
-			for(var/each_item in my_kit.items_inside)
+		if(ispath(UI.item, /obj/item/storage)) //if the item has a storage path
+			var/obj/item/storage/my_storage = new UI.item //init that item so I can get the variables from it
+			for(var/each_item in my_storage.items_inside)
 				//TODO: Default off bitflag for items, ILLEGAL_TECH, that is checked here so that when an item is searched this proc can check it for illegal technology
 				//we don't want to give illegal tech for items like paper, since those also spawn in syndicate things
 				//or I change the box definition to major/minor items, but eh

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -996,8 +996,6 @@
 		var/datum/uplink_item/UI = new path
 		if(!UI.item || !UI.illegal_tech) // if there is no item, or node does not allow illegal_tech
 			continue
-		if(ispath(UI.item, /obj/item/storage/box) || ispath(UI.item, /obj/item/storage/backpack)) //disallow box/item containers
-			continue
 		if(ispath(UI.item, /obj/item/storage/box/syndie_kit)) //if the item awards a syndie kit PATH
 			var/obj/item/storage/box/syndie_kit/my_kit = new UI.item //init that item so I can get the variables from it
 			for(var/each_item in my_kit.items_inside)
@@ -1006,6 +1004,8 @@
 				//or I change the box definition to major/minor items, but eh
 				// recursive check for contents?
 				boost_item_paths |= each_item
+		if(ispath(UI.item, /obj/item/storage/box) || ispath(UI.item, /obj/item/storage/backpack)) //disallow box/item containers
+			continue
 		boost_item_paths |= UI.item //allows deconning to unlock.
 
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -994,7 +994,7 @@
 	boost_item_paths = list()
 	for(var/path in GLOB.uplink_items)
 		var/datum/uplink_item/UI = new path
-		if(!UI.item || !UI.illegal_tech)
+		if(!UI.item || !UI.illegal_tech || ispath(UI.item, /obj/item/storage/box) || ispath(UI.item, /obj/item/storage/backpack))
 			continue
 		boost_item_paths |= UI.item //allows deconning to unlock.
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1911,9 +1911,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/role_restricted/reverse_revolver
 	name = "Reverse Revolver"
 	desc = "A revolver that always fires at its user. \"Accidentally\" drop your weapon, then watch as the greedy corporate pigs blow their own brains all over the wall. \
-	The revolver itself is actually real. Only clumsy people, and clowns, can fire it normally. Comes in a box of hugs. Honk."
+	The revolver itself is actually real. Only clumsy people, and clowns, can fire it normally. Comes in a counterfeit box of hugs. Honk."
 	cost = 14
-	item = /obj/item/storage/box/hug/reverse_revolver
+	item = /obj/item/storage/box/syndie_kit/reverse_revolver
 	restricted_roles = list("Clown")
 
 /datum/uplink_item/role_restricted/clownpin

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -187,6 +187,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/briefcase/sniperbundle
 	cost = 20 // normally 26
 	include_modes = list(/datum/game_mode/nuclear)
+	illegal_tech = FALSE
 
 /datum/uplink_item/bundles_tc/firestarter
 	name = "Spetsnaz Pyro bundle"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1911,9 +1911,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/role_restricted/reverse_revolver
 	name = "Reverse Revolver"
 	desc = "A revolver that always fires at its user. \"Accidentally\" drop your weapon, then watch as the greedy corporate pigs blow their own brains all over the wall. \
-	The revolver itself is actually real. Only clumsy people, and clowns, can fire it normally. Comes in a counterfeit box of hugs. Honk."
+	The revolver itself is actually real. Only clumsy people, and clowns, can fire it normally. Comes in a box of hugs. Honk."
 	cost = 14
-	item = /obj/item/storage/box/syndie_kit/reverse_revolver
+	item = /obj/item/storage/box/hug/reverse_revolver
 	restricted_roles = list("Clown")
 
 /datum/uplink_item/role_restricted/clownpin


### PR DESCRIPTION
Related; https://github.com/BeeStation/BeeStation-Hornet/pull/4001

## About The Pull Request

Boxes spawn their contents with PopulateContents() when the box is created. This is fine, except no procs can see into those boxes.

In order for RnD's illegal technology to see into boxes in order to determine what should be illegal or not, it needs to have runtime access to box/storage contents.

This allows RnD's illegal tech to read the contents of storages from uplink datums.

For example, this allows BuzzKill grenades to grant illegal tech, whereas before only the box would. BuzzKill grenades can only be purchased from an uplink in a box of three.

TODO: 

- [ ] Explicit tagging of items to allow illegal tech
- [ ] Recursive search of storages for additional storages (a kit box inside of a kit box should be searched)

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/3241376/113039998-e979ed00-915d-11eb-8cc1-b3bf92cd3170.png)
![image](https://user-images.githubusercontent.com/3241376/113040007-ec74dd80-915d-11eb-86dd-7288e169ecfe.png)


## Changelog
:cl:
add: More traitor uplink items award illegal technology
code: RnD Illegal Tech techweb now searches inside of storages for illegal items
refactor: Syndicate box kits use "items_inside" list to create their contents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
