### PR TITLE
Assistant role gets harder the more you play

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -77,7 +77,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 			if(quirk_to_check.value >= 0)
 				quirk_list -= quirk_to_check
 
-		for(var/i in 1 to bad_quirks_to_add)
+		for(var/i in 1 to min(3, bad_quirks_to_add))
 			var/quirk_to_give = pick_n_take(quirk_list)
 			if(user.has_quirk(quirk_to_give))
 				continue //no need to add it again

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -70,7 +70,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 
 	var/list/player_records = cli.prefs.exp
 	var/assistant_playtime = text2num(player_records["Assistant"])
-	var/bad_quirks_to_add = assistant_playtime % 100
+	var/bad_quirks_to_add = assistant_playtime % 12000
 	if(bad_quirks_to_add > 0 && user.job == "Assistant")
 		var/list/quirk_list = subtypesof(/datum/quirk)
 		for(var/datum/quirk/quirk_to_check in quirk_list)

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -68,6 +68,21 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	if(cli.get_exp_living(TRUE) < EXP_ASSIGN_WAYFINDER && !user.has_quirk(/datum/quirk/needswayfinder))
 		user.add_quirk(/datum/quirk/needswayfinder, TRUE)
 
+	var/list/quirk_list = subtypesof(/datum/quirk)
+	for(var/datum/quirk/quirk_to_check in quirk_list)
+		if(quirk_to_check.value >= 0)
+			quirk_list -= quirk_to_check
+
+	var/list/player_records = cli.prefs.exp
+	var/assistant_playtime = text2num(player_records["Assistant"])
+	var/bad_quirks_to_add = assistant_playtime % 100
+	if(bad_quirks_to_add > 0 && user.job == "Assistant")
+		for(var/i in 1 to bad_quirks_to_add)
+			var/quirk_to_give = pick_n_take(quirk_list)
+			if(user.has_quirk(quirk_to_give))
+				continue //no need to add it again
+			user.add_quirk(quirk_to_give, TRUE)
+
 /*
  *Randomises the quirks for a specified mob
  */

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -68,15 +68,15 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	if(cli.get_exp_living(TRUE) < EXP_ASSIGN_WAYFINDER && !user.has_quirk(/datum/quirk/needswayfinder))
 		user.add_quirk(/datum/quirk/needswayfinder, TRUE)
 
-	var/list/quirk_list = subtypesof(/datum/quirk)
-	for(var/datum/quirk/quirk_to_check in quirk_list)
-		if(quirk_to_check.value >= 0)
-			quirk_list -= quirk_to_check
-
 	var/list/player_records = cli.prefs.exp
 	var/assistant_playtime = text2num(player_records["Assistant"])
 	var/bad_quirks_to_add = assistant_playtime % 100
 	if(bad_quirks_to_add > 0 && user.job == "Assistant")
+		var/list/quirk_list = subtypesof(/datum/quirk)
+		for(var/datum/quirk/quirk_to_check in quirk_list)
+			if(quirk_to_check.value >= 0)
+				quirk_list -= quirk_to_check
+
 		for(var/i in 1 to bad_quirks_to_add)
 			var/quirk_to_give = pick_n_take(quirk_list)
 			if(user.has_quirk(quirk_to_give))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR will make the assistant role more challenging for veteran assistant players. Now for every 200 hours of play as an assistant, you'll get a free random bad quirk round start (max three bad quirks, so it caps at 600hours)
You can now choose the quirks beforehand to avoid getting random ones
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
~~Makes assistants the ultimate badasses! Who can overcome those challenges will be crowned the ultimate veteran assistant (not really)~~
Assistants are the only role that have the full freedom of having no responsabilities, giving nothing back to the round. This balance that
New players will have plenty of time to adjust to the game before the tick starts.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: assistants are more challenging the more you play them, every 200 h of play will randomly give you one bad quirk (unless you select one beforehand so the system won't give you one, warning the mood changing ones don't count, only the higher values one will work)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
