### PR TITLE
refactors pods, new helper for spawning items from pods through code

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1474,3 +1474,49 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 			return "[number]-tuple"
 
 #define TURF_FROM_COORDS_LIST(List) (locate(List[1], List[2], List[3]))
+
+
+/**
+ * One proc for easy spawning of pods in the code to drop off items before whizzling (please don't proc call this in game, it will destroy you)
+ *
+ * Arguments:
+ * * specifications: special mods to the pod, see non var edit specifications for details on what you should fill this with
+ * Non var edit specifications:
+ * * target = where you want the pod to drop
+ * * path = a special specific pod path if you want, this can save you a lot of var edits
+ * * style = style of the pod, defaults to the normal pod
+ * * spawn = spawned path or a list of the paths spawned, what you're sending basically
+ * Returns the pod spawned, in case you want to spawn items yourself and modify them before putting them in.
+ */
+/proc/podspawn_path(specifications)
+	//get non var edit specifications
+	var/turf/landing_location = specifications["target"]
+	var/spawn_type = specifications["path"]
+	var/style = specifications["style"]
+	var/list/paths_to_spawn = specifications["spawn"]
+
+	//setup pod, add contents
+	if(!isturf(landing_location))
+		landing_location = get_turf(landing_location)
+	if(!spawn_type)
+		spawn_type = /obj/structure/closet/supplypod/podspawn
+	var/obj/structure/closet/supplypod/podspawn/pod = new spawn_type(null, style)
+	if(!islist(paths_to_spawn))
+		paths_to_spawn = list(paths_to_spawn)
+	for(var/atom/path as anything in paths_to_spawn)
+		path = new path(pod)
+
+	//remove non var edits from specifications
+	specifications -= landing_location
+	specifications -= style
+	specifications -= spawn_type
+	specifications -= paths_to_spawn
+
+	//rest of specificiations are edits on the pod
+	for(var/variable_name in specifications)
+		var/variable_value = specifications[variable_name]
+		if(!pod.vv_edit_var(variable_name, variable_value))
+			stack_trace("WARNING! podspawn vareditting \"[variable_name]\" to \"[variable_value]\" was rejected by the pod!")
+	new /obj/effect/pod_landingzone(landing_location, pod)
+	return pod
+

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1488,7 +1488,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
  * * spawn = spawned path or a list of the paths spawned, what you're sending basically
  * Returns the pod spawned, in case you want to spawn items yourself and modify them before putting them in.
  */
-/proc/podspawn_path(specifications)
+/proc/podspawn(specifications)
 	//get non var edit specifications
 	var/turf/landing_location = specifications["target"]
 	var/spawn_type = specifications["path"]

--- a/code/datums/skills/_skill.dm
+++ b/code/datums/skills/_skill.dm
@@ -72,10 +72,12 @@ GLOBAL_LIST_INIT(skill_types, subtypesof(/datum/skill))
 	if (LAZYFIND(mind.skills_rewarded, src.type))
 		to_chat(mind.current, "<span class='nicegreen'>It seems the Professional [title] Association won't send me another status symbol.</span>")
 		return
-	var/obj/structure/closet/supplypod/bluespacepod/pod = new()
-	pod.delays[POD_TRANSIT] = 150
-	pod.explosionSize = list(0,0,0,0)
+	podspawn_path(list(
+		"target" = get_turf(mind.current),
+		"path" = /obj/structure/closet/supplypod/mechpod,
+		"style" = STYLE_BLUESPACE,
+		"spawn" = skill_cape_path,
+		"delays" = list(POD_TRANSIT = 150, POD_FALLING = 4, POD_OPENING = 30, POD_LEAVING = 30)
+	))
 	to_chat(mind.current, "<span class='nicegreen'>My legendary skill has attracted the attention of the Professional [title] Association. It seems they are sending me a status symbol to commemorate my abilities.</span>")
-	var/turf/T = get_turf(mind.current)
-	new /obj/effect/pod_landingzone(T, pod , new skill_cape_path(T))
 	LAZYADD(mind.skills_rewarded, src.type)

--- a/code/datums/skills/_skill.dm
+++ b/code/datums/skills/_skill.dm
@@ -72,7 +72,7 @@ GLOBAL_LIST_INIT(skill_types, subtypesof(/datum/skill))
 	if (LAZYFIND(mind.skills_rewarded, src.type))
 		to_chat(mind.current, "<span class='nicegreen'>It seems the Professional [title] Association won't send me another status symbol.</span>")
 		return
-	podspawn_path(list(
+	podspawn(list(
 		"target" = get_turf(mind.current),
 		"path" = /obj/structure/closet/supplypod/mechpod,
 		"style" = STYLE_BLUESPACE,

--- a/code/game/machinery/computer/chef_orders/chef_order.dm
+++ b/code/game/machinery/computer/chef_orders/chef_order.dm
@@ -111,13 +111,15 @@
 				return
 			say("Thank you for your purchase! Please note: The charge of this purchase and machine cooldown has been doubled!")
 			COOLDOWN_START(src, order_cooldown, 120 SECONDS)
-			var/obj/structure/closet/supplypod/bluespacepod/pod = new()
-			pod.explosionSize = list(0,0,0,0)
+			var/list/ordered_paths = list()
 			for(var/datum/orderable_item/item as anything in grocery_list)//every order
 				for(var/amt in 1 to grocery_list[item])//every order amount
-					new item.item_instance.type(pod)
-			var/turf/landing_location = get_turf(chef)
-			new /obj/effect/pod_landingzone(landing_location, pod)
+					ordered_paths += item.item_instance.type
+			podspawn_path(list(
+				"target" = get_turf(chef),
+				"style" = STYLE_BLUESPACE,
+				"spawn" = ordered_paths
+			))
 			grocery_list.Cut()
 			update_static_data(chef)
 	. = TRUE

--- a/code/game/machinery/computer/chef_orders/chef_order.dm
+++ b/code/game/machinery/computer/chef_orders/chef_order.dm
@@ -115,7 +115,7 @@
 			for(var/datum/orderable_item/item as anything in grocery_list)//every order
 				for(var/amt in 1 to grocery_list[item])//every order amount
 					ordered_paths += item.item_instance.type
-			podspawn_path(list(
+			podspawn(list(
 				"target" = get_turf(chef),
 				"style" = STYLE_BLUESPACE,
 				"spawn" = ordered_paths

--- a/code/game/machinery/mechlaunchpad.dm
+++ b/code/game/machinery/mechlaunchpad.dm
@@ -54,7 +54,7 @@
  */
 /obj/machinery/mechpad/proc/launch(obj/machinery/mechpad/where)
 	var/turf/reverse_turf = get_turf(where)
-	podspawn_path(list(
+	podspawn(list(
 		"target" = get_turf(src),
 		"path" = /obj/structure/closet/supplypod/mechpod,
 		"style" = STYLE_SEETHROUGH,

--- a/code/game/machinery/mechlaunchpad.dm
+++ b/code/game/machinery/mechlaunchpad.dm
@@ -53,10 +53,13 @@
  * * where - where the supply pod will land after grabbing the mech
  */
 /obj/machinery/mechpad/proc/launch(obj/machinery/mechpad/where)
-	var/obj/structure/closet/supplypod/mechpod/pod = new()
-	var/turf/target_turf = get_turf(where)
-	pod.reverse_dropoff_coords = list(target_turf.x, target_turf.y, target_turf.z)
-	new /obj/effect/pod_landingzone(get_turf(src), pod)
+	var/turf/reverse_turf = get_turf(where)
+	podspawn_path(list(
+		"target" = get_turf(src),
+		"path" = /obj/structure/closet/supplypod/mechpod,
+		"style" = STYLE_SEETHROUGH,
+		"reverse_dropoff_coords" = list(reverse_turf.x, reverse_turf.y, reverse_turf.z)
+	))
 
 /obj/structure/closet/supplypod/mechpod
 	style = STYLE_SEETHROUGH

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -51,7 +51,7 @@
 		to_chat(M, "<span class='notice'>[uses] use[uses > 1 ? "s" : ""] remaining on the [src].</span>")
 
 /obj/item/choice_beacon/proc/spawn_option(obj/choice,mob/living/M)
-	podspawn_path(list(
+	podspawn(list(
 		"target" = get_turf(src),
 		"style" = STYLE_BLUESPACE,
 		"spawn" = choice,

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -51,17 +51,17 @@
 		to_chat(M, "<span class='notice'>[uses] use[uses > 1 ? "s" : ""] remaining on the [src].</span>")
 
 /obj/item/choice_beacon/proc/spawn_option(obj/choice,mob/living/M)
-	var/obj/structure/closet/supplypod/bluespacepod/pod = new()
-	new choice(pod)
-	pod.explosionSize = list(0,0,0,0)
+	podspawn_path(list(
+		"target" = get_turf(src),
+		"style" = STYLE_BLUESPACE,
+		"spawn" = choice,
+	))
 	var/msg = "<span class=danger>After making your selection, you notice a strange target on the ground. It might be best to step back!</span>"
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(istype(H.ears, /obj/item/radio/headset))
 			msg = "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: <span class='bold'>Item request received. Your package is inbound, please stand back from the landing site.</span> Message ends.\""
 	to_chat(M, msg)
-
-	new /obj/effect/pod_landingzone(get_turf(src), pod)
 
 /obj/item/choice_beacon/ingredient
 	name = "ingredient delivery beacon"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -713,15 +713,18 @@
 	var/chosen = pick_closest_path(object)
 	if(!chosen)
 		return
-	var/turf/T = get_turf(usr)
+	var/turf/target_turf = get_turf(usr)
 
 	if(ispath(chosen, /turf))
-		T.ChangeTurf(chosen)
+		target_turf.ChangeTurf(chosen)
 	else
-		var/obj/structure/closet/supplypod/centcompod/pod = new()
+		var/obj/structure/closet/supplypod/pod = podspawn_path(list(
+			"target" = target_turf,
+			"path" = /obj/structure/closet/supplypod/centcompod,
+		))
+		//we need to set the admin spawn flag for the spawned items so we do it outside of the podspawn_path proc
 		var/atom/A = new chosen(pod)
 		A.flags_1 |= ADMIN_SPAWNED_1
-		new /obj/effect/pod_landingzone(T, pod)
 
 	log_admin("[key_name(usr)] pod-spawned [chosen] at [AREACOORD(usr)]")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Podspawn Atom") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -718,11 +718,11 @@
 	if(ispath(chosen, /turf))
 		target_turf.ChangeTurf(chosen)
 	else
-		var/obj/structure/closet/supplypod/pod = podspawn_path(list(
+		var/obj/structure/closet/supplypod/pod = podspawn(list(
 			"target" = target_turf,
 			"path" = /obj/structure/closet/supplypod/centcompod,
 		))
-		//we need to set the admin spawn flag for the spawned items so we do it outside of the podspawn_path proc
+		//we need to set the admin spawn flag for the spawned items so we do it outside of the podspawn proc
 		var/atom/A = new chosen(pod)
 		A.flags_1 |= ADMIN_SPAWNED_1
 

--- a/code/modules/admin/smites/supply_pod_quick.dm
+++ b/code/modules/admin/smites/supply_pod_quick.dm
@@ -34,7 +34,7 @@
 
 /datum/smite/supply_pod_quick/effect(client/user, mob/living/target)
 	. = ..()
-	podspawn_path(list(
+	podspawn(list(
 		"target" = get_turf(target),
 		"path" = /obj/structure/closet/supplypod/centcompod,
 		"style" = STYLE_CENTCOM,

--- a/code/modules/admin/smites/supply_pod_quick.dm
+++ b/code/modules/admin/smites/supply_pod_quick.dm
@@ -34,16 +34,15 @@
 
 /datum/smite/supply_pod_quick/effect(client/user, mob/living/target)
 	. = ..()
-
-	var/obj/structure/closet/supplypod/centcompod/pod = new
-	pod.damage = SUPPLY_POD_QUICK_DAMAGE
-	pod.explosionSize = list(0, 0, 0, SUPPLY_POD_QUICK_FIRE_RANGE)
-	pod.effectStun = TRUE
-
-	if (!isnull(target_path))
-		new target_path(pod)
-
-	new /obj/effect/pod_landingzone(get_turf(target), pod)
+	podspawn_path(list(
+		"target" = get_turf(target),
+		"path" = /obj/structure/closet/supplypod/centcompod,
+		"style" = STYLE_CENTCOM,
+		"spawn" = target_path,
+		"damage" = SUPPLY_POD_QUICK_DAMAGE,
+		"explosionSize" = list(0, 0, 0, SUPPLY_POD_QUICK_FIRE_RANGE),
+		"effectStun" = TRUE
+	))
 
 #undef SUPPLY_POD_QUICK_DAMAGE
 #undef SUPPLY_POD_QUICK_FIRE_RANGE

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -397,11 +397,11 @@
 				LAZYADD(rev_mind.special_statuses, "<span class='bad'>Former head revolutionary</span>")
 				if(!charter_given && rev_mind.current && rev_mind.current.stat == CONSCIOUS)
 					charter_given = TRUE
-					var/obj/structure/closet/supplypod/bluespacepod/syndicate/pod = new()
-					pod.explosionSize = list(0,0,0,0)
-					new /obj/item/station_charter/revolution(pod)
-					var/turf/landing_location = get_turf(rev_mind.current)
-					new /obj/effect/pod_landingzone(landing_location, pod)
+					podspawn_path(list(
+						"target" = get_turf(rev_mind.current),
+						"style" = STYLE_SYNDICATE,
+						"spawn" = /obj/item/station_charter/revolution
+					))
 					to_chat(rev_mind.current, "<span class='hear'>You hear something crackle in your ears for a moment before a voice speaks. \
 						\"Please stand by for a message from your benefactor. Message as follows, provocateur. \
 						<b>You have been chosen out of your fellow provocateurs to rename the station. Choose wisely.</b> Message ends.\"</span>")

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -397,7 +397,7 @@
 				LAZYADD(rev_mind.special_statuses, "<span class='bad'>Former head revolutionary</span>")
 				if(!charter_given && rev_mind.current && rev_mind.current.stat == CONSCIOUS)
 					charter_given = TRUE
-					podspawn_path(list(
+					podspawn(list(
 						"target" = get_turf(rev_mind.current),
 						"style" = STYLE_SYNDICATE,
 						"spawn" = /obj/item/station_charter/revolution

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -64,8 +64,10 @@
 	bluespace = TRUE
 	explosionSize = list(0,0,1,2)
 
-/obj/structure/closet/supplypod/bluespacepod/syndicate
-	style = STYLE_SYNDICATE
+//type used for one drop spawning items. doesn't have a style as style is set by the helper that creates this
+/obj/structure/closet/supplypod/podspawn
+	bluespace = TRUE
+	explosionSize = list(0,0,0,0)
 
 /obj/structure/closet/supplypod/extractionpod
 	name = "Syndicate Extraction Pod"

--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -179,9 +179,11 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 /// Crashes the drone somewhere random if there's no launchpad to be found.
 /obj/item/exodrone/proc/drop_somewhere_on_station()
 	var/turf/random_spot = get_safe_random_station_turf()
-	var/obj/structure/closet/supplypod/pod = new
-	pod.bluespace = TRUE
-	new /obj/effect/pod_landingzone(random_spot, pod, src)
+
+	var/obj/structure/closet/supplypod/pod = podspawn_path(list(
+		"target" = random_spot,
+	))
+	forceMove(pod)
 	return random_spot
 
 /// Tries to find landing pad, starting with the one we launched from.

--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -180,7 +180,7 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 /obj/item/exodrone/proc/drop_somewhere_on_station()
 	var/turf/random_spot = get_safe_random_station_turf()
 
-	var/obj/structure/closet/supplypod/pod = podspawn_path(list(
+	var/obj/structure/closet/supplypod/pod = podspawn(list(
 		"target" = random_spot,
 	))
 	forceMove(pod)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Admins have some ease of use in podspawning for IC deliveries, but as it is it's kind of a dumb copypastapalooza for coders who want to do the same.

## Why It's Good For The Game

Easier to add IC deliveries, to show you the power of podspawn_path i refactored all but all instance of creating a pod via code into this

## Changelog
:cl: 
refactor: added podspawning helper codewise, most code pod spawns use it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
