### PR TITLE
Allows you to ignite cigars with cauteries and recently-fired revolvers

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -15,6 +15,12 @@
 	tac_reloads = FALSE
 	var/spin_delay = 10
 	var/recent_spin = 0
+	var/last_fire = 0
+
+/obj/item/gun/ballistic/revolver/process_fire(atom/target, mob/living/user, message, params, zone_override, bonus_spread)
+	..()
+	last_fire = world.time
+
 
 /obj/item/gun/ballistic/revolver/chamber_round(keep_bullet, spin_cylinder = TRUE, replace_new_round)
 	if(!magazine) //if it mag was qdel'd somehow.
@@ -74,6 +80,10 @@
 	if (current_skin)
 		. += "It can be spun with <b>alt+click</b>"
 
+/obj/item/gun/ballistic/revolver/ignition_effect(atom/A, mob/user)
+	if(last_fire && last_fire + 15 SECONDS > world.time)
+		. = "<span class='notice'>[user] touches the end of [src] to \the [A], using the residual heat to ignite it in a puff of smoke. What a badass.</span>"
+
 /obj/item/gun/ballistic/revolver/detective
 	name = "\improper Colt Detective Special"
 	desc = "A classic, if not outdated, law enforcement firearm. Uses .38 Special rounds. \nSome spread rumors that if you loosen the barrel with a wrench, you can \"improve\" it."
@@ -87,7 +97,7 @@
 	can_modify_ammo = TRUE
 	alternative_ammo_misfires = TRUE
 	can_misfire = FALSE
-	misfire_probability = 0 
+	misfire_probability = 0
 	misfire_percentage_increment = 25 //about 1 in 4 rounds, which increases rapidly every shot
 	obj_flags = UNIQUE_RENAME
 	unique_reskin = list("Default" = "detective",

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -57,6 +57,9 @@
 	tool_behaviour = TOOL_CAUTERY
 	toolspeed = 1
 
+/obj/item/cautery/ignition_effect(atom/A, mob/user)
+	. = "<span class='notice'>[user] touches the end of [src] to \the [A], igniting it with a puff of smoke.</span>"
+
 /obj/item/cautery/augment
 	desc = "A heated element that cauterizes wounds."
 	toolspeed = 0.5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#58055 added this for Mansus Grasp and I thought why the hell not, this is also badass. Fifteen seconds sounds like long enough to do this after firing the gun.

Also EOB noticed you can't ignite cigars with the cautery and that seems odd, so I added that too. Not sure who'd want to do that, but here you go.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Gun hot after firing also badassery
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Recently-fired revolvers can now be used to ignite cigars like a fucking badass.
add: Cauteries can now be used to ignite cigars like a very irresponsible doctor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
