### PR TITLE
Fixes openspace failing to render properly on all multi-z maps.

### DIFF
--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -9,7 +9,6 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 	icon_state      = "grey"
 	plane           = OPENSPACE_BACKDROP_PLANE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	plane           = SPLASHSCREEN_PLANE
 	//I don't know why the others are aligned but I shall do the same.
 	vis_flags = VIS_INHERIT_ID
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#57915 had an uwupsie.

![image](https://user-images.githubusercontent.com/24975989/113050532-da665f80-919c-11eb-875c-d5885062ac95.png)

A lot of stuff in that PR was removing layers and putting plane equivalents in their place, however /atom/movable/openspace_backdrop already had a plane. A plane that worked.

![NXfACyeWNf](https://user-images.githubusercontent.com/24975989/113050971-5eb8e280-919d-11eb-8443-91e4e24b3a62.gif)

When we set the plane back to it's former value of OPENSPACE_BACKDROP_PLANE (-8) instead of SPLASHSCREEN_PLANE (9999) it just works. We can even see that -8 is the highest plane that will work for openspace backdrops in the above gif.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Multi-z works again.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Transparent turfs once again work properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
