### PR TITLE
Dummies equipping outfits no longer call equipped

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -489,6 +489,16 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	return
 
 /**
+ * To be overwritten to only perform visual tasks;
+ * this is directly called instead of equipped on visual-only features like human dummies equipping outfits.
+ *
+ * This separation exists to prevent things like the monkey sentience helmet from
+ * polling ghosts while it's just being equipped as a visual preview for a dummy.
+ */
+/obj/item/proc/visual_equipped(mob/user, initial = FALSE)
+	return
+
+/**
  * Called after an item is placed in an equipment slot.
  *
  * Note that hands count as slots.
@@ -500,6 +510,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
  */
 /obj/item/proc/equipped(mob/user, slot, initial = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
+	visual_equipped(user, initial)
 	SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED, user, slot)
 	for(var/X in actions)
 		var/datum/action/A = X

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -495,7 +495,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
  * This separation exists to prevent things like the monkey sentience helmet from
  * polling ghosts while it's just being equipped as a visual preview for a dummy.
  */
-/obj/item/proc/visual_equipped(mob/user, initial = FALSE)
+/obj/item/proc/visual_equipped(mob/user, slot, initial = FALSE)
 	return
 
 /**
@@ -510,7 +510,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
  */
 /obj/item/proc/equipped(mob/user, slot, initial = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
-	visual_equipped(user, initial)
+	visual_equipped(user, slot, initial)
 	SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED, user, slot)
 	for(var/X in actions)
 		var/datum/action/A = X

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -490,7 +490,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 
 /**
  * To be overwritten to only perform visual tasks;
- * this is directly called instead of equipped on visual-only features like human dummies equipping outfits.
+ * this is directly called instead of `equipped` on visual-only features like human dummies equipping outfits.
  *
  * This separation exists to prevent things like the monkey sentience helmet from
  * polling ghosts while it's just being equipped as a visual preview for a dummy.

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -339,7 +339,7 @@
 	inhand_icon_state = "blindfoldwhite"
 	var/colored_before = FALSE
 
-/obj/item/clothing/glasses/blindfold/white/equipped(mob/living/carbon/human/user, slot)
+/obj/item/clothing/glasses/blindfold/white/visual_equipped(mob/living/carbon/human/user, slot)
 	if(ishuman(user) && slot == ITEM_SLOT_EYES)
 		update_icon(ALL, user)
 		user.update_inv_glasses() //Color might have been changed by update_icon.

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -418,8 +418,6 @@
 	. = ..()
 	if(slot != ITEM_SLOT_HEAD)
 		return
-	if(istype(user, /mob/living/carbon/human/dummy)) //Prevents ghosts from being polled when the helmet is put on a dummy.
-		return
 	if(!ismonkey(user) || user.ckey)
 		var/mob/living/something = user
 		to_chat(something, "<span class='boldnotice'>You feel a stabbing pain in the back of your head for a moment.</span>")

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -203,7 +203,7 @@
 
 	dog_fashion = /datum/dog_fashion/head/cardborg
 
-/obj/item/clothing/head/cardborg/visual_equipped(mob/living/user, slot)
+/obj/item/clothing/head/cardborg/equipped(mob/living/user, slot)
 	..()
 	if(ishuman(user) && slot == ITEM_SLOT_HEAD)
 		var/mob/living/carbon/human/H = user

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -165,7 +165,7 @@
 
 	dog_fashion = /datum/dog_fashion/head/kitty
 
-/obj/item/clothing/head/kitty/equipped(mob/living/carbon/human/user, slot)
+/obj/item/clothing/head/kitty/visual_equipped(mob/living/carbon/human/user, slot)
 	if(ishuman(user) && slot == ITEM_SLOT_HEAD)
 		update_icon(ALL, user)
 		user.update_inv_head() //Color might have been changed by update_appearance.
@@ -203,7 +203,7 @@
 
 	dog_fashion = /datum/dog_fashion/head/cardborg
 
-/obj/item/clothing/head/cardborg/equipped(mob/living/user, slot)
+/obj/item/clothing/head/cardborg/visual_equipped(mob/living/user, slot)
 	..()
 	if(ishuman(user) && slot == ITEM_SLOT_HEAD)
 		var/mob/living/carbon/human/H = user
@@ -294,7 +294,7 @@
 	hairstyle = pick(GLOB.hairstyles_list - "Bald")
 	. = ..()
 
-/obj/item/clothing/head/wig/natural/equipped(mob/living/carbon/human/user, slot)
+/obj/item/clothing/head/wig/natural/visual_equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(ishuman(user) && slot == ITEM_SLOT_HEAD)
 		if (color != "#[user.hair_color]") // only update if necessary

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -61,13 +61,16 @@
 	else if(tied == SHOES_KNOTTED)
 		. += "The shoelaces are all knotted together."
 
-/obj/item/clothing/shoes/equipped(mob/user, slot)
-	. = ..()
+/obj/item/clothing/shoes/visual_equipped(mob/user, slot)
+	..()
 	if(offset && (slot_flags & slot))
 		user.pixel_y += offset
 		worn_y_dimension -= (offset * 2)
 		user.update_inv_shoes()
 		equipped_before_drop = TRUE
+
+/obj/item/clothing/shoes/equipped(mob/user, slot)
+	. = ..()
 	if(can_be_tied && tied == SHOES_UNTIED)
 		our_alert = user.throw_alert("shoealert", /atom/movable/screen/alert/shoes/untied)
 		RegisterSignal(src, COMSIG_SHOES_STEP_ACTION, .proc/check_trip, override=TRUE)

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -189,7 +189,7 @@
 	flags_inv = HIDEJUMPSUIT
 	dog_fashion = /datum/dog_fashion/back
 
-/obj/item/clothing/suit/cardborg/equipped(mob/living/user, slot)
+/obj/item/clothing/suit/cardborg/visual_equipped(mob/living/user, slot)
 	..()
 	if(slot == ITEM_SLOT_OCLOTHING)
 		disguise(user)

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -189,7 +189,7 @@
 	flags_inv = HIDEJUMPSUIT
 	dog_fashion = /datum/dog_fashion/back
 
-/obj/item/clothing/suit/cardborg/visual_equipped(mob/living/user, slot)
+/obj/item/clothing/suit/cardborg/equipped(mob/living/user, slot)
 	..()
 	if(slot == ITEM_SLOT_OCLOTHING)
 		disguise(user)

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -225,12 +225,12 @@
 /obj/item/clothing/suit/armor/reactive/tesla/dropped(mob/user)
 	..()
 	if(istype(user))
-		ADD_TRAIT(user, TRAIT_TESLA_SHOCKIMMUNE, "reactive_tesla_armor")
+		REMOVE_TRAIT(user, TRAIT_TESLA_SHOCKIMMUNE, "reactive_tesla_armor")
 
 /obj/item/clothing/suit/armor/reactive/tesla/equipped(mob/user, slot)
 	..()
 	if(slot_flags & slot) //Was equipped to a valid slot for this item?
-		REMOVE_TRAIT(user, TRAIT_TESLA_SHOCKIMMUNE, "reactive_tesla_armor")
+		ADD_TRAIT(user, TRAIT_TESLA_SHOCKIMMUNE, "reactive_tesla_armor")
 
 /obj/item/clothing/suit/armor/reactive/tesla/cooldown_activation(mob/living/carbon/human/owner)
 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -70,7 +70,7 @@
 			var/mob/M = loc
 			to_chat(M,"<span class='warning'>The sensors on the [src] change rapidly!</span>")
 
-/obj/item/clothing/under/equipped(mob/user, slot)
+/obj/item/clothing/under/visual_equipped(mob/user, slot)
 	..()
 	if(adjusted)
 		adjusted = NORMAL_STYLE
@@ -84,16 +84,18 @@
 			adjusted = DIGITIGRADE_STYLE
 		H.update_inv_w_uniform()
 
-	if(slot == ITEM_SLOT_ICLOTHING && freshly_laundered)
-		freshly_laundered = FALSE
-		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "fresh_laundry", /datum/mood_event/fresh_laundry)
-
 	if(attached_accessory && slot != ITEM_SLOT_HANDS && ishuman(user))
 		var/mob/living/carbon/human/H = user
 		attached_accessory.on_uniform_equip(src, user)
 		H.fan_hud_set_fandom()
 		if(attached_accessory.above_suit)
 			H.update_inv_wear_suit()
+
+/obj/item/clothing/under/equipped(mob/user, slot)
+	..()
+	if(slot == ITEM_SLOT_ICLOTHING && freshly_laundered)
+		freshly_laundered = FALSE
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "fresh_laundry", /datum/mood_event/fresh_laundry)
 
 /obj/item/clothing/under/dropped(mob/user)
 	if(attached_accessory)

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -17,8 +17,8 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 /mob/living/carbon/human/dummy/attach_rot(mapload)
 	return
 
-/mob/living/carbon/human/dummy/has_equipped(obj/item/I, slot, initial = FALSE)
-	return I.visual_equipped(src, slot, initial)
+/mob/living/carbon/human/dummy/has_equipped(obj/item/item, slot, initial = FALSE)
+	return item.visual_equipped(src, slot, initial)
 
 /mob/living/carbon/human/dummy/proc/wipe_state()
 	delete_equipment()

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -17,6 +17,9 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 /mob/living/carbon/human/dummy/attach_rot(mapload)
 	return
 
+/mob/living/carbon/human/dummy/has_equipped(obj/item/I, slot, initial = FALSE)
+	return I.visual_equipped(src, slot, initial)
+
 /mob/living/carbon/human/dummy/proc/wipe_state()
 	delete_equipment()
 	cut_overlays(TRUE)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -168,7 +168,7 @@
 
 	return not_handled //For future deeper overrides
 
-/mob/living/carbon/human/proc/has_equipped(obj/item/I, slot, initial = FALSE)
+/mob/living/carbon/proc/has_equipped(obj/item/I, slot, initial = FALSE)
 	return I.equipped(src, slot, initial)
 
 /mob/living/carbon/human/dummy/has_equipped(obj/item/I, slot, initial = FALSE)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -160,13 +160,19 @@
 
 	//Item is handled and in slot, valid to call callback, for this proc should always be true
 	if(!not_handled)
-		I.equipped(src, slot, initial)
+		has_equipped(I, slot, initial)
 
 		// Send a signal for when we equip an item that used to cover our feet/shoes. Used for bloody feet
 		if((I.body_parts_covered & FEET) || (I.flags_inv | I.transparent_protection) & HIDESHOES)
 			SEND_SIGNAL(src, COMSIG_CARBON_EQUIP_SHOECOVER, I, slot, initial, redraw_mob)
 
 	return not_handled //For future deeper overrides
+
+/mob/living/carbon/human/proc/has_equipped(obj/item/I, slot, initial = FALSE)
+	return I.equipped(src, slot, initial)
+
+/mob/living/carbon/human/dummy/has_equipped(obj/item/I, slot, initial = FALSE)
+	return I.visual_equipped(src, slot, initial)
 
 /mob/living/carbon/human/equipped_speed_mods()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -168,12 +168,6 @@
 
 	return not_handled //For future deeper overrides
 
-/mob/living/carbon/proc/has_equipped(obj/item/I, slot, initial = FALSE)
-	return I.equipped(src, slot, initial)
-
-/mob/living/carbon/human/dummy/has_equipped(obj/item/I, slot, initial = FALSE)
-	return I.visual_equipped(src, slot, initial)
-
 /mob/living/carbon/human/equipped_speed_mods()
 	. = ..()
 	for(var/sloties in get_all_slots() - list(l_store, r_store, s_store))

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -94,8 +94,9 @@
 
 	return not_handled
 
-/mob/living/carbon/proc/has_equipped(obj/item/I, slot, initial = FALSE)
-	return I.equipped(src, slot, initial)
+/// This proc is called after an item has been successfully handled and equipped to a slot.
+/mob/living/carbon/proc/has_equipped(obj/item/item, slot, initial = FALSE)
+	return item.equipped(src, slot, initial)
 
 /mob/living/carbon/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, silent = FALSE)
 	. = ..() //Sets the default return value to what the parent returns.

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -90,7 +90,7 @@
 	//We cannot call it for items that have not been handled as they are not yet correctly
 	//in a slot (handled further down inheritance chain, probably living/carbon/human/equip_to_slot
 	if(!not_handled)
-		I.equipped(src, slot)
+		has_equipped(I, slot, initial)
 
 	return not_handled
 

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -94,6 +94,9 @@
 
 	return not_handled
 
+/mob/living/carbon/proc/has_equipped(obj/item/I, slot, initial = FALSE)
+	return I.equipped(src, slot, initial)
+
 /mob/living/carbon/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, silent = FALSE)
 	. = ..() //Sets the default return value to what the parent returns.
 	if(!. || !I) //We don't want to set anything to null if the parent returned 0.

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -21,7 +21,7 @@
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
 
-/obj/item/zombie_hand/equipped(mob/user, slot)
+/obj/item/zombie_hand/visual_equipped(mob/user, slot)
 	. = ..()
 	//these are intentionally inverted
 	var/i = user.get_held_index_of_item(src)


### PR DESCRIPTION
## About The Pull Request

This is the cleanest way I found to do this.

- There is a new proc, `obj/item/visual_equipped`: It is used to perform visual tasks when equipping an item (like changing its color depending on who wears it). See the comment in items.dm for a more complete explanation.
- `carbon/equip_to_slot` now calls another new proc, `carbon/has_equipped` instead of directly calling `obj/item/equipped`. Dummies overwrite this proc to directly call `visual_equipped` and skip `equipped`.
- I went through all implementations of `obj/item/equipped` and moved visual tasks to `visual_equipped`, though I was half asleep when I was doing that and may have missed something.
- I also found a funny bug with the reactive tesla armor and thought I'd fix it while I was at it.

## Why It's Good For The Game

closes #57865 
Also patches an exploit no one knew about.

## Changelog
:cl: Trigg
fix: The reactive tesla armor prototype has been given a remote firmware update. Nanotrasen denies any claims that given prototype was able to give anyone permanent shock immunity after simply being held and dropped.
/:cl:
