### PR TITLE
Fixes bounty cubes paying out extremely low speedy delivery bonuses

### DIFF
--- a/code/modules/cargo/exports/civilain_bounty.dm
+++ b/code/modules/cargo/exports/civilain_bounty.dm
@@ -5,4 +5,4 @@
 	export_types = list(/obj/item/bounty_cube)
 
 /datum/export/bounty_box/get_cost(obj/item/bounty_cube/cube, apply_elastic)
-	return cube.bounty_value + (cube.bounty_value * (cube.speed_bonus / 100))
+	return cube.bounty_value + (cube.bounty_value * (cube.speed_bonus))

--- a/code/modules/cargo/exports/civilain_bounty.dm
+++ b/code/modules/cargo/exports/civilain_bounty.dm
@@ -5,4 +5,4 @@
 	export_types = list(/obj/item/bounty_cube)
 
 /datum/export/bounty_box/get_cost(obj/item/bounty_cube/cube, apply_elastic)
-	return cube.bounty_value + (cube.bounty_value * (cube.speed_bonus))
+	return cube.bounty_value + (cube.bounty_value * cube.speed_bonus)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes issue https://github.com/tgstation/tgstation/issues/58431.

Although the speed_bonus variable is supposed to be a multiplier, in the code it is divided by 100 when paying out to the person that completed the bounty, making it a percentage. This PR just removes that division by 100 and makes it a multiplier as it was intended to be. 

Old code:
![image](https://user-images.githubusercontent.com/60072879/114758786-5e871e00-9d2b-11eb-961f-55f77bb28b65.png)

Fixed code:
![image](https://user-images.githubusercontent.com/60072879/114758849-6d6dd080-9d2b-11eb-84ae-5f49b30a63e7.png)

## Why It's Good For The Game

It's an extremely simple fix to bounty payouts.

## Changelog
:cl:
fix: Bounty cubes now pay out the correct speedy delivery bonus.
/:cl: