### PR TITLE
Fixes simplemobs bypassing machine interaction checks with right-click verbs

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -236,10 +236,8 @@
 	if(!isliving(usr))
 		to_chat(usr, "<span class='warning'>You can't do that!</span>")
 		return
-	if(isanimal(usr))
-		var/mob/living/simple_animal/user_animal = usr
-		if (!user_animal.canUseTopic())
-			return
+	if (!usr.canUseTopic())
+		return
 	if(usr.incapacitated())
 		return
 	mode = !mode

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -100,7 +100,7 @@
 /obj/machinery/iv_drip/attackby(obj/item/W, mob/user, params)
 	if(use_internal_storage)
 		return ..()
-	
+
 	if(is_type_in_typecache(W, drip_containers) || IS_EDIBLE(W))
 		if(reagent_container)
 			to_chat(user, "<span class='warning'>[reagent_container] is already loaded on [src]!</span>")
@@ -217,7 +217,9 @@
 	if(!isliving(usr))
 		to_chat(usr, "<span class='warning'>You can't do that!</span>")
 		return
-
+	if(isanimal(usr))
+		var/mob/living/simple_animal/usr_mob = usr
+		return usr_mob.canUseTopic()
 	if(usr.incapacitated())
 		return
 	if(reagent_container)
@@ -233,7 +235,9 @@
 	if(!isliving(usr))
 		to_chat(usr, "<span class='warning'>You can't do that!</span>")
 		return
-
+	if(isanimal(usr))
+		var/mob/living/simple_animal/usr_mob = usr
+		return usr_mob.canUseTopic()
 	if(usr.incapacitated())
 		return
 	mode = !mode

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -219,7 +219,8 @@
 		return
 	if(isanimal(usr))
 		var/mob/living/simple_animal/user_animal = usr
-		return user_animal.canUseTopic()
+		if (!user_animal.canUseTopic())
+			return
 	if(usr.incapacitated())
 		return
 	if(reagent_container)
@@ -237,7 +238,8 @@
 		return
 	if(isanimal(usr))
 		var/mob/living/simple_animal/user_animal = usr
-		return user_animal.canUseTopic()
+		if (!user_animal.canUseTopic())
+			return
 	if(usr.incapacitated())
 		return
 	mode = !mode

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -217,10 +217,8 @@
 	if(!isliving(usr))
 		to_chat(usr, "<span class='warning'>You can't do that!</span>")
 		return
-	if(isanimal(usr))
-		var/mob/living/simple_animal/user_animal = usr
-		if (!user_animal.canUseTopic())
-			return
+	if (!usr.canUseTopic())
+		return
 	if(usr.incapacitated())
 		return
 	if(reagent_container)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -236,8 +236,8 @@
 		to_chat(usr, "<span class='warning'>You can't do that!</span>")
 		return
 	if(isanimal(usr))
-		var/mob/living/simple_animal/usr_mob = usr
-		return usr_mob.canUseTopic()
+		var/mob/living/simple_animal/user_animal = usr
+		return user_animal.canUseTopic()
 	if(usr.incapacitated())
 		return
 	mode = !mode

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -218,8 +218,8 @@
 		to_chat(usr, "<span class='warning'>You can't do that!</span>")
 		return
 	if(isanimal(usr))
-		var/mob/living/simple_animal/usr_mob = usr
-		return usr_mob.canUseTopic()
+		var/mob/living/simple_animal/user_animal = usr
+		return user_animal.canUseTopic()
 	if(usr.incapacitated())
 		return
 	if(reagent_container)

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -127,7 +127,8 @@
 		return
 	if(isanimal(usr))
 		var/mob/living/simple_animal/user_animal = usr
-		return user_animal.canUseTopic()
+		if (!user_animal.canUseTopic())
+			return
 	src.go_out()
 	add_fingerprint(usr)
 	return

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -126,8 +126,8 @@
 	if (usr.stat != CONSCIOUS || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED))
 		return
 	if(isanimal(usr))
-		var/mob/living/simple_animal/usr_mob = usr
-		return usr_mob.canUseTopic()
+		var/mob/living/simple_animal/user_animal = usr
+		return user_animal.canUseTopic()
 	src.go_out()
 	add_fingerprint(usr)
 	return

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -123,9 +123,11 @@
 	set category = "Object"
 	set name = "Empty gibber"
 	set src in oview(1)
-
 	if (usr.stat != CONSCIOUS || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED))
 		return
+	if(isanimal(usr))
+		var/mob/living/simple_animal/usr_mob = usr
+		return usr_mob.canUseTopic()
 	src.go_out()
 	add_fingerprint(usr)
 	return

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -125,10 +125,8 @@
 	set src in oview(1)
 	if (usr.stat != CONSCIOUS || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED))
 		return
-	if(isanimal(usr))
-		var/mob/living/simple_animal/user_animal = usr
-		if (!user_animal.canUseTopic())
-			return
+	if(!usr.canUseTopic())
+		return
 	src.go_out()
 	add_fingerprint(usr)
 	return

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -162,10 +162,8 @@
 	set src in oview(1)
 	if(usr.stat != CONSCIOUS || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED))
 		return
-	if(isanimal(usr))
-		var/mob/living/simple_animal/user_animal = usr
-		if (!user_animal.canUseTopic())
-			return
+	if (!usr.canUseTopic())
+		return
 	if(isliving(usr))
 		var/mob/living/L = usr
 		if(!(L.mobility_flags & MOBILITY_UI))

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -163,8 +163,8 @@
 	if(usr.stat != CONSCIOUS || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED))
 		return
 	if(isanimal(usr))
-		var/mob/living/simple_animal/usr_mob = usr
-		return usr_mob.canUseTopic()
+		var/mob/living/simple_animal/user_animal = usr
+		return user_animal.canUseTopic()
 	if(isliving(usr))
 		var/mob/living/L = usr
 		if(!(L.mobility_flags & MOBILITY_UI))

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -162,6 +162,9 @@
 	set src in oview(1)
 	if(usr.stat != CONSCIOUS || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED))
 		return
+	if(isanimal(usr))
+		var/mob/living/simple_animal/usr_mob = usr
+		return usr_mob.canUseTopic()
 	if(isliving(usr))
 		var/mob/living/L = usr
 		if(!(L.mobility_flags & MOBILITY_UI))

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -164,7 +164,8 @@
 		return
 	if(isanimal(usr))
 		var/mob/living/simple_animal/user_animal = usr
-		return user_animal.canUseTopic()
+		if (!user_animal.canUseTopic())
+			return
 	if(isliving(usr))
 		var/mob/living/L = usr
 		if(!(L.mobility_flags & MOBILITY_UI))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/17409
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Simplemobs, and more importantly revenants, were able to bypass the canUseTopic check for any right click verbs, allowing them to use a few machines that they shouldn't be able to.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Simplemobs can no longer use right-click verbs that they shouldn't be able to use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
