### PR TITLE
Breaking a mirror now gives you a bad omen

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -53,14 +53,34 @@
 		return list()// no message spam
 	return ..()
 
+/obj/structure/mirror/attacked_by(obj/item/I, mob/living/user)
+	if(broken || !istype(user) || !I.force)
+		return ..()
+
+	. = ..()
+	if(broken) // breaking a mirror truly gets you bad luck!
+		to_chat(user, "<span class='warning'>A chill runs down your spine as [src] shatters...</span>")
+		user.AddComponent(/datum/component/omen, silent=TRUE) // we have our own message
+
+/obj/structure/mirror/bullet_act(obj/projectile/P)
+	if(broken || !isliving(P.firer) || !P.damage)
+		return ..()
+
+	. = ..()
+	if(broken) // breaking a mirror truly gets you bad luck!
+		var/mob/living/unlucky_dude = P.firer
+		to_chat(unlucky_dude, "<span class='warning'>A chill runs down your spine as [src] shatters...</span>")
+		unlucky_dude.AddComponent(/datum/component/omen, silent=TRUE) // we have our own message
+
 /obj/structure/mirror/obj_break(damage_flag, mapload)
-	if(!broken && !(flags_1 & NODECONSTRUCT_1))
-		icon_state = "mirror_broke"
-		if(!mapload)
-			playsound(src, "shatter", 70, TRUE)
-		if(desc == initial(desc))
-			desc = "Oh no, seven years of bad luck!"
-		broken = TRUE
+	if(broken || (flags_1 & NODECONSTRUCT_1))
+		return
+	icon_state = "mirror_broke"
+	if(!mapload)
+		playsound(src, "shatter", 70, TRUE)
+	if(desc == initial(desc))
+		desc = "Oh no, seven years of bad luck!"
+	broken = TRUE
 
 /obj/structure/mirror/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is a pretty lightweight PR, if you shatter a mirror by attacking it or shooting it, you get an omen applied to you which means you're gonna have some serious pain coming your way in the very near future.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nice little mix of mechanics and fluff coming together to reflect old superstitions in a funny, impactful way.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
add: Nanotrasen's Human Resources department would like to remind crewmembers that shattering mirrors, whether by striking them or shooting them, will bring you bad luck and probably also get you maimed. Don't do it!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
