### PR TITLE
removes icebox having more prisoner slots

### DIFF
--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -46,10 +46,6 @@
 	],
 	"minetype": "none",
 	"job_changes": {
-		"prisoner": {
-			"total_positions": 4,
-			"spawn_positions": 4
-		},
 		"cook": {
 			"additional_cqc_areas": ["/area/service/kitchen/diner"]
 		}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

removes icebox having more prisoner slots, which should go from 4 back to 2
fixes #56191

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
it causes bugs where you can latejoin as prisoner
we shouldnt have almost as many prisoners as cargo techs, scientist, engineers or doctors, 2 is fine and makes place for actual perma'd people in the brigg

## Changelog
:cl:
del: icebox no longer has more prisoner slots
fix: because of this, you can no longer latejoin as prisoner
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
