### PR TITLE
Lore accurate Felinids - Replaces Felinid blood with Felinid mutation toxin

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -4,6 +4,7 @@
 	id = "felinid"
 	say_mod = "meows"
 	limbs_id = "human"
+	exotic_blood = /datum/reagent/mutationtoxin/felinid
 
 	mutant_bodyparts = list("tail_human" = "Cat", "ears" = "Cat", "wings" = "None")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes felinidism contagious via exposure to felinid blood. 

This is a code solution to a lore issue. The new lore for felinids is as follwos:
Felinids are no longer born. Adult felinids inject their blood into healthy members of other species causing them to morph into another felinid.

I think this is the best way to represent the felinid community within the lore as OOCly they tend to spread through subliminal brainwashing. Now ICly felinids will need to over many months encourage other players to take some of their blood. I am absolutely certain that not one felinid player would turn someone else into a felinid without their consent.

<details>
<summary>Spoiler warning</summary>
If you hadn't guessed, this is a slightly early April fools day joke

But its not April fools yet I hear you say
The actual joke is merging it tomorrow (joke implied)
</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

A lore master said that they didn't want to write lore for species reproduction so I made a code solution for felinid reproduction.
![image](https://user-images.githubusercontent.com/40036527/113165512-dfc5b780-9239-11eb-8b01-f1390c790e39.png)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Made felinid lore intresting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
