### PR TITLE
Add "Except DM" build mode to build.js

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -25,6 +25,7 @@ const STANDARD_BUILD = "Standard Build"
 const TGS_BUILD = "TGS Build"
 const ALL_MAPS_BUILD = "CI All Maps Build"
 const TEST_RUN_BUILD = "CI Integration Tests Build"
+const NO_DM_BUILD = "Except DM Build"
 
 let BUILD_MODE = STANDARD_BUILD;
 if (process.env.CBT_BUILD_MODE) {
@@ -37,6 +38,9 @@ if (process.env.CBT_BUILD_MODE) {
       break;
     case "TGS":
       BUILD_MODE = TGS_BUILD
+      break;
+    case "NO_DM":
+      BUILD_MODE = NO_DM_BUILD
       break;
     default:
       BUILD_MODE = process.env.CBT_BUILD_MODE
@@ -224,6 +228,13 @@ switch (BUILD_MODE) {
       taskTgfont,
       taskTgui,
       taskDm('CBT','CIBUILDING')
+    ];
+    break;
+  case NO_DM_BUILD:
+    tasksToRun = [
+      taskYarn,
+      taskTgfont,
+      taskTgui
     ];
     break;
   default:

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -196,46 +196,25 @@ const taskDm = (...injectedDefines) => new Task('dm')
   });
 
 // Frontend
-let tasksToRun = [];
+let tasksToRun = [
+  taskYarn,
+  taskTgfont,
+  taskTgui,
+];
 switch (BUILD_MODE) {
   case STANDARD_BUILD:
-    tasksToRun = [
-      taskYarn,
-      taskTgfont,
-      taskTgui,
-      taskDm('CBT'),
-    ]
+    tasksToRun.push(taskDm('CBT'));
     break;
   case TGS_BUILD:
-    tasksToRun = [
-      taskYarn,
-      taskTgfont,
-      taskTgui,
-      taskPrependDefines('TGS'),
-    ]
+    tasksToRun.push(taskPrependDefines('TGS'));
     break;
   case ALL_MAPS_BUILD:
-    tasksToRun = [
-      taskYarn,
-      taskTgfont,
-      taskTgui,
-      taskDm('CBT','CIBUILDING','CITESTING','ALL_MAPS')
-    ];
+    tasksToRun.push(taskDm('CBT','CIBUILDING','CITESTING','ALL_MAPS'));
     break;
   case TEST_RUN_BUILD:
-    tasksToRun = [
-      taskYarn,
-      taskTgfont,
-      taskTgui,
-      taskDm('CBT','CIBUILDING')
-    ];
+    tasksToRun.push(taskDm('CBT','CIBUILDING'));
     break;
   case NO_DM_BUILD:
-    tasksToRun = [
-      taskYarn,
-      taskTgfont,
-      taskTgui
-    ];
     break;
   default:
     console.error(`Unknown build mode : ${BUILD_MODE}`)


### PR DESCRIPTION
## About The Pull Request
This adds a new build mode to tools/build/build, which runs everything except DM.

This might seem pretty useless, but my use case is I dev in a Linux env, and test my code in a Windows virtual machine. I would like to build the tgfont and tgui before transferring the files to the windows VM, and then finally run build there again, which will skip the tgfont and tgui steps because they were already completed.

**Further additions:**
902cdc840b de-duplicates the common portion of the tasksToRun array in each build mode.