### PR TITLE
Fixes a small typo on the medical kiosk

### DIFF
--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -301,7 +301,7 @@
 	if(rad_sickness_value >= 1000)  //
 		rad_sickness_status = "Patient is suffering from extreme radiation poisoning, high toxen damage expected. Suggested treatment: Repeated dosages of Pentetic Acid or high amounts of Cold Seiver and anti-toxen"
 	else if(rad_sickness_value >= 300)
-		rad_sickness_status = "Patient is suffering from alarming radiation poisoning. Suggested treatment: Take Cold Seiver or Potassium Iodine, watch the toxen levels."
+		rad_sickness_status = "Patient is suffering from alarming radiation poisoning. Suggested treatment: Take Cold Seiver or Potassium Iodine, watch the toxin levels."
 	else if(rad_sickness_value >= 100)
 		rad_sickness_status = "Patient has moderate radioactive signatures. Symptoms will subside in a few minutes"
 


### PR DESCRIPTION
## Why It's Good For The Game

![final_60712e0c1c145500a02d3b44_646203](https://user-images.githubusercontent.com/68669754/114258960-6eec7100-9998-11eb-9c08-3027ce4129b6.png)


## Changelog
:cl:
spellcheck: Fixed a small typo that existed on the medical kiosk's radiation poisoning warning.
/:cl: