### PR TITLE
Colorblind users can now examine the atmos components to read on what color they are

### DIFF
--- a/code/__HELPERS/piping_colors_lists.dm
+++ b/code/__HELPERS/piping_colors_lists.dm
@@ -29,3 +29,19 @@ GLOBAL_LIST_INIT(pipe_colors_ordered, sortList(list(
 	COLOR_STRONG_VIOLET = 4,
 	COLOR_YELLOW = 5
 )))
+
+///Names shown in the examine for every colored atmos component
+GLOBAL_LIST_INIT(pipe_color_name, sortList(list(
+	COLOR_VERY_LIGHT_GRAY = "grey",
+	COLOR_BLUE = "blue",
+	COLOR_RED = "red",
+	COLOR_VIBRANT_LIME = "green",
+	COLOR_TAN_ORANGE = "orange",
+	COLOR_CYAN = "cyan",
+	COLOR_DARK = "dark",
+	COLOR_YELLOW = "yellow",
+	COLOR_BROWN = "brown",
+	COLOR_LIGHT_PINK = "pink",
+	COLOR_PURPLE = "purple",
+	COLOR_STRONG_VIOLET = "violet"
+)))

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -68,7 +68,7 @@
 /obj/machinery/atmospherics/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>[src] is on layer [piping_layer].</span>"
-	. += "<span class='notice'>[src] is of [GLOB.pipe_paint_colors[GLOB.pipe_paint_colors[pipe_color]]] color"
+	. += "<span class='notice'>[src] is of [GLOB.pipe_color_name[pipe_color]] color"
 	if((vent_movement & VENTCRAWL_ENTRANCE_ALLOWED) && isliving(user))
 		var/mob/living/L = user
 		if(HAS_TRAIT(L, TRAIT_VENTCRAWLER_NUDE) || HAS_TRAIT(L, TRAIT_VENTCRAWLER_ALWAYS))

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -65,10 +65,13 @@
 	///Store the smart pipes connections, used for pipe construction
 	var/connection_num = 0
 
+/obj/machinery/atmospherics/LateInitialize()
+	. = ..()
+	name = "[GLOB.pipe_color_name[pipe_color]] [name]"
+
 /obj/machinery/atmospherics/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>[src] is on layer [piping_layer].</span>"
-	. += "<span class='notice'>[src] is of [GLOB.pipe_color_name[pipe_color]] color"
 	if((vent_movement & VENTCRAWL_ENTRANCE_ALLOWED) && isliving(user))
 		var/mob/living/L = user
 		if(HAS_TRAIT(L, TRAIT_VENTCRAWLER_NUDE) || HAS_TRAIT(L, TRAIT_VENTCRAWLER_ALWAYS))

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -67,6 +67,8 @@
 
 /obj/machinery/atmospherics/examine(mob/user)
 	. = ..()
+	. += "<span class='notice'>[src] is on layer [piping_layer].</span>"
+	. += "<span class='notice'>[src] is of [GLOB.pipe_paint_colors[GLOB.pipe_paint_colors[pipe_color]]] color"
 	if((vent_movement & VENTCRAWL_ENTRANCE_ALLOWED) && isliving(user))
 		var/mob/living/L = user
 		if(HAS_TRAIT(L, TRAIT_VENTCRAWLER_NUDE) || HAS_TRAIT(L, TRAIT_VENTCRAWLER_ALWAYS))

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -31,10 +31,6 @@
 	if(hide)
 		RegisterSignal(src, COMSIG_OBJ_HIDE, .proc/hide_pipe)
 
-/obj/machinery/atmospherics/components/examine(mob/user)
-	. = ..()
-	. += "<span class='notice'>[src] is on layer [piping_layer].</span>"
-
 // Iconnery
 
 /**

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -26,10 +26,6 @@
 	if(hide)
 		AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE) //if changing this, change the subtypes RemoveElements too, because thats how bespoke works
 
-/obj/machinery/atmospherics/pipe/examine(mob/user)
-	. = ..()
-	. += "<span class='notice'>[src] is on layer [piping_layer].</span>"
-
 /obj/machinery/atmospherics/pipe/nullifyNode(i)
 	var/obj/machinery/atmospherics/oldN = nodes[i]
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title, the PR adds a way to directly read the color of all atmos components by examining them
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
better support for colorblind people
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Colorblind users can now examine the atmos components to read on what color they are
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
