### PR TITLE
Stunbatons no longer knockdown people

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -33,7 +33,6 @@
 
 	var/confusion_amt = 10
 	var/stamina_loss_amt = 60
-	var/apply_stun_delay = 2 SECONDS
 	var/stun_time = 5 SECONDS
 
 	var/convertible = TRUE //if it can be converted with a conversion kit
@@ -235,9 +234,6 @@
 	L.stuttering = max(8, L.stuttering)
 	L.apply_damage(stamina_loss_amt, STAMINA, BODY_ZONE_CHEST)
 
-	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
-	addtimer(CALLBACK(src, .proc/apply_stun_effect_end, L), apply_stun_delay)
-
 	if(user)
 		L.lastattacker = user.real_name
 		L.lastattackerckey = user.ckey
@@ -253,17 +249,6 @@
 	addtimer(TRAIT_CALLBACK_REMOVE(L, TRAIT_IWASBATONED, STATUS_EFFECT_TRAIT), attack_cooldown)
 
 	return 1
-
-/// After the initial stun period, we check to see if the target needs to have the stun applied.
-/obj/item/melee/baton/proc/apply_stun_effect_end(mob/living/target)
-	var/trait_check = HAS_TRAIT(target, TRAIT_STUNRESISTANCE) //var since we check it in out to_chat as well as determine stun duration
-	if(!target.IsKnockdown())
-		to_chat(target, "<span class='warning'>Your muscles seize, making you collapse[trait_check ? ", but your body quickly recovers..." : "!"]</span>")
-
-	if(trait_check)
-		target.Knockdown(stun_time * 0.1)
-	else
-		target.Knockdown(stun_time)
 
 /obj/item/melee/baton/emp_act(severity)
 	. = ..()

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -453,7 +453,6 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	attack_cooldown = 0 SECONDS
 	confusion_amt = 0
 	stamina_loss_amt = 0
-	apply_stun_delay = 0 SECONDS
 	stun_time = 14 SECONDS
 
 	preload_cell_type = /obj/item/stock_parts/cell/infinite //Any sufficiently advanced technology is indistinguishable from magic
@@ -544,9 +543,6 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 		if(BATON_PROBE)
 			ProbeAttack(L,user)
 	return
-
-/obj/item/melee/baton/abductor/apply_stun_effect_end(mob/living/target)
-	StunAttack(target)
 
 /obj/item/melee/baton/abductor/proc/StunAttack(mob/living/L)
 	L.Paralyze(stun_time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes knockdown effect from stunbatons and its children, they still deal 60 stamina + confusion though

## Why It's Good For The Game
After a long time playing both as security and antagonist, and getting opinions from other security mains and many other gamers we came to a decision, to remove knockdown from batons as it is very strong already, I hope this will make stuff that can block attacks and bolas more popular than they are already. Also done at request of Naloac
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: SparkezelPL
balance: removed knockdown from stunbatons, stunprods, teleprods and surprisingly abductor batons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
