### PR TITLE
Ice cream vat grammar fix

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
@@ -140,7 +140,7 @@
 		if(product_types[cone_path] >= 1)
 			product_types[cone_path]--
 			var/obj/item/food/icecream/cone = new cone_path(loc)
-			visible_message("<span class='info'>[usr] dispenses a crunchy [cone] from [src].</span>")
+			visible_message("<span class='info'>[usr] dispenses a crunchy [cone.name] from [src].</span>")
 		else
 			to_chat(usr, "<span class='warning'>There are no [initial(cone_path.name)]s left!</span>")
 


### PR DESCRIPTION
## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/58450

## Why It's Good For The Game
It removes a 'the' which wasn't necessary

## Changelog
:cl:
spellcheck: Ice cream vats don't needlessly say the an additional time when dispensing cones.
/:cl:
