### PR TITLE
Tweak - minerals.dm - Added Bananium into the mineral generation.

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -180,11 +180,11 @@
 		/obj/item/stack/ore/silver = 12, /obj/item/stack/ore/plasma = 20, /obj/item/stack/ore/iron = 40, /obj/item/stack/ore/titanium = 11,
 		/turf/closed/mineral/gibtonite = 4, /obj/item/stack/ore/bluespace_crystal = 1)
 		//Currently, Adamantine won't spawn as it has no uses. -Durandan
-	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
-		mineralSpawnChanceList[/obj/item/stack/ore/bananium] = 3
 	var/mineralChance = 13
 
 /turf/closed/mineral/random/Initialize()
+	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
+		mineralSpawnChanceList[/obj/item/stack/ore/bananium] = 3
 
 	mineralSpawnChanceList = typelist("mineralSpawnChanceList", mineralSpawnChanceList)
 

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -180,6 +180,8 @@
 		/obj/item/stack/ore/silver = 12, /obj/item/stack/ore/plasma = 20, /obj/item/stack/ore/iron = 40, /obj/item/stack/ore/titanium = 11,
 		/turf/closed/mineral/gibtonite = 4, /obj/item/stack/ore/bluespace_crystal = 1)
 		//Currently, Adamantine won't spawn as it has no uses. -Durandan
+	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
+		mineralSpawnChanceList[/obj/item/stack/ore/bananium] = 3
 	var/mineralChance = 13
 
 /turf/closed/mineral/random/Initialize()


### PR DESCRIPTION
## About The Pull Request

...during April Fools.

## Why It's Good For The Game

A fun little prank on april fools. Low impact, rewards doing your job, provides inter-departmental cooperation during funny week.

:cl: 
fix: Fixes a material not spawning on lavaland during April Fools. (Honk related)
/:cl: