### PR TITLE
Fixes some oddities on wintercoats and labcoats allowed items.

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -160,7 +160,8 @@ GLOBAL_LIST_INIT(advanced_hardsuit_allowed, typecacheof(list(
 	/obj/item/melee/classic_baton,
 	/obj/item/reagent_containers/spray/pepper,
 	/obj/item/restraints/handcuffs,
-	/obj/item/tank/internals)))
+	/obj/item/tank/internals,
+	)))
 
 GLOBAL_LIST_INIT(security_hardsuit_allowed, typecacheof(list(
 	/obj/item/ammo_box,
@@ -172,14 +173,14 @@ GLOBAL_LIST_INIT(security_hardsuit_allowed, typecacheof(list(
 	/obj/item/melee/classic_baton,
 	/obj/item/reagent_containers/spray/pepper,
 	/obj/item/restraints/handcuffs,
-	/obj/item/tank/internals)))
+	/obj/item/tank/internals,
+	)))
 
 GLOBAL_LIST_INIT(detective_vest_allowed, typecacheof(list(
 	/obj/item/ammo_box,
 	/obj/item/ammo_casing,
 	/obj/item/detective_scanner,
 	/obj/item/flashlight,
-	/obj/item/taperecorder,
 	/obj/item/gun/ballistic,
 	/obj/item/gun/energy,
 	/obj/item/lighter,
@@ -188,8 +189,10 @@ GLOBAL_LIST_INIT(detective_vest_allowed, typecacheof(list(
 	/obj/item/reagent_containers/spray/pepper,
 	/obj/item/restraints/handcuffs,
 	/obj/item/storage/fancy/cigarettes,
+	/obj/item/taperecorder,
 	/obj/item/tank/internals/emergency_oxygen,
-	/obj/item/tank/internals/plasmaman)))
+	/obj/item/tank/internals/plasmaman,
+	)))
 
 GLOBAL_LIST_INIT(security_vest_allowed, typecacheof(list(
 	/obj/item/ammo_box,
@@ -203,20 +206,16 @@ GLOBAL_LIST_INIT(security_vest_allowed, typecacheof(list(
 	/obj/item/reagent_containers/spray/pepper,
 	/obj/item/restraints/handcuffs,
 	/obj/item/tank/internals/emergency_oxygen,
-	/obj/item/tank/internals/plasmaman)))
+	/obj/item/tank/internals/plasmaman,
+	)))
 
 GLOBAL_LIST_INIT(security_wintercoat_allowed, typecacheof(list(
 	/obj/item/ammo_box,
 	/obj/item/ammo_casing,
-	/obj/item/flashlight,
-	/obj/item/storage/fancy/cigarettes,
 	/obj/item/gun/ballistic,
 	/obj/item/gun/energy,
-	/obj/item/lighter,
 	/obj/item/melee/baton,
 	/obj/item/melee/classic_baton,
 	/obj/item/reagent_containers/spray/pepper,
 	/obj/item/restraints/handcuffs,
-	/obj/item/tank/internals/emergency_oxygen,
-	/obj/item/tank/internals/plasmaman,
-	/obj/item/toy)))
+	)))

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -5,7 +5,26 @@
 	inhand_icon_state = "labcoat"
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|ARMS
-	allowed = list(/obj/item/analyzer, /obj/item/stack/medical, /obj/item/dnainjector, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/healthanalyzer, /obj/item/flashlight/pen, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/pill, /obj/item/storage/pill_bottle, /obj/item/paper, /obj/item/melee/classic_baton/telescopic, /obj/item/soap, /obj/item/sensor_device, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/biopsy_tool)
+	allowed = list(
+		/obj/item/analyzer,
+		/obj/item/biopsy_tool,
+		/obj/item/dnainjector,
+		/obj/item/flashlight/pen,
+		/obj/item/healthanalyzer,
+		/obj/item/paper,
+		/obj/item/reagent_containers/dropper,
+		/obj/item/reagent_containers/glass/beaker,
+		/obj/item/reagent_containers/glass/bottle,
+		/obj/item/reagent_containers/hypospray,
+		/obj/item/reagent_containers/pill,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/sensor_device,
+		/obj/item/soap,
+		/obj/item/stack/medical,
+		/obj/item/storage/pill_bottle,
+		/obj/item/tank/internals/emergency_oxygen,
+		/obj/item/tank/internals/plasmaman,
+		)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 50, RAD = 0, FIRE = 50, ACID = 50)
 	togglename = "buttons"
 	species_exception = list(/datum/species/golem)
@@ -15,6 +34,12 @@
 	desc = "Bluer than the standard model."
 	icon_state = "labcoat_cmo"
 	inhand_icon_state = "labcoat_cmo"
+
+/obj/item/clothing/suit/toggle/labcoat/cmo/Initialize()
+	. = ..()
+	allowed += list(
+		/obj/item/melee/classic_baton/telescopic,
+	)	
 
 /obj/item/clothing/suit/toggle/labcoat/paramedic
 	name = "paramedic's jacket"

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -287,7 +287,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 20, BIO = 0, RAD = 0, FIRE = 30, ACID = 0)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/science/rd
 	
-/obj/item/clothing/suit/hooded/wintercoat/science/Initialize()
+/obj/item/clothing/suit/hooded/wintercoat/science/rd/Initialize()
 	. = ..()
 	allowed += list(
 		/obj/item/melee/classic_baton/telescopic,

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -202,10 +202,13 @@
 	icon_state = "coatcmo"
 	inhand_icon_state = "coatcmo"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 50, RAD = 0, FIRE = 20, ACID = 30)
-	allowed = list(
+	hoodtype = /obj/item/clothing/head/hooded/winterhood/medical/cmo
+	
+/obj/item/clothing/suit/hooded/wintercoat/medical/Initialize()
+	. = ..()
+	allowed += list(
 		/obj/item/melee/classic_baton/telescopic,
 	)	
-	hoodtype = /obj/item/clothing/head/hooded/winterhood/medical/cmo
 
 /obj/item/clothing/head/hooded/winterhood/medical/cmo
 	desc = "A blue winter coat hood."
@@ -282,10 +285,13 @@
 	icon_state = "coatrd"
 	inhand_icon_state = "coatrd"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 20, BIO = 0, RAD = 0, FIRE = 30, ACID = 0)
-	allowed = list(
+	hoodtype = /obj/item/clothing/head/hooded/winterhood/science/rd
+	
+/obj/item/clothing/suit/hooded/wintercoat/science/Initialize()
+	. = ..()
+	allowed += list(
 		/obj/item/melee/classic_baton/telescopic,
 	)		
-	hoodtype = /obj/item/clothing/head/hooded/winterhood/science/rd
 
 /obj/item/clothing/head/hooded/winterhood/science/rd
 	desc = "A white winter coat hood. It smells faintly of hair gel."
@@ -344,10 +350,13 @@
 	icon_state = "coatce"
 	inhand_icon_state = "coatce"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 20, FIRE = 30, ACID = 10)
-	allowed = list(
-		/obj/item/melee/classic_baton/telescopic,
-	)	
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/engineering/ce
+
+/obj/item/clothing/suit/hooded/wintercoat/engineering/ce/Initialize()
+	. = ..()
+	allowed += list(
+		/obj/item/melee/classic_baton/telescopic,
+	)		
 
 /obj/item/clothing/head/hooded/winterhood/engineering/ce
 	desc = "A white winter coat hood. Feels surprisingly heavy. The tag says that it's not child safe."

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -204,7 +204,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 50, RAD = 0, FIRE = 20, ACID = 30)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/medical/cmo
 	
-/obj/item/clothing/suit/hooded/wintercoat/medical/Initialize()
+/obj/item/clothing/suit/hooded/wintercoat/medical/cmo/Initialize()
 	. = ..()
 	allowed += list(
 		/obj/item/melee/classic_baton/telescopic,

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -9,15 +9,22 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-	allowed = list(
+	allowed = list()
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, RAD = 0, FIRE = 0, ACID = 0)
+
+/obj/item/clothing/suit/hooded/wintercoat/Initialize()
+	. = ..()
+	allowed += list(
 		/obj/item/flashlight,
 		/obj/item/lighter,
+		/obj/item/modular_computer/tablet,
+		/obj/item/pda,
+		/obj/item/radio,
 		/obj/item/storage/fancy/cigarettes,
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
 		/obj/item/toy,
-)
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, RAD = 0, FIRE = 0, ACID = 0)
+	)
 
 /obj/item/clothing/head/hooded/winterhood
 	name = "winter hood"
@@ -74,6 +81,9 @@
 	icon_state = "coathop"
 	inhand_icon_state = "coathop"
 	armor = list(MELEE = 10, BULLET = 15, LASER = 15, ENERGY = 25, BOMB = 10, BIO = 0, RAD = 0, FIRE = 0, ACID = 35)
+	allowed = list(
+		/obj/item/melee/classic_baton/telescopic,
+	)	
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/hop
 
 /obj/item/clothing/head/hooded/winterhood/hop
@@ -88,18 +98,13 @@
 	allowed = list(
 		/obj/item/cultivator,
 		/obj/item/hatchet,
-		/obj/item/lighter,
 		/obj/item/plant_analyzer,
 		/obj/item/reagent_containers/spray/plantbgone,
 		/obj/item/reagent_containers/glass/bottle,
 		/obj/item/reagent_containers/spray/pestspray,
 		/obj/item/seeds,
 		/obj/item/storage/bag/plants,
-		/obj/item/storage/fancy/cigarettes,
-		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/tank/internals/plasmaman,
-		/obj/item/toy,
-)
+	)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/hydro
 
 /obj/item/clothing/head/hooded/winterhood/hydro
@@ -113,11 +118,9 @@
 	icon_state = "coatjanitor"
 	inhand_icon_state = "coatjanitor"
 	allowed = list(
-		/obj/item/flashlight,
 		/obj/item/grenade/chem_grenade,
 		/obj/item/holosign_creator,
 		/obj/item/key/janitor,
-		/obj/item/lighter,
 		/obj/item/lightreplacer,
 		/obj/item/melee/flyswatter,
 		/obj/item/paint/paint_remover,
@@ -127,11 +130,7 @@
 		/obj/item/reagent_containers/spray,
 		/obj/item/soap,
 		/obj/item/storage/bag/trash,
-		/obj/item/storage/fancy/cigarettes,
-		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/tank/internals/plasmaman,
-		/obj/item/toy,
-)
+	)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/janitor
 
 /obj/item/clothing/head/hooded/winterhood/janitor
@@ -176,13 +175,8 @@
 	icon_state = "coatmedical"
 	inhand_icon_state = "coatmedical"
 	allowed = list(
-		/obj/item/analyzer,
-		/obj/item/dnainjector,
 		/obj/item/flashlight/pen,
 		/obj/item/healthanalyzer,
-		/obj/item/lighter,
-		/obj/item/melee/classic_baton/telescopic,
-		/obj/item/paper,
 		/obj/item/reagent_containers/dropper,
 		/obj/item/reagent_containers/glass/beaker,
 		/obj/item/reagent_containers/glass/bottle,
@@ -191,12 +185,8 @@
 		/obj/item/reagent_containers/syringe,
 		/obj/item/stack/medical,
 		/obj/item/sensor_device,
-		/obj/item/storage/fancy/cigarettes,
 		/obj/item/storage/pill_bottle,
-		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/tank/internals/plasmaman,
-		/obj/item/toy,
-)
+	)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 40, RAD = 0, FIRE = 10, ACID = 20)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/medical
 
@@ -212,6 +202,9 @@
 	icon_state = "coatcmo"
 	inhand_icon_state = "coatcmo"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 50, RAD = 0, FIRE = 20, ACID = 30)
+	allowed = list(
+		/obj/item/melee/classic_baton/telescopic,
+	)	
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/medical/cmo
 
 /obj/item/clothing/head/hooded/winterhood/medical/cmo
@@ -264,10 +257,6 @@
 	allowed = list(
 		/obj/item/analyzer,
 		/obj/item/dnainjector,
-		/obj/item/flashlight/pen,
-		/obj/item/healthanalyzer,
-		/obj/item/lighter,
-		/obj/item/melee/classic_baton/telescopic,
 		/obj/item/paper,
 		/obj/item/reagent_containers/dropper,
 		/obj/item/reagent_containers/glass/beaker,
@@ -275,13 +264,8 @@
 		/obj/item/reagent_containers/hypospray,
 		/obj/item/reagent_containers/pill,
 		/obj/item/reagent_containers/syringe,
-		/obj/item/stack/medical,
-		/obj/item/storage/fancy/cigarettes,
 		/obj/item/storage/pill_bottle,
-		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/tank/internals/plasmaman,
-		/obj/item/toy,
-)
+	)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 0, RAD = 0, FIRE = 20, ACID = 0)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/science
 	species_exception = list(/datum/species/golem)
@@ -298,6 +282,9 @@
 	icon_state = "coatrd"
 	inhand_icon_state = "coatrd"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 20, BIO = 0, RAD = 0, FIRE = 30, ACID = 0)
+	allowed = list(
+		/obj/item/melee/classic_baton/telescopic,
+	)		
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/science/rd
 
 /obj/item/clothing/head/hooded/winterhood/science/rd
@@ -338,15 +325,9 @@
 	allowed = list(
 		/obj/item/analyzer,
 		/obj/item/construction/rcd,
-		/obj/item/flashlight,
-		/obj/item/lighter,
 		/obj/item/pipe_dispenser,
-		/obj/item/storage/fancy/cigarettes,
 		/obj/item/t_scanner,
-		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/tank/internals/plasmaman,
-		/obj/item/toy,
-)
+	)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 10, FIRE = 20, ACID = 0)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/engineering
 	species_exception = list(/datum/species/golem/uranium)
@@ -363,6 +344,9 @@
 	icon_state = "coatce"
 	inhand_icon_state = "coatce"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 20, FIRE = 30, ACID = 10)
+	allowed = list(
+		/obj/item/melee/classic_baton/telescopic,
+	)	
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/engineering/ce
 
 /obj/item/clothing/head/hooded/winterhood/engineering/ce
@@ -413,14 +397,13 @@
 	icon_state = "coatminer"
 	inhand_icon_state = "coatminer"
 	allowed = list(
-		/obj/item/flashlight,
-		/obj/item/lighter,
+		/obj/item/gun/energy/kinetic_accelerator,
+		/obj/item/mining_scanner,
 		/obj/item/pickaxe,
-		/obj/item/storage/fancy/cigarettes,
-		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/tank/internals/plasmaman,
-		/obj/item/toy,
-)
+		/obj/item/resonator,
+		/obj/item/t_scanner/adv_mining_scanner,
+		/obj/item/tank/internals,
+	)
 	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/miner
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Winter coats could carry some odd items and this PR tries to fix some of that.

I added a list of generic items to be loaded on `/Initialize()` so it cuts on copy paste on the list and hopefully makes it easier to find mistakes for each winter coat list in future updates.

Also... maybe this is something that should be done for the basic `/suit` so that all suits can carry basic things like internals and have less copy pasta in the code?
No idea if this is something that would have any performance weight or issues but if it is a good idea I might try it soonTM.

## Update
After checking more on it I found that wintercoats were mirroring their `allowed_list` from the labcoats which also have the issue of holding both medical and science/engineering equipment + telebatons so I started working on those, split the labcoats into 2 subtypes, medical and science labcoats, each with their fitting `allowed_list` and started to work on a unique RD labcoat so they can keep their batons together with the CMO.

Then... I realized I would need to do map edits, and I left this update for later, for now I just moved the baton to the CMO labcoat and sorry RD, you will need your own shiny labcoat for that later...

### Winners:
All winter coats could carry a list of basic items and now the PDA, tablet and bounced radios are on that list.
Miner coat can carry mining tools
CE and HoP ones can carry their telebatons

### Losers:
All of science and medical winter coats can't carry telebatons anymore, neither can labcoats other than the CMO one, they are not command or security...
Science ones can't carry medical equipment like health analyzers and medical stack items
Medical ones can't carry engineering equipment like analyzers or genetic injectors
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No... I didn't get killed by a random virologist removing an *extended* telebaton from his suit pocket to insta stun me, stalp!!!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Guillaume Prata
qol: Miner winter coat can carry mining equipment on their exo slot like the explorer suits can.
fix: Items that winter coats can carry on their exo slot are more consistent with their job and now you carry tablets on them too!
balance: Labcoats and wintercoats that aren't from a head of staff can't carry batons anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
