### PR TITLE
Puts status displays on top of windows, instead of underneath it.

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -21,6 +21,7 @@
 	density = FALSE
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 10
+	layer = ABOVE_WINDOW_LAYER
 
 	maptext_height = 26
 	maptext_width = 32


### PR DESCRIPTION
## About The Pull Request
• Defines the layer of obj/machinery/status_display to 3.3 (ABOVE_WINDOW_LAYER). It needs to be above 3.2, which is the window layer. Previously, it inherited layer 2.9 from obj/machinery.
• Status displays on maps will now appear on top of windows instead of underneath them and underneath grilles.

## Why It's Good For The Game
Fixes an oversight. As mappers have placed these status displays on windows and it's been in the map for a thousand generations, I think it's more than fair to assume they should be on top of the windows and actually visible, not inside the window and hidden by the grille too.
## Before
![image](https://user-images.githubusercontent.com/53862927/115331080-29e0ef80-a18d-11eb-8ccd-c9d4e5509ba9.png)
## After
![image](https://user-images.githubusercontent.com/53862927/115331052-1b92d380-a18d-11eb-9da1-cdc014ef08f6.png)

## Changelog
:cl:
fix: Status displays now go on top of windows, instead of underneath it.
/:cl:
