### PR TITLE
makes wittel more common

### DIFF
--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -48,7 +48,7 @@
 
 /obj/structure/geyser/random
 	erupting_state = null
-	var/list/options = list(/datum/reagent/clf3 = 10, /datum/reagent/water/hollowwater = 10,/datum/reagent/plasma_oxide = 8, /datum/reagent/medicine/omnizine/protozine = 6, /datum/reagent/wittel = 1)
+	var/list/options = list(/datum/reagent/water/hollowwater = 1,/datum/reagent/plasma_oxide = 1, /datum/reagent/medicine/omnizine/protozine = 1, /datum/reagent/wittel = 1)
 
 /obj/structure/geyser/random/Initialize()
 	. = ..()

--- a/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
@@ -387,17 +387,17 @@
 /datum/micro_organism/cell_line/netherworld
 	desc = "Aberrant residue"
 	required_reagents = list(//theme here: very odd requirements
-							/datum/reagent/water/hollowwater,//geyser reagent, so plentiful when found
+							/datum/reagent/water/hollowwater, //geyser reagent, so plentiful when found
 							/datum/reagent/consumable/ethanol/wizz_fizz, //EZ bartender drink, like brainless
 							/datum/reagent/yuck) //since the other two are easy to make tons of, this is kind of a limiter
 
-	supplementary_reagents = list( //all of these are just geyser stuff, rated by their rarity
-							/datum/reagent/wittel = 10, //stupid rare
-							/datum/reagent/medicine/omnizine/protozine = 5,
+	supplementary_reagents = list(//all of these chems either are or used to be in the geyser chem pool
+							/datum/reagent/wittel = 3,
+							/datum/reagent/medicine/omnizine/protozine = 3,
 							/datum/reagent/plasma_oxide = 3,
-							/datum/reagent/clf3 = 1)//since this is also chemistry it's worth near nothing
+							/datum/reagent/clf3 = 1) //clf3 can be made just using chem dispenser chems, so it's not worth much
 
-	suppressive_reagents = list(//generics you would regularly put in a vat kill abberant residue
+	suppressive_reagents = list(//generics you would regularly put in a vat kill aberrant residue
 						/datum/reagent/consumable/nutriment/peptides = -6,
 						/datum/reagent/consumable/nutriment/protein = -4,
 						/datum/reagent/consumable/nutriment = -3,


### PR DESCRIPTION
## About The Pull Request

Each Lavaland geyser chem is now equally likely to appear in a given geyser. ClF3 has been removed from the pool of Lavaland geyser chems.

The aberrant cell line's code comments and supplementary reagent growth assistance rates have been adjusted to reflect this change.

## Why It's Good For The Game

Currently, if you want to get access to a wittel as a chemist, you either have to rely on absurdly RNG-reliant methods (such as random botany mutations) or go geyser plumbing on Lavaland. If you go through the effort of finding THIRTY-FIVE geysers (is it possible for that many geysers to even be on Lavaland?) AND plumb each one of them, you will have only a **50% chance** of actually finding one that contains wittel.

Needless to say, any chem that has wittel in its recipe is basically never made... ever (using that recipe, anyway). This is a shame, as the wittel-derived chems (and geysers in general) are actually pretty cool. Hopefully, if this PR is merged, we'll see more chemists experimenting with chems like penthrite, nooartrium, and gravitum instead of sticking with "the classics" and never leaving Medbay.

## Changelog
:cl: ATHATH
balance: Each Lavaland geyser chem is now equally likely to appear in a given geyser. ClF3 has been removed from the pool of Lavaland geyser chems. The (vatgrowing) aberrant cell line's supplementary reagent growth assistance rates have been adjusted to reflect this change.
/:cl: