### PR TITLE
Fix connect_loc not reconnecting turf changes

### DIFF
--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -88,6 +88,12 @@
 	post_change_callbacks += changeturf_callback
 
 /datum/element/connect_loc/proc/post_turf_change(turf/new_turf)
-	for (var/atom/movable/tracked as anything in targets[new_turf])
-		var/datum/listener = targets[new_turf][tracked]
+	// If we don't cut the targets list before iterating,
+	// then we won't re-register the change turf signal.
+	var/list/turf_targets = targets[new_turf]
+	var/list/targets_copy = turf_targets.Copy()
+	turf_targets.Cut()
+
+	for (var/atom/movable/tracked as anything in targets_copy)
+		var/datum/listener = targets_copy[tracked]
 		update_signals(listener, tracked)

--- a/code/modules/unit_tests/connect_loc.dm
+++ b/code/modules/unit_tests/connect_loc.dm
@@ -35,9 +35,12 @@
 
 	current_turf.ChangeTurf(/turf/closed/wall)
 
-	current_turf = get_turf(watcher)
 	SEND_SIGNAL(current_turf, COMSIG_MOCK_SIGNAL)
 	TEST_ASSERT_EQUAL(watcher.times_called, 2, "After changing turf, connect_loc didn't reconnect it")
+
+	current_turf.ChangeTurf(/turf/open/floor/carpet)
+	SEND_SIGNAL(current_turf, COMSIG_MOCK_SIGNAL)
+	TEST_ASSERT_EQUAL(watcher.times_called, 3, "After changing turf a second time, connect_loc didn't reconnect it")
 
 /datum/unit_test/connect_loc_change_turf/Destroy()
 	run_loc_floor_bottom_left.ChangeTurf(old_turf_type)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #58447.

This was caused by `existing = length(targets[tracked.loc])` being TRUE, since `tracked.loc` was the same reference.

Regression tests updated to match.

## Changelog
:cl:
fix: Windoors will now properly block you after the underlying tile changes twice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
