### PR TITLE
Fixes a few roulette wheel runtimes.

### DIFF
--- a/code/game/machinery/roulette_machine.dm
+++ b/code/game/machinery/roulette_machine.dm
@@ -71,7 +71,7 @@
 	data["IsAnchored"] = anchored
 	data["BetAmount"] = chosen_bet_amount
 	data["BetType"] = chosen_bet_type
-	data["HouseBalance"] = my_card?.registered_account ? my_card?.registered_account.account_balance : 0
+	data["HouseBalance"] = my_card?.registered_account?.account_balance || 0
 	data["LastSpin"] = last_spin
 	data["Spinning"] = playing
 

--- a/code/game/machinery/roulette_machine.dm
+++ b/code/game/machinery/roulette_machine.dm
@@ -71,16 +71,19 @@
 	data["IsAnchored"] = anchored
 	data["BetAmount"] = chosen_bet_amount
 	data["BetType"] = chosen_bet_type
-	data["HouseBalance"] = my_card?.registered_account.account_balance
+	data["HouseBalance"] = my_card?.registered_account ? my_card?.registered_account.account_balance : 0
 	data["LastSpin"] = last_spin
 	data["Spinning"] = playing
-	var/mob/living/carbon/human/H = user
-	var/obj/item/card/id/C = H.get_idcard(TRUE)
-	if(C)
-		data["AccountBalance"] = C.registered_account.account_balance
+
+
+	if(ishuman(user))
+		var/mob/living/carbon/human/human_user = user
+		var/obj/item/card/id/id_card = human_user.get_idcard(TRUE)
+		data["AccountBalance"] = id_card?.registered_account ? id_card.registered_account.account_balance : 0
+		data["CanUnbolt"] = (id_card == my_card)
 	else
 		data["AccountBalance"] = 0
-	data["CanUnbolt"] = (C == my_card)
+		data["CanUnbolt"] = FALSE
 
 	return data
 

--- a/code/game/machinery/roulette_machine.dm
+++ b/code/game/machinery/roulette_machine.dm
@@ -79,7 +79,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/human_user = user
 		var/obj/item/card/id/id_card = human_user.get_idcard(TRUE)
-		data["AccountBalance"] = id_card?.registered_account ? id_card.registered_account.account_balance : 0
+		data["AccountBalance"] = id_card?.registered_account?.account_balance || 0
 		data["CanUnbolt"] = (id_card == my_card)
 	else
 		data["AccountBalance"] = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Roulette wheel would runtime/bluescreen when an observer used it because of a naked cast of user to /mob/living/carbon/human
Roulette wheel would runtime/bluescreen when the ID card linked to it lost its registered account for any reason.
Roulette wheel would runtime/bluescreen when the user had an ID card that had no registered account.

Fixes all three of these runtimes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtimes bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The Roulette Wheel interface should no longer bluescreen for bank account-less ID cards and observers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
