### PR TITLE
Removes CHECK_TICK from overlays, following the same theory as instant explosions.

### DIFF
--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -60,12 +60,6 @@ SUBSYSTEM_DEF(overlays)
 			UNSETEMPTY(A.remove_overlays)
 			STAT_STOP_STOPWATCH
 			STAT_LOG_ENTRY(stats, A.type)
-		if(mc_check)
-			if(MC_TICK_CHECK)
-				break
-		else
-			CHECK_TICK
-
 	if (count)
 		queue.Cut(1,count+1)
 		count = 0


### PR DESCRIPTION
## About The Pull Request

as we learned with instant explosions, sleeping needlessly between appearance changes results in a heavier sendmaps load, let's see how this performs

## Why It's Good For The Game

see above

## Changelog
:cl:
fix: potentially reduces overlay impact on SendMaps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
