### PR TITLE
Tramstation: Big Brother Update

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -23,13 +23,10 @@
 "aae" = (
 /turf/closed/mineral/random/stationside/asteroid,
 /area/mine/explored)
-"aaf" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "aag" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/mouse/brown/tom,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/security/prison)
 "aai" = (
@@ -40,12 +37,14 @@
 	name = "Prison Cells APC";
 	pixel_y = 23
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "aaj" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "aak" = (
@@ -226,6 +225,7 @@
 /obj/structure/rack,
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/clothing/mask/breath,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "aaF" = (
@@ -285,7 +285,9 @@
 /area/commons/dorms)
 "aaQ" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/airlock/public/glass{
+	name = "Command Wing Hallway"
+	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -320,7 +322,6 @@
 /area/security/prison)
 "aba" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -328,6 +329,9 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/public/glass{
+	name = "Command Wing Hallway"
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "abb" = (
@@ -402,12 +406,14 @@
 /area/hallway/primary/port)
 "abm" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Wing"
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
@@ -443,7 +449,6 @@
 /area/security/courtroom)
 "abt" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
@@ -651,6 +656,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/security/prison)
 "acm" = (
@@ -824,6 +830,7 @@
 "acP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/security/prison)
 "acS" = (
@@ -990,6 +997,7 @@
 	req_access_txt = "28"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "adr" = (
@@ -3238,6 +3246,10 @@
 "akZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/camera{
+	c_tag = "Civilian - West Restroom";
+	dir = 6
+	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "alb" = (
@@ -3257,6 +3269,9 @@
 "ald" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/camera{
+	c_tag = "Civilian - East Restroom"
+	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "ale" = (
@@ -4165,12 +4180,14 @@
 /area/service/bar)
 "anZ" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Service Wing Hallway"
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
@@ -4182,7 +4199,9 @@
 /area/commons/dorms)
 "aob" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/airlock/public/glass{
+	name = "Service Wing Hallway"
+	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -8720,6 +8739,15 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"aBi" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "aBm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -10596,6 +10624,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Civilian - Upper Power Hatch";
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
 "aHh" = (
@@ -11080,9 +11112,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"aIN" = (
-/turf/open/floor/plating,
-/area/maintenance/central)
 "aIO" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -11217,10 +11246,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"aJh" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "aJk" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Tunnel Access";
@@ -11668,6 +11693,10 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/camera{
+	c_tag = "Hallway - Bar Stairs East";
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aMF" = (
@@ -11885,6 +11914,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Maintenance - West Tram Tunnel 2";
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
@@ -12138,6 +12171,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "aPq" = (
@@ -12398,6 +12432,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/camera{
+	c_tag = "Hallway - Bar Stairs West"
+	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aRd" = (
@@ -12857,6 +12894,15 @@
 /obj/item/holosign_creator/robot_seat/restaurant,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
+"aTM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "aTQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -14008,6 +14054,11 @@
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Security - Upper Power Hatch";
+	dir = 6;
+	network = list("ss13","Security")
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "bfg" = (
@@ -14041,18 +14092,6 @@
 /obj/item/staff,
 /turf/open/floor/wood,
 /area/service/library)
-"bfF" = (
-/obj/effect/turf_decal/trimline/yellow/warning,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/maintenance/tram/mid)
 "bfM" = (
 /obj/machinery/power/emitter/welded{
 	dir = 8
@@ -14102,6 +14141,15 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
+"bhj" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -15113,8 +15161,8 @@
 /area/maintenance/disposal)
 "bBD" = (
 /obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office";
-	req_access_txt = "31"
+	name = "Mailing Sorting Office";
+	req_access_txt = "50"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -15838,6 +15886,11 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"bOp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "bOv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16522,6 +16575,10 @@
 	dir = 1
 	},
 /obj/effect/spawner/lootdrop/food_packaging,
+/obj/machinery/camera{
+	c_tag = "Maintenance - West Tram Tunnel 3";
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "cbb" = (
@@ -16685,6 +16742,18 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"cdY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison)
 "cdZ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -17024,6 +17093,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "clC" = (
@@ -17789,6 +17859,10 @@
 	},
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Command - Upper Power Hatch";
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/command/bridge)
@@ -18643,7 +18717,6 @@
 /area/hallway/secondary/command)
 "cTD" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -19542,6 +19615,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Maintenance - West Tram Tunnel 1";
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "dnN" = (
@@ -20095,6 +20172,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "dvK" = (
@@ -20321,6 +20399,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "dBf" = (
@@ -20982,6 +21061,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "dLp" = (
@@ -21905,7 +21985,14 @@
 	},
 /obj/structure/cable,
 /obj/machinery/duct,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Prison Maintenance Access";
+	req_access_txt = "2";
+	security_level = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating,
 /area/maintenance/central)
 "egz" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -22229,6 +22316,12 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/security/prison)
+"eni" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "enp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/cone{
@@ -22501,6 +22594,10 @@
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Command - Lower Power Hatch";
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -22872,11 +22969,11 @@
 /turf/open/floor/iron,
 /area/commons/lounge)
 "eAw" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/plumbing/synthesizer{
 	dir = 4;
 	reagent_id = /datum/reagent/water
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "eAE" = (
@@ -23160,6 +23257,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/machinery/camera{
+	c_tag = "Service - Lower Power Hatch";
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "eGF" = (
@@ -23324,6 +23425,10 @@
 /obj/effect/spawner/lootdrop/food_packaging,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"eLO" = (
+/obj/structure/sign/warning/docking,
+/turf/closed/wall,
+/area/hallway/secondary/exit)
 "eLP" = (
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -23659,6 +23764,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"eTa" = (
+/turf/closed/wall,
+/area/science/server)
 "eTg" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/light,
@@ -23948,6 +24056,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "eZa" = (
@@ -23957,6 +24066,7 @@
 /area/maintenance/port/central)
 "eZn" = (
 /obj/effect/spawner/lootdrop/food_packaging,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "eZr" = (
@@ -24439,6 +24549,7 @@
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "fiD" = (
@@ -24664,13 +24775,6 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "fnk" = (
-/turf/open/floor/iron,
-/area/security/prison)
-"fnR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
 "fnT" = (
@@ -25171,8 +25275,17 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/item/food/deadmouse,
+/obj/item/plate,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/item/food/deadmouse{
+	pixel_x = -1;
+	pixel_y = 7
+	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "fzC" = (
@@ -25200,6 +25313,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "fAK" = (
@@ -25806,6 +25920,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Maintenance - Central Tram Tunnel 3";
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "fLB" = (
@@ -26064,6 +26182,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"fPW" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/holosign/barrier/atmos/sturdy,
+/obj/machinery/camera{
+	c_tag = "Hallway - North-West Tram Bridge";
+	dir = 1
+	},
+/turf/open/floor/vault,
+/area/hallway/primary/tram/center)
 "fQb" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
@@ -26616,6 +26743,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"gcr" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 3;
+	height = 5;
+	id = "commonmining_home";
+	name = "SS13: Common Mining Dock";
+	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
+	width = 7
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/mine/explored)
 "gct" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -26830,6 +26969,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"ghc" = (
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "ghi" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -27388,6 +27533,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"gtS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "guh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/shower{
@@ -28066,7 +28225,6 @@
 /area/science/robotics/lab)
 "gIC" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -28076,6 +28234,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Wing"
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "gIF" = (
@@ -28122,8 +28283,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "gIN" = (
-/obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "gIO" = (
@@ -28423,6 +28584,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Maintenance - Escape Pod";
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "gOk" = (
@@ -28528,6 +28693,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"gQi" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/showroomfloor,
+/area/service/kitchen)
 "gQo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
@@ -30449,6 +30618,11 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
+"hzv" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/brown/corner,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "hzw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -30527,6 +30701,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "hAH" = (
@@ -31574,6 +31749,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "iaM" = (
@@ -31614,6 +31790,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/camera{
+	c_tag = "Hallway - Bar West Restroom";
+	dir = 8
+	},
 /turf/open/floor/iron/freezer,
 /area/service/bar)
 "ibO" = (
@@ -32398,6 +32578,14 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/service/janitor)
+"ium" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Hallway - Upper West Power Hatch";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/tram/right)
 "iuu" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -32418,6 +32606,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
 	},
+/obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "ivk" = (
@@ -32580,9 +32769,20 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"iyj" = (
+/obj/structure/bed,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/mask/muzzle,
+/obj/machinery/camera{
+	c_tag = "Security - Prison Sanitarium";
+	dir = 6;
+	network = list("ss13","Security","prison")
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "iyq" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -32590,6 +32790,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/public/glass{
+	name = "Service Wing Hallway"
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "iyu" = (
@@ -33185,20 +33388,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"iJM" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/plate,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/maintenance/tram/mid)
 "iJQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -33298,6 +33487,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"iLW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Hallway - Lower West Power Hatch";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/tram/right)
 "iMo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33480,7 +33677,6 @@
 /area/tcommsat/server)
 "iOT" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -33489,6 +33685,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/public/glass{
+	name = "Command Wing Hallway"
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "iOU" = (
@@ -33935,6 +34134,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"iYk" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/line,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison)
 "iYt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -34174,6 +34381,19 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"jfY" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Command Wing Hallway"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "jgi" = (
 /obj/item/pickaxe,
 /obj/structure/rack,
@@ -34544,6 +34764,24 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"jol" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/camera{
+	c_tag = "Maintenance - Central Tram Tunnel 4";
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/maintenance/tram/mid)
 "jor" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/scrubber/huge,
@@ -35222,6 +35460,21 @@
 /obj/item/paper/pamphlet/radstorm,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/civil)
+"jDc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "jDf" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -35402,6 +35655,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "jHg" = (
@@ -36074,6 +36328,15 @@
 /obj/machinery/chem_master,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"jUV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Science - Lower Power Hatch";
+	dir = 1;
+	network = list("ss13","science")
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "jVb" = (
 /obj/structure/transit_tube,
 /turf/open/floor/plating/airless,
@@ -36538,7 +36801,6 @@
 /area/maintenance/tram/right)
 "kcR" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
@@ -36547,6 +36809,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Wing"
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "kcS" = (
@@ -36873,6 +37138,11 @@
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Science - Restroom";
+	dir = 1;
+	network = list("ss13","science")
 	},
 /turf/open/floor/iron/freezer,
 /area/science/research)
@@ -37286,6 +37556,14 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
+"kpB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Hallway - Upper West Power Hatch";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/tram/left)
 "kpL" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -37506,6 +37784,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Security - Escape Pod";
+	dir = 6;
+	network = list("ss13","Security")
+	},
 /turf/open/floor/plating,
 /area/security/office)
 "kso" = (
@@ -37851,6 +38134,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"kzq" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/structure/table,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "kzt" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -38016,6 +38305,10 @@
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
+/obj/machinery/camera{
+	c_tag = "Service - Upper Power Hatch";
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/service/hydroponics)
 "kCp" = (
@@ -39066,6 +39359,21 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
+"kYu" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
+/obj/structure/rack,
+/obj/item/gps/mining{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/gps/mining{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "kZb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/engine,
@@ -39145,6 +39453,11 @@
 "kZV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
+	},
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Atmospherics Incinerator ACcess";
+	dir = 6;
+	network = list("ss13","engineering")
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -39285,6 +39598,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
+"lcO" = (
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "lcW" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/heater{
 	dir = 8
@@ -39418,7 +39734,7 @@
 "lft" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office";
-	req_access_txt = "50"
+	req_access_txt = "31"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -39865,6 +40181,7 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "lnB" = (
@@ -40075,6 +40392,21 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/prison)
+"lrM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Maintenance - East Tram Tunnel 1";
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/maintenance/tram/right)
 "lsF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/light/small{
@@ -40214,6 +40546,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"luW" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "lva" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41678,7 +42019,6 @@
 /area/cargo/sorting)
 "mbx" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -42158,18 +42498,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"mlJ" = (
-/obj/effect/turf_decal/trimline/yellow/warning,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/maintenance/tram/mid)
 "mlP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
@@ -43316,6 +43644,7 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "mMK" = (
@@ -43408,6 +43737,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "mOw" = (
@@ -43530,6 +43860,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "mQb" = (
@@ -43900,6 +44231,10 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
+"mYq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "mYF" = (
 /turf/open/floor/engine,
 /area/engineering/supermatter)
@@ -44784,6 +45119,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "ntB" = (
@@ -45162,6 +45498,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "nAU" = (
@@ -46340,6 +46677,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
+/obj/machinery/camera{
+	c_tag = "Maintenance - East Tram Tunnel 3";
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
 "ocS" = (
@@ -46713,6 +47054,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "oiX" = (
@@ -46760,8 +47102,20 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "oju" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/corner,
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "ojL" = (
@@ -47064,6 +47418,7 @@
 /area/science/robotics/lab)
 "ooT" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/security/prison)
 "ooW" = (
@@ -47967,6 +48322,11 @@
 /area/science/robotics/lab)
 "oHI" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Cargo - Upper Power Hatch";
+	dir = 6;
+	network = list("ss13","cargo")
+	},
 /turf/open/floor/plating,
 /area/cargo/storage)
 "oHS" = (
@@ -48062,6 +48422,17 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"oJB" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Security - Prison Lower Hall";
+	dir = 5;
+	network = list("ss13","Security","prison")
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "oJH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -48069,6 +48440,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "oJJ" = (
@@ -48232,6 +48604,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin{
+	pixel_x = -2;
+	pixel_y = -2
+	},
 /turf/open/floor/iron/dark,
 /area/science/research)
 "oMz" = (
@@ -48967,6 +49344,15 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"paP" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "paY" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 1;
@@ -49166,6 +49552,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"peK" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison)
 "peZ" = (
 /obj/effect/turf_decal/box/white,
 /obj/effect/decal/cleanable/dirt,
@@ -49266,6 +49661,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"phh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Maintenance - Central Tram Tunnel 1";
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/maintenance/tram/mid)
 "phq" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -49843,6 +50253,11 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "pto" = (
+/obj/machinery/camera{
+	c_tag = "Science - Upper Power Hatch";
+	dir = 1;
+	network = list("ss13","science")
+	},
 /turf/open/floor/plating,
 /area/science/research)
 "pty" = (
@@ -50780,8 +51195,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "pNt" = (
@@ -50828,6 +51243,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Medical - Upper Power Hatch";
+	dir = 5;
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -50918,6 +51338,17 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"pPA" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Security - Prison Upper Hall";
+	dir = 5;
+	network = list("ss13","Security","prison")
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "pQa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -51057,6 +51488,20 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"pSo" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Security - Prisoner Courtroom Transit Hall";
+	dir = 9;
+	network = list("ss13","Security")
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "pSq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -51562,6 +52007,7 @@
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "qdM" = (
@@ -51606,6 +52052,16 @@
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/department/medical)
+"qfD" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "qgg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
@@ -51697,6 +52153,15 @@
 "qhx" = (
 /turf/closed/wall,
 /area/science/xenobiology)
+"qhY" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/folder/yellow,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "qih" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
 	dir = 1
@@ -51892,6 +52357,10 @@
 	name = "graffiti";
 	paint_colour = "#FF0000";
 	pixel_y = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Maintenance - Central Tram Tunnel 5";
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
@@ -52435,6 +52904,10 @@
 	auto_patrol = 1;
 	name = "Officer Tunnel Rat"
 	},
+/obj/machinery/camera{
+	c_tag = "Maintenance - East Tram Tunnel 4";
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
 "qyW" = (
@@ -52698,6 +53171,7 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "qDt" = (
@@ -53016,6 +53490,10 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/camera{
+	c_tag = "Maintenance - East Tram Tunnel 2";
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
 "qIG" = (
@@ -53240,6 +53718,15 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"qQJ" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/holosign/barrier/atmos/sturdy,
+/obj/machinery/camera{
+	c_tag = "Hallway - North-East Tram Bridge";
+	dir = 1
+	},
+/turf/open/floor/vault,
+/area/hallway/primary/tram/right)
 "qQR" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -53516,6 +54003,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "qVK" = (
@@ -53652,14 +54140,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
-"qYU" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/turf/open/floor/iron,
-/area/maintenance/tram/mid)
 "qZl" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -53894,6 +54374,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "rcH" = (
@@ -55664,9 +56145,6 @@
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "rMa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
@@ -55678,6 +56156,9 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "rMf" = (
@@ -56140,6 +56621,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/right)
+"rXp" = (
+/obj/machinery/door/airlock/external{
+	name = "Common Mining Dock"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "rXr" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -56693,6 +57180,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Medical - Lower Power Hatch";
+	dir = 5;
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -57550,6 +58042,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
+"sxP" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/obj/structure/sign/poster/official/safety_internals{
+	pixel_x = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Cargo - Public Mining Dock";
+	dir = 4;
+	network = list("ss13","cargo")
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "syc" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -57834,6 +58340,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"sEy" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "sEA" = (
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
@@ -57873,6 +58388,10 @@
 /obj/structure/table,
 /obj/item/multitool,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Hallway - Lower West Power Hatch";
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
 "sFC" = (
@@ -57966,11 +58485,11 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "sHL" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/plumbing/synthesizer{
 	dir = 4;
 	reagent_id = /datum/reagent/water
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "sHQ" = (
@@ -58015,6 +58534,11 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
+"sIY" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/warning,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "sJU" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -58609,6 +59133,15 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
+"sWT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "sXa" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -58787,6 +59320,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"tcf" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "tci" = (
 /obj/structure/chair{
 	dir = 8
@@ -59291,6 +59836,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
 	},
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "tjo" = (
@@ -59744,6 +60292,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Civilian - Lower Power Hatch";
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/commons/lounge)
 "tqL" = (
@@ -59838,6 +60390,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"tsm" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison)
 "tsp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -59889,17 +60450,6 @@
 "ttN" = (
 /turf/open/openspace,
 /area/cargo/storage)
-"ttQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "ttV" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -60168,6 +60718,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"txV" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/camera{
+	c_tag = "Maintenance - Central Tram Tunnel 2";
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/maintenance/tram/mid)
 "txZ" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/light/small{
@@ -60212,6 +60777,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "tzc" = (
@@ -60427,6 +60993,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "tEA" = (
@@ -61670,6 +62237,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "tZl" = (
@@ -61939,6 +62507,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"ueH" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Lavaland Mining Dock"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "ueN" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
@@ -63267,6 +63854,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "uIZ" = (
@@ -64241,6 +64829,12 @@
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"vaa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "vas" = (
 /obj/effect/turf_decal/sand,
 /obj/item/chair,
@@ -64360,6 +64954,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"vdf" = (
+/obj/machinery/computer/shuttle/mining/common{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "vdk" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/holosign/barrier/atmos/sturdy,
@@ -64530,6 +65133,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "vgz" = (
@@ -66471,6 +67075,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"vSR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Cargo - Lower Power Hatch";
+	dir = 6;
+	network = list("ss13","cargo")
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "vTg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
@@ -67775,6 +68388,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/research)
+"wtI" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "wtK" = (
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
@@ -68427,7 +69044,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Hallway - Bar West";
+	c_tag = "Hallway - Bar Entry West";
 	dir = 6
 	},
 /obj/effect/landmark/start/hangover,
@@ -68660,6 +69277,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "wGY" = (
@@ -69174,6 +69792,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Security - Lower Power Hatch";
+	dir = 6;
+	network = list("ss13","Security")
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "wPP" = (
@@ -69555,6 +70178,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "wYY" = (
@@ -70038,6 +70662,10 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/camera{
+	c_tag = "Hallway - Bar East Restroom";
+	dir = 4
+	},
 /turf/open/floor/iron/freezer,
 /area/service/bar)
 "xja" = (
@@ -70715,6 +71343,7 @@
 /obj/structure/rack,
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "xxn" = (
@@ -70904,6 +71533,7 @@
 	pixel_y = -30
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "xAA" = (
@@ -71260,6 +71890,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
@@ -72819,6 +73452,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "yli" = (
@@ -99178,7 +99812,7 @@ aae
 aae
 aae
 nTn
-osQ
+iyj
 vPp
 osQ
 nTn
@@ -101526,7 +102160,7 @@ aBM
 aae
 aae
 aHH
-hZa
+phh
 wiA
 gcW
 aMP
@@ -102811,13 +103445,13 @@ hpO
 hpO
 tmB
 fIe
-bfF
-wiA
-aMP
-aMP
-aMP
-vQt
-qYU
+mBa
+sbm
+aMT
+aMT
+aMT
+aMT
+cEd
 fTY
 aHH
 aae
@@ -103068,13 +103702,13 @@ aGF
 aGF
 aHH
 aHH
-mBa
-sbm
-aMT
-aMT
-aMT
-aMT
-cEd
+qcw
+wiA
+aMP
+aMP
+aMP
+vQt
+rwy
 aHH
 aHH
 aae
@@ -103282,18 +103916,18 @@ aae
 aae
 nTn
 acD
-gTp
+iYk
 oiN
 mMz
 lnr
 wGU
 nAy
 mOu
-gBA
-vJR
-eNH
+tsm
+peK
+teD
 dvB
-gBA
+tsm
 mOu
 dAM
 uIY
@@ -103301,8 +103935,8 @@ hAD
 tEt
 rcF
 yle
-jRn
-vPp
+bOp
+wtI
 txB
 nTn
 aae
@@ -103548,7 +104182,7 @@ cIh
 cIh
 cIh
 afo
-drV
+sUB
 tsF
 cIh
 cIh
@@ -103559,7 +104193,7 @@ txx
 emA
 eLS
 jRn
-vPp
+wtI
 rge
 nTn
 aae
@@ -103588,7 +104222,7 @@ aMP
 aMP
 aMP
 vQt
-rwy
+txV
 aHH
 aHH
 aHH
@@ -103805,7 +104439,7 @@ rZn
 hkZ
 cIh
 ttL
-qCK
+cdY
 pmL
 cIh
 hkZ
@@ -103816,7 +104450,7 @@ eru
 mcy
 laM
 jRn
-vPp
+wtI
 ieo
 nTn
 aae
@@ -104062,7 +104696,7 @@ iQg
 cbG
 gWt
 fLV
-eNH
+teD
 fBG
 gWE
 vgs
@@ -104576,7 +105210,7 @@ fcZ
 hkZ
 cIh
 uXd
-qCK
+cdY
 sYd
 cIh
 hkZ
@@ -104833,7 +105467,7 @@ iQg
 cbG
 qAw
 fLV
-fnR
+pNt
 fBG
 iHr
 vgs
@@ -105090,7 +105724,7 @@ cIh
 cIh
 cIh
 abB
-qCK
+cdY
 ofB
 cIh
 cIh
@@ -105347,7 +105981,7 @@ rzK
 ewN
 ccM
 ttL
-qCK
+cdY
 uBm
 ccM
 dGC
@@ -105604,7 +106238,7 @@ hTT
 pKD
 gEc
 ttL
-qCK
+cdY
 pmL
 ccM
 abO
@@ -106666,13 +107300,13 @@ qCQ
 aGF
 aHH
 aHH
-nXD
-efX
-efX
-efX
-efX
-efX
-usA
+eSp
+wiA
+aMP
+aMP
+aMP
+vQt
+jol
 aHH
 aHH
 aae
@@ -106886,13 +107520,13 @@ gJE
 abx
 rpv
 nHL
-nUW
+pPA
 nlp
 wPE
 sUB
 wzc
 uPs
-nUW
+oJB
 gls
 nUW
 afX
@@ -106923,13 +107557,13 @@ agQ
 agQ
 aIb
 rTT
-mlJ
-wiA
-aMP
-aMP
-aMP
-vQt
-iJM
+nXD
+efX
+efX
+efX
+efX
+efX
+usA
 tvn
 aHH
 aae
@@ -107917,8 +108551,8 @@ fUD
 iSL
 ccM
 aai
-ttQ
-aIN
+kei
+vLw
 ccM
 sjX
 jpo
@@ -108173,9 +108807,9 @@ xPA
 rMZ
 xPA
 ccM
-aIN
-ttQ
-aIN
+vLw
+kei
+vLw
 ccM
 nTN
 xMx
@@ -108431,8 +109065,8 @@ nTn
 nTn
 nTn
 aaj
-ttQ
-aJh
+kei
+hod
 nTn
 nTn
 nTn
@@ -108686,10 +109320,10 @@ aae
 aae
 aae
 aac
-aaf
-aIN
-ttQ
-aIN
+goZ
+vLw
+kei
+vLw
 aaE
 aac
 aae
@@ -108944,10 +109578,10 @@ aae
 aae
 aac
 eZn
-aIN
-ttQ
-aIN
-aIN
+vLw
+kei
+vLw
+vLw
 aac
 aae
 aae
@@ -111549,7 +112183,7 @@ aae
 aae
 aae
 aHI
-xGb
+lrM
 pmY
 aMY
 aMY
@@ -112561,7 +113195,7 @@ nzB
 wwj
 fmq
 dzy
-aet
+vSR
 huY
 aeu
 veY
@@ -112604,7 +113238,7 @@ gGO
 wGY
 jcZ
 lUD
-neO
+jUV
 aJy
 aae
 aJo
@@ -115172,7 +115806,7 @@ pnl
 cTs
 bJd
 oMq
-msN
+paP
 rMa
 teJ
 tkl
@@ -115429,8 +116063,8 @@ pnl
 cTs
 bJd
 iuF
-msN
-vyG
+bhj
+gtS
 jPn
 ujs
 aRO
@@ -117979,7 +118613,7 @@ fKQ
 aNi
 lTO
 vZj
-aMY
+iLW
 aMG
 aJf
 aMY
@@ -157301,7 +157935,7 @@ hjB
 sxO
 sxO
 oCU
-apv
+kpB
 awF
 lJR
 apv
@@ -159593,7 +160227,7 @@ kze
 apd
 amK
 acK
-auC
+gQi
 aXK
 aGY
 aBQ
@@ -164975,7 +165609,7 @@ ccM
 xKu
 xak
 rOs
-rOs
+pSo
 rIQ
 rOs
 dHF
@@ -165262,15 +165896,15 @@ aBM
 aBM
 aBM
 dOi
-eFB
+anG
 azN
 azN
 vdk
 mjd
 ohl
 azP
-azP
-jpW
+fPW
+avn
 aRN
 aBM
 aae
@@ -171685,7 +172319,7 @@ vhe
 dvg
 sjf
 aDY
-aaQ
+jfY
 wpS
 avK
 axr
@@ -175542,15 +176176,15 @@ aae
 aBM
 aBM
 dOi
-jpW
+avn
 azP
 azP
 fsL
 bnl
 tZs
 aAJ
-aAJ
-xMC
+qQJ
+aod
 aRN
 aBM
 aBM
@@ -183515,7 +184149,7 @@ aux
 rWR
 rWR
 qua
-aux
+ium
 axR
 avY
 aux
@@ -183779,7 +184413,7 @@ aod
 aod
 nQC
 uwx
-tCx
+hzv
 qze
 gSB
 gSB
@@ -184036,14 +184670,14 @@ eoj
 aod
 cCK
 pjY
-tCx
-qze
-aae
-aae
-aae
-aae
-aae
-aae
+sIY
+mYq
+sxP
+aBi
+sEy
+eni
+qfD
+kYu
 xjn
 vnK
 gDX
@@ -184292,15 +184926,15 @@ xNV
 the
 abm
 xHK
-uwx
+sWT
 oju
-qze
-aae
-aae
-aae
-aae
-aae
-aae
+ueH
+jDc
+aTM
+vaa
+vaa
+vaa
+kzq
 xjn
 nTD
 xdC
@@ -184548,17 +185182,17 @@ hRb
 wHf
 tCx
 cmf
-nQC
+tcf
 bdb
-tCx
-qze
-aae
-aae
-aae
-aae
-aae
-aae
-xjn
+sIY
+mYq
+luW
+ghc
+ghc
+vdf
+ghc
+qhY
+eTa
 xjn
 xjn
 xjn
@@ -184809,13 +185443,13 @@ jrA
 gIK
 tjm
 qze
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+mYq
+mYq
+rXp
+mYq
+mYq
+eLO
+qze
 aae
 aae
 aae
@@ -185066,13 +185700,13 @@ qze
 qze
 qze
 qze
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aBM
+mYq
+lcO
+mYq
+aBM
+aBM
+aBM
 aae
 aae
 aae
@@ -185321,16 +185955,16 @@ jsj
 gBY
 gBY
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aBM
+aBM
+aBM
+mYq
+rXp
+mYq
+aBM
+aBM
+aBM
+aBM
 aae
 aae
 aae
@@ -185578,16 +186212,16 @@ jbm
 iff
 gBY
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aBM
+aBM
+aBM
+aBM
+gcr
+aBM
+aBM
+aBM
+aBM
+aBM
 aae
 aae
 aae
@@ -185834,20 +186468,20 @@ fxr
 jbm
 aFu
 gBY
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
 aae
 aae
 aae
@@ -186091,19 +186725,19 @@ eHH
 jbm
 sBJ
 gBY
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
 aae
 aBM
 aBM
@@ -186348,18 +186982,18 @@ eHH
 jbm
 mqd
 gBY
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
 aBM
 aBM
 aBM
@@ -186605,14 +187239,14 @@ ark
 arn
 ybL
 gBY
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
 aBM
 aBM
 aBM
@@ -186862,18 +187496,18 @@ eHH
 aro
 oKj
 gBY
-aae
-aae
-aae
 aBM
 aBM
 aBM
 aBM
 aBM
 aBM
-aYr
-aYr
-aYr
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
 aYr
 gNY
 aYr
@@ -187119,16 +187753,16 @@ eHH
 aro
 khm
 gBY
-aae
-aae
 aBM
 aBM
 aBM
-aYr
-aYr
-aYr
-aYr
-aYr
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
 aYr
 aYr
 aYr
@@ -187377,15 +188011,15 @@ aro
 arp
 gBY
 aae
-aae
 aBM
 aBM
 aBM
-aYr
-aYr
-aYr
-aYr
-aYr
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
 aYr
 aYr
 aYr
@@ -187635,13 +188269,13 @@ xWQ
 gBY
 aae
 aae
+aBM
+aBM
+aBM
 aYr
 aYr
-aYr
-aYr
-aYr
-aYr
-aYr
+aBM
+aBM
 aYr
 aYr
 aYr

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -11498,10 +11498,10 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/chem_heater,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
+/obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "aLx" = (
@@ -35048,12 +35048,12 @@
 /obj/structure/window/reinforced{
 	pixel_y = 2
 	},
-/obj/machinery/chem_heater,
 /obj/machinery/camera{
 	c_tag = "Medical - Pharmacy";
 	dir = 4;
 	network = list("ss13","medbay")
 	},
+/obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "juo" = (
@@ -58888,7 +58888,6 @@
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/ce)
 "sSd" = (
-/obj/machinery/chem_heater,
 /obj/structure/window/reinforced{
 	pixel_y = 2
 	},
@@ -58898,6 +58897,7 @@
 	pixel_x = 24;
 	pixel_y = 8
 	},
+/obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "sSh" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -14041,7 +14041,7 @@
 "beR" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "beV" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	dir = 4
@@ -15384,7 +15384,7 @@
 "bFu" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix,
 /turf/open/floor/engine,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "bFz" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
@@ -23868,7 +23868,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "eUX" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -26418,6 +26418,7 @@
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/science/mixing)
 "fTY" = (
@@ -28242,7 +28243,7 @@
 "gIF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "gIG" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -36167,7 +36168,7 @@
 	network = list("ss13","science")
 	},
 /turf/open/floor/engine,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "jSl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -42211,7 +42212,7 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /turf/open/floor/engine,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "mhz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -44520,6 +44521,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"neU" = (
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "nfa" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -45934,7 +45938,7 @@
 /area/maintenance/tram/mid)
 "nKT" = (
 /turf/open/floor/engine/vacuum,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "nLa" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
@@ -50179,7 +50183,7 @@
 "prF" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "prM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -57941,15 +57945,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"svk" = (
-/obj/effect/landmark/blobstart,
-/obj/machinery/duct,
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "svq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
@@ -58177,6 +58172,10 @@
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
+"sAP" = (
+/obj/machinery/air_sensor/atmos/toxins_mixing_tank,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "sAS" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral{
@@ -60329,7 +60328,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "tre" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
@@ -62318,7 +62317,7 @@
 	pixel_x = -24
 	},
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "uaP" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/event_spawn,
@@ -63303,7 +63302,7 @@
 "usG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/closed/wall/r_wall,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "usM" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -63391,7 +63390,7 @@
 "uuB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "uuG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -70454,7 +70453,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/engine,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "xeO" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -72011,7 +72010,7 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /turf/open/floor/engine,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "xJA" = (
 /obj/effect/turf_decal/stripes,
 /obj/effect/turf_decal/stripes{
@@ -117619,7 +117618,7 @@ cbV
 ess
 ruh
 cht
-mSi
+neU
 beR
 beR
 beR
@@ -117876,7 +117875,7 @@ cbV
 ess
 xwF
 axC
-mSi
+neU
 nKT
 prF
 nKT
@@ -118133,9 +118132,9 @@ bOv
 aUr
 lgh
 kbJ
-mSi
+neU
 eUU
-nKT
+sAP
 tqT
 wiT
 vml
@@ -118390,7 +118389,7 @@ cgy
 xDy
 jys
 dSz
-mSi
+neU
 gIF
 xJw
 usG
@@ -118904,7 +118903,7 @@ wUd
 sOv
 vgg
 swZ
-mSi
+neU
 gIF
 mhs
 usG
@@ -156688,7 +156687,7 @@ aOb
 buP
 jpX
 oKb
-svk
+fZt
 aOb
 aae
 aae

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -51916,6 +51916,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
+/obj/item/storage/box/beakers,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "qcs" = (
@@ -68582,6 +68583,11 @@
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
+	},
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/bodybags{
+	pixel_x = 5;
+	pixel_y = 5
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -43265,6 +43265,14 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron/white,
 /area/science/explab)
+"mCw" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/mob/living/carbon/human/species/monkey/punpun,
+/turf/open/floor/iron,
+/area/service/bar)
 "mDh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil/cut,
@@ -95474,7 +95482,7 @@ amm
 aej
 tdQ
 ahV
-ahV
+mCw
 ayI
 atF
 ulk

--- a/code/game/objects/structures/industrial_lift.dm
+++ b/code/game/objects/structures/industrial_lift.dm
@@ -518,4 +518,4 @@ GLOBAL_LIST_EMPTY(lifts)
 /obj/effect/landmark/tram/right_part
 	name = "East Wing"
 	destination_id = "right_part"
-	tgui_icons = list("Departures" = "plane-departure", "Cargo" = "box")
+	tgui_icons = list("Departures" = "plane-departure", "Cargo" = "box", "Science" = "beaker")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A big camera update to help make viewing the map as AI less painful, along with some other fixes/changes.

## Why It's Good For The Game
Staring at static for an hour is not engaging.

## Changelog
:cl: MMMiracles
add: Tramstation now has several new cameras to help the AI look over the map.
add: Tramstation now has a public lavaland dock beside the Research wing.
fix: Tramstation paramedics now have Cargo access.
/:cl:

Fixes #58075
Fixes #58338
Fixes #58866
Fixes #58849

- The AI now has cameras in a few spots that had subpar coverage or no coverage. The AI can now see power hatches, main segments of restrooms, and the main segment of the lower tram tunnel.
- Paramedics can now enter Cargo properly.
- There are now two beaker boxes as well as 1 body bag box in the central treatment area.
- Chem heaters now start with a buffer.
- There is now a public mining dock to the right of the Research wing.
- There is now an icon on the tram gui to indicate that the Research wing exists on the East wing.
- The maintenance section of the Prison wing now has a high security door instead of an r-wall to allow pipes/cable to pass through. The door is varedited to be security level 4 and is bolted round-start in hopes of making it about as annoying an r-wall to break through. I did this because I don't like so much stuff going through walls that otherwise would go through doors/windows.
