### PR TITLE
focus changes (like opening a verb window) caused by clicking stat verbs work again

### DIFF
--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -310,6 +310,15 @@ var under_menu = document.querySelector('#under_menu');
 var statcontentdiv = document.querySelector('#statcontent');
 var storedimages = [];
 
+// Any BYOND commands that could result in the client's focus changing go through this
+// to ensure that when we relinquish our focus, we don't do it after the result of
+// a command has already taken focus for itself.
+function send_byond_focus_command(url) {
+	setTimeout(function() {
+		window.location.href = url;
+	}, 0);
+}
+
 function createStatusTab(name) {
 	if (name.indexOf(".") != -1)
 		name = name.split(".")[0];
@@ -1018,6 +1027,12 @@ function draw_spells(cat) {
 	document.getElementById("statcontent").appendChild(table);
 }
 
+function make_verb_onclick(command) {
+	return function() {
+		send_byond_focus_command("byond://winset?command=" + command);
+	};
+}
+
 function draw_verbs(cat){
 	statcontentdiv[textContentKey] = "";
 	var table = document.createElement("div");
@@ -1039,7 +1054,8 @@ function draw_verbs(cat){
 			}
 
 			var a = document.createElement("a");
-			a.href = "byond://winset?command=" + command.replace(/\s/g, "-");
+			a.href = "#"
+			a.onclick = make_verb_onclick(command.replace(/\s/g, "-"));
 			a.className = "grid-item";
 			var t = document.createElement("span");
 			t[textContentKey] = command;
@@ -1091,9 +1107,7 @@ function set_style_sheet(sheet) {
 }
 
 function restoreFocus() {
-	setTimeout(function() {
-		window.location.href = "byond://winset?map.focus=true";
-	}, 0);
+	send_byond_focus_command("byond://winset?map.focus=true")
 }
 
 document[addEventListenerKey]("mouseup", restoreFocus);


### PR DESCRIPTION
## About The Pull Request
After https://github.com/tgstation/tgstation/pull/58143, clicking a verb in the stat panel would process said verb _before_ setting focus back to the map. This meant that clicking a verb such as `say` would result in the say input box appearing but not being focused.

This change just makes both events go through the same queue so that the verbs process _after_ the map focus is set, meaning any windows they create can keep focus.

The delay is necessary because setting focus back to the map directly from mouseup can stop button events from firing.

## Changelog
:cl:
fix: pop-up boxes created by clicking a verb in the stat panel get focused (again)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
