### PR TITLE
Thermomachine pipe color change

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
@@ -226,7 +226,7 @@
 		update_appearance()
 		return
 
-	if(!anchored && item.tool_behaviour == TOOL_MULTITOOL)
+	if(panel_open && item.tool_behaviour == TOOL_MULTITOOL)
 		piping_layer = (piping_layer >= PIPING_LAYER_MAX) ? PIPING_LAYER_MIN : (piping_layer + 1)
 		to_chat(user, "<span class='notice'>You change the circuitboard to layer [piping_layer].</span>")
 		update_appearance()
@@ -280,7 +280,7 @@
 	if(panel_open && item.tool_behaviour == TOOL_WRENCH && !check_pipe_on_turf())
 		if(default_unfasten_wrench(user, item))
 			return SECONDARY_ATTACK_CONTINUE_CHAIN
-	if(panel_open && item.tool_behaviour == TOOL_MULTITOOL && !anchored)
+	if(panel_open && item.tool_behaviour == TOOL_MULTITOOL)
 		color_index = (color_index >= GLOB.pipe_paint_colors.len) ? (color_index = 1) : (color_index = 1 + color_index)
 		pipe_color = GLOB.pipe_paint_colors[GLOB.pipe_paint_colors[color_index]]
 		visible_message("<span class='notice'>You set [src] pipe color to [GLOB.pipe_color_name[pipe_color]].")

--- a/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
@@ -104,6 +104,9 @@
 
 /obj/machinery/atmospherics/components/binary/thermomachine/examine(mob/user)
 	. = ..()
+	. += "<span class='notice'>With the panel open:</span>"
+	. += "<span class='notice'>-use a wrench with left-click to rotate [src] and right-click to unanchor it.</span>"
+	. += "<span class='notice'>-use a multitool with left-click to change the piping layer and right-click to change the piping color.</span>"
 	. += "<span class='notice'>The thermostat is set to [target_temperature]K ([(T0C-target_temperature)*-1]C).</span>"
 	if(in_range(user, src) || isobserver(user))
 		. += "<span class='notice'>The status display reads: Efficiency <b>[(heat_capacity/7500)*100]%</b>.</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR allow the players to change the thermomachines pipe color with the multitool right click when it's unanchored.
plus some fixes for hitting the machine with tools 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
players can now connect the machine to colors other than grey
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: players can change the thermomachines pipe color with the multitool right click when it's unanchored.
fix: fixed hitting the machine with tools in some cases
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
