### PR TITLE
Custom Chaplain Bible Names

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -7,6 +7,7 @@
 
 #define DEFAULT_RELIGION "Christianity"
 #define DEFAULT_DEITY "Space Jesus"
+#define DEFAULT_BIBLE "The Holy Bible"
 
 #define JOB_DISPLAY_ORDER_DEFAULT 0
 

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -7,7 +7,7 @@
 
 #define DEFAULT_RELIGION "Christianity"
 #define DEFAULT_DEITY "Space Jesus"
-#define DEFAULT_BIBLE "The Holy Bible"
+#define DEFAULT_BIBLE "Default Bible Name"
 
 #define JOB_DISPLAY_ORDER_DEFAULT 0
 

--- a/code/_globalvars/lists/names.dm
+++ b/code/_globalvars/lists/names.dm
@@ -49,5 +49,6 @@ GLOBAL_LIST_INIT(preferences_custom_names, list(
 	"cyborg" = list("pref_name" = "Cyborg", "qdesc" = "cyborg name (Leave empty to use default naming scheme)", "allow_numbers" = TRUE , "group" = "silicons", "allow_null" = TRUE),
 	"ai" = list("pref_name" = "AI", "qdesc" = "ai name", "allow_numbers" = TRUE , "group" = "silicons", "allow_null" = FALSE),
 	"religion" = list("pref_name" = "Chaplain religion", "qdesc" = "religion" , "allow_numbers" = TRUE , "group" = "chaplain", "allow_null" = FALSE),
-	"deity" = list("pref_name" = "Chaplain deity", "qdesc" = "deity", "allow_numbers" = TRUE , "group" = "chaplain", "allow_null" = FALSE)
+	"deity" = list("pref_name" = "Chaplain deity", "qdesc" = "deity", "allow_numbers" = TRUE , "group" = "chaplain", "allow_null" = FALSE),
+	"bible" = list("pref_name" = "Chaplain bible name", "qdesc" = "bible name (Leave empty to use default naming scheme)", "allow_numbers" = TRUE , "group" = "chaplain", "allow_null" = TRUE)
 	))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2022,6 +2022,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			return DEFAULT_RELIGION
 		if("deity")
 			return DEFAULT_DEITY
+		if("bible")
+			return DEFAULT_BIBLE
 	return random_unique_name()
 
 /datum/preferences/proc/ask_for_custom_name(mob/user,name_id)

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -55,69 +55,74 @@
 
 	B.deity_name = new_deity
 
+	var/new_bible = DEFAULT_BIBLE
+	if(M.client && M.client.prefs.custom_names["bible"])
+		new_bible = M.client.prefs.custom_names["bible"]
+
 	switch(lowertext(new_religion))
 		if("christianity") // DEFAULT_RELIGION
-			B.name = pick("The Holy Bible","The Dead Sea Scrolls")
+			new_bible = pick("The Holy Bible","The Dead Sea Scrolls")
 		if("buddhism")
-			B.name = "The Sutras"
+			new_bible = "The Sutras"
 		if("clownism","honkmother","honk","honkism","comedy")
-			B.name = pick("The Holy Joke Book", "Just a Prank", "Hymns to the Honkmother")
+			new_bible = pick("The Holy Joke Book", "Just a Prank", "Hymns to the Honkmother")
 		if("chaos")
-			B.name = "The Book of Lorgar"
+			new_bible = "The Book of Lorgar"
 		if("cthulhu")
-			B.name = "The Necronomicon"
+			new_bible = "The Necronomicon"
 		if("hinduism")
-			B.name = "The Vedas"
+			new_bible = "The Vedas"
 		if("homosexuality")
-			B.name = pick("Guys Gone Wild","Coming Out of The Closet")
+			new_bible = pick("Guys Gone Wild","Coming Out of The Closet")
 		if("imperium")
-			B.name = "Uplifting Primer"
+			new_bible = "Uplifting Primer"
 		if("islam")
-			B.name = "Quran"
+			new_bible = "Quran"
 		if("judaism")
-			B.name = "The Torah"
+			new_bible = "The Torah"
 		if("lampism")
-			B.name = "Fluorescent Incandescence"
+			new_bible = "Fluorescent Incandescence"
 		if("lol", "wtf", "gay", "penis", "ass", "poo", "badmin", "shitmin", "deadmin", "cock", "cocks", "meme", "memes")
-			B.name = pick("Woodys Got Wood: The Aftermath", "War of the Cocks", "Sweet Bro and Hella Jef: Expanded Edition","F.A.T.A.L. Rulebook")
+			new_bible = pick("Woodys Got Wood: The Aftermath", "War of the Cocks", "Sweet Bro and Hella Jef: Expanded Edition","F.A.T.A.L. Rulebook")
 			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 100) // starts off brain damaged as fuck
 		if("monkeyism","apism","gorillism","primatism")
-			B.name = pick("Going Bananas", "Bananas Out For Harambe")
+			new_bible = pick("Going Bananas", "Bananas Out For Harambe")
 		if("mormonism")
-			B.name = "The Book of Mormon"
+			new_bible = "The Book of Mormon"
 		if("pastafarianism")
-			B.name = "The Gospel of the Flying Spaghetti Monster"
+			new_bible = "The Gospel of the Flying Spaghetti Monster"
 		if("rastafarianism","rasta")
-			B.name = "The Holy Piby"
+			new_bible = "The Holy Piby"
 		if("satanism")
-			B.name = "The Unholy Bible"
+			new_bible = "The Unholy Bible"
 		if("sikhism")
-			B.name = "Guru Granth Sahib"
+			new_bible = "Guru Granth Sahib"
 		if("science")
-			B.name = pick("Principle of Relativity", "Quantum Enigma: Physics Encounters Consciousness", "Programming the Universe", "Quantum Physics and Theology", "String Theory for Dummies", "How To: Build Your Own Warp Drive", "The Mysteries of Bluespace", "Playing God: Collector's Edition")
+			new_bible = pick("Principle of Relativity", "Quantum Enigma: Physics Encounters Consciousness", "Programming the Universe", "Quantum Physics and Theology", "String Theory for Dummies", "How To: Build Your Own Warp Drive", "The Mysteries of Bluespace", "Playing God: Collector's Edition")
 		if("scientology")
-			B.name = pick("The Biography of L. Ron Hubbard","Dianetics")
+			new_bible = pick("The Biography of L. Ron Hubbard","Dianetics")
 		if("servicianism", "partying")
-			B.name = "The Tenets of Servicia"
+			new_bible = "The Tenets of Servicia"
 			B.deity_name = pick("Servicia", "Space Bacchus", "Space Dionysus")
 			B.desc = "Happy, Full, Clean. Live it and give it."
 		if("subgenius")
-			B.name = "Book of the SubGenius"
+			new_bible = "Book of the SubGenius"
 		if("toolboxia","greytide")
-			B.name = pick("Toolbox Manifesto","iGlove Assistants")
+			new_bible = pick("Toolbox Manifesto","iGlove Assistants")
 		if("weeaboo","kawaii")
-			B.name = pick("Fanfiction Compendium","Japanese for Dummies","The Manganomicon","Establishing Your O.T.P")
-		else
-			B.name = "The Holy Book of [new_religion]"
+			new_bible = pick("Fanfiction Compendium","Japanese for Dummies","The Manganomicon","Establishing Your O.T.P")
+
+	B.name = new_bible
 
 	GLOB.religion = new_religion
-	GLOB.bible_name = B.name
+	GLOB.bible_name = new_bible
 	GLOB.deity = B.deity_name
 
 	H.equip_to_slot_or_del(B, ITEM_SLOT_BACKPACK)
 
 	SSblackbox.record_feedback("text", "religion_name", 1, "[new_religion]", 1)
 	SSblackbox.record_feedback("text", "religion_deity", 1, "[new_deity]", 1)
+	SSblackbox.record_feedback("text", "religion_bible", 1, "[new_bible]", 1)
 
 /datum/outfit/job/chaplain
 	name = "Chaplain"

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -111,6 +111,9 @@
 			new_bible = pick("Toolbox Manifesto","iGlove Assistants")
 		if("weeaboo","kawaii")
 			new_bible = pick("Fanfiction Compendium","Japanese for Dummies","The Manganomicon","Establishing Your O.T.P")
+		else
+			if(new_bible == DEFAULT_BIBLE)
+				new_bible = "The Holy Book of [new_religion]"
 
 	B.name = new_bible
 


### PR DESCRIPTION
## About The Pull Request

Adds a pref for the name of the chaplain's bible. Unless overriden by a specific religion name or left as its default value of "Default Bible Name", the bible will use this name instead of "The Holy Book of [religion]".

## Why It's Good For The Game

This brings a little more flavor customization to chaplains and their religions.

## Changelog
:cl:
add: You can now change the name of your chaplain bible in the Setup Character menu. If left as its default value of "Default Bible Name", your bible will use the old naming scheme.
/:cl: