### PR TITLE
Fixes Chameleon Projector Dummies escaping containers

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -151,7 +151,7 @@
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/relaymove(mob/living/user, direction)
-	if(!isturf(loc) || !direction)
+	if(!isturf(loc) || isspaceturf(loc) || !direction)
 		return //No magical movement! Trust me, this bad boy can do things like leap out of pipes if you're not careful
 
 	if(can_move < world.time)

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -151,8 +151,8 @@
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/relaymove(mob/living/user, direction)
-	if(isspaceturf(loc) || !direction)
-		return //No magical space movement!
+	if(!isturf(loc) || !direction)
+		return //No magical movement! Trust me, this bad boy can do things like leap out of pipes if you're not careful
 
 	if(can_move < world.time)
 		var/amount


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #58675

## Why It's Good For The Game

You can see why this is bad from the issue, but it applies a lot of other places you can cram the projector into. Like transit tubes! Or vehicles! Or free escapes from welded lockers! Spooky.

## Changelog
:cl:
fix: Fixes Chameleon Projector Dummies escaping containers
/:cl:
