### PR TITLE
Stops loading extools in version 513.1540 and up

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -57,8 +57,8 @@
 #error You need version 513.1514 or higher
 #endif
 
-//Don't load extools on 514
-#if DM_VERSION < 514
+//Don't load extools on 514 and 513.1539+
+#if DM_VERSION < 514 && DM_BUILD < 1540
 #define USE_EXTOOLS
 #endif
 


### PR DESCRIPTION
To prevent confusion for new coders from all the ouch messages.