### PR TITLE
Stops hangover station trait from making bottles spawn in the walls/windows/dense objects

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -465,12 +465,14 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 		var/bottle_count = rand(1, 3)
 		for(var/index in 1 to bottle_count)
 			var/turf/turf_to_spawn_on = get_step(src, pick(GLOB.alldirs))
+          if(!isopenturf(turf_to_spawn_on))
+              continue
 			var/dense_object = FALSE
 			for(var/atom/content in turf_to_spawn_on.contents)
 				if(content.density)
 					dense_object = TRUE
 					break
-			if(!isopenturf(turf_to_spawn_on) || dense_object)
+			if(dense_object)
 				continue
 			new /obj/item/reagent_containers/food/drinks/beer/almost_empty(turf_to_spawn_on)
 

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -452,7 +452,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	icon_state = "hangover_spawn"
 
 /obj/effect/landmark/start/hangover/Initialize()
-	..()
+	. = ..()
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/landmark/start/hangover/LateInitialize()

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -465,8 +465,8 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 		var/bottle_count = rand(1, 3)
 		for(var/index in 1 to bottle_count)
 			var/turf/turf_to_spawn_on = get_step(src, pick(GLOB.alldirs))
-          if(!isopenturf(turf_to_spawn_on))
-              continue
+			if(!isopenturf(turf_to_spawn_on))
+				continue
 			var/dense_object = FALSE
 			for(var/atom/content in turf_to_spawn_on.contents)
 				if(content.density)

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -452,6 +452,10 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	icon_state = "hangover_spawn"
 
 /obj/effect/landmark/start/hangover/Initialize()
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/effect/landmark/start/hangover/LateInitialize()
 	. = ..()
 	if(!HAS_TRAIT(SSstation, STATION_TRAIT_HANGOVER))
 		return
@@ -461,7 +465,12 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 		var/bottle_count = rand(1, 3)
 		for(var/index in 1 to bottle_count)
 			var/turf/turf_to_spawn_on = get_step(src, pick(GLOB.alldirs))
-			if(!isopenturf(turf_to_spawn_on))
+			var/dense_object = FALSE
+			for(var/atom/content in turf_to_spawn_on.contents)
+				if(content.density)
+					dense_object = TRUE
+					break
+			if(!isopenturf(turf_to_spawn_on) || dense_object)
 				continue
 			new /obj/item/reagent_containers/food/drinks/beer/almost_empty(turf_to_spawn_on)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin

Fixes https://github.com/tgstation/tgstation/issues/58046
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We can't have bottles spawning in walls...

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Stops bottles from spawning in walls when the hangover station trait is in effect.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
