### PR TITLE
highroll punches can no longer knock down people with enough melee armor

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1412,7 +1412,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			target.apply_damage(damage*1.5, STAMINA, affecting, armor_block)
 			log_combat(user, target, "punched")
 
-		if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold)
+		if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold && armor_block < 50)
 			target.visible_message("<span class='danger'>[user] knocks [target] down!</span>", \
 							"<span class='userdanger'>You're knocked down by [user]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
 			to_chat(user, "<span class='danger'>You knock [target] down!</span>")

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1412,7 +1412,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			target.apply_damage(damage*1.5, STAMINA, affecting, armor_block)
 			log_combat(user, target, "punched")
 
-		if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold && armor_block < 50 && !target.is_shove_knockdown_blocked())
+		if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold && armor_block < 50)
 			target.visible_message("<span class='danger'>[user] knocks [target] down!</span>", \
 							"<span class='userdanger'>You're knocked down by [user]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
 			to_chat(user, "<span class='danger'>You knock [target] down!</span>")

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1412,7 +1412,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			target.apply_damage(damage*1.5, STAMINA, affecting, armor_block)
 			log_combat(user, target, "punched")
 
-		if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold && armor_block < 50)
+		if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold && armor_block < 50 && !target.is_shove_knockdown_blocked())
 			target.visible_message("<span class='danger'>[user] knocks [target] down!</span>", \
 							"<span class='userdanger'>You're knocked down by [user]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
 			to_chat(user, "<span class='danger'>You knock [target] down!</span>")


### PR DESCRIPTION
## About The Pull Request

Highroll punches (punches that roll your species's punchstunthreshold or more as their base damage value) can no longer knock someone down if they hit a body part that has 50 or more melee armor. Shoves are not affected by this change.

## Why It's Good For The Game

This makes highroll punches more consistent with blunt melee attacks against the chest, which also have a chance to knock the struck person down (with a similar wording in the produced message), but only if the struck region has less than 50 melee armor (after factoring armor penetration). If riot armor can stop a toolbox to the chest or a shove (riot armor has a special flag that makes the person wearing it immune to direct shove knockdowns) from knocking you over, it should also be able to stop a punch from knocking you over.

I received a PM from someone expressing frustration about this not being a thing, so I guess this technically counts as a uded PR?

I'm also considering adding a !target.is_shove_knockdown_blocked() check to highroll punches. Every piece of armor in the game with the BLOCKS_SHOVE_KNOCKDOWN flag has >=50 melee armor, so it wouldn't affect much, but it'd be a nice piece of future-proofing. A side effect of this would be that wearing riot armor and a baseball cap or something would stop you from getting knocked down by highroll punches that target the head, but that might be worth keeping as a feature. Does anyone have any strong opinions one way or the other on this?

## Changelog
:cl: ATHATH
balance: Strong punches can no longer knock someone with 50% or greater melee armor down.
/:cl: