### PR TITLE
Fixes the 2 windows in meta atmos

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -69722,6 +69722,7 @@
 "tMH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "tMR" = (
@@ -76922,6 +76923,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "wiZ" = (


### PR DESCRIPTION
somone fucked this up

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the missing windows in meta atmos
![image](https://user-images.githubusercontent.com/47158596/115568103-a4f8f180-a2c4-11eb-80cf-79b5d7741875.png)

## Why It's Good For The Game
somone with dementia forgot to fix these after they did a change

## Changelog
:cl:
fix: Fixes the 2 missing rwindows in metastation atmos
/:cl:


