### PR TITLE
Adds proper logging to Holodeck safeties and programs

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -153,6 +153,8 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 			var/list/checked = program_cache.Copy()
 			if (obj_flags & EMAGGED)
 				checked |= emag_programs
+				log_game("[key_name(usr)] loaded a restricted Holodeck program: [program_to_load].")
+				message_admins("[ADMIN_LOOKUPFLW(usr)] loaded a restricted Holodeck program: [program_to_load].")
 			var/valid = FALSE //dont tell security about this
 
 			for (var/prog in checked)//checks if program_to_load is any one of the loadable programs, if it isnt then it rejects it
@@ -171,6 +173,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 			nerf(obj_flags & EMAGGED,FALSE)
 			obj_flags ^= EMAGGED
 			say("Safeties reset. Restarting...")
+			log_game("[key_name(usr)] disabled Holodeck safeties.")
 
 ///this is what makes the holodeck not spawn anything on broken tiles (space and non engine plating / non holofloors)
 /datum/map_template/holodeck/update_blacklist(turf/placement, list/input_blacklist)

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -153,8 +153,6 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 			var/list/checked = program_cache.Copy()
 			if (obj_flags & EMAGGED)
 				checked |= emag_programs
-				log_game("[key_name(usr)] loaded a restricted Holodeck program: [program_to_load].")
-				message_admins("[ADMIN_LOOKUPFLW(usr)] loaded a restricted Holodeck program: [program_to_load].")
 			var/valid = FALSE //dont tell security about this
 
 			for (var/prog in checked)//checks if program_to_load is any one of the loadable programs, if it isnt then it rejects it
@@ -229,6 +227,10 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 
 	template = SSmapping.holodeck_templates[map_id]
 	template.load(bottom_left) //this is what actually loads the holodeck simulation into the map
+
+	if(template.restricted)
+		log_game("[key_name(usr)] loaded a restricted Holodeck program: [program].")
+		message_admins("[ADMIN_LOOKUPFLW(usr)] loaded a restricted Holodeck program: [program].")
 
 	spawned = template.created_atoms //populate the spawned list with the atoms belonging to the holodeck
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I kept meaning to do this before but I also kept forgetting because ADHD

Players disabling the safeties on the holodeck is now logged to game.log. This was logged before for emagging but there wasn't actual logging for when a silicon did it by clicking the "Safeties" button, so that's there now. The game also now logs and prints to admin chat when someone picks one of the restricted programs and which program was picked.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Logging is never not good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Added proper logging for Holodeck misuse
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
