### PR TITLE
You can now unbuckle others from a borg

### DIFF
--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -62,11 +62,11 @@
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /mob/living/silicon/attack_hand(mob/living/carbon/human/user, list/modifiers)
 	. = FALSE
-	if(has_buckled_mobs())
+	if(SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_HAND, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
+		. = TRUE
+	if(has_buckled_mobs() && !user.combat_mode)
 		user_unbuckle_mob(buckled_mobs[1], user)
 	else
-		if(SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_HAND, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
-			. = TRUE
 		if(user.combat_mode)
 			user.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
 			playsound(src.loc, 'sound/effects/bang.ogg', 10, TRUE)

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -62,19 +62,22 @@
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /mob/living/silicon/attack_hand(mob/living/carbon/human/user, list/modifiers)
 	. = FALSE
-	if(SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_HAND, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
-		. = TRUE
-	if(user.combat_mode)
-		user.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
-		playsound(src.loc, 'sound/effects/bang.ogg', 10, TRUE)
-		visible_message("<span class='danger'>[user] punches [src], but doesn't leave a dent!</span>", \
-						"<span class='warning'>[user] punches you, but doesn't leave a dent!</span>", null, COMBAT_MESSAGE_RANGE, user)
-		to_chat(user, "<span class='danger'>You punch [src], but don't leave a dent!</span>")
+	if(has_buckled_mobs())
+		user_unbuckle_mob(buckled_mobs[1], user)
 	else
-		visible_message("<span class='notice'>[user] pets [src].</span>", \
-						"<span class='notice'>[user] pets you.</span>", null, null, user)
-		to_chat(user, "<span class='notice'>You pet [src].</span>")
-		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT_RND, "pet_borg", /datum/mood_event/pet_borg)
+		if(SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_HAND, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
+			. = TRUE
+		if(user.combat_mode)
+			user.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
+			playsound(src.loc, 'sound/effects/bang.ogg', 10, TRUE)
+			visible_message("<span class='danger'>[user] punches [src], but doesn't leave a dent!</span>", \
+							"<span class='warning'>[user] punches you, but doesn't leave a dent!</span>", null, COMBAT_MESSAGE_RANGE, user)
+			to_chat(user, "<span class='danger'>You punch [src], but don't leave a dent!</span>")
+		else
+			visible_message("<span class='notice'>[user] pets [src].</span>", \
+							"<span class='notice'>[user] pets you.</span>", null, null, user)
+			to_chat(user, "<span class='notice'>You pet [src].</span>")
+			SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT_RND, "pet_borg", /datum/mood_event/pet_borg)
 
 
 /mob/living/silicon/attack_drone(mob/living/simple_animal/drone/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When trying to unbuckle someone from a cyborg you should actually unbuckle them, instead of just petting the borg.

Fixes https://github.com/tgstation/tgstation/issues/26310
AKA a four year old issue

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You should be able to unbuckle people from borgs.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can now unbuckle others from a borg.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
