### PR TITLE
Hacked AI Law Upload Module cost change

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1459,7 +1459,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "When used with an upload console, this module allows you to upload priority laws to an artificial intelligence. \
 			Be careful with wording, as artificial intelligences may look for loopholes to exploit."
 	item = /obj/item/ai_module/syndicate
-	cost = 9
+	cost = 4
 
 /datum/uplink_item/device_tools/hypnotic_flash
 	name = "Hypnotic Flash"


### PR DESCRIPTION
## About The Pull Request

Hacked AI Law Upload Module now costs 4 TC instead of 9

## Why It's Good For The Game

The Hacked AI Law Upload Module is almost never used unless heavily discounted because of it's major initial cost (more than an energy sword, only 2TC less than a power sink etc) and the fact that it's unusable without getting an AI Upload board, or access in the AI Upload, and by the time any traitor get this, they also generally have access to regular Law changes Modules who are almost as good (if not straight better in some cases) than the Hacked AI Law Upload Module.

This simple change aim at bringing this module back (mostly with stealing the Upload board from Storage), instead of having every traitor who wanna sub the AI just use the OneHuman Module.

## Changelog
:cl:
The Syndicate found a big stash of Hacked AI Law Upload Modules sitting in their inventory and, as a result, slashed it's price for their agents.
/:cl: