### PR TITLE
Add exp tracking for Maintenance Drones

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -102,7 +102,7 @@ GLOBAL_LIST_INIT(exp_jobsmap, list(
 GLOBAL_LIST_INIT(exp_specialmap, list(
 	EXP_TYPE_LIVING = list(), // all living mobs
 	EXP_TYPE_ANTAG = list(),
-	EXP_TYPE_SPECIAL = list("Lifebringer","Ash Walker","Exile","Servant Golem","Free Golem","Hermit","Translocated Vet","Escaped Prisoner","Hotel Staff","SuperFriend","Space Syndicate","Ancient Crew","Space Doctor","Space Bartender","Beach Bum","Skeleton","Zombie","Space Bar Patron","Lavaland Syndicate","Ghost Role"), // Ghost roles
+	EXP_TYPE_SPECIAL = list("Lifebringer","Ash Walker","Exile","Servant Golem","Free Golem","Hermit","Translocated Vet","Escaped Prisoner","Hotel Staff","SuperFriend","Space Syndicate","Ancient Crew","Space Doctor","Space Bartender","Beach Bum","Skeleton","Zombie","Space Bar Patron","Lavaland Syndicate","Maintenance Drone","Ghost Role"), // Ghost roles
 	EXP_TYPE_GHOST = list() // dead people, observers
 ))
 GLOBAL_PROTECT(exp_jobsmap)

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -26,6 +26,7 @@
 	short_desc = "You are a Maintenance Drone."
 	flavour_text = "Born out of science, your purpose is to maintain Space Station 13. Maintenance Drones can become the backbone of a healthy station."
 	important_info = "You MUST read and follow your laws carefully."
+	assignedrole = "Maintenance Drone"
 
 /obj/effect/mob_spawn/drone/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -65,6 +65,7 @@
 	short_desc = "You are a Syndicate Maintenance Drone."
 	flavour_text = "In a prior life, you maintained a Nanotrasen Research Station. Abducted from your home, you were given some upgrades... and now serve an enemy of your former masters."
 	important_info = ""
+	assignedrole = null
 
 /obj/effect/mob_spawn/drone/syndrone/badass
 	name = "badass syndrone shell"
@@ -116,6 +117,7 @@
 	short_desc = "You are a drone on Kosmicheskaya Stantsiya 13."
 	flavour_text = "Something has brought you out of hibernation, and the station is in gross disrepair."
 	important_info = "Build, repair, maintain and improve the station that housed you on activation."
+	assignedrole = null
 
 /mob/living/simple_animal/drone/derelict
 	name = "derelict drone"


### PR DESCRIPTION
## About The Pull Request

Playtime as a Maintenance Drone is now tracked, which may be viewed under "View tracked maintenance".

## Why It's Good For The Game

Fun stat tracking, and serious stat tracking.

## Changelog
:cl: JJRcop
qol: Maintenance Drone playtime is now tracked.
/:cl:
