### PR TITLE
Make you not hit the cans with tanks anymore

### DIFF
--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -133,7 +133,6 @@
 	return TRUE
 
 /obj/machinery/portable_atmospherics/attackby(obj/item/W, mob/user, params)
-	. = ..()
 	if(!istype(W, /obj/item/tank))
 		return FALSE
 	if(machine_stat & BROKEN)

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -134,6 +134,7 @@
 
 /obj/machinery/portable_atmospherics/attackby(obj/item/W, mob/user, params)
 	if(!istype(W, /obj/item/tank))
+		. = ..()
 		return FALSE
 	if(machine_stat & BROKEN)
 		return FALSE

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -134,8 +134,7 @@
 
 /obj/machinery/portable_atmospherics/attackby(obj/item/W, mob/user, params)
 	if(!istype(W, /obj/item/tank))
-		. = ..()
-		return FALSE
+		return ..()
 	if(machine_stat & BROKEN)
 		return FALSE
 	var/obj/item/tank/T = W


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ghilker by mistake put callback to parrent at the start of portable atmos attack chain, I moved it 2 lines lower and it works fine now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes this piece of shit: https://github.com/tgstation/tgstation/issues/58152
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: SparkezelPL
fix: You can no longer hit canisters with tanks 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
