### PR TITLE
Shorten april fools to 3 days

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -166,9 +166,10 @@
 
 /datum/holiday/april_fools
 	name = APRIL_FOOLS
-	begin_day = 1
-	end_day = 5
-	begin_month = APRIL
+	begin_month = MARCH
+	begin_day = 31
+	end_month = APRIL
+	end_day = 2
 
 /datum/holiday/april_fools/celebrate()
 	SSjob.set_overflow_role("Clown")


### PR DESCRIPTION
this way it covers all the timezones
## Changelog
:cl:
balance: april fools is now 3 days long, instead of 5
/:cl:
