### PR TITLE
Pacifists can no longer swat bugs

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -737,7 +737,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 				to_chat(user, "<span class='warning'>You easily splat [target].</span>")
 				if(isliving(target))
 					var/mob/living/bug = target
-					bug.death(1)
+					bug.gib()
 				else
 					qdel(target)
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -735,7 +735,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			if(!HAS_TRAIT(user, TRAIT_PACIFISM))
 				new /obj/effect/decal/cleanable/insectguts(target.drop_location())
 				to_chat(user, "<span class='warning'>You easily splat [target].</span>")
-				if(istype(target, /mob/living/))
+				if(isliving(target))
 					var/mob/living/bug = target
 					bug.death(1)
 				else

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -732,13 +732,14 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	. = ..()
 	if(proximity_flag)
 		if(is_type_in_typecache(target, strong_against))
-			new /obj/effect/decal/cleanable/insectguts(target.drop_location())
-			to_chat(user, "<span class='warning'>You easily splat the [target].</span>")
-			if(istype(target, /mob/living/))
-				var/mob/living/bug = target
-				bug.death(1)
-			else
-				qdel(target)
+			if(!HAS_TRAIT(user, TRAIT_PACIFISM))
+				new /obj/effect/decal/cleanable/insectguts(target.drop_location())
+				to_chat(user, "<span class='warning'>You easily splat [target].</span>")
+				if(istype(target, /mob/living/))
+					var/mob/living/bug = target
+					bug.death(1)
+				else
+					qdel(target)
 
 /obj/item/proc/can_trigger_gun(mob/living/user)
 	if(!user.can_use_guns(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## About The Pull Request
Adds a pacifism check to killing bugs with fly swatters, and incidentally removes an extra "the" from the swatting message
Fixes #49291
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a bug by protecting other bugs
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Pacifists are no longer able to kill bugs with flyswatters. Bugs have feelings too!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
