### PR TITLE
fixes heretics

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -129,7 +129,7 @@
 	var/obj/effect/proc_holder/spell/spell_to_add
 
 /datum/eldritch_knowledge/spell/on_gain(mob/user)
-	spell_to_add = new
+	spell_to_add = new spell_to_add
 	user.mind.AddSpell(spell_to_add)
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This bit of code didn't specify that the new thing was what the variable was, and without that information byond assumes you want to create what the variable is typed to (a generic proc holder spell)

## Why It's Good For The Game

fixes #58677
fixes #58678

## Changelog
:cl:
fix: fixes heretics being given an incorrect spell path, leading to heretic being given "spell" spells
/:cl:
