### PR TITLE
Limits heretic to 30 pop

### DIFF
--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -6,7 +6,7 @@
 	false_report_weight = 5
 	protected_jobs = list("Prisoner","Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 0
+	required_players = 30
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Heretic is an antagonist type designed around murdering a lot of people. Most objectives involve sacrificing a specific amount of people, or murdering people etc. The core mechanic of advancing as a heretic also almost always involves murdering.

it's current population requirement of **zero** means that lowpop rounds are flooded with constant heretic rounds and the subsequent murderbone that follows.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Lowpop heretic fucking sucks, I say this as someone who has been on the giving and receiving end of a lowpop heretic ascension. Frankly: it isn't fun. I don't know anyone who enjoys having this happen multiple rounds in a row. Plus, I'm sure we all know how people feel about murderbone.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Heretic now requires 30 players.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
