### PR TITLE
Fixes multiple issues related to suicides

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -39,9 +39,9 @@
 		user.visible_message("<span class='suicide'>[user]'s [src] receives a signal, killing [user.p_them()] instantly!</span>")
 	else
 		user.visible_message("<span class='suicide'>[user]'s [src] receives a signal and [user.p_they()] die[user.p_s()] like a gamer!</span>")
+	user.set_suicide(TRUE)
 	user.adjustOxyLoss(200)//it sends an electrical pulse to their heart, killing them. or something.
 	user.death(0)
-	user.set_suicide(TRUE)
 	user.suicide_log()
 	playsound(user, 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
 	qdel(src)

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -32,6 +32,9 @@
 	if(!canSuicide())
 		return
 	if(confirm == "Yes")
+		if(suiciding)
+			to_chat(src, "<span class='warning'>You're already trying to commit suicide!</span>")
+			return
 		set_suicide(TRUE) //need to be called before calling suicide_act as fuck knows what suicide_act will do with your suicider
 		var/obj/item/held_item = get_active_held_item()
 		if(held_item)

--- a/code/modules/vehicles/vehicle_key.dm
+++ b/code/modules/vehicles/vehicle_key.dm
@@ -57,8 +57,6 @@
 
 /obj/item/key/proc/manual_suicide(mob/living/user)
 	if(user)
-		if(!user.suiciding)
-			user.suiciding = TRUE
 		user.remove_atom_colour(ADMIN_COLOUR_PRIORITY)
 		user.visible_message("<span class='suicide'>[user] forgot [user.p_they()] isn't actually a janicart! That's a paddlin'!</span>")
 		if(user.mind?.get_skill_level(/datum/skill/cleaning) >= SKILL_LEVEL_LEGENDARY) //Janny janny janny janny janny

--- a/code/modules/vehicles/vehicle_key.dm
+++ b/code/modules/vehicles/vehicle_key.dm
@@ -57,6 +57,8 @@
 
 /obj/item/key/proc/manual_suicide(mob/living/user)
 	if(user)
+		if(!user.suiciding)
+			user.suiciding = TRUE
 		user.remove_atom_colour(ADMIN_COLOUR_PRIORITY)
 		user.visible_message("<span class='suicide'>[user] forgot [user.p_they()] isn't actually a janicart! That's a paddlin'!</span>")
 		if(user.mind?.get_skill_level(/datum/skill/cleaning) >= SKILL_LEVEL_LEGENDARY) //Janny janny janny janny janny


### PR DESCRIPTION
## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/58171
fixes https://github.com/tgstation/tgstation/issues/58151
fixes https://github.com/tgstation/tgstation/issues/55777

## Why It's Good For The Game
Puts a restriction on suicides to create more sane conditions, preventing unpredictable and unintended behavior.


## Changelog
:cl:
fix: Suicidal ethereals are less likely to fail to kill themselves from unexpected revivals trapping them
del: You can no longer attempt to commit suicide multiple times at once.
/:cl: