### PR TITLE
Fix multiz ventcrawling

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -484,10 +484,8 @@
 
 	if(!target_move)
 		return
-	message_admins("PASS TARGET")
 	if(target_move.vent_movement & VENTCRAWL_ALLOWED)
 		user.forceMove(target_move)
-		message_admins("PASS MOVE")
 		user.client.eye = target_move  //Byond only updates the eye every tick, This smooths out the movement
 		var/list/pipenetdiff = returnPipenets() ^ target_move.returnPipenets()
 		if(pipenetdiff.len)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -208,7 +208,7 @@
  */
 /obj/machinery/atmospherics/proc/findConnecting(direction, prompted_layer)
 	for(var/obj/machinery/atmospherics/target in get_step_multiz(src, direction))
-		if(!(target.initialize_directions & get_dir_multiz(target,src)) && !istype(target, /obj/machinery/atmospherics/pipe/multiz))
+		if(!(target.initialize_directions & get_dir(target,src)) && !istype(target, /obj/machinery/atmospherics/pipe/multiz))
 			continue
 		if(connection_check(target, prompted_layer))
 			return target

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -207,8 +207,8 @@
  * * prompted_layer - the piping_layer we are inside
  */
 /obj/machinery/atmospherics/proc/findConnecting(direction, prompted_layer)
-	for(var/obj/machinery/atmospherics/target in get_step(src, direction))
-		if(!(target.initialize_directions & get_dir(target,src)))
+	for(var/obj/machinery/atmospherics/target in get_step_multiz(src, direction))
+		if(!(target.initialize_directions & get_dir_multiz(target,src)) && !istype(target, /obj/machinery/atmospherics/pipe/multiz))
 			continue
 		if(connection_check(target, prompted_layer))
 			return target
@@ -223,7 +223,7 @@
  * * given_layer - the piping_layer we are checking
  */
 /obj/machinery/atmospherics/proc/connection_check(obj/machinery/atmospherics/target, given_layer)
-	if(isConnectable(target, given_layer) && target.isConnectable(src, given_layer) && (target.initialize_directions & get_dir(target,src)))
+	if(isConnectable(target, given_layer) && target.isConnectable(src, given_layer) && (target.initialize_directions & get_dir(target,src) || istype(target, /obj/machinery/atmospherics/pipe/multiz)))
 		return TRUE
 	return FALSE
 
@@ -475,29 +475,31 @@
 
 // Handles mob movement inside a pipenet
 /obj/machinery/atmospherics/relaymove(mob/living/user, direction)
-	direction &= initialize_directions
-	if(!direction || !(direction in GLOB.cardinals)) //cant go this way.
-		return
 
+	if(!direction || !(direction in GLOB.cardinals_multiz)) //cant go this way.
+		return
 	if(user in buckled_mobs)// fixes buckle ventcrawl edgecase fuck bug
 		return
-
 	var/obj/machinery/atmospherics/target_move = findConnecting(direction, user.ventcrawl_layer)
-	if(target_move)
-		if(target_move.vent_movement & VENTCRAWL_ALLOWED)
-			user.forceMove(target_move)
-			user.client.eye = target_move  //Byond only updates the eye every tick, This smooths out the movement
-			var/list/pipenetdiff = returnPipenets() ^ target_move.returnPipenets()
-			if(pipenetdiff.len)
-				user.update_pipe_vision()
-			if(world.time - user.last_played_vent > VENT_SOUND_DELAY)
-				user.last_played_vent = world.time
-				playsound(src, 'sound/machines/ventcrawl.ogg', 50, TRUE, -3)
+
+	if(!target_move)
+		return
+	message_admins("PASS TARGET")
+	if(target_move.vent_movement & VENTCRAWL_ALLOWED)
+		user.forceMove(target_move)
+		message_admins("PASS MOVE")
+		user.client.eye = target_move  //Byond only updates the eye every tick, This smooths out the movement
+		var/list/pipenetdiff = returnPipenets() ^ target_move.returnPipenets()
+		if(pipenetdiff.len)
+			user.update_pipe_vision()
+		if(world.time - user.last_played_vent > VENT_SOUND_DELAY)
+			user.last_played_vent = world.time
+			playsound(src, 'sound/machines/ventcrawl.ogg', 50, TRUE, -3)
 
 	//Would be great if this could be implemented when someone alt-clicks the image.
 	if (target_move.vent_movement & VENTCRAWL_ENTRANCE_ALLOWED)
 		user.handle_ventcrawl(target_move)
-	//PLACEHOLDER COMMENT FOR ME TO READD THE 1 (?) DS DELAY THAT WAS IMPLEMENTED WITH A... TIMER?
+		//PLACEHOLDER COMMENT FOR ME TO READD THE 1 (?) DS DELAY THAT WAS IMPLEMENTED WITH A... TIMER?
 
 /obj/machinery/atmospherics/AltClick(mob/living/L)
 	if(!(vent_movement & VENTCRAWL_ALLOWED)) // Early return for machines which does not allow ventcrawling at all.

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -88,6 +88,11 @@ Passive gate is similar to the regular pump except:
 	))
 	radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
 
+/obj/machinery/atmospherics/components/binary/passive_gate/relaymove(mob/living/user, direction)
+	if(!on || direction != dir)
+		return
+	. = ..()
+
 /obj/machinery/atmospherics/components/binary/passive_gate/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)

--- a/code/modules/atmospherics/machinery/components/binary_devices/pressure_valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pressure_valve.dm
@@ -91,6 +91,11 @@
 	))
 	radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
 
+/obj/machinery/atmospherics/components/binary/pressure_valve/relaymove(mob/living/user, direction)
+	if(!on || direction != dir)
+		return
+	. = ..()
+
 /obj/machinery/atmospherics/components/binary/pressure_valve/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -18,6 +18,7 @@
 	shift_underlay_only = FALSE
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "pump"
+	vent_movement = NONE
 	///Pressure that the pump will reach when on
 	var/target_pressure = ONE_ATMOSPHERE
 	///Frequency for radio signaling

--- a/code/modules/atmospherics/machinery/components/binary_devices/temperature_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/temperature_gate.dm
@@ -74,6 +74,11 @@
 			is_gas_flowing = FALSE
 	update_icon_nopipes()
 
+/obj/machinery/atmospherics/components/binary/temperature_gate/relaymove(mob/living/user, direction)
+	if(!on || direction != dir)
+		return
+	. = ..()
+
 /obj/machinery/atmospherics/components/binary/temperature_gate/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)

--- a/code/modules/atmospherics/machinery/components/binary_devices/temperature_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/temperature_pump.dm
@@ -6,6 +6,7 @@
 	shift_underlay_only = FALSE
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "tpump"
+	vent_movement = NONE
 	///Percent of the heat delta to transfer
 	var/heat_transfer_rate = 0
 	///Maximum allowed transfer percentage

--- a/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
@@ -14,7 +14,7 @@
 	hide = TRUE
 
 	move_resist = MOVE_RESIST_DEFAULT
-
+	vent_movement = NONE
 	pipe_flags = PIPING_ONE_PER_TURF
 
 	var/icon_state_off = "freezer"

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -33,6 +33,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 		on = FALSE
 		update_icon_nopipes()
 		investigate_log("was closed by [usr ? key_name(usr) : "a remote signal"]", INVESTIGATE_ATMOS)
+		vent_movement &= ~VENTCRAWL_ALLOWED
 	else
 		on = TRUE
 		update_icon_nopipes()
@@ -40,6 +41,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 		var/datum/pipeline/parent1 = parents[1]
 		parent1.reconcile_air()
 		investigate_log("was opened by [usr ? key_name(usr) : "a remote signal"]", INVESTIGATE_ATMOS)
+		vent_movement |= VENTCRAWL_ALLOWED
 
 /obj/machinery/atmospherics/components/binary/valve/interact(mob/user)
 	add_fingerprint(usr)

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -18,6 +18,7 @@
 	shift_underlay_only = FALSE
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "volumepump"
+	vent_movement = NONE
 	///Transfer rate of the component in L/s
 	var/transfer_rate = MAX_TRANSFER_RATE
 	///Check if the component has been overclocked

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
@@ -14,6 +14,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 100, BOMB = 0, BIO = 100, RAD = 100, FIRE = 80, ACID = 30)
 	circuit = /obj/item/circuitboard/machine/crystallizer
 	pipe_flags = PIPING_ONE_PER_TURF | PIPING_DEFAULT_LAYER_ONLY
+	vent_movement = NONE
 
 	///Base icon state for the machine to be used in update_icon()
 	var/base_icon = "crystallizer"

--- a/code/modules/atmospherics/machinery/components/trinary_devices/trinary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/trinary_devices.dm
@@ -6,6 +6,7 @@
 	device_type = TRINARY
 	layer = GAS_FILTER_LAYER
 	pipe_flags = PIPING_ONE_PER_TURF
+	vent_movement = NONE
 
 	var/flipped = FALSE
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -496,12 +496,13 @@
 
 	var/turf/current_turf = get_turf(src)
 	var/turf/above_turf = SSmapping.get_turf_above(current_turf)
+	var/ventcrawling_mob = HAS_TRAIT(src, TRAIT_MOVE_VENTCRAWLING)
 
-	if(can_zFall(above_turf, 1, current_turf, DOWN)) //Will be fall down if we go up?
+	if(can_zFall(above_turf, 1, current_turf, DOWN) && !ventcrawling_mob) //Will be fall down if we go up?
 		to_chat(src, "<span class='notice'>You are not Superman.<span>")
 		return
 
-	if(zMove(UP, TRUE))
+	if(zMove(UP, TRUE, ventcrawling_mob))
 		to_chat(src, "<span class='notice'>You move upwards.</span>")
 
 ///Moves a mob down a z level
@@ -509,11 +510,13 @@
 	set name = "Move Down"
 	set category = "IC"
 
-	if(zMove(DOWN, TRUE))
+	var/ventcrawling_mob = HAS_TRAIT(src, TRAIT_MOVE_VENTCRAWLING)
+
+	if(zMove(DOWN, TRUE, ventcrawling_mob))
 		to_chat(src, "<span class='notice'>You move down.</span>")
 
 ///Move a mob between z levels, if it's valid to move z's on this turf
-/mob/proc/zMove(dir, feedback = FALSE)
+/mob/proc/zMove(dir, feedback = FALSE, ventcrawling = FALSE)
 	if(dir != UP && dir != DOWN)
 		return FALSE
 	if(incapacitated())
@@ -525,11 +528,15 @@
 		if(feedback)
 			to_chat(src, "<span class='warning'>There's nowhere to go in that direction!</span>")
 		return FALSE
-	if(!canZMove(dir, target))
+	if(!canZMove(dir, target) && !ventcrawling)
 		if(feedback)
 			to_chat(src, "<span class='warning'>You couldn't move there!</span>")
 		return FALSE
-	forceMove(target)
+	if(!ventcrawling) //let this be handled in atmosmachinery.dm
+		forceMove(target)
+	else
+		var/obj/machinery/atmospherics/pipe = loc
+		pipe.relaymove(src, dir)
 	return TRUE
 
 /// Can this mob move between z levels


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allow mobs to travel through multiz adaptors,
fixes runtimes caused by ventcrawling
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: allows ventcrawling between zlevels by using the multiz adapters and using the actions move_upwards and move_downwards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
