### PR TITLE
Prevent flashing tabs issue

### DIFF
--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -862,7 +862,6 @@ function remove_tickets() {
 function remove_interviews() {
 	if(tickets) {
 		tickets = [];
-		update_verbs();
 	}
 	checkStatusTab();
 }


### PR DESCRIPTION
This was occurring due to remove_admin_tabs being called for non admins in statpanel.dm:44. This ended up being redundant and not needed, therefore I removed the line.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes flashing

## Why It's Good For The Game

see above

## Changelog
:cl: Celotajs
fix: Fixed flashing for non admin users
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
