### PR TITLE
fixes metastation maint having a cyborg subtype mop instead of a normal one

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -76148,11 +76148,11 @@
 /turf/open/floor/iron,
 /area/construction/storage_wing)
 "wdk" = (
-/obj/item/mop/cyborg,
 /obj/structure/mopbucket,
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/mop,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "wdq" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #58535