### PR TITLE
VoG nerf/fix

### DIFF
--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -159,7 +159,7 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 
 /datum/voice_of_god_command/sleeping/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
 	for(var/mob/living/carbon/target as anything in listeners)
-		target.Sleeping(20 * power_multiplier)
+		target.Sleeping(2 SECONDS * power_multiplier)
 
 /// This command makes carbon listeners throw up like Mr. Creosote.
 /datum/voice_of_god_command/vomit

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -141,7 +141,7 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 /datum/voice_of_god_command/stun/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
 	// Ensure 'as anything' is not used for loops that don't target all living mob types.
 	for(var/mob/living/target as anything in listeners)
-		target.Stun(40 * power_multiplier)
+		target.Stun(4 SECONDS * power_multiplier)
 
 /// This command knocks the listeners down.
 /datum/voice_of_god_command/paralyze

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -150,7 +150,7 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 
 /datum/voice_of_god_command/paralyze/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
 	for(var/mob/living/target as anything in listeners)
-		target.Paralyze(40 * power_multiplier)
+		target.Paralyze(4 SECONDS * power_multiplier)
 
 /// This command puts carbon listeners to sleep.
 /datum/voice_of_god_command/sleeping

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -1,6 +1,6 @@
-#define COOLDOWN_STUN 12 SECONDS
-#define COOLDOWN_DAMAGE 6 SECONDS
-#define COOLDOWN_MEME 3 SECONDS
+#define COOLDOWN_STUN 120 SECONDS
+#define COOLDOWN_DAMAGE 60 SECONDS
+#define COOLDOWN_MEME 30 SECONDS
 #define COOLDOWN_NONE 1 SECONDS
 
 /// Used to stop listeners with silly or clown-esque (first) names such as "Honk" or "Flip" from screwing up certain commands.
@@ -141,7 +141,7 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 /datum/voice_of_god_command/stun/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
 	// Ensure 'as anything' is not used for loops that don't target all living mob types.
 	for(var/mob/living/target as anything in listeners)
-		target.Stun(60 * power_multiplier)
+		target.Stun(40 * power_multiplier)
 
 /// This command knocks the listeners down.
 /datum/voice_of_god_command/paralyze
@@ -150,7 +150,7 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 
 /datum/voice_of_god_command/paralyze/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
 	for(var/mob/living/target as anything in listeners)
-		target.Paralyze(60 * power_multiplier)
+		target.Paralyze(40 * power_multiplier)
 
 /// This command puts carbon listeners to sleep.
 /datum/voice_of_god_command/sleeping
@@ -159,7 +159,7 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 
 /datum/voice_of_god_command/sleeping/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
 	for(var/mob/living/carbon/target as anything in listeners)
-		target.Sleeping(40 * power_multiplier)
+		target.Sleeping(20 * power_multiplier)
 
 /// This command makes carbon listeners throw up like Mr. Creosote.
 /datum/voice_of_god_command/vomit


### PR DESCRIPTION

## About The Pull Request

The cooldowns for the commands were broken which im assuming happend with the pr that broke wizard spells and nobody bothered to fix these,

## Why It's Good For The Game
Fixes the timer for the vog commands so you cant AOE SLEEP everyone for 4 seconds every 12 seconds
nerfs stuns of vog to a reasonable degree as its almost non counterable unless you are a chaplain or want to sacrifice hearing.

## Changelog
:cl:
fix: Fixes the cooldown of vog spells back to the normal timers instead of seconds
balance: lowers the stun times on commands to be more reasonable for an aoe effect, sleep from 4s to 2s,stop to 4s from 6s, 
/:cl: