### PR TITLE
Player Lobstrosities Can Right-Click To Charge

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/lobstrosity.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/lobstrosity.dm
@@ -35,6 +35,12 @@
 	footstep_type = FOOTSTEP_MOB_CLAW
 	gold_core_spawnable = HOSTILE_SPAWN
 
+/mob/living/simple_animal/hostile/asteroid/lobstrosity/ranged_secondary_attack(atom/target, modifiers)
+	if(COOLDOWN_FINISHED(src, charge_cooldown))
+		INVOKE_ASYNC(src, /mob/living/simple_animal/hostile/.proc/enter_charge, target)
+	else
+		to_chat(src, "<span class='notice'>Your charge is still on cooldown!</B></span>")
+
 /mob/living/simple_animal/hostile/asteroid/lobstrosity/lava
 	name = "tropical lobstrosity"
 	desc = "A marvel of evolution gone wrong, the sulfur lakes of lavaland have given them a vibrant, red hued shell. Beware its charge."

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/lobstrosity.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/lobstrosity.dm
@@ -39,7 +39,7 @@
 	if(COOLDOWN_FINISHED(src, charge_cooldown))
 		INVOKE_ASYNC(src, /mob/living/simple_animal/hostile/.proc/enter_charge, target)
 	else
-		to_chat(src, "<span class='notice'>Your charge is still on cooldown!</B></span>")
+		to_chat(src, "<span class='notice'>Your charge is still on cooldown!</span>")
 
 /mob/living/simple_animal/hostile/asteroid/lobstrosity/lava
 	name = "tropical lobstrosity"


### PR DESCRIPTION
## About The Pull Request

This PR resolves a long-standing issue where player lobstrosities couldn't use their signature charge ability.  It can now be used by right-clicking on a valid target.

## Why It's Good For The Game

This was an oversight when they were being developed which should be rectified.

## Changelog
:cl:
qol: Player Lobstrosities can now charge using right-click.
/:cl: