### PR TITLE
Makes rot more forgiving of slow cleanup

### DIFF
--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -8,6 +8,8 @@
 	var/start_time = 0
 	///The delay in ticks between the start of rot and effects kicking in
 	var/start_delay = 0
+	///The time in ticks before a rot component reaches its full effectiveness
+	var/scaling_delay = 0
 	///How strong is the rot? used for scaling different aspects of the component. Between 0 and 1
 	var/strength = 0
 	///Is the component active right now?
@@ -15,7 +17,7 @@
 	///Bitfield of sources preventing the component from rotting
 	var/blockers = NONE
 
-/datum/component/rot/Initialize(delay, severity)
+/datum/component/rot/Initialize(delay, scaling, severity)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 	if(isliving(parent))
@@ -25,6 +27,7 @@
 			return COMPONENT_INCOMPATIBLE
 
 	start_delay = delay
+	scaling_delay = scaling
 	strength = severity
 
 	RegisterSignal(parent, list(COMSIG_ATOM_HULK_ATTACK, COMSIG_ATOM_ATTACK_ANIMAL, COMSIG_ATOM_ATTACK_HAND), .proc/rot_react_touch)
@@ -98,7 +101,7 @@
 
 /datum/component/rot/proc/rot_react_touch(datum/source, mob/living/react_to)
 	SIGNAL_HANDLER
-	rot_react(source, react_to, react_to.zone_selected)
+	rot_react(source, react_to, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 
 ///The main bit of logic for the rot component, does a temperature check and has a chance to infect react_to
 /datum/component/rot/proc/rot_react(source, mob/living/react_to, target_zone = null)
@@ -115,15 +118,18 @@
 	if(!active)
 		return
 
+	var/time_delta = world.time - start_time
 	// Wait a bit before decaying
-	if(world.time - start_time < start_delay)
+	if(time_delta < start_delay)
 		return
 
-	if(!prob(strength * 3))
+	var/time_scaling = min((time_delta - start_delay) / scaling_delay, 1)
+
+	if(!prob(strength * 1 * time_scaling))
 		return
 
 	//We're running just under the "worst disease", since we don't want these to be too strong
-	var/datum/disease/advance/random/rand_disease = new(rand(5 * strength), rand(strength * 7))
+	var/datum/disease/advance/random/rand_disease = new(rand(4 * strength * time_scaling), rand(strength * 5 * time_scaling))
 	rand_disease.name = "Unknown"
 	react_to.ContactContractDisease(rand_disease, target_zone)
 

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -107,7 +107,7 @@
 
 /obj/effect/decal/cleanable/blood/gibs/dry()
 	. = ..()
-	AddComponent(/datum/component/rot, 0, 0.7)
+	AddComponent(/datum/component/rot, 0, 5 MINUTES, 0.7)
 
 /obj/effect/decal/cleanable/blood/gibs/ex_act(severity, target)
 	return FALSE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1272,4 +1272,4 @@
 
 
 /mob/living/carbon/proc/attach_rot(mapload)
-	AddComponent(/datum/component/rot, 6 MINUTES, 1)
+	AddComponent(/datum/component/rot, 6 MINUTES, 10 MINUTES, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives rotting things a timer before they become fully effective to give more leeway for cleanup. Lowers the max values for disease effect and proc chance significantly. Cleans up some silly zone selection code.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Hopefully this maintains the effect of rotting while making it less of an instant thing. I'm kind of concerned I've stumbled into another one of the "This was never meant to work" features, but ahhhh I'm sure it'll come out in the wash

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Rotting things are less potent, and will ramp up their effectiveness over time, rather then being all or nothing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
