### PR TITLE
makes slapping someone in the face more intuitive

### DIFF
--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -123,9 +123,14 @@
 			L.dna.species.stop_wagging_tail(M)
 	user.do_attack_animation(M)
 	playsound(M, 'sound/weapons/slap.ogg', 50, TRUE, -1)
-	user.visible_message("<span class='danger'>[user] slaps [M]!</span>",
-	"<span class='notice'>You slap [M]!</span>",\
-	"<span class='hear'>You hear a slap.</span>")
+	if(user.zone_selected == BODY_ZONE_HEAD || user.zone_selected == BODY_ZONE_PRECISE_MOUTH)
+		user.visible_message("<span class='danger'>[user] slaps [M] in the face!</span>",
+		"<span class='notice'>You slap [M] in the face!</span>",\
+		"<span class='hear'>You hear a slap.</span>")
+	else
+		user.visible_message("<span class='danger'>[user] slaps [M]!</span>",
+		"<span class='notice'>You slap [M]!</span>",\
+		"<span class='hear'>You hear a slap.</span>")
 	return
 
 /obj/item/slapper/attack_obj(obj/O, mob/living/user, params)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -242,16 +242,6 @@
  * or another carbon.
 */
 /mob/living/carbon/proc/disarm(mob/living/carbon/target)
-	if(zone_selected == BODY_ZONE_PRECISE_MOUTH)
-		var/target_on_help_and_unarmed = !target.combat_mode && !target.get_active_held_item()
-		if(target_on_help_and_unarmed || HAS_TRAIT(target, TRAIT_RESTRAINED))
-			do_slap_animation(target)
-			playsound(target.loc, 'sound/weapons/slap.ogg', 50, TRUE, -1)
-			visible_message("<span class='danger'>[src] slaps [target] in the face!</span>",
-				"<span class='notice'>You slap [target] in the face! </span>",\
-			"You hear a slap.")
-			target.dna?.species?.stop_wagging_tail(target)
-			return
 	do_attack_animation(target, ATTACK_EFFECT_DISARM)
 	playsound(target, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
 	if (ishuman(target))


### PR DESCRIPTION
## About The Pull Request

Attempting to right click with an empty hand on someone who is either restrained or both unarmed and not in combat mode while you are targeting the mouth zone will no longer result in you slapping them in the face instead of shoving them.

Using the dedicated slapper item (from the *slap emote) on someone while you are targeting either the mouth zone or the head zone will now result in you slapping them in the face instead of just generically slapping them.

## Why It's Good For The Game

Sweet mother of body zone and intent combinations, Batman!

This bit of code is entirely redundant with our already existing slapper item (that anyone can create using the *slap) emote, and is a relic of old intent code.

Also, someone, somewhere has probably accidentally slapped someone while trying to shove them and lost a fight because of that, and I feel bad for them.

## Changelog
:cl: ATHATH
refactor: Attempting to right click with an empty hand on someone who is either restrained or both unarmed and not in combat mode while you are targeting the mouth zone will no longer result in you slapping them in the face instead of shoving them.
refactor: Using the dedicated slapper item (from the *slap emote) on someone while you are targeting either the mouth zone or the head zone will now result in you slapping them in the face instead of just generically slapping them.
/:cl: