### PR TITLE
Gargle blasters use lemon juice instead of lime.

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -111,7 +111,7 @@
 
 /datum/chemical_reaction/drink/gargle_blaster
 	results = list(/datum/reagent/consumable/ethanol/gargle_blaster = 5)
-	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 1, /datum/reagent/consumable/ethanol/gin = 1, /datum/reagent/consumable/ethanol/whiskey = 1, /datum/reagent/consumable/ethanol/cognac = 1, /datum/reagent/consumable/limejuice = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 1, /datum/reagent/consumable/ethanol/gin = 1, /datum/reagent/consumable/ethanol/whiskey = 1, /datum/reagent/consumable/ethanol/cognac = 1, /datum/reagent/consumable/lemonjuice = 1)
 	reaction_tags = REACTION_TAG_DRINK | REACTION_TAG_EASY | REACTION_TAG_OTHER
 
 /datum/chemical_reaction/drink/brave_bull


### PR DESCRIPTION
## About The Pull Request

Honestly, I always thought there was an issue with another recipe conflicting with lemon juice and the other alcohols, I guess someone was just dumb.

## Why It's Good For The Game

Reference drink is accurate to reference now.

## Changelog
:cl:

fix: Makes gargle blaster require lemon juice instead of lime
/:cl: