### PR TITLE
Update dependencies installed for TGSv4 precompile scripts

### DIFF
--- a/config/admins.txt
+++ b/config/admins.txt
@@ -142,3 +142,4 @@ Skoglol = Game Master
 Time-Green = Game Master
 StyleMistake = Game Master
 actioninja = Game Master
+bobbahbrown = Game Master

--- a/tools/tgs4_scripts/PreCompile.sh
+++ b/tools/tgs4_scripts/PreCompile.sh
@@ -45,7 +45,7 @@ fi
 dpkg --add-architecture i386
 apt-get update
 #apt-get upgrade -y
-apt-get install -y lib32z1 pkg-config libssl-dev:i386 libssl-dev
+apt-get install -y lib32z1 pkg-config libssl-dev:i386 libssl-dev libssl1.1:i386
 #update rust-g
 if [ ! -d "rust-g" ]; then
 	echo "Cloning rust-g..."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As discovered today, we realized that rust-g requires ``libssl1.1``, but this is not a dependency we install explicitly. To run rustg this is required!

*Side note: I also added myself to the admins.txt as I was told by mso and cyberboss this would be useful as I then don't have to edit any configs when we're testing servers*

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows running of tgs4 servers, as previously rustg couldn't run without this dependency.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
server: Fixed missing dependency for libssl1.1 in PreCompile.sh
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
