### PR TITLE
Fix mindbreaker toxin not completely stopping Reality Dissociation Syndrome

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -429,6 +429,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_EXTROVERT "extrovert"
 #define TRAIT_INTROVERT "introvert"
 #define TRAIT_ANXIOUS "anxious"
+#define TRAIT_INSANITY "insanity"
+
 ///Trait for dryable items
 #define TRAIT_DRYABLE "trait_dryable"
 ///Trait for dried items

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -386,7 +386,7 @@
 	name = "Reality Dissociation Syndrome"
 	desc = "You suffer from a severe disorder that causes very vivid hallucinations. Mindbreaker toxin can suppress its effects, and you are immune to mindbreaker's hallucinogenic properties. <b>This is not a license to grief.</b>"
 	value = -8
-	//no mob trait because it's handled uniquely
+	mob_trait = TRAIT_INSANITY
 	gain_text = "<span class='userdanger'>...</span>"
 	lose_text = "<span class='notice'>You feel in tune with the world again.</span>"
 	medical_record_text = "Patient suffers from acute Reality Dissociation Syndrome and experiences vivid hallucinations."

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -306,7 +306,8 @@
 	addiction_types = list(/datum/addiction/hallucinogens = 18)  //7.2 per 2 seconds
 
 /datum/reagent/toxin/mindbreaker/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.hallucination += 5 * REM * delta_time
+	if(!HAS_TRAIT(M, TRAIT_INSANITY))
+		M.hallucination += 5 * REM * delta_time
 	return ..()
 
 /datum/reagent/toxin/plantbgone


### PR DESCRIPTION
## About The Pull Request

Currently, mindbreaker toxin is supposed to suppress hallucinations, but the reagent itself still applies hallucination to the user which is counted towards handling hallucinations before it gets purged by the quirk.

## Why It's Good For The Game

It's annoying that the one thing advertised that should fix hallucinations with RDS doesn't work.

## Changelog
:cl: Urumasi
fix: Mindbreaker toxin will now completely suppress your Reality Dissociation Syndrome.
/:cl:
