### PR TITLE
Fixes plane master filters not working properly

### DIFF
--- a/code/_onclick/hud/plane_master_controller.dm
+++ b/code/_onclick/hud/plane_master_controller.dm
@@ -12,6 +12,9 @@
 	var/assoc_controlled_planes = list()
 	for(var/i in controlled_planes)
 		var/atom/movable/screen/plane_master/instance = owner_hud.plane_masters["[i]"]
+		if(!instance) //If we looked for a hud that isn't instanced, just keep going
+			stack_trace("[i] isn't a valid plane master layer for [owner_hud.type], are you sure it exists in the first place?")
+			continue
 		assoc_controlled_planes["[i]"] = instance
 	controlled_planes = assoc_controlled_planes
 
@@ -75,7 +78,6 @@
 /atom/movable/plane_master_controller/game
 	name = PLANE_MASTERS_GAME
 	controlled_planes = list(
-		OPENSPACE_PLANE,
 		FLOOR_PLANE,
 		OVER_TILE_PLANE,
 		WALL_PLANE,


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

They were failing to apply filters due to a null in the controlled planes list. Turns out OPENSPACE_PLANE isn't an actual plane master. Let's add a stack trace for this case just in, well case yeah?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Blurry eye filters will actually work now, among other things
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Some stuff that applied blurred vision and roatated things on screen wasn't working, let's fix that up shall we?
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
