### PR TITLE
Fixes Orion Exploit

### DIFF
--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -268,9 +268,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 			execute_crewmember(gamer, params["who"])
 		//Spaceport specific interactions
 		if("buycrew") //buy a crewmember
-			if(gameStatus != ORION_STATUS_MARKET)
-				return
-			if(!spaceport_raided && food >= 10 && fuel >= 10)
+			if(!spaceport_raided && food >= 10 && fuel >= 10 && gameStatus != ORION_STATUS_MARKET)
 				if(params["odd"])
 					//find some silly crewmember name
 					add_crewmember(pick(GLOB.commando_names + GLOB.nightmare_names + GLOB.ai_names + GLOB.clown_names + GLOB.mime_names + GLOB.plasmaman_names + GLOB.ethereal_names + GLOB.carp_names))
@@ -280,9 +278,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 				food -= ORION_BUY_CREW_PRICE
 				killed_crew-- // I mean not really but you know
 		if("sellcrew") //sell a crewmember
-			if(gameStatus != ORION_STATUS_MARKET)
-				return
-			if(!spaceport_raided && settlers.len > 1)
+			if(!spaceport_raided && settlers.len > 1 && gameStatus != ORION_STATUS_MARKET)
 				remove_crewmember()
 				fuel += ORION_SELL_CREW_PRICE
 				food += ORION_SELL_CREW_PRICE
@@ -297,9 +293,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 			spaceport_raided = TRUE
 			encounter_event(/datum/orion_event/space_port_raid, gamer, gamer_skill, gamer_skill_level, gamer_skill_rands)
 		if("buyparts")
-			if(gameStatus != ORION_STATUS_MARKET)
-				return
-			if(!spaceport_raided && fuel > ORION_TRADE_RATE)
+			if(!spaceport_raided && fuel > ORION_TRADE_RATE && gameStatus != ORION_STATUS_MARKET)
 				switch(params["part"])
 					if(ORION_BUY_ENGINE_PARTS)
 						engine++
@@ -309,9 +303,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 						electronics++
 				fuel -= ORION_TRADE_RATE
 		if("trade")
-			if(gameStatus != ORION_STATUS_MARKET)
-				return
-			if(!spaceport_raided)
+			if(!spaceport_raided && gameStatus != ORION_STATUS_MARKET)
 				switch(params["what"])
 					if(ORION_I_WANT_FUEL)
 						if(fuel > ORION_TRADE_RATE)

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -268,7 +268,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 			execute_crewmember(gamer, params["who"])
 		//Spaceport specific interactions
 		if("buycrew") //buy a crewmember
-			if(!spaceport_raided && food >= 10 && fuel >= 10 && gameStatus != ORION_STATUS_MARKET)
+			if(!spaceport_raided && food >= 10 && fuel >= 10 && gameStatus == ORION_STATUS_MARKET)
 				if(params["odd"])
 					//find some silly crewmember name
 					add_crewmember(pick(GLOB.commando_names + GLOB.nightmare_names + GLOB.ai_names + GLOB.clown_names + GLOB.mime_names + GLOB.plasmaman_names + GLOB.ethereal_names + GLOB.carp_names))
@@ -278,7 +278,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 				food -= ORION_BUY_CREW_PRICE
 				killed_crew-- // I mean not really but you know
 		if("sellcrew") //sell a crewmember
-			if(!spaceport_raided && settlers.len > 1 && gameStatus != ORION_STATUS_MARKET)
+			if(!spaceport_raided && settlers.len > 1 && gameStatus == ORION_STATUS_MARKET)
 				remove_crewmember()
 				fuel += ORION_SELL_CREW_PRICE
 				food += ORION_SELL_CREW_PRICE
@@ -293,7 +293,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 			spaceport_raided = TRUE
 			encounter_event(/datum/orion_event/space_port_raid, gamer, gamer_skill, gamer_skill_level, gamer_skill_rands)
 		if("buyparts")
-			if(!spaceport_raided && fuel > ORION_TRADE_RATE && gameStatus != ORION_STATUS_MARKET)
+			if(!spaceport_raided && fuel > ORION_TRADE_RATE && gameStatus == ORION_STATUS_MARKET)
 				switch(params["part"])
 					if(ORION_BUY_ENGINE_PARTS)
 						engine++
@@ -303,7 +303,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 						electronics++
 				fuel -= ORION_TRADE_RATE
 		if("trade")
-			if(!spaceport_raided && gameStatus != ORION_STATUS_MARKET)
+			if(!spaceport_raided && gameStatus == ORION_STATUS_MARKET)
 				switch(params["what"])
 					if(ORION_I_WANT_FUEL)
 						if(fuel > ORION_TRADE_RATE)

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -268,6 +268,8 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 			execute_crewmember(gamer, params["who"])
 		//Spaceport specific interactions
 		if("buycrew") //buy a crewmember
+			if(gameStatus != ORION_STATUS_MARKET)
+				return
 			if(!spaceport_raided && food >= 10 && fuel >= 10)
 				if(params["odd"])
 					//find some silly crewmember name
@@ -278,17 +280,25 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 				food -= ORION_BUY_CREW_PRICE
 				killed_crew-- // I mean not really but you know
 		if("sellcrew") //sell a crewmember
+			if(gameStatus != ORION_STATUS_MARKET)
+				return
 			if(!spaceport_raided && settlers.len > 1)
 				remove_crewmember()
 				fuel += ORION_SELL_CREW_PRICE
 				food += ORION_SELL_CREW_PRICE
 		if("leave_spaceport")
+			if(gameStatus != ORION_STATUS_MARKET) //Can't leave a place you aren't in
+				return
 			gameStatus = ORION_STATUS_NORMAL
 			spaceport_raided = FALSE
 		if("raid_spaceport")
+			if(gameStatus != ORION_STATUS_MARKET)
+				return
 			spaceport_raided = TRUE
 			encounter_event(/datum/orion_event/space_port_raid, gamer, gamer_skill, gamer_skill_level, gamer_skill_rands)
 		if("buyparts")
+			if(gameStatus != ORION_STATUS_MARKET)
+				return
 			if(!spaceport_raided && fuel > ORION_TRADE_RATE)
 				switch(params["part"])
 					if(ORION_BUY_ENGINE_PARTS)
@@ -299,6 +309,8 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 						electronics++
 				fuel -= ORION_TRADE_RATE
 		if("trade")
+			if(gameStatus != ORION_STATUS_MARKET)
+				return
 			if(!spaceport_raided)
 				switch(params["what"])
 					if(ORION_I_WANT_FUEL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes issue #58349 
Untested, shouldn't be needed since it only checks to see if the user is currently at the market. You can't actually see any of the buttons unless your game status is ORION_STATUS_MARKET. Not sure if this is considered hacky, I can look at changing it if needed, not great at DM.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents players from cheating in an arcade game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes exploit in orion arcade machine that allowed players to steal, sell, and buy resources without being at a spaceport.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
