### PR TITLE
Add Show Hiddenprints action to VV on atoms

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -81,6 +81,7 @@
 #define VV_HK_MODIFY_TRANSFORM "atom_transform"
 #define VV_HK_MODIFY_GREYSCALE "modify_greyscale"
 #define VV_HK_ADD_REAGENT "addreagent"
+#define VV_HK_SHOW_HIDDENPRINTS "show_hiddenprints"
 #define VV_HK_TRIGGER_EMP "empulse"
 #define VV_HK_TRIGGER_EXPLOSION "explode"
 #define VV_HK_AUTO_RENAME "auto_rename"

--- a/code/datums/components/forensics.dm
+++ b/code/datums/components/forensics.dm
@@ -161,12 +161,12 @@
 			hasgloves = "(gloves)"
 	var/current_time = time_stamp()
 	if(!LAZYACCESS(hiddenprints, M.key))
-		LAZYSET(hiddenprints, M.key, "First: [M.real_name]\[[current_time]\][hasgloves]. Ckey: [M.ckey]")
+		LAZYSET(hiddenprints, M.key, "First: \[[current_time]\] \"[M.real_name]\"[hasgloves]. Ckey: [M.ckey]")
 	else
-		var/laststamppos = findtext(LAZYACCESS(hiddenprints, M.key), " Last: ")
+		var/laststamppos = findtext(LAZYACCESS(hiddenprints, M.key), "\nLast: ")
 		if(laststamppos)
 			LAZYSET(hiddenprints, M.key, copytext(hiddenprints[M.key], 1, laststamppos))
-		hiddenprints[M.key] += " Last: [M.real_name]\[[current_time]\][hasgloves]. Ckey: [M.ckey]" //made sure to be existing by if(!LAZYACCESS);else
+		hiddenprints[M.key] += "\nLast: \[[current_time]\] \"[M.real_name]\"[hasgloves]. Ckey: [M.ckey]" //made sure to be existing by if(!LAZYACCESS);else
 	var/atom/A = parent
 	A.fingerprintslast = M.ckey
 	return TRUE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1196,6 +1196,7 @@
 		if(curturf)
 			. += "<option value='?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[curturf.x];Y=[curturf.y];Z=[curturf.z]'>Jump To</option>"
 	VV_DROPDOWN_OPTION(VV_HK_MODIFY_TRANSFORM, "Modify Transform")
+	VV_DROPDOWN_OPTION(VV_HK_SHOW_HIDDENPRINTS, "Show Hiddenprint log")
 	VV_DROPDOWN_OPTION(VV_HK_ADD_REAGENT, "Add Reagent")
 	VV_DROPDOWN_OPTION(VV_HK_TRIGGER_EMP, "EMP Pulse")
 	VV_DROPDOWN_OPTION(VV_HK_TRIGGER_EXPLOSION, "Explosion")
@@ -1240,14 +1241,20 @@
 					reagents.add_reagent(chosen_id, amount)
 					log_admin("[key_name(usr)] has added [amount] units of [chosen_id] to [src]")
 					message_admins("<span class='notice'>[key_name(usr)] has added [amount] units of [chosen_id] to [src]</span>")
+
 	if(href_list[VV_HK_TRIGGER_EXPLOSION] && check_rights(R_FUN))
 		usr.client.cmd_admin_explosion(src)
+
 	if(href_list[VV_HK_TRIGGER_EMP] && check_rights(R_FUN))
 		usr.client.cmd_admin_emp(src)
+
 	if(href_list[VV_HK_RADIATE] && check_rights(R_FUN))
 		var/strength = input(usr, "Choose the radiation strength.", "Choose the strength.") as num|null
 		if(!isnull(strength))
 			AddComponent(/datum/component/radioactive, strength, src)
+
+	if(href_list[VV_HK_SHOW_HIDDENPRINTS] && check_rights(R_ADMIN))
+		usr.client.cmd_show_hiddenprints(src)
 
 
 	if(href_list[VV_HK_ADD_AI])
@@ -1276,6 +1283,7 @@
 				var/angle = input(usr, "Choose angle to rotate","Transform Mod") as null|num
 				if(!isnull(angle))
 					transform = M.Turn(angle)
+
 	if(href_list[VV_HK_AUTO_RENAME] && check_rights(R_VAREDIT))
 		var/newname = input(usr, "What do you want to rename this to?", "Automatic Rename") as null|text
 		// Check the new name against the chat filter. If it triggers the IC chat filter, give an option to confirm.

--- a/code/modules/admin/verbs/hiddenprints.dm
+++ b/code/modules/admin/verbs/hiddenprints.dm
@@ -1,0 +1,30 @@
+/client/proc/cmd_show_hiddenprints(atom/victim)
+	if(!check_rights(R_ADMIN))
+		return
+
+	var/interface = "A log of every player who has touched [victim], sorted by last touch.<br><br><ol>"
+	var/victim_hiddenprints = victim.return_hiddenprints()
+
+	if(!islist(victim_hiddenprints))
+		victim_hiddenprints = list()
+
+	var/list/hiddenprints = flatten_list(victim_hiddenprints)
+	removeNullsFromList(hiddenprints)
+
+	if(!length(hiddenprints))
+		hiddenprints = list("Nobody has touched this yet!")
+
+	hiddenprints = sortList(hiddenprints, /proc/cmp_hiddenprint_lasttime_dsc)
+	for(var/record in hiddenprints)
+		interface += "<li>[record]</li><br>"
+
+	interface += "</ol>"
+
+	var/datum/browser/hiddenprint_view = new(usr, "view_hiddenprints_[REF(victim)]", "[victim]'s hiddenprints", 450, 760)
+	hiddenprint_view.set_content(interface)
+	hiddenprint_view.open()
+
+/proc/cmp_hiddenprint_lasttime_dsc(a, b)
+	var/last_a = copytext(a, findtext(a, "\nLast: "))
+	var/last_b = copytext(b, findtext(b, "\nLast: "))
+	return cmp_text_dsc(last_a, last_b)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1565,6 +1565,7 @@
 #include "code\modules\admin\verbs\fps.dm"
 #include "code\modules\admin\verbs\getlogs.dm"
 #include "code\modules\admin\verbs\ghost_pool_protection.dm"
+#include "code\modules\admin\verbs\hiddenprints.dm"
 #include "code\modules\admin\verbs\highlander_datum.dm"
 #include "code\modules\admin\verbs\individual_logging.dm"
 #include "code\modules\admin\verbs\machine_upgrade.dm"


### PR DESCRIPTION
## About The Pull Request
This displays the hiddenprint log from `/datum/component/forensics` in a simple to view form, sorted by last touch. I didn't make it fancy, it's very bare bones.

![image](https://user-images.githubusercontent.com/5211576/115955941-c8d85500-a4c7-11eb-8cae-398e216ff692.png)

I could have refactored hiddenprints to use lists in lists, which would make getting data out a lot easier, but I worry about the additional memory overhead on every atom that gets touched, so I left it as strings in lists. I did reformat it a little bit, however, to make it simpler to sort, and it looks a little nicer. Namely moving the timestamp in front of the name.

## Why It's Good For The Game

It can help a lot in admin investigations on whodunnit. Right now they have to look at the forensics component, and that's if they even know about it. This way it is discoverable by using the VV tool.

## Changelog
:cl: JJRcop
admin: Admins get a new Show Hiddenprints drop-down option in View Variables. This allows them to easily view a log of who touched something.
/:cl:
