### PR TITLE
Fixes a bunch of invalid icon states

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -152,7 +152,7 @@ DEFINE_BITFIELD(turret_flags, list(
 		icon_state = "[base_icon_state]_broken"
 		return ..()
 	if(!powered())
-		icon_state = "[base_icon_state]_unpowered"
+		icon_state = "[base_icon_state]_off"
 		return ..()
 	if(!on || !raised)
 		icon_state = "[base_icon_state]_off"

--- a/code/game/objects/effects/decals/cleanable/robots.dm
+++ b/code/game/objects/effects/decals/cleanable/robots.dm
@@ -52,12 +52,12 @@
 	random_icon_states = list("gibarm", "gibleg")
 
 /obj/effect/decal/cleanable/robot_debris/up
-	icon_state = "gibup1"
-	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6", "gib7","gibup1","gibup1")
+	icon_state = "gibup"
+	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6", "gib7","gibup","gibup")
 
 /obj/effect/decal/cleanable/robot_debris/down
-	icon_state = "gibdown1"
-	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6", "gib7","gibdown1","gibdown1")
+	icon_state = "gibdown"
+	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6", "gib7","gibdown","gibdown")
 
 /obj/effect/decal/cleanable/oil
 	name = "motor oil"

--- a/code/game/objects/structures/training_machine.dm
+++ b/code/game/objects/structures/training_machine.dm
@@ -342,7 +342,8 @@
 /obj/item/training_toolbox
 	name = "Training Toolbox"
 	desc = "AURUMILL-Brand Baby's First Training Toolbox. A digital display on the back keeps track of hits made by the user. Second toolbox sold seperately!"
-	icon_state = "his_grace_ascended"
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "gold"
 	inhand_icon_state = "toolbox_gold"
 	lefthand_file = 'icons/mob/inhands/equipment/toolbox_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'

--- a/code/modules/projectiles/guns/energy/mounted.dm
+++ b/code/modules/projectiles/guns/energy/mounted.dm
@@ -16,7 +16,7 @@
 	name = "mounted laser"
 	desc = "An arm mounted cannon that fires lethal lasers."
 	icon = 'icons/obj/items_cyborg.dmi'
-	icon_state = "laser"
+	icon_state = "laser_cyborg"
 	inhand_icon_state = "armcannonlase"
 	force = 5
 	selfcharge = 1


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There's more, but my brain isn't fried enough for that.

gibup1 and gibdown1 don't exist
items_and_weapons.dmi doesn't have an icon state called his_grace_ascended, in fact nothing does
items_cyborg.dmi doesn't have an icon state called laser, it  does however have an icon state called
laser_cyborg
no porta_turret has an icon state with the _unpowered suffix, in fact I'm convinced none of them ever have
## Why It's Good For The Game

The long march continues


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
