### PR TITLE
Armless people can no longer buckle people

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -251,7 +251,7 @@
 
 	if(iscarbon(user))
 		var/mob/living/carbon/carbon_user = user
-		if(carbon_user.num_hands <= 0)
+		if(carbon_user.usable_hands <= 0)
 			return FALSE
 
 	// In buckling even possible in the first place?

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -249,6 +249,11 @@
 	if(!Adjacent(user) || !Adjacent(target) || !isturf(user.loc) || user.incapacitated() || target.anchored)
 		return FALSE
 
+	if(iscarbon(user))
+		var/mob/living/carbon/carbon_user = user
+		if(carbon_user.num_hands <= 0)
+			return FALSE
+
 	// In buckling even possible in the first place?
 	if(!is_buckle_possible(target, FALSE, check_loc))
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/53257

Disallows armless people from buckling others
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Surely people with no arms don't have the dexterity to buckle someone to a chair
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Armless people can no longer buckle others
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
