### PR TITLE
Monkeys are now too primitive to pilots mechs

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -12,7 +12,7 @@
 	meat = /obj/item/food/meat/slab/monkey
 	knife_butcher_results = list(/obj/item/food/meat/slab/monkey = 5, /obj/item/stack/sheet/animalhide/monkey = 1)
 	species_traits = list(HAS_FLESH,HAS_BONE,NO_UNDERWEAR,LIPS,NOEYESPRITES,NOBLOODOVERLAY,NOTRANSSTING, NOAUGMENTS)
-	inherent_traits = list(TRAIT_VENTCRAWLER_NUDE, TRAIT_WEAK_SOUL)
+	inherent_traits = list(TRAIT_VENTCRAWLER_NUDE, TRAIT_PRIMITIVE, TRAIT_WEAK_SOUL)
 	no_equip = list(ITEM_SLOT_EARS, ITEM_SLOT_EYES, ITEM_SLOT_OCLOTHING, ITEM_SLOT_GLOVES, ITEM_SLOT_FEET, ITEM_SLOT_ICLOTHING, ITEM_SLOT_SUITSTORE)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | ERT_SPAWN | SLIME_EXTRACT
 	liked_food = MEAT | FRUIT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives monkeys the trait TRAIT_PRIMITIVE, which prevents them from being able to use mechs as intended. An oversight from when monkeys were made a human species. 

fixes https://github.com/tgstation/tgstation/issues/58278 even if goof closed it. I'm fixing it because an oversight is a valid reason to have an issue open, and this is an unintended consequence of a large scale refactor.

If a maintainer wants to make a strong case for this being retained I'm happy to hear it.

## Why It's Good For The Game

Hey imagine if you put a bunch of mind magnification helmets on some monkeys and then told them to get into mechs wouldn't that be awesome or what.

Fuck actually that is awesome I hate that I'm fixing this before I ever got to do that.

## Changelog
:cl:
fix: Monkeys can no longer get into mechs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
