### PR TITLE
Persistence now cleans up json entries (fixes a lot of runtimes involved)

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -337,20 +337,21 @@
 	if(!persistence_id || !SSpersistence.paintings || !SSpersistence.paintings[persistence_id])
 		return
 	var/list/painting_category = SSpersistence.paintings[persistence_id]
-	var/found_painting = FALSE
-	while(!found_painting)
+	var/list/painting
+	while(!painting)
 		if(!length(SSpersistence.paintings[persistence_id]))
 			return //aborts loading anything this category has no usable paintings
 		var/list/chosen = pick(painting_category)
-		var/title = chosen["title"]
-		var/author = chosen["ckey"]
-		var/png = "data/paintings/[persistence_id]/[chosen["md5"]].png"
-		if(!title)
-			title = "Untitled Artwork" //Should prevent NULL named art from loading as NULL, if you're still getting the admin log chances are persistence is broken
-		if(!fexists(png)) //shitmin deleted this art, lets remove json entry to avoid errors
+		if(!fexists("data/paintings/[persistence_id]/[chosen["md5"]].png")) //shitmin deleted this art, lets remove json entry to avoid errors
 			painting_category.Remove(chosen)
-			continue //tries again
-		found_painting = TRUE
+			continue //and try again
+		painting = chosen
+	var/title = painting["title"]
+	var/author = painting["ckey"]
+	var/png = "data/paintings/[persistence_id]/[painting["md5"]].png"
+	if(!title)
+		title = "Untitled Artwork" //legacy artwork allowed null names which was bad for the json, lets fix that
+		painting["title"] = title
 	var/icon/I = new(png)
 	var/obj/item/canvas/new_canvas
 	var/w = I.Width()

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -328,22 +328,29 @@
 	frame.pixel_y = current_canvas.framed_offset_y - 1
 	. += frame
 
+/**
+ * Loads a painting from SSpersistence. Called globally by said subsystem when it inits
+ *
+ * Deleting paintings leaves their json, so this proc will remove the json and try again if it finds one of those.
+ */
 /obj/structure/sign/painting/proc/load_persistent()
-	if(!persistence_id)
+	if(!persistence_id || !SSpersistence.paintings || !SSpersistence.paintings[persistence_id])
 		return
-	if(!SSpersistence.paintings || !SSpersistence.paintings[persistence_id] || !length(SSpersistence.paintings[persistence_id]))
-		return
-	var/list/chosen = pick(SSpersistence.paintings[persistence_id])
-	var/title = chosen["title"]
-	var/author = chosen["ckey"]
-	var/png = "data/paintings/[persistence_id]/[chosen["md5"]].png"
-	if(!title)
-		title = "Untitled Artwork" //Should prevent NULL named art from loading as NULL, if you're still getting the admin log chances are persistence is broken
-	if(!title)
-		message_admins("<span class='notice'>Painting with NO TITLE loaded on a [persistence_id] frame in [get_area(src)]. Please delete it, it is saved in the database with no name and will create bad assets.</span>")
-	if(!fexists(png))
-		stack_trace("Persistent painting [chosen["md5"]].png was not found in [persistence_id] directory.")
-		return
+	var/list/painting_category = SSpersistence.paintings[persistence_id]
+	var/found_painting = FALSE
+	while(!found_painting)
+		if(!length(SSpersistence.paintings[persistence_id]))
+			return //aborts loading anything this category has no usable paintings
+		var/list/chosen = pick(painting_category)
+		var/title = chosen["title"]
+		var/author = chosen["ckey"]
+		var/png = "data/paintings/[persistence_id]/[chosen["md5"]].png"
+		if(!title)
+			title = "Untitled Artwork" //Should prevent NULL named art from loading as NULL, if you're still getting the admin log chances are persistence is broken
+		if(!fexists(png)) //shitmin deleted this art, lets remove json entry to avoid errors
+			painting_category.Remove(chosen)
+			continue //tries again
+		found_painting = TRUE
 	var/icon/I = new(png)
 	var/obj/item/canvas/new_canvas
 	var/w = I.Width()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Admins deleting paintings did not delete the json, which means the json would still think there's a valid painting there despite no png.
