### PR TITLE
Lavaland Xeno Nest Fix

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_xeno_nest.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_xeno_nest.dmm
@@ -165,6 +165,15 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
+"Y" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/resin/wall{
+	move_force = 1000;
+	move_resist = 3000;
+	pull_force = 1000
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/xenonest)
 
 (1,1,1) = {"
 a
@@ -243,7 +252,7 @@ b
 g
 g
 b
-b
+Y
 G
 a
 a


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/29403316/115130909-91e2da80-9fc1-11eb-89d5-eb9bf31c7282.png)
Has this ever happened to you, terrifying alien from outer space? Well, this will probably still be an issue for any sentient xenomorphs because **I only edited move_resist on the lavaland ruin to avoid unintended balance side effects.** With that said, the lavaland xeno ruin can no longer get fucked up by normal lavaland fauna. Megafauna can STILL push these aside though.

## Why It's Good For The Game
This is the dumbest shit. You can even still do this by yourself however it shouldn't be random simplemobs that cause this to happen.
![image](https://user-images.githubusercontent.com/29403316/115130945-e7b78280-9fc1-11eb-94aa-79fc878ec863.png)
If you think this should stay because it's funny then you are right that it's funny however keep in mind that I often see eggs in the walls, which looks horrible and offends me as a mapper.

## Changelog
:cl:
fix: The lavaland xeno ruin can no longer get pushed around by puny fauna. This fix will not help if you hide inside to avoid a megafauna chasing you.
/:cl: