### PR TITLE
renames a typepath

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -222,7 +222,7 @@
 	..()
 
 //Orange
-/datum/chemical_reaction/slime/slimecasp
+/datum/chemical_reaction/slime/slimecapsaicin
 	results = list(/datum/reagent/consumable/capsaicin = 10)
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_container = /obj/item/slime_extract/orange


### PR DESCRIPTION
## About The Pull Request

The /datum/chemical_reaction/slime/slimecasp reaction has had its typepath changed to /datum/chemical_reaction/slime/slimecapsaicin.

## Why It's Good For The Game

Someone switched the "s" and the "p" around by mistake when they were abbreviating the word "capsaicin" in the name of this typepath. It mildly irritated me (and I need more GBP), so I made this PR.