### PR TITLE
remove input pass-through from statpanel and give focus to map instead

### DIFF
--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -288,53 +288,6 @@ if (!String.prototype.trim) {
   }, 0, 'test');
 }())
 
-// Browser passthrough code ---------------------------------------------------
-if (window.location) {
-	var anti_spam = []; // wow I wish I could use e.repeat but IE is dumb and doesn't have it.
-	document[addEventListenerKey]("keydown", function(e) {
-		if(e.target && (e.target.localName == "input" || e.target.localName == "textarea"))
-			return;
-		if(e.defaultPrevented)
-			return; // do e.preventDefault() to prevent this behavior.
-		if(e.which) {
-			if(!anti_spam[e.which]) {
-				anti_spam[e.which] = true;
-				var key = String.fromCharCode(e.which);
-				var x = event.x || event.clientX;
-				var y = event.y || event.clientY;
-				if(x || y ) // if either of these exist this is happening after a click
-					return;
-				window.location.href = "byond://winset?command=keyDown " + e.key;
-			}
-		}
-	});
-	document[addEventListenerKey]("keyup", function(e) {
-		if(e.target && (e.target.localName == "input" || e.target.localName == "textarea"))
-			return;
-		if(e.defaultPrevented)
-			return;
-		if(e.which) {
-			anti_spam[e.which] = false;
-			var key = String.fromCharCode(e.which);
-			var x = event.x || event.clientX;
-			var y = event.y || event.clientY;
-			if( x || y ) // if either of these exist this is happening after a click
-				return;
-
-			window.location.href = "byond://winset?command=keyUp " + e.key;
-		}
-	});
-}
-/* document.addEventListener("mousedown", function(e){
- var shiftPressed=0;
- var evt = e?e:window.event;
- shiftPressed=evt.shiftKey;
-  if (shiftPressed) {
-   return false;
-  }
- return true;
-}); */
-
 // Status panel implementation ------------------------------------------------
 var status_tab_parts = ["Loading..."];
 var current_tab = null;
@@ -1137,9 +1090,14 @@ function set_style_sheet(sheet) {
 	head.appendChild(sheetElement);
 }
 
-document[addEventListenerKey]("click", function(e) {
-	window.location.href = "byond://winset?map.focus=true";
-});
+function restoreFocus() {
+	setTimeout(function() {
+		window.location.href = "byond://winset?map.focus=true";
+	}, 0);
+}
+
+document[addEventListenerKey]("mouseup", restoreFocus);
+document[addEventListenerKey]("keyup", restoreFocus);
 
 if(!current_tab) {
 	addPermanentTab("Status");


### PR DESCRIPTION
## About The Pull Request
The input pass-through didn't work anyway, as it would pass through lower-case keys which our input code doesn't understand (unless you were holding shift or hadcaps lock on.) It also didn't translate arrow keys to NORTH, etc. which is how BYOND expects them.

If you double clicked on the stat panel it would eat all following input from you. If you happened to have caps lock on, you might not notice this because the correct WASD values get passed to BYOND. If you were then to stop walking while holding shift because you want to examine something, your key release would be sent to BYOND as _lowercase_, causing it to be ignored.

Under all of those conditions, your movement would get stuck in one direction. It's more likely than you think!!!

A similar chain of events could cause Alt releases to not be sent to BYOND due to this as well.

--

The fix is to just give back focus to the map similarly to how TGUI does it. It's not quite as majestic as TGUI, but it seems to have fine results.

## Why It's Good For The Game
Nobody likes sticky keys

## Changelog
:cl:
fix: Stat panel no longer captures input (potentially causing keys to get stuck down)
/:cl:
