### PR TITLE
Fixes painted directional window opacity bug

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -299,7 +299,7 @@
 /obj/structure/window/proc/on_painted(is_dark_color)
 	SIGNAL_HANDLER
 
-	if (is_dark_color)
+	if (is_dark_color && fulltile) //Opaque directional windows restrict vision even in directions they are not placed in, please don't do this
 		set_opacity(255)
 	else
 		set_opacity(initial(opacity))


### PR DESCRIPTION
## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/44489
Preserves the ability to paint directional windows, but they no longer block line of sight.

## Why It's Good For The Game
this is the current behavior that is bad and sucks
![image](https://user-images.githubusercontent.com/51932756/115456910-f5971e80-a1e0-11eb-9a4f-80d8001c9dc7.png)

this is the changed behavior, which doesn't encourage concealing instant death traps
![image](https://user-images.githubusercontent.com/51932756/115456954-03e53a80-a1e1-11eb-9487-df781b9eebbb.png)


## Changelog
:cl:
fix: Painted directional windows are no longer opaque.
/:cl: