### PR TITLE
Allows you to repair trophy cases (the ones found in the library)

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -301,7 +301,7 @@
 		return
 	if(user.combat_mode)
 		return ..()
-	if(W.tool_behaviour == TOOL_WELDER && !user.combat_mode && !broken)
+	if(W.tool_behaviour == TOOL_WELDER && !broken)
 		return ..()
 
 	if(user.is_holding_item_of_type(/obj/item/key/displaycase))

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -301,20 +301,8 @@
 		return
 	if(user.combat_mode)
 		return ..()
-
 	if(W.tool_behaviour == TOOL_WELDER && !user.combat_mode && !broken)
-		if(obj_integrity < max_integrity)
-			if(!W.tool_start_check(user, amount=5))
-				return
-
-			to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
-			if(W.use_tool(src, user, 40, amount=5, volume=50))
-				obj_integrity = max_integrity
-				update_appearance()
-				to_chat(user, "<span class='notice'>You repair [src].</span>")
-		else
-			to_chat(user, "<span class='warning'>[src] is already in good condition!</span>")
-		return
+		return ..()
 
 	if(user.is_holding_item_of_type(/obj/item/key/displaycase))
 		if(added_roundstart)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -302,6 +302,20 @@
 	if(user.combat_mode)
 		return ..()
 
+	if(W.tool_behaviour == TOOL_WELDER && !user.combat_mode && !broken)
+		if(obj_integrity < max_integrity)
+			if(!W.tool_start_check(user, amount=5))
+				return
+
+			to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
+			if(W.use_tool(src, user, 40, amount=5, volume=50))
+				obj_integrity = max_integrity
+				update_appearance()
+				to_chat(user, "<span class='notice'>You repair [src].</span>")
+		else
+			to_chat(user, "<span class='warning'>[src] is already in good condition!</span>")
+		return
+
 	if(user.is_holding_item_of_type(/obj/item/key/displaycase))
 		if(added_roundstart)
 			is_locked = !is_locked


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Apparently you haven't been able to repair these for the last four years.
Fixes https://github.com/tgstation/tgstation/issues/27926

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

All other display cases can be repaired, why shouldnt this one be able to.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can repair trophy cases with a welding tool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
