### PR TITLE
attack_self hotkey can check for modifiers (Shift, Alt, Ctrl)

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -62,7 +62,16 @@
 
 	return afterattack(target, user, TRUE, params)
 
-/// Called when the item is in the active hand, and clicked; alternately, there is an 'activate held object' verb or you can hit pagedown.
+/** 
+ * Called when the item is in the active hand and clicked. 
+ * Alternately, there is an 'activate held object' hotkey that you can hit on pagedown or z (default).
+ *
+ * Modifiers will be using regular mouse click params if it isn't a hotkey.
+ * Modifiers will pass detections of alt, ctrl, and shift modifiers if 
+ * the activate held object hotkey is pressed.
+ *
+ * Implement these alt, shift, and ctrl functionalities on an item-to-item basis.
+*/
 /obj/item/proc/attack_self(mob/user, modifiers)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return TRUE

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -47,7 +47,16 @@
 	if(.)
 		return
 	var/mob/M = user.mob
-	M.mode()
+	// We check for additional modifiers if the activate_inhand hotkey is pressed.
+	var/list/modifiers = list()
+	if(user.keys_held["Alt"])
+		modifiers["alt"] = TRUE
+	if(user.keys_held["Ctrl"])
+		modifiers["ctrl"] = TRUE
+	if(user.keys_held["Shift"])
+		modifiers["shift"] = TRUE
+	var/params = list2params(modifiers)
+	M.mode(params)
 	return TRUE
 
 /datum/keybinding/mob/drop_item

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -241,9 +241,9 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 /obj/item/pipe_dispenser/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'> <i>Alt-click</i> will change the piping layer. </span>"
+	. += "<span class='notice'> <i>Alt+click</i> will change the piping layer. </span>"
 	if (mode_allowed & UNWRENCH_MODE)
-		. += "<span class='notice'> <i>Ctrl-click</i> will toggle the unwrench mode. </span>"
+		. += "<span class='notice'> <i>Ctrl+click</i> will toggle the unwrench mode. </span>"
 
 /obj/item/pipe_dispenser/dropped(mob/user, silent)
 	UnregisterSignal(user, COMSIG_MOUSE_SCROLL_ON)

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -406,7 +406,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/queued_p_flipped = p_flipped
 
 	//Unwrench pipe before we build one over/paint it, but only if we're not already running a do_after on it already to prevent a potential runtime.
-	if((mode & UNWRENCH_MODE) && istype(attack_target, /obj/machinery/atmospherics) && !(DOING_INTERACTION_WITH_TARGET(user, attack_target)))
+	if((mode & UNWRENCH_MODE) && (mode_allowed & UNWRENCH_MODE) && istype(attack_target, /obj/machinery/atmospherics) && !(DOING_INTERACTION_WITH_TARGET(user, attack_target)))
 		attack_target = attack_target.wrench_act(user, src)
 		if(!isatom(attack_target))
 			CRASH("When attempting to call [attack_target.type].wrench_act(), received the following non-atom return value: [attack_target]")

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -61,10 +61,15 @@
 	cooling_power = 1.5
 	power = 3
 
-/obj/item/extinguisher/crafted/attack_self(mob/user)
-	safety = !safety
-	icon_state = "[sprite_name][!safety]"
-	to_chat(user, "[safety ? "You remove the straw and put it on the side of the cool canister" : "You insert the straw, readying it for use"].")
+/// Overrides the parent for some flavor text.
+/obj/item/extinguisher/crafted/attack_self(mob/user, modifiers)
+	if (LAZYACCESS(modifiers, ALT_CLICK))
+		AltClick(user)
+		return TRUE
+	else	
+		safety = !safety
+		icon_state = "[sprite_name][!safety]"
+		to_chat(user, "[safety ? "You remove the straw and put it on the side of the cool canister" : "You insert the straw, readying it for use"].")
 
 /obj/item/extinguisher/proc/refill()
 	if(!chem)
@@ -105,11 +110,16 @@
 		user.visible_message("<span class='warning'>[user] puts the nozzle to [user.p_their()] mouth... [src] is empty!</span>")
 		return SHAME
 
-/obj/item/extinguisher/attack_self(mob/user)
-	safety = !safety
-	src.icon_state = "[sprite_name][!safety]"
-	to_chat(user, "The safety is [safety ? "on" : "off"].")
-	return
+/// Attack_self toggles safety on and off.
+/obj/item/extinguisher/attack_self(mob/user, modifiers)
+	if (LAZYACCESS(modifiers, ALT_CLICK))
+		AltClick(user)
+		return TRUE
+	else
+		safety = !safety
+		src.icon_state = "[sprite_name][!safety]"
+		to_chat(user, "The safety is [safety ? "on" : "off"].")
+		return
 
 /obj/item/extinguisher/attack(mob/M, mob/living/user)
 	if(!user.combat_mode && !safety) //If we're on help intent and going to spray people, don't bash them.

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -823,13 +823,23 @@
 	stored.forceMove(get_turf(usr))
 	return
 
-/obj/item/borg/apparatus/attack_self(mob/living/silicon/robot/user)
+/**
+* Attack_self will check for alt in order to check for drops. 
+* Otherwise it's like self attacking the stored item.
+*/
+/obj/item/borg/apparatus/attack_self(mob/living/silicon/robot/user, modifiers)
+	if(stored)
+		if (LAZYACCESS(modifiers, ALT_CLICK))
+			AltClick(user)
+			return .. ()
+		else
+			stored.attack_self(user)
+
+//Alt click drops the stored item.
+/obj/item/borg/apparatus/AltClick(mob/living/silicon/robot/user)
 	if(!stored)
 		return ..()
-	if(user.client?.keys_held["Alt"])
-		stored.forceMove(get_turf(user))
-		return
-	stored.attack_self(user)
+	stored.forceMove(get_turf(user))
 
 /obj/item/borg/apparatus/pre_attack(atom/A, mob/living/user, params)
 	if(!stored)
@@ -867,13 +877,18 @@
 		return
 	. = ..()
 
+/// Parent proc for all apparatus, tells the player that they can alt-click to drop.
+/obj/item/borg/apparatus/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'> <i>Alt-click</i> will drop the currently stored item. </span>"
+
 /////////////////
 //beaker holder//
 /////////////////
 
 /obj/item/borg/apparatus/beaker
 	name = "beaker storage apparatus"
-	desc = "A special apparatus for carrying beakers without spilling the contents. Alt-Z or right-click to drop the beaker."
+	desc = "A special apparatus for carrying beakers without spilling the contents."
 	icon_state = "borg_beaker_apparatus"
 	storable = list(/obj/item/reagent_containers/glass/beaker,
 					/obj/item/reagent_containers/glass/bottle)
@@ -919,12 +934,11 @@
 		arm.pixel_y = arm.pixel_y - 5
 	. += arm
 
-/obj/item/borg/apparatus/beaker/attack_self(mob/living/silicon/robot/user)
-	if(stored && !user.client?.keys_held["Alt"] && user.combat_mode)
-		var/obj/item/reagent_containers/C = stored
-		C.SplashReagents(get_turf(user))
-		loc.visible_message("<span class='notice'>[user] spills the contents of the [C] all over the floor.</span>")
-		return
+/// Secondary attack spills the content of the beaker.
+/obj/item/borg/apparatus/beaker/pre_attack_secondary(atom/target, mob/living/silicon/robot/user)
+	var/obj/item/reagent_containers/stored_beaker = stored
+	stored_beaker.SplashReagents(get_turf(user))
+	loc.visible_message("<span class='notice'>[user] spills the contents of the [stored_beaker] all over the floor.</span>")
 	. = ..()
 
 /obj/item/borg/apparatus/beaker/extra
@@ -933,7 +947,7 @@
 
 /obj/item/borg/apparatus/beaker/service
 	name = "beverage storage apparatus"
-	desc = "A special apparatus for carrying drinks without spilling the contents. Alt-Z or right-click to drop the beaker."
+	desc = "A special apparatus for carrying drinks without spilling the contents."
 	icon_state = "borg_beaker_apparatus"
 	storable = list(/obj/item/reagent_containers/food/drinks,
 					/obj/item/reagent_containers/food/condiment)
@@ -983,7 +997,8 @@
 		bag = mutable_appearance(icon, icon_state = "evidenceobj") // empty bag
 	. += bag
 
-/obj/item/borg/apparatus/organ_storage/attack_self(mob/user)
+/obj/item/borg/apparatus/organ_storage/AltClick(mob/living/silicon/robot/user)
+	. = ..()
 	if(stored)
 		var/obj/item/organ = stored
 		user.visible_message("<span class='notice'>[user] dumps [organ] from [src].</span>", "<span class='notice'>You dump [organ] from [src].</span>")
@@ -991,7 +1006,6 @@
 		organ.forceMove(get_turf(src))
 	else
 		to_chat(user, "<span class='notice'>[src] is empty.</span>")
-	return
 
 ////////////////////////////
 //engi circuitboard holder//
@@ -999,7 +1013,7 @@
 
 /obj/item/borg/apparatus/circuit
 	name = "circuit manipulation apparatus"
-	desc = "A special apparatus for carrying and manipulating circuit boards. Alt-Z or right-click to drop the stored object."
+	desc = "A special apparatus for carrying and manipulating circuit boards."
 	icon_state = "borg_hardware_apparatus"
 	storable = list(/obj/item/circuitboard,
 				/obj/item/electronics)

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -880,7 +880,7 @@
 /// Parent proc for all apparatus, tells the player that they can alt-click to drop.
 /obj/item/borg/apparatus/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'> <i>Alt-click</i> will drop the currently stored item. </span>"
+	. += "<span class='notice'> <i>Alt+click</i> will drop the currently stored item. </span>"
 
 /////////////////
 //beaker holder//
@@ -916,6 +916,8 @@
 				. += "[R.volume] units of [R.name]"
 		else
 			. += "Nothing."
+		
+		. += "<span class='notice'> <i>Right-clicking</i> will splash the beaker on the floor.</span>"
 
 /obj/item/borg/apparatus/beaker/update_overlays()
 	. = ..()

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -67,6 +67,11 @@
 			else
 				full_key = _key
 	var/keycount = 0
+
+	// Snowflake case for activate_inhand. This allows combos like Alt+Click to be replicated by Alt+Z
+	if ("activate_inhand" in prefs.key_bindings[_key])
+		full_key = _key
+
 	for(var/kb_name in prefs.key_bindings[full_key])
 		keycount++
 		var/datum/keybinding/kb = GLOB.keybindings_by_name[kb_name]

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -625,9 +625,11 @@
 /**
  * Verb to activate the object in your held hand
  *
- * Calls attack self on the item and updates the inventory hud for hands
+ * Calls attack self on the item and updates the inventory hud for hands.
+ * Changes the params into a modifier list, 
+ * will only take effect for items triggered using activate_inhand hotkey.
  */
-/mob/verb/mode()
+/mob/verb/mode(params as text)
 	set name = "Activate Held Object"
 	set category = "Object"
 	set src = usr
@@ -640,7 +642,7 @@
 
 	var/obj/item/I = get_active_held_item()
 	if(I)
-		I.attack_self(src)
+		I.attack_self(src, params2list(params))
 		update_inv_hands()
 		return
 

--- a/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
@@ -33,6 +33,10 @@ const TOOLS = [
     name: 'Destroy',
     bitmask: 4,
   },
+  {
+    name: 'Unwrench',
+    bitmask: 8,
+  },
 ];
 
 export const RapidPipeDispenser = (props, context) => {
@@ -43,6 +47,7 @@ export const RapidPipeDispenser = (props, context) => {
     selected_color,
     piping_layer,
     mode,
+    mode_allowed,
   } = data;
   const previews = data.preview_rows.flatMap(row => row.previews);
   const [
@@ -76,6 +81,7 @@ export const RapidPipeDispenser = (props, context) => {
                 <Button.Checkbox
                   key={tool.bitmask}
                   checked={mode & tool.bitmask}
+                  disabled={!(mode_allowed & tool.bitmask)}
                   content={tool.name}
                   onClick={() => act('mode', {
                     mode: tool.bitmask,


### PR DESCRIPTION
## About The Pull Request
Title is pretty self explanatory on the main purpose of the PR.

I implemented an if check in `code/modules/keybindings/bindings_client.dm` to change the `full_key` value if the activate held object hotkey is pressed. This allows modified Z presses (with shift, alt, etc) to actually properly be called and registered. This is quite snowflakey, but I believe this gives significantly better user experience.

This will need to be implemented in a case to case basis however, since most instances of `attack_self` are mostly overrides. I have only implemented this in three major parts: RPD (my original goal here), borg apparatus, and fire extinguisher.

Current Implementations:
(whenever i say something +click you can substitute +z for that)
RPD will now accept ctrl+click  to toggle the unwrench mode. A sadly underused but cool upgrade. This should breathe some life back to it.
You can also alt+click to change layers. The scroll wheel implementation was good, but I believe actual keys make it easier to control. Give me your thoughts here. 
Borg apparatus can now properly eject their contents (beaker, circuit, organs) using alt+click. While I'm at it, beaker apparatus also splashes their content using right click, in order to be more consistent. I think the previous implementation only allows for splashing on your location turf, so i kept it.
Fire extinguisher can be alt+z'd to wet the floor. Pretty self explanatory.

So, why does the old Alt+Z on apparatus didn't work?
The old alt+z was in attack_self, and this proc is only called when the `full_key` in `code/modules/keybindings/bindings_client.dm` matches your keybinding options. Pressing any combination of Shift, Alt, Ctrl in tandem with Z will change the `full_key` and result in attack_self not being called. 
Also, another thing to note is that we currently have the `key_combos_held[_key]` list. I initially wanted to use this instead of manually checking by using `user.keys_held["Shift"]`, but it probably needs a bit of regex and manually accessing the `_key` variable, which seems like a lot of trouble. Let me know if this is preferabble to the current implementation.

TL:DR; This will allow pressing Z (or any custom-bound hotkeys) to pass alt, shift, and ctrl arguments just like clicking. Needs to be implemented in a case-to-case basis. Only in RPD, extinguisher, and borg apparatus for now.

## Why It's Good For The Game
Better UX. Gives room for future implementations. 

## Changelog
:cl:
fix: Borgs can properly drop items in their apparatus modules. Use Alt+Click or Alt+ whatever key you set your activate held object to (default: Z). Splashing reagents is moved to right-click.
qol: You can change RPD layers using Alt+Click or Alt+activate held object key. 
del: Scroll wheel RPD functionality is moved to ditto.
qol: You can toggle the RPD unwrenching upgrade using Ctrl+Click or Ctrl+activate held object key.
qol: You can alt click (empty) extinguisher by using Alt+ activate object hotkey too now.
/:cl: