### PR TITLE
Adds signals for right clicking, right click opens storage items instead of alt click

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -312,6 +312,8 @@
 #define COMSIG_EXIT_AREA "exit_area"
 ///from base of atom/Click(): (location, control, params, mob/user)
 #define COMSIG_CLICK "atom_click"
+///from base of atom/RightClick(): (/mob)
+#define COMSIG_CLICK_RIGHT "right_click"
 ///from base of atom/ShiftClick(): (/mob)
 #define COMSIG_CLICK_SHIFT "shift_click"
 	#define COMPONENT_ALLOW_EXAMINATE (1<<0) //Allows the user to examinate regardless of client.eye.

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -77,8 +77,10 @@
 
 	if(SEND_SIGNAL(src, COMSIG_MOB_CLICKON, A, params) & COMSIG_MOB_CANCEL_CLICKON)
 		return
-
 	var/list/modifiers = params2list(params)
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
+		if(RightClickOn(A))
+			return
 	if(LAZYACCESS(modifiers, SHIFT_CLICK))
 		if(LAZYACCESS(modifiers, MIDDLE_CLICK))
 			ShiftMiddleClickOn(A)
@@ -299,6 +301,17 @@
  * Useful for mobs that have their abilities mapped to right click.
  */
 /mob/proc/ranged_secondary_attack(atom/target, modifiers)
+
+/**
+ * Right click
+ */
+/mob/proc/RightClickOn(atom/target, params)
+	return target.RightClick(src)
+
+/atom/proc/RightClick(mob/user)
+	if(SEND_SIGNAL(src, COMSIG_CLICK_RIGHT, user) & COMPONENT_CANCEL_CLICK_ALT)
+		return FALSE
+	return TRUE
 
 /**
  * Middle click

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -310,8 +310,7 @@
 
 /atom/proc/RightClick(mob/user)
 	if(SEND_SIGNAL(src, COMSIG_CLICK_RIGHT, user) & COMPONENT_CANCEL_CLICK_ALT)
-		return FALSE
-	return TRUE
+		return TRUE
 
 /**
  * Middle click

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -8,7 +8,7 @@
 	. = ..()
 	if(. && silent && !prevent_warning)
 		if(quickdraw)
-			to_chat(user, "<span class='notice'>You discreetly slip [I] into [parent]. Alt-click [parent] to remove it.</span>")
+			to_chat(user, "<span class='notice'>You discreetly slip [I] into [parent]. Right-click [parent] to remove it.</span>")
 		else
 			to_chat(user, "<span class='notice'>You discreetly slip [I] into [parent].</span>")
 

--- a/code/datums/components/storage/concrete/wallet.dm
+++ b/code/datums/components/storage/concrete/wallet.dm
@@ -1,4 +1,4 @@
-/datum/component/storage/concrete/wallet/on_alt_click(datum/source, mob/user)
+/datum/component/storage/concrete/wallet/on_right_click(datum/source, mob/user)
 	if(!isliving(user) || !user.CanReach(parent) || user.incapacitated())
 		return
 	if(locked)

--- a/code/datums/components/storage/concrete/wallet.dm
+++ b/code/datums/components/storage/concrete/wallet.dm
@@ -10,7 +10,7 @@
 		var/obj/item/I = A.front_id
 		A.add_fingerprint(user)
 		remove_from_storage(I, get_turf(user))
-		if(!user.put_in_hands(I))
+		if(INVOKE_ASYNC(!user.put_in_hands(I)))
 			to_chat(user, "<span class='notice'>You fumble for [I] and it falls on the floor.</span>")
 			return
 		user.visible_message("<span class='warning'>[user] draws [I] from [parent]!</span>", "<span class='notice'>You draw [I] from [parent].</span>")

--- a/code/datums/components/storage/concrete/wallet.dm
+++ b/code/datums/components/storage/concrete/wallet.dm
@@ -10,9 +10,6 @@
 		var/obj/item/I = A.front_id
 		A.add_fingerprint(user)
 		remove_from_storage(I, get_turf(user))
-		if(INVOKE_ASYNC(!user.put_in_hands(I)))
-			to_chat(user, "<span class='notice'>You fumble for [I] and it falls on the floor.</span>")
-			return
-		user.visible_message("<span class='warning'>[user] draws [I] from [parent]!</span>", "<span class='notice'>You draw [I] from [parent].</span>")
+		INVOKE_ASYNC(src, .proc/quickdraw.quickdraw, user, I)
 		return
 	..()

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -98,6 +98,7 @@
 	RegisterSignal(parent, COMSIG_MOVABLE_POST_THROW, .proc/close_all)
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/on_move)
 
+	RegisterSignal(parent, COMSIG_CLICK_RIGHT, .proc/on_right_click)
 	RegisterSignal(parent, COMSIG_CLICK_ALT, .proc/on_alt_click)
 	RegisterSignal(parent, COMSIG_MOUSEDROP_ONTO, .proc/mousedrop_onto)
 	RegisterSignal(parent, COMSIG_MOUSEDROPPED_ONTO, .proc/mousedrop_receive)
@@ -827,15 +828,11 @@
 
 	return hide_from(target)
 
-/datum/component/storage/proc/on_alt_click(datum/source, mob/user)
-	SIGNAL_HANDLER_DOES_SLEEP
+/datum/component/storage/proc/on_right_click(datum/source, mob/user)
+	SIGNAL_HANDLER
 
 	if(!isliving(user) || !user.CanReach(parent) || user.incapacitated())
 		return
-	if(locked)
-		to_chat(user, "<span class='warning'>[parent] seems to be locked!</span>")
-		return
-
 	var/atom/A = parent
 	if(!quickdraw)
 		A.add_fingerprint(user)
@@ -852,6 +849,16 @@
 		to_chat(user, "<span class='notice'>You fumble for [I] and it falls on the floor.</span>")
 		return
 	user.visible_message("<span class='warning'>[user] draws [I] from [parent]!</span>", "<span class='notice'>You draw [I] from [parent].</span>")
+
+
+/datum/component/storage/proc/on_alt_click(datum/source, mob/user)
+	SIGNAL_HANDLER_DOES_SLEEP
+
+	if(!isliving(user) || !user.CanReach(parent) || user.incapacitated())
+		return
+	if(locked)
+		to_chat(user, "<span class='warning'>[parent] seems to be locked!</span>")
+		return
 
 /datum/component/storage/proc/action_trigger(datum/signal_source, datum/action/source)
 	SIGNAL_HANDLER

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -828,7 +828,7 @@
 	return hide_from(target)
 
 /datum/component/storage/proc/on_right_click(datum/source, mob/user)
-	SIGNAL_HANDLER_DOES_SLEEP
+	SIGNAL_HANDLER
 
 	if(!isliving(user) || !user.CanReach(parent) || user.incapacitated())
 		return
@@ -848,7 +848,7 @@
 		return
 	A.add_fingerprint(user)
 	remove_from_storage(I, get_turf(user))
-	if(!user.put_in_hands(I))
+	if(INVOKE_ASYNC(!user.put_in_hands(I)))
 		to_chat(user, "<span class='notice'>You fumble for [I] and it falls on the floor.</span>")
 		return
 	user.visible_message("<span class='warning'>[user] draws [I] from [parent]!</span>", "<span class='notice'>You draw [I] from [parent].</span>")

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -835,7 +835,7 @@
 	if(locked)
 		to_chat(user, "<span class='warning'>[parent] seems to be locked!</span>")
 		return
-
+	. = COMPONENT_CANCEL_CLICK_ALT
 	var/atom/A = parent
 	if(!quickdraw)
 		A.add_fingerprint(user)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -848,7 +848,7 @@
 		return
 	A.add_fingerprint(user)
 	remove_from_storage(I, get_turf(user))
-	INVOKE_ASYNC(src, .proc/quickdraw.quickdraw, user, I)
+	INVOKE_ASYNC(src, .proc/quickdraw, user, I)
 
 /datum/component/storage/proc/quickdraw(mob/user, obj/target)
 	if(!user.put_in_hands(target))

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -99,7 +99,6 @@
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/on_move)
 
 	RegisterSignal(parent, COMSIG_CLICK_RIGHT, .proc/on_right_click)
-	RegisterSignal(parent, COMSIG_CLICK_ALT, .proc/on_alt_click)
 	RegisterSignal(parent, COMSIG_MOUSEDROP_ONTO, .proc/mousedrop_onto)
 	RegisterSignal(parent, COMSIG_MOUSEDROPPED_ONTO, .proc/mousedrop_receive)
 
@@ -829,10 +828,14 @@
 	return hide_from(target)
 
 /datum/component/storage/proc/on_right_click(datum/source, mob/user)
-	SIGNAL_HANDLER
+	SIGNAL_HANDLER_DOES_SLEEP
 
 	if(!isliving(user) || !user.CanReach(parent) || user.incapacitated())
 		return
+	if(locked)
+		to_chat(user, "<span class='warning'>[parent] seems to be locked!</span>")
+		return
+
 	var/atom/A = parent
 	if(!quickdraw)
 		A.add_fingerprint(user)
@@ -850,15 +853,6 @@
 		return
 	user.visible_message("<span class='warning'>[user] draws [I] from [parent]!</span>", "<span class='notice'>You draw [I] from [parent].</span>")
 
-
-/datum/component/storage/proc/on_alt_click(datum/source, mob/user)
-	SIGNAL_HANDLER_DOES_SLEEP
-
-	if(!isliving(user) || !user.CanReach(parent) || user.incapacitated())
-		return
-	if(locked)
-		to_chat(user, "<span class='warning'>[parent] seems to be locked!</span>")
-		return
 
 /datum/component/storage/proc/action_trigger(datum/signal_source, datum/action/source)
 	SIGNAL_HANDLER

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -848,11 +848,13 @@
 		return
 	A.add_fingerprint(user)
 	remove_from_storage(I, get_turf(user))
-	if(INVOKE_ASYNC(!user.put_in_hands(I)))
-		to_chat(user, "<span class='notice'>You fumble for [I] and it falls on the floor.</span>")
-		return
-	user.visible_message("<span class='warning'>[user] draws [I] from [parent]!</span>", "<span class='notice'>You draw [I] from [parent].</span>")
+	INVOKE_ASYNC(src, .proc/quickdraw.quickdraw, user, I)
 
+/datum/component/storage/proc/quickdraw(mob/user, obj/target)
+	if(!user.put_in_hands(target))
+		to_chat(user, "<span class='notice'>You fumble for [target] and it falls on the floor.</span>")
+		return
+	user.visible_message("<span class='warning'>[user] draws [target] from [parent]!</span>", "<span class='notice'>You draw [target] from [parent].</span>")
 
 /datum/component/storage/proc/action_trigger(datum/signal_source, datum/action/source)
 	SIGNAL_HANDLER

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -309,7 +309,7 @@
 		else
 			how_cool_are_your_threads += "[src] can store [pockets.max_items] item\s that are [weightclass2text(pockets.max_w_class)] or smaller.\n"
 		if(pockets.quickdraw)
-			how_cool_are_your_threads += "You can quickly remove an item from [src] using Alt-Click.\n"
+			how_cool_are_your_threads += "You can quickly remove an item from [src] using Right-Click.\n"
 		if(pockets.silent)
 			how_cool_are_your_threads += "Adding or removing items from [src] makes no noise.\n"
 		how_cool_are_your_threads += "</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds signals for right click. Alt click no longer opens storage items like boxes, right click now does.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It reinforces right click as the secondary action key, by adding it to one of the most common actions in the game. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Storage items can be opened with right click, alt click no longer works for this.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
