### PR TITLE
Fix latejoin injection timer not resetting

### DIFF
--- a/code/game/gamemodes/dynamic/ruleset_picking.dm
+++ b/code/game/gamemodes/dynamic/ruleset_picking.dm
@@ -63,6 +63,7 @@
 	if (!rule.repeatable)
 		latejoin_rules = remove_from_list(latejoin_rules, rule.type)
 	addtimer(CALLBACK(src, .proc/execute_midround_latejoin_rule, rule), rule.delay)
+	return TRUE
 
 /// Mainly here to facilitate delayed rulesets. All midround/latejoin rulesets are executed with a timered callback to this proc.
 /datum/game_mode/dynamic/proc/execute_midround_latejoin_rule(sent_rule)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Related to #57925--fixes the main bug of it, though this report also encompasses the bug where deciseconds are being shown as seconds.

## Changelog
:cl:
fix: Fixed a bug where the latejoin injection timer would not reset, meaning past a certain point anyone who joined would get antag, draining all the threat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
