### PR TITLE
heretic blade teleports are now invoked by using them in-hand

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -32,38 +32,9 @@
 	if(target.stat == DEAD)
 		to_chat(user,"<span class='warning'>[target.real_name] is dead. Bring them to a transmutation rune!</span>")
 
-/datum/action/innate/heretic_shatter
-	name = "Shattering Offer"
-	desc = "By breaking your blade, you will be granted salvation from a dire situation. (Teleports you to a random safe turf on your current z level, but destroys your blade.)"
-	background_icon_state = "bg_ecult"
-	button_icon_state = "shatter"
-	icon_icon = 'icons/mob/actions/actions_ecult.dmi'
-	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE
-	var/mob/living/carbon/human/holder
-	var/obj/item/melee/sickly_blade/sword
-
-/datum/action/innate/heretic_shatter/Grant(mob/user, obj/object)
-	sword = object
-	holder = user
-	//i know what im doing
-	return ..()
-
-/datum/action/innate/heretic_shatter/IsAvailable()
-	if(IS_HERETIC(holder) || IS_HERETIC_MONSTER(holder))
-		return TRUE
-	else
-		return FALSE
-
-/datum/action/innate/heretic_shatter/Activate()
-	var/turf/safe_turf = find_safe_turf(zlevels = sword.z, extended_safety_checks = TRUE)
-	do_teleport(holder,safe_turf,forceMove = TRUE)
-	to_chat(holder,"<span class='warning'>You feel a gust of energy flow through your body... the Rusted Hills heard your call...</span>")
-	qdel(sword)
-
-
 /obj/item/melee/sickly_blade
 	name = "\improper Sickly Blade"
-	desc = "A sickly green crescent blade, decorated with an ornamental eye. You feel like you're being watched..."
+	desc = "A sickly green crescent blade, decorated with an ornamental eye. You feel like you're being watched... A heretic (or a servant of one) can shatter this blade to teleport to a random mostly safe location by activating it in-hand."
 	icon = 'icons/obj/eldritch.dmi'
 	icon_state = "eldritch_blade"
 	inhand_icon_state = "eldritch_blade"
@@ -79,11 +50,6 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "rend")
-	var/datum/action/innate/heretic_shatter/linked_action
-
-/obj/item/melee/sickly_blade/Initialize()
-	. = ..()
-	linked_action = new(src)
 
 /obj/item/melee/sickly_blade/attack(mob/living/M, mob/living/user)
 	if(!(IS_HERETIC(user) || IS_HERETIC_MONSTER(user)))
@@ -93,13 +59,16 @@
 		return FALSE
 	return ..()
 
-/obj/item/melee/sickly_blade/pickup(mob/user)
-	. = ..()
-	linked_action.Grant(user, src)
-
-/obj/item/melee/sickly_blade/dropped(mob/user, silent)
-	. = ..()
-	linked_action.Remove(user, src)
+/obj/item/melee/sickly_blade/attack_self(mob/user)
+	var/turf/safe_turf = find_safe_turf(zlevels = z, extended_safety_checks = TRUE)
+	if(IS_HERETIC(user) || IS_HERETIC_MONSTER(user))
+		if(do_teleport(user, safe_turf, forceMove = TRUE, channel = TELEPORT_CHANNEL_MAGIC))
+			to_chat(user,"<span class='warning'>As you shatter [src], you feel a gust of energy flow through your body. The Rusted Hills heard your call...</span>")
+		else
+			to_chat(user,"<span class='warning'>You shatter [src], but your plea goes unanswered.</span>")
+	else
+		to_chat(user,"<span class='warning'>You shatter [src].</span>")
+	qdel(src)
 
 /obj/item/melee/sickly_blade/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
@@ -118,25 +87,25 @@
 
 /obj/item/melee/sickly_blade/rust
 	name = "\improper Rusted Blade"
-	desc = "This crescent blade is decrepit, wasting to rust. Yet still it bites, ripping flesh and bone with jagged, rotten teeth."
+	desc = "This crescent blade is decrepit, wasting to rust. Yet still it bites, ripping flesh and bone with jagged, rotten teeth. A heretic (or a servant of one) can shatter this blade to teleport to a random mostly safe location by activating it in-hand."
 	icon_state = "rust_blade"
 	inhand_icon_state = "rust_blade"
 
 /obj/item/melee/sickly_blade/ash
 	name = "\improper Ashen Blade"
-	desc = "Molten and unwrought, a hunk of metal warped to cinders and slag. Unmade, it aspires to be more than it is, and shears soot-filled wounds with a blunt edge."
+	desc = "Molten and unwrought, a hunk of metal warped to cinders and slag. Unmade, it aspires to be more than it is, and shears soot-filled wounds with a blunt edge. A heretic (or a servant of one) can shatter this blade to teleport to a random mostly safe location by activating it in-hand."
 	icon_state = "ash_blade"
 	inhand_icon_state = "ash_blade"
 
 /obj/item/melee/sickly_blade/flesh
 	name = "Flesh Blade"
-	desc = "A crescent blade born from a fleshwarped creature. Keenly aware, it seeks to spread to others the suffering it has endured from its dreadful origins."
+	desc = "A crescent blade born from a fleshwarped creature. Keenly aware, it seeks to spread to others the suffering it has endured from its dreadful origins. A heretic (or a servant of one) can shatter this blade to teleport to a random mostly safe location by activating it in-hand."
 	icon_state = "flesh_blade"
 	inhand_icon_state = "flesh_blade"
 
 /obj/item/melee/sickly_blade/void
 	name = "Void Blade"
-	desc = "Devoid of any substance, this blade reflects nothingness. It is a real depiction of purity, and chaos that ensues after its implementation."
+	desc = "Devoid of any substance, this blade reflects nothingness. It is a real depiction of purity, and chaos that ensues after its implementation. A heretic (or a servant of one) can shatter this blade to teleport to a random mostly safe location by activating it in-hand."
 	icon_state = "void_blade"
 	inhand_icon_state = "void_blade"
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -89,7 +89,7 @@
 /obj/item/melee/sickly_blade/examine(mob/user)
 	. = ..()
 	if(IS_HERETIC(user) || IS_HERETIC_MONSTER(user))
-		. += {"<span class='notice'>A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand.</span>"}
+		. += {"<span class='notice'><B>A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand.</B></span>"}
 
 /obj/item/melee/sickly_blade/rust
 	name = "\improper Rusted Blade"

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -34,7 +34,7 @@
 
 /obj/item/melee/sickly_blade
 	name = "\improper Sickly Blade"
-	desc = "A sickly green crescent blade, decorated with an ornamental eye. You feel like you're being watched... A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand."
+	desc = "A sickly green crescent blade, decorated with an ornamental eye. You feel like you're being watched..."
 	icon = 'icons/obj/eldritch.dmi'
 	icon_state = "eldritch_blade"
 	inhand_icon_state = "eldritch_blade"
@@ -68,6 +68,7 @@
 			to_chat(user,"<span class='warning'>You shatter [src], but your plea goes unanswered.</span>")
 	else
 		to_chat(user,"<span class='warning'>You shatter [src].</span>")
+	playsound(src, "shatter", 70, TRUE) //copied from the code for smashing a glass sheet onto the ground to turn it into a shard
 	qdel(src)
 
 /obj/item/melee/sickly_blade/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
@@ -85,27 +86,32 @@
 		else
 			eldritch_knowledge_datum.on_ranged_attack_eldritch_blade(target,user,click_parameters)
 
+/obj/item/melee/sickly_blade/examine(mob/user)
+	. = ..()
+	if(IS_HERETIC(user) || IS_HERETIC_MONSTER(user))
+		. += {"<span class='notice'>A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand.</span>"}
+
 /obj/item/melee/sickly_blade/rust
 	name = "\improper Rusted Blade"
-	desc = "This crescent blade is decrepit, wasting to rust. Yet still it bites, ripping flesh and bone with jagged, rotten teeth. A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand."
+	desc = "This crescent blade is decrepit, wasting to rust. Yet still it bites, ripping flesh and bone with jagged, rotten teeth."
 	icon_state = "rust_blade"
 	inhand_icon_state = "rust_blade"
 
 /obj/item/melee/sickly_blade/ash
 	name = "\improper Ashen Blade"
-	desc = "Molten and unwrought, a hunk of metal warped to cinders and slag. Unmade, it aspires to be more than it is, and shears soot-filled wounds with a blunt edge. A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand."
+	desc = "Molten and unwrought, a hunk of metal warped to cinders and slag. Unmade, it aspires to be more than it is, and shears soot-filled wounds with a blunt edge."
 	icon_state = "ash_blade"
 	inhand_icon_state = "ash_blade"
 
 /obj/item/melee/sickly_blade/flesh
 	name = "Flesh Blade"
-	desc = "A crescent blade born from a fleshwarped creature. Keenly aware, it seeks to spread to others the suffering it has endured from its dreadful origins. A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand."
+	desc = "A crescent blade born from a fleshwarped creature. Keenly aware, it seeks to spread to others the suffering it has endured from its dreadful origins."
 	icon_state = "flesh_blade"
 	inhand_icon_state = "flesh_blade"
 
 /obj/item/melee/sickly_blade/void
 	name = "Void Blade"
-	desc = "Devoid of any substance, this blade reflects nothingness. It is a real depiction of purity, and chaos that ensues after its implementation. A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand."
+	desc = "Devoid of any substance, this blade reflects nothingness. It is a real depiction of purity, and chaos that ensues after its implementation."
 	icon_state = "void_blade"
 	inhand_icon_state = "void_blade"
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -89,7 +89,7 @@
 /obj/item/melee/sickly_blade/examine(mob/user)
 	. = ..()
 	if(IS_HERETIC(user) || IS_HERETIC_MONSTER(user))
-		. += {"<span class='notice'><B>A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand.</B></span>"}
+		. += "<span class='notice'><B>A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand.</B></span>"
 
 /obj/item/melee/sickly_blade/rust
 	name = "\improper Rusted Blade"

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -34,7 +34,7 @@
 
 /obj/item/melee/sickly_blade
 	name = "\improper Sickly Blade"
-	desc = "A sickly green crescent blade, decorated with an ornamental eye. You feel like you're being watched... A heretic (or a servant of one) can shatter this blade to teleport to a random mostly safe location by activating it in-hand."
+	desc = "A sickly green crescent blade, decorated with an ornamental eye. You feel like you're being watched... A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand."
 	icon = 'icons/obj/eldritch.dmi'
 	icon_state = "eldritch_blade"
 	inhand_icon_state = "eldritch_blade"
@@ -87,25 +87,25 @@
 
 /obj/item/melee/sickly_blade/rust
 	name = "\improper Rusted Blade"
-	desc = "This crescent blade is decrepit, wasting to rust. Yet still it bites, ripping flesh and bone with jagged, rotten teeth. A heretic (or a servant of one) can shatter this blade to teleport to a random mostly safe location by activating it in-hand."
+	desc = "This crescent blade is decrepit, wasting to rust. Yet still it bites, ripping flesh and bone with jagged, rotten teeth. A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand."
 	icon_state = "rust_blade"
 	inhand_icon_state = "rust_blade"
 
 /obj/item/melee/sickly_blade/ash
 	name = "\improper Ashen Blade"
-	desc = "Molten and unwrought, a hunk of metal warped to cinders and slag. Unmade, it aspires to be more than it is, and shears soot-filled wounds with a blunt edge. A heretic (or a servant of one) can shatter this blade to teleport to a random mostly safe location by activating it in-hand."
+	desc = "Molten and unwrought, a hunk of metal warped to cinders and slag. Unmade, it aspires to be more than it is, and shears soot-filled wounds with a blunt edge. A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand."
 	icon_state = "ash_blade"
 	inhand_icon_state = "ash_blade"
 
 /obj/item/melee/sickly_blade/flesh
 	name = "Flesh Blade"
-	desc = "A crescent blade born from a fleshwarped creature. Keenly aware, it seeks to spread to others the suffering it has endured from its dreadful origins. A heretic (or a servant of one) can shatter this blade to teleport to a random mostly safe location by activating it in-hand."
+	desc = "A crescent blade born from a fleshwarped creature. Keenly aware, it seeks to spread to others the suffering it has endured from its dreadful origins. A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand."
 	icon_state = "flesh_blade"
 	inhand_icon_state = "flesh_blade"
 
 /obj/item/melee/sickly_blade/void
 	name = "Void Blade"
-	desc = "Devoid of any substance, this blade reflects nothingness. It is a real depiction of purity, and chaos that ensues after its implementation. A heretic (or a servant of one) can shatter this blade to teleport to a random mostly safe location by activating it in-hand."
+	desc = "Devoid of any substance, this blade reflects nothingness. It is a real depiction of purity, and chaos that ensues after its implementation. A heretic (or a servant of one) can shatter this blade to teleport to a random, mostly safe location by activating it in-hand."
 	icon_state = "void_blade"
 	inhand_icon_state = "void_blade"
 


### PR DESCRIPTION
## About The Pull Request

Shattering a heretic blade as a heretic or a heretic monster to teleport a random, mostly safe location is now done by activating the blade in-hand instead of by pressing an action button. This information will be given to a heretic or a heretic monster if they examine a heretic blade.

Teleporting using a heretic blade now plays a glass shattering noise, produces a slightly different message (that factors in whether or not the teleportation attempt was successful), and uses the TELEPORT_CHANNEL_MAGIC teleportation channel.

Muggles can now shatter heretic blades, but will not be teleported upon shattering a blade.

## Why It's Good For The Game

I definitely didn't die as a heretic because I thought that this power was sensibly bound to "z" (or another reasonable activation method) during the several times that I tried to invoke it. Haha, nope, I am just a gamer with a perfect memory who can play around unintuitive design decisions and think to check the top left corner of their screen in the middle of combat for a new ability that's only present while you have your blade outside of a container ahhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh

uh, action button bad, game telling you important information about your abilities without you needing to dive through the wiki (or the code) for it good.

## Changelog
:cl: ATHATH
qol: Shattering a heretic blade as a heretic or a heretic monster to teleport a random, mostly safe location is now done by activating the blade in-hand instead of by pressing an action button. This information will be given to a heretic or a heretic monster if they examine a heretic blade.
soundadd: Teleporting using a heretic blade now plays a glass shattering noise and produces a slightly different message (that factors in whether or not the teleportation attempt was successful).
fix: Teleporting using a heretic blade is now considered to be a magical teleportation method by the game.
/:cl: