### PR TITLE
Revert "Poor Aim now gives you Stormtrooper Aim."

### DIFF
--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -323,8 +323,8 @@
 			quirk_holder.put_in_hands(I)
 
 /datum/quirk/poor_aim
-	name = "Stormtrooper Aim"
-	desc = "You've never hit anything you were aiming for in your life."
+	name = "Poor Aim"
+	desc = "You're terrible with guns and can't line up a straight shot to save your life. Dual-wielding is right out. You also close your eyes when you shoot."
 	value = -4
 	mob_trait = TRAIT_POOR_AIM
 	medical_record_text = "Patient possesses a strong tremor in both hands."

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -328,8 +328,6 @@
 
 /obj/item/gun/proc/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	if(user)
-		if(HAS_TRAIT(user, TRAIT_POOR_AIM)) //nice shootin' tex
-			target = pick(orange(2, target))
 		SEND_SIGNAL(user, COMSIG_MOB_FIRED_GUN, user, target, params, zone_override)
 
 	SEND_SIGNAL(src, COMSIG_GUN_FIRED, user, target, params, zone_override)
@@ -343,7 +341,10 @@
 	var/randomized_gun_spread = 0
 	var/rand_spr = rand()
 	if(spread)
-		randomized_gun_spread =	rand(0,spread)
+		randomized_gun_spread = rand(0,spread)
+	if(HAS_TRAIT(user, TRAIT_POOR_AIM)) //nice shootin' tex
+		user.blind_eyes(1)
+		bonus_spread += 25
 	var/randomized_bonus_spread = rand(0, bonus_spread)
 
 	if(burst_size > 1)


### PR DESCRIPTION
## About The Pull Request
Removes the jank added in https://github.com/tgstation/tgstation/pull/56511
Fixes https://github.com/tgstation/tgstation/issues/58049

## Why It's Good For The Game
This is the current dogshit behavior, which allows for 100% accuracy against a mob which was clearly untested: 
https://streamable.com/rp4luz

## Changelog
:cl:
fix: The stormtrooper aim quirk has been reverted to the poor aim quirk, which blinds you when firing.
/:cl: