### PR TITLE
[DNM] doubles all turf decals to test whether they actually affect maptick at all under live conditions

### DIFF
--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -26,6 +26,10 @@ SUBSYSTEM_DEF(atoms)
 	initialized = INITIALIZATION_INNEW_MAPLOAD
 	InitializeAtoms()
 	initialized = INITIALIZATION_INNEW_REGULAR
+	for(var/station_level in SSmapping.levels_by_trait(ZTRAIT_STATION))
+		for(var/turf/open/floor/station_floor in block(locate(1,1,station_level), locate(world.maxx,world.maxy,station_level)))
+			new /obj/effect/turf_decal/tile/blue (station_floor)
+
 	return ..()
 
 /datum/controller/subsystem/atoms/proc/InitializeAtoms(list/atoms, list/atoms_to_return = null)

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -26,9 +26,6 @@ SUBSYSTEM_DEF(atoms)
 	initialized = INITIALIZATION_INNEW_MAPLOAD
 	InitializeAtoms()
 	initialized = INITIALIZATION_INNEW_REGULAR
-	for(var/station_level in SSmapping.levels_by_trait(ZTRAIT_STATION))
-		for(var/turf/open/floor/station_floor in block(locate(1,1,station_level), locate(world.maxx,world.maxy,station_level)))
-			new /obj/effect/turf_decal/tile/blue (station_floor)
 
 	return ..()
 

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -155,7 +155,7 @@ SUBSYSTEM_DEF(statpanels)
 		list("World Time:", "[world.time]"),
 		list("Globals:", GLOB.stat_entry(), "\ref[GLOB]"),
 		list("[config]:", config.stat_entry(), "\ref[config]"),
-		list("Byond:", "(FPS:[world.fps]) (TickCount:[world.time/world.tick_lag]) (TickDrift:[round(Master.tickdrift,1)]([round((Master.tickdrift/(world.time/world.tick_lag))*100,0.1)]%)) (Internal Tick Usage: [round(MAPTICK_LAST_INTERNAL_TICK_USAGE,0.1)]%) (Maptick Per Player: [SStime_track.maptick_per_player])"),
+		list("Byond:", "(FPS:[world.fps]) (TickCount:[world.time/world.tick_lag]) (TickDrift:[round(Master.tickdrift,1)]([round((Master.tickdrift/(world.time/world.tick_lag))*100,0.1)]%)) (Internal Tick Usage: [round(MAPTICK_LAST_INTERNAL_TICK_USAGE,0.1)]%) (Maptick Per Player: [SStime_track.maptick_per_player]) (Average Maptick Per Player: [SStime_track.average_maptick_per_player])"),
 		list("Master Controller:", Master.stat_entry(), "\ref[Master]"),
 		list("Failsafe Controller:", Failsafe.stat_entry(), "\ref[Failsafe]"),
 		list("","")

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -155,7 +155,7 @@ SUBSYSTEM_DEF(statpanels)
 		list("World Time:", "[world.time]"),
 		list("Globals:", GLOB.stat_entry(), "\ref[GLOB]"),
 		list("[config]:", config.stat_entry(), "\ref[config]"),
-		list("Byond:", "(FPS:[world.fps]) (TickCount:[world.time/world.tick_lag]) (TickDrift:[round(Master.tickdrift,1)]([round((Master.tickdrift/(world.time/world.tick_lag))*100,0.1)]%)) (Internal Tick Usage: [round(MAPTICK_LAST_INTERNAL_TICK_USAGE,0.1)]%)"),
+		list("Byond:", "(FPS:[world.fps]) (TickCount:[world.time/world.tick_lag]) (TickDrift:[round(Master.tickdrift,1)]([round((Master.tickdrift/(world.time/world.tick_lag))*100,0.1)]%)) (Internal Tick Usage: [round(MAPTICK_LAST_INTERNAL_TICK_USAGE,0.1)]%) (Maptick Per Player: [SStime_track.maptick_per_player])"),
 		list("Master Controller:", Master.stat_entry(), "\ref[Master]"),
 		list("Failsafe Controller:", Failsafe.stat_entry(), "\ref[Failsafe]"),
 		list("","")

--- a/code/controllers/subsystem/time_track.dm
+++ b/code/controllers/subsystem/time_track.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(time_track)
 	name = "Time Tracking"
-	wait = 100
+	wait = 10
 	init_order = INIT_ORDER_TIMETRACK
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 
@@ -15,6 +15,8 @@ SUBSYSTEM_DEF(time_track)
 	var/last_tick_realtime = 0
 	var/last_tick_byond_time = 0
 	var/last_tick_tickcount = 0
+
+	var/maptick_per_player = 0
 
 /datum/controller/subsystem/time_track/Initialize(start_timeofday)
 	. = ..()
@@ -68,6 +70,7 @@ SUBSYSTEM_DEF(time_track)
 	last_tick_realtime = current_realtime
 	last_tick_byond_time = current_byondtime
 	last_tick_tickcount = current_tickcount
+	maptick_per_player = (player_amount > 0) ? MAPTICK_LAST_INTERNAL_TICK_USAGE / player_amount : ""
 	SSblackbox.record_feedback("associative", "time_dilation_current", 1, list("[SQLtime()]" = list("current" = "[time_dilation_current]", "avg_fast" = "[time_dilation_avg_fast]", "avg" = "[time_dilation_avg]", "avg_slow" = "[time_dilation_avg_slow]")))
 	log_perf(
 		list(
@@ -78,7 +81,7 @@ SUBSYSTEM_DEF(time_track)
 			time_dilation_avg,
 			time_dilation_avg_slow,
 			MAPTICK_LAST_INTERNAL_TICK_USAGE,
-			(player_amount > 0) ? MAPTICK_LAST_INTERNAL_TICK_USAGE / player_amount : "",
+			maptick_per_player,
 			length(SStimer.timer_id_dict),
 			SSair.cost_turfs,
 			SSair.cost_groups,

--- a/code/controllers/subsystem/time_track.dm
+++ b/code/controllers/subsystem/time_track.dm
@@ -28,6 +28,7 @@ SUBSYSTEM_DEF(time_track)
 			"tidi_avg",
 			"tidi_slowavg",
 			"maptick",
+			"maptick per player",
 			"num_timers",
 			"air_turf_cost",
 			"air_eg_cost",
@@ -51,6 +52,8 @@ SUBSYSTEM_DEF(time_track)
 	var/current_byondtime = world.time
 	var/current_tickcount = world.time/world.tick_lag
 
+	var/player_amount = length(GLOB.clients)
+
 	if (!first_run)
 		var/tick_drift = max(0, (((current_realtime - last_tick_realtime) - (current_byondtime - last_tick_byond_time)) / world.tick_lag))
 
@@ -69,12 +72,13 @@ SUBSYSTEM_DEF(time_track)
 	log_perf(
 		list(
 			world.time,
-			length(GLOB.clients),
+			player_amount,
 			time_dilation_current,
 			time_dilation_avg_fast,
 			time_dilation_avg,
 			time_dilation_avg_slow,
 			MAPTICK_LAST_INTERNAL_TICK_USAGE,
+			(player_amount > 0) ? MAPTICK_LAST_INTERNAL_TICK_USAGE / player_amount : "",
 			length(SStimer.timer_id_dict),
 			SSair.cost_turfs,
 			SSair.cost_groups,

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -46,3 +46,4 @@
 	if(!istype(T)) //you know this will happen somehow
 		CRASH("Turf decal initialized in an object/nullspace")
 	T.AddElement(/datum/element/decal, icon, icon_state, dir, FALSE, color, null, null, alpha)
+	T.AddElement(/datum/element/decal, icon, icon_state, dir, FALSE, color, null, null, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
makes every turf decal add a second decal element on Initialize that has an alpha of 1 so its almost invisible

#53798 has been pinned for a few months and made sense at the time given what little we knew about maptick, but now what it claims contradicts what I have found with my own testing of overlays and completely contradicts what lummox has said about overlays having zero maptick cost when not changed. I did find a difference between having no overlays and having 5 overlays when moving during at home testing but that difference was far too small to account for live maptick usage going from 30% to 15% and i want to redo those tests again anyways. the only cost that overlays should have in terms of maptick would be when the overlay list is changing as the new appearance gets calculated and sent to clients, SendMaps should not be processing overlays lists at all like it does with movables and vis_contents in view of client mobs. action has said that they dont remember who made the measurement anyways and i am suspicious of any judgement about maptick without an overall average of some kind. so thats what i added as well.

halves the wait time of SStime_track, and tracks maptick per player and average maptick per player and the MC tab shows those stats. @LemonInTheDark should have current stats for average maptick per player by map so we can compare what we find in the test merges to the overall averages to see if it makes a difference.

if this causes OOM's i can try disabling space ruins or going the other way and making turf_decals add no decal element
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
figure out whether a pinned issue is actually still an issue or not
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
