### PR TITLE
Heretic Target Selection Dialog Tells you Which Possible Targets are on the Same Team as You

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -283,29 +283,21 @@
 			var/datum/objective/A = new
 			A.owner = user.mind
 			var/list/datum/team/teams = list()
-			var/list/datum/mind/deprioritized = list()
 			for(var/datum/antagonist/antag in user.mind.antag_datums)
 				var/datum/team/team = antag.get_team()
 				if(team)
 					teams |= team
-					deprioritized |= team.members
 			var/list/targets = list()
-			var/i = 0
-			while(i < 4)
-				var/datum/mind/targeted =  A.find_target(blacklist = deprioritized)//easy way, i dont feel like copy pasting that entire block of code
-				if(!targeted)
-					if(deprioritized.len)
-						deprioritized = list()
-						continue
-					else
-						break
+			for(var/i in 0 to 3)
+				var/datum/mind/targeted =  A.find_target()//easy way, i dont feel like copy pasting that entire block of code
 				var/is_teammate = FALSE
 				for(var/datum/team/team in teams)
 					if(targeted in team.members)
 						is_teammate = TRUE
 						break
+				if(!targeted)
+					break
 				targets["[targeted.current.real_name] the [targeted.assigned_role][is_teammate ? " (ally)" : ""]"] = targeted.current
-				i++
 			LH.target = targets[input(user,"Choose your next target","Target") in targets]
 			qdel(A)
 			if(LH.target)

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -282,12 +282,22 @@
 		if(!LH.target)
 			var/datum/objective/A = new
 			A.owner = user.mind
+			var/list/datum/team/teams = list()
+			for(var/datum/antagonist/antag in user.mind.antag_datums)
+				var/datum/team/T = antag.get_team()
+				if(T)
+					teams |= T
 			var/list/targets = list()
 			for(var/i in 0 to 3)
 				var/datum/mind/targeted =  A.find_target()//easy way, i dont feel like copy pasting that entire block of code
+				var/is_teammate = FALSE
+				for(var/datum/team/T in teams)
+					if(targeted in T.members)
+						is_teammate = TRUE
+						break
 				if(!targeted)
 					break
-				targets["[targeted.current.real_name] the [targeted.assigned_role]"] = targeted.current
+				targets["[targeted.current.real_name] the [targeted.assigned_role][is_teammate ? " (ally)" : ""]"] = targeted.current
 			LH.target = targets[input(user,"Choose your next target","Target") in targets]
 			qdel(A)
 			if(LH.target)

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -284,15 +284,15 @@
 			A.owner = user.mind
 			var/list/datum/team/teams = list()
 			for(var/datum/antagonist/antag in user.mind.antag_datums)
-				var/datum/team/T = antag.get_team()
-				if(T)
-					teams |= T
+				var/datum/team/team = antag.get_team()
+				if(team)
+					teams |= team
 			var/list/targets = list()
 			for(var/i in 0 to 3)
 				var/datum/mind/targeted =  A.find_target()//easy way, i dont feel like copy pasting that entire block of code
 				var/is_teammate = FALSE
-				for(var/datum/team/T in teams)
-					if(targeted in T.members)
+				for(var/datum/team/team in teams)
+					if(targeted in team.members)
 						is_teammate = TRUE
 						break
 				if(!targeted)

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -283,7 +283,7 @@
 			var/datum/objective/A = new
 			A.owner = user.mind
 			var/list/datum/team/teams = list()
-			for(var/datum/antagonist/antag in user.mind.antag_datums)
+			for(var/datum/antagonist/antag as anything in user.mind.antag_datums)
 				var/datum/team/team = antag.get_team()
 				if(team)
 					teams |= team
@@ -291,7 +291,7 @@
 			for(var/i in 0 to 3)
 				var/datum/mind/targeted =  A.find_target()//easy way, i dont feel like copy pasting that entire block of code
 				var/is_teammate = FALSE
-				for(var/datum/team/team in teams)
+				for(var/datum/team/team as anything in teams)
 					if(targeted in team.members)
 						is_teammate = TRUE
 						break

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -283,21 +283,29 @@
 			var/datum/objective/A = new
 			A.owner = user.mind
 			var/list/datum/team/teams = list()
+			var/list/datum/mind/deprioritized = list()
 			for(var/datum/antagonist/antag in user.mind.antag_datums)
 				var/datum/team/team = antag.get_team()
 				if(team)
 					teams |= team
+					deprioritized |= team.members
 			var/list/targets = list()
-			for(var/i in 0 to 3)
-				var/datum/mind/targeted =  A.find_target()//easy way, i dont feel like copy pasting that entire block of code
+			var/i = 0
+			while(i < 4)
+				var/datum/mind/targeted =  A.find_target(blacklist = deprioritized)//easy way, i dont feel like copy pasting that entire block of code
+				if(!targeted)
+					if(deprioritized.len)
+						deprioritized = list()
+						continue
+					else
+						break
 				var/is_teammate = FALSE
 				for(var/datum/team/team in teams)
 					if(targeted in team.members)
 						is_teammate = TRUE
 						break
-				if(!targeted)
-					break
 				targets["[targeted.current.real_name] the [targeted.assigned_role][is_teammate ? " (ally)" : ""]"] = targeted.current
+				i++
 			LH.target = targets[input(user,"Choose your next target","Target") in targets]
 			qdel(A)
 			if(LH.target)


### PR DESCRIPTION
## About The Pull Request
When selecting your sacrifice target, the selection dialog will let you know if you're on the same antag team(s) as them by appending their name/job with "(ally)".

edit: Target selection also deprioritizes teammates, meaning that teammates can only be selected as sacrifice targets if there aren't enough possible sacrifice targets otherwise. If this is considered out of scope, the commit responsible will be removed and, if this one is merged, made into its own PR.

## Why It's Good For The Game
I was originally planning to make it so you cannot select people you share an antag team with as sacrifice targets because of the server rules requiring consent in order to sacrifice fellow cultists/revs, but after discussing the subject with @MrMelbert, I decided a fair compromise would be letting heretics know which of the targets they get to pick from are allies.

## Changelog
:cl:
qol: When selecting a sacrifice target, heretics that are also on an antag team(s) (E.G. cult, revs) will be told which of their potential targets are also on the same team(s) as them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
