### PR TITLE
Full Auto Update: no crit firing, no spamclicking, more autofire, more balance

### DIFF
--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -61,11 +61,12 @@
 	if(autofire_stat & (AUTOFIRE_STAT_ALERT|AUTOFIRE_STAT_FIRING))
 		return
 	autofire_stat = AUTOFIRE_STAT_ALERT
-	clicker = usercli
-	shooter = clicker.mob
-	RegisterSignal(clicker, COMSIG_CLIENT_MOUSEDOWN, .proc/on_mouse_down)
-	RegisterSignal(shooter, COMSIG_MOB_LOGOUT, .proc/autofire_off)
+	if(!QDELETED(usercli))
+		clicker = usercli
+		shooter = clicker.mob
+		RegisterSignal(clicker, COMSIG_CLIENT_MOUSEDOWN, .proc/on_mouse_down)
 	if(!QDELETED(shooter))
+		RegisterSignal(shooter, COMSIG_MOB_LOGOUT, .proc/autofire_off)
 		UnregisterSignal(shooter, COMSIG_MOB_LOGIN)
 	parent.RegisterSignal(src, COMSIG_AUTOFIRE_ONMOUSEDOWN, /obj/item/gun/.proc/autofire_bypass_check)
 	parent.RegisterSignal(parent, COMSIG_AUTOFIRE_SHOT, /obj/item/gun/.proc/do_autofire)
@@ -73,7 +74,7 @@
 
 /datum/component/automatic_fire/proc/autofire_off(datum/source)
 	SIGNAL_HANDLER
-	if(autofire_stat & (AUTOFIRE_STAT_IDLE))
+	if(autofire_stat & AUTOFIRE_STAT_IDLE)
 		return
 	if(autofire_stat & AUTOFIRE_STAT_FIRING)
 		stop_autofiring()
@@ -84,8 +85,8 @@
 		UnregisterSignal(clicker, list(COMSIG_CLIENT_MOUSEDOWN, COMSIG_CLIENT_MOUSEUP, COMSIG_CLIENT_MOUSEDRAG))
 	mouse_status = AUTOFIRE_MOUSEUP //In regards to the component there's no click anymore to care about.
 	clicker = null
-	RegisterSignal(shooter, COMSIG_MOB_LOGIN, .proc/on_client_login)
 	if(!QDELETED(shooter))
+		RegisterSignal(shooter, COMSIG_MOB_LOGIN, .proc/on_client_login)
 		UnregisterSignal(shooter, COMSIG_MOB_LOGOUT)
 	UnregisterSignal(parent, list(COMSIG_PARENT_PREQDELETED, COMSIG_ITEM_DROPPED))
 	shooter = null

--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -258,7 +258,7 @@
 
 /obj/item/gun/proc/do_autofire(datum/source, atom/target, mob/living/shooter, params)
 	SIGNAL_HANDLER
-	if(semicd || shooter.stat || !can_shoot())
+	if(semicd || shooter.stat)
 		return NONE
 	if(!can_shoot())
 		shoot_with_empty_chamber(shooter)

--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -44,20 +44,15 @@
 	if(autofire_stat == AUTOFIRE_STAT_FIRING)
 		stop_autofiring() //Let's stop shooting to avoid issues.
 		return
-
-	RegisterSignal(parent, list(COMSIG_PARENT_PREQDELETED, COMSIG_ITEM_DROPPED), .proc/autofire_off)
-
 	if(iscarbon(user))
-		var/mob/living/carbon/shooter = user
-		if(shooter.is_holding(parent))
-			autofire_on(shooter.client)
-		else
-			autofire_off()
-
+		var/mob/living/carbon/arizona_ranger = user
+		if(arizona_ranger.is_holding(parent))
+			autofire_on(arizona_ranger.client)
 
 // There is a gun and there is a user wielding it. The component now waits for the mouse click.
 /datum/component/automatic_fire/proc/autofire_on(client/usercli)
 	SIGNAL_HANDLER
+
 	if(autofire_stat != AUTOFIRE_STAT_IDLE)
 		return
 	autofire_stat = AUTOFIRE_STAT_ALERT
@@ -68,6 +63,7 @@
 	if(!QDELETED(shooter))
 		RegisterSignal(shooter, COMSIG_MOB_LOGOUT, .proc/autofire_off)
 		UnregisterSignal(shooter, COMSIG_MOB_LOGIN)
+	RegisterSignal(parent, list(COMSIG_PARENT_PREQDELETED, COMSIG_ITEM_DROPPED), .proc/autofire_off)
 	parent.RegisterSignal(src, COMSIG_AUTOFIRE_ONMOUSEDOWN, /obj/item/gun/.proc/autofire_bypass_check)
 	parent.RegisterSignal(parent, COMSIG_AUTOFIRE_SHOT, /obj/item/gun/.proc/do_autofire)
 

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -77,7 +77,7 @@
 
 /obj/item/ammo_casing/energy/tesla_cannon
 	fire_sound = 'sound/magic/lightningshock.ogg'
-	e_cost = 50
+	e_cost = 30
 	select_name = "shock"
 	projectile_type = /obj/projectile/energy/tesla_cannon
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -61,7 +61,7 @@
 	bolt_type = BOLT_TYPE_LOCKING
 	show_bolt_icon = FALSE
 
-/obj/item/gun/ballistic/automatic/proto/ComponentInitialize()
+/obj/item/gun/ballistic/automatic/proto/Initialize()
 	. = ..()
 	AddComponent(/datum/component/automatic_fire, 0.2 SECONDS)
 
@@ -115,7 +115,7 @@
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
 
-/obj/item/gun/ballistic/automatic/wt550/ComponentInitialize()
+/obj/item/gun/ballistic/automatic/wt550/Initialize()
 	. = ..()
 	AddComponent(/datum/component/automatic_fire, 0.3 SECONDS)
 
@@ -230,7 +230,7 @@
 	empty_indicator = TRUE
 	show_bolt_icon = FALSE
 
-/obj/item/gun/ballistic/automatic/tommygun/ComponentInitialize()
+/obj/item/gun/ballistic/automatic/tommygun/Initialize()
 	. = ..()
 	AddComponent(/datum/component/automatic_fire, 0.1 SECONDS)
 
@@ -276,7 +276,7 @@
 /obj/item/gun/ballistic/automatic/l6_saw/unrestricted
 	pin = /obj/item/firing_pin
 
-/obj/item/gun/ballistic/automatic/l6_saw/ComponentInitialize()
+/obj/item/gun/ballistic/automatic/l6_saw/Initialize()
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 	AddComponent(/datum/component/automatic_fire, 0.2 SECONDS)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -13,21 +13,6 @@
 	var/select = 1 ///fire selector position. 1 = semi, 2 = burst. anything past that can vary between guns.
 	var/selector_switch_icon = FALSE ///if it has an icon for a selector switch indicating current firemode.
 
-/obj/item/gun/ballistic/automatic/proto
-	name = "\improper Nanotrasen Saber SMG"
-	desc = "A prototype three-round burst 9mm submachine gun, designated 'SABR'. Has a threaded barrel for suppressors."
-	icon_state = "saber"
-	selector_switch_icon = TRUE
-	mag_display = TRUE
-	empty_indicator = TRUE
-	mag_type = /obj/item/ammo_box/magazine/smgm9mm
-	pin = null
-	bolt_type = BOLT_TYPE_LOCKING
-	show_bolt_icon = FALSE
-
-/obj/item/gun/ballistic/automatic/proto/unrestricted
-	pin = /obj/item/firing_pin
-
 /obj/item/gun/ballistic/automatic/update_overlays()
 	. = ..()
 	if(!selector_switch_icon)
@@ -62,6 +47,27 @@
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
+
+/obj/item/gun/ballistic/automatic/proto
+	name = "\improper Nanotrasen Saber SMG"
+	desc = "A prototype full-auto 9mm submachine gun, designated 'SABR'. Has a threaded barrel for suppressors."
+	icon_state = "saber"
+	burst_size = 1
+	actions_types = list()
+	mag_display = TRUE
+	empty_indicator = TRUE
+	mag_type = /obj/item/ammo_box/magazine/smgm9mm
+	pin = null
+	bolt_type = BOLT_TYPE_LOCKING
+	show_bolt_icon = FALSE
+
+/obj/item/gun/ballistic/automatic/proto/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/automatic_fire, 0.2 SECONDS)
+
+/obj/item/gun/ballistic/automatic/proto/unrestricted
+	pin = /obj/item/firing_pin
+
 
 /obj/item/gun/ballistic/automatic/c20r
 	name = "\improper C-20r SMG"
@@ -101,7 +107,7 @@
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_delay = 2
 	can_suppress = FALSE
-	burst_size = 0
+	burst_size = 1
 	actions_types = list()
 	can_bayonet = TRUE
 	knife_x_offset = 25
@@ -109,6 +115,10 @@
 	mag_display = TRUE
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
+
+/obj/item/gun/ballistic/automatic/wt550/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/automatic_fire, 0.3 SECONDS)
 
 /obj/item/gun/ballistic/automatic/plastikov
 	name = "\improper PP-95 SMG"
@@ -214,11 +224,16 @@
 	slot_flags = 0
 	mag_type = /obj/item/ammo_box/magazine/tommygunm45
 	can_suppress = FALSE
-	burst_size = 4
+	burst_size = 1
+	actions_types = list()
 	fire_delay = 1
 	bolt_type = BOLT_TYPE_OPEN
 	empty_indicator = TRUE
 	show_bolt_icon = FALSE
+
+/obj/item/gun/ballistic/automatic/tommygun/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/automatic_fire, 0.1 SECONDS)
 
 /obj/item/gun/ballistic/automatic/ar
 	name = "\improper NT-ARG 'Boarder'"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -68,7 +68,6 @@
 /obj/item/gun/ballistic/automatic/proto/unrestricted
 	pin = /obj/item/firing_pin
 
-
 /obj/item/gun/ballistic/automatic/c20r
 	name = "\improper C-20r SMG"
 	desc = "A bullpup three-round burst .45 SMG, designated 'C-20r'. Has a 'Scarborough Arms - Per falcis, per pravitas' buttstamp."

--- a/code/modules/projectiles/guns/energy/laser_gatling.dm
+++ b/code/modules/projectiles/guns/energy/laser_gatling.dm
@@ -111,17 +111,12 @@
 	var/obj/item/minigunpack/ammo_pack
 
 /obj/item/gun/energy/minigun/Initialize()
-	if(istype(loc, /obj/item/minigunpack)) //We should spawn inside an ammo pack so let's use that one.
-		ammo_pack = loc
-	else
+	if(!istype(loc, /obj/item/minigunpack)) //We should spawn inside an ammo pack so let's use that one.
 		return INITIALIZE_HINT_QDEL //No pack, no gun
-
-	return ..()
-
-/obj/item/gun/energy/minigun/ComponentInitialize()
-	. = ..()
+	ammo_pack = loc
 	AddElement(/datum/element/update_icon_blocker)
 	AddComponent(/datum/component/automatic_fire, 0.2 SECONDS)
+	return ..()
 
 /obj/item/gun/energy/minigun/attack_self(mob/living/user)
 	return

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -300,6 +300,7 @@
 /obj/item/gun/energy/printer/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/update_icon_blocker)
+	AddComponent(/datum/component/automatic_fire, 0.3 SECONDS)
 
 /obj/item/gun/energy/printer/emp_act()
 	return
@@ -387,7 +388,7 @@
 	inhand_icon_state = "tesla"
 	desc = "A gun that shoots balls of \"tesla\", whatever that is."
 	ammo_type = list(/obj/item/ammo_casing/energy/tesla_cannon)
-	shaded_charge = 1
+	shaded_charge = TRUE
 	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/energy/tesla_cannon/ComponentInitialize()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -391,6 +391,6 @@
 	shaded_charge = TRUE
 	weapon_weight = WEAPON_HEAVY
 
-/obj/item/gun/energy/tesla_cannon/ComponentInitialize()
+/obj/item/gun/energy/tesla_cannon/Initialize()
 	. = ..()
 	AddComponent(/datum/component/automatic_fire, 0.1 SECONDS)

--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -25,7 +25,7 @@
 
 /obj/projectile/bullet/mm712x82
 	name = "7.12x82mm bullet"
-	damage = 40
+	damage = 30
 	armour_penetration = 5
 	wound_bonus = -50
 	wound_falloff_tile = 0
@@ -45,7 +45,7 @@
 
 /obj/projectile/bullet/incendiary/mm712x82
 	name = "7.12x82mm incendiary bullet"
-	damage = 20
+	damage = 15
 	fire_stacks = 3
 
 /obj/projectile/bullet/mm712x82/match
@@ -57,7 +57,7 @@
 
 /obj/projectile/bullet/mm712x82/bouncy
 	name = "7.12x82mm rubber bullet"
-	damage = 25
+	damage = 20
 	ricochets_max = 40
 	ricochet_chance = 500 // will bounce off anything and everything, whether they like it or not
 	ricochet_auto_aim_range = 4

--- a/code/modules/projectiles/projectile/energy/tesla.dm
+++ b/code/modules/projectiles/projectile/energy/tesla.dm
@@ -36,4 +36,4 @@
 	. = ..()
 	if(isliving(target))
 		var/mob/living/victim = target
-		victim.electrocute_act(shock_damage, src, siemens_coeff = 1, flags = SHOCK_NOSTUN)
+		victim.electrocute_act(shock_damage, src, siemens_coeff = 1, flags = SHOCK_NOSTUN|SHOCK_TESLA)

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -93,8 +93,8 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/stunrevolver
-	name = "Tesla Revolver Part Kit"
-	desc = "The kit for a high-tech revolver that fires internal, reusable shock cartridges in a revolving cylinder. The cartridges can be recharged using conventional rechargers."
+	name = "Tesla Cannon Part Kit"
+	desc = "The kit for a high-tech cannon that fires internal, reusable bolt cartridges in a revolving cylinder. The cartridges can be recharged using conventional rechargers."
 	id = "stunrevolver"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 10000, /datum/material/glass = 10000, /datum/material/silver = 10000)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
You can no longer fire full-auto while in crit (Fixes #57963)
You can no longer spamclick to fire infinitely fast
Adds full-auto to saber smg (0.2 seconds), borg l6 (0.3 seconds), tommy gun (0.1 seconds), security autorifle (0.3 seconds)
tesla cannon projectiles now cost less to shoot and are tesla level zaps so they should now work against swarmers for example, and a full mag will actually crit a person now that they cost less
l6 projectiles other than hollow point now do less damage

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
adds some really needed fixes and balance for fullauto

## Changelog
:cl:
balance: adds fullauto to saber smg's, borg l6's, tommy guns and security autorifles
balance: tesla cannon sucks less
balance: l6 bullets now do less damage
fix: fixes full auto letting you fire in crit or spamclick
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
