### PR TITLE
Removes the slur from a possible smoke bomb description

### DIFF
--- a/code/game/objects/items/grenades/smokebomb.dm
+++ b/code/game/objects/items/grenades/smokebomb.dm
@@ -11,7 +11,7 @@
 	inhand_icon_state = "smoke"
 	slot_flags = ITEM_SLOT_BELT
 	///It's extremely important to keep this list up to date. It helps to generate the insightful description of the smokebomb
-	var/static/list/bruh_moment = list("Dank", "Hip", "Lit", "Based", "Robust", "Bruh", "Nyagger")
+	var/static/list/bruh_moment = list("Dank", "Hip", "Lit", "Based", "Robust", "Bruh", "Gamer")
 
 ///Here we generate the extremely insightful description.
 /obj/item/grenade/smokebomb/Initialize()


### PR DESCRIPTION
## About The Pull Request

There's a slur as a possible smoke bomb description, this changes it to something more fitting.
I wasn't sure what tag to add, hopefully spellcheck is enough.

## Why It's Good For The Game

Slurs in item descriptions doesnt seem like a good idea.

## Changelog
:cl:
spellcheck: Slightly changed the smoke bomb description
/:cl:
