### PR TITLE
Adds the Option to turn on assistants population scaling

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -88,6 +88,11 @@
 	integer = FALSE
 	min_val = 0
 
+/datum/config_entry/number/assistant_scaling_coeff //how much does the amount of players get divided by to determine open security officer positions
+	config_entry_value = 8
+	integer = FALSE
+	min_val = 0
+
 /datum/config_entry/number/security_scaling_coeff //how much does the amount of players get divided by to determine open security officer positions
 	config_entry_value = 8
 	integer = FALSE

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -88,7 +88,8 @@
 	integer = FALSE
 	min_val = 0
 
-/datum/config_entry/number/assistant_scaling_coeff //how much does the amount of players get divided by to determine open assistants positions
+///how much does the amount of players get divided by to determine open assistants positions
+/datum/config_entry/number/assistant_scaling_coeff
 	config_entry_value = 8
 	integer = FALSE
 	min_val = 0

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -88,7 +88,7 @@
 	integer = FALSE
 	min_val = 0
 
-/datum/config_entry/number/assistant_scaling_coeff //how much does the amount of players get divided by to determine open security officer positions
+/datum/config_entry/number/assistant_scaling_coeff //how much does the amount of players get divided by to determine open assistants positions
 	config_entry_value = 8
 	integer = FALSE
 	min_val = 0

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -440,7 +440,7 @@ SUBSYSTEM_DEF(job)
 		RejectPlayer(player)
 	else if(player.client.prefs.joblessrole == BEOVERFLOW)
 		var/allowed_to_be_a_loser = !is_banned_from(player.ckey, SSjob.overflow_role)
-		if(QDELETED(player) || !allowed_to_be_a_loser)
+		if(QDELETED(player) || !allowed_to_be_a_loser || player.IsJobUnavailable(SSjob.overflow_role) != JOB_AVAILABLE)
 			RejectPlayer(player)
 		else
 			if(!AssignRole(player, SSjob.overflow_role))

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -13,6 +13,8 @@ SUBSYSTEM_DEF(job)
 	var/list/latejoin_trackers = list() //Don't read this list, use GetLateJoinTurfs() instead
 
 	var/overflow_role = "Assistant"
+	///Role that new players are always allowed to use and can be always chosen when all other slots are filled
+	var/new_player_role = "Assistant"
 
 	var/list/level_order = list(JP_HIGH,JP_MEDIUM,JP_LOW)
 
@@ -570,17 +572,17 @@ SUBSYSTEM_DEF(job)
 		return C.holder.auto_deadmin()
 
 /datum/controller/subsystem/job/proc/setup_assistant_positions()
-	var/datum/job/job = SSjob.GetJob("Assistant")
+	var/datum/job/job = SSjob.GetJob(new_player_role)
 	if(!job)
 		CRASH("setup_assistant_positions(): Assistant job is missing")
 
 	var/assistant_ratio = CONFIG_GET(number/assistant_scaling_coeff)
-	if(assistant_ratio > 0)
-		if(job.spawn_positions > 0)
-			var/assistant_positions = max(3, max(job.spawn_positions, round(unassigned.len / assistant_ratio))) //with a ratio of 8, we'd need a pop of more than 24 to have more than 3 assistants (we'll alway have at least 3 of them)
-			JobDebug("Setting open assistants positions to [assistant_positions]")
-			job.total_positions = assistant_positions
-			job.spawn_positions = assistant_positions
+	if (assistant_ratio <= 0 || job.spawn_positions <= 0)
+		return
+	var/assistant_positions = max(3, max(job.spawn_positions, round(unassigned.len / assistant_ratio))) //with a ratio of 8, we'd need a pop of more than 24 to have more than 3 assistants (we'll always have at least 3 of them)
+	JobDebug("Setting open assistants positions to [assistant_positions]")
+	job.total_positions = assistant_positions
+	job.spawn_positions = assistant_positions
 
 /datum/controller/subsystem/job/proc/setup_officer_positions()
 	var/datum/job/J = SSjob.GetJob("Security Officer")

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -269,14 +269,14 @@
 	if(!job)
 		return JOB_UNAVAILABLE_GENERIC
 	if((job.current_positions >= job.total_positions) && job.total_positions != -1)
-		if(job.title == "Assistant")
+		if(job.title == SSjob.overflow_role)
 			if(isnum(client.player_age) && client.player_age <= 14) //Newbies can always be assistants
 				return JOB_AVAILABLE
 			for(var/datum/job/job_to_check in SSjob.occupations)
 				if(job_to_check && job_to_check.title != job.title && !is_banned_from(ckey, href_list[job_to_check.title])) //you have at least one job you are not banned from
 					return JOB_UNAVAILABLE_SLOTFULL
-			for(var/datum/job/J in SSjob.occupations)
-				if(J && J.current_positions < J.total_positions && J.title != job.title)
+			for(var/datum/job/job_to_check in SSjob.occupations)
+				if(job_to_check && job_to_check.current_positions < job_to_check.total_positions && job_to_check.title != job.title)
 					return JOB_UNAVAILABLE_SLOTFULL
 		else
 			return JOB_UNAVAILABLE_SLOTFULL

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -272,6 +272,9 @@
 		if(job.title == "Assistant")
 			if(isnum(client.player_age) && client.player_age <= 14) //Newbies can always be assistants
 				return JOB_AVAILABLE
+			for(var/datum/job/job_to_check in SSjob.occupations)
+				if(job_to_check && job_to_check.title != job.title && !is_banned_from(ckey, href_list[job_to_check.title])) //you have at least one job you are not banned from
+					return JOB_UNAVAILABLE_SLOTFULL
 			for(var/datum/job/J in SSjob.occupations)
 				if(J && J.current_positions < J.total_positions && J.title != job.title)
 					return JOB_UNAVAILABLE_SLOTFULL

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -269,22 +269,22 @@
 	if(!job)
 		return JOB_UNAVAILABLE_GENERIC
 
-	if(job.title == "Assistant" && latejoin) //check for latejoin overflow
+	if(job.title == SSjob.new_player_role && latejoin) //check for latejoin overflow
 		var/job_overflow_check = TRUE
 		for(var/datum/job/job_overflow in SSjob.occupations)
-			if(job_overflow && job_overflow.total_positions > 0 && job_overflow.current_positions < job_overflow.total_positions)
+			if(job_overflow?.total_positions > 0 && job_overflow.current_positions < job_overflow.total_positions)
 				job_overflow_check = FALSE
 				break
 		if(job_overflow_check && !is_banned_from(ckey, job.title))
 			return JOB_AVAILABLE
 
 	if((job.current_positions >= job.total_positions) && job.total_positions != -1)
-		if(job.title == "Assistant")
+		if(job.title == SSjob.new_player_role)
 			if(isnum(client.player_age) && client.player_age <= 14) //Newbies can always be assistants
 				return JOB_AVAILABLE
 			for(var/datum/job/job_to_check in SSjob.occupations)
 				//you have at least one job you are not banned from and it has slots to join to
-				if(job_to_check && job_to_check.current_positions < job_to_check.total_positions && job_to_check.title != job.title && !is_banned_from(ckey, job_to_check.title))
+				if(job_to_check?.current_positions < job_to_check.total_positions && job_to_check.title != job.title && !is_banned_from(ckey, job_to_check.title))
 					return JOB_UNAVAILABLE_SLOTFULL
 		else
 			return JOB_UNAVAILABLE_SLOTFULL
@@ -301,7 +301,7 @@
 	return JOB_AVAILABLE
 
 /mob/dead/new_player/proc/AttemptLateSpawn(rank)
-	var/error = IsJobUnavailable(rank, TRUE)
+	var/error = IsJobUnavailable(rank, latejoin = TRUE)
 	if(error != JOB_AVAILABLE)
 		alert(src, get_job_unavailable_error_message(error, rank))
 		return FALSE

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -268,8 +268,18 @@
 	var/datum/job/job = SSjob.GetJob(rank)
 	if(!job)
 		return JOB_UNAVAILABLE_GENERIC
+
+	if(job.title == "Assistant" && latejoin) //check for latejoin overflow
+		var/job_overflow_check = TRUE
+		for(var/datum/job/job_overflow in SSjob.occupations)
+			if(job_overflow && job_overflow.total_positions > 0 && job_overflow.current_positions < job_overflow.total_positions)
+				job_overflow_check = FALSE
+				break
+		if(job_overflow_check && !is_banned_from(ckey, job.title))
+			return JOB_AVAILABLE
+
 	if((job.current_positions >= job.total_positions) && job.total_positions != -1)
-		if(job.title == SSjob.overflow_role)
+		if(job.title == "Assistant")
 			if(isnum(client.player_age) && client.player_age <= 14) //Newbies can always be assistants
 				return JOB_AVAILABLE
 			for(var/datum/job/job_to_check in SSjob.occupations)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -273,10 +273,8 @@
 			if(isnum(client.player_age) && client.player_age <= 14) //Newbies can always be assistants
 				return JOB_AVAILABLE
 			for(var/datum/job/job_to_check in SSjob.occupations)
-				if(job_to_check && job_to_check.title != job.title && !is_banned_from(ckey, job_to_check.title)) //you have at least one job you are not banned from
-					return JOB_UNAVAILABLE_SLOTFULL
-			for(var/datum/job/job_to_check in SSjob.occupations)
-				if(job_to_check && job_to_check.current_positions < job_to_check.total_positions && job_to_check.title != job.title)
+				//you have at least one job you are not banned from and it has slots to join to
+				if(job_to_check && job_to_check.current_positions < job_to_check.total_positions && job_to_check.title != job.title && !is_banned_from(ckey, job_to_check.title))
 					return JOB_UNAVAILABLE_SLOTFULL
 		else
 			return JOB_UNAVAILABLE_SLOTFULL
@@ -293,7 +291,7 @@
 	return JOB_AVAILABLE
 
 /mob/dead/new_player/proc/AttemptLateSpawn(rank)
-	var/error = IsJobUnavailable(rank)
+	var/error = IsJobUnavailable(rank, TRUE)
 	if(error != JOB_AVAILABLE)
 		alert(src, get_job_unavailable_error_message(error, rank))
 		return FALSE

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -273,7 +273,7 @@
 			if(isnum(client.player_age) && client.player_age <= 14) //Newbies can always be assistants
 				return JOB_AVAILABLE
 			for(var/datum/job/job_to_check in SSjob.occupations)
-				if(job_to_check && job_to_check.title != job.title && !is_banned_from(ckey, href_list[job_to_check.title])) //you have at least one job you are not banned from
+				if(job_to_check && job_to_check.title != job.title && !is_banned_from(ckey, job_to_check.title)) //you have at least one job you are not banned from
 					return JOB_UNAVAILABLE_SLOTFULL
 			for(var/datum/job/job_to_check in SSjob.occupations)
 				if(job_to_check && job_to_check.current_positions < job_to_check.total_positions && job_to_check.title != job.title)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -205,6 +205,11 @@ CHANGELING_SCALING_COEFF 6
 ## Set to 0 to disable scaling and use default numbers instead.
 SECURITY_SCALING_COEFF 8
 
+## Variables calculate how number of open assistant positions will scale to population.
+## Used as (Assistants = Population / Coeff)
+## Set to 0 to disable scaling and use default numbers instead.
+ASSISTANT_SCALING_COEFF 8
+
 ## The number of objectives traitors get.
 ## Not including escaping/hijacking.
 TRAITOR_OBJECTIVES_AMOUNT 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The PR adds the OPTION to set up assistants to scale with the population. 
Currently it does nothing since the spawn_positions gets set to -1 by config
Needs an headmin intervention to use this change properly
https://tgstation13.org/phpBB/viewtopic.php?f=33&t=28972
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Assistant flood has become a stale meme, scaling with population is good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
config: assistants have the option to scale with the population
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
