### PR TITLE
White russian ratio fix

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -93,8 +93,8 @@
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 2, /datum/reagent/consumable/ethanol/vermouth = 1)
 
 /datum/chemical_reaction/drink/white_russian
-	results = list(/datum/reagent/consumable/ethanol/white_russian = 5)
-	required_reagents = list(/datum/reagent/consumable/ethanol/black_russian = 3, /datum/reagent/consumable/cream = 2)
+	results = list(/datum/reagent/consumable/ethanol/white_russian = 8)
+	required_reagents = list(/datum/reagent/consumable/ethanol/black_russian = 5, /datum/reagent/consumable/cream = 3)
 
 /datum/chemical_reaction/drink/whiskey_cola
 	results = list(/datum/reagent/consumable/ethanol/whiskey_cola = 3)


### PR DESCRIPTION
## About The Pull Request

Black russians require a 2:3 Ratio to be made, therefore the default size of black russians will tend to be 25u. White Russians require 3:2, 25 is not divisible by 3. This Pr fixes it by giving it a 5:3 ratio so that cream can be easy to use 15u.

## Why It's Good For The Game

Fuck decimals in drinks, it's fucking annoying. 

## Changelog
:cl:
fix: Gives white russians a proper ratio of creation.
/:cl: