### PR TITLE
Allows grenades to chain explode

### DIFF
--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -44,6 +44,9 @@
 	sleep(det_time)//so you dont die instantly
 	return BRUTELOSS
 
+/obj/item/grenade/ex_act(severity, target) // Little boom can chain a big boom.
+	detonate()
+
 /obj/item/grenade/deconstruct(disassembled = TRUE)
 	if(!disassembled)
 		detonate()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows grenades to chain explode. That's it. When something goes boom your grenade goes boom. Do I really need to explain this?

## Why It's Good For The Game

More funny gimmicks and tricks

## Changelog
:cl:
balance: Grenades now can chain explode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
