### PR TITLE
freezes addictions and sanity during death

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -175,6 +175,9 @@
 
 ///Called on SSmood process
 /datum/component/mood/process(delta_time)
+	var/mob/living/moody_fellow = parent
+	if(moody_fellow.stat == DEAD)
+		return //updating sanity during death leads to people getting revived and being completely insane for simply being dead for a long time
 	switch(mood_level)
 		if(1)
 			setSanity(sanity-0.3*delta_time, SANITY_INSANE)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -37,7 +37,7 @@
 	//Updates the number of stored chemicals for powers
 	handle_changeling(delta_time, times_fired)
 
-	if(mind)
+	if(. && mind) //. == not dead
 		for(var/key in mind.addiction_points)
 			var/datum/addiction/addiction = SSaddiction.all_addictions[key]
 			addiction.process_addiction(src, delta_time, times_fired)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #58463


## Changelog
:cl:
fix: sanity and addiction processes freeze after death
/:cl:

