### PR TITLE
Fixes a funny regex moment quoting half the file in weak editors

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -160,7 +160,7 @@
 	. = ""
 	var/newletter = ""
 	var/rawchar = ""
-	var/static/regex/nostutter = regex(@@[aeiouAEIOU "'()[\]{}.!?,:;_`~-]@)
+	var/static/regex/nostutter = regex(@@[aeiouAEIOU ""''()[\]{}.!?,:;_`~-]@)
 	for(var/i = 1, i <= leng, i += length(rawchar))
 		rawchar = newletter = phrase[i]
 		if(prob(80) && !nostutter.Find(rawchar))


### PR DESCRIPTION
## About The Pull Request

Found an issue while doing stuff downstream and thought something was fucked 
![image](https://user-images.githubusercontent.com/26744576/115953284-2660a780-a4b0-11eb-9888-f6d9f14811b4.png)

Turns out it wasn't as fucked as previously thought.
![image](https://user-images.githubusercontent.com/26744576/115953158-565b7b00-a4af-11eb-919f-9c3d3904aec1.png)

DM has no issue reading it, it's just funny regex stuff and our super advanced code editors not being a fan of reading it.

Doubling up the quotations and apostrophes has also changed nothing in the regex itself, it still reads fine. 
![image](https://user-images.githubusercontent.com/26744576/115953302-43957600-a4b0-11eb-803b-c3dcc928f7bd.png)


## Why It's Good For The Game

It changes literally nothing in the game.

## Changelog
Improved readability in mob helpers.
