### PR TITLE
Cleanup some for loops that use "as contents" over special lists until we upgrade to 514.

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -196,7 +196,7 @@
 	if(check_contents(a, R, contents))
 		if(check_tools(a, R, contents))
 			if(R.one_per_turf)
-				for(var/content as anything in get_turf(a))
+				for(var/content in get_turf(a))
 					if(istype(content, R.result))
 						return ", object already present."
 			//If we're a mob we'll try a do_after; non mobs will instead instantly construct the item

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -39,8 +39,12 @@
 
 /obj/vehicle/ridden/wheelchair/motorized/obj_destruction(damage_flag)
 	var/turf/T = get_turf(src)
-	for(var/atom/movable/thing as anything in contents)
-		thing.forceMove(T)
+#if MIN_COMPILER_VERSION >= 514
+	#warn Please replace the loop below this warning with an `as anything` loop.
+#endif
+	for(var/wheelchair_content in contents)
+		var/atom/movable/atom_content = wheelchair_content
+		atom_content.forceMove(T)
 	return ..()
 
 /obj/vehicle/ridden/wheelchair/motorized/relaymove(mob/living/user, direction)
@@ -116,8 +120,12 @@
 	new /obj/item/stack/rods(drop_location(), 8)
 	new /obj/item/stack/sheet/iron(drop_location(), 10)
 	var/turf/T = get_turf(src)
-	for(var/atom/movable/thing as anything in contents)
-		thing.forceMove(T)
+#if MIN_COMPILER_VERSION >= 514
+	#warn Please replace the loop below this warning with an `as anything` loop.
+#endif
+	for(var/wheelchair_content in contents)
+		var/atom/movable/atom_content = wheelchair_content
+		atom_content.forceMove(T)
 	qdel(src)
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

`as x` doesn't work properly when used in for loops over special lists.

![image](https://user-images.githubusercontent.com/24975989/113933250-40ca2e00-97ec-11eb-9227-2853bd414cfd.png)

One instance of `as anything in get_turf()` in crafting code was removed as entirely redundant. It was an untyped for loop anyway.

Two instances of `as anything in contents` changed for wheelchairs with warnings added to change them to `as anything` loops when we upgrade to 514.

Motochairs tested on Manuel in the thunderdome. Do not return components when deconstructed as expected on live servers. Return components on fixed code testing locally.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes instances where code doesn't work as expected on 513.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Motorised wheelchairs should now drop all their components when deconstruted or destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
