### PR TITLE
Tramstation Map Fixes

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -8430,6 +8430,9 @@
 /obj/item/folder/red,
 /obj/item/folder/red,
 /obj/item/folder/blue,
+/obj/item/clothing/head/wizard/fake,
+/obj/item/clothing/suit/wizrobe/fake,
+/obj/item/staff,
 /turf/open/floor/wood,
 /area/service/library)
 "aAg" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -15428,7 +15428,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
-	req_access_txt = "11"
+	req_access_txt = "47"
 	},
 /turf/open/floor/plating,
 /area/science/research)
@@ -15741,7 +15741,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
-/obj/machinery/navbeacon/wayfinding/aiupload,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
@@ -21703,10 +21702,6 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "ebm" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Power Access Hatch";
-	req_one_access_txt = "11"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -21720,6 +21715,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload Access";
+	req_access_txt = "16"
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -23317,7 +23316,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
-	req_access_txt = "11"
+	req_access_txt = "35"
 	},
 /turf/open/floor/plating,
 /area/service/hydroponics)
@@ -31211,6 +31210,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/aiupload,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "hPc" = (
@@ -33442,6 +33442,11 @@
 	pixel_x = -5;
 	pixel_y = 1
 	},
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper{
+	pixel_y = -5
+	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "iMV" = (
@@ -35647,8 +35652,8 @@
 "jKb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
-	req_access_txt = null;
-	req_one_access_txt = "11, 1"
+	req_access_txt = "12";
+	req_one_access_txt = null
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -43917,7 +43922,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
-	req_access_txt = "11"
+	req_access_txt = "50"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -45405,7 +45410,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry";
-	req_access_txt = "69"
+	req_access_txt = "33"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/disposalpipe/segment,
@@ -46988,7 +46993,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry";
-	req_access_txt = "69"
+	req_access_txt = "33"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -50305,6 +50310,11 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/inspector,
+/obj/item/inspector{
+	pixel_x = -5;
+	pixel_y = 12
+	},
 /turf/open/floor/iron,
 /area/security/office)
 "pCI" = (
@@ -63659,6 +63669,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/folder/documents,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "uQm" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2420,6 +2420,7 @@
 "aiy" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
+/obj/item/pen/fourcolor,
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "aiz" = (
@@ -8410,10 +8411,25 @@
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "aAd" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
+/obj/structure/closet/crate{
+	name = "Stations and Syndicate Starter Bundle"
+	},
+/obj/item/toy/figure/assistant,
+/obj/item/toy/figure/assistant,
+/obj/item/toy/figure/syndie,
+/obj/item/toy/figure/syndie,
+/obj/item/toy/figure/wizard,
+/obj/item/toy/figure/borg,
+/obj/item/toy/figure/botanist,
+/obj/item/toy/figure/chef,
+/obj/item/toy/figure/curator,
+/obj/item/folder/blue,
+/obj/item/folder/red,
+/obj/item/folder/red,
+/obj/item/folder/blue,
 /turf/open/floor/wood,
 /area/service/library)
 "aAg" = (
@@ -27345,6 +27361,24 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
+"grW" = (
+/obj/structure/table/wood,
+/obj/item/toy/figure/wizard{
+	pixel_y = -3
+	},
+/obj/item/toy/figure/hos{
+	pixel_y = 15
+	},
+/obj/item/toy/figure/secofficer{
+	pixel_x = -9;
+	pixel_y = 15
+	},
+/obj/item/toy/figure/secofficer{
+	pixel_x = 9;
+	pixel_y = 15
+	},
+/turf/open/floor/iron/grimy,
+/area/service/library)
 "gsa" = (
 /obj/machinery/exodrone_launcher,
 /turf/open/floor/plating,
@@ -88650,7 +88684,7 @@ hlW
 aMr
 unq
 aiy
-aSJ
+grW
 aMr
 fHH
 aRQ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Xenobiology has syringes+droppers
- Power hatches connecting directly to departments have had their access changed on the upper-half
- AI Upload nav beacon has been moved to where it should be
- Chemistry and Pharmacy have their appropriate access now
- External AI Upload airlock fixed
- Brig now has 2 N-spect scanners
- Maintenance door near Security now has proper access
- Vault now has secret documents
- The library game room now has a Stations and Syndicate starter kit with figurines to roleplay as a character roleplaying another character.

## Why It's Good For The Game

Fixes #57791
Fixes #57812
Fixes #57811
Fixes #57810
Fixes #57809
Fixes #57807
Fixes #58080
Fixes #58079

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I put on my robe and wizard hat.
