### PR TITLE
[April Fools'] Replaces most red lasers with practice lasers

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -1,58 +1,55 @@
 /obj/item/ammo_casing/energy/laser
-	projectile_type = /obj/projectile/beam/laser
-	select_name = "kill"
+	projectile_type = /obj/projectile/beam/practice
+	select_name = "practice"
+	harmful = FALSE
 
 /obj/item/ammo_casing/energy/laser/hellfire
 	projectile_type = /obj/projectile/beam/laser/hellfire
 	e_cost = 130
-	select_name = "maim"
+	select_name = "practice to an unhealthy degree"
 
 /obj/item/ammo_casing/energy/laser/hellfire/antique
 	e_cost = 100
 
 /obj/item/ammo_casing/energy/lasergun
-	projectile_type = /obj/projectile/beam/laser
 	e_cost = 71
-	select_name = "kill"
 
 /obj/item/ammo_casing/energy/lasergun/old
-	projectile_type = /obj/projectile/beam/laser
 	e_cost = 200
-	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/hos
 	e_cost = 120
 
 /obj/item/ammo_casing/energy/laser/practice
-	projectile_type = /obj/projectile/beam/practice
+	projectile_type = /obj/projectile/beam/practice //redundant now, but whatever
 	select_name = "practice"
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/laser/scatter
-	projectile_type = /obj/projectile/beam/scatter
+	projectile_type = /obj/projectile/beam/scatter //I think this is actually orange, but eh, fuck it
 	pellets = 5
 	variance = 25
-	select_name = "scatter"
+	select_name = "come with me if you want to practice"
 
 /obj/item/ammo_casing/energy/laser/scatter/disabler
-	projectile_type = /obj/projectile/beam/disabler
+	projectile_type = /obj/projectile/beam/disabler //disablers are blue and thus exempt
 	pellets = 3
 	variance = 15
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/laser/heavy
 	projectile_type = /obj/projectile/beam/laser/heavylaser
-	select_name = "anti-vehicle"
+	select_name = "practice REALLY hard"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
 /obj/item/ammo_casing/energy/laser/pulse
-	projectile_type = /obj/projectile/beam/pulse
+	projectile_type = /obj/projectile/beam/pulse //blue
 	e_cost = 200
 	select_name = "DESTROY"
 	fire_sound = 'sound/weapons/pulse.ogg'
 
 /obj/item/ammo_casing/energy/laser/bluetag
-	projectile_type = /obj/projectile/beam/lasertag/bluetag
+	projectile_type = /obj/projectile/beam/lasertag/bluetag //I'm blue dabadeedabada
 	select_name = "bluetag"
 	harmful = FALSE
 
@@ -60,24 +57,23 @@
 	projectile_type = /obj/projectile/beam/lasertag/bluetag/hitscan
 
 /obj/item/ammo_casing/energy/laser/redtag
-	projectile_type = /obj/projectile/beam/lasertag/redtag
-	select_name = "redtag"
+	projectile_type = /obj/projectile/beam/lasertag/redtag //let the laser taggers have their fun
+	select_name = "practice your l33t laser tag skillz" //how do you do, fellow kids?
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/laser/redtag/hitscan
 	projectile_type = /obj/projectile/beam/lasertag/redtag/hitscan
 
 /obj/item/ammo_casing/energy/xray
-	projectile_type = /obj/projectile/beam/xray
+	projectile_type = /obj/projectile/beam/xray //green
 	e_cost = 50
 	fire_sound = 'sound/weapons/laser3.ogg'
 
 /obj/item/ammo_casing/energy/mindflayer
-	projectile_type = /obj/projectile/beam/mindflayer
+	projectile_type = /obj/projectile/beam/mindflayer //Brian from Family Guy
 	select_name = "MINDFUCK"
 	fire_sound = 'sound/weapons/laser.ogg'
 
 /obj/item/ammo_casing/energy/laser/minigun
-	select_name = "kill"
-	projectile_type = /obj/projectile/beam/weak/penetrator
+	select_name = "practice your Rambo cosplay"
 	variance = 0.8

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -96,19 +96,19 @@
 	ammo_x_offset = 3
 
 /obj/item/ammo_casing/energy/laser/accelerator
-	projectile_type = /obj/projectile/beam/laser/accelerator
-	select_name = "accelerator"
+	projectile_type = /obj/projectile/beam/laser/accelerator //I think this is also orange, but it tried to hide from me, so it must be punished
+	select_name = "practice accelerating"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
 /obj/projectile/beam/laser/accelerator
 	name = "accelerator laser"
 	icon_state = "scatterlaser"
 	range = 255
-	damage = 6
+	damage = 0
+	nodamage = TRUE
 
 /obj/projectile/beam/laser/accelerator/Range()
 	..()
-	damage += 7
 	transform *= 1 + ((damage/7) * 0.2)//20% larger per tile
 
 ///X-ray gun

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -97,11 +97,11 @@
 
 /obj/item/ammo_casing/energy/laser/accelerator
 	projectile_type = /obj/projectile/beam/laser/accelerator //I think this is also orange, but it tried to hide from me, so it must be punished
-	select_name = "practice accelerating"
+	select_name = "long-distance practice"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
 /obj/projectile/beam/laser/accelerator
-	name = "accelerator laser"
+	name = "accelerator practice laser"
 	icon_state = "scatterlaser"
 	range = 255
 	damage = 0

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -29,19 +29,27 @@
 
 //overclocked laser, does a bit more damage but has much higher wound power (-0 vs -20)
 /obj/projectile/beam/laser/hellfire
-	name = "hellfire laser"
+	name = "hell-practice laser"
 	wound_bonus = 0
-	damage = 25
+	damage = 0
+	nodamage = TRUE
 	speed = 0.6 // higher power = faster, that's how light works right
 
 /obj/projectile/beam/laser/hellfire/Initialize()
 	. = ..()
 	transform *= 2
 
+/obj/projectile/beam/laser/hellfire/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/carbontarget = target
+		SEND_SIGNAL(carbontarget, COMSIG_ADD_MOOD_EVENT, "hell-practice laser", /datum/mood_event/depression_moderate) //oh my god you burned them out you monster
+
 /obj/projectile/beam/laser/heavylaser
-	name = "heavy laser"
+	name = "heavy practice laser"
 	icon_state = "heavylaser"
-	damage = 40
+	damage = 0
+	nodamage = TRUE
 	tracer_type = /obj/effect/projectile/tracer/heavy_laser
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
 	impact_type = /obj/effect/projectile/impact/heavy_laser
@@ -53,6 +61,19 @@
 		M.IgniteMob()
 	else if(isturf(target))
 		impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser/wall
+
+/obj/projectile/beam/laser/heavylaser/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/carbontarget = target
+		carbontarget.say("BRAIN BLAST!!", forced = "heavy practice laser")
+		if(prob(33)) //mostly copy+pasted from the code for the brain trauma abductor gland
+			carbontarget.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, rand(TRAUMA_RESILIENCE_BASIC, TRAUMA_RESILIENCE_LOBOTOMY))
+		else
+			if(prob(20))
+				carbontarget.gain_trauma_type(BRAIN_TRAUMA_SEVERE, rand(TRAUMA_RESILIENCE_BASIC, TRAUMA_RESILIENCE_LOBOTOMY))
+			else
+				carbontarget.gain_trauma_type(BRAIN_TRAUMA_MILD, rand(TRAUMA_RESILIENCE_BASIC, TRAUMA_RESILIENCE_LOBOTOMY))
 
 /obj/projectile/beam/weak
 	damage = 15
@@ -66,9 +87,10 @@
 	nodamage = TRUE
 
 /obj/projectile/beam/scatter
-	name = "laser pellet"
+	name = "practice laser pellet"
 	icon_state = "scatterlaser"
-	damage = 5
+	damage = 0
+	nodamage = TRUE
 
 /obj/projectile/beam/xray
 	name = "\improper X-ray beam"
@@ -181,6 +203,7 @@
 				M.adjustStaminaLoss(34)
 
 /obj/projectile/beam/lasertag/redtag
+	name = "practice laser tag beam"
 	icon_state = "laser"
 	suit_types = list(/obj/item/clothing/suit/bluetag)
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -59,11 +59,11 @@
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
 	equip_cooldown = 8
-	name = "\improper CH-PS \"Immolator\" laser"
+	name = "\improper CH-PS \"Immolator\" practice laser"
 	desc = "A weapon for combat exosuits. Shoots basic lasers."
 	icon_state = "mecha_laser"
 	energy_drain = 30
-	projectile = /obj/projectile/beam/laser
+	projectile = /obj/projectile/beam/practice
 	fire_sound = 'sound/weapons/laser.ogg'
 	harmful = TRUE
 
@@ -78,7 +78,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
 	equip_cooldown = 15
-	name = "\improper CH-LC \"Solaris\" laser cannon"
+	name = "\improper CH-LC \"Solaris\" practice laser cannon"
 	desc = "A weapon for combat exosuits. Shoots heavy lasers."
 	icon_state = "mecha_laser"
 	energy_drain = 60


### PR DESCRIPTION
## About The Pull Request

Most of the red laser settings (and some of the orange laser settings, because they were close enough and I felt like it) in the game have been turned into practice variants that fire practice lasers that deal no damage.

Lasers settings that use other colors, like disable and DESTROY, are unaffected.

Hellfire and heavy lasers are a bit special.

## Why It's Good For The Game

Our security force clearly needs more practice, so I've decided to help them with that.

It's also funny to see someone try to kill someone with a practice laser. The inverse of this PR would have been making practice lasers deal damage, but I think that that would have been shot down for enabling some powergaming.

I spent like an hour on this PR help

## Changelog
:cl: ATHATH
balance: Lethal laser weaponry has been rebalanced.
/:cl: