### PR TITLE
Kills off C3 damage-healing chems that have C2 alternatives.

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -288,8 +288,8 @@ GLOBAL_LIST_INIT(rarity_loot, list(//rare: really good items
 			/obj/item/storage/firstaid/emergency = 1,
 			) = 1,
 		list(//medical chems
-			/obj/item/reagent_containers/hypospray/medipen/salacid = 1,
-			/obj/item/reagent_containers/hypospray/medipen/oxandrolone = 1,
+			/obj/item/reagent_containers/hypospray/medipen/libital = 1,
+			/obj/item/reagent_containers/hypospray/medipen/lenturi = 1,
 			/obj/item/reagent_containers/syringe/contraband/methamphetamine = 1,
 			) = 1,
 		) = 1,

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -60,7 +60,7 @@
 										/datum/reagent/pax, /datum/reagent/drug/happiness, /datum/reagent/medicine/ephedrine
 									),
 									list( // level 9
-										/datum/reagent/toxin/lipolicide, /datum/reagent/medicine/sal_acid
+										/datum/reagent/toxin/lipolicide, /datum/reagent/medicine/c2/helbital
 									),
 									list( // level 10
 										/datum/reagent/medicine/haloperidol, /datum/reagent/drug/aranesp, /datum/reagent/medicine/diphenhydramine

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -9,9 +9,6 @@ Self-Respiration
 	Decreases transmittablity tremendously.
 	Fatal Level.
 
-Bonus
-	The body generates salbutamol.
-
 //////////////////////////////////////
 */
 

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -295,7 +295,7 @@
 /datum/status_effect/hippocratic_oath/proc/consume_owner()
 	owner.visible_message("<span class='notice'>[owner]'s soul is absorbed into the rod, relieving the previous snake of its duty.</span>")
 	var/mob/living/simple_animal/hostile/retaliate/poison/snake/healSnake = new(owner.loc)
-	var/list/chems = list(/datum/reagent/medicine/sal_acid, /datum/reagent/medicine/c2/convermol, /datum/reagent/medicine/oxandrolone)
+	var/list/chems = list(/datum/reagent/medicine/c2/helbital, /datum/reagent/medicine/c2/convermol, /datum/reagent/medicine/c2/aiuri)
 	healSnake.poison_type = pick(chems)
 	healSnake.name = "Asclepius's Snake"
 	healSnake.real_name = "Asclepius's Snake"
@@ -522,4 +522,3 @@
 
 /datum/movespeed_modifier/status_speed_boost
 	multiplicative_slowdown = -1
-

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -21,7 +21,7 @@
 	var/list/possible_chems = list(
 		list(/datum/reagent/medicine/epinephrine, /datum/reagent/medicine/morphine, /datum/reagent/medicine/c2/convermol, /datum/reagent/medicine/c2/libital, /datum/reagent/medicine/c2/aiuri),
 		list(/datum/reagent/medicine/oculine,/datum/reagent/medicine/inacusiate),
-		list(/datum/reagent/medicine/c2/multiver, /datum/reagent/medicine/mutadone, /datum/reagent/medicine/mannitol, /datum/reagent/medicine/salbutamol, /datum/reagent/medicine/pen_acid),
+		list(/datum/reagent/medicine/c2/multiver, /datum/reagent/medicine/mutadone, /datum/reagent/medicine/mannitol),
 		list(/datum/reagent/medicine/omnizine)
 	)
 	var/list/chem_buttons //Used when emagged to scramble which chem is used, eg: mutadone -> morphine

--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -299,7 +299,7 @@
 		brain_status = "Mild brain damage detected."  //You may have a miiiild case of severe brain damage.
 
 	if(rad_sickness_value >= 1000)  //
-		rad_sickness_status = "Patient is suffering from extreme radiation poisoning, high toxen damage expected. Suggested treatment: Repeated dosages of High amounts of Cold Seiver and anti-toxin"
+		rad_sickness_status = "Patient is suffering from extreme radiation poisoning, high toxin damage expected. Suggested treatment: Repeated dosages of high amounts of cold seiver and anti-toxin"
 	else if(rad_sickness_value >= 300)
 		rad_sickness_status = "Patient is suffering from alarming radiation poisoning. Suggested treatment: Take Cold Seiver or Potassium Iodine, watch the toxin levels."
 	else if(rad_sickness_value >= 100)

--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -299,7 +299,7 @@
 		brain_status = "Mild brain damage detected."  //You may have a miiiild case of severe brain damage.
 
 	if(rad_sickness_value >= 1000)  //
-		rad_sickness_status = "Patient is suffering from extreme radiation poisoning, high toxen damage expected. Suggested treatment: Repeated dosages of Pentetic Acid or high amounts of Cold Seiver and anti-toxen"
+		rad_sickness_status = "Patient is suffering from extreme radiation poisoning, high toxen damage expected. Suggested treatment: Repeated dosages of High amounts of Cold Seiver and anti-toxin"
 	else if(rad_sickness_value >= 300)
 		rad_sickness_status = "Patient is suffering from alarming radiation poisoning. Suggested treatment: Take Cold Seiver or Potassium Iodine, watch the toxin levels."
 	else if(rad_sickness_value >= 100)

--- a/code/game/machinery/medipen_refiller.dm
+++ b/code/game/machinery/medipen_refiller.dm
@@ -9,10 +9,9 @@
 	/// list of medipen subtypes it can refill
 	var/list/allowed = list(/obj/item/reagent_containers/hypospray/medipen = /datum/reagent/medicine/epinephrine,
 						    /obj/item/reagent_containers/hypospray/medipen/atropine = /datum/reagent/medicine/atropine,
-						    /obj/item/reagent_containers/hypospray/medipen/salbutamol = /datum/reagent/medicine/salbutamol,
-						    /obj/item/reagent_containers/hypospray/medipen/oxandrolone = /datum/reagent/medicine/oxandrolone,
-						    /obj/item/reagent_containers/hypospray/medipen/salacid = /datum/reagent/medicine/sal_acid,
-						    /obj/item/reagent_containers/hypospray/medipen/penacid = /datum/reagent/medicine/pen_acid)
+						    /obj/item/reagent_containers/hypospray/medipen/convermol = /datum/reagent/medicine/c2/convermol,
+						    /obj/item/reagent_containers/hypospray/medipen/lenturi = /datum/reagent/medicine/c2/lenturi,
+						    /obj/item/reagent_containers/hypospray/medipen/libital = /datum/reagent/medicine/c2/libital)
 	/// var to prevent glitches in the animation
 	var/busy = FALSE
 

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -570,7 +570,7 @@
 	icon = 'icons/obj/lollipop.dmi'
 	icon_state = "gumball"
 	worn_icon_state = "bubblegum"
-	food_reagents = list(/datum/reagent/consumable/sugar = 5, /datum/reagent/medicine/sal_acid = 2, /datum/reagent/medicine/oxandrolone = 2) //Kek
+	food_reagents = list(/datum/reagent/consumable/sugar = 5, /datum/reagent/medicine/c2/libital = 1, /datum/reagent/medicine/c2/aiuri = 1) //Kek
 	tastes = list("candy")
 	foodtypes = JUNKFOOD
 	slot_flags = ITEM_SLOT_MASK

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -436,8 +436,8 @@
 	desc = "An upgrade to the Medical model's hypospray, allowing it \
 		to treat a wider range of conditions and problems."
 	additional_reagents = list(/datum/reagent/medicine/mannitol, /datum/reagent/medicine/oculine, /datum/reagent/medicine/inacusiate,
-		/datum/reagent/medicine/mutadone, /datum/reagent/medicine/haloperidol, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/sal_acid,
-		/datum/reagent/medicine/rezadone, /datum/reagent/medicine/pen_acid)
+		/datum/reagent/medicine/mutadone, /datum/reagent/medicine/haloperidol, /datum/reagent/medicine/c2/aiuri, /datum/reagent/medicine/c2/helbital,
+		/datum/reagent/medicine/rezadone)
 
 /obj/item/borg/upgrade/piercing_hypospray
 	name = "cyborg piercing hypospray"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -436,7 +436,7 @@
 	desc = "An upgrade to the Medical model's hypospray, allowing it \
 		to treat a wider range of conditions and problems."
 	additional_reagents = list(/datum/reagent/medicine/mannitol, /datum/reagent/medicine/oculine, /datum/reagent/medicine/inacusiate,
-		/datum/reagent/medicine/mutadone, /datum/reagent/medicine/haloperidol, /datum/reagent/medicine/c2/aiuri, /datum/reagent/medicine/c2/helbital,
+		/datum/reagent/medicine/mutadone, /datum/reagent/medicine/haloperidol, /datum/reagent/medicine/c2/lenturi, /datum/reagent/medicine/c2/helbital,
 		/datum/reagent/medicine/rezadone)
 
 /obj/item/borg/upgrade/piercing_hypospray

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -171,7 +171,7 @@
 	var/static/items_inside = list(
 		/obj/item/reagent_containers/pill/patch/aiuri = 3,
 		/obj/item/reagent_containers/spray/hercuri = 1,
-		/obj/item/reagent_containers/hypospray/medipen/oxandrolone = 1,
+		/obj/item/reagent_containers/hypospray/medipen/lenturi = 1,
 		/obj/item/reagent_containers/hypospray/medipen = 1)
 	generate_items_inside(items_inside,src)
 
@@ -196,8 +196,7 @@
 	var/static/items_inside = list(
 	    /obj/item/storage/pill_bottle/multiver/less = 1,
 		/obj/item/reagent_containers/syringe/syriniver = 3,
-		/obj/item/storage/pill_bottle/potassiodide = 1,
-		/obj/item/reagent_containers/hypospray/medipen/penacid = 1)
+		/obj/item/storage/pill_bottle/potassiodide = 1)
 	generate_items_inside(items_inside,src)
 
 /obj/item/storage/firstaid/o2
@@ -220,7 +219,7 @@
 		return
 	var/static/items_inside = list(
 		/obj/item/reagent_containers/syringe/convermol = 3,
-		/obj/item/reagent_containers/hypospray/medipen/salbutamol = 1,
+		/obj/item/reagent_containers/hypospray/medipen/convermol = 1,
 		/obj/item/reagent_containers/hypospray/medipen = 1,
 		/obj/item/storage/pill_bottle/iron = 1)
 	generate_items_inside(items_inside,src)
@@ -247,7 +246,7 @@
 		/obj/item/reagent_containers/pill/patch/libital = 3,
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/storage/pill_bottle/probital = 1,
-		/obj/item/reagent_containers/hypospray/medipen/salacid = 1)
+		/obj/item/reagent_containers/hypospray/medipen/libital = 1)
 	generate_items_inside(items_inside,src)
 
 /obj/item/storage/firstaid/advanced
@@ -264,8 +263,7 @@
 	var/static/items_inside = list(
 		/obj/item/reagent_containers/pill/patch/synthflesh = 3,
 		/obj/item/reagent_containers/hypospray/medipen/atropine = 2,
-		/obj/item/stack/medical/gauze = 1,
-		/obj/item/storage/pill_bottle/penacid = 1)
+		/obj/item/stack/medical/gauze = 1)
 	generate_items_inside(items_inside,src)
 
 /obj/item/storage/firstaid/tactical
@@ -470,15 +468,6 @@
 /obj/item/storage/pill_bottle/psicodine/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/reagent_containers/pill/psicodine(src)
-
-/obj/item/storage/pill_bottle/penacid
-	name = "bottle of pentetic acid pills"
-	desc = "Contains pills to expunge radiation and toxins."
-
-/obj/item/storage/pill_bottle/penacid/PopulateContents()
-	for(var/i in 1 to 3)
-		new /obj/item/reagent_containers/pill/penacid(src)
-
 
 /obj/item/storage/pill_bottle/neurine
 	name = "bottle of neurine pills"

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -486,6 +486,14 @@
 		loc.visible_message("<span class='warning'>[loc.name]\'s flesh rapidly inflates, forming a bloated mass around [loc.p_their()] body!</span>", "<span class='warning'>We inflate our flesh, creating a spaceproof suit!</span>", "<span class='hear'>You hear organic matter ripping and tearing!</span>")
 	START_PROCESSING(SSobj, src)
 
+/obj/item/clothing/suit/space/changeling/equipped(mob/living/carbon/human/user, slot)
+	. = ..()
+	ADD_TRAIT(user, TRAIT_NOBREATH, ITEM_SLOT_OCLOTHING)
+
+/obj/item/clothing/suit/space/changeling/dropped(mob/living/carbon/human/user)
+	REMOVE_TRAIT(user, TRAIT_NOBREATH, ITEM_SLOT_OCLOTHING)
+	return ..()
+
 // seal the cell door
 /obj/item/clothing/suit/space/changeling/toggle_spacesuit_cell(mob/user)
 	return
@@ -493,7 +501,6 @@
 /obj/item/clothing/suit/space/changeling/process(delta_time)
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
-		H.reagents.add_reagent(/datum/reagent/medicine/salbutamol, REAGENTS_METABOLISM * (delta_time / SSMOBS_DT))
 		H.adjust_bodytemperature(temperature_setting - H.bodytemperature) // force changelings to normal temp step mode played badly
 
 /obj/item/clothing/head/helmet/space/changeling

--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -26,7 +26,7 @@
 			C.vomit(0)
 		O.forceMove(get_turf(user))
 
-	for(var/datum/reagent/the_reagent in user.reagents.reagent_list as anything)
+	for(var/datum/reagent/the_reagent as anything in user.reagents.reagent_list)
 		if(!the_reagent.harmful)
 			continue
 		user.reagents.remove_reagent(the_reagent.type)

--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -26,8 +26,7 @@
 			C.vomit(0)
 		O.forceMove(get_turf(user))
 
-	for(var/i in user.reagents.reagent_list)
-		var/datum/reagent/the_reagent = i
+	for(var/datum/reagent/the_reagent in user.reagents.reagent_list as anything)
 		if(!the_reagent.harmful)
 			continue
 		user.reagents.remove_reagent(the_reagent.type)

--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -27,7 +27,6 @@
 		O.forceMove(get_turf(user))
 
 	user.reagents.add_reagent(/datum/reagent/medicine/mutadone, 10)
-	user.reagents.add_reagent(/datum/reagent/medicine/pen_acid, 20)
 	user.reagents.add_reagent(/datum/reagent/medicine/antihol, 10)
 	user.reagents.add_reagent(/datum/reagent/medicine/mannitol, 25)
 

--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -26,6 +26,12 @@
 			C.vomit(0)
 		O.forceMove(get_turf(user))
 
+	for(var/i in user.reagents.reagent_list)
+		var/datum/reagent/the_reagent = i
+		if(!the_reagent.harmful)
+			continue
+		user.reagents.remove_reagent(the_reagent.type)
+
 	user.reagents.add_reagent(/datum/reagent/medicine/mutadone, 10)
 	user.reagents.add_reagent(/datum/reagent/medicine/antihol, 10)
 	user.reagents.add_reagent(/datum/reagent/medicine/mannitol, 25)

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -134,7 +134,6 @@
 		/datum/reagent/toxin/itching_powder,\
 		/datum/reagent/toxin/cyanide,\
 		/datum/reagent/toxin/heparin,\
-		/datum/reagent/medicine/pen_acid,\
 		/datum/reagent/medicine/atropine,\
 		/datum/reagent/drug/aranesp,\
 		/datum/reagent/drug/krokodil,\
@@ -216,10 +215,9 @@
 	var/static/list/possible_reagents = list(\
 		/datum/reagent/medicine/spaceacillin,\
 		/datum/reagent/medicine/c2/synthflesh,\
-		/datum/reagent/medicine/pen_acid,\
 		/datum/reagent/medicine/atropine,\
 		/datum/reagent/medicine/cryoxadone,\
-		/datum/reagent/medicine/salbutamol,\
+		/datum/reagent/medicine/c2/convermol,\
 		/datum/reagent/medicine/c2/hercuri,\
 		/datum/reagent/medicine/c2/probital,\
 		/datum/reagent/drug/methamphetamine,\

--- a/code/modules/explorer_drone/loot.dm
+++ b/code/modules/explorer_drone/loot.dm
@@ -74,7 +74,7 @@ GLOBAL_LIST_INIT(adventure_loot_generator_index,generate_generator_index())
 /// Drugs
 /datum/adventure_loot_generator/simple/drugs
 	id = "drugs"
-	loot_list = list(/obj/item/storage/pill_bottle/happy,/obj/item/storage/pill_bottle/lsd,/obj/item/storage/pill_bottle/penacid,/obj/item/storage/pill_bottle/stimulant)
+	loot_list = list(/obj/item/storage/pill_bottle/happy,/obj/item/storage/pill_bottle/lsd,/obj/item/storage/pill_bottle/stimulant)
 
 /// Rare minerals/materials
 /datum/adventure_loot_generator/simple/materials

--- a/code/modules/hydroponics/grown/tobacco.dm
+++ b/code/modules/hydroponics/grown/tobacco.dm
@@ -31,7 +31,7 @@
 	plantname = "Space Tobacco Plant"
 	product = /obj/item/food/grown/tobacco/space
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/medicine/salbutamol = 0.05, /datum/reagent/drug/nicotine = 0.08, /datum/reagent/consumable/nutriment = 0.03)
+	reagents_add = list(/datum/reagent/oxygen = 0.05, /datum/reagent/drug/nicotine = 0.08, /datum/reagent/consumable/nutriment = 0.03)
 	rarity = 20
 
 /obj/item/food/grown/tobacco/space

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -276,30 +276,6 @@
 
 //Goon Chems. Ported mainly from Goonstation. Easily mixable (or not so easily) and provide a variety of effects.
 
-/datum/reagent/medicine/oxandrolone
-	name = "Oxandrolone"
-	description = "Stimulates the healing of severe burns. Extremely rapidly heals severe burns and slowly heals minor ones. Overdose will worsen existing burns."
-	reagent_state = LIQUID
-	color = "#1E8BFF"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
-	overdose_threshold = 25
-	ph = 10.7
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-
-/datum/reagent/medicine/oxandrolone/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	if(M.getFireLoss() > 25)
-		M.adjustFireLoss(-4 * REM * delta_time, 0) //Twice as effective as AIURI for severe burns
-	else
-		M.adjustFireLoss(-0.5 * REM * delta_time, 0) //But only a quarter as effective for more minor ones
-	..()
-	. = TRUE
-
-/datum/reagent/medicine/oxandrolone/overdose_process(mob/living/M, delta_time, times_fired)
-	if(M.getFireLoss()) //It only makes existing burns worse
-		M.adjustFireLoss(4.5 * REM * delta_time, FALSE, FALSE, BODYPART_ORGANIC) // it's going to be healing either 4 or 0.5
-		. = TRUE
-	..()
-
 /datum/reagent/medicine/salglu_solution
 	name = "Saline-Glucose Solution"
 	description = "Has a 33% chance per metabolism cycle to heal brute and burn damage. Can be used as a temporary blood substitute, as well as slowly speeding blood regeneration."
@@ -450,64 +426,6 @@
 	if(M.radiation > 0)
 		M.radiation -= min(8 * REM * delta_time, M.radiation)
 	..()
-
-/datum/reagent/medicine/pen_acid
-	name = "Pentetic Acid"
-	description = "Reduces massive amounts of radiation and toxin damage while purging other chemicals from the body."
-	reagent_state = LIQUID
-	color = "#E6FFF0"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
-	ph = 1 //One of the best buffers, NEVERMIND!
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-
-/datum/reagent/medicine/pen_acid/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.radiation -= (max(M.radiation - RAD_MOB_SAFE, 0) / 50) * REM * delta_time
-	M.adjustToxLoss(-2 * REM * delta_time, 0)
-	for(var/datum/reagent/R in M.reagents.reagent_list)
-		if(R != src)
-			M.reagents.remove_reagent(R.type, 2 * REM * delta_time)
-	..()
-	. = TRUE
-
-/datum/reagent/medicine/sal_acid
-	name = "Salicylic Acid"
-	description = "Stimulates the healing of severe bruises. Extremely rapidly heals severe bruising and slowly heals minor ones. Overdose will worsen existing bruising."
-	reagent_state = LIQUID
-	color = "#D2D2D2"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
-	overdose_threshold = 25
-	ph = 2.1
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-
-/datum/reagent/medicine/sal_acid/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	if(M.getBruteLoss() > 25)
-		M.adjustBruteLoss(-4 * REM * delta_time, 0)
-	else
-		M.adjustBruteLoss(-0.5 * REM * delta_time, 0)
-	..()
-	. = TRUE
-
-/datum/reagent/medicine/sal_acid/overdose_process(mob/living/M, delta_time, times_fired)
-	if(M.getBruteLoss()) //It only makes existing bruises worse
-		M.adjustBruteLoss(4.5 * REM * delta_time, FALSE, FALSE, BODYPART_ORGANIC) // it's going to be healing either 4 or 0.5
-		. = TRUE
-	..()
-
-/datum/reagent/medicine/salbutamol
-	name = "Salbutamol"
-	description = "Rapidly restores oxygen deprivation as well as preventing more of it to an extent."
-	reagent_state = LIQUID
-	color = "#00FFFF"
-	metabolization_rate = 0.25 * REAGENTS_METABOLISM
-	ph = 2
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-
-/datum/reagent/medicine/salbutamol/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.adjustOxyLoss(-3 * REM * delta_time, 0)
-	if(M.losebreath >= 4)
-		M.losebreath -= 2 * REM * delta_time
-	..()
-	. = TRUE
 
 /datum/reagent/medicine/ephedrine
 	name = "Ephedrine"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -958,7 +958,7 @@
 
 /datum/reagent/toxin/anacea/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	var/remove_amt = 5
-	if(holder.has_reagent(/datum/reagent/medicine/calomel) || holder.has_reagent(/datum/reagent/medicine/pen_acid))
+	if(holder.has_reagent(/datum/reagent/medicine/calomel))
 		remove_amt = 0.5
 	for(var/datum/reagent/medicine/R in M.reagents.reagent_list)
 		M.reagents.remove_reagent(R.type, remove_amt * REM * normalise_creation_purity() * delta_time)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -132,26 +132,6 @@
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/iodine = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_OTHER
 
-/datum/chemical_reaction/medicine/pen_acid
-	results = list(/datum/reagent/medicine/pen_acid = 6)
-	required_reagents = list(/datum/reagent/fuel = 1, /datum/reagent/chlorine = 1, /datum/reagent/ammonia = 1, /datum/reagent/toxin/formaldehyde = 1, /datum/reagent/sodium = 1, /datum/reagent/toxin/cyanide = 1)
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_OTHER
-
-/datum/chemical_reaction/medicine/sal_acid
-	results = list(/datum/reagent/medicine/sal_acid = 5)
-	required_reagents = list(/datum/reagent/sodium = 1, /datum/reagent/phenol = 1, /datum/reagent/carbon = 1, /datum/reagent/oxygen = 1, /datum/reagent/toxin/acid = 1)
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BRUTE
-
-/datum/chemical_reaction/medicine/oxandrolone
-	results = list(/datum/reagent/medicine/oxandrolone = 6)
-	required_reagents = list(/datum/reagent/carbon = 3, /datum/reagent/phenol = 1, /datum/reagent/hydrogen = 1, /datum/reagent/oxygen = 1)
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BURN
-
-/datum/chemical_reaction/medicine/salbutamol
-	results = list(/datum/reagent/medicine/salbutamol = 5)
-	required_reagents = list(/datum/reagent/medicine/sal_acid = 1, /datum/reagent/lithium = 1, /datum/reagent/aluminium = 1, /datum/reagent/bromine = 1, /datum/reagent/ammonia = 1)
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_OXY
-
 /datum/chemical_reaction/medicine/ephedrine
 	results = list(/datum/reagent/medicine/ephedrine = 4)
 	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/fuel/oil = 1, /datum/reagent/hydrogen = 1, /datum/reagent/diethylamine = 1)

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -181,7 +181,7 @@
 
 /datum/chemical_reaction/lexorin
 	results = list(/datum/reagent/toxin/lexorin = 3)
-	required_reagents = list(/datum/reagent/toxin/plasma = 1, /datum/reagent/hydrogen = 1, /datum/reagent/medicine/salbutamol = 1)
+	required_reagents = list(/datum/reagent/toxin/plasma = 1, /datum/reagent/hydrogen = 1, /datum/reagent/medicine/c2/ convermol = 1)
 	mix_message = "The mixture turns clear and stops reacting."
 	is_cold_recipe = FALSE
 	required_temp = 100

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -181,7 +181,7 @@
 
 /datum/chemical_reaction/lexorin
 	results = list(/datum/reagent/toxin/lexorin = 3)
-	required_reagents = list(/datum/reagent/toxin/plasma = 1, /datum/reagent/hydrogen = 1, /datum/reagent/medicine/c2/ convermol = 1)
+	required_reagents = list(/datum/reagent/toxin/plasma = 1, /datum/reagent/hydrogen = 1, /datum/reagent/medicine/c2/convermol = 1)
 	mix_message = "The mixture turns clear and stops reacting."
 	is_cold_recipe = FALSE
 	required_temp = 100

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -195,7 +195,7 @@
 	icon_state = "salpen"
 	inhand_icon_state = "salpen"
 	base_icon_state = "salpen"
-	list_reagents = list(/datum/reagent/medicine/c2/convermol = 10)
+	list_reagents = list(/datum/reagent/medicine/c2/convermol = 5)
 
 /obj/item/reagent_containers/hypospray/medipen/tuberculosiscure
 	name = "BVAK autoinjector"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -249,7 +249,7 @@
 	base_icon_state = "luxpen"
 	volume = 20
 	amount_per_transfer_from_this = 20
-	list_reagents = list(/datum/reagent/medicine/omnizine = 10 ,/datum/reagent/medicine/leporazine = 10)
+	list_reagents = list(/datum/reagent/medicine/c2/penthrite = 10, /datum/reagent/medicine/omnizine = 10 ,/datum/reagent/medicine/leporazine = 10)
 
 /obj/item/reagent_containers/hypospray/medipen/atropine
 	name = "atropine autoinjector"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -173,37 +173,29 @@
 	base_icon_state = "morphen"
 	list_reagents = list(/datum/reagent/medicine/morphine = 10)
 
-/obj/item/reagent_containers/hypospray/medipen/oxandrolone
-	name = "oxandrolone medipen"
-	desc = "An autoinjector containing oxandrolone, used to treat severe burns."
+/obj/item/reagent_containers/hypospray/medipen/lenturi
+	name = "lenturi medipen"
+	desc = "An autoinjector containing lenturi, used to treat burns. Makes you slower while in patient's symptom, and provides stomach cramps once fully removed."
 	icon_state = "oxapen"
 	inhand_icon_state = "oxapen"
 	base_icon_state = "oxapen"
-	list_reagents = list(/datum/reagent/medicine/oxandrolone = 10)
+	list_reagents = list(/datum/reagent/medicine/c2/lenturi = 5)
 
-/obj/item/reagent_containers/hypospray/medipen/penacid
-	name = "pentetic acid medipen"
-	desc = "An autoinjector containing pentetic acid, used to reduce high levels of radiations and moderate toxins."
-	icon_state = "penacid"
-	inhand_icon_state = "penacid"
-	base_icon_state = "penacid"
-	list_reagents = list(/datum/reagent/medicine/pen_acid = 10)
-
-/obj/item/reagent_containers/hypospray/medipen/salacid
-	name = "salicylic acid medipen"
-	desc = "An autoinjector containing salicylic acid, used to treat severe brute damage."
+/obj/item/reagent_containers/hypospray/medipen/libital
+	name = "libital medipen"
+	desc = "An autoinjector containing libital, used to treat brute damage at a cost of minor liver toxicity."
 	icon_state = "salacid"
 	inhand_icon_state = "salacid"
 	base_icon_state = "salacid"
-	list_reagents = list(/datum/reagent/medicine/sal_acid = 10)
+	list_reagents = list(/datum/reagent/medicine/c2/libital = 5)
 
-/obj/item/reagent_containers/hypospray/medipen/salbutamol
-	name = "salbutamol medipen"
-	desc = "An autoinjector containing salbutamol, used to heal oxygen damage quickly."
+/obj/item/reagent_containers/hypospray/medipen/convermol
+	name = "convermol medipen"
+	desc = "An autoinjector containing convermol, used to quickly cure asphyxiation but is toxic."
 	icon_state = "salpen"
 	inhand_icon_state = "salpen"
 	base_icon_state = "salpen"
-	list_reagents = list(/datum/reagent/medicine/salbutamol = 10)
+	list_reagents = list(/datum/reagent/medicine/c2/convermol = 10)
 
 /obj/item/reagent_containers/hypospray/medipen/tuberculosiscure
 	name = "BVAK autoinjector"
@@ -255,9 +247,9 @@
 	icon_state = "luxpen"
 	inhand_icon_state = "atropen"
 	base_icon_state = "luxpen"
-	volume = 60
-	amount_per_transfer_from_this = 60
-	list_reagents = list(/datum/reagent/medicine/salbutamol = 10, /datum/reagent/medicine/c2/penthrite = 10, /datum/reagent/medicine/oxandrolone = 10, /datum/reagent/medicine/sal_acid = 10 ,/datum/reagent/medicine/omnizine = 10 ,/datum/reagent/medicine/leporazine = 10)
+	volume = 20
+	amount_per_transfer_from_this = 20
+	list_reagents = list(/datum/reagent/medicine/omnizine = 10 ,/datum/reagent/medicine/leporazine = 10)
 
 /obj/item/reagent_containers/hypospray/medipen/atropine
 	name = "atropine autoinjector"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -123,7 +123,7 @@
 	name = "convermol pill"
 	desc = "Used to treat oxygen deprivation at the cost of toxicity."
 	icon_state = "pill16"
-	list_reagents = list(/datum/reagent/medicine/c2/convermol = 15)
+	list_reagents = list(/datum/reagent/medicine/c2/convermol = 5)
 	rename_with_volume = TRUE
 
 /obj/item/reagent_containers/pill/multiver

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -119,11 +119,11 @@
 	icon_state = "pill19"
 	list_reagents = list(/datum/reagent/medicine/ephedrine = 10, /datum/reagent/medicine/antihol = 10, /datum/reagent/consumable/coffee = 30)
 
-/obj/item/reagent_containers/pill/salbutamol
-	name = "salbutamol pill"
-	desc = "Used to treat oxygen deprivation."
+/obj/item/reagent_containers/pill/convermol
+	name = "convermol pill"
+	desc = "Used to treat oxygen deprivation at the cost of toxicity."
 	icon_state = "pill16"
-	list_reagents = list(/datum/reagent/medicine/salbutamol = 30)
+	list_reagents = list(/datum/reagent/medicine/c2/convermol = 15)
 	rename_with_volume = TRUE
 
 /obj/item/reagent_containers/pill/multiver
@@ -159,18 +159,11 @@
 	list_reagents = list(/datum/reagent/medicine/mutadone = 50)
 	rename_with_volume = TRUE
 
-/obj/item/reagent_containers/pill/salicylic
-	name = "salicylic acid pill"
-	desc = "Used to dull pain."
-	icon_state = "pill9"
-	list_reagents = list(/datum/reagent/medicine/sal_acid = 24)
-	rename_with_volume = TRUE
-
-/obj/item/reagent_containers/pill/oxandrolone
-	name = "oxandrolone pill"
-	desc = "Used to stimulate burn healing."
+/obj/item/reagent_containers/pill/lenturi
+	name = "lenturi pill"
+	desc = "Used to stimulate burn healing. Slows the patient down and gives stomach cramps once fully metabolized."
 	icon_state = "pill11"
-	list_reagents = list(/datum/reagent/medicine/oxandrolone = 24)
+	list_reagents = list(/datum/reagent/medicine/c2/lenturi = 12)
 	rename_with_volume = TRUE
 
 /obj/item/reagent_containers/pill/insulin
@@ -184,13 +177,6 @@
 	name = "psicodine pill"
 	desc = "Used to treat mental instability and phobias."
 	list_reagents = list(/datum/reagent/medicine/psicodine = 10)
-	icon_state = "pill22"
-	rename_with_volume = TRUE
-
-/obj/item/reagent_containers/pill/penacid
-	name = "pentetic acid pill"
-	desc = "Used to expunge radiation and toxins."
-	list_reagents = list(/datum/reagent/medicine/pen_acid = 10)
 	icon_state = "pill22"
 	rename_with_volume = TRUE
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -235,20 +235,10 @@
 	desc = "Contains crikey juice - makes any gold core create the most deadly companions in the world."
 	list_reagents = list(/datum/reagent/spider_extract = 1)
 
-/obj/item/reagent_containers/syringe/oxandrolone
-	name = "syringe (oxandrolone)"
-	desc = "Contains oxandrolone, used to treat severe burns."
-	list_reagents = list(/datum/reagent/medicine/oxandrolone = 15)
-
-/obj/item/reagent_containers/syringe/salacid
-	name = "syringe (salicylic acid)"
-	desc = "Contains salicylic acid, used to treat severe brute damage."
-	list_reagents = list(/datum/reagent/medicine/sal_acid = 15)
-
-/obj/item/reagent_containers/syringe/penacid
-	name = "syringe (pentetic acid)"
-	desc = "Contains pentetic acid, used to reduce high levels of radiation and heal severe toxins."
-	list_reagents = list(/datum/reagent/medicine/pen_acid = 15)
+/obj/item/reagent_containers/syringe/aiuri
+	name = "syringe (aiuri)"
+	desc = "Contains aiuri, used to treat burns. Causes minor eye damage."
+	list_reagents = list(/datum/reagent/medicine/c2/aiuri = 15)
 
 /obj/item/reagent_containers/syringe/syriniver
 	name = "syringe (syriniver)"

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -563,7 +563,8 @@
 /obj/item/slime_extract/cerulean/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
-			user.reagents.add_reagent(/datum/reagent/medicine/salbutamol,15)
+			ADD_TRAIT(user, TRAIT_NOBREATH, src)
+			addtimer(TRAIT_CALLBACK_REMOVE(user, TRAIT_NOBREATH, src), (15 SECONDS))
 			to_chat(user, "<span class='notice'>You feel like you don't need to breathe!</span>")
 			return 150
 

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -18,7 +18,7 @@
 	high_threshold_cleared = "<span class='info'>The constriction around your chest loosens as your breathing calms down.</span>"
 
 
-	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/medicine/salbutamol = 5)
+	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/oxygen = 2, /datum/reagent/nitrogen = 8)
 
 	//Breath damage
 	//These thresholds are checked against what amounts to total_mix_pressure * (gas_type_mols/total_mols)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Kills off the major remaining C3s pertaining to direct healing of your 4 fav damages.

Replaces them with one of the C2 counterparts where applicable (I tried to not give you duplicates, IE hercuri is in some forms since lenturi was already in the medkit as a patch). Toxin largely not included.

I'm not entirely sure what to do with "luxury" items, since they were really only luxury in the sense you don't have to talk to chemistry if chemistry was remotely competent at making meds (I personally make all the C3s and put them in a pill and can factory it in under 15 minutes, so i imagine people using dispenser muscle memory can churn these suckers out even faster).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

C3s have no situational efficacy, and therefore make them a superb chem by that nature alone. The only cost associated with them is a theoretical opportunity cost pertaining to "could I have swallowed another pill or taken another injection", which could be countered by simply mixing the chems into combo pills so you receive both (but slightly less) of each chem simultaneously since you often care more about upfront than long term (especially in a world where wounds exist).

I can make a factory having all the c3 chems and not have to worry about if that is the ideal healing numbers because C3s are foolproof bar OD (there is never a situation where they aren't viable, just situations when they aren't AS viable) and are easily dopable, so I don't ever need to worry about a doctor using the roundstart supply of meds in addition to what i'm providing because they're symbiotic/stacking.

Reason why I removed pent largely without alternatives is because pent did both toxin healing the damage number, reagent purging, and radiation. I believe i replaced medpens with syriniver.

As for removing vs. replacing, im pretty peculiar on adding more chems that overlap in function for the reason that chems work together just as much / more than they compete. I don't want the same chem being pooped out ad naseum but I also don't want super diluted mixes that give you all the upsides with the downsides spread out to the point of non-existence.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Cobby
balance: C3s (Salicylic Acid/Oxandrolone/Salbutamol/Pentetic) have been removed and largely replaced with a corresponding C2, varying where appropriate. This can include items that contain said chemicals, such as gumballs and luxury pens.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
