### PR TITLE
[s] Restores Cargo Shuttle Blacklist Enforcement

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -67,10 +67,19 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 /obj/docking_port/mobile/supply/proc/check_blacklist(areaInstances)
 	for(var/place in areaInstances)
 		var/area/shuttle/shuttle_area = place
-		for(var/turf/shuttle_turf as anything in shuttle_area)
+		to_chat(world, "ITERATION LEVEL: AREAS")
+		to_chat(world, shuttle_area.name)
+		for(var/turf/shuttle_turf in shuttle_area)
+			to_chat(world, "ITERATION LEVEL: TURFS")
+			to_chat(world, shuttle_turf.x + shuttle_turf.y)
 			for(var/atom/passenger in shuttle_turf.GetAllContents())
+				to_chat(world, "ITERATION LEVEL: PASSENGERS")
+				to_chat(world, passenger.name)
 				if((is_type_in_typecache(passenger, GLOB.blacklisted_cargo_types) || HAS_TRAIT(passenger, TRAIT_BANNED_FROM_CARGO_SHUTTLE)) && !istype(passenger, /obj/docking_port))
+					to_chat(world, "ILLEGAL CARGO: " + passenger.name)
+					to_chat(world, "SHIPMENT REJECTED BY ORDER OF check_blacklist()")
 					return FALSE
+	to_chat(world, "SHIPMENT APPROVED BY ORDER OF check_blacklist()")
 	return TRUE
 
 /obj/docking_port/mobile/supply/request(obj/docking_port/stationary/S)

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -67,19 +67,10 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 /obj/docking_port/mobile/supply/proc/check_blacklist(areaInstances)
 	for(var/place in areaInstances)
 		var/area/shuttle/shuttle_area = place
-		to_chat(world, "ITERATION LEVEL: AREAS")
-		to_chat(world, shuttle_area.name)
 		for(var/turf/shuttle_turf in shuttle_area)
-			to_chat(world, "ITERATION LEVEL: TURFS")
-			to_chat(world, shuttle_turf.x + shuttle_turf.y)
 			for(var/atom/passenger in shuttle_turf.GetAllContents())
-				to_chat(world, "ITERATION LEVEL: PASSENGERS")
-				to_chat(world, passenger.name)
 				if((is_type_in_typecache(passenger, GLOB.blacklisted_cargo_types) || HAS_TRAIT(passenger, TRAIT_BANNED_FROM_CARGO_SHUTTLE)) && !istype(passenger, /obj/docking_port))
-					to_chat(world, "ILLEGAL CARGO: " + passenger.name)
-					to_chat(world, "SHIPMENT REJECTED BY ORDER OF check_blacklist()")
 					return FALSE
-	to_chat(world, "SHIPMENT APPROVED BY ORDER OF check_blacklist()")
 	return TRUE
 
 /obj/docking_port/mobile/supply/request(obj/docking_port/stationary/S)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removed an inappropriate as anything inside the cargo shuttle's blacklist check that was breaking it.

## Why It's Good For The Game

The blacklist exists for a reason, this bug can easily be exploited to access CentComm, what more can I say?

## Changelog
:cl:
fix: Preflight checks have been reenabled on your cargo shuttle, forbidden goods can no longer be shipped to CentComm for sale.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
