### PR TITLE
Placing a fireman carried person onto a table no longer harms them

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -82,7 +82,7 @@
 			else
 				pushed_mob.visible_message("<span class='notice'>[user] begins to place [pushed_mob] onto [src]...</span>", \
 									"<span class='userdanger'>[user] begins to place [pushed_mob] onto [src]...</span>")
-				if(do_after(user, 35, target = pushed_mob))
+				if(do_after(user, 3.5 SECONDS, target = pushed_mob))
 					tableplace(user, pushed_mob)
 				else
 					return
@@ -210,7 +210,7 @@
 				"<span class='userdanger'>[user] begins to[skills_space] place [carried_mob] onto [src]...</span>")
 			if(do_after(user, tableplace_delay, target = carried_mob))
 				user.unbuckle_mob(carried_mob)
-				tablepush(user, carried_mob)
+				tableplace(user, carried_mob)
 		return TRUE
 
 	if(!user.combat_mode && !(I.item_flags & ABSTRACT))


### PR DESCRIPTION
## About The Pull Request

Previously, clicking on a table with a fireman carried person while not in combat mode would start a do_after(), then harmfully smash the person you fireman carrying into the table. This harmful smash has been replaced by your character merely placing the fireman carried person onto the table, like what happens when you click on a table while not in combat mode while you have someone in a grab. You can still click on a table with a fireman carried person while in combat mode to perform a limb smash, if you wish.

## Why It's Good For The Game

This call to tablepush() was almost certainly intended to be a call to tableplace(). The length of the do_after to perform it is the same as the length of the do_after() to place a grabbed person onto a table, the messages produced say that you're placing the person you're carrying onto the table (not smashing them into it), none of the other ways to smash people into tables (directly) use a do_after(), and clicking with combat mode on instead of with combat mode off calls tablelimbsmash(), which does more damage than tablepush() does (and isn't preceded by a do_after()).

## Changelog
:cl: ATHATH
fix: Clicking on a table with a fireman carried person while not in combat mode will no longer cause you to attempt to hurt them.
/:cl: