### PR TITLE
Centralized dummy lookalike generation

### DIFF
--- a/code/modules/admin/outfit_editor.dm
+++ b/code/modules/admin/outfit_editor.dm
@@ -37,7 +37,7 @@
 
 /datum/outfit_editor/proc/init_dummy()
 	dummy_key = "outfit_editor_[owner]"
-	generate_dummy_lookalike(owner.mob)
+	generate_dummy_lookalike(dummy_key, owner.mob)
 	unset_busy_human_dummy(dummy_key)
 
 /datum/outfit_editor/ui_interact(mob/user, datum/tgui/ui)
@@ -73,9 +73,9 @@
 	data["outfit"] = serialize_outfit()
 	data["saveable"] = !GLOB.custom_outfits.Find(drip)
 
-	var/datum/preferences/prefs = owner.prefs
+	if(!dummy_key)
+		init_dummy()
 	var/icon/dummysprite = get_flat_human_icon(null,
-		prefs = prefs,
 		dummy_key = dummy_key,
 		showDirs = list(SOUTH),
 		outfit_override = drip)

--- a/code/modules/admin/outfit_editor.dm
+++ b/code/modules/admin/outfit_editor.dm
@@ -37,12 +37,7 @@
 
 /datum/outfit_editor/proc/init_dummy()
 	dummy_key = "outfit_editor_[owner]"
-	var/mob/living/carbon/human/dummy/dummy = generate_or_wait_for_human_dummy(dummy_key)
-	var/mob/living/carbon/carbon_target = owner.mob
-	if(istype(carbon_target))
-		carbon_target.dna.transfer_identity(dummy)
-		dummy.updateappearance()
-
+	generate_dummy_lookalike(owner.mob)
 	unset_busy_human_dummy(dummy_key)
 
 /datum/outfit_editor/ui_interact(mob/user, datum/tgui/ui)

--- a/code/modules/admin/verbs/selectequipment.dm
+++ b/code/modules/admin/verbs/selectequipment.dm
@@ -23,7 +23,6 @@
 	var/mob/target_mob
 
 	var/dummy_key
-	var/mob/living/carbon/human/dummy/dummy
 
 	//static list to share all the outfit typepaths between all instances of this datum.
 	var/static/list/cached_outfits
@@ -63,12 +62,7 @@
 
 /datum/select_equipment/proc/init_dummy()
 	dummy_key = "selectequipmentUI_[target_mob]"
-	dummy = generate_or_wait_for_human_dummy(dummy_key)
-	var/mob/living/carbon/carbon_target = target_mob
-	if(istype(carbon_target))
-		carbon_target.dna.transfer_identity(dummy)
-		dummy.updateappearance()
-
+	generate_dummy_lookalike(dummy_key, target_mob)
 	unset_busy_human_dummy(dummy_key)
 	return
 
@@ -112,14 +106,16 @@
 
 /datum/select_equipment/ui_data(mob/user)
 	var/list/data = list()
-	if(!dummy)
+	if(!dummy_key)
 		init_dummy()
 
-	var/datum/preferences/prefs = target_mob?.client?.prefs
-	var/icon/dummysprite = get_flat_human_icon(null, prefs=prefs, dummy_key = dummy_key, outfit_override = selected_outfit)
+	var/icon/dummysprite = get_flat_human_icon(null,
+		dummy_key = dummy_key,
+		outfit_override = selected_outfit)
 	data["icon64"] = icon2base64(dummysprite)
 	data["name"] = target_mob
 
+	var/datum/preferences/prefs = user?.client?.prefs
 	data["favorites"] = list()
 	if(prefs)
 		data["favorites"] = prefs.favorite_outfits

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -51,11 +51,11 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 
 	var/mob/living/carbon/human/dummy/copycat = generate_or_wait_for_human_dummy(slotkey)
 
-	if(istype(target, /mob/living/carbon))
+	if(iscarbon(target))
 		var/mob/living/carbon/carbon_target = target
 		carbon_target.dna.transfer_identity(copycat, transfer_SE = TRUE)
 
-		if(istype(target, /mob/living/carbon/human))
+		if(ishuman(target))
 			var/mob/living/carbon/human/human_target = target
 			human_target.copy_clothing_prefs(copycat)
 
@@ -63,9 +63,7 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 	else
 		//even if target isn't a carbon, if they have a client we can make the
 		//dummy look like what their human would look like based on their prefs
-		var/datum/preferences/prefs = target?.client?.prefs
-		if(istype(prefs))
-			prefs.copy_to(copycat, icon_updates=TRUE, roundstart_checks=FALSE, character_setup=TRUE)
+		target?.client?.prefs?.copy_to(copycat, icon_updates=TRUE, roundstart_checks=FALSE, character_setup=TRUE)
 
 	return copycat
 

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -51,12 +51,6 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 
 	var/mob/living/carbon/human/dummy/copycat = generate_or_wait_for_human_dummy(slotkey)
 
-	//even if target isn't a carbon, if they have a client we can make the
-	//dummy look like what their human would look like based on their prefs
-	var/datum/preferences/prefs = target?.client?.prefs
-	if(istype(prefs))
-		prefs.copy_to(copycat, icon_updates=TRUE, roundstart_checks=FALSE, character_setup=TRUE)
-
 	if(istype(target, /mob/living/carbon))
 		var/mob/living/carbon/carbon_target = target
 		carbon_target.dna.transfer_identity(copycat, transfer_SE = TRUE)
@@ -65,8 +59,13 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 			var/mob/living/carbon/human/human_target = target
 			human_target.copy_clothing_prefs(copycat)
 
-		//updating appearance if target isn't a carbon will reset the appearance given above by prefs
 		copycat.updateappearance(icon_update=TRUE, mutcolor_update=TRUE, mutations_overlay_update=TRUE)
+	else
+		//even if target isn't a carbon, if they have a client we can make the
+		//dummy look like what their human would look like based on their prefs
+		var/datum/preferences/prefs = target?.client?.prefs
+		if(istype(prefs))
+			prefs.copy_to(copycat, icon_updates=TRUE, roundstart_checks=FALSE, character_setup=TRUE)
 
 	return copycat
 

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -51,17 +51,21 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 
 	var/mob/living/carbon/human/dummy/copycat = generate_or_wait_for_human_dummy(slotkey)
 
-	//copy prefs (underwear, hair color, etc)
-	var/datum/preferences/prefs = target.client?.prefs
+	//even if target isn't a carbon, if they have a client we can make the
+	//dummy look like what their human would look like based on their prefs
+	var/datum/preferences/prefs = target?.client?.prefs
 	if(istype(prefs))
-		prefs.copy_to(copycat, icon_updates = TRUE, roundstart_checks = FALSE)
+		prefs.copy_to(copycat, icon_updates=TRUE, roundstart_checks=FALSE, character_setup=TRUE)
 
-	//copy dna features (species and name mostly)
+	//trigg todo: hair and shit still randomized on mobs without client
 	if(istype(target, /mob/living/carbon))
 		var/mob/living/carbon/carbon_target = target
-		carbon_target.dna.transfer_identity(copycat)
+		carbon_target.dna.transfer_identity(copycat, transfer_SE = TRUE)
 
-	copycat.updateappearance()
+	if(istype(target, /mob/living/carbon/human))
+		var/mob/living/carbon/human/human_target = target
+		human_target.copy_clothing_prefs(copycat)
+
 	return copycat
 
 /proc/unset_busy_human_dummy(slotkey)

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -45,6 +45,25 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 	D.in_use = TRUE
 	return D
 
+/proc/generate_dummy_lookalike(slotkey, mob/target)
+	if(!istype(target))
+		return generate_or_wait_for_human_dummy(slotkey)
+
+	var/mob/living/carbon/human/dummy/copycat = generate_or_wait_for_human_dummy(slotkey)
+
+	//copy prefs (underwear, hair color, etc)
+	var/datum/preferences/prefs = target.client?.prefs
+	if(istype(prefs))
+		prefs.copy_to(copycat, icon_updates = TRUE, roundstart_checks = FALSE)
+
+	//copy dna features (species and name mostly)
+	if(istype(target, /mob/living/carbon))
+		var/mob/living/carbon/carbon_target = target
+		carbon_target.dna.transfer_identity(copycat)
+
+	copycat.updateappearance()
+	return copycat
+
 /proc/unset_busy_human_dummy(slotkey)
 	if(!slotkey)
 		return

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -57,14 +57,16 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 	if(istype(prefs))
 		prefs.copy_to(copycat, icon_updates=TRUE, roundstart_checks=FALSE, character_setup=TRUE)
 
-	//trigg todo: hair and shit still randomized on mobs without client
 	if(istype(target, /mob/living/carbon))
 		var/mob/living/carbon/carbon_target = target
 		carbon_target.dna.transfer_identity(copycat, transfer_SE = TRUE)
 
-	if(istype(target, /mob/living/carbon/human))
-		var/mob/living/carbon/human/human_target = target
-		human_target.copy_clothing_prefs(copycat)
+		if(istype(target, /mob/living/carbon/human))
+			var/mob/living/carbon/human/human_target = target
+			human_target.copy_clothing_prefs(copycat)
+
+		//updating appearance if target isn't a carbon will reset the appearance given above by prefs
+		copycat.updateappearance(icon_update=TRUE, mutcolor_update=TRUE, mutations_overlay_update=TRUE)
 
 	return copycat
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -32,6 +32,7 @@
 
 	var/age = 30 //Player's age
 
+	//consider updating /mob/living/carbon/human/copy_clothing_prefs() if adding more of these
 	var/underwear = "Nude" //Which underwear the player wants
 	var/underwear_color = "000"
 	var/undershirt = "Nude" //Which undershirt the player wants

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -231,3 +231,10 @@
 	else
 		return "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has departed...</span>"
 
+///copies over clothing preferences like underwear to another human
+/mob/living/carbon/human/proc/copy_clothing_prefs(mob/living/carbon/human/destination)
+	destination.underwear = underwear
+	destination.underwear_color = underwear_color
+	destination.undershirt = undershirt
+	destination.socks = socks
+	destination.jumpsuit_style = jumpsuit_style


### PR DESCRIPTION
## About The Pull Request
Man I'm bad at PR names.
Anyways.
Since I used pretty much the exact same code to make dummies that copy people's appearance in my last two PRs, I decided to make a specialized proc for that. It also does it better.
Also squashed a bug while I was at it.

Oh yeah, and another new proc - `/mob/living/carbon/human/copy_clothing_prefs()` - It copies underwear, undershirt and socks because apparently there wasn't a proc that did that before (except `preferences.copy_to()`, but I couldn't rely on the target mob having a client to steal their socks now, could I?)

## Why It's Good For The Game

Less copypastas to achieve the same end result, I guess.

## Changelog
:cl: Trigg
fix: The Select Equipment menu now uses the UI owner's favorite outfits instead of the target mob's. Whoops.
/:cl:
