### PR TITLE
fixes a minor typo in an area name

### DIFF
--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -404,7 +404,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "hallCF"
 
 /area/hallway/primary/central/aft
-	name = "Aft Cntral Primary Hallway"
+	name = "Aft Central Primary Hallway"
 	icon_state = "hallCA"
 
 /area/hallway/primary/upper


### PR DESCRIPTION
## About The Pull Request
puts the e into where it belongs in the Aft Cntral Primary Hallway

## Changelog
:cl: Pepsiman0
spellcheck: Aft Cntral Primary Hallway is now Aft Central Primary Hallway
/:cl: