### PR TITLE
Fixes full unrestrained interaction while buckled to a xeno nest.

### DIFF
--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -65,12 +65,14 @@
 			"<span class='hear'>You hear squelching...</span>")
 
 /obj/structure/bed/nest/post_buckle_mob(mob/living/M)
+	ADD_TRAIT(M, TRAIT_RESTRAINED, TRAIT_GENERIC)
 	M.pixel_y = M.base_pixel_y
 	M.pixel_x = M.base_pixel_x + 2
 	M.layer = BELOW_MOB_LAYER
 	add_overlay(nest_overlay)
 
 /obj/structure/bed/nest/post_unbuckle_mob(mob/living/M)
+	REMOVE_TRAIT(M, TRAIT_RESTRAINED, TRAIT_GENERIC)
 	M.pixel_x = M.base_pixel_x + M.body_position_pixel_x_offset
 	M.pixel_y = M.base_pixel_y + M.body_position_pixel_y_offset
 	M.layer = initial(M.layer)

--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -65,14 +65,14 @@
 			"<span class='hear'>You hear squelching...</span>")
 
 /obj/structure/bed/nest/post_buckle_mob(mob/living/M)
-	ADD_TRAIT(M, TRAIT_RESTRAINED, TRAIT_GENERIC)
+	ADD_TRAIT(M, TRAIT_RESTRAINED, type)
 	M.pixel_y = M.base_pixel_y
 	M.pixel_x = M.base_pixel_x + 2
 	M.layer = BELOW_MOB_LAYER
 	add_overlay(nest_overlay)
 
 /obj/structure/bed/nest/post_unbuckle_mob(mob/living/M)
-	REMOVE_TRAIT(M, TRAIT_RESTRAINED, TRAIT_GENERIC)
+	REMOVE_TRAIT(M, TRAIT_RESTRAINED, type)
 	M.pixel_x = M.base_pixel_x + M.body_position_pixel_x_offset
 	M.pixel_y = M.base_pixel_y + M.body_position_pixel_y_offset
 	M.layer = initial(M.layer)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/24271
Another 2017 issue :)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

When you get buckled to a xeno nest it should be fully retrained movement. However, currently you're able to fully interact with things around you: you can unbuckle people from xeno nests directly adjacent to you, punch things that may be near you, etc.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed xeno nests not properly restricting interaction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
