### PR TITLE
Fixes mannitoil runtime

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -436,6 +436,7 @@
 	for(var/datum/mutation/human/HM in mutations)
 		if(HM.type == A)
 			return HM
+	return FALSE
 
 /datum/dna/proc/check_block_string(mutation)
 	if((LAZYLEN(mutation_index) > DNA_MUTATION_BLOCKS) || !(mutation in mutation_index))

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -436,7 +436,6 @@
 	for(var/datum/mutation/human/HM in mutations)
 		if(HM.type == A)
 			return HM
-	return FALSE
 
 /datum/dna/proc/check_block_string(mutation)
 	if((LAZYLEN(mutation_index) > DNA_MUTATION_BLOCKS) || !(mutation in mutation_index))

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -631,6 +631,8 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	var/obj/item/organ/brain/brain = owner.getorganslot(ORGAN_SLOT_BRAIN)
 	while(length(traumalist) || !temp_trauma)
 		var/datum/brain_trauma/trauma = pick_n_take(traumalist)
+		if(!trauma)
+			return
 		if(brain.brain_gain_trauma(trauma, TRAUMA_RESILIENCE_MAGIC))
 			temp_trauma = trauma
 			return

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -591,14 +591,12 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	if(!carbon.dna)
 		return
 	var/list/speech_options = list(SWEDISH, UNINTELLIGIBLE, STONER, MEDIEVAL, WACKY, NERVOUS, MUT_MUTE)
-	while(length(speech_options) || !speech_option)
-		var/potential_option = pick_n_take(speech_options)
-		if(!potential_option)
-			return
-		if(carbon.dna.get_mutation(potential_option))
+	speech_options = shuffle(speech_options)
+	for(var/option in speech_options)
+		if(carbon.dna.get_mutation(option))
 			continue
-		carbon.dna.add_mutation(potential_option)
-		speech_option = potential_option
+		carbon.dna.add_mutation(option)
+		speech_option = option
 		return
 
 /datum/reagent/impurity/mannitol/on_mob_delete(mob/living/owner)
@@ -629,10 +627,8 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	traumalist -= /datum/brain_trauma/severe/split_personality //Uses a ghost, I don't want to use a ghost for a temp thing.
 	traumalist -= /datum/brain_trauma/special/obsessed //Sets the owner as an antag - I presume this will lead to problems, so we'll remove it
 	var/obj/item/organ/brain/brain = owner.getorganslot(ORGAN_SLOT_BRAIN)
-	while(length(traumalist) || !temp_trauma)
-		var/datum/brain_trauma/trauma = pick_n_take(traumalist)
-		if(!trauma)
-			return
+	traumalist = shuffle(traumalist)
+	for(var/trauma in traumalist)
 		if(brain.brain_gain_trauma(trauma, TRAUMA_RESILIENCE_MAGIC))
 			temp_trauma = trauma
 			return

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -593,12 +593,13 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	var/list/speech_options = list(SWEDISH, UNINTELLIGIBLE, STONER, MEDIEVAL, WACKY, NERVOUS, MUT_MUTE)
 	while(length(speech_options) || !speech_option)
 		var/potential_option = pick_n_take(speech_options)
-		if(carbon.dna.get_mutation(potential_option))
-			speech_options -= potential_option
-			continue
-		if(carbon.dna.activate_mutation(potential_option))
-			speech_option = potential_option
+		if(!potential_option)
 			return
+		if(carbon.dna.get_mutation(potential_option))
+			continue
+		carbon.dna.add_mutation(potential_option)
+		speech_option = potential_option
+		return
 
 /datum/reagent/impurity/mannitol/on_mob_delete(mob/living/owner)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -591,17 +591,14 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	if(!carbon.dna)
 		return
 	var/list/speech_options = list(SWEDISH, UNINTELLIGIBLE, STONER, MEDIEVAL, WACKY, NERVOUS, MUT_MUTE)
-	while(speech_options || !speech_option)
-		var/potential_option = pick(speech_options)
+	while(length(speech_options) || !speech_option)
+		var/potential_option = pick_n_take(speech_options)
 		if(carbon.dna.get_mutation(potential_option))
 			speech_options -= potential_option
 			continue
 		if(carbon.dna.activate_mutation(potential_option))
 			speech_option = potential_option
 			return
-		else
-			speech_options -= potential_option
-
 
 /datum/reagent/impurity/mannitol/on_mob_delete(mob/living/owner)
 	. = ..()
@@ -631,13 +628,11 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	traumalist -= /datum/brain_trauma/severe/split_personality //Uses a ghost, I don't want to use a ghost for a temp thing.
 	traumalist -= /datum/brain_trauma/special/obsessed //Sets the owner as an antag - I presume this will lead to problems, so we'll remove it
 	var/obj/item/organ/brain/brain = owner.getorganslot(ORGAN_SLOT_BRAIN)
-	while(traumalist || !temp_trauma)
-		var/datum/brain_trauma/trauma = pick(traumalist)
+	while(length(traumalist) || !temp_trauma)
+		var/datum/brain_trauma/trauma = pick_n_take(traumalist)
 		if(brain.brain_gain_trauma(trauma, TRAUMA_RESILIENCE_MAGIC))
 			temp_trauma = trauma
 			return
-		else
-			traumalist -= trauma
 
 /datum/reagent/inverse/neurine/on_mob_delete(mob/living/carbon/owner)
 	.=..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mannitoil checks for the presence of a list, rather than the length of a list, causing a runtime if no impediments can be applied. This should fix that!
Also fixes neruwhine to use the same method too, just in case.
And swaps out pick with pick_n_take

## Why It's Good For The Game

Runtiming in metabolism is causing problems.

## Changelog
:cl:
fix: Fixes mannitol (and possibly neurine) from causing runtimes if no effects can be applied.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
