### PR TITLE
Failed headrevs become enemies of the state

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -719,9 +719,9 @@
 	var/count = 1
 	for(var/datum/objective/objective in objectives)
 		if(objective.check_completion())
-			objective_parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='greentext'>Success!</span>"
+			objective_parts += "<b>[objective.objective_name] #[count]</b>: [objective.explanation_text] <span class='greentext'>Success!</span>"
 		else
-			objective_parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
+			objective_parts += "<b>[objective.objective_name] #[count]</b>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
 		count++
 	return objective_parts.Join("<br>")
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -659,9 +659,8 @@
 /datum/mind/proc/announce_objectives()
 	var/obj_count = 1
 	to_chat(current, "<span class='notice'>Your current objectives:</span>")
-	for(var/objective in get_all_objectives())
-		var/datum/objective/O = objective
-		to_chat(current, "<B>Objective #[obj_count]</B>: [O.explanation_text]")
+	for(var/datum/objective/objective as anything in get_all_objectives())
+		to_chat(current, "<B>[objective.objective_name] #[obj_count]</B>: [objective.explanation_text]")
 		obj_count++
 
 /datum/mind/proc/find_syndicate_uplink()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -519,15 +519,14 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 
 /datum/objective/exile
 	name = "exile"
-	explanation_text = "Stay alive off station. Do not go to centcom."
+	explanation_text = "Stay alive off station. Do not go to CentCom."
 
 /datum/objective/exile/check_completion()
 	var/list/owners = get_owners()
 	for(var/datum/mind/mind as anything in owners)
-		if(!considered_alive(mind)) //dead
+		if(!considered_alive(mind))
 			return FALSE
-		var/mob/living/alive_current = mind.current
-		if(SSmapping.level_has_any_trait(alive_current.z, list(ZTRAIT_STATION, ZTRAIT_CENTCOM))) //went to centcom or ended round on station
+		if(SSmapping.level_has_any_trait(mind.current.z, list(ZTRAIT_STATION, ZTRAIT_CENTCOM))) //went to centcom or ended round on station
 			return FALSE
 	return TRUE
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -5,6 +5,8 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 	var/datum/team/team //An alternative to 'owner': a team. Use this when writing new code.
 	var/name = "generic objective" //Name for admin prompts
 	var/explanation_text = "Nothing" //What that person is supposed to do.
+	///name used in printing this objective (Objective #1)
+	var/objective_name = "Objective"
 	var/team_explanation_text //For when there are multiple owners.
 	var/datum/mind/target = null //If they are focused on a particular person.
 	var/target_amount = 0 //If they are focused on a particular number. Steal objectives have their own counter.
@@ -514,6 +516,20 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 		if(!istype(mindobj, /mob/living/silicon/robot) && !considered_alive(mindobj, FALSE)) //Shells (and normal borgs for that matter) are considered alive for Malf
 			return FALSE
 		return TRUE
+
+/datum/objective/exile
+	name = "exile"
+	explanation_text = "Stay alive off station. Do not go to centcom."
+
+/datum/objective/exile/check_completion()
+	var/list/owners = get_owners()
+	for(var/datum/mind/mind as anything in owners)
+		if(!considered_alive(mind)) //dead
+			return FALSE
+		var/mob/living/alive_current = mind.current
+		if(SSmapping.level_has_any_trait(alive_current.z, list(ZTRAIT_STATION, ZTRAIT_CENTCOM))) //went to centcom or ended round on station
+			return FALSE
+	return TRUE
 
 /datum/objective/martyr
 	name = "martyr"

--- a/code/modules/antagonists/revolution/enemy_of_the_revolution.dm
+++ b/code/modules/antagonists/revolution/enemy_of_the_revolution.dm
@@ -14,6 +14,7 @@
 	objectives += survive
 
 /datum/antagonist/enemy_of_the_revolution/on_gain()
+	//the state version of this antag has to sleep a tick, this doesn't because it's not replacing an old antag datum.
 	owner.special_role = "revolution enemy"
 	forge_objectives()
 	. = ..()

--- a/code/modules/antagonists/revolution/enemy_of_the_revolution.dm
+++ b/code/modules/antagonists/revolution/enemy_of_the_revolution.dm
@@ -1,0 +1,24 @@
+
+/**
+ * When the revolution wins, any remaining heads and security become Enemies of the Revolution.
+ * Previously being nonantagonists, they only have one simple objective: survive!
+ */
+/datum/antagonist/enemy_of_the_revolution
+	name = "Enemy of the Revolution"
+	show_in_antagpanel = FALSE
+
+/datum/antagonist/enemy_of_the_revolution/proc/forge_objectives()
+	var/datum/objective/survive/survive = new
+	survive.owner = owner
+	survive.explanation_text = "The station has been overrun by revolutionaries, stay alive until the end."
+	objectives += survive
+
+/datum/antagonist/enemy_of_the_revolution/on_gain()
+	owner.special_role = "revolution enemy"
+	forge_objectives()
+	. = ..()
+
+/datum/antagonist/enemy_of_the_revolution/greet()
+	to_chat(owner, "<span class='userdanger'>The station is lost.</span>")
+	to_chat(owner, "<b>As a surviving loyalist of the previous system, Your days are numbered.</b>")
+	owner.announce_objectives()

--- a/code/modules/antagonists/revolution/enemy_of_the_state.dm
+++ b/code/modules/antagonists/revolution/enemy_of_the_state.dm
@@ -22,6 +22,8 @@
 	objectives += hijack_choice
 
 /datum/antagonist/enemy_of_the_state/on_gain()
+	//needs to sleep for a tick so the old antag datum can begone before it announces objectives.
+	sleep(1)
 	owner.special_role = "exiled headrev"
 	forge_objectives()
 	. = ..()

--- a/code/modules/antagonists/revolution/enemy_of_the_state.dm
+++ b/code/modules/antagonists/revolution/enemy_of_the_state.dm
@@ -7,15 +7,15 @@
 
 /datum/antagonist/enemy_of_the_state/proc/forge_objectives()
 
-	var/datum/objective/exile/choice_1 = new
-	choice_1.owner = owner
-	choice_1.objective_name = "Choice"
-	objectives += choice_1
+	var/datum/objective/exile/exile_choice = new
+	exile_choice.owner = owner
+	exile_choice.objective_name = "Choice"
+	objectives += exile_choice
 
-	var/datum/objective/hijack/choice_2 = new
-	choice_2.owner = owner
-	choice_2.objective_name = "Choice"
-	objectives += choice_2
+	var/datum/objective/hijack/hijack_choice = new
+	hijack_choice.owner = owner
+	hijack_choice.objective_name = "Choice"
+	objectives += hijack_choice
 
 /datum/antagonist/enemy_of_the_state/on_gain()
 	forge_objectives()

--- a/code/modules/antagonists/revolution/enemy_of_the_state.dm
+++ b/code/modules/antagonists/revolution/enemy_of_the_state.dm
@@ -1,0 +1,61 @@
+
+/datum/antagonist/enemy_of_the_state
+	name = "enemy of the state"
+	show_in_antagpanel = FALSE
+	show_name_in_check_antagonists = TRUE
+	hijack_speed = 2 //not like they have much to do
+
+/datum/antagonist/enemy_of_the_state/proc/forge_objectives()
+
+	var/datum/objective/exile/choice_1 = new
+	choice_1.owner = owner
+	choice_1.objective_name = "Choice"
+	objectives += choice_1
+
+	var/datum/objective/hijack/choice_2 = new
+	choice_2.owner = owner
+	choice_2.objective_name = "Choice"
+	objectives += choice_2
+
+/datum/antagonist/enemy_of_the_state/on_gain()
+	forge_objectives()
+	. = ..()
+
+/datum/antagonist/enemy_of_the_state/greet()
+	to_chat(owner, "<span class='userdanger'>The revolution is dead.</span>")
+	to_chat(owner, "<span class='boldannounce'>You're an enemy of the state to Nanotrasen. You're a loose end to the Syndicate.</span>")
+	to_chat(owner, "<b>It's time to live out your days as an exile... or go out in one last big bang.</b>")
+	owner.announce_objectives()
+
+/datum/antagonist/enemy_of_the_state/roundend_report()
+	var/list/report = list()
+
+	if(!owner)
+		CRASH("Antagonist datum without owner")
+
+	report += printplayer(owner)
+
+	//needs to complete only one objective, not all
+
+	var/option_chosen = FALSE
+	var/badass = FALSE
+	if(objectives.len)
+		report += printobjectives(objectives)
+		for(var/datum/objective/objective in objectives)
+			if(objective.check_completion())
+				option_chosen = TRUE
+				if(istype(objective, /datum/objective/hijack))
+					badass = TRUE
+				break
+
+	if(objectives.len == 0 || option_chosen)
+		if(badass)
+			report += "<span class='greentext big'>Major [name] Victory</span>"
+			report += "<B>[name] chose the badass option, and hijacked the shuttle!</B>"
+		else
+			report += "<span class='greentext big'>Minor [name] Victory</span>"
+			report += "<B>[name] has survived as an exile!</B>"
+	else
+		report += "<span class='redtext big'>The [name] has failed!</span>"
+
+	return report.Join("<br>")

--- a/code/modules/antagonists/revolution/enemy_of_the_state.dm
+++ b/code/modules/antagonists/revolution/enemy_of_the_state.dm
@@ -1,6 +1,10 @@
 
+/**
+ * When the station wins, any remaining living headrevs become Enemies of the State, a small solo antagonist.
+ * They either have the choice to fuck off and do their own thing, or try and regain their honor with a hijack.
+ */
 /datum/antagonist/enemy_of_the_state
-	name = "enemy of the state"
+	name = "Enemy of the State"
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
 	hijack_speed = 2 //not like they have much to do
@@ -18,6 +22,7 @@
 	objectives += hijack_choice
 
 /datum/antagonist/enemy_of_the_state/on_gain()
+	owner.special_role = "exiled headrev"
 	forge_objectives()
 	. = ..()
 

--- a/code/modules/antagonists/revolution/enemy_of_the_state.dm
+++ b/code/modules/antagonists/revolution/enemy_of_the_state.dm
@@ -22,8 +22,6 @@
 	objectives += hijack_choice
 
 /datum/antagonist/enemy_of_the_state/on_gain()
-	//needs to sleep for a tick so the old antag datum can begone before it announces objectives.
-	sleep(1)
 	owner.special_role = "exiled headrev"
 	forge_objectives()
 	. = ..()

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -231,13 +231,10 @@
 		to_chat(owner, "<span class='userdanger'>The frame's firmware detects and deletes your neural reprogramming! You remember nothing but the name of the one who flashed you.</span>")
 
 /datum/antagonist/rev/head/farewell()
-	if (announce_victorious())
+	if (announce_victorious() || deconversion_reason == DECONVERTER_STATION_WIN)
 		return
-
 	if((ishuman(owner.current)))
 		if(owner.current.stat != DEAD)
-			if(deconversion_reason == DECONVERTER_STATION_WIN)
-				return //don't show deconversion messages, you're still an antagonist (just a new one)
 			owner.current.visible_message("<span class='deconversion_message'>[owner.current] looks like [owner.current.p_theyve()] just remembered [owner.current.p_their()] real allegiance!</span>", null, null, null, owner.current)
 			to_chat(owner, "<span class ='deconversion_message bold'>You have given up your cause of overthrowing the command staff. You are no longer a Head Revolutionary.</span>")
 		else

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -396,8 +396,12 @@
 		for (var/_rev_head_mind in ex_revs)
 			var/datum/mind/rev_head_mind = _rev_head_mind
 			var/mob/living/carbon/rev_head_body = rev_head_mind.current
-			if(istype(rev_head_body) && rev_head_body.stat == DEAD)
+			if(!istype(rev_head_body))
+				continue
+			if(rev_head_body.stat == DEAD)
 				rev_head_body.makeUncloneable()
+			else
+				rev_head_mind.add_antag_datum(/datum/antagonist/enemy_of_the_state)
 
 		priority_announce("It appears the mutiny has been quelled. Please return yourself and your incapacitated colleagues to work. \
 		We have remotely blacklisted the head revolutionaries in your medical records to prevent accidental revival.", null, null, null, "Central Command Loyalty Monitoring Division")

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -259,11 +259,14 @@
 	owner.remove_antag_datum(type)
 
 /datum/antagonist/rev/head/remove_revolutionary(borged, deconverter)
+	var/re_antag = FALSE
+	var/datum/mind/old_owner = owner //owner gets nulled when rev antag removed
 	if(borged || deconverter == DECONVERTER_STATION_WIN || deconverter == DECONVERTER_REVS_WIN)
 		if(owner.current.stat != DEAD && deconverter == DECONVERTER_STATION_WIN)
-			owner.add_antag_datum(/datum/antagonist/enemy_of_the_state)
+			re_antag = TRUE
 		. = ..()
-
+		if(re_antag)
+			old_owner.add_antag_datum(/datum/antagonist/enemy_of_the_state) //needs to be post ..() so old antag status is cleaned up
 /datum/antagonist/rev/head/equip_rev()
 	var/mob/living/carbon/C = owner.current
 	if(!ishuman(C))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1716,6 +1716,7 @@
 #include "code\modules\antagonists\revenant\revenant_antag.dm"
 #include "code\modules\antagonists\revenant\revenant_blight.dm"
 #include "code\modules\antagonists\revenant\revenant_spawn_event.dm"
+#include "code\modules\antagonists\revolution\enemy_of_the_state.dm"
 #include "code\modules\antagonists\revolution\revolution.dm"
 #include "code\modules\antagonists\santa\santa.dm"
 #include "code\modules\antagonists\separatist\separatist.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1716,6 +1716,7 @@
 #include "code\modules\antagonists\revenant\revenant_antag.dm"
 #include "code\modules\antagonists\revenant\revenant_blight.dm"
 #include "code\modules\antagonists\revenant\revenant_spawn_event.dm"
+#include "code\modules\antagonists\revolution\enemy_of_the_revolution.dm"
 #include "code\modules\antagonists\revolution\enemy_of_the_state.dm"
 #include "code\modules\antagonists\revolution\revolution.dm"
 #include "code\modules\antagonists\santa\santa.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Headrevs now gain a solo antagonist status if they are exiled instead of killed in a failed revolution. They have two objectives that conflict with eachother: exile (survive off zlevel and don't go to centcom) and hijack (steal the shuttle). They must pick one to be considered victorious.

## Why It's Good For The Game

Right now: Revolution ends, all revs are deantagged, exiled headrevs are now nonantagonists?? Admin headache because this headrev is not an antag but still facing the conseqences of being one

With this change: Revolution ends, exiled headrevs become enemies of the state. they have two options. Live it out off station as an exile, or one last big bang. Show Nanotrasen. Maybe the syndicate won't kill you with such a badass display of power?

## Changelog
:cl:
add: Headrevs become enemies of the state when the revolution is over!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
