### PR TITLE
Fixes Shaft miner and QM access on IceBox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -11144,8 +11144,8 @@
 /area/hallway/secondary/entry)
 "aXM" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Warehouse Maintenance";
-	req_access_txt = "31"
+	name = "Quartermaster Office Maintenance";
+	req_access_txt = "41"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -39420,7 +39420,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office";
-	req_one_access_txt = "31,48"
+	req_one_access_txt = "31;48"
 	},
 /obj/machinery/navbeacon/wayfinding,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{


### PR DESCRIPTION
## About The Pull Request

Quartermaster's office maint door was still the cargo warehouse, meaning it was tied to Cargo tech access rather than Quartermaster. The front door to Cargo required Cargo bay access, which miners dont get. This fixes both of those problems.
This has been a problem for a while and I didn't see any PRs fixing it, so I downloaded StrongDMM to fix it myself.

## Why It's Good For The Game

Cargo techs shouldnt have access to QM's office, and Shaft miners should be able to get to their workplace.

## Changelog
:cl: John Willard
fix: Shaft Miners can now enter Cargo on IceBox, and Cargo techs can no longer enter the QM's office through maintenance.
/:cl:
