### PR TITLE
Fixes some can_adjust jumpsuit slot error sprites

### DIFF
--- a/code/modules/clothing/under/costume.dm
+++ b/code/modules/clothing/under/costume.dm
@@ -253,6 +253,7 @@
 	strip_delay = 50
 	sensor_mode = SENSOR_COORDS
 	random_sensor = FALSE
+	can_adjust = FALSE
 
 /obj/item/clothing/under/costume/jackbros
 	name = "jack bros outfit"
@@ -274,6 +275,7 @@
 	icon_state = "DutchUniform"
 	inhand_icon_state = "DutchUniform"
 	can_adjust = FALSE
+
 /obj/item/clothing/under/costume/swagoutfit
 	name = "Swag outfit"
 	desc = "Why don't you go secure some bitches?"

--- a/code/modules/clothing/under/jobs/civilian/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian/civilian.dm
@@ -236,3 +236,4 @@
 	name = "grilling shorts"
 	desc = "For when all you want in life is to grill for god's sake!"
 	icon_state = "cookjorts"
+	can_adjust = FALSE

--- a/code/modules/clothing/under/jobs/civilian/clown_mime.dm
+++ b/code/modules/clothing/under/jobs/civilian/clown_mime.dm
@@ -29,6 +29,7 @@
 	icon_state = "clown"
 	inhand_icon_state = "clown"
 	species_exception = list(/datum/species/golem/bananium)
+	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/civilian/clown/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/55011
Clown outfits and their subtypes, grilling shorts, and the russian officer's uniform were adjustable but didn't have an adjusted icon state

## Why It's Good For The Game
This lad is too powerful to be kept alive, and must be defeated
https://streamable.com/df1t89

## Changelog
:cl:
fix: Clown outfits, grilling shorts, and russian officer's uniforms are no longer able to be adjusted into a purple and black trench coat.
/:cl: