### PR TITLE
Changes reinforced window deconstruction to right click

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -74,7 +74,7 @@
 
 /obj/item/weldingtool/process(delta_time)
 	switch(welding)
-		if(0)
+		if(FALSE)
 			force = 3
 			damtype = BRUTE
 			update_appearance()
@@ -82,12 +82,12 @@
 				STOP_PROCESSING(SSobj, src)
 			return
 	//Welders left on now use up fuel, but lets not have them run out quite that fast
-		if(1)
+		if(TRUE)
 			force = 15
 			damtype = BURN
 			burned_fuel_for += delta_time
 			if(burned_fuel_for >= WELDER_FUEL_BURN_INTERVAL)
-				use(1)
+				use(TRUE)
 			update_appearance()
 
 	//This is to start fires. process() is only called if the welder is on.

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -74,7 +74,7 @@
 
 /obj/item/weldingtool/process(delta_time)
 	switch(welding)
-		if(FALSE)
+		if(0)
 			force = 3
 			damtype = BRUTE
 			update_appearance()
@@ -82,12 +82,12 @@
 				STOP_PROCESSING(SSobj, src)
 			return
 	//Welders left on now use up fuel, but lets not have them run out quite that fast
-		if(TRUE)
+		if(1)
 			force = 15
 			damtype = BURN
 			burned_fuel_for += delta_time
 			if(burned_fuel_for >= WELDER_FUEL_BURN_INTERVAL)
-				use(TRUE)
+				use(1)
 			update_appearance()
 
 	//This is to start fires. process() is only called if the welder is on.

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -73,21 +73,22 @@
 
 
 /obj/item/weldingtool/process(delta_time)
-	if(!welding)
-		force = 3
-		damtype = BRUTE
-		update_appearance()
-		if(!can_off_process)
-			STOP_PROCESSING(SSobj, src)
-		return
-	//Welders left on now use up fuel, but lets not have them run out quite that fast
-	else
+	if(welding)
 		force = 15
 		damtype = BURN
 		burned_fuel_for += delta_time
 		if(burned_fuel_for >= WELDER_FUEL_BURN_INTERVAL)
 			use(TRUE)
 		update_appearance()
+
+	//Welders left on now use up fuel, but lets not have them run out quite that fast
+	else
+		force = 3
+		damtype = BRUTE
+		update_appearance()
+		if(!can_off_process)
+			STOP_PROCESSING(SSobj, src)
+		return
 
 	//This is to start fires. process() is only called if the welder is on.
 	open_flame()

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -73,22 +73,21 @@
 
 
 /obj/item/weldingtool/process(delta_time)
-	switch(welding)
-		if(0)
-			force = 3
-			damtype = BRUTE
-			update_appearance()
-			if(!can_off_process)
-				STOP_PROCESSING(SSobj, src)
-			return
+	if(!welding)
+		force = 3
+		damtype = BRUTE
+		update_appearance()
+		if(!can_off_process)
+			STOP_PROCESSING(SSobj, src)
+		return
 	//Welders left on now use up fuel, but lets not have them run out quite that fast
-		if(1)
-			force = 15
-			damtype = BURN
-			burned_fuel_for += delta_time
-			if(burned_fuel_for >= WELDER_FUEL_BURN_INTERVAL)
-				use(1)
-			update_appearance()
+	else
+		force = 15
+		damtype = BURN
+		burned_fuel_for += delta_time
+		if(burned_fuel_for >= WELDER_FUEL_BURN_INTERVAL)
+			use(TRUE)
+		update_appearance()
 
 	//This is to start fires. process() is only called if the welder is on.
 	open_flame()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -509,22 +509,21 @@
 	else
 		return "<span class='notice'>The top cover is firmly <b>welded</b> on.</span>"
 
-/obj/structure/table/reinforced/attackby(obj/item/W, mob/living/user, params)
-	var/list/modifiers = params2list(params)
-	if(W.tool_behaviour == TOOL_WELDER && LAZYACCESS(modifiers, RIGHT_CLICK))
-		if(!W.tool_start_check(user, amount=0))
-			return
+/obj/structure/table/reinforced/attackby_secondary(obj/item/weapon, mob/user, params)
+	if(weapon.tool_behaviour == TOOL_WELDER)
+		if(weapon.tool_start_check(user, amount = 0))
+			if(deconstruction_ready)
+				to_chat(user, "<span class='notice'>You start strengthening the reinforced table...</span>")
+				if (weapon.use_tool(src, user, 50, volume = 50))
+					to_chat(user, "<span class='notice'>You strengthen the table.</span>")
+					deconstruction_ready = FALSE
+			else
+				to_chat(user, "<span class='notice'>You start weakening the reinforced table...</span>")
+				if (weapon.use_tool(src, user, 50, volume = 50))
+					to_chat(user, "<span class='notice'>You weaken the table.</span>")
+					deconstruction_ready = TRUE
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
-		if(deconstruction_ready)
-			to_chat(user, "<span class='notice'>You start strengthening the reinforced table...</span>")
-			if (W.use_tool(src, user, 50, volume=50))
-				to_chat(user, "<span class='notice'>You strengthen the table.</span>")
-				deconstruction_ready = 0
-		else
-			to_chat(user, "<span class='notice'>You start weakening the reinforced table...</span>")
-			if (W.use_tool(src, user, 50, volume=50))
-				to_chat(user, "<span class='notice'>You weaken the table.</span>")
-				deconstruction_ready = 1
 	else
 		. = ..()
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -395,37 +395,37 @@
 //this is shitcode but all of construction is shitcode and needs a refactor, it works for now
 //If you find this like 4 years later and construction still hasn't been refactored, I'm so sorry for this //Adding a timestamp, I found this in 2020, I hope it's from this year -Lemon
 //2021 AND STILLLL GOING STRONG
-/obj/structure/window/reinforced/attackby(obj/item/I, mob/living/user, params)
+/obj/structure/window/reinforced/attackby(obj/item/tool, mob/living/user, params)
 	switch(state)
 		if(RWINDOW_BOLTS_HEATED)
-			if(I.tool_behaviour == TOOL_SCREWDRIVER)
+			if(tool.tool_behaviour == TOOL_SCREWDRIVER)
 				user.visible_message("<span class='notice'>[user] digs into the heated security screws and starts removing them...</span>",
 										"<span class='notice'>You dig into the heated screws hard and they start turning...</span>")
-				if(I.use_tool(src, user, 50, volume = 50))
+				if(tool.use_tool(src, user, 50, volume = 50))
 					state = RWINDOW_BOLTS_OUT
 					to_chat(user, "<span class='notice'>The screws come out, and a gap forms around the edge of the pane.</span>")
 				return
 		if(RWINDOW_BOLTS_OUT)
-			if(I.tool_behaviour == TOOL_CROWBAR)
-				user.visible_message("<span class='notice'>[user] wedges \the [I] into the gap in the frame and starts prying...</span>",
-										"<span class='notice'>You wedge \the [I] into the gap in the frame and start prying...</span>")
-				if(I.use_tool(src, user, 40, volume = 50))
+			if(tool.tool_behaviour == TOOL_CROWBAR)
+				user.visible_message("<span class='notice'>[user] wedges \the [tool] into the gap in the frame and starts prying...</span>",
+										"<span class='notice'>You wedge \the [tool] into the gap in the frame and start prying...</span>")
+				if(tool.use_tool(src, user, 40, volume = 50))
 					state = RWINDOW_POPPED
 					to_chat(user, "<span class='notice'>The panel pops out of the frame, exposing some thin metal bars that looks like they can be cut.</span>")
 				return
 		if(RWINDOW_POPPED)
-			if(I.tool_behaviour == TOOL_WIRECUTTER)
+			if(tool.tool_behaviour == TOOL_WIRECUTTER)
 				user.visible_message("<span class='notice'>[user] starts cutting the exposed bars on \the [src]...</span>",
 										"<span class='notice'>You start cutting the exposed bars on \the [src]</span>")
-				if(I.use_tool(src, user, 20, volume = 50))
+				if(tool.use_tool(src, user, 20, volume = 50))
 					state = RWINDOW_BARS_CUT
 					to_chat(user, "<span class='notice'>The panels falls out of the way exposing the frame bolts.</span>")
 				return
 		if(RWINDOW_BARS_CUT)
-			if(I.tool_behaviour == TOOL_WRENCH)
+			if(tool.tool_behaviour == TOOL_WRENCH)
 				user.visible_message("<span class='notice'>[user] starts unfastening \the [src] from the frame...</span>",
 					"<span class='notice'>You start unfastening the bolts from the frame...</span>")
-				if(I.use_tool(src, user, 40, volume = 50))
+				if(tool.use_tool(src, user, 40, volume = 50))
 					to_chat(user, "<span class='notice'>You unscrew the bolts from the frame and the window pops loose.</span>")
 					state = WINDOW_OUT_OF_FRAME
 					set_anchored(FALSE)
@@ -442,7 +442,8 @@
 				state = RWINDOW_BOLTS_HEATED
 				addtimer(CALLBACK(src, .proc/cool_bolts), 300)
 				return SECONDARY_ATTACK_CALL_NORMAL
-	to_chat("<span class='notice'>The security screws need to be heated first!</span>")
+		else if (tool.tool_behaviour)
+			to_chat(user, "<span class='warning'>The security screws need to be heated first!</span>")
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/structure/window/proc/cool_bolts()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -438,7 +438,7 @@
 			var/obj/item/weldingtool/welder = tool
 			if(welder.isOn())
 				user.visible_message("<span class='notice'>[user] holds \the [tool] to the security screws on \the [src]...</span>",
-									"<span class='notice'>You begin heating the security screws on \the [src]...</span>")
+				"<span class='notice'>You begin heating the security screws on \the [src]...</span>")
 			if(tool.use_tool(src, user, 150, volume = 100))
 				to_chat(user, "<span class='notice'>The security screws are glowing white hot and look ready to be removed.</span>")
 				state = RWINDOW_BOLTS_HEATED

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -396,9 +396,10 @@
 //If you find this like 4 years later and construction still hasn't been refactored, I'm so sorry for this //Adding a timestamp, I found this in 2020, I hope it's from this year -Lemon
 //2021 AND STILLLL GOING STRONG
 /obj/structure/window/reinforced/attackby(obj/item/I, mob/living/user, params)
+	var/list/modifiers = params2list(params)
 	switch(state)
 		if(RWINDOW_SECURE)
-			if(I.tool_behaviour == TOOL_WELDER && user.combat_mode)
+			if(I.tool_behaviour == TOOL_WELDER && modifiers && modifiers["right"])
 				user.visible_message("<span class='notice'>[user] holds \the [I] to the security screws on \the [src]...</span>",
 										"<span class='notice'>You begin heating the security screws on \the [src]...</span>")
 				if(I.use_tool(src, user, 150, volume = 100))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -435,13 +435,14 @@
 /obj/structure/window/reinforced/attackby_secondary(obj/item/tool, mob/user, params)
 	if(state == RWINDOW_SECURE)
 		if(tool.tool_behaviour == TOOL_WELDER)
-			user.visible_message("<span class='notice'>[user] holds \the [tool] to the security screws on \the [src]...</span>",
-								"<span class='notice'>You begin heating the security screws on \the [src]...</span>")
+			var/obj/item/weldingtool/welder = tool
+			if(welder.isOn())
+				user.visible_message("<span class='notice'>[user] holds \the [tool] to the security screws on \the [src]...</span>",
+									"<span class='notice'>You begin heating the security screws on \the [src]...</span>")
 			if(tool.use_tool(src, user, 150, volume = 100))
 				to_chat(user, "<span class='notice'>The security screws are glowing white hot and look ready to be removed.</span>")
 				state = RWINDOW_BOLTS_HEATED
 				addtimer(CALLBACK(src, .proc/cool_bolts), 300)
-				return SECONDARY_ATTACK_CALL_NORMAL
 		else if (tool.tool_behaviour)
 			to_chat(user, "<span class='warning'>The security screws need to be heated first!</span>")
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -395,8 +395,21 @@
 //this is shitcode but all of construction is shitcode and needs a refactor, it works for now
 //If you find this like 4 years later and construction still hasn't been refactored, I'm so sorry for this //Adding a timestamp, I found this in 2020, I hope it's from this year -Lemon
 //2021 AND STILLLL GOING STRONG
-/obj/structure/window/reinforced/attackby(obj/item/tool, mob/living/user, params)
+/obj/structure/window/reinforced/attackby_secondary(obj/item/tool, mob/user, params)
 	switch(state)
+		if(RWINDOW_SECURE)
+			if(tool.tool_behaviour == TOOL_WELDER)
+				var/obj/item/weldingtool/welder = tool
+				if(welder.isOn())
+					user.visible_message("<span class='notice'>[user] holds \the [tool] to the security screws on \the [src]...</span>",
+						"<span class='notice'>You begin heating the security screws on \the [src]...</span>")
+				if(tool.use_tool(src, user, 150, volume = 100))
+					to_chat(user, "<span class='notice'>The security screws are glowing white hot and look ready to be removed.</span>")
+					state = RWINDOW_BOLTS_HEATED
+					addtimer(CALLBACK(src, .proc/cool_bolts), 300)
+			else if (tool.tool_behaviour)
+				to_chat(user, "<span class='warning'>The security screws need to be heated first!</span>")
+
 		if(RWINDOW_BOLTS_HEATED)
 			if(tool.tool_behaviour == TOOL_SCREWDRIVER)
 				user.visible_message("<span class='notice'>[user] digs into the heated security screws and starts removing them...</span>",
@@ -404,7 +417,9 @@
 				if(tool.use_tool(src, user, 50, volume = 50))
 					state = RWINDOW_BOLTS_OUT
 					to_chat(user, "<span class='notice'>The screws come out, and a gap forms around the edge of the pane.</span>")
-				return
+			else if (tool.tool_behaviour)
+				to_chat(user, "<span class='warning'>The security screws need to be removed first!</span>")
+
 		if(RWINDOW_BOLTS_OUT)
 			if(tool.tool_behaviour == TOOL_CROWBAR)
 				user.visible_message("<span class='notice'>[user] wedges \the [tool] into the gap in the frame and starts prying...</span>",
@@ -412,7 +427,9 @@
 				if(tool.use_tool(src, user, 40, volume = 50))
 					state = RWINDOW_POPPED
 					to_chat(user, "<span class='notice'>The panel pops out of the frame, exposing some thin metal bars that looks like they can be cut.</span>")
-				return
+			else if (tool.tool_behaviour)
+				to_chat(user, "<span class='warning'>The gap needs to be pried first!</span>")
+
 		if(RWINDOW_POPPED)
 			if(tool.tool_behaviour == TOOL_WIRECUTTER)
 				user.visible_message("<span class='notice'>[user] starts cutting the exposed bars on \the [src]...</span>",
@@ -420,7 +437,9 @@
 				if(tool.use_tool(src, user, 20, volume = 50))
 					state = RWINDOW_BARS_CUT
 					to_chat(user, "<span class='notice'>The panels falls out of the way exposing the frame bolts.</span>")
-				return
+			else if (tool.tool_behaviour)
+				to_chat(user, "<span class='warning'>The bars need to be cut first!</span>")
+
 		if(RWINDOW_BARS_CUT)
 			if(tool.tool_behaviour == TOOL_WRENCH)
 				user.visible_message("<span class='notice'>[user] starts unfastening \the [src] from the frame...</span>",
@@ -429,22 +448,9 @@
 					to_chat(user, "<span class='notice'>You unscrew the bolts from the frame and the window pops loose.</span>")
 					state = WINDOW_OUT_OF_FRAME
 					set_anchored(FALSE)
-				return
-	return ..()
+			else if (tool.tool_behaviour)
+				to_chat(user, "<span class='warning'>The bolts need to be loosened first!</span>")
 
-/obj/structure/window/reinforced/attackby_secondary(obj/item/tool, mob/user, params)
-	if(state == RWINDOW_SECURE)
-		if(tool.tool_behaviour == TOOL_WELDER)
-			var/obj/item/weldingtool/welder = tool
-			if(welder.isOn())
-				user.visible_message("<span class='notice'>[user] holds \the [tool] to the security screws on \the [src]...</span>",
-					"<span class='notice'>You begin heating the security screws on \the [src]...</span>")
-			if(tool.use_tool(src, user, 150, volume = 100))
-				to_chat(user, "<span class='notice'>The security screws are glowing white hot and look ready to be removed.</span>")
-				state = RWINDOW_BOLTS_HEATED
-				addtimer(CALLBACK(src, .proc/cool_bolts), 300)
-		else if (tool.tool_behaviour)
-			to_chat(user, "<span class='warning'>The security screws need to be heated first!</span>")
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/structure/window/proc/cool_bolts()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -438,7 +438,7 @@
 			var/obj/item/weldingtool/welder = tool
 			if(welder.isOn())
 				user.visible_message("<span class='notice'>[user] holds \the [tool] to the security screws on \the [src]...</span>",
-				"<span class='notice'>You begin heating the security screws on \the [src]...</span>")
+					"<span class='notice'>You begin heating the security screws on \the [src]...</span>")
 			if(tool.use_tool(src, user, 150, volume = 100))
 				to_chat(user, "<span class='notice'>The security screws are glowing white hot and look ready to be removed.</span>")
 				state = RWINDOW_BOLTS_HEATED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Previously to start deconstructing a reinforced window you had to be in combat mode. This changes all of the reinforced window deconstruction steps to attack_secondary, to be consistent with other deconstruction steps (like for tables). This also moves weakening reinforced tables to attack_secondary.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Brings a deconstruction in line with other deconstruction methods. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: initiating deconstructing a reinforced window is now done by right clicking for each step
code: reinforced table weakening moved to attack_secondary
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
