### PR TITLE
Fixes Cyborg Interaction With Cult Offer Rune

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -340,12 +340,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 		stone.invisibility = 0
 
 	if(sacrificial)
-		if(iscyborg(sacrificial))
-			playsound(sacrificial, 'sound/magic/disable_tech.ogg', 100, TRUE)
-			sacrificial.dust() //To prevent the MMI from remaining
-		else
-			playsound(sacrificial, 'sound/magic/disintegrate.ogg', 100, TRUE)
-			sacrificial.gib()
+		playsound(sacrificial, 'sound/magic/disintegrate.ogg', 100, TRUE)
+		sacrificial.gib()
 	return TRUE
 
 

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -316,7 +316,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 			"Wraith" = image(icon = 'icons/mob/cult.dmi', icon_state = "wraith"),
 			"Artificer" = image(icon = 'icons/mob/cult.dmi', icon_state = "artificer")
 			)
-		var/construct_class = show_radial_menu(first_invoker, src, constructs, require_near = TRUE, tooltips = TRUE)
+		var/construct_class = show_radial_menu(first_invoker, sacrificial, constructs, require_near = TRUE, tooltips = TRUE)
 		if(QDELETED(sacrificial))
 			return FALSE
 		switch(construct_class)

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -309,6 +309,29 @@ structure_check() searches for nearby cultist structures required for the invoca
 				to_chat(M, "<span class='cultlarge'>\"I accept this sacrifice.\"</span>")
 			else
 				to_chat(M, "<span class='cultlarge'>\"I accept this meager sacrifice.\"</span>")
+	
+	if(iscyborg(sacrificial))
+		var/static/list/constructs = list(
+			"Juggernaut" = image(icon = 'icons/mob/cult.dmi', icon_state = "juggernaut"),
+			"Wraith" = image(icon = 'icons/mob/cult.dmi', icon_state = "wraith"),
+			"Artificer" = image(icon = 'icons/mob/cult.dmi', icon_state = "artificer")
+			)
+		var/construct_class = show_radial_menu(first_invoker, src, constructs, require_near = TRUE, tooltips = TRUE)
+		if(QDELETED(sacrificial))
+			return FALSE
+		switch(construct_class)
+			if("Juggernaut")
+				makeNewConstruct(/mob/living/simple_animal/hostile/construct/juggernaut, sacrificial, first_invoker, FALSE, get_turf(src))
+			if("Wraith")
+				makeNewConstruct(/mob/living/simple_animal/hostile/construct/wraith, sacrificial, first_invoker, FALSE, get_turf(src))
+			if("Artificer")
+				makeNewConstruct(/mob/living/simple_animal/hostile/construct/artificer, sacrificial, first_invoker, FALSE, get_turf(src))
+			else
+				return FALSE
+		var/mob/living/silicon/robot/sacriborg = sacrificial
+		sacriborg.mmi = null
+		qdel(sacrificial)
+		return TRUE
 
 	var/obj/item/soulstone/stone = new /obj/item/soulstone(get_turf(src))
 	if(sacrificial.mind && !sacrificial.suiciding)


### PR DESCRIPTION
## About The Pull Request

Fixes #38239
Fixes #48015

This PR fixes cyborgs' interactions with Cult's offer rune.  Before this PR, the game would attempt to sacrifice the cyborg and put its mind into a soulstone by handing it over to a method that was incapable of doing so, thus creating an empty soulstone and permanently removing the cyborg from the round as a result.  Now, attempting to offer a cyborg on an offer rune provides the first activator with an option of any construct to turn the cyborg into, and turns them into that when chosen, similar to how twisted construct operates but without the wait time.

## Why It's Good For The Game

Fixes an extremely annoying issue where cyborgs would get round-removed because people would try to normally sacrifice them instead of always remembering to use Twisted Construct instead.  Now, the offer rune provides the same utility for cyborgs, allowing them to be properly converted instead of being round removed.  Twisted Construct is still useful on cyborgs however since it allows you to transform the borg by yourself while it is still alive as long as you can keep it stunned for the duration, or to just transform a dead cyborg that's far enough away from any offer rune on the spot instead of dragging it around.

## Changelog
:cl:
qol: Offering a cyborg on a cult rune now allows the cultist to transform the cyborg into a construct of their choosing.
fix: Offering a cyborg on a cult offer rune no longer creates an empty soulstone and round removes the cyborg.
/:cl: