### PR TITLE
Ashwalkers Virus Free!

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -116,7 +116,7 @@ Lizard subspecies: ASHWALKERS
 	id = "ashlizard"
 	limbs_id = "lizard"
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE,HAS_FLESH,HAS_BONE)
-	inherent_traits = list(TRAIT_ADVANCEDTOOLUSER,TRAIT_CHUNKYFINGERS,TRAIT_NOBREATH)
+	inherent_traits = list(TRAIT_ADVANCEDTOOLUSER,TRAIT_CHUNKYFINGERS,TRAIT_NOBREATH,TRAIT_VIRUSIMMUNE)
 	species_language_holder = /datum/language_holder/lizard/ash
 
 /*


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

One line Change, to add a Trait to a Subspecies in Mob/living/carbon/Human

## Why It's Good For The Game

Ashwalkers Dying of Diseases due to being arround gibs and gibbed Bodys is no fun, considering that they do not have accesss to any form of virology this will make them unable to have any virus like theyr Silverscale brethren.

## Changelog
:cl:
balance: Ashwalkers have been seen to not be affected by viruses anymore, likely due to evolution
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
