### PR TITLE
Teensy tiny improvements for freerunning

### DIFF
--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -56,12 +56,14 @@
 	user.visible_message("<span class='warning'>[user] starts climbing onto [climbed_thing].</span>", \
 								"<span class='notice'>You start climbing onto [climbed_thing]...</span>")
 	var/adjusted_climb_time = climb_time
+	var/adjusted_climb_stun = climb_stun
 	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED)) //climbing takes twice as long without help from the hands.
 		adjusted_climb_time *= 2
 	if(isalien(user))
 		adjusted_climb_time *= 0.25 //aliens are terrifyingly fast
 	if(HAS_TRAIT(user, TRAIT_FREERUNNING)) //do you have any idea how fast I am???
 		adjusted_climb_time *= 0.8
+		adjusted_climb_stun *= 0.8
 	LAZYADDASSOCLIST(current_climbers, climbed_thing, user)
 	if(do_after(user, adjusted_climb_time, climbed_thing))
 		if(QDELETED(climbed_thing)) //Checking if structure has been destroyed
@@ -70,8 +72,8 @@
 			user.visible_message("<span class='warning'>[user] climbs onto [climbed_thing].</span>", \
 								"<span class='notice'>You climb onto [climbed_thing].</span>")
 			log_combat(user, climbed_thing, "climbed onto")
-			if(climb_stun)
-				user.Stun(climb_stun)
+			if(adjusted_climb_stun)
+				user.Stun(adjusted_climb_stun)
 		else
 			to_chat(user, "<span class='warning'>You fail to climb onto [climbed_thing].</span>")
 	LAZYREMOVEASSOC(current_climbers, climbed_thing, user)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -47,7 +47,7 @@
 		return ..()
 	visible_message("<span class='danger'>[src] makes a hard landing on [T] but remains unharmed from the fall.</span>", \
 					"<span class='userdanger'>You brace for the fall. You make a hard landing on [T] but remain unharmed.</span>")
-	Knockdown(levels * 50)
+	Knockdown(levels * 40)
 
 /mob/living/carbon/human/prepare_data_huds()
 	//Update med hud images...


### PR DESCRIPTION
## About The Pull Request

Since climb_time is multiplied by 0.8, climb_stun should also be. Not much point in taking it if whoever is chasing you can still arrive with you *stunned* on the table and simply pull you off it. If this is too much taken off in total, in my opinion, the stun time should be adjusted, rather than the climb time.
Also reduces the ZImpactDamage knockdown multiplier. Right now both with freerunning and without you get knocked down the same amount, now with it you're actually better at catching yourself on those z level falls and so suffer less of a knockdown.

I also don't know what to put the changelog to, some admin should either change it themselves or tell me before they merge it what it should be.

## Why It's Good For The Game

Because it makes sense for these changes to be added. And also because freerunning right now does basically fuck all, and it seems like it should be doing more. Only two things, and both of those things make basically no difference, so I want it to make a slightly bigger difference.

## Changelog
:cl:
balance: adds a stun time modifier (reducing the stun) to climbing tables for the freerunning quirk, and reduces the knockdown penalty for the freerunning falling down z levels
/:cl: