### PR TITLE
Fixes canister labeling

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -726,22 +726,26 @@
 	SEND_SIGNAL(src, COMSIG_ATOM_UPDATE_OVERLAYS, .)
 
 /// Checks if the colors given are different and if so causes a greyscale icon update
-/atom/proc/set_greyscale_colors(list/colors)
+/// The colors argument can be either a list or the full color string
+/atom/proc/set_greyscale_colors(list/colors, update=TRUE)
 	SHOULD_CALL_PARENT(TRUE)
-	var/new_colors = colors.Join("")
-	if(greyscale_colors == new_colors)
+	if(istype(colors))
+		colors = colors.Join("")
+	if(greyscale_colors == colors)
 		return
-	greyscale_colors = new_colors
+	greyscale_colors = colors
 	if(!greyscale_config)
 		return
-	update_greyscale()
+	if(update)
+		update_greyscale()
 
 /// Checks if the greyscale config given is different and if so causes a greyscale icon update
-/atom/proc/set_greyscale_config(new_config)
+/atom/proc/set_greyscale_config(new_config, update=TRUE)
 	if(greyscale_config == new_config)
 		return
 	greyscale_config = new_config
-	update_greyscale()
+	if(update)
+		update_greyscale()
 
 /// Checks if this atom uses the GAS system and if so updates the icon
 /atom/proc/update_greyscale()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -610,6 +610,8 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 					desc = initial(replacement.desc)
 					icon_state = initial(replacement.icon_state)
 					base_icon_state = icon_state
+					set_greyscale_config(initial(replacement.greyscale_config), FALSE)
+					set_greyscale_colors(initial(replacement.greyscale_colors))
 		if("restricted")
 			restricted = !restricted
 			if(restricted)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -610,7 +610,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 					desc = initial(replacement.desc)
 					icon_state = initial(replacement.icon_state)
 					base_icon_state = icon_state
-					set_greyscale_config(initial(replacement.greyscale_config), FALSE)
+					set_greyscale_config(initial(replacement.greyscale_config), update=FALSE)
 					set_greyscale_colors(initial(replacement.greyscale_colors))
 		if("restricted")
 			restricted = !restricted


### PR DESCRIPTION
As it is in title, so it is in description.

fixes #58517

## Changelog
:cl:
fix: Canisters can be relabeled again
/:cl: