### PR TITLE
Fixes gluttony's blessing oversight

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -743,7 +743,8 @@
 
 /datum/reagent/gluttonytoxin/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message=TRUE, touch_protection=0)
 	. = ..()
-	exposed_mob.ForceContractDisease(new /datum/disease/transformation/morph(), FALSE, TRUE)
+	if(reac_volume >= 1)//This prevents microdosing from infecting masses of people
+		exposed_mob.ForceContractDisease(new /datum/disease/transformation/morph(), FALSE, TRUE)
 
 /datum/reagent/serotrotium
 	name = "Serotrotium"


### PR DESCRIPTION
## About The Pull Request
Gluttony's blessing didn't have a minimum `reac_volume` when mobs were exposed to it, so this adds one

## Why It's Good For The Game
The other rewards from the sin ruins are benefits exclusive to a single user, gluttony shouldn't be any different.

The lack of a minimum requirement allowed smokes, cigarettes, cutting pizzas, and other methods of transferring small volumes of reagents to multiple users to convert large portions of the crew into morphs.
The most direct method being .06u pills for 16 users, but smokes/foams allow for theoretically higher numbers.

We don't need morphstation going on.
## Changelog
:cl:
fix: Gluttony's blessing will no longer turn you into a morph if you do not receive the entire volume of the reagent contained in the syringe at once. You weren't supposed to be sharing to begin with, you should've taken a lesson from Greed.
/:cl: