### PR TITLE
Allows blind crewmembers to use health/chem/atmos scanners

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -148,6 +148,10 @@ GENE SCANNER
 	if(user.incapacitated())
 		return
 
+	if(user.is_blind())
+		to_chat(user, "<span class='warning'>You realize that your scanner has no accessibility support for the blind!</span>")
+		return
+
 	// the final list of strings to render
 	var/render_list = list()
 
@@ -425,6 +429,10 @@ GENE SCANNER
 	if(user.incapacitated())
 		return
 
+	if(user.is_blind())
+		to_chat(user, "<span class='warning'>You realize that your scanner has no accessibility support for the blind!</span>")
+		return
+
 	if(istype(M) && M.reagents)
 		var/render_list = list()
 		if(M.reagents.reagent_list.len)
@@ -484,6 +492,10 @@ GENE SCANNER
 /// Displays wounds with extended information on their status vs medscanners
 /proc/woundscan(mob/user, mob/living/carbon/patient, obj/item/healthanalyzer/wound/scanner)
 	if(!istype(patient) || user.incapacitated())
+		return
+
+	if(user.is_blind())
+		to_chat(user, "<span class='warning'>You realize that your scanner has no accessibility support for the blind!</span>")
 		return
 
 	var/render_list = ""
@@ -576,7 +588,7 @@ GENE SCANNER
 /obj/item/analyzer/attack_self(mob/user)
 	add_fingerprint(user)
 
-	if (user.stat)
+	if (user.stat || user.is_blind())
 		return
 
 	var/turf/location = user.loc

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -148,10 +148,6 @@ GENE SCANNER
 	if(user.incapacitated())
 		return
 
-	if(user.is_blind())
-		to_chat(user, "<span class='warning'>You realize that your scanner has no accessibility support for the blind!</span>")
-		return
-
 	// the final list of strings to render
 	var/render_list = list()
 
@@ -429,10 +425,6 @@ GENE SCANNER
 	if(user.incapacitated())
 		return
 
-	if(user.is_blind())
-		to_chat(user, "<span class='warning'>You realize that your scanner has no accessibility support for the blind!</span>")
-		return
-
 	if(istype(M) && M.reagents)
 		var/render_list = list()
 		if(M.reagents.reagent_list.len)
@@ -492,10 +484,6 @@ GENE SCANNER
 /// Displays wounds with extended information on their status vs medscanners
 /proc/woundscan(mob/user, mob/living/carbon/patient, obj/item/healthanalyzer/wound/scanner)
 	if(!istype(patient) || user.incapacitated())
-		return
-
-	if(user.is_blind())
-		to_chat(user, "<span class='warning'>You realize that your scanner has no accessibility support for the blind!</span>")
 		return
 
 	var/render_list = ""
@@ -588,7 +576,7 @@ GENE SCANNER
 /obj/item/analyzer/attack_self(mob/user)
 	add_fingerprint(user)
 
-	if (user.stat || user.is_blind())
+	if (user.stat)
 		return
 
 	var/turf/location = user.loc

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -122,15 +122,14 @@
 	else
 		qdel(src)
 
-/obj/item/clothing/attack(mob/attacker, mob/living/user, params)
-	if(!user.combat_mode && ismoth(attacker))
-		if (isnull(moth_snack))
-			moth_snack = new
-			moth_snack.name = name
-			moth_snack.clothing = WEAKREF(src)
-		moth_snack.attack(attacker, user, params)
-	else
+/obj/item/clothing/attack(mob/living/M, mob/living/user, params)
+	if(user.combat_mode || !ismoth(M))
 		return ..()
+	if(isnull(moth_snack))
+		moth_snack = new
+		moth_snack.name = name
+		moth_snack.clothing = WEAKREF(src)
+	moth_snack.attack(M, user, params)
 
 /obj/item/clothing/attackby(obj/item/W, mob/user, params)
 	if(!istype(W, repairable_by))

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -55,31 +55,34 @@
 	user.visible_message("<span class='suicide'>[user] puts \the [src] to [user.p_their()] chest! It looks like [user.p_they()] won't hear much!</span>")
 	return OXYLOSS
 
-/obj/item/clothing/neck/stethoscope/attack(mob/living/carbon/human/M, mob/living/user)
-	if(ishuman(M) && isliving(user))
-		if(!user.combat_mode)
-			var/body_part = parse_zone(user.zone_selected)
+/obj/item/clothing/neck/stethoscope/attack(mob/living/M, mob/living/user)
+	if(!ishuman(M) || !isliving(user))
+		return ..()
+	if(user.combat_mode)
+		return
 
-			var/heart_strength = "<span class='danger'>no</span>"
-			var/lung_strength = "<span class='danger'>no</span>"
+	var/mob/living/carbon/carbon_patient = M
+	var/body_part = parse_zone(user.zone_selected)
 
-			var/obj/item/organ/heart/heart = M.getorganslot(ORGAN_SLOT_HEART)
-			var/obj/item/organ/lungs/lungs = M.getorganslot(ORGAN_SLOT_LUNGS)
+	var/heart_strength = "<span class='danger'>no</span>"
+	var/lung_strength = "<span class='danger'>no</span>"
 
-			if(!(M.stat == DEAD || (HAS_TRAIT(M, TRAIT_FAKEDEATH))))
-				if(heart && istype(heart))
-					heart_strength = "<span class='danger'>an unstable</span>"
-					if(heart.beating)
-						heart_strength = "a healthy"
-				if(lungs && istype(lungs))
-					lung_strength = "<span class='danger'>strained</span>"
-					if(!(M.failed_last_breath || M.losebreath))
-						lung_strength = "healthy"
+	var/obj/item/organ/heart/heart = carbon_patient.getorganslot(ORGAN_SLOT_HEART)
+	var/obj/item/organ/lungs/lungs = carbon_patient.getorganslot(ORGAN_SLOT_LUNGS)
 
-			var/diagnosis = (body_part == BODY_ZONE_CHEST ? "You hear [heart_strength] pulse and [lung_strength] respiration." : "You faintly hear [heart_strength] pulse.")
-			user.visible_message("<span class='notice'>[user] places [src] against [M]'s [body_part] and listens attentively.</span>", "<span class='notice'>You place [src] against [M]'s [body_part]. [diagnosis]</span>")
-			return
-	return ..(M,user)
+	if(carbon_patient.stat != DEAD && !(HAS_TRAIT(carbon_patient, TRAIT_FAKEDEATH)))
+		if(istype(heart))
+			heart_strength = (heart.beating ? "a healthy" : "<span class='danger'>an unstable</span>")
+		if(istype(lungs))
+			lung_strength = ((carbon_patient.failed_last_breath || carbon_patient.losebreath) ? "<span class='danger'>strained</span>" : "healthy")
+
+	user.visible_message("<span class='notice'>[user] places [src] against [carbon_patient]'s [body_part] and listens attentively.</span>", ignored_mobs = user)
+
+	var/diagnosis = (body_part == BODY_ZONE_CHEST ? "You hear [heart_strength] pulse and [lung_strength] respiration" : "You faintly hear [heart_strength] pulse")
+	if(!user.can_hear())
+		diagnosis = "Fat load of good it does you though, since you can't hear"
+
+	to_chat(user, "<span class='notice'>You place [src] against [carbon_patient]'s [body_part]. [diagnosis].</span>")
 
 ///////////
 //SCARVES//


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Wayyy back in #54164 I made it so blind people couldn't use chem scans to bring them in line with health scans. Having received feedback from some players who enjoy playing as blind characters but are locked out of basic tasks as doctors and engineers, I think it's better to allow the blind to use these scanners. Blindness is still a massive disability gameplay-wise, but at least those suffering from it can be a bit more self-sufficient and helpful to their crewmates on their own terms.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows players using blind characters to still perform basic job functions as doctors/engineers, providing more ways for them to interact with other crewmembers and carve out their own niche on the station.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
balance: In a landmark victory for NT's blind medical and engineering personnel, medical and atmospheric scanners have been equipped with hyper-braille support, allowing them to be used by those without eyesight!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
