### PR TITLE
Makes holidays span all timezones by default

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -53,6 +53,9 @@ When using time2text(), please use "DDD" to find the weekday. Refrain from using
 
 /*Timezones*/
 
+/// Line Islands Time
+#define TIMEZONE_LINT 14
+
 /// Tokelau Time
 #define TIMEZONE_TKT 13
 
@@ -124,3 +127,6 @@ When using time2text(), please use "DDD" to find the weekday. Refrain from using
 
 /// Niue Time
 #define TIMEZONE_NUT -11
+
+/// Anywhere on Earth
+#define TIMEZONE_AoE -12

--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -129,4 +129,4 @@ When using time2text(), please use "DDD" to find the weekday. Refrain from using
 #define TIMEZONE_NUT -11
 
 /// Anywhere on Earth
-#define TIMEZONE_AoE -12
+#define TIMEZONE_ANYWHERE_ON_EARTH -12

--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -50,3 +50,77 @@ When using time2text(), please use "DDD" to find the weekday. Refrain from using
 #define DS2TICKS(DS) ((DS)/world.tick_lag)
 
 #define TICKS2DS(T) ((T) TICKS)
+
+/*Timezones*/
+
+/// Tokelau Time
+#define TIMEZONE_TKT 13
+
+/// Tonga Time
+#define TIMEZONE_TOT 13
+
+/// New Zealand Daylight Time
+#define TIMEZONE_NZDT 13
+
+/// New Zealand Standard Time
+#define TIMEZONE_NZST 12
+
+/// Norfolk Time
+#define TIMEZONE_NFT 11
+
+/// Lord Howe Standard Time
+#define TIMEZONE_LHST 10.5
+
+/// Australian Eastern Standard Time
+#define TIMEZONE_AEST 10
+
+/// Australian Central Standard Time
+#define TIMEZONE_ACST 9.5
+
+/// Australian Central Western Standard Time
+#define TIMEZONE_ACWST 8.75
+
+/// Australian Western Standard Time
+#define TIMEZONE_AWST 8
+
+/// Christmas Island Time
+#define TIMEZONE_CXT 7
+
+/// Cocos Islands Time
+#define TIMEZONE_CCT 6.5
+
+/// Central European Summer Time
+#define TIMEZONE_CEST 2
+
+/// Coordinated Universal Time
+#define TIMEZONE_UTC 0
+
+/// Eastern Daylight Time
+#define TIMEZONE_EDT -4
+
+/// Central Daylight Time
+#define TIMEZONE_CDT -5
+
+/// Mountain Daylight Time
+#define TIMEZONE_MDT -6
+
+/// Mountain Standard Time
+#define TIMEZONE_MST -7
+
+/// Pacific Daylight Time
+#define TIMEZONE_PDT -7
+
+/// Alaska Daylight Time
+#define TIMEZONE_AKDT -8
+
+/// Hawaii-Aleutian Daylight Time
+#define TIMEZONE_HDT -9
+
+/// Hawaii Standard Time
+#define TIMEZONE_HST -10
+
+/// Cook Island Time
+#define TIMEZONE_CKT -10
+
+/// Niue Time
+#define TIMEZONE_NUT -11

--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -56,6 +56,9 @@ When using time2text(), please use "DDD" to find the weekday. Refrain from using
 /// Line Islands Time
 #define TIMEZONE_LINT 14
 
+// Chatham Daylight Time
+#define TIMEZONE_CHADT 13.75
+
 /// Tokelau Time
 #define TIMEZONE_TKT 13
 

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -157,7 +157,7 @@ SUBSYSTEM_DEF(events)
 		var/datum/holiday/holiday = new H()
 		var/delete_holiday = TRUE
 		for(var/timezone in holiday.timezones)
-			var/time_in_timezone = world.realtime + timezone * 36000
+			var/time_in_timezone = world.realtime + timezone HOURS
 
 			var/YYYY = text2num(time2text(time_in_timezone, "YYYY")) // get the current year
 			var/MM = text2num(time2text(time_in_timezone, "MM")) // get the current month

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -153,20 +153,25 @@ SUBSYSTEM_DEF(events)
 /datum/controller/subsystem/events/proc/getHoliday()
 	if(!CONFIG_GET(flag/allow_holidays))
 		return // Holiday stuff was not enabled in the config!
-
-	var/YYYY = text2num(time2text(world.timeofday, "YYYY")) // get the current year
-	var/MM = text2num(time2text(world.timeofday, "MM")) // get the current month
-	var/DD = text2num(time2text(world.timeofday, "DD")) // get the current day
-	var/DDD = time2text(world.timeofday, "DDD") // get the current weekday
-
 	for(var/H in subtypesof(/datum/holiday))
 		var/datum/holiday/holiday = new H()
-		if(holiday.shouldCelebrate(DD, MM, YYYY, DDD))
-			holiday.celebrate()
-			if(!holidays)
-				holidays = list()
-			holidays[holiday.name] = holiday
-		else
+		var/delete_holiday = TRUE
+		for(var/timezone in holiday.timezones)
+			var/time_in_timezone = world.realtime + timezone * 36000
+
+			var/YYYY = text2num(time2text(time_in_timezone, "YYYY")) // get the current year
+			var/MM = text2num(time2text(time_in_timezone, "MM")) // get the current month
+			var/DD = text2num(time2text(time_in_timezone, "DD")) // get the current day
+			var/DDD = time2text(time_in_timezone, "DDD") // get the current weekday
+
+			if(holiday.shouldCelebrate(DD, MM, YYYY, DDD))
+				holiday.celebrate()
+				if(!holidays)
+					holidays = list()
+				holidays[holiday.name] = holiday
+				delete_holiday = FALSE
+				break
+		if(delete_holiday)
 			qdel(holiday)
 
 	if(holidays)

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -166,9 +166,7 @@ SUBSYSTEM_DEF(events)
 
 			if(holiday.shouldCelebrate(DD, MM, YYYY, DDD))
 				holiday.celebrate()
-				if(!holidays)
-					holidays = list()
-				holidays[holiday.name] = holiday
+				LAZYSET(holidays, holiday.name, holiday)
 				delete_holiday = FALSE
 				break
 		if(delete_holiday)

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -63,7 +63,7 @@
 
 /datum/holiday/new_year
 	name = NEW_YEAR
-	begin_day = 30
+	begin_day = 31
 	begin_month = DECEMBER
 	end_day = 2
 	end_month = JANUARY
@@ -83,7 +83,7 @@
 
 /datum/holiday/valentines
 	name = VALENTINES
-	begin_day = 13
+	begin_day = 14
 	end_day = 15
 	begin_month = FEBRUARY
 
@@ -168,8 +168,9 @@
 
 /datum/holiday/april_fools
 	name = APRIL_FOOLS
-	begin_day = 1
 	begin_month = APRIL
+	begin_day = 1
+	end_day = 2
 
 /datum/holiday/april_fools/celebrate()
 	SSjob.set_overflow_role("Clown")
@@ -369,8 +370,10 @@
 
 /datum/holiday/halloween
 	name = HALLOWEEN
-	begin_day = 31
+	begin_day = 29
 	begin_month = OCTOBER
+	end_day = 2
+	end_month = NOVEMBER
 
 /datum/holiday/halloween/greet()
 	return "Have a spooky Halloween!"
@@ -463,9 +466,9 @@
 
 /datum/holiday/xmas
 	name = CHRISTMAS
-	begin_day = 24 //Christmas Eve
+	begin_day = 23
 	begin_month = DECEMBER
-	end_day = 26 //Boxing Day
+	end_day = 27
 	drone_hat = /obj/item/clothing/head/santa
 
 /datum/holiday/xmas/greet()

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -8,6 +8,8 @@
 	var/always_celebrate = FALSE // for christmas neverending, or testing.
 	var/current_year = 0
 	var/year_offset = 0
+	///Timezones this holiday is celebrated in
+	var/list/timezones = list(TIMEZONE_UTC)
 	var/obj/item/drone_hat //If this is defined, drones without a default hat will spawn with this one during the holiday; check drones_as_items.dm to see this used
 
 // This proc gets run before the game starts when the holiday is activated. Do festive shit here.
@@ -255,6 +257,7 @@
 
 /datum/holiday/usa
 	name = "US Independence Day"
+	timezones = list(TIMEZONE_EDT, TIMEZONE_CDT, TIMEZONE_MDT, TIMEZONE_MST, TIMEZONE_PDT, TIMEZONE_AKDT, TIMEZONE_HDT, TIMEZONE_HST)
 	begin_day = 4
 	begin_month = JULY
 
@@ -263,6 +266,7 @@
 
 /datum/holiday/nz
 	name = "Waitangi Day"
+	timezones = list(TIMEZONE_NZDT)
 	begin_day = 6
 	begin_month = FEBRUARY
 
@@ -270,11 +274,12 @@
 	return pick("Aotearoa","Kiwi","Fish 'n' Chips","Kākāpō","Southern Cross")
 
 /datum/holiday/nz/greet()
-	var/nz_age = text2num(time2text(world.timeofday, "YYYY")) - 1840 //is this work
-	return "On this day [nz_age] years ago, New Zealand's Treaty of Waitangi, the founding document of the nation, was signed!" //thus creating much controversy
+	var/nz_age = text2num(time2text(world.timeofday, "YYYY")) - 1840
+	return "On this day [nz_age] years ago, New Zealand's Treaty of Waitangi, the founding document of the nation, was signed!"
 
 /datum/holiday/anz
 	name = "ANZAC Day"
+	timezones = list(TIMEZONE_TKT, TIMEZONE_TOT, TIMEZONE_NZST, TIMEZONE_NFT, TIMEZONE_LHST, TIMEZONE_AEST, TIMEZONE_ACST, TIMEZONE_ACWST, TIMEZONE_AWST, TIMEZONE_CXT, TIMEZONE_CCT, TIMEZONE_CKT, TIMEZONE_NUT)
 	begin_day = 25
 	begin_month = APRIL
 	drone_hat = /obj/item/food/grown/poppy
@@ -289,6 +294,7 @@
 
 /datum/holiday/france
 	name = "Bastille Day"
+	timezones = list(TIMEZONE_CEST)
 	begin_day = 14
 	begin_month = JULY
 	drone_hat = /obj/item/clothing/head/beret

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -9,7 +9,7 @@
 	var/current_year = 0
 	var/year_offset = 0
 	///Timezones this holiday is celebrated in (defaults to three timezones spanning a 50 hour window covering all timezones)
-	var/list/timezones = list(TIMEZONE_LINT, TIMEZONE_UTC, TIMEZONE_AoE)
+	var/list/timezones = list(TIMEZONE_LINT, TIMEZONE_UTC, TIMEZONE_ANYWHERE_ON_EARTH)
 	var/obj/item/drone_hat //If this is defined, drones without a default hat will spawn with this one during the holiday; check drones_as_items.dm to see this used
 
 // This proc gets run before the game starts when the holiday is activated. Do festive shit here.

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -265,7 +265,7 @@
 
 /datum/holiday/nz
 	name = "Waitangi Day"
-	timezones = list(TIMEZONE_NZDT)
+	timezones = list(TIMEZONE_NZDT, TIMEZONE_CHADT)
 	begin_day = 6
 	begin_month = FEBRUARY
 

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -8,8 +8,8 @@
 	var/always_celebrate = FALSE // for christmas neverending, or testing.
 	var/current_year = 0
 	var/year_offset = 0
-	///Timezones this holiday is celebrated in
-	var/list/timezones = list(TIMEZONE_UTC)
+	///Timezones this holiday is celebrated in (defaults to three timezones spanning a 50 hour window covering all timezones)
+	var/list/timezones = list(TIMEZONE_LINT, TIMEZONE_UTC, TIMEZONE_AoE)
 	var/obj/item/drone_hat //If this is defined, drones without a default hat will spawn with this one during the holiday; check drones_as_items.dm to see this used
 
 // This proc gets run before the game starts when the holiday is activated. Do festive shit here.
@@ -168,10 +168,8 @@
 
 /datum/holiday/april_fools
 	name = APRIL_FOOLS
-	begin_month = MARCH
-	begin_day = 31
-	end_month = APRIL
-	end_day = 2
+	begin_day = 1
+	begin_month = APRIL
 
 /datum/holiday/april_fools/celebrate()
 	SSjob.set_overflow_role("Clown")
@@ -371,10 +369,8 @@
 
 /datum/holiday/halloween
 	name = HALLOWEEN
-	begin_day = 28
+	begin_day = 31
 	begin_month = OCTOBER
-	end_day = 2
-	end_month = NOVEMBER
 
 /datum/holiday/halloween/greet()
 	return "Have a spooky Halloween!"
@@ -467,9 +463,9 @@
 
 /datum/holiday/xmas
 	name = CHRISTMAS
-	begin_day = 22
+	begin_day = 24 //Christmas Eve
 	begin_month = DECEMBER
-	end_day = 27
+	end_day = 26 //Boxing Day
 	drone_hat = /obj/item/clothing/head/santa
 
 /datum/holiday/xmas/greet()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Holiday periods can be offset by timezones instead of using GMT. 

This PR:

- Makes holidays span every timezone by default. I did this by:
    - Starting holidays 14 hours earlier (UTC+14 is the earliest timezone)
    - Making holidays 26 hours longer (the difference between UTC+14 and the latest timezone, UTC-12)
- Adds timezones to the following regional holidays:
    - Waitangi Day
    - ANZAC Day
    - US Independence Day
    - Bastille Day
- Shortens the following holidays by 1 day to compensate for the fact they'll be 26 extra hours now:
    - Christmas
    - Halloween
    - April Fool's Day
    - New Year's
    - Valentine's Day
<details>
<summary>Table exemplifying 50 hour holiday</summary>


Halloween (October 31st) ends 50 hours after beginning in the first timezone. 

I used UTC to trigger the holiday in the two hours between timezones. The holiday is still active in other timezones.




| Hour    | Line Islands Time (UTC+14) | BYOND Time (GMT/UTC+0) | Anywhere on Earth (UTC-12) |
|----------|----------------------------|------------------------|----------------------------|
| 1:00:00  | 31/10/2021 00:00:00        | 30/10/2021 10:00:00    | 29/10/2021 22:00:00        |
| 2:00:00  | 31/10/2021 01:00:00        | 30/10/2021 11:00:00    | 29/10/2021 23:00:00        |
| 3:00:00  | 31/10/2021 02:00:00        | 30/10/2021 12:00:00    | 30/10/2021 00:00:00        |
| 4:00:00  | 31/10/2021 03:00:00        | 30/10/2021 13:00:00    | 30/10/2021 01:00:00        |
| 5:00:00  | 31/10/2021 04:00:00        | 30/10/2021 14:00:00    | 30/10/2021 02:00:00        |
| 6:00:00  | 31/10/2021 05:00:00        | 30/10/2021 15:00:00    | 30/10/2021 03:00:00        |
| 7:00:00  | 31/10/2021 06:00:00        | 30/10/2021 16:00:00    | 30/10/2021 04:00:00        |
| 8:00:00  | 31/10/2021 07:00:00        | 30/10/2021 17:00:00    | 30/10/2021 05:00:00        |
| 9:00:00  | 31/10/2021 08:00:00        | 30/10/2021 18:00:00    | 30/10/2021 06:00:00        |
| 10:00:00 | 31/10/2021 09:00:00        | 30/10/2021 19:00:00    | 30/10/2021 07:00:00        |
| 11:00:00 | 31/10/2021 10:00:00        | 30/10/2021 20:00:00    | 30/10/2021 08:00:00        |
| 12:00:00 | 31/10/2021 11:00:00        | 30/10/2021 21:00:00    | 30/10/2021 09:00:00        |
| 13:00:00 | 31/10/2021 12:00:00        | 30/10/2021 22:00:00    | 30/10/2021 10:00:00        |
| 14:00:00 | 31/10/2021 13:00:00        | 30/10/2021 23:00:00    | 30/10/2021 11:00:00        |
| 15:00:00 | 31/10/2021 14:00:00        | 31/10/2021 00:00:00    | 30/10/2021 12:00:00        |
| 16:00:00 | 31/10/2021 15:00:00        | 31/10/2021 01:00:00    | 30/10/2021 13:00:00        |
| 17:00:00 | 31/10/2021 16:00:00        | 31/10/2021 02:00:00    | 30/10/2021 14:00:00        |
| 18:00:00 | 31/10/2021 17:00:00        | 31/10/2021 03:00:00    | 30/10/2021 15:00:00        |
| 19:00:00 | 31/10/2021 18:00:00        | 31/10/2021 04:00:00    | 30/10/2021 16:00:00        |
| 20:00:00 | 31/10/2021 19:00:00        | 31/10/2021 05:00:00    | 30/10/2021 17:00:00        |
| 21:00:00 | 31/10/2021 20:00:00        | 31/10/2021 06:00:00    | 30/10/2021 18:00:00        |
| 22:00:00 | 31/10/2021 21:00:00        | 31/10/2021 07:00:00    | 30/10/2021 19:00:00        |
| 23:00:00 | 31/10/2021 22:00:00        | 31/10/2021 08:00:00    | 30/10/2021 20:00:00        |
| 24:00:00 | 31/10/2021 23:00:00        | 31/10/2021 09:00:00    | 30/10/2021 21:00:00        |
| 25:00:00 | 01/11/2021 00:00:00        | 31/10/2021 10:00:00    | 30/10/2021 22:00:00        |
| 26:00:00 | 01/11/2021 01:00:00        | 31/10/2021 11:00:00    | 30/10/2021 23:00:00        |
| 27:00:00 | 01/11/2021 02:00:00        | 31/10/2021 12:00:00    | 31/10/2021 00:00:00        |
| 28:00:00 | 01/11/2021 03:00:00        | 31/10/2021 13:00:00    | 31/10/2021 01:00:00        |
| 29:00:00 | 01/11/2021 04:00:00        | 31/10/2021 14:00:00    | 31/10/2021 02:00:00        |
| 30:00:00 | 01/11/2021 05:00:00        | 31/10/2021 15:00:00    | 31/10/2021 03:00:00        |
| 31:00:00 | 01/11/2021 06:00:00        | 31/10/2021 16:00:00    | 31/10/2021 04:00:00        |
| 32:00:00 | 01/11/2021 07:00:00        | 31/10/2021 17:00:00    | 31/10/2021 05:00:00        |
| 33:00:00 | 01/11/2021 08:00:00        | 31/10/2021 18:00:00    | 31/10/2021 06:00:00        |
| 34:00:00 | 01/11/2021 09:00:00        | 31/10/2021 19:00:00    | 31/10/2021 07:00:00        |
| 35:00:00 | 01/11/2021 10:00:00        | 31/10/2021 20:00:00    | 31/10/2021 08:00:00        |
| 36:00:00 | 01/11/2021 11:00:00        | 31/10/2021 21:00:00    | 31/10/2021 09:00:00        |
| 37:00:00 | 01/11/2021 12:00:00        | 31/10/2021 22:00:00    | 31/10/2021 10:00:00        |
| 38:00:00 | 01/11/2021 13:00:00        | 31/10/2021 23:00:00    | 31/10/2021 11:00:00        |
| 39:00:00 | 01/11/2021 14:00:00        | 01/11/2021 00:00:00    | 31/10/2021 12:00:00        |
| 40:00:00 | 01/11/2021 15:00:00        | 01/11/2021 01:00:00    | 31/10/2021 13:00:00        |
| 41:00:00 | 01/11/2021 16:00:00        | 01/11/2021 02:00:00    | 31/10/2021 14:00:00        |
| 42:00:00 | 01/11/2021 17:00:00        | 01/11/2021 03:00:00    | 31/10/2021 15:00:00        |
| 43:00:00 | 01/11/2021 18:00:00        | 01/11/2021 04:00:00    | 31/10/2021 16:00:00        |
| 44:00:00 | 01/11/2021 19:00:00        | 01/11/2021 05:00:00    | 31/10/2021 17:00:00        |
| 45:00:00 | 01/11/2021 20:00:00        | 01/11/2021 06:00:00    | 31/10/2021 18:00:00        |
| 46:00:00 | 01/11/2021 21:00:00        | 01/11/2021 07:00:00    | 31/10/2021 19:00:00        |
| 47:00:00 | 01/11/2021 22:00:00        | 01/11/2021 08:00:00    | 31/10/2021 20:00:00        |
| 48:00:00 | 01/11/2021 23:00:00        | 01/11/2021 09:00:00    | 31/10/2021 21:00:00        |
| 49:00:00 | 02/11/2021 00:00:00        | 01/11/2021 10:00:00    | 31/10/2021 22:00:00        |
| 50:00:00 | 02/11/2021 01:00:00        | 01/11/2021 11:00:00    | 31/10/2021 23:00:00        |



</details>



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

1. Regional holidays can begin and end with the countries that celebrate them
1. Universal holidays will cover every timezone by default
1. Holidays can cover every timezone without having to run long

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
code: Universal holidays will cover every timezone by default. This means they'll start 14 hours earlier and last 26 hours longer
code: Shortens Christmas, Halloween, April Fool's Day, New Year's and Valentine's Day periods by one day. They will start 14 hours earlier but only last 2 hours longer
code: US Independence Day, ANZAC Day, Bastille Day and Waitangi Day will begin and end when they do in the countries that celebrate them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
