### PR TITLE
Can no longer buckle to objects through walls

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -204,6 +204,10 @@
 	if(target == src)
 		return FALSE
 
+	// Check if the target to buckle isn't INSIDE OF A WALL
+	if(!isopenturf(get_turf(loc)))
+		return FALSE
+
 	// Check if this atom can have things buckled to it.
 	if(!can_buckle && !force)
 		return FALSE

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -105,8 +105,12 @@
 			var/mob/living/L = M.pulledby
 			L.reset_pull_offsets(M, TRUE)
 
-	if(!check_loc && M.loc != loc)
-		M.forceMove(loc)
+	if (!M.Move(loc))
+		if (!check_loc && M.loc != loc && src.density)
+			M.forceMove(loc)
+		else
+			return FALSE
+
 
 	if(anchored)
 		ADD_TRAIT(M, TRAIT_NO_FLOATING_ANIM, BUCKLED_TRAIT)
@@ -205,7 +209,7 @@
 		return FALSE
 
 	// Check if the target to buckle isn't INSIDE OF A WALL
-	if(!isopenturf(get_turf(loc)))
+	if(!isopenturf(loc))
 		return FALSE
 
 	// Check if this atom can have things buckled to it.

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -105,12 +105,13 @@
 			var/mob/living/L = M.pulledby
 			L.reset_pull_offsets(M, TRUE)
 
-	if (!M.Move(loc))
+	if (CanPass(M, loc))
+		M.Move(loc)
+	else
 		if (!check_loc && M.loc != loc && src.density)
 			M.forceMove(loc)
 		else
 			return FALSE
-
 
 	if(anchored)
 		ADD_TRAIT(M, TRAIT_NO_FLOATING_ANIM, BUCKLED_TRAIT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

~~Fixes half of https://github.com/tgstation/tgstation/issues/31426~~
Fixes https://github.com/tgstation/tgstation/issues/31426
Fixes https://github.com/tgstation/tgstation/issues/42924

Stops you from buckling to chairs, scooters, etc... through walls, air flaps, the gate on the luxury shuttle, and probably some other things that shouldn't be buckled through

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Glitching through walls is not an ideal feature.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can no longer buckle yourself through walls, air flaps, and a few other things that shouldn't be buckled through.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
