### PR TITLE
Fixes the speed on the Pimpin' Ride being slow as hell.

### DIFF
--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -6,6 +6,7 @@
 	key_type = /obj/item/key/janitor
 	var/obj/item/storage/bag/trash/mybag = null
 	var/floorbuffer = FALSE
+	movedelay = 1
 
 /obj/vehicle/ridden/janicart/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

See title.
## Why It's Good For The Game

When the Pimpin' Ride got moved to the new vehicles system, the speed was broken and made way too slow. This restores the original Pimpin' Ride speed.

## Changelog
:cl:
fix: Fixed the speed on the Pimpin' Ride.
/:cl: