### PR TITLE
Adds flavortext for trying to speak with a vow of silence

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -156,7 +156,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		language = get_selected_language()
 	var/mob/living/carbon/human/H = src
 	if(!can_speak_vocal(message))
-		if(H.mind.miming)
+		if(H.mind?.miming)
 			if(HAS_TRAIT(src, TRAIT_SIGN_LANG))
 				to_chat(src, "<span class='warning'>You stop yourself from signing in favor of the artform of mimery!</span>")
 				return

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -156,9 +156,13 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		language = get_selected_language()
 	var/mob/living/carbon/human/H = src
 	if(!can_speak_vocal(message))
-		if (HAS_TRAIT(src, TRAIT_SIGN_LANG) && H.mind.miming)
-			to_chat(src, "<span class='warning'>You stop yourself from signing in favor of the artform of mimery!</span>")
-			return
+		if(H.mind.miming)
+			if(HAS_TRAIT(src, TRAIT_SIGN_LANG))
+				to_chat(src, "<span class='warning'>You stop yourself from signing in favor of the artform of mimery!</span>")
+				return
+			else
+				to_chat(src, "<span class='warning'>Your vow of silence prevents you from speaking!</span>")
+				return
 		else
 			to_chat(src, "<span class='warning'>You find yourself unable to speak!</span>")
 			return

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -161,7 +161,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 				to_chat(src, "<span class='warning'>You stop yourself from signing in favor of the artform of mimery!</span>")
 				return
 			else
-				to_chat(src, "<span class='warning'>Your vow of silence prevents you from speaking!</span>")
+				to_chat(src, "<span class='green'>Your vow of silence prevents you from speaking!</span>")
 				return
 		else
 			to_chat(src, "<span class='warning'>You find yourself unable to speak!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When you try to speak with a vow of silence you get the general "You find yourself unable to speak!" which doesn't work well for mimes, the vow is part of the character and that message seems more like an emergency/bad situation (which it usually is). So I added a check (one already existed for mimes and sign language) that references the vow, and I made it green because the vow is a good thing for mimes so it should be a positive to_chat. This might be a bit confusing but if a player picks mime and doesn't get that they are meant to be quiet I don't think a red warning about their vow of silence protecting them from getting dunked on for speaking will help them.

## Why It's Good For The Game

A little bit of immersion for mimes that try to speak. (Or when the nanites are forcesay and you are spared from spewing the meme through dedication your artform.)

## Changelog
:cl:
qol: added a unique message to trying to speak with a vow of silence
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
