### PR TITLE
Adds BBQ Sauce to the Chef Produce Console

### DIFF
--- a/code/game/machinery/computer/chef_orders/order_datum.dm
+++ b/code/game/machinery/computer/chef_orders/order_datum.dm
@@ -141,6 +141,12 @@
 	item_instance = /obj/item/food/fishmeat
 	cost_per_order = 12
 
+/datum/orderable_item/meat_product
+	name = "Meat Product"
+	category_index = CATEGORY_MILK_EGGS
+	item_instance = /obj/item/food/meat/slab/meatproduct
+	cost_per_order = 15
+
 /datum/orderable_item/spider_eggs
 	name = "Spider Eggs"
 	category_index = CATEGORY_MILK_EGGS
@@ -188,4 +194,10 @@
 	name = "Soy Sauce"
 	category_index = CATEGORY_SAUCES_REAGENTS
 	item_instance = /obj/item/reagent_containers/food/condiment/soysauce
+	cost_per_order = 15
+
+/datum/orderable_item/bbqsauce
+	name = "BBQ Sauce"
+	category_index = CATEGORY_SAUCES_REAGENTS
+	item_instance = /obj/item/reagent_containers/food/condiment/bbqsauce
 	cost_per_order = 15

--- a/code/game/machinery/computer/chef_orders/order_datum.dm
+++ b/code/game/machinery/computer/chef_orders/order_datum.dm
@@ -141,12 +141,6 @@
 	item_instance = /obj/item/food/fishmeat
 	cost_per_order = 12
 
-/datum/orderable_item/meat_product
-	name = "Meat Product"
-	category_index = CATEGORY_MILK_EGGS
-	item_instance = /obj/item/food/meat/slab/meatproduct
-	cost_per_order = 15
-
 /datum/orderable_item/spider_eggs
 	name = "Spider Eggs"
 	category_index = CATEGORY_MILK_EGGS
@@ -200,4 +194,4 @@
 	name = "BBQ Sauce"
 	category_index = CATEGORY_SAUCES_REAGENTS
 	item_instance = /obj/item/reagent_containers/food/condiment/bbqsauce
-	cost_per_order = 15
+	cost_per_order = 60

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -234,6 +234,12 @@
 	list_reagents = list(/datum/reagent/consumable/rice = 30)
 	fill_icon_thresholds = null
 
+/obj/item/reagent_containers/food/condiment/bbqsauce
+	name = "bbq sauce"
+	desc = "Hand wipes not included."
+	icon_state = "bbqsauce"
+	list_reagents = list(/datum/reagent/consumable/bbqsauce = 50)
+
 /obj/item/reagent_containers/food/condiment/soysauce
 	name = "soy sauce"
 	desc = "A salty soy-based flavoring."


### PR DESCRIPTION
## About The Pull Request

Adds a spawnable BBQ sauce container.
Adds BBQ Sauce a~~nd Meat Product~~ to the Produce Console

## Why It's Good For The Game

Nice to order BBQ sauce without draining the kitchens roundstart ingredients.

Also, I'm not sure if this should be considered an addition, or QoL, it's kinda both?

## Changelog
:cl:
add: BBQ Sauce can now be ordered in the kitchen console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
