### PR TITLE
Adjust stat panel grid item widths and breakpoints

### DIFF
--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -144,13 +144,13 @@
 	}
 
 	.grid-item {
-		box-sizing: border-box;
+		position: relative;
 		display: inline-block;
+		width: 100%;
+		box-sizing: border-box;
 		overflow: visible;
 		padding: 3px 2px;
-		position: relative;
 		text-decoration: none;
-		width: 100%;
 	}
 
 	@media only screen and (min-width: 300px) {

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -144,25 +144,36 @@
 	}
 
 	.grid-item {
-		position: relative;
+		box-sizing: border-box;
 		display: inline-block;
-		width: 150px;
-		padding: 3px 2px;
-		text-decoration: none;
 		overflow: visible;
+		padding: 3px 2px;
+		position: relative;
+		text-decoration: none;
+		width: 100%;
 	}
 
-	@media only screen and (min-width: 720px) {
+	@media only screen and (min-width: 300px) {
 		.grid-item {
-			width: 25%;
-			box-sizing: border-box;
+			width: 50%;
 		}
 	}
 
-	@media only screen and (min-width: 800px) {
+	@media only screen and (min-width: 430px) {
+		.grid-item {
+			width: 33%;
+		}
+	}
+
+	@media only screen and (min-width: 560px) {
+		.grid-item {
+			width: 25%;
+		}
+	}
+
+	@media only screen and (min-width: 770px) {
 		.grid-item {
 			width: 20%;
-			box-sizing: border-box;
 		}
 	}
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I have made it so that stat panel grid items would not have fixed widths for 1, 2 and 3 column views, as well as have more sensible break points.

Minimum width for 2 column view:
![image](https://user-images.githubusercontent.com/81999976/114273081-67bd7580-9a21-11eb-884d-e2a84eff8473.png)

Minimum width for 3 column view:
![image](https://user-images.githubusercontent.com/81999976/114273084-6e4bed00-9a21-11eb-9dd9-1d08307a1b24.png)

Minimum width for 4 column view:
![image](https://user-images.githubusercontent.com/81999976/114273086-7441ce00-9a21-11eb-8ed9-d8e1a4794416.png)

Minimum width for 5 column view (slightly non-standard, tried to keep it closer to how it was):
![image](https://user-images.githubusercontent.com/81999976/114273094-7f94f980-9a21-11eb-86f6-26f5fa474542.png)

Bonus image - maximum width for 3 column view, where you can see that the items do not have fixed widths like earlier:
![image](https://user-images.githubusercontent.com/81999976/114273106-8b80bb80-9a21-11eb-9067-1dd4e383bbc6.png)

## Why It's Good For The Game

The stat panel items' text is no longer unnecessarily truncated.

## Changelog
:cl: Celotajs
qol: Improved how stat panel items are displayed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
