### PR TITLE
Stabilized light pink extract makes you a pacifist while active

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -598,6 +598,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define BEAUTY_ELEMENT_TRAIT "beauty_element"
 #define MOOD_COMPONENT_TRAIT "mood_component"
 #define DRONE_SHY_TRAIT "drone_shy"
+/// Pacifism trait given by stabilized light pink extracts.
+#define STABILIZED_LIGHT_PINK_TRAIT "stabilized_light_pink"
 
 /**
 * Trait granted by [/mob/living/carbon/Initialize] and

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -1,5 +1,3 @@
-
-
 /atom/movable/screen/alert/status_effect/rainbow_protection
 	name = "Rainbow Protection"
 	desc = "You are defended from harm, but so are those you might seek to injure!"

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -1,4 +1,4 @@
-#define STABILIZED_LIGHT_PINK_TRAIT "stabilized_light_pink"
+
 
 /atom/movable/screen/alert/status_effect/rainbow_protection
 	name = "Rainbow Protection"
@@ -974,5 +974,3 @@
 				qdel(src)
 				qdel(linked_extract)
 	return ..()
-
-#undef STABILIZED_LIGHT_PINK_TRAIT

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -1,3 +1,5 @@
+#define STABILIZED_LIGHT_PINK_TRAIT "stabilized_light_pink"
+
 /atom/movable/screen/alert/status_effect/rainbow_protection
 	name = "Rainbow Protection"
 	desc = "You are defended from harm, but so are those you might seek to injure!"
@@ -902,6 +904,7 @@
 
 /datum/status_effect/stabilized/lightpink/on_apply()
 	owner.add_movespeed_modifier(/datum/movespeed_modifier/status_effect/lightpink)
+	ADD_TRAIT(owner, TRAIT_PACIFISM, STABILIZED_LIGHT_PINK_TRAIT)
 	return ..()
 
 /datum/status_effect/stabilized/lightpink/tick()
@@ -913,6 +916,7 @@
 
 /datum/status_effect/stabilized/lightpink/on_remove()
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/status_effect/lightpink)
+	REMOVE_TRAIT(owner, TRAIT_PACIFISM, STABILIZED_LIGHT_PINK_TRAIT)
 
 /datum/status_effect/stabilized/adamantine
 	id = "stabilizedadamantine"
@@ -970,3 +974,5 @@
 				qdel(src)
 				qdel(linked_extract)
 	return ..()
+
+#undef STABILIZED_LIGHT_PINK_TRAIT


### PR DESCRIPTION
## About The Pull Request

The stabilized light pink extract (the ambulance one) now also makes you a pacifist while it affects you.

## Why It's Good For The Game

Pretty much all the stabilized extracts are absurd in some way so someone's gotta start to bring them in at some point. (Or I could just remove them all.)

## Changelog
:cl: Melbert
balance: The stabilized light pink extract now makes you a pacifist while active.
/:cl:

