### PR TITLE
Firelocks can't close if an holofan is placed on their turf

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -436,6 +436,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Minor trait used for beakers, or beaker-ishes. [/obj/item/reagent_containers], to show that they've been used in a reagent grinder.
 #define TRAIT_MAY_CONTAIN_BLENDED_DUST "may_contain_blended_dust"
 
+///Trait applied to turfs when an atmos holosign is placed on them. It will stop firedoors from closing.
 #define TRAIT_FIREDOOR_STOP "firedoor_stop"
 
 //Medical Categories for quirks

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -436,6 +436,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Minor trait used for beakers, or beaker-ishes. [/obj/item/reagent_containers], to show that they've been used in a reagent grinder.
 #define TRAIT_MAY_CONTAIN_BLENDED_DUST "may_contain_blended_dust"
 
+#define TRAIT_FIREDOOR_STOP "firedoor_stop"
+
 //Medical Categories for quirks
 #define CAT_QUIRK_ALL 0
 #define CAT_QUIRK_NOTES 1

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -224,6 +224,8 @@
 	latetoggle()
 
 /obj/machinery/door/firedoor/close()
+	if(check_holofan())
+		return
 	. = ..()
 	latetoggle()
 
@@ -253,6 +255,14 @@
 		if(FIREDOOR_CLOSED)
 			nextstate = null
 			close()
+
+/obj/machinery/door/firedoor/proc/check_holofan()
+	var/turf/loc = get_turf(src)
+	for(var/obj/structure/holosign/barrier/atmos/holo in loc.contents)
+		if(!holo)
+			continue
+		return TRUE
+	return FALSE
 
 /obj/machinery/door/firedoor/border_only
 	icon = 'icons/obj/doors/edge_Doorfire.dmi'

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -224,7 +224,7 @@
 	latetoggle()
 
 /obj/machinery/door/firedoor/close()
-	if(check_holofan())
+	if(HAS_TRAIT(loc, TRAIT_FIREDOOR_STOP))
 		return
 	. = ..()
 	latetoggle()
@@ -255,14 +255,6 @@
 		if(FIREDOOR_CLOSED)
 			nextstate = null
 			close()
-
-/obj/machinery/door/firedoor/proc/check_holofan()
-	var/turf/loc = get_turf(src)
-	for(var/obj/structure/holosign/barrier/atmos/holo in loc.contents)
-		if(!holo)
-			continue
-		return TRUE
-	return FALSE
 
 /obj/machinery/door/firedoor/border_only
 	icon = 'icons/obj/doors/edge_Doorfire.dmi'

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -106,14 +106,18 @@
 
 /obj/structure/holosign/barrier/atmos/Initialize()
 	. = ..()
+	var/turf/local = get_turf(loc)
+	ADD_TRAIT(local, TRAIT_FIREDOOR_STOP, TRAIT_GENERIC)
 	air_update_turf(TRUE, TRUE)
 
 /obj/structure/holosign/barrier/atmos/BlockSuperconductivity() //Didn't used to do this, but it's "normal", and will help ease heat flow transitions with the players.
 	return TRUE
 
 /obj/structure/holosign/barrier/atmos/Destroy()
-	. = ..()
+	var/turf/local = get_turf(loc)
+	REMOVE_TRAIT(local, TRAIT_FIREDOOR_STOP, TRAIT_GENERIC)
 	air_update_turf(TRUE, FALSE)
+	return ..()
 
 /obj/structure/holosign/barrier/cyborg
 	name = "Energy Field"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, placing an holofan on the firedoor's turf will prevent it from closing by any means. Removing the holofan will allow the door to close.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More holofan uses, less firelocks pain
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: firelocks won't close if there is an atmos holofan on their turf.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
