### PR TITLE
Fixes monkey mind magnification helmet

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -463,7 +463,8 @@
 /obj/item/clothing/head/helmet/monkey_sentience/Destroy()
 	if(magnification)
 		ADD_TRAIT(magnification, TRAIT_PRIMITIVE, SPECIES_TRAIT)
-		magnification.ghostize(FALSE)
+		if(magnification.key)
+			magnification.ghostize(FALSE)
 		magnification = null
 	return ..()
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -463,6 +463,7 @@
 /obj/item/clothing/head/helmet/monkey_sentience/Destroy()
 	if(magnification)
 		ADD_TRAIT(magnification, TRAIT_PRIMITIVE, SPECIES_TRAIT)
+		magnification.ghostize(FALSE)
 		magnification = null
 	return ..()
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -461,7 +461,8 @@
 	REMOVE_TRAIT(magnification, TRAIT_PRIMITIVE, SPECIES_TRAIT) //Monkeys with sentience should be able to use less primitive tools.
 
 /obj/item/clothing/head/helmet/monkey_sentience/Destroy()
-	disconnect()
+	if(magnification)
+		magnification = null
 	return ..()
 
 /obj/item/clothing/head/helmet/monkey_sentience/proc/disconnect()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -393,7 +393,7 @@
 	desc = "A fragile, circuitry embedded helmet for boosting the intelligence of a monkey to a higher level. You see several warning labels..."
 	icon_state = "monkeymind"
 	inhand_icon_state = "monkeymind"
-	strip_delay = 120
+	strip_delay = 100
 	var/mob/living/carbon/human/magnification = null ///if the helmet is on a valid target (just works like a normal helmet if not (cargo please stop))
 	var/polling = FALSE///if the helmet is currently polling for targets (special code for removal)
 	var/light_colors = 1 ///which icon state color this is (red, blue, yellow)
@@ -487,7 +487,6 @@
 				if(4) //genetic mass susceptibility (gib)
 					magnification.gib()
 	magnification = null
-
 
 /obj/item/clothing/head/helmet/monkey_sentience/dropped(mob/user)
 	. = ..()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -462,6 +462,7 @@
 
 /obj/item/clothing/head/helmet/monkey_sentience/Destroy()
 	if(magnification)
+		ADD_TRAIT(magnification, TRAIT_PRIMITIVE, SPECIES_TRAIT)
 		magnification = null
 	return ..()
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -467,7 +467,7 @@
 /obj/item/clothing/head/helmet/monkey_sentience/proc/disconnect()
 	if(!magnification) //not put on a viable head
 		return
-	//either used up correctly or taken off before polling finished (punish this by destroying the helmet)
+	//either used up correctly or taken off before polling finished (punish this by having a chance to gib the monkey?)
 	UnregisterSignal(magnification, COMSIG_SPECIES_LOSS)
 	playsound(src, 'sound/machines/buzz-sigh.ogg', 30, TRUE)
 	magnification.dropItemToGround(src)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -472,7 +472,6 @@
 	//either used up correctly or taken off before polling finished (punish this by having a chance to gib the monkey?)
 	UnregisterSignal(magnification, COMSIG_SPECIES_LOSS)
 	playsound(src, 'sound/machines/buzz-sigh.ogg', 30, TRUE)
-	magnification.dropItemToGround(src)
 	ADD_TRAIT(magnification, TRAIT_PRIMITIVE, SPECIES_TRAIT) //We removed it, now that they're back to being dumb, add the trait again.
 	if(!polling)//put on a viable head, but taken off after polling finished.
 		if(magnification.client)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -439,7 +439,7 @@
 
 /obj/item/clothing/head/helmet/monkey_sentience/proc/connect(mob/user)
 	polling = TRUE
-	var/list/candidates = pollCandidatesForMob("Do you want to play as a mind magnified monkey?", ROLE_SENTIENCE, M = magnification, ignore_category = POLL_IGNORE_SENTIENCE_POTION) //SKYRAT EDIT CHANGE
+	var/list/candidates = pollCandidatesForMob("Do you want to play as a mind magnified monkey?", ROLE_SENTIENCE, M = magnification, ignore_category = POLL_IGNORE_SENTIENCE_POTION)
 	polling = FALSE
 	if(!magnification)
 		return


### PR DESCRIPTION
## About The Pull Request

Did you know that these don't work? It sucks. I bought one and was scammed! They're broken!

In my fit of rage over my broken product, I decided to fix it up! So that's what this PR is.

In my investigations, I found that:
A: The ghost polling was not set up correctly, meaning no ghosts were being polled, thus, the hat failed every time.
B: When a monke put the hat on themselves(they seem to prioritize these helmets), it would spam the buzz sound for it failing and then dust the hat several times. Thus breaking it even further given point A.

Not sure if these have ever worked correctly, but now they do! 

I removed the dusting part of it because that's actually dumb.

## Why It's Good For The Game

Having content work is good, right?

## Changelog
:cl:
fix: The monkey mind magnification helmet should now work correctly!
/:cl:

