### PR TITLE
holy staff nullrod now has shielded component instead of 50% block rate

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -322,19 +322,25 @@
 	w_class = WEIGHT_CLASS_HUGE
 	force = 5
 	slot_flags = ITEM_SLOT_BACK
-	block_chance = 50
-	var/shield_icon = "shield-red"
+	var/user_shield_icon = "shield-red"
 
-/obj/item/nullrod/staff/worn_overlays(isinhands)
-	. = list()
-	if(isinhands)
-		. += mutable_appearance('icons/effects/effects.dmi', shield_icon, MOB_SHIELD_LAYER)
+/obj/item/nullrod/staff/Initialize()
+	. = ..()
+	AddComponent(/datum/component/shielded, max_charges = 1, recharge_start_delay = 10 SECONDS, shield_icon = user_shield_icon, shield_inhand = TRUE, run_hit_callback = CALLBACK(src, .proc/shield_damaged))
+
+/obj/item/nullrod/staff/proc/shield_damaged(mob/living/wearer, attack_text, new_current_charges)
+	wearer.visible_message("<span class='danger'>[wearer]'s [src] neutralizes [attack_text] in a burst of sparks!</span>")
+	do_sparks(2, TRUE, wearer)
+	if(!wearer.mind?.holy_role && iscarbon(wearer))
+		var/mob/living/carbon/carbon_wearer = wearer
+		carbon_wearer.visible_message("<span class='danger'>[carbon_wearer] gets knocked down from the blow!</span>")
+		carbon_wearer.Knockdown(3 SECONDS)
 
 /obj/item/nullrod/staff/blue
 	name = "blue holy staff"
 	icon_state = "godstaff-blue"
 	inhand_icon_state = "godstaff-blue"
-	shield_icon = "shield-old"
+	user_shield_icon = "shield-old"
 
 /obj/item/nullrod/claymore
 	icon_state = "claymore_gold"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
the holy staff nullrod now has shielded component instead of 50% block rate. it has 1 charge that recharges every 10 seconds (those numbers maybe could use change? idk if this is too weak), if it gets used by a non holy person it knocks them down for 3 seconds after the shield discharges

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
i think the real shields are way more fun than rng blocking, also the staff already emulated the shields on the user so why not?

## Changelog
:cl:
balance: holy staff nullrod now creates a 1 charge real shield that recharges very 10 seconds instead of 50% block rate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
