### PR TITLE
Scrolling layers for RPD is more snappy. It is also no longer flipped.

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -535,21 +535,14 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	if(source.incapacitated(ignore_restraints = TRUE, ignore_stasis = TRUE))
 		return
 
-	if(delta_y > 0)
+	if(delta_y < 0)
 		piping_layer = min(PIPING_LAYER_MAX, piping_layer + 1)
-	else if(delta_y < 0)
+	else if(delta_y > 0)
 		piping_layer = max(PIPING_LAYER_MIN, piping_layer - 1)
 	else
 		return
+	SStgui.update_uis(src)
 	to_chat(source, "<span class='notice'>You set the layer to [piping_layer].</span>")
-
-#undef ATMOS_CATEGORY
-#undef DISPOSALS_CATEGORY
-#undef TRANSIT_CATEGORY
-
-#undef BUILD_MODE
-#undef DESTROY_MODE
-#undef WRENCH_MODE
 
 /obj/item/rpd_upgrade
 	name = "RPD advanced design disk"
@@ -562,3 +555,11 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /obj/item/rpd_upgrade/unwrench
 	desc = "Adds reverse wrench mode to the RPD. Attention, due to budget cuts, the mode is hard linked to the destroy mode control button."
 	upgrade_flags = RPD_UPGRADE_UNWRENCH
+
+#undef ATMOS_CATEGORY
+#undef DISPOSALS_CATEGORY
+#undef TRANSIT_CATEGORY
+
+#undef BUILD_MODE
+#undef DESTROY_MODE
+#undef WRENCH_MODE

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -544,6 +544,14 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	SStgui.update_uis(src)
 	to_chat(source, "<span class='notice'>You set the layer to [piping_layer].</span>")
 
+#undef ATMOS_CATEGORY
+#undef DISPOSALS_CATEGORY
+#undef TRANSIT_CATEGORY
+
+#undef BUILD_MODE
+#undef DESTROY_MODE
+#undef WRENCH_MODE
+
 /obj/item/rpd_upgrade
 	name = "RPD advanced design disk"
 	desc = "It seems to be empty."
@@ -555,11 +563,3 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /obj/item/rpd_upgrade/unwrench
 	desc = "Adds reverse wrench mode to the RPD. Attention, due to budget cuts, the mode is hard linked to the destroy mode control button."
 	upgrade_flags = RPD_UPGRADE_UNWRENCH
-
-#undef ATMOS_CATEGORY
-#undef DISPOSALS_CATEGORY
-#undef TRANSIT_CATEGORY
-
-#undef BUILD_MODE
-#undef DESTROY_MODE
-#undef WRENCH_MODE


### PR DESCRIPTION
## About The Pull Request
The change layer for RPD actually calls `SStgui.update_uis` now instead of waiting for the controller to update it. This makes scrolling layers a lot better. Scroll up also goes up on the ui and scroll down goes down; this was flipped earlier.

## Why It's Good For The Game
More intuitive user experience.

## Changelog
:cl:
fix: RPD's scroll mousewheel to change layer should now be snappier and more responsive. It is also no longer flipped.
/:cl: