### PR TITLE
Sets April Fools to last for a week, codewise.

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -166,10 +166,9 @@
 
 /datum/holiday/april_fools
 	name = APRIL_FOOLS
-	begin_month = MARCH
-	begin_day = 31
-	end_month = APRIL
-	end_day = 2
+	begin_day = 1
+	end_day = 5
+	begin_month = APRIL
 
 /datum/holiday/april_fools/celebrate()
 	SSjob.set_overflow_role("Clown")


### PR DESCRIPTION
April Fools lasting a week is perfectly fine.

**_Provided that we curate the stuff that shows up during the april fools event to low impact stuff, ie. rainbow tiles._**

### If you have a problem with a specific april fools thing, change the specific april fools thing, because by reducing the time to account for more intrusive april fools changes, we're missing the point of the april fools event.

We should instead change stuff to be less intrusive instead of reducing how long it is around for.

The april fools event itself is fine.