### PR TITLE
raises stabilized bluespace extract threshold for activation

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -661,7 +661,7 @@
 		linked_alert.desc = "The stabilized bluespace extract will try to redirect you from harm!"
 		linked_alert.icon_state = "slime_bluespace_on"
 
-	if(healthcheck && (healthcheck - owner.health) > 5)
+	if(healthcheck && (healthcheck - owner.health) > 50)
 		owner.visible_message("<span class='warning'>[linked_extract] notices the sudden change in [owner]'s physical health, and activates!</span>")
 		do_sparks(5,FALSE,owner)
 		var/F = find_safe_turf(zlevels = owner.z, extended_safety_checks = TRUE)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -643,7 +643,7 @@
 
 /datum/status_effect/bluespacestabilization
 	id = "stabilizedbluespacecooldown"
-	duration = 1200
+	duration = 3000
 	alert_type = null
 
 /datum/status_effect/stabilized/bluespace


### PR DESCRIPTION
## About The Pull Request

raises the  thresholds for the teleportation effect of the crossbreed extract

## Why It's Good For The Game
Raising the thresholds will make it useful and make it work like its supposed to as a get out of jail free card rather then actively teleporting around the station because a rat farted in your general direction

## Changelog
:cl:
balance: Raises the damage threshold and the cooldown of the stabilized bluespace extract
/:cl: