### PR TITLE
Gives the slippery component a default whitelist of allowed slots

### DIFF
--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -13,7 +13,7 @@
 	/// If parent is an item, this is the person currently holding/wearing the parent (or the parent if no one is holding it)
 	var/mob/living/holder
 	/// Whitelist of item slots the parent can be equipped in that make the holder slippery. If null or empty, it will always make the holder slippery.
-	var/list/slot_whitelist
+	var/list/slot_whitelist = list(ITEM_SLOT_OCLOTHING, ITEM_SLOT_ICLOTHING, ITEM_SLOT_GLOVES, ITEM_SLOT_FEET, ITEM_SLOT_HEAD, ITEM_SLOT_MASK, ITEM_SLOT_BELT, ITEM_SLOT_NECK)
 
 /datum/component/slippery/Initialize(knockdown, lube_flags = NONE, datum/callback/callback, paralyze, force_drop = FALSE, slot_whitelist)
 	src.knockdown_time = max(knockdown, 0)
@@ -21,7 +21,8 @@
 	src.force_drop_items = force_drop
 	src.lube_flags = lube_flags
 	src.callback = callback
-	src.slot_whitelist = slot_whitelist
+	if(slot_whitelist)
+		src.slot_whitelist = slot_whitelist
 	RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/Slip)
 	if(isitem(parent))
 		holder = parent


### PR DESCRIPTION
## About The Pull Request

#57878 allowed slippery component items to whitelist slots the item is allowed to be slippery in, with the default whitelist being... every slot. This combined with the prior slip component refactor had the unintentional consequence of making more things slippery than expected - specifically, things in your pockets. 

Now, by default anything slippery requires it must be equipped in one of the clothing slots to make the mob slippery.

## Why It's Good For The Game

Apparently, havoc has been wrought due to pocket soap by accident. Whoops. (Insert 'No GBP' label here)

## Changelog
:cl: Melbert
fix: Slippery things in your pocket no longer make you slippery. If you want to become slippery, you need to wear slippery things on your person actual.
/:cl:

