### PR TITLE
Disables drone restrictions on Derelict drones

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -133,6 +133,7 @@
 	"<span class='notice'>     - Interacting with non-drone players outside KS13, dead or alive.</span>\n"+\
 	"<span class='warning'>These rules are at admin discretion and will be heavily enforced.</span>\n"+\
 	"<span class='warning'><u>If you do not have the regular drone laws, follow your laws to the best of your ability.</u></span>"
+	shy = FALSE
 
 /mob/living/simple_animal/drone/derelict/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Removes derelict drone restrictions like item whitelist, machinery whitelist, being range limit.
I haven't reverted them back to their old drone satchel, so they can be used as practice for the real maintenance drones.

This also disables the Silicon hours requirement for them, which is tied to the `shy` var.

Closes #58409 

## Why It's Good For The Game
They got gimped with the drone update, and they are locked to the derelict station by stationstuck, so they shouldn't be a bother. They were available as a role all this time anyway without issue.

## Changelog
:cl: JJRcop
qol: Derelict drones have had their limits released
/:cl:
