### PR TITLE
Remove Uncross() and CheckExit(), add connect_loc element to cover the cases we used it for

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -358,18 +358,12 @@
 #define COMSIG_MOVABLE_CROSS "movable_cross"
 ///from base of atom/movable/Crossed(): (/atom/movable)
 #define COMSIG_MOVABLE_CROSSED "movable_crossed"
-///from base of atom/movable/Uncross(): (/atom/movable)
-#define COMSIG_MOVABLE_UNCROSS "movable_uncross"
-	#define COMPONENT_MOVABLE_BLOCK_UNCROSS (1<<0)
 ///from base of atom/movable/Uncrossed(): (/atom/movable)
 #define COMSIG_MOVABLE_UNCROSSED "movable_uncrossed"
 ///from base of atom/movable/Cross(): (/atom/movable)
 #define COMSIG_MOVABLE_CROSS_OVER "movable_cross_am"
 ///from base of atom/movable/Crossed(): (/atom/movable)
 #define COMSIG_MOVABLE_CROSSED_OVER "movable_crossed_am"
-///from base of atom/movable/Uncross(): (/atom/movable)
-#define COMSIG_MOVABLE_UNCROSS_OVER "movable_uncross_am"
-	#define COMPONENT_MOVABLE_BLOCK_UNCROSS_OVER (1<<0)
 ///from base of atom/movable/Uncrossed(): (/atom/movable)
 #define COMSIG_MOVABLE_UNCROSSED_OVER "movable_uncross_am"
 ///from base of atom/movable/Bump(): (/atom)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -334,7 +334,10 @@
 
 // /turf signals
 
-///from base of turf/ChangeTurf(): (path, list/new_baseturfs, flags, list/transferring_comps)
+/// from base of turf/ChangeTurf(): (path, list/new_baseturfs, flags, list/post_change_callbacks).
+/// `post_change_callbacks` is a list that signal handlers can mutate to append `/datum/callback` objects.
+/// They will be called with the new turf and the old turf after the turf has changed.
+/// These callbacks should never yield. Add `SHOULD_NOT_SLEEP(TRUE)` to statically guarantee this.
 #define COMSIG_TURF_CHANGE "turf_change"
 ///from base of atom/has_gravity(): (atom/asker, list/forced_gravities)
 #define COMSIG_TURF_HAS_GRAVITY "turf_has_gravity"
@@ -404,9 +407,6 @@
 	/* #define HEARING_RADIO_FREQ 5
 	#define HEARING_SPANS 6
 	#define HEARING_MESSAGE_MODE 7 */
-/// Fired after the turf of this movable changes through ChangeTurf. (turf/old_turf)
-/// This is not fired when the movable simply moves.
-#define COMSIG_MOVABLE_TURF_CHANGED "movable_turf_changed"
 
 ///called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -336,7 +336,7 @@
 
 /// from base of turf/ChangeTurf(): (path, list/new_baseturfs, flags, list/post_change_callbacks).
 /// `post_change_callbacks` is a list that signal handlers can mutate to append `/datum/callback` objects.
-/// They will be called with the new turf and the old turf after the turf has changed.
+/// They will be called with the new turf after the turf has changed.
 #define COMSIG_TURF_CHANGE "turf_change"
 ///from base of atom/has_gravity(): (atom/asker, list/forced_gravities)
 #define COMSIG_TURF_HAS_GRAVITY "turf_has_gravity"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -337,7 +337,6 @@
 /// from base of turf/ChangeTurf(): (path, list/new_baseturfs, flags, list/post_change_callbacks).
 /// `post_change_callbacks` is a list that signal handlers can mutate to append `/datum/callback` objects.
 /// They will be called with the new turf and the old turf after the turf has changed.
-/// These callbacks should never yield. Add `SHOULD_NOT_SLEEP(TRUE)` to statically guarantee this.
 #define COMSIG_TURF_CHANGE "turf_change"
 ///from base of atom/has_gravity(): (atom/asker, list/forced_gravities)
 #define COMSIG_TURF_HAS_GRAVITY "turf_has_gravity"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -404,6 +404,9 @@
 	/* #define HEARING_RADIO_FREQ 5
 	#define HEARING_SPANS 6
 	#define HEARING_MESSAGE_MODE 7 */
+/// Fired after the turf of this movable changes through ChangeTurf. (turf/old_turf)
+/// This is not fired when the movable simply moves.
+#define COMSIG_MOVABLE_TURF_CHANGED "movable_turf_changed"
 
 ///called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -142,7 +142,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define FLYING (1<<1)
 #define VENTCRAWLING (1<<2)
 #define FLOATING (1<<3)
-/// When moving, will Cross()/Uncross() everything, but won't stop or Bump() anything.
+/// When moving, will Cross() everything, but won't stop or Bump() anything.
 #define PHASING (1<<4)
 
 //Fire and Acid stuff, for resistance_flags

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -37,7 +37,7 @@
 #define TRACK_MAX_SHARE //Allows max share tracking, for use in the atmos debugging ui
 #endif //ifdef TESTING
 
-//#define UNIT_TESTS //If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
+#define UNIT_TESTS //If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 
 #ifndef PRELOAD_RSC //set to:
 #define PRELOAD_RSC 2 // 0 to allow using external resources or on-demand behaviour;

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -37,7 +37,7 @@
 #define TRACK_MAX_SHARE //Allows max share tracking, for use in the atmos debugging ui
 #endif //ifdef TESTING
 
-#define UNIT_TESTS //If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
+//#define UNIT_TESTS //If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 
 #ifndef PRELOAD_RSC //set to:
 #define PRELOAD_RSC 2 // 0 to allow using external resources or on-demand behaviour;

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -78,8 +78,6 @@
 	post_change_callbacks += CALLBACK(src, .proc/post_turf_change)
 
 /datum/element/connect_loc/proc/post_turf_change(turf/new_turf, turf/old_turf)
-	SHOULD_NOT_SLEEP(TRUE)
-
 	for (var/atom/movable/target as anything in targets)
 		if (target.loc != new_turf)
 			continue

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -43,7 +43,7 @@
 		RegisterSignal(target.loc, COMSIG_TURF_CHANGE, .proc/on_turf_change)
 
 /datum/element/connect_loc/proc/unregister_signals(atom/movable/target, atom/old_loc)
-	LAZYREMOVE(targets[target.loc], target)
+	LAZYREMOVE(targets[old_loc], target)
 
 	for (var/signal in connections)
 		target.UnregisterSignal(old_loc, signal)

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -7,6 +7,9 @@
 	/// An assoc list of signal -> procpath to register to the loc this object is on.
 	var/list/connections
 
+	/// A list of everything with this element so that it can be tracked during ChangeTurf.
+	var/list/targets
+
 /datum/element/connect_loc/Attach(datum/target, list/connections)
 	. = ..()
 	if (!ismovable(target))
@@ -14,8 +17,9 @@
 
 	src.connections = connections
 
+	LAZYADD(targets, target)
+
 	RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/on_moved)
-	RegisterSignal(target, COMSIG_MOVABLE_TURF_CHANGED, .proc/on_turf_changed)
 	update_signals(target)
 
 /datum/element/connect_loc/Detach(datum/source, force)
@@ -29,7 +33,7 @@
 	if (!isnull(movable_source.loc))
 		unregister_signals(source, movable_source.loc)
 
-	UnregisterSignal(source, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_TURF_CHANGED))
+	LAZYREMOVE(targets, source)
 
 /datum/element/connect_loc/proc/update_signals(atom/movable/target)
 	if (isnull(target.loc))
@@ -38,9 +42,21 @@
 	for (var/signal in connections)
 		target.RegisterSignal(target.loc, signal, connections[signal])
 
+	if (isturf(target.loc))
+		// override is fine, it just means multiple `connect_loc`s are on the same turf.
+		RegisterSignal(target.loc, COMSIG_TURF_CHANGE, .proc/on_turf_change, override = TRUE)
+
 /datum/element/connect_loc/proc/unregister_signals(atom/movable/target, atom/old_loc)
 	for (var/signal in connections)
 		target.UnregisterSignal(old_loc, signal)
+
+	if (isturf(old_loc))
+		// Only unregister this signal once no other target needs it.
+		for (var/atom/movable/on_old_location in old_loc)
+			if (on_old_location in targets && on_old_location != target)
+				return
+
+		UnregisterSignal(old_loc, COMSIG_TURF_CHANGE)
 
 /datum/element/connect_loc/proc/on_moved(atom/movable/source, atom/old_loc)
 	SIGNAL_HANDLER
@@ -50,8 +66,21 @@
 
 	update_signals(source)
 
-/datum/element/connect_loc/proc/on_turf_changed(atom/movable/source, turf/old_turf)
+/datum/element/connect_loc/proc/on_turf_change(
+	turf/source,
+	path,
+	new_baseturfs,
+	flags,
+	list/post_change_callbacks,
+)
 	SIGNAL_HANDLER
 
-	unregister_signals(source, old_turf)
-	update_signals(source)
+	post_change_callbacks += CALLBACK(src, .proc/post_turf_change)
+
+/datum/element/connect_loc/proc/post_turf_change(turf/new_turf, turf/old_turf)
+	for (var/atom/movable/target as anything in targets)
+		if (target.loc != new_turf)
+			continue
+
+		unregister_signals(target, old_turf)
+		update_signals(target)

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -77,5 +77,4 @@
 	SHOULD_NOT_SLEEP(TRUE)
 
 	for (var/atom/movable/target as anything in targets[new_turf])
-		unregister_signals(target, old_turf)
 		update_signals(target)

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -1,0 +1,52 @@
+// MOTHBLOCKS TODO: Hook to ChangeTurf (change transferring_comps to use proc paths)
+// MOTHBLOCKS TODO: Shuttle moving tiles too?
+// MOTHBLOCKS TODO: Unit test all this
+
+/// This element hooks a signal onto the loc the current object is on.
+/// When the object moves, it will unhook the signal and rehook it to the new object.
+/datum/element/connect_loc
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	id_arg_index = 2
+
+	/// An assoc list of signal -> procpath to register to the loc this object is on.
+	var/list/connections
+
+/datum/element/connect_loc/Attach(datum/target, list/connections)
+	. = ..()
+	if (!ismovable(target))
+		return ELEMENT_INCOMPATIBLE
+
+	src.connections = connections
+
+	RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/on_moved)
+	update_signals(target)
+
+/datum/element/connect_loc/Detach(datum/source, force)
+	. = ..()
+
+	if (!ismovable(source))
+		return
+
+	var/atom/movable/movable_source = source
+
+	if (!isnull(movable_source.loc))
+		unregister_signals(source, movable_source.loc)
+
+/datum/element/connect_loc/proc/update_signals(atom/movable/target)
+	if (isnull(target.loc))
+		return
+
+	for (var/signal in connections)
+		target.RegisterSignal(target.loc, signal, connections[signal])
+
+/datum/element/connect_loc/proc/unregister_signals(atom/movable/target, atom/old_loc)
+	for (var/signal in connections)
+		target.UnregisterSignal(old_loc, signal)
+
+/datum/element/connect_loc/proc/on_moved(atom/movable/source, atom/old_loc)
+	SIGNAL_HANDLER
+
+	if (!isnull(old_loc))
+		unregister_signals(source, old_loc)
+
+	update_signals(source)

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -46,8 +46,7 @@
 		RegisterSignal(target.loc, COMSIG_TURF_CHANGE, .proc/on_turf_change, override = TRUE)
 
 /datum/element/connect_loc/proc/unregister_signals(atom/movable/target, atom/old_loc)
-	if (!isnull(old_loc))
-		LAZYREMOVEASSOC(targets, target.loc, target)
+	LAZYREMOVEASSOC(targets, target.loc, target)
 
 	for (var/signal in connections)
 		target.UnregisterSignal(old_loc, signal)

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -78,6 +78,8 @@
 	post_change_callbacks += CALLBACK(src, .proc/post_turf_change)
 
 /datum/element/connect_loc/proc/post_turf_change(turf/new_turf, turf/old_turf)
+	SHOULD_NOT_SLEEP(TRUE)
+
 	for (var/atom/movable/target as anything in targets)
 		if (target.loc != new_turf)
 			continue

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -73,12 +73,9 @@
 
 	post_change_callbacks += CALLBACK(src, .proc/post_turf_change)
 
-/datum/element/connect_loc/proc/post_turf_change(turf/new_turf, turf/old_turf)
+/datum/element/connect_loc/proc/post_turf_change(turf/new_turf)
 	SHOULD_NOT_SLEEP(TRUE)
 
 	for (var/atom/movable/target as anything in targets[new_turf])
-		if (target.loc != new_turf)
-			continue
-
 		unregister_signals(target, old_turf)
 		update_signals(target)

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -1,7 +1,3 @@
-// MOTHBLOCKS TODO: Hook to ChangeTurf (change transferring_comps to use proc paths)
-// MOTHBLOCKS TODO: Shuttle moving tiles too?
-// MOTHBLOCKS TODO: Unit test all this
-
 /// This element hooks a signal onto the loc the current object is on.
 /// When the object moves, it will unhook the signal and rehook it to the new object.
 /datum/element/connect_loc
@@ -19,6 +15,7 @@
 	src.connections = connections
 
 	RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/on_moved)
+	RegisterSignal(target, COMSIG_MOVABLE_TURF_CHANGED, .proc/on_turf_changed)
 	update_signals(target)
 
 /datum/element/connect_loc/Detach(datum/source, force)
@@ -31,6 +28,8 @@
 
 	if (!isnull(movable_source.loc))
 		unregister_signals(source, movable_source.loc)
+
+	UnregisterSignal(source, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_TURF_CHANGED))
 
 /datum/element/connect_loc/proc/update_signals(atom/movable/target)
 	if (isnull(target.loc))
@@ -49,4 +48,10 @@
 	if (!isnull(old_loc))
 		unregister_signals(source, old_loc)
 
+	update_signals(source)
+
+/datum/element/connect_loc/proc/on_turf_changed(atom/movable/source, turf/old_turf)
+	SIGNAL_HANDLER
+
+	unregister_signals(source, old_turf)
 	update_signals(source)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1279,14 +1279,15 @@
  * An atom is attempting to exit this atom's contents
  *
  * Default behaviour is to send the [COMSIG_ATOM_EXIT]
- *
- * Return value should be set to FALSE if the moving atom is unable to leave,
- * otherwise leave value the result of the parent call
  */
 /atom/Exit(atom/movable/AM, atom/newLoc)
-	. = ..()
+	// Don't call `..()` here, otherwise `Uncross()` gets called.
+	// See the doc comment on `Uncross()` to learn why this is bad.
+
 	if(SEND_SIGNAL(src, COMSIG_ATOM_EXIT, AM, newLoc) & COMPONENT_ATOM_BLOCK_EXIT)
 		return FALSE
+
+	return TRUE
 
 /**
  * An atom has exited this atom's contents

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -515,9 +515,6 @@
 /atom/proc/AllowDrop()
 	return FALSE
 
-/atom/proc/CheckExit()
-	return TRUE
-
 ///Is this atom within 1 tile of another atom
 /atom/proc/HasProximity(atom/movable/AM as mob|obj)
 	return

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -531,15 +531,6 @@
 	SEND_SIGNAL(src, COMSIG_MOVABLE_CROSSED, AM)
 	SEND_SIGNAL(AM, COMSIG_MOVABLE_CROSSED_OVER, src)
 
-/atom/movable/Uncross(atom/movable/AM, atom/newloc)
-	. = ..()
-	if(SEND_SIGNAL(src, COMSIG_MOVABLE_UNCROSS, AM) & COMPONENT_MOVABLE_BLOCK_UNCROSS)
-		return FALSE
-	if(SEND_SIGNAL(AM, COMSIG_MOVABLE_UNCROSS_OVER, src) & COMPONENT_MOVABLE_BLOCK_UNCROSS_OVER)
-		return FALSE
-	if(isturf(newloc) && !CheckExit(AM, newloc))
-		return FALSE
-
 /atom/movable/Uncrossed(atom/movable/AM)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_UNCROSSED, AM)
 	SEND_SIGNAL(AM, COMSIG_MOVABLE_UNCROSSED_OVER, src)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -531,6 +531,30 @@
 	SEND_SIGNAL(src, COMSIG_MOVABLE_CROSSED, AM)
 	SEND_SIGNAL(AM, COMSIG_MOVABLE_CROSSED_OVER, src)
 
+/**
+ * `Uncross()` is a default BYOND proc that is called when something is *going*
+ * to exit this atom's turf. It is prefered over `Uncrossed` when you want to
+ * deny that movement, such as in the case of border objects, objects that allow
+ * you to walk through them in any direction except the one they block
+ * (think side windows).
+ *
+ * While being seemingly harmless, most everything doesn't actually want to
+ * use this, meaning that we are wasting proc calls for every single atom
+ * on a turf, every single time something exits it, when basically nothing
+ * cares.
+ *
+ * This overhead caused real problems on Sybil round #159709, where lag
+ * attributed to Uncross was so bad that the entire master controller
+ * collapsed and people made Among Us lobbies in OOC.
+ *
+ * If you want to replicate the old `Uncross()` behavior, the most apt
+ * replacement is [`/datum/element/connect_loc`] while hooking onto
+ * [`COMSIG_ATOM_EXIT`].
+ */
+/atom/movable/Uncross()
+	SHOULD_NOT_OVERRIDE(TRUE)
+	CRASH("Uncross() should not be being called, please read the doc-comment for it for why.")
+
 /atom/movable/Uncrossed(atom/movable/AM)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_UNCROSSED, AM)
 	SEND_SIGNAL(AM, COMSIG_MOVABLE_UNCROSSED_OVER, src)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -223,15 +223,25 @@
 	opacity = TRUE
 	density = TRUE
 
+/obj/machinery/door/firedoor/border_only/Initialize()
+	. = ..()
+
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_EXIT = .proc/on_exit,
+	)
+
+	AddElement(/datum/element/connect_loc, loc_connections)
+
 /obj/machinery/door/firedoor/border_only/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
 	if(!(get_dir(loc, target) == dir)) //Make sure looking at appropriate border
 		return TRUE
 
-/obj/machinery/door/firedoor/border_only/CheckExit(atom/movable/mover as mob|obj, turf/target)
-	if(get_dir(loc, target) == dir)
-		return !density
-	return TRUE
+/obj/machinery/door/firedoor/border_only/proc/on_exit(datum/source, atom/movable/leaving, atom/new_location)
+	SIGNAL_HANDLER
+
+	if(get_dir(leaving.loc, new_location) == dir && density)
+		return COMPONENT_ATOM_BLOCK_EXIT
 
 /obj/machinery/door/firedoor/border_only/CanAtmosPass(turf/T)
 	if(get_dir(loc, T) == dir)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -241,6 +241,7 @@
 	SIGNAL_HANDLER
 
 	if(get_dir(leaving.loc, new_location) == dir && density)
+		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 
 /obj/machinery/door/firedoor/border_only/CanAtmosPass(turf/T)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -145,6 +145,7 @@
 		return
 
 	if(get_dir(loc, new_location) == dir && density)
+		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 
 /obj/machinery/door/window/open(forced=FALSE)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -42,6 +42,12 @@
 
 	RegisterSignal(src, COMSIG_COMPONENT_NTNET_RECEIVE, .proc/ntnet_receive)
 
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_EXIT = .proc/on_exit,
+	)
+
+	AddElement(/datum/element/connect_loc, loc_connections)
+
 /obj/machinery/door/window/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/atmos_sensitive)
@@ -132,12 +138,14 @@
 /obj/machinery/door/window/CanAStarPass(obj/item/card/id/ID, to_dir)
 	return !density || (dir != to_dir) || (check_access(ID) && hasPower())
 
-/obj/machinery/door/window/CheckExit(atom/movable/mover, turf/target)
-	if((pass_flags_self & mover.pass_flags) || ((pass_flags_self & LETPASSTHROW) && mover.throwing))
-		return TRUE
-	if(get_dir(loc, target) == dir)
-		return !density
-	return TRUE
+/obj/machinery/door/window/proc/on_exit(datum/source, atom/movable/leaving, atom/new_location)
+	SIGNAL_HANDLER
+
+	if((pass_flags_self & leaving.pass_flags) || ((pass_flags_self & LETPASSTHROW) && leaving.throwing))
+		return
+
+	if(get_dir(loc, new_location) == dir && density)
+		return COMPONENT_ATOM_BLOCK_EXIT
 
 /obj/machinery/door/window/open(forced=FALSE)
 	if (operating) //doors can still open when emag-disabled

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -104,6 +104,7 @@
 	if (leaving.move_force >= MOVE_FORCE_EXTREMELY_STRONG)
 		return
 
+	leaving.Bump(src)
 	return COMPONENT_ATOM_BLOCK_EXIT
 
 // Corner railings don't block anything, so they don't create the element.

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -15,16 +15,14 @@
 	density = FALSE
 	climbable = FALSE
 
-/obj/structure/railing/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS ,null,CALLBACK(src, .proc/can_be_rotated),CALLBACK(src,.proc/after_rotation))
-
-
 /obj/structure/railing/Initialize()
 	. = ..()
 	ini_dir = dir
 	if(climbable)
 		AddElement(/datum/element/climbable)
+
+	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS ,null,CALLBACK(src, .proc/can_be_rotated),CALLBACK(src,.proc/after_rotation))
+	init_connect_loc_element()
 
 /obj/structure/railing/attackby(obj/item/I, mob/living/user, params)
 	..()
@@ -81,15 +79,35 @@
 	..()
 	return TRUE
 
-/obj/structure/railing/CheckExit(atom/movable/mover, turf/target)
-	..()
-	if(get_dir(loc, target) & dir)
-		var/checking = PHASING | FLYING | FLOATING
-		return !density || mover.throwing || mover.movement_type & checking || mover.move_force >= MOVE_FORCE_EXTREMELY_STRONG
-	return TRUE
+/obj/structure/railing/proc/init_connect_loc_element()
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_EXIT = .proc/on_exit,
+	)
 
-/obj/structure/railing/corner/CheckExit()
-	return TRUE
+	AddElement(/datum/element/connect_loc, loc_connections)
+
+/obj/structure/railing/proc/on_exit(datum/source, atom/movable/leaving, atom/new_location)
+	SIGNAL_HANDLER
+
+	if(!(get_dir(leaving.loc, new_location) & dir))
+		return
+
+	if (!density)
+		return
+
+	if (leaving.throwing)
+		return
+
+	if (leaving.movement_type & (PHASING | FLYING | FLOATING))
+		return
+
+	if (leaving.move_force >= MOVE_FORCE_EXTREMELY_STRONG)
+		return
+
+	return COMPONENT_ATOM_BLOCK_EXIT
+
+// Corner railings don't block anything, so they don't create the element.
+/obj/structure/railing/corner/init_connect_loc_element()
 
 /obj/structure/railing/proc/can_be_rotated(mob/user,rotation_type)
 	if(anchored)

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -108,6 +108,7 @@
 
 // Corner railings don't block anything, so they don't create the element.
 /obj/structure/railing/corner/init_connect_loc_element()
+	return
 
 /obj/structure/railing/proc/can_be_rotated(mob/user,rotation_type)
 	if(anchored)

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -65,6 +65,7 @@
 
 	if(!isobserver(leaving) && isTerminator() && (get_dir(src, new_location) == dir))
 		INVOKE_ASYNC(src, .proc/stair_ascend, leaving)
+		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 
 /obj/structure/stairs/Cross(atom/movable/AM)

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -33,6 +33,13 @@
 		force_open_above()
 		build_signal_listener()
 	update_surrounding()
+
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_EXIT = .proc/on_exit,
+	)
+
+	AddElement(/datum/element/connect_loc, loc_connections)
+
 	return ..()
 
 /obj/structure/stairs/Destroy()
@@ -53,13 +60,12 @@
 		if(S)
 			S.update_appearance()
 
-/obj/structure/stairs/Uncross(atom/movable/AM, atom/newloc)
-	if(!newloc || !AM)
-		return ..()
-	if(!isobserver(AM) && isTerminator() && (get_dir(src, newloc) == dir))
-		stair_ascend(AM)
-		return FALSE
-	return ..()
+/obj/structure/stairs/proc/on_exit(datum/source, atom/movable/leaving, atom/new_location)
+	SIGNAL_HANDLER
+
+	if(!isobserver(leaving) && isTerminator() && (get_dir(src, new_location) == dir))
+		INVOKE_ASYNC(src, .proc/stair_ascend, leaving)
+		return COMPONENT_ATOM_BLOCK_EXIT
 
 /obj/structure/stairs/Cross(atom/movable/AM)
 	if(isTerminator() && (get_dir(src, AM) == dir))

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -30,7 +30,7 @@
 	CanAtmosPass = ATMOS_PASS_PROC
 
 /obj/structure/windoor_assembly/Initialize(loc, set_dir)
-	..()
+	. = ..()
 	if(set_dir)
 		setDir(set_dir)
 	air_update_turf(TRUE, TRUE)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -29,11 +29,17 @@
 	var/state = "01" //How far the door assembly has progressed
 	CanAtmosPass = ATMOS_PASS_PROC
 
-/obj/structure/windoor_assembly/New(loc, set_dir)
+/obj/structure/windoor_assembly/Initialize(loc, set_dir)
 	..()
 	if(set_dir)
 		setDir(set_dir)
 	air_update_turf(TRUE, TRUE)
+
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_EXIT = .proc/on_exit,
+	)
+
+	AddElement(/datum/element/connect_loc, loc_connections)
 
 /obj/structure/windoor_assembly/Destroy()
 	density = FALSE
@@ -68,13 +74,14 @@
 	else
 		return 1
 
-/obj/structure/windoor_assembly/CheckExit(atom/movable/mover, turf/target)
-	if(mover.pass_flags & pass_flags_self)
-		return TRUE
-	if(get_dir(loc, target) == dir)
-		return !density
-	else
-		return TRUE
+/obj/structure/windoor_assembly/proc/on_exit(datum/source, atom/movable/leaving, atom/new_location)
+	SIGNAL_HANDLER
+
+	if (leaving.pass_flags & pass_flags_self)
+		return
+
+	if (get_dir(loc, new_location) == dir && density)
+		return COMPONENT_ATOM_BLOCK_EXIT
 
 /obj/structure/windoor_assembly/attackby(obj/item/W, mob/user, params)
 	//I really should have spread this out across more states but thin little windoors are hard to sprite.

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -81,6 +81,7 @@
 		return
 
 	if (get_dir(loc, new_location) == dir && density)
+		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 
 /obj/structure/windoor_assembly/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -72,7 +72,8 @@
 		COMSIG_ATOM_EXIT = .proc/on_exit,
 	)
 
-	AddElement(/datum/element/connect_loc, loc_connections)
+	if (flags_1 & ON_BORDER_1)
+		AddElement(/datum/element/connect_loc, loc_connections)
 
 /obj/structure/window/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -68,6 +68,12 @@
 	flags_1 |= ALLOW_DARK_PAINTS_1
 	RegisterSignal(src, COMSIG_OBJ_PAINTED, .proc/on_painted)
 
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_EXIT = .proc/on_exit,
+	)
+
+	AddElement(/datum/element/connect_loc, loc_connections)
+
 /obj/structure/window/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS ,null,CALLBACK(src, .proc/can_be_rotated),CALLBACK(src,.proc/after_rotation))
@@ -117,12 +123,17 @@
 
 	return TRUE
 
-/obj/structure/window/CheckExit(atom/movable/O, turf/target)
-	if(istype(O) && (O.pass_flags & pass_flags_self))
-		return TRUE
-	if(!fulltile && get_dir(O.loc, target) == dir)
-		return !density
-	return TRUE
+/obj/structure/window/proc/on_exit(datum/source, atom/movable/leaving, atom/new_location)
+	SIGNAL_HANDLER
+
+	if (istype(leaving) && (leaving.pass_flags & pass_flags_self))
+		return
+
+	if (fulltile)
+		return
+
+	if(get_dir(leaving.loc, new_location) == dir && density)
+		return COMPONENT_ATOM_BLOCK_EXIT
 
 
 /obj/structure/window/attack_tk(mob/user)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -133,8 +133,8 @@
 		return
 
 	if(get_dir(leaving.loc, new_location) == dir && density)
+		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
-
 
 /obj/structure/window/attack_tk(mob/user)
 	user.changeNext_move(CLICK_CD_MELEE)

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -97,7 +97,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	var/turf/W = new path(src)
 
 	for(var/datum/callback/callback as anything in post_change_callbacks)
-		callback.InvokeAsync(W, src)
+		callback.InvokeAsync(W)
 
 	if(new_baseturfs)
 		W.baseturfs = baseturfs_string_list(new_baseturfs, W)

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -97,7 +97,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	var/turf/W = new path(src)
 
 	for(var/datum/callback/callback as anything in post_change_callbacks)
-		callback.Invoke(W, src)
+		callback.InvokeAsync(W, src)
 
 	if(new_baseturfs)
 		W.baseturfs = baseturfs_string_list(new_baseturfs, W)

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -132,6 +132,16 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	QUEUE_SMOOTH_NEIGHBORS(src)
 	QUEUE_SMOOTH(src)
 
+	#if MIN_COMPILER_VERSION >= 514
+	#warn Please replace the loop below this warning with an `as anything` loop.
+	#endif
+
+	for (var/_content_of_turf in contents)
+		// `as anything` doesn't play well on 513 with special lists such as contents.
+		// When the minimum version is raised to 514, upgrade this to `as anything`.
+		var/atom/content_of_turf = _content_of_turf
+		SEND_SIGNAL(content_of_turf, COMSIG_MOVABLE_TURF_CHANGED, src)
+
 	return W
 
 /turf/open/ChangeTurf(path, list/new_baseturfs, flags) //Resist the temptation to make this default to keeping air.

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -325,12 +325,6 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	for(var/i in contents)
 		if(i == mover)
 			continue
-		var/atom/movable/thing = i
-		if(!thing.Uncross(mover, newloc))
-			if(thing.flags_1 & ON_BORDER_1)
-				mover.Bump(thing)
-			if(!(mover.movement_type & PHASING))
-				return FALSE
 		if(QDELETED(mover))
 			return FALSE //We were deleted.
 

--- a/code/modules/fields/fields.dm
+++ b/code/modules/fields/fields.dm
@@ -129,9 +129,6 @@
 /datum/proximity_monitor/advanced/proc/field_turf_canpass(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/field_turf/F, turf/entering)
 	return TRUE
 
-/datum/proximity_monitor/advanced/proc/field_turf_uncross(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/field_turf/F)
-	return TRUE
-
 /datum/proximity_monitor/advanced/proc/field_turf_crossed(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/field_turf/F)
 	return TRUE
 
@@ -139,9 +136,6 @@
 	return TRUE
 
 /datum/proximity_monitor/advanced/proc/field_edge_canpass(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/field_edge/F, turf/entering)
-	return TRUE
-
-/datum/proximity_monitor/advanced/proc/field_edge_uncross(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/field_edge/F)
 	return TRUE
 
 /datum/proximity_monitor/advanced/proc/field_edge_crossed(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/field_edge/F)

--- a/code/modules/fields/turf_objects.dm
+++ b/code/modules/fields/turf_objects.dm
@@ -34,11 +34,6 @@
 		return parent.field_turf_crossed(AM, src)
 	return TRUE
 
-/obj/effect/abstract/proximity_checker/advanced/field_turf/Uncross(atom/movable/AM)
-	if(parent)
-		return parent.field_turf_uncross(AM, src)
-	return TRUE
-
 /obj/effect/abstract/proximity_checker/advanced/field_turf/Uncrossed(atom/movable/AM)
 	if(parent)
 		return parent.field_turf_uncrossed(AM, src)
@@ -57,11 +52,6 @@
 	. = ..()
 	if(parent)
 		return parent.field_edge_crossed(AM, src)
-	return TRUE
-
-/obj/effect/abstract/proximity_checker/advanced/field_edge/Uncross(atom/movable/AM)
-	if(parent)
-		return parent.field_edge_uncross(AM, src)
 	return TRUE
 
 /obj/effect/abstract/proximity_checker/advanced/field_edge/Uncrossed(atom/movable/AM)

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -71,6 +71,7 @@
 	SIGNAL_HANDLER
 
 	if (get_dir(leaving.loc, new_location) == dir && density)
+		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 
 /obj/structure/opacity_blocker

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -46,6 +46,12 @@
 	dais_overlay.layer = CLOSED_TURF_LAYER
 	add_overlay(dais_overlay)
 
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_EXIT = .proc/on_exit,
+	)
+
+	AddElement(/datum/element/connect_loc, loc_connections)
+
 /obj/structure/necropolis_gate/Destroy(force)
 	if(force)
 		qdel(sight_blocker, TRUE)
@@ -61,10 +67,11 @@
 	if(!(get_dir(loc, target) == dir))
 		return TRUE
 
-/obj/structure/necropolis_gate/CheckExit(atom/movable/O, target)
-	if(get_dir(O.loc, target) == dir)
-		return !density
-	return 1
+/obj/structure/necropolis_gate/proc/on_exit(datum/source, atom/movable/leaving, atom/new_location)
+	SIGNAL_HANDLER
+
+	if (get_dir(leaving.loc, new_location) == dir && density)
+		return COMPONENT_ATOM_BLOCK_EXIT
 
 /obj/structure/opacity_blocker
 	icon = 'icons/effects/96x96.dmi'

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -48,6 +48,7 @@
 #include "chain_pull_through_space.dm"
 #include "combat.dm"
 #include "component_tests.dm"
+#include "connect_loc.dm"
 #include "confusion.dm"
 #include "crayons.dm"
 #include "designs.dm"

--- a/code/modules/unit_tests/connect_loc.dm
+++ b/code/modules/unit_tests/connect_loc.dm
@@ -24,8 +24,6 @@
 /datum/unit_test/connect_loc_change_turf
 	var/old_turf_type
 
-TEST_FOCUS(/datum/unit_test/connect_loc_change_turf)
-
 /datum/unit_test/connect_loc_change_turf/Run()
 	var/obj/item/watches_mock_calls/watcher = allocate(/obj/item/watches_mock_calls, run_loc_floor_bottom_left)
 

--- a/code/modules/unit_tests/connect_loc.dm
+++ b/code/modules/unit_tests/connect_loc.dm
@@ -1,0 +1,39 @@
+#define COMSIG_MOCK_SIGNAL "mock_signal"
+
+/// Test that the connect_loc component handles basic movement cases
+/datum/unit_test/connect_loc_basic
+
+/datum/unit_test/connect_loc_basic/Run()
+	var/obj/item/watches_mock_calls/watcher = allocate(/obj/item/watches_mock_calls)
+
+	var/turf/current_turf = get_turf(watcher)
+
+	SEND_SIGNAL(current_turf, COMSIG_MOCK_SIGNAL)
+	TEST_ASSERT_EQUAL(watcher.times_called, 1, "After firing mock signal, connect_loc didn't send it")
+
+	watcher.forceMove(run_loc_floor_top_right)
+
+	SEND_SIGNAL(current_turf, COMSIG_MOCK_SIGNAL)
+	TEST_ASSERT_EQUAL(watcher.times_called, 1, "Mock signal was fired on old turf, but connect_loc still picked it up")
+
+	current_turf = get_turf(watcher)
+	SEND_SIGNAL(current_turf, COMSIG_MOCK_SIGNAL)
+	TEST_ASSERT_EQUAL(watcher.times_called, 2, "Mock signal was fired after turf move, but it wasn't picked up")
+
+/obj/item/watches_mock_calls
+	var/times_called
+
+/obj/item/watches_mock_calls/Initialize()
+	. = ..()
+
+	var/static/list/connections = list(
+		COMSIG_MOCK_SIGNAL = .proc/on_receive_mock_signal,
+	)
+
+	AddElement(/datum/element/connect_loc, connections)
+
+/obj/item/watches_mock_calls/proc/on_receive_mock_signal(datum/source)
+	SIGNAL_HANDLER
+	times_called += 1
+
+#undef COMSIG_MOCK_SIGNAL

--- a/code/modules/unit_tests/connect_loc.dm
+++ b/code/modules/unit_tests/connect_loc.dm
@@ -1,6 +1,6 @@
 #define COMSIG_MOCK_SIGNAL "mock_signal"
 
-/// Test that the connect_loc component handles basic movement cases
+/// Test that the connect_loc element handles basic movement cases
 /datum/unit_test/connect_loc_basic
 
 /datum/unit_test/connect_loc_basic/Run()
@@ -19,6 +19,31 @@
 	current_turf = get_turf(watcher)
 	SEND_SIGNAL(current_turf, COMSIG_MOCK_SIGNAL)
 	TEST_ASSERT_EQUAL(watcher.times_called, 2, "Mock signal was fired after turf move, but it wasn't picked up")
+
+/// Test that the connect_loc element handles turf changes
+/datum/unit_test/connect_loc_change_turf
+	var/old_turf_type
+
+TEST_FOCUS(/datum/unit_test/connect_loc_change_turf)
+
+/datum/unit_test/connect_loc_change_turf/Run()
+	var/obj/item/watches_mock_calls/watcher = allocate(/obj/item/watches_mock_calls, run_loc_floor_bottom_left)
+
+	var/turf/current_turf = get_turf(watcher)
+	old_turf_type = current_turf.type
+
+	SEND_SIGNAL(current_turf, COMSIG_MOCK_SIGNAL)
+	TEST_ASSERT_EQUAL(watcher.times_called, 1, "After firing mock signal, connect_loc didn't send it")
+
+	current_turf.ChangeTurf(/turf/closed/wall)
+
+	current_turf = get_turf(watcher)
+	SEND_SIGNAL(current_turf, COMSIG_MOCK_SIGNAL)
+	TEST_ASSERT_EQUAL(watcher.times_called, 2, "After changing turf, connect_loc didn't reconnect it")
+
+/datum/unit_test/connect_loc_change_turf/Destroy()
+	. = ..()
+	run_loc_floor_bottom_left.ChangeTurf(old_turf_type)
 
 /obj/item/watches_mock_calls
 	var/times_called

--- a/code/modules/unit_tests/connect_loc.dm
+++ b/code/modules/unit_tests/connect_loc.dm
@@ -40,8 +40,8 @@
 	TEST_ASSERT_EQUAL(watcher.times_called, 2, "After changing turf, connect_loc didn't reconnect it")
 
 /datum/unit_test/connect_loc_change_turf/Destroy()
-	. = ..()
 	run_loc_floor_bottom_left.ChangeTurf(old_turf_type)
+	return ..()
 
 /obj/item/watches_mock_calls
 	var/times_called

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -647,6 +647,7 @@
 #include "code\datums\elements\caltrop.dm"
 #include "code\datums\elements\cleaning.dm"
 #include "code\datums\elements\climbable.dm"
+#include "code\datums\elements\connect_loc.dm"
 #include "code\datums\elements\decal.dm"
 #include "code\datums\elements\deferred_aquarium_content.dm"
 #include "code\datums\elements\digitalcamo.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Requested by @optimumtact.

This adds a `connect_loc` component to automatically register signals onto the location of the movable its attached to, and updates based on when the location changes.

CC @norill -- you might be interested in this for https://github.com/tgstation/tgstation/pull/58124, it would likely make it much easier.

Drafted until the TODOs in the code are covered.
