### PR TITLE
Adds keybinds for moving up/down z-levels

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -82,4 +82,5 @@
 #define COMSIG_KB_MOVEMENT_SOUTH_DOWN "keybinding_movement_south_down"
 #define COMSIG_KB_MOVEMENT_WEST_DOWN "keybinding_movement_west_down"
 #define COMSIG_KB_MOVEMENT_EAST_DOWN "keybinding_movement_east_down"
-
+#define COMSIG_KB_MOVEMENT_ZLEVEL_MOVEUP_DOWN "keybinding_mob_zlevel_moveup_down"
+#define COMSIG_KB_MOVEMENT_ZLEVEL_MOVEDOWN_DOWN "keybinding_mob_zlevel_movedown_down"

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -21,7 +21,7 @@
 	return TRUE
 
 /datum/keybinding/mob/swap_hands
-	hotkey_keys = list("X", "Northeast") // PAGEUP
+	hotkey_keys = list("X")
 	name = "swap_hands"
 	full_name = "Swap hands"
 	description = ""
@@ -36,7 +36,7 @@
 	return TRUE
 
 /datum/keybinding/mob/activate_inhand
-	hotkey_keys = list("Z", "Southeast") // Southeast = PAGEDOWN
+	hotkey_keys = list("Z")
 	name = "activate_inhand"
 	full_name = "Activate in-hand"
 	description = "Uses whatever item you have inhand"

--- a/code/datums/keybinding/movement.dm
+++ b/code/datums/keybinding/movement.dm
@@ -29,3 +29,33 @@
 	full_name = "Move East"
 	description = "Moves your character east"
 	keybind_signal = COMSIG_KB_MOVEMENT_EAST_DOWN
+
+/datum/keybinding/movement/zlevel_upwards
+	hotkey_keys = list("Northeast") // PGUP
+	name = "Upwards"
+	full_name = "Move Upwards"
+	description = "Moves your character up a z-level if possible"
+	keybind_signal = COMSIG_KB_MOVEMENT_ZLEVEL_MOVEUP_DOWN
+
+/datum/keybinding/movement/zlevel_upwards/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/moving_mob = user.mob
+	moving_mob.up()
+	return TRUE
+
+/datum/keybinding/movement/zlevel_downwards
+	hotkey_keys = list("Southeast") // PGDOWN
+	name = "Downwards"
+	full_name = "Move Downwards"
+	description = "Moves your character down a z-level if possible"
+	keybind_signal = COMSIG_KB_MOVEMENT_ZLEVEL_MOVEDOWN_DOWN
+
+/datum/keybinding/movement/zlevel_downwards/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/moving_mob = user.mob
+	moving_mob.down()
+	return TRUE

--- a/code/datums/keybinding/movement.dm
+++ b/code/datums/keybinding/movement.dm
@@ -41,8 +41,7 @@
 	. = ..()
 	if(.)
 		return
-	var/mob/moving_mob = user.mob
-	moving_mob.up()
+	user.mob.up()
 	return TRUE
 
 /datum/keybinding/movement/zlevel_downwards
@@ -56,6 +55,5 @@
 	. = ..()
 	if(.)
 		return
-	var/mob/moving_mob = user.mob
-	moving_mob.down()
+	user.mob.down()
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I always thought it was annoying as a ghost that you can only move up/down z-levels by using the IC stat panel tab, rather than having hotkeys for it. Thus, this PR adds keybinds for moving upwards/downwards. The defaults for these are the page up/page down keys, which are currently used as secondaries for swapping hands and activating something in hand. I don't think those are very crucial binds to tie up the page up/down buttons with, but if maintainers want me to switch it to another set of keys by default, I've got no problem doing so.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes navigating multi-z maps as a ghost easier
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
qol: Added keybinds for moving up/down z-levels, useful as a ghost on multi-z maps! These default to the page up/page down buttons (previously used as the secondary binds for switching hands and activating items in hand).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
