### PR TITLE
Fixes a critical accidental early return

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -60,7 +60,7 @@
 
 	for(var/mob/mob_to_teleport in GLOB.mob_list) //gotta make sure the whole crew's here!
 		if(isnewplayer(mob_to_teleport))
-			return
+			continue
 
 		if (mob_to_teleport.key) //fully immerse the mob in the experience if they're player controlled
 			to_chat(mob_to_teleport, announcement)

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -62,11 +62,11 @@
 		if(isnewplayer(mob_to_teleport))
 			continue
 
-		//fully immerse the mob in the experience
-		to_chat(mob_to_teleport, announcement)
-		SEND_SOUND(mob_to_teleport, meeting_sound) //no preferences here, you must hear the funny sound
-		mob_to_teleport.overlay_fullscreen("emergency_meeting", /atom/movable/screen/fullscreen/emergency_meeting, 1)
-		addtimer(CALLBACK(mob_to_teleport, /mob/.proc/clear_fullscreen, "emergency_meeting"), 3 SECONDS)
+		if (mob_to_teleport.key) //fully immerse the mob in the experience if they're player controlled
+			to_chat(mob_to_teleport, announcement)
+			SEND_SOUND(mob_to_teleport, meeting_sound) //no preferences here, you must hear the funny sound
+			mob_to_teleport.overlay_fullscreen("emergency_meeting", /atom/movable/screen/fullscreen/emergency_meeting, 1)
+			addtimer(CALLBACK(mob_to_teleport, /mob/.proc/clear_fullscreen, "emergency_meeting"), 3 SECONDS)
 
 		if (is_station_level(mob_to_teleport.z)) //teleport the mob to the crew meeting
 			var/turf/target

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -62,11 +62,11 @@
 		if(isnewplayer(mob_to_teleport))
 			continue
 
-		if (mob_to_teleport.key) //fully immerse the mob in the experience if they're player controlled
-			to_chat(mob_to_teleport, announcement)
-			SEND_SOUND(mob_to_teleport, meeting_sound) //no preferences here, you must hear the funny sound
-			mob_to_teleport.overlay_fullscreen("emergency_meeting", /atom/movable/screen/fullscreen/emergency_meeting, 1)
-			addtimer(CALLBACK(mob_to_teleport, /mob/.proc/clear_fullscreen, "emergency_meeting"), 3 SECONDS)
+		//fully immerse the mob in the experience
+		to_chat(mob_to_teleport, announcement)
+		SEND_SOUND(mob_to_teleport, meeting_sound) //no preferences here, you must hear the funny sound
+		mob_to_teleport.overlay_fullscreen("emergency_meeting", /atom/movable/screen/fullscreen/emergency_meeting, 1)
+		addtimer(CALLBACK(mob_to_teleport, /mob/.proc/clear_fullscreen, "emergency_meeting"), 3 SECONDS)
 
 		if (is_station_level(mob_to_teleport.z)) //teleport the mob to the crew meeting
 			var/turf/target

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -84,6 +84,7 @@
 
 /atom/movable/screen/fullscreen/emergency_meeting
 	icon_state = "emergency_meeting"
+	show_when_dead = TRUE
 	layer = CURSE_LAYER
 	plane = SPLASHSCREEN_PLANE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This loop shouldn't give up so quickly
Makes emergency meetings work when there are new players about
Also sets the 'show when dead' var to true so ghosts get the full experience
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The entire crew should be able to join in meetings to vote off traitors
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Emergency meetings work now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
