### PR TITLE
Fixes escaping into hyperspace during drop landing

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -728,6 +728,7 @@ SUBSYSTEM_DEF(job)
 	var/turf/spawn_turf = get_safe_random_station_turf(typesof(/area/hallway))
 
 	var/obj/structure/closet/supplypod/centcompod/toLaunch = new()
+	living_mob.Paralyze(54, TRUE) //54 is the added time of transit, falling, and opening. you're unparalyzed as soon as you land. needed to prevent fuckery in hyperspace
 	living_mob.forceMove(toLaunch)
 	new /obj/effect/pod_landingzone(spawn_turf, toLaunch)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the paralyze is the combined time of dropping, falling, and opening. it should clear up the second you land
fixes #58559

## Changelog
:cl:
fix: Fixes escaping into hyperspace during drop landing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
