### PR TITLE
Fixes issues with the stormtrooper aim quirk

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -329,7 +329,7 @@
 /obj/item/gun/proc/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	if(user)
 		if(HAS_TRAIT(user, TRAIT_POOR_AIM)) //nice shootin' tex
-			target = pick(orange(2, target))
+			bonus_spread += 45
 		SEND_SIGNAL(user, COMSIG_MOB_FIRED_GUN, user, target, params, zone_override)
 
 	SEND_SIGNAL(src, COMSIG_GUN_FIRED, user, target, params, zone_override)


### PR DESCRIPTION
## About The Pull Request
Removes the jank added in https://github.com/tgstation/tgstation/pull/56511
Doesn't add the blind back, 'cause that wasn't fun and could lag
Makes the spread bigger because it's funny

Alternate to https://github.com/tgstation/tgstation/pull/58288, which brings in a blind that I think is trash and ruins the game experience.


Fixes https://github.com/tgstation/tgstation/issues/58049

## Why It's Good For The Game
This is the current dogshit behavior, which allows for 100% accuracy against a mob which was clearly untested: 
https://streamable.com/rp4luz

This is what it looks like after increasing the bonus_spread to a comical amount: 
https://streamable.com/p876y0


## Changelog
:cl:
fix: The stormtrooper aim quirk will now have you blasting inaccurately down hallways again instead of being able to land precise, repeated impacts on targets.
/:cl: