### PR TITLE
Flypeople can now use more than 1 s at a time.

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -197,14 +197,12 @@
 /obj/item/organ/tongue/fly/handle_speech(datum/source, list/speech_args)
 	var/static/regex/fly_buzz = new("z+", "g")
 	var/static/regex/fly_buZZ = new("Z+", "g")
-	var/static/regex/fly_buss = new("s+", "g")
-	var/static/regex/fly_buSS = new("S+", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = fly_buzz.Replace(message, "zzz")
 		message = fly_buZZ.Replace(message, "ZZZ")
-		message = fly_buss.Replace(message, "z")
-		message = fly_buSS.Replace(message, "Z")
+		message = replacetext(message, "s", "z")
+		message = replacetext(message, "S", "Z")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/fly/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

So when I originally made my Flyperson tongue PR in #55802 I forgot to take into account people using 2 S' at once. So for example, saying 'SSD' would turn into 'ZD', rather than 'ZZD'. 
This PR fixes that problem, but doesn't do the same for 'z' -> 'zzz', because it felt like it was flooding chat more than it should, so I don't see much reason to change it.

## Why It's Good For The Game

Fixing an error I caused.

## Changelog
:cl: John Willard
fix: Flypeople can now use more than 1 S
/:cl:

