### PR TITLE
turns one of the vis_contents in openspace turfs to an overlay instead

### DIFF
--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -32,7 +32,7 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 
 /turf/open/openspace/Initialize() // handle plane and layer here so that they don't cover other obs/turfs in Dream Maker
 	. = ..()
-	vis_contents += GLOB.openspace_backdrop_one_for_all //Special grey square for projecting backdrop darkness filter on it.
+	overlays += GLOB.openspace_backdrop_one_for_all //Special grey square for projecting backdrop darkness filter on it.
 	return INITIALIZE_HINT_LATELOAD
 
 /turf/open/openspace/LateInitialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
one of the appearances that open space tiles add as vis_contents was an unchanging grey cover. its useless to keep it as vis_contents since its not supposed to change so its better to have it as an overlay. its possible that i can make openspace tiles not add the turf below as vis_contents and instead listen to objects entering and leaving it with connect_loc and add those objects as vis_contents then but that sounds like more trouble than its worth

edit: probably not the last part
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
overlays < vis_contents in maptick cost

also tramstation has the most open space tiles in high traffic areas compared to other maps. openspace tiles have 2 vis_contents each, equivalent to 2 objects that sendmaps processes every tick this pr only makes it 1 appearance in vis_contents. its also the map with the current highest maptick per player according to lemons graphs
![maptick3](https://user-images.githubusercontent.com/15794172/115102589-b3c85880-9f00-11eb-9129-681b064a9d16.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
