### PR TITLE
Fix connect_loc runtiming when connecting to the same turf.

### DIFF
--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -43,7 +43,9 @@
 		RegisterSignal(target.loc, COMSIG_TURF_CHANGE, .proc/on_turf_change)
 
 /datum/element/connect_loc/proc/unregister_signals(atom/movable/target, atom/old_loc)
-	LAZYREMOVE(targets[old_loc], target)
+	targets[old_loc] -= target
+	if (length(targets[old_loc]) == 0)
+		targets -= old_loc
 
 	for (var/signal in connections)
 		target.UnregisterSignal(old_loc, signal)

--- a/code/modules/unit_tests/connect_loc.dm
+++ b/code/modules/unit_tests/connect_loc.dm
@@ -43,6 +43,16 @@
 	run_loc_floor_bottom_left.ChangeTurf(old_turf_type)
 	return ..()
 
+/// Tests that multiple objects can have connect_loc on the same turf without runtimes.
+/datum/unit_test/connect_loc_multiple_on_turf
+
+/datum/unit_test/connect_loc_multiple_on_turf/Run()
+	var/obj/item/watches_mock_calls/watcher_one = allocate(/obj/item/watches_mock_calls, run_loc_floor_bottom_left)
+	qdel(watcher_one)
+
+	var/obj/item/watches_mock_calls/watcher_two = allocate(/obj/item/watches_mock_calls, run_loc_floor_bottom_left)
+	qdel(watcher_two)
+
 /obj/item/watches_mock_calls
 	var/times_called
 


### PR DESCRIPTION
I forgot `= null` on an assoc list doesn't clear it, like in Lua. This is now fixed with a regression test.