### PR TITLE
Changes the Science Hub tablet app from RND to Heads

### DIFF
--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -7,7 +7,7 @@
 	size = 16
 	tgui_id = "NtosTechweb"
 	program_icon = "atom"
-	required_access = ACCESS_RND
+	required_access = ACCESS_HEADS
 	transfer_access = ACCESS_RD
 	/// Reference to global science techweb
 	var/datum/techweb/stored_research


### PR DESCRIPTION
## About The Pull Request

The Science Hub app is able to do research, and the Core RnD consoles were moved to the Bridge a while ago, making it Command's job. All head of staff tablets even spawn with this app, but they can't even open it, because it requires Scientist access, and said Scientists dont even have the app, or can download it since it requires RD's office access.

## Why It's Good For The Game

Command can now do their job on the go like the tablet app implies is supposed to allow.

## Changelog
:cl:
fix: Command personnel can now use the Science Hub tablet app they start with.
/:cl:
