### PR TITLE
revamps meta incinerator

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -156,7 +156,10 @@
 /area/maintenance/disposal/incinerator)
 "aaX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/atmos_control/incinerator,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/computer/atmos_control/incinerator{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "aaZ" = (
@@ -51991,6 +51994,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "oed" = (
@@ -52035,6 +52039,7 @@
 "oeB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold/general,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "oeE" = (
@@ -121535,7 +121540,7 @@ bYr
 muv
 nuA
 mKO
-aeD
+aaX
 aeD
 apX
 amV
@@ -121791,7 +121796,7 @@ qUk
 apc
 qYi
 nuA
-aaX
+xOg
 adk
 afQ
 afQ

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -143,33 +143,20 @@
 "aaU" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/structure/sign/warning/deathsposal{
-	pixel_y = 32
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
-"aaW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = -28
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "aaX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
+/obj/machinery/computer/atmos_control/incinerator,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "aaZ" = (
@@ -2337,7 +2324,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -29
 	},
-/obj/machinery/computer/atmos_control/incinerator{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -2536,9 +2523,7 @@
 "anz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/valve{
-	name = "output gas to space"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "anM" = (
@@ -2947,9 +2932,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "aqe" = (
@@ -3461,10 +3443,7 @@
 "atw" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Incinerator Output Pump";
-	target_pressure = 4500
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer1,
 /turf/open/space,
 /area/maintenance/disposal/incinerator)
 "atF" = (
@@ -7666,6 +7645,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"baO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "baP" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -11660,6 +11646,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"bLL" = (
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/space,
+/area/space/nearstation)
 "bLO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -13184,7 +13176,6 @@
 	pixel_y = 26
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -13456,14 +13447,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"ccJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "ccY" = (
 /obj/structure/disposalpipe/junction/flip,
 /obj/structure/cable,
@@ -15465,7 +15448,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "cpN" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
@@ -17905,6 +17888,9 @@
 /area/maintenance/solars/port/aft)
 "cKZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "cLb" = (
@@ -19726,6 +19712,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"dcA" = (
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer1,
+/turf/open/space,
+/area/space/nearstation)
 "dcE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -23871,11 +23863,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"euv" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall,
-/area/service/janitor)
 "eux" = (
 /obj/structure/window/fulltile,
 /obj/structure/flora/ausbushes/fernybush,
@@ -26410,7 +26397,9 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "fhC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "fhD" = (
@@ -29897,6 +29886,11 @@
 	name = "Pure to Mix"
 	},
 /turf/open/floor/iron,
+/area/engineering/atmos)
+"gxt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "gxu" = (
 /obj/structure/disposalpipe/segment,
@@ -34351,9 +34345,6 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Fuel Pipe to Incinerator"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "hXR" = (
@@ -35616,7 +35607,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "itW" = (
@@ -45163,6 +45153,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"lNs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall,
+/area/maintenance/starboard)
 "lNC" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
@@ -45308,6 +45302,10 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"lPb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall,
+/area/service/janitor)
 "lPn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -46037,9 +46035,6 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "mee" = (
@@ -46170,11 +46165,8 @@
 "mge" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -46837,9 +46829,8 @@
 	},
 /area/service/chapel/main)
 "mqJ" = (
-/obj/machinery/meter,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "mqU" = (
@@ -49975,6 +49966,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"nuA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall,
+/area/maintenance/disposal/incinerator)
 "nuF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
 	dir = 8
@@ -51995,9 +51990,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -52042,8 +52034,7 @@
 /area/science/research)
 "oeB" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/general,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "oeE" = (
@@ -58257,6 +58248,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"qkN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/disposal/incinerator)
 "qkZ" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/holofloor/dark,
@@ -59906,6 +59903,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"qNi" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall,
+/area/service/janitor)
 "qNp" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -65224,7 +65225,6 @@
 "stM" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "stQ" = (
@@ -67124,16 +67124,6 @@
 "tay" = (
 /turf/closed/wall,
 /area/medical/medbay/central)
-"taE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "tbf" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
@@ -69076,7 +69066,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "tIw" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/service/janitor)
 "tIU" = (
@@ -71769,7 +71759,7 @@
 "uAj" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/open/space,
 /area/space/nearstation)
 "uAl" = (
@@ -75177,12 +75167,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "vKk" = (
@@ -77531,10 +77517,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"wBK" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "wBX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -77930,15 +77912,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"wIH" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "wIK" = (
 /obj/item/clothing/head/cone{
 	pixel_x = -4;
@@ -78824,9 +78797,6 @@
 	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
 /turf/open/floor/iron,
 /area/service/janitor)
 "wZN" = (
@@ -79258,9 +79228,6 @@
 "xgh" = (
 /obj/machinery/light/small{
 	dir = 8
-	},
-/obj/structure/sign/warning/fire{
-	pixel_x = -32
 	},
 /obj/machinery/airlock_sensor/incinerator_atmos{
 	pixel_x = -8;
@@ -80053,11 +80020,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"xwF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xwG" = (
@@ -81082,10 +81044,6 @@
 /area/security/courtroom)
 "xOg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "xOl" = (
@@ -121318,10 +121276,10 @@ sRZ
 evA
 teN
 ezE
-alq
-euv
-tIw
-tIw
+lNs
+lPb
+lPb
+qNi
 tIw
 tIw
 ozE
@@ -121575,9 +121533,9 @@ bVC
 grp
 bYr
 muv
-bZE
+nuA
 mKO
-aaW
+aeD
 aeD
 apX
 amV
@@ -121832,16 +121790,16 @@ oCR
 qUk
 apc
 qYi
-bZE
+nuA
 aaX
 adk
 afQ
-wIH
+afQ
 anz
 oeB
 atw
-uAj
-uAj
+dcA
+bLL
 uAj
 uAj
 crc
@@ -122089,13 +122047,13 @@ bPn
 oNh
 aPE
 bZE
-bZE
+nuA
 odQ
 itV
 stM
 xOg
 vKe
-wBK
+cgz
 fhC
 cgz
 cgz
@@ -122348,7 +122306,7 @@ est
 qzU
 bZJ
 mge
-taE
+itV
 aiT
 mqJ
 apP
@@ -122602,9 +122560,9 @@ jod
 cXa
 mhI
 lWr
-bZE
+qkN
 aaU
-ccJ
+afQ
 meb
 cgx
 cgx
@@ -122859,7 +122817,7 @@ bUy
 alq
 waS
 uHb
-bZE
+qkN
 cba
 eWc
 hXQ
@@ -123116,8 +123074,8 @@ jMk
 jMk
 vTw
 inX
-jMk
-jMk
+cSa
+cSa
 cKZ
 qeS
 uwZ
@@ -128523,7 +128481,7 @@ ubx
 ekh
 tdZ
 pqE
-pqE
+baO
 cor
 aaa
 aaa
@@ -128779,9 +128737,9 @@ eOt
 tvX
 dRZ
 pqE
-xwF
+pqE
 dTi
-dhI
+gxt
 kuD
 aaa
 aaa


### PR DESCRIPTION
cleans pipes in meta incinerator

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Revamps the incinerator room in Metastation and adds thermomachine support
Before 
![image](https://user-images.githubusercontent.com/47158596/113755216-bbc21480-9718-11eb-82eb-af1c66ef15c7.png)


After
![image](https://user-images.githubusercontent.com/47158596/113755184-b4027000-9718-11eb-8a9d-1568bd548c6f.png)


## Why It's Good For The Game

For some reason mappers add scrubbers in the middle of the incinerator room and made a mess of pipes as well so removing these will give way for more advanced setups also giving it a cleaner look. Will fasten the setup of the turbine since there is now a thermomachine input for waste so you do not have to bother with piping it.

## Changelog
:cl:
Revamps meta incinerator to make better use of pipes with the addition of  smart pipes.
also gives the hfr room a manifolded  injector so it can be used for waste output for the hfr  and the scrubbers for the room
Gives the incinerator room a waste input to make it viable with the new thermomachines
/:cl:


