### PR TITLE
Tend Wounds and Debride Infection surgeries now estimate how long you have left to finish

### DIFF
--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -143,7 +143,7 @@
 			if(1.25 to 2.75)
 				bandage_condition = "badly worn"
 			if(2.75 to 4)
-				bandage_condition = "slightly pus-stained"
+				bandage_condition = "slightly stained"
 			if(4 to INFINITY)
 				bandage_condition = "clean"
 
@@ -155,7 +155,7 @@
 			if(WOUND_INFECTION_SEVERE to WOUND_INFECTION_CRITICAL)
 				condition += ", <span class='deadsay'>with growing clouds of infection.</span>"
 			if(WOUND_INFECTION_CRITICAL to WOUND_INFECTION_SEPTIC)
-				condition += ", <span class='deadsay'>with streaks of rotten, pulsating infection!</span>"
+				condition += ", <span class='deadsay'>with streaks of rotten infection!</span>"
 			if(WOUND_INFECTION_SEPTIC to INFINITY)
 				return "<span class='deadsay'><B>[victim.p_their(TRUE)] [limb.name] is a mess of charred skin and infected rot!</B></span>"
 			else
@@ -185,7 +185,7 @@
 			if(WOUND_INFECTION_SEPTIC to INFINITY)
 				. += "Infection Level: <span class='deadsay'>LOSS IMMINENT</span>\n"
 		if(infestation > sanitization)
-			. += "\tSurgical debridement, antiobiotics/sterilizers, or regenerative mesh will rid infection. Paramedic UV penlights are also effective.\n"
+			. += "\tSurgical debridement, antibiotics/sterilizers, or regenerative mesh will rid infection. Paramedic UV penlights are also effective.\n"
 
 		if(flesh_damage > 0)
 			. += "Flesh damage detected: Application of ointment, regenerative mesh, Synthflesh, or ingestion of \"Miner's Salve\" will repair damaged flesh. Good nutrition, rest, and keeping the wound clean can also slowly repair flesh.\n"

--- a/code/modules/surgery/burn_dressing.dm
+++ b/code/modules/surgery/burn_dressing.dm
@@ -3,7 +3,7 @@
 
 ///// Debride burnt flesh
 /datum/surgery/debride
-	name = "Debride infected flesh"
+	name = "Debride burnt flesh"
 	steps = list(/datum/surgery_step/debride, /datum/surgery_step/dress)
 	target_mobtypes = list(/mob/living/carbon/human)
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)
@@ -26,6 +26,29 @@
 	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCALPEL = 85, TOOL_SAW = 60, TOOL_WIRECUTTER = 40)
 	time = 30
 	repeatable = TRUE
+	/// How much sanitization is added per step
+	var/sanitization_added = 0.5
+	/// How much infestation is removed per step (positive number)
+	var/infestation_removed = 0.5
+
+/// To give the surgeon a heads up how much work they have ahead of them
+/datum/surgery_step/debride/proc/get_progress(mob/user, mob/living/carbon/target, datum/wound/burn/burn_wound)
+	if(!burn_wound?.infestation || !infestation_removed)
+		return
+	var/estimated_remaining_steps = burn_wound.infestation / infestation_removed
+	var/progress_text
+
+	switch(estimated_remaining_steps)
+		if(-INFINITY to 1)
+			return
+		if(1 to 2)
+			progress_text = ", preparing to remove the last remaining bits of infection"
+		if(2 to 4)
+			progress_text = ", steadily narrowing the remaining bits of infection"
+		if(5 to INFINITY)
+			progress_text = ", though there's still quite a lot to excise"
+
+	return progress_text
 
 /datum/surgery_step/debride/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(surgery.operated_wound)
@@ -44,13 +67,14 @@
 /datum/surgery_step/debride/success(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/datum/wound/burn/burn_wound = surgery.operated_wound
 	if(burn_wound)
-		display_results(user, target, "<span class='notice'>You successfully excise some of the infected flesh from [target]'s [parse_zone(target_zone)].</span>",
+		var/progress_text = get_progress(user, target, burn_wound)
+		display_results(user, target, "<span class='notice'>You successfully excise some of the infected flesh from [target]'s [parse_zone(target_zone)][progress_text].</span>",
 			"<span class='notice'>[user] successfully excises some of the infected flesh from [target]'s [parse_zone(target_zone)] with [tool]!</span>",
 			"<span class='notice'>[user] successfully excises some of the infected flesh from  [target]'s [parse_zone(target_zone)]!</span>")
 		log_combat(user, target, "excised infected flesh in", addition="COMBAT MODE: [uppertext(user.combat_mode)]")
 		surgery.operated_bodypart.receive_damage(brute=3, wound_bonus=CANT_WOUND)
-		burn_wound.infestation -= 0.5
-		burn_wound.sanitization += 0.5
+		burn_wound.infestation -= infestation_removed
+		burn_wound.sanitization += sanitization_added
 		if(burn_wound.infestation <= 0)
 			repeatable = FALSE
 	else
@@ -77,6 +101,11 @@
 	name = "bandage burns"
 	implements = list(/obj/item/stack/medical/gauze = 100, /obj/item/stack/sticky_tape/surgical = 100)
 	time = 40
+	/// How much sanitization is added
+	var/sanitization_added = 3
+	/// How much flesh healing is added
+	var/flesh_healing_added = 5
+
 
 /datum/surgery_step/dress/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/datum/wound/burn/burn_wound = surgery.operated_wound
@@ -94,8 +123,8 @@
 			"<span class='notice'>[user] successfully wraps [target]'s [parse_zone(target_zone)] with [tool]!</span>",
 			"<span class='notice'>[user] successfully wraps [target]'s [parse_zone(target_zone)]!</span>")
 		log_combat(user, target, "dressed burns in", addition="COMBAT MODE: [uppertext(user.combat_mode)]")
-		burn_wound.sanitization += 3
-		burn_wound.flesh_healing += 5
+		burn_wound.sanitization += sanitization_added
+		burn_wound.flesh_healing += flesh_healing_added
 		var/obj/item/bodypart/the_part = target.get_bodypart(target_zone)
 		the_part.apply_gauze(tool)
 	else

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -137,21 +137,24 @@
 	var/estimated_remaining_steps = target.getBruteLoss() / brute_healed
 	var/progress_text
 
-	switch(estimated_remaining_steps)
-		if(-INFINITY to 1)
-			return
-		if(1 to 3)
-			progress_text = ", stitching up the last few scrapes"
-		if(3 to 6)
-			progress_text = ", counting down the last few bruises left to treat"
-		if(6 to 9)
-			progress_text = ", continuing to plug away at [target.p_their()] extensive rupturing"
-		if(9 to 12)
-			progress_text = ", steadying yourself for the long surgery ahead"
-		if(12 to 15)
-			progress_text = ", though [target.p_they()] still look[target.p_s()] more like ground beef than a person"
-		if(15 to INFINITY)
-			progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] pulped body"
+	if(locate(/obj/item/healthanalyzer) in user.held_items)
+		progress_text = ". Remaining brute: <font color='#ff3333'>[target.getBruteLoss()]</font>"
+	else
+		switch(estimated_remaining_steps)
+			if(-INFINITY to 1)
+				return
+			if(1 to 3)
+				progress_text = ", stitching up the last few scrapes"
+			if(3 to 6)
+				progress_text = ", counting down the last few bruises left to treat"
+			if(6 to 9)
+				progress_text = ", continuing to plug away at [target.p_their()] extensive rupturing"
+			if(9 to 12)
+				progress_text = ", steadying yourself for the long surgery ahead"
+			if(12 to 15)
+				progress_text = ", though [target.p_they()] still look[target.p_s()] more like ground beef than a person"
+			if(15 to INFINITY)
+				progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] pulped body"
 
 	return progress_text
 
@@ -199,21 +202,24 @@
 	var/estimated_remaining_steps = target.getFireLoss() / burn_healed
 	var/progress_text
 
-	switch(estimated_remaining_steps)
-		if(-INFINITY to 1)
-			return
-		if(1 to 3)
-			progress_text = ", finishing up the last few singe marks"
-		if(3 to 6)
-			progress_text = ", counting down the last few blisters left to treat"
-		if(6 to 9)
-			progress_text = ", continuing to plug away at [target.p_their()] thorough roasting"
-		if(9 to 12)
-			progress_text = ", steadying yourself for the long surgery ahead"
-		if(12 to 15)
-			progress_text = ", though [target.p_they()] still look[target.p_s()] more like burnt steak than a person"
-		if(15 to INFINITY)
-			progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] charred body"
+	if(locate(/obj/item/healthanalyzer) in user.held_items)
+		progress_text = ". Remaining brute: <font color='#ff9933'>[target.getFireLoss()]</font>"
+	else
+		switch(estimated_remaining_steps)
+			if(-INFINITY to 1)
+				return
+			if(1 to 3)
+				progress_text = ", finishing up the last few singe marks"
+			if(3 to 6)
+				progress_text = ", counting down the last few blisters left to treat"
+			if(6 to 9)
+				progress_text = ", continuing to plug away at [target.p_their()] thorough roasting"
+			if(9 to 12)
+				progress_text = ", steadying yourself for the long surgery ahead"
+			if(12 to 15)
+				progress_text = ", though [target.p_they()] still look[target.p_s()] more like burnt steak than a person"
+			if(15 to INFINITY)
+				progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] charred body"
 
 	return progress_text
 
@@ -258,27 +264,33 @@
 /datum/surgery_step/heal/combo/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
 	var/estimated_remaining_steps = 0
 	if(brute_healed > 0)
-		estimated_remaining_steps += max(0, (target.getBruteLoss() / brute_healed))
+		estimated_remaining_steps = max(0, (target.getBruteLoss() / brute_healed))
 	if(burn_healed > 0)
-		estimated_remaining_steps += max(0, (target.getFireLoss() / burn_healed))
+		estimated_remaining_steps = max(estimated_remaining_steps, (target.getFireLoss() / burn_healed)) // whichever is higher between brute or burn steps
 
 	var/progress_text
 
-	switch(estimated_remaining_steps)
-		if(-INFINITY to 1)
-			return
-		if(1 to 3)
-			progress_text = ", finishing up the last few signs of damage"
-		if(3 to 6)
-			progress_text = ", counting down the last few patches of trauma"
-		if(6 to 9)
-			progress_text = ", continuing to plug away at [target.p_their()] extensive injuries"
-		if(9 to 12)
-			progress_text = ", steadying yourself for the long surgery ahead"
-		if(12 to 15)
-			progress_text = ", though [target.p_they()] still look[target.p_s()] more like smooshed baby food than a person"
-		if(15 to INFINITY)
-			progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] broken body"
+	if(locate(/obj/item/healthanalyzer) in user.held_items)
+		if(target.getBruteLoss())
+			progress_text = ". Remaining brute: <font color='#ff3333'>[target.getBruteLoss()]</font>"
+		if(target.getFireLoss())
+			progress_text += ". Remaining burn: <font color='#ff9933'>[target.getFireLoss()]</font>"
+	else
+		switch(estimated_remaining_steps)
+			if(-INFINITY to 1)
+				return
+			if(1 to 3)
+				progress_text = ", finishing up the last few signs of damage"
+			if(3 to 6)
+				progress_text = ", counting down the last few patches of trauma"
+			if(6 to 9)
+				progress_text = ", continuing to plug away at [target.p_their()] extensive injuries"
+			if(9 to 12)
+				progress_text = ", steadying yourself for the long surgery ahead"
+			if(12 to 15)
+				progress_text = ", though [target.p_they()] still look[target.p_s()] more like smooshed baby food than a person"
+			if(15 to INFINITY)
+				progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] broken body"
 
 	return progress_text
 

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -40,6 +40,10 @@
 	var/brute_multiplier = 0 //multiplies the damage that the patient has. if 0 the patient wont get any additional healing from the damage he has.
 	var/burn_multiplier = 0
 
+/// Returns a string letting the surgeon know roughly how much longer the surgery is estimated to take at the going rate
+/datum/surgery_step/heal/proc/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	return
+
 /datum/surgery_step/heal/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/woundtype
 	if(brutehealing && burnhealing)
@@ -79,6 +83,8 @@
 		umsg += " as best as you can while [target.p_they()] [target.p_have()] clothing on"
 		tmsg += " as best as [user.p_they()] can while [target.p_they()] [target.p_have()] clothing on"
 	target.heal_bodypart_damage(brute_healed,burn_healed)
+
+	umsg += get_progress(user, target, brute_healed, burn_healed)
 
 	display_results(user, target, "<span class='notice'>[umsg].</span>",
 		"[tmsg].",
@@ -124,6 +130,31 @@
 	desc = "A surgical procedure that provides experimental treatment for a patient's brute traumas. Heals considerably more when the patient is severely injured."
 
 /********************BRUTE STEPS********************/
+/datum/surgery_step/heal/brute/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	if(!brute_healed)
+		return
+
+	var/estimated_remaining_steps = target.getBruteLoss() / brute_healed
+	var/progress_text
+
+	switch(estimated_remaining_steps)
+		if(-INFINITY to 1)
+			return
+		if(1 to 3)
+			progress_text = ", stitching up the last few scrapes"
+		if(3 to 6)
+			progress_text = ", counting down the last few bruises left to treat"
+		if(6 to 9)
+			progress_text = ", continuing to plug away at [target.p_their()] extensive rupturing"
+		if(9 to 12)
+			progress_text = ", steadying yourself for the long surgery ahead"
+		if(12 to 15)
+			progress_text = ", though [target.p_they()] still look[target.p_s()] more like ground beef than a person"
+		if(15 to INFINITY)
+			progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] pulped body"
+
+	return progress_text
+
 /datum/surgery_step/heal/brute/basic
 	name = "tend bruises"
 	brutehealing = 5
@@ -162,6 +193,30 @@
 	desc = "A surgical procedure that provides experimental treatment for a patient's burns. Heals considerably more when the patient is severely injured."
 
 /********************BURN STEPS********************/
+/datum/surgery_step/heal/burn/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	if(!burn_healed)
+		return
+	var/estimated_remaining_steps = target.getFireLoss() / burn_healed
+	var/progress_text
+
+	switch(estimated_remaining_steps)
+		if(-INFINITY to 1)
+			return
+		if(1 to 3)
+			progress_text = ", finishing up the last few singe marks"
+		if(3 to 6)
+			progress_text = ", counting down the last few blisters left to treat"
+		if(6 to 9)
+			progress_text = ", continuing to plug away at [target.p_their()] thorough roasting"
+		if(9 to 12)
+			progress_text = ", steadying yourself for the long surgery ahead"
+		if(12 to 15)
+			progress_text = ", though [target.p_they()] still look[target.p_s()] more like burnt steak than a person"
+		if(15 to INFINITY)
+			progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] charred body"
+
+	return progress_text
+
 /datum/surgery_step/heal/burn/basic
 	name = "tend burn wounds"
 	burnhealing = 5
@@ -200,6 +255,33 @@
 	desc = "A surgical procedure that provides experimental treatment for a patient's burns and brute traumas. Heals considerably more when the patient is severely injured."
 
 /********************COMBO STEPS********************/
+/datum/surgery_step/heal/combo/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	var/estimated_remaining_steps = 0
+	if(brute_healed > 0)
+		estimated_remaining_steps += max(0, (target.getBruteLoss() / brute_healed))
+	if(burn_healed > 0)
+		estimated_remaining_steps += max(0, (target.getFireLoss() / burn_healed))
+
+	var/progress_text
+
+	switch(estimated_remaining_steps)
+		if(-INFINITY to 1)
+			return
+		if(1 to 3)
+			progress_text = ", finishing up the last few signs of damage"
+		if(3 to 6)
+			progress_text = ", counting down the last few patches of trauma"
+		if(6 to 9)
+			progress_text = ", continuing to plug away at [target.p_their()] extensive injuries"
+		if(9 to 12)
+			progress_text = ", steadying yourself for the long surgery ahead"
+		if(12 to 15)
+			progress_text = ", though [target.p_they()] still look[target.p_s()] more like smooshed baby food than a person"
+		if(15 to INFINITY)
+			progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] broken body"
+
+	return progress_text
+
 /datum/surgery_step/heal/combo
 	name = "tend physical wounds"
 	brutehealing = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Treating an injured patient with Tend Wounds can take anywhere from a few seconds to upwards of a few minutes depending on how badly they're hurt, if you're treating them through their clothes, if they're dead, what level surgery you have, etc etc. This PR makes it so the message from succeeding the looping step gives you a little blurb about how many times you'll have to repeat it to finish up, so you can get a sense for if it's worth continuing the surgery, or if you should pursue another, quicker course of treatment.

[![dreamseeker_2021-04-25_00-28-13.png](https://i.imgur.com/us1CbL5l.jpg)](https://i.imgur.com/us1CbL5.png)

Having a health analyzer in your offhand will give you updates on the precise numbers of damage left to treat, in case you want to know when you're approaching defibbable levels or you just want more precise numbers.

[![dreamseeker_2021-05-06_03-09-09.png](https://i.imgur.com/rH3qmOJl.jpg)](https://i.imgur.com/rH3qmOJ.png)

The specific numbers and thresholds might need some tweaking, I figured that having to repeat the same step 15+ times is a good cap for saying "listen, maybe you should just use some sutures or something", but let me know if different numbers would work better. 

I also tweaked some of the wording related to burn wounds to be a bit less unnecessarily gross.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Is your Tend Wounds surgery dragging on forever? Did you forget to open up the operating computer before you started, or do you not have one available, so you can't see how fast you're progressing? Afraid that you damned yourself to spend the next five minutes standing still, but you don't want to interrupt the treatment by using a health analyzer to check your progress? This is the PR for you!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
qol: Tend Wounds and Debride Infected Flesh surgeries now tell the surgeon roughly how many more repetitions are left before the patient is fully treated.
qol: Having a health analyzer in your offhand during Tend Wounds will give you precise updates on how much damage is left after each step.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
