### PR TITLE
Fixes an infinite RCD material exploit

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -167,8 +167,12 @@ RLD
 		return TRUE
 
 /obj/item/construction/proc/checkResource(amount, mob/user)
-	if(!silo_link || !silo_mats || !silo_mats.mat_container)
-		. = matter >= amount
+	if(!silo_mats || !silo_mats.mat_container)
+		if(silo_link)
+			to_chat(user, "<span class='alert'>Connected silo link is invalid. Reconnect to silo via multitool.</span>")
+			return FALSE
+		else
+			. = matter >= amount
 	else
 		if(silo_mats.on_hold())
 			if(user)
@@ -399,7 +403,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 
 /obj/item/construction/rcd/proc/toggle_silo_link(mob/user)
 	if(silo_mats)
-		if(!silo_mats.mat_container)
+		if(!silo_mats.mat_container && !silo_link) // Allow them to turn off an invalid link
 			to_chat(user, "<span class='alert'>No silo link detected. Connect to silo via multitool.</span>")
 			return FALSE
 		silo_link = !silo_link


### PR DESCRIPTION
## About The Pull Request

Fixes a bug where an invalid silo link would cause a materials check to check internal buffer, but then trying to consume mats from the invalid silo link and failing silently.

How to reproduce:
* Add some materials to an RCD, enough to build something
* Build ore silo
* Link RCD to ore silo
* Turn on silo link
* Deconstruct ore silo
* You can now use the RCD for free :trollface: 

## Why It's Good For The Game

Infinite materials bad

## Changelog
:cl: Urumasi
fix: Fixed an infinite RCD material exploit
/:cl: