### PR TITLE
Venus human traps no longer take cold damage

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -113,8 +113,7 @@
 	attacked_sound = 'sound/creatures/venus_trap_hurt.ogg'
 	deathsound = 'sound/creatures/venus_trap_death.ogg'
 	attack_sound = 'sound/creatures/venus_trap_hit.ogg'
-	unsuitable_cold_damage = 5
-	unsuitable_heat_damage = 10
+	unsuitable_heat_damage = 5 //note that venus human traps do not take cold damage, only heat damage- this is because space vines can cause hull breaches
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 0
 	/// copied over from the code from eyeballs (the mob) to make it easier for venus human traps to see in kudzu that doesn't have the transparency mutation


### PR DESCRIPTION
## About The Pull Request

Partially reverts https://github.com/tgstation/tgstation/pull/56565.

Venus human traps no longer take damage from being in a cold environment.

Venus human traps now take twice as long to die from being in a hot environment.

## Why It's Good For The Game

This is the current state of venus human trap gameplay: https://www.youtube.com/watch?v=8l9jI0-jNGc.

Venus human traps should not be heat seeking missiles that have an average lifespan of a few seconds.

## Changelog
:cl: ATHATH
balance: Venus human traps no longer take damage from being in a cold environment.
balance: Venus human traps now take twice as long to die from being in a hot environment.
/:cl: