### PR TITLE
stations name their respective celestial bodies

### DIFF
--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -54,7 +54,7 @@
 			"additional_cqc_areas": ["/area/service/kitchen/diner"]
 		},
 		"captain": {
-			"special_charter": 1
+			"special_charter": "moon"
 		}
 	}
 }

--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -52,6 +52,9 @@
 		},
 		"cook": {
 			"additional_cqc_areas": ["/area/service/kitchen/diner"]
+		},
+		"captain": {
+			"planet_charter": true
 		}
 	}
 }

--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -54,7 +54,7 @@
 			"additional_cqc_areas": ["/area/service/kitchen/diner"]
 		},
 		"captain": {
-			"planet_charter": true
+			"special_charter": 1
 		}
 	}
 }

--- a/_maps/kilostation.json
+++ b/_maps/kilostation.json
@@ -13,6 +13,9 @@
 	"job_changes": {
 		"cook": {
 			"additional_cqc_areas": ["/area/service/bar/atrium"]
+		},
+		"captain": {
+			"special_charter": 2
 		}
 	}
 }

--- a/_maps/kilostation.json
+++ b/_maps/kilostation.json
@@ -15,7 +15,7 @@
 			"additional_cqc_areas": ["/area/service/bar/atrium"]
 		},
 		"captain": {
-			"special_charter": 2
+			"special_charter": "asteroid"
 		}
 	}
 }

--- a/_maps/tramstation.json
+++ b/_maps/tramstation.json
@@ -26,7 +26,7 @@
 			"additional_cqc_areas": ["/area/service/kitchen/diner"]
 		},
 		"captain": {
-			"special_charter": 2
+			"special_charter": "asteroid"
 		}
 	}
 }

--- a/_maps/tramstation.json
+++ b/_maps/tramstation.json
@@ -24,6 +24,9 @@
 	"job_changes": {
 		"cook": {
 			"additional_cqc_areas": ["/area/service/kitchen/diner"]
+		},
+		"captain": {
+			"special_charter": 2
 		}
 	}
 }

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -124,8 +124,8 @@ require only minor tweaks.
 
 ///Captain charter defines, decides what kind of charter the cap spawns with on what map. no json setting = default station charter
 ///cap names the moon
-#define CAPTAIN_MOON_CHARTER 1
+#define CAPTAIN_MOON_CHARTER "moon"
 ///cap names the asteroid
-#define CAPTAIN_ASTEROID_CHARTER 2
+#define CAPTAIN_ASTEROID_CHARTER "asteroid"
 ///cap names the planet (unused, planned for planetstation)
-#define CAPTAIN_PLANET_CHARTER 3
+#define CAPTAIN_PLANET_CHARTER "planet"

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -121,11 +121,3 @@ require only minor tweaks.
 #define BIOME_LOWMEDIUM_HUMIDITY "lowmedium_humidity"
 #define BIOME_HIGHMEDIUM_HUMIDITY "highmedium_humidity"
 #define BIOME_HIGH_HUMIDITY "high_humidity"
-
-///Captain charter defines, decides what kind of charter the cap spawns with on what map. no json setting = default station charter
-///cap names the moon
-#define CAPTAIN_MOON_CHARTER "moon"
-///cap names the asteroid
-#define CAPTAIN_ASTEROID_CHARTER "asteroid"
-///cap names the planet (unused, planned for planetstation)
-#define CAPTAIN_PLANET_CHARTER "planet"

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -121,3 +121,11 @@ require only minor tweaks.
 #define BIOME_LOWMEDIUM_HUMIDITY "lowmedium_humidity"
 #define BIOME_HIGHMEDIUM_HUMIDITY "highmedium_humidity"
 #define BIOME_HIGH_HUMIDITY "high_humidity"
+
+///Captain charter defines, decides what kind of charter the cap spawns with on what map. no json setting = default station charter
+///cap names the moon
+#define CAPTAIN_MOON_CHARTER 1
+///cap names the asteroid
+#define CAPTAIN_ASTEROID_CHARTER 2
+///cap names the planet (unused, planned for planetstation)
+#define CAPTAIN_PLANET_CHARTER 3

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -106,13 +106,9 @@
 	inhand_icon_state = "banner"
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/banners_righthand.dmi'
-	desc = "A cunning device used to claim ownership of planets."
+	desc = "A cunning device used to claim ownership of celestial bodies."
 	w_class = WEIGHT_CLASS_HUGE
 	force = 15
-
-/obj/item/station_charter/banner/Initialize()
-	. = ..()
-	desc = "A cunning device used to claim ownership of [name_type]s."
 
 /obj/item/station_charter/banner/rename_station(designation, uname, ureal_name, ukey)
 	set_station_name(designation)
@@ -123,11 +119,5 @@
 	SSblackbox.record_feedback("text", "station_renames", 1, "[station_name()]")
 	if(!unlimited_uses)
 		used = TRUE
-
-/obj/item/station_charter/banner/moon
-	name_type = "moon"
-
-/obj/item/station_charter/banner/asteroid
-	name_type = "asteroid"
 
 #undef STATION_RENAME_TIME_LIMIT

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -98,7 +98,7 @@
 	ignores_timeout = TRUE
 
 
-/obj/item/station_charter/flag
+/obj/item/station_charter/banner
 	name = "\improper Nanotrasen banner"
 	icon = 'icons/obj/banner.dmi'
 	name_type = "planet"
@@ -107,17 +107,27 @@
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/banners_righthand.dmi'
 	desc = "A cunning device used to claim ownership of planets."
-	w_class = 5
+	w_class = WEIGHT_CLASS_HUGE
 	force = 15
 
-/obj/item/station_charter/flag/rename_station(designation, uname, ureal_name, ukey)
+/obj/item/station_charter/banner/Initialize()
+	. = ..()
+	desc = "A cunning device used to claim ownership of [name_type]s."
+
+/obj/item/station_charter/banner/rename_station(designation, uname, ureal_name, ukey)
 	set_station_name(designation)
-	minor_announce("[ureal_name] has designated the planet as [station_name()]", "Captain's Banner", 0)
-	log_game("[ukey] has renamed the planet as [station_name()].")
+	minor_announce("[ureal_name] has designated the [name_type] as [station_name()]", "Captain's Banner", 0)
+	log_game("[ukey] has renamed the [name_type] as [station_name()].")
 	name = "banner of [station_name()]"
 	desc = "The banner bears the official coat of arms of Nanotrasen, signifying that [station_name()] has been claimed by Captain [uname] in the name of the company."
 	SSblackbox.record_feedback("text", "station_renames", 1, "[station_name()]")
 	if(!unlimited_uses)
 		used = TRUE
+
+/obj/item/station_charter/banner/moon
+	name_type = "moon"
+
+/obj/item/station_charter/banner/asteroid
+	name_type = "asteroid"
 
 #undef STATION_RENAME_TIME_LIMIT

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -71,7 +71,7 @@
 	var/special_charter = captain_changes["special_charter"]
 	if(!special_charter)
 		return
-	backpack_contents = list(/obj/item/melee/classic_baton/telescopic = 1) //removes normal charter
+	backpack_contents.Remove(/obj/item/station_charter)
 	switch(special_charter)
 		if(CAPTAIN_MOON_CHARTER)
 			l_hand = /obj/item/station_charter/banner/moon

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -59,6 +59,20 @@
 
 	id_trim = /datum/id_trim/job/captain
 
+/datum/outfit/job/captain/pre_equip(mob/living/carbon/human/H, visualsOnly)
+	. = ..()
+	SSmapping.HACK_LoadMapConfig()
+	var/list/job_changes = SSmapping.config.job_changes
+	if(!length(job_changes))
+		return
+	var/list/captain_changes = job_changes["captain"]
+	if(!length(captain_changes))
+		return
+	var/planet_charter = captain_changes["planet_charter"]
+	if(!planet_charter)
+		return
+	backpack_contents = list(/obj/item/melee/classic_baton/telescopic = 1, /obj/item/station_charter/flag = 1)
+
 /datum/outfit/job/captain/hardsuit
 	name = "Captain (Hardsuit)"
 

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -58,6 +58,7 @@
 	chameleon_extras = list(/obj/item/gun/energy/e_gun, /obj/item/stamp/captain)
 
 	id_trim = /datum/id_trim/job/captain
+	var/special_charter
 
 /datum/outfit/job/captain/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()
@@ -68,19 +69,18 @@
 	var/list/captain_changes = job_changes["captain"]
 	if(!length(captain_changes))
 		return
-	var/special_charter = captain_changes["special_charter"]
+	special_charter = captain_changes["special_charter"]
 	if(!special_charter)
 		return
 	backpack_contents.Remove(/obj/item/station_charter)
-	switch(special_charter)
-		if(CAPTAIN_MOON_CHARTER)
-			l_hand = /obj/item/station_charter/banner/moon
-		if(CAPTAIN_ASTEROID_CHARTER)
-			l_hand = /obj/item/station_charter/banner/asteroid
-		if(CAPTAIN_PLANET_CHARTER)
-			l_hand = /obj/item/station_charter/banner
-		else
-			stack_trace("WARNING: this map file's JSON has an incorrect \"special_charter\" value for the captain job! (special_charter = [special_charter])")
+	l_hand = /obj/item/station_charter/banner
+
+/datum/outfit/job/captain/post_equip(mob/living/carbon/human/equipped, visualsOnly)
+	. = ..()
+	var/obj/item/station_charter/banner/celestial_charter = equipped.held_items[LEFT_HANDS]
+	if(!celestial_charter)
+		return
+	celestial_charter.name_type = special_charter
 
 /datum/outfit/job/captain/hardsuit
 	name = "Captain (Hardsuit)"

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -68,10 +68,19 @@
 	var/list/captain_changes = job_changes["captain"]
 	if(!length(captain_changes))
 		return
-	var/planet_charter = captain_changes["planet_charter"]
-	if(!planet_charter)
+	var/special_charter = captain_changes["special_charter"]
+	if(!special_charter)
 		return
-	backpack_contents = list(/obj/item/melee/classic_baton/telescopic = 1, /obj/item/station_charter/flag = 1)
+	backpack_contents = list(/obj/item/melee/classic_baton/telescopic = 1) //removes normal charter
+	switch(special_charter)
+		if(CAPTAIN_MOON_CHARTER)
+			l_hand = /obj/item/station_charter/banner/moon
+		if(CAPTAIN_ASTEROID_CHARTER)
+			l_hand = /obj/item/station_charter/banner/asteroid
+		if(CAPTAIN_PLANET_CHARTER)
+			l_hand = /obj/item/station_charter/banner
+		else
+			stack_trace("WARNING: this map file's JSON has an incorrect \"special_charter\" value for the captain job! (special_charter = [special_charter])")
 
 /datum/outfit/job/captain/hardsuit
 	name = "Captain (Hardsuit)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

on icebox, captain gets a nanotrasen banner instead of a normal charter and he can choose the name of the entire moon. asteroid stations get the same deal with their asteroid

## Why It's Good For The Game

well that's why it's supposed to be in the game after all!

## Changelog
:cl:
qol: captains name their respective celestial bodies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
