### PR TITLE
Remove baton knockdown

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -34,7 +34,7 @@
 	var/confusion_amt = 10
 	var/stamina_loss_amt = 60
 	var/apply_stun_delay = 0 SECONDS
-	var/stun_time = 0 SECONDS
+	var/stun_time = 5 SECONDS
 
 	var/convertible = TRUE //if it can be converted with a conversion kit
 
@@ -176,7 +176,7 @@
 		playsound(src, stun_sound, 75, TRUE, -1)
 		user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \
 							"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
-		user.Knockdown(5 SECONDS * 3) //should really be an equivalent to attack(user,user)
+		user.Knockdown(15 SECONDS) //should really be an equivalent to attack(user,user)
 		deductcharge(cell_hit_cost)
 		return TRUE
 	return FALSE
@@ -188,7 +188,6 @@
 	if(iscyborg(M))
 		..()
 		return
-
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/L = M
@@ -236,7 +235,6 @@
 	L.apply_damage(stamina_loss_amt, STAMINA, BODY_ZONE_CHEST)
 
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
-	addtimer(CALLBACK(src, .proc/apply_stun_effect_end, L), apply_stun_delay)
 
 	if(user)
 		L.lastattacker = user.real_name
@@ -253,15 +251,6 @@
 	addtimer(TRAIT_CALLBACK_REMOVE(L, TRAIT_IWASBATONED, STATUS_EFFECT_TRAIT), attack_cooldown)
 
 	return 1
-
-/// After the initial stun period, we check to see if the target needs to have the stun applied.
-/obj/item/melee/baton/proc/apply_stun_effect_end(mob/living/target)
-	var/trait_check = HAS_TRAIT(target, TRAIT_STUNRESISTANCE) //var since we check it in out to_chat as well as determine stun duration
-
-	if(trait_check)
-		target.Knockdown(stun_time * 0.1)
-	else
-		target.Knockdown(stun_time)
 
 /obj/item/melee/baton/emp_act(severity)
 	. = ..()
@@ -341,3 +330,4 @@
 
 /obj/item/melee/baton/boomerang/loaded //Same as above, comes with a cell.
 	preload_cell_type = /obj/item/stock_parts/cell/high
+	

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -33,8 +33,8 @@
 
 	var/confusion_amt = 10
 	var/stamina_loss_amt = 60
-	var/apply_stun_delay = 2 SECONDS
-	var/stun_time = 5 SECONDS
+	var/apply_stun_delay = 0 SECONDS
+	var/stun_time = 0 SECONDS
 
 	var/convertible = TRUE //if it can be converted with a conversion kit
 
@@ -176,7 +176,7 @@
 		playsound(src, stun_sound, 75, TRUE, -1)
 		user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \
 							"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
-		user.Knockdown(stun_time*3) //should really be an equivalent to attack(user,user)
+		user.Knockdown(5 SECONDS * 3) //should really be an equivalent to attack(user,user)
 		deductcharge(cell_hit_cost)
 		return TRUE
 	return FALSE
@@ -257,8 +257,6 @@
 /// After the initial stun period, we check to see if the target needs to have the stun applied.
 /obj/item/melee/baton/proc/apply_stun_effect_end(mob/living/target)
 	var/trait_check = HAS_TRAIT(target, TRAIT_STUNRESISTANCE) //var since we check it in out to_chat as well as determine stun duration
-	if(!target.IsKnockdown())
-		to_chat(target, "<span class='warning'>Your muscles seize, making you collapse[trait_check ? ", but your body quickly recovers..." : "!"]</span>")
 
 	if(trait_check)
 		target.Knockdown(stun_time * 0.1)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -176,7 +176,7 @@
 		playsound(src, stun_sound, 75, TRUE, -1)
 		user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \
 							"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
-		user.Knockdown(5 SECONDS * 3) //should really be an equivalent to attack(user,user)
+		user.Knockdown(15 SECONDS) //should really be an equivalent to attack(user,user)
 		deductcharge(cell_hit_cost)
 		return TRUE
 	return FALSE

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -330,4 +330,3 @@
 
 /obj/item/melee/baton/boomerang/loaded //Same as above, comes with a cell.
 	preload_cell_type = /obj/item/stock_parts/cell/high
-	

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -537,6 +537,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	switch (mode)
 		if(BATON_STUN)
 			..()
+			addtimer(CALLBACK(src, .proc/apply_stun_effect_end, L), apply_stun_delay)
 		if(BATON_SLEEP)
 			SleepAttack(L,user)
 		if(BATON_CUFF)
@@ -545,7 +546,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 			ProbeAttack(L,user)
 	return
 
-/obj/item/melee/baton/abductor/apply_stun_effect_end(mob/living/target)
+/obj/item/melee/baton/abductor/proc/apply_stun_effect_end(mob/living/target)
 	StunAttack(target)
 
 /obj/item/melee/baton/abductor/proc/StunAttack(mob/living/L)


### PR DESCRIPTION
## About The Pull Request

Removes the Knock down from sec batons, keeping the slow and confusion it gives. Leaving the detective baton and head of staff batons the same.

## Why It's Good For The Game

https://github.com/tgstation/tgstation/pull/45377 in this pr where the batons where reworked they didnt have the knockdown to begin with. it was added later on and effectively returns to the same combat that relies on hitting people as fast as possible, rushing antagonists with your baton to get the knockdown which leads to another hit which depletes all the stamina of the target.

This should start sec using their many other tools in conjunction to the baton while leaving the heads of staff the same.

## Changelog
:cl:
balance: Removes the knockdown from stunbatons
/:cl: