### PR TITLE
Prevent negative open positions in crew manifest

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -160,6 +160,8 @@
 		"Service" = GLOB.service_positions,
 		"Silicon" = GLOB.nonhuman_positions
 	)
+	var/list/heads = GLOB.command_positions + list("Quartermaster")
+
 	for(var/datum/data/record/t in GLOB.data_core.general)
 		var/name = t.fields["name"]
 		var/rank = t.fields["rank"]
@@ -170,7 +172,7 @@
 				if(!manifest_out[department])
 					manifest_out[department] = list()
 				// Append to beginning of list if captain or department head
-				if (rank == "Captain" || (department != "Command" && (rank in GLOB.command_positions)))
+				if (rank == "Captain" || (department != "Command" && (rank in heads)))
 					manifest_out[department] = list(list(
 						"name" = name,
 						"rank" = rank

--- a/code/modules/mob/dead/crew_manifest.dm
+++ b/code/modules/mob/dead/crew_manifest.dm
@@ -18,14 +18,15 @@
 
 /datum/crew_manifest/ui_data(mob/user)
 	var/list/positions = list(
-		"Command" = 0,
-		"Security" = 0,
-		"Engineering" = 0,
-		"Medical" = 0,
-		"Science" = 0,
-		"Supply" = 0,
-		"Service" = 0,
-		"Silicon" = 0
+		"Command" = list("exceptions" = list(), "open" = 0),
+		"Security" = list("exceptions" = list(), "open" = 0),
+		"Engineering" = list("exceptions" = list(), "open" = 0),
+		"Medical" = list("exceptions" = list(), "open" = 0),
+		"Misc" = list("exceptions" = list(), "open" = 0),
+		"Science" = list("exceptions" = list(), "open" = 0),
+		"Supply" = list("exceptions" = list(), "open" = 0),
+		"Service" = list("exceptions" = list(), "open" = 0),
+		"Silicon" = list("exceptions" = list(), "open" = 0)
 	)
 	var/list/departments = list(
 		list("flag" = DEPARTMENT_COMMAND, "name" = "Command"),
@@ -39,12 +40,18 @@
 	)
 
 	for(var/job in SSjob.occupations)
-		for(var/department in departments)
-			// Check if the job is part of a department using its flag
-			// Will return true for Research Director if the department is Science or Command, for example
-			if(job["departments"] & department["flag"])
-				// Add open positions to current department
-				positions[department["name"]] += (job["total_positions"] - job["current_positions"])
+		// Check if there are additional open positions or if there is no limit
+		if ((job["total_positions"] > 0 && job["total_positions"] > job["current_positions"]) || (job["total_positions"] == -1))
+			for(var/department in departments)
+				// Check if the job is part of a department using its flag
+				// Will return true for Research Director if the department is Science or Command, for example
+				if(job["departments"] & department["flag"])
+					if(job["total_positions"] == -1)
+						// Add job to list of exceptions, meaning it does not have a position limit
+						positions[department["name"]]["exceptions"] += list(job["title"])
+					else
+						// Add open positions to current department
+						positions[department["name"]]["open"] += (job["total_positions"] - job["current_positions"])
 
 	return list(
 		"manifest" = GLOB.data_core.get_manifest(),

--- a/tgui/packages/tgui/interfaces/CrewManifest.js
+++ b/tgui/packages/tgui/interfaces/CrewManifest.js
@@ -1,9 +1,8 @@
 import { useBackend } from "../backend";
-import { Icon, Section, Table } from "../components";
+import { Icon, Section, Table, Tooltip } from "../components";
 import { Window } from "../layouts";
 
 const commandJobs = [
-  "Captain",
   "Head of Personnel",
   "Head of Security",
   "Chief Engineer",
@@ -17,12 +16,13 @@ export const CrewManifest = (props, context) => {
   return (
     <Window title="Crew Manifest" width={350} height={500}>
       <Window.Content scrollable>
-        {Object.entries(manifest).map(([department, crew]) => (
+        {Object.entries(manifest).map(([dept, crew]) => (
           <Section
-            className={"CrewManifest--" + department}
-            key={department}
+            className={"CrewManifest--" + dept}
+            key={dept}
             title={
-              department + " (" + positions[department] + " positions open)"
+              dept + (dept !== "Misc"
+                ? ` (${positions[dept].open} positions open)` : "")
             }
           >
             <Table>
@@ -32,24 +32,49 @@ export const CrewManifest = (props, context) => {
                     {crewMember.name}
                   </Table.Cell>
                   <Table.Cell
-                    className={
-                      "CrewManifest__Cell CrewManifest__Cell--"
-                      + (crewMember.rank === "Captain" ? "Captain" : "Command")
-                    }
+                    className="CrewManifest__Cell CrewManifest__Icons"
                     collapsing
                   >
+                    {positions[dept].exceptions.includes(crewMember.rank) && (
+                      <Icon className="CrewManifest__Icon" name="infinity">
+                        <Tooltip
+                          content="No position limit"
+                          position="bottom"
+                        />
+                      </Icon>
+                    )}
+                    {crewMember.rank === "Captain" && (
+                      <Icon
+                        className={
+                          "CrewManifest__Icon"
+                          + " CrewManifest__Icon--Command"
+                        }
+                        name="star"
+                      >
+                        <Tooltip
+                          content="Captain"
+                          position="bottom"
+                        />
+                      </Icon>
+                    )}
                     {commandJobs.includes(crewMember.rank) && (
                       <Icon
-                        name={
-                          crewMember.rank === "Captain" ? "star" : "chevron-up"
+                        className={
+                          "CrewManifest__Icon CrewManifest__Icon--Command"
+                          + " CrewManifest__Icon--Chevron"
                         }
-                      />
+                        name="chevron-up"
+                      >
+                        <Tooltip
+                          content="Member of command"
+                          position="bottom"
+                        />
+                      </Icon>
                     )}
                   </Table.Cell>
                   <Table.Cell
-                    className={"CrewManifest__Cell"}
+                    className={"CrewManifest__Cell CrewManifest__Cell--Rank"}
                     collapsing
-                    color="label"
                   >
                     {crewMember.rank}
                   </Table.Cell>

--- a/tgui/packages/tgui/interfaces/CrewManifest.js
+++ b/tgui/packages/tgui/interfaces/CrewManifest.js
@@ -1,3 +1,4 @@
+import { classes } from 'common/react';
 import { useBackend } from "../backend";
 import { Icon, Section, Table, Tooltip } from "../components";
 import { Window } from "../layouts";
@@ -32,7 +33,10 @@ export const CrewManifest = (props, context) => {
                     {crewMember.name}
                   </Table.Cell>
                   <Table.Cell
-                    className="CrewManifest__Cell CrewManifest__Icons"
+                    className={classes([
+                      "CrewManifest__Cell",
+                      "CrewManifest__Icons",
+                    ])}
                     collapsing
                   >
                     {positions[dept].exceptions.includes(crewMember.rank) && (
@@ -45,10 +49,10 @@ export const CrewManifest = (props, context) => {
                     )}
                     {crewMember.rank === "Captain" && (
                       <Icon
-                        className={
-                          "CrewManifest__Icon"
-                          + " CrewManifest__Icon--Command"
-                        }
+                        className={classes([
+                          "CrewManifest__Icon",
+                          "CrewManifest__Icon--Command",
+                        ])}
                         name="star"
                       >
                         <Tooltip
@@ -59,10 +63,11 @@ export const CrewManifest = (props, context) => {
                     )}
                     {commandJobs.includes(crewMember.rank) && (
                       <Icon
-                        className={
-                          "CrewManifest__Icon CrewManifest__Icon--Command"
-                          + " CrewManifest__Icon--Chevron"
-                        }
+                        className={classes([
+                          "CrewManifest__Icon",
+                          "CrewManifest__Icon--Command",
+                          "CrewManifest__Icon--Chevron",
+                        ])}
                         name="chevron-up"
                       >
                         <Tooltip
@@ -73,7 +78,10 @@ export const CrewManifest = (props, context) => {
                     )}
                   </Table.Cell>
                   <Table.Cell
-                    className={"CrewManifest__Cell CrewManifest__Cell--Rank"}
+                    className={classes([
+                      "CrewManifest__Cell",
+                      "CrewManifest__Cell--Rank",
+                    ])}
                     collapsing
                   >
                     {crewMember.rank}

--- a/tgui/packages/tgui/styles/components/Tooltip.scss
+++ b/tgui/packages/tgui/styles/components/Tooltip.scss
@@ -16,6 +16,7 @@ $border-radius: base.$border-radius !default;
   left: 0;
   right: 0;
   bottom: 0;
+  font-family: Verdana, sans-serif;
   font-style: normal;
   font-weight: normal;
 

--- a/tgui/packages/tgui/styles/interfaces/CrewManifest.scss
+++ b/tgui/packages/tgui/styles/interfaces/CrewManifest.scss
@@ -5,6 +5,7 @@ $department_map: (
   'Security': colors.$red,
   'Engineering': colors.$orange,
   'Medical': colors.$teal,
+  'Misc': colors.$white,
   'Science': colors.$purple,
   'Supply': colors.$brown,
   'Service': colors.$green,
@@ -28,14 +29,30 @@ $department_map: (
   &__Cell {
     padding: 3px 0;
 
-    &--Captain {
-      color: colors.$yellow;
-      padding: 3px 8px;
+    &--Rank {
+      color: colors.$label;
+    }
+  }
+
+  &__Icons {
+    padding: 3px 9px;
+    text-align: right;
+  }
+
+  &__Icon {
+    color: colors.$label;
+    position: relative;
+
+    &:not(:last-child) {
+      margin-right: 7px;
+    }
+
+    &--Chevron {
+      padding-right: 2px;
     }
 
     &--Command {
       color: colors.$yellow;
-      padding: 3px 9px;
     }
   }
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is a hotfix for the new crew manifest. Because I forgot to add a check for whether there is more than 0 total positions available (assistants have -1) and whether total positions have a larger or equal number than current positions, there can be a negative number of open positions. This PR aims to prevent that from happening.

Roles with no position limit will now have an infinity icon. A tooltip has also been added to icons.

![image](https://user-images.githubusercontent.com/81999976/114284256-3eb7d780-9a57-11eb-9d9c-6e32b6954209.png)

## Why It's Good For The Game

There shouldn't be a negative number of open positions, but currently it is possible.

## Changelog
:cl: Celotajs
fix: Prevented departments from having negative or undefined open positions in the crew manifest
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
