### PR TITLE
Small Crystallizer Fixes

### DIFF
--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
@@ -131,17 +131,6 @@
 
 ///Calculation for the heat of the various gas mixes and controls the quality of the item
 /obj/machinery/atmospherics/components/binary/crystallizer/proc/heat_calculations()
-	var/datum/gas_mixture/cooling_port = airs[1]
-	if(cooling_port.total_moles() > MINIMUM_MOLE_COUNT)
-		if(internal.total_moles() > 0)
-			var/coolant_temperature_delta = cooling_port.temperature - internal.temperature
-			var/cooling_heat_capacity = cooling_port.heat_capacity()
-			var/internal_heat_capacity = internal.heat_capacity()
-			var/cooling_heat_amount = HIGH_CONDUCTIVITY_RATIO * coolant_temperature_delta * (cooling_heat_capacity * internal_heat_capacity / (cooling_heat_capacity + internal_heat_capacity))
-			cooling_port.temperature = max(cooling_port.temperature - cooling_heat_amount / cooling_heat_capacity, TCMB)
-			internal.temperature = max(internal.temperature + cooling_heat_amount / internal_heat_capacity, TCMB)
-		update_parents()
-
 	if(	(internal.temperature >= (selected_recipe.min_temp * MIN_DEVIATION_RATE) && internal.temperature <= selected_recipe.min_temp) || \
 		(internal.temperature >= selected_recipe.max_temp && internal.temperature <= (selected_recipe.max_temp * MAX_DEVIATION_RATE)))
 		quality_loss = min(quality_loss + 1.5, 100)
@@ -154,6 +143,19 @@
 		internal.temperature = max(internal.temperature - (selected_recipe.energy_release / internal.heat_capacity()), TCMB)
 	else if(selected_recipe.reaction_type == "exothermic")
 		internal.temperature = max(internal.temperature + (selected_recipe.energy_release / internal.heat_capacity()), TCMB)
+
+///Conduction between the internal gasmix and the moderating (cooling/heating) gasmix.
+/obj/machinery/atmospherics/components/binary/crystallizer/proc/heat_conduction()
+	var/datum/gas_mixture/cooling_port = airs[1]
+	if(cooling_port.total_moles() > MINIMUM_MOLE_COUNT)
+		if(internal.total_moles() > 0)
+			var/coolant_temperature_delta = cooling_port.temperature - internal.temperature
+			var/cooling_heat_capacity = cooling_port.heat_capacity()
+			var/internal_heat_capacity = internal.heat_capacity()
+			var/cooling_heat_amount = HIGH_CONDUCTIVITY_RATIO * coolant_temperature_delta * (cooling_heat_capacity * internal_heat_capacity / (cooling_heat_capacity + internal_heat_capacity))
+			cooling_port.temperature = max(cooling_port.temperature - cooling_heat_amount / cooling_heat_capacity, TCMB)
+			internal.temperature = max(internal.temperature + cooling_heat_amount / internal_heat_capacity, TCMB)
+		update_parents()
 
 ///Calculate the total moles needed for the recipe
 /obj/machinery/atmospherics/components/binary/crystallizer/proc/moles_calculations()
@@ -172,14 +174,14 @@
 	if(!on || !is_operational || selected_recipe == null)
 		return
 
-	if(!check_gas_requirements())
-		return
-
-	inject_gases()
+	if(check_gas_requirements())
+		inject_gases()
 
 	if(!internal.total_moles())
 		update_parents()
 		return
+
+	heat_conduction()
 
 	if(internal_check())
 		if(check_temp_requirements())


### PR DESCRIPTION
## About The Pull Request
Fixes crystallizer locking up when the airs[2] port ran out of proper gas and early returns. This proc is now used as an if statement to check for gas injection. 
Lets the crystallizer actually conduct outside of reacting temperatures. Accomplishes this by splitting the temp based quality management proc into two.

cc: @Ghilker 

## Why It's Good For The Game
Bugfix, friendlier behaviour.

## Changelog
:cl:
fix: fixed crystallizer locking up when the input port is devoid of proper gases.
fix: fixed crystallizer conducting heat with the heat loop only on reactions. It should conduct at all times now.
/:cl: