### PR TITLE
IAA now properly removes martyrdom when you reinstate escape objectives

### DIFF
--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -139,10 +139,8 @@
 
 /datum/antagonist/traitor/internal_affairs/reinstate_escape_objective()
 	..()
-	for (var/objective in objectives)
-		if(!(istype(objective, /datum/objective/martyr)))
-			continue
-		remove_objective(objective)
+	for (var/datum/objective/martyr/martyr_objective in objectives)
+		remove_objective(martyr_objective)
 
 	var/objtype = traitor_kind == TRAITOR_HUMAN ? /datum/objective/escape : /datum/objective/survive/malf
 	var/datum/objective/escape_objective = new objtype

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -119,7 +119,7 @@
 	if(!objectives.len)
 		return
 	for (var/objective_ in objectives)
-		if(!(istype(objective_, /datum/objective/escape)||istype(objective_, /datum/objective/survive/malf)))
+		if(!(istype(objective_, /datum/objective/escape) || istype(objective_, /datum/objective/survive/malf)))
 			continue
 		remove_objective(objective_)
 
@@ -139,6 +139,11 @@
 
 /datum/antagonist/traitor/internal_affairs/reinstate_escape_objective()
 	..()
+	for (var/objective in objectives)
+		if(!(istype(objective, /datum/objective/martyr)))
+			continue
+		remove_objective(objective)
+
 	var/objtype = traitor_kind == TRAITOR_HUMAN ? /datum/objective/escape : /datum/objective/survive/malf
 	var/datum/objective/escape_objective = new objtype
 	escape_objective.owner = owner


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #58610

Escape > martyrdom removed escape,

martyrdom > escape didn't remove martyrdom.

## Changelog
:cl:
fix: IAA now properly removes martyrdom when you reinstate escape objectives
/:cl: