### PR TITLE
Adds color picking as RPD right click action

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -239,6 +239,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /obj/item/pipe_dispenser/examine(mob/user)
 	. = ..()
 	. += "You can scroll your mouse wheel to change the piping layer."
+	. += "You can right click a pipe to set the RPD to its color."
 
 /obj/item/pipe_dispenser/equipped(mob/user, slot, initial)
 	. = ..()
@@ -266,11 +267,11 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 /obj/item/pipe_dispenser/pre_attack_secondary(obj/machinery/atmospherics/target, mob/user, params)
 	if(!istype(target, /obj/machinery/atmospherics))
-		return ..()
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	if(target.pipe_color)
 		paint_color = GLOB.pipe_color_name[target.pipe_color]
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-	return ..()
+		to_chat(user, "<span class='notice'>You change the color setting of the RPD to [paint_color].</span>")
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/pipe_dispenser/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/rpd_upgrade))

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -271,7 +271,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	if(target.pipe_color && target.piping_layer)
 		paint_color = GLOB.pipe_color_name[target.pipe_color]
 		piping_layer = target.piping_layer
-		to_chat(user, "<span class='notice'>You change the RPD to [paint_color] color and layer [piping_layer] pipes.</span>")
+		to_chat(user, "<span class='notice'>You change [src] to [paint_color] color and layer [piping_layer] pipes.</span>")
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/pipe_dispenser/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -267,13 +267,10 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /obj/item/pipe_dispenser/pre_attack_secondary(obj/machinery/atmospherics/target, mob/user, params)
 	if(!istype(target, /obj/machinery/atmospherics))
 		return ..()
-
 	if(target.pipe_color)
 		paint_color = GLOB.pipe_color_name[target.pipe_color]
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
 	return ..()
-
 
 /obj/item/pipe_dispenser/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/rpd_upgrade))

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -239,7 +239,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /obj/item/pipe_dispenser/examine(mob/user)
 	. = ..()
 	. += "You can scroll your mouse wheel to change the piping layer."
-	. += "You can right click a pipe to set the RPD to its color."
+	. += "You can right click a pipe to set the RPD to its color and layer."
 
 /obj/item/pipe_dispenser/equipped(mob/user, slot, initial)
 	. = ..()
@@ -268,9 +268,10 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /obj/item/pipe_dispenser/pre_attack_secondary(obj/machinery/atmospherics/target, mob/user, params)
 	if(!istype(target, /obj/machinery/atmospherics))
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-	if(target.pipe_color)
+	if(target.pipe_color && target.piping_layer)
 		paint_color = GLOB.pipe_color_name[target.pipe_color]
-		to_chat(user, "<span class='notice'>You change the color setting of the RPD to [paint_color].</span>")
+		piping_layer = target.piping_layer
+		to_chat(user, "<span class='notice'>You change the RPD to [paint_color] color and layer [piping_layer] pipes.</span>")
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/pipe_dispenser/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -264,6 +264,17 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 		return TRUE
 	return ..()
 
+/obj/item/pipe_dispenser/pre_attack_secondary(obj/machinery/atmospherics/target, mob/user, params)
+	if(!istype(target, /obj/machinery/atmospherics))
+		return ..()
+
+	if(target.pipe_color)
+		paint_color = GLOB.pipe_color_name[target.pipe_color]
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	return ..()
+
+
 /obj/item/pipe_dispenser/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/rpd_upgrade))
 		install_upgrade(W, user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This will make the RPD change to the color of any pipe that is right clicked with it.
![rpdpick](https://user-images.githubusercontent.com/43266738/114289594-ea761d00-9a81-11eb-8275-7c9752e3c3cb.gif)



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it easier to change colors when working on multi-color pipe setups.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Thebleh
tweak: RPDs can now pick the color of a pipe by right clicking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
