### PR TITLE
Carved statue rotation bug fix

### DIFF
--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -28,7 +28,7 @@
 	to_chat(user, "<span class='warning'>It's bolted to the floor, you'll need to unwrench it first.</span>")
 
 /obj/structure/statue/proc/can_user_rotate(mob/user)
-	return !user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user))
+	return user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user))
 
 /obj/structure/statue/attackby(obj/item/W, mob/living/user, params)
 	add_fingerprint(user)


### PR DESCRIPTION
## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/56582

## Why It's Good For The Game
Allows people to position their statues against a wall facing a direction they'd like without needing to remove obstacles around it.

I spent far too long deconstructing walls outside of a chapel so that I could have frog statues standing at either side of the door facing out to greet the congregation as they entered.

## Changelog
:cl:
fix: Statues can be rotated by alt clicking on them now.
/:cl: