### PR TITLE
Add smite which throws target through walls

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -89,6 +89,8 @@
 
 #define STATUS_EFFECT_GO_AWAY /datum/status_effect/go_away //makes you launch through walls in a single direction for a while
 
+#define STATUS_EFFECT_GO_AWAY_HARD /datum/status_effect/go_away/hard //variant which throws you hard at walls before you pass through
+ 
 #define STATUS_EFFECT_STASIS /datum/status_effect/grouped/stasis //Halts biological functions like bleeding, chemical processing, blood regeneration, walking, etc
 
 #define STATUS_EFFECT_FAKE_VIRUS /datum/status_effect/fake_virus //gives you fluff messages for cough, sneeze, headache, etc but without an actual virus

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -835,7 +835,7 @@
 	id = "go_away_hard"
 
 /datum/status_effect/go_away/hard/move_owner(turf/target)
-	owner.throw_at(target, 2, 4)
+	owner.throw_at(target, 1, 4)
 	..()
 
 /datum/status_effect/fake_virus

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -818,15 +818,24 @@
 	direction = pick(NORTH, SOUTH, EAST, WEST)
 	new_owner.setDir(direction)
 
+/datum/status_effect/go_away/proc/move_owner(turf/target)
+	owner.forceMove(target)
+
 /datum/status_effect/go_away/tick()
 	owner.AdjustStun(1, ignore_canstun = TRUE)
-	var/turf/T = get_step(owner, direction)
-	owner.forceMove(T)
+	var/turf/target = get_step(owner, direction)
+	move_owner(target)
 
 /atom/movable/screen/alert/status_effect/go_away
 	name = "TO THE STARS AND BEYOND!"
 	desc = "I must go, my people need me!"
 	icon_state = "high"
+
+/datum/status_effect/go_away/hard
+	id = "go_away_hard"
+
+/datum/status_effect/go_away/hard/move_owner(turf/target)
+	..()
 
 /datum/status_effect/fake_virus
 	id = "fake_virus"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -835,6 +835,7 @@
 	id = "go_away_hard"
 
 /datum/status_effect/go_away/hard/move_owner(turf/target)
+	owner.throw_at(target, 2, 4)
 	..()
 
 /datum/status_effect/fake_virus

--- a/code/modules/admin/smites/away_with_ye.dm
+++ b/code/modules/admin/smites/away_with_ye.dm
@@ -1,3 +1,4 @@
+/// Throws target in a random direction, passing through walls and taking damage if they hit anything
 /datum/smite/away_with_ye
 	name = "THEY MUST GO"
 

--- a/code/modules/admin/smites/away_with_ye.dm
+++ b/code/modules/admin/smites/away_with_ye.dm
@@ -1,0 +1,6 @@
+/datum/smite/away_with_ye
+	name = "THEY MUST GO"
+
+/datum/smite/away_with_ye/effect(client/user, mob/living/target)
+	. = ..()
+	target.apply_status_effect(STATUS_EFFECT_GO_AWAY_HARD)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1521,6 +1521,7 @@
 #include "code\modules\admin\topic.dm"
 #include "code\modules\admin\whitelist.dm"
 #include "code\modules\admin\callproc\callproc.dm"
+#include "code\modules\admin\smites\away_with_ye.dm"
 #include "code\modules\admin\smites\bad_luck.dm"
 #include "code\modules\admin\smites\berforate.dm"
 #include "code\modules\admin\smites\bloodless.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a new smite which tosses the target in a random direction through walls. This uses a variant of the dna melt debuff that actually throws you in the direction so you take damage.

## Why It's Good For The Game
I'm not entirely sure how good for the game a new admin smite is.

## Changelog
:cl: JJRcop
admin: New THEY MUST GO smite.
/:cl:

This pull request authored ~~entirely~~ mostly on Android.