### PR TITLE
Removes handheld subtype from flashes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -1272,7 +1272,7 @@
 /area/ruin/space/derelict/bridge/access)
 "fy" = (
 /obj/structure/table,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/bridge/access)
 "fz" = (

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -1892,7 +1892,7 @@
 "eV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -3927,8 +3927,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /obj/item/storage/box/firingpins,
 /obj/structure/closet/crate/secure/weapon{
 	req_access_txt = "203"

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -410,7 +410,7 @@
 /area/awaymission/undergroundoutpost45/central)
 "bf" = (
 /obj/item/storage/belt/security,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet{
 	icon_state = "sec";
@@ -5666,7 +5666,7 @@
 "lu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/item/reagent_containers/spray/pepper,
 /obj/structure/closet/secure_closet{
 	icon_state = "sec";

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -7517,7 +7517,7 @@
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -11855,7 +11855,7 @@
 "bJN" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -16710,7 +16710,7 @@
 "cgZ" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -31240,17 +31240,17 @@
 /obj/item/bodypart/l_arm/robot{
 	pixel_x = -3
 	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /obj/structure/table/reinforced,
 /obj/machinery/light_switch{
 	pixel_x = -38;
 	pixel_y = 26
 	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
@@ -38372,7 +38372,7 @@
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -47739,7 +47739,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -67582,7 +67582,7 @@
 	pixel_y = 32
 	},
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "mam" = (
@@ -76252,7 +76252,7 @@
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
@@ -81470,7 +81470,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/disposalpipe/segment,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/aft)
@@ -107035,8 +107035,8 @@
 "wnJ" = (
 /obj/structure/table/reinforced,
 /obj/item/ai_module/reset,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
@@ -107552,7 +107552,7 @@
 "wva" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -8271,7 +8271,7 @@
 "aFL" = (
 /obj/item/radio/off,
 /obj/item/crowbar,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -14452,12 +14452,12 @@
 	amount = 10
 	},
 /obj/item/stack/cable_coil,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
@@ -35386,8 +35386,8 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
@@ -47448,8 +47448,8 @@
 /area/engineering/supermatter)
 "rsQ" = (
 /obj/structure/table/reinforced,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /obj/machinery/bounty_board{
 	dir = 4;
 	pixel_x = -28
@@ -47572,7 +47572,7 @@
 /area/service/janitor)
 "rxB" = (
 /obj/structure/table,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /turf/open/floor/iron,
 /area/security/office)
 "rxV" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -89,7 +89,7 @@
 	pixel_y = 32
 	},
 /obj/item/storage/toolbox/electrical,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai)
@@ -6100,7 +6100,7 @@
 	},
 /obj/item/folder/red,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -25949,12 +25949,12 @@
 	pixel_y = 2
 	},
 /obj/item/book/manual/wiki/robotics_cyborgs,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "bhC" = (
@@ -62608,8 +62608,8 @@
 /obj/item/aicard{
 	pixel_x = 4
 	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -78536,7 +78536,7 @@
 "qFC" = (
 /obj/structure/rack,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -89197,8 +89197,8 @@
 	},
 /obj/item/aicard,
 /obj/item/ai_module/reset,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -638,7 +638,7 @@
 "adW" = (
 /obj/structure/rack,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -8398,7 +8398,7 @@
 	},
 /obj/structure/closet,
 /obj/item/crowbar,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/item/radio,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -26876,7 +26876,7 @@
 	pixel_x = -3
 	},
 /obj/item/storage/fancy/cigarettes,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/item/reagent_containers/spray/pepper,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -30415,7 +30415,7 @@
 	pixel_x = -6;
 	pixel_y = 4
 	},
-/obj/item/assembly/flash/handheld{
+/obj/item/assembly/flash{
 	pixel_x = 6;
 	pixel_y = 13
 	},
@@ -32312,23 +32312,23 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/item/assembly/flash/handheld{
+/obj/item/assembly/flash{
 	pixel_x = -1;
 	pixel_y = -1
 	},
-/obj/item/assembly/flash/handheld{
+/obj/item/assembly/flash{
 	pixel_x = 3;
 	pixel_y = 2
 	},
-/obj/item/assembly/flash/handheld{
+/obj/item/assembly/flash{
 	pixel_x = 1;
 	pixel_y = 4
 	},
-/obj/item/assembly/flash/handheld{
+/obj/item/assembly/flash{
 	pixel_x = -4;
 	pixel_y = 5
 	},
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/item/bodypart/r_arm/robot{
 	pixel_x = 3
 	},
@@ -52331,7 +52331,7 @@
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/item/storage/secure/briefcase,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/machinery/computer/security/telescreen/vault{
 	pixel_y = 30
 	},
@@ -66282,8 +66282,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /obj/item/radio/intercom{
 	pixel_y = 28
 	},
@@ -76387,7 +76387,7 @@
 	pixel_y = -30
 	},
 /obj/item/stack/sheet/glass,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/item/assembly/signaler,
 /obj/item/assembly/timer{
 	pixel_x = 3;

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -311,7 +311,7 @@
 "iy" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs/cable/zipties,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/centcom/control)
@@ -1047,7 +1047,7 @@
 "kd" = (
 /obj/item/wrench,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1653,7 +1653,7 @@
 /obj/structure/table/reinforced,
 /obj/item/wrench,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -2410,7 +2410,7 @@
 "mX" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs/cable/zipties,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -4153,7 +4153,7 @@
 /obj/item/folder/red,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
@@ -5093,7 +5093,7 @@
 /obj/structure/table/reinforced,
 /obj/item/wrench,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -5859,7 +5859,7 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -9023,7 +9023,7 @@
 "BA" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs/cable/zipties,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -9331,7 +9331,7 @@
 "Ce" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs/cable/zipties,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -9413,7 +9413,7 @@
 /obj/item/folder/red,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -13223,7 +13223,7 @@
 /obj/item/folder/red,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -13647,7 +13647,7 @@
 /area/centcom/evac)
 "Ln" = (
 /obj/structure/table,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/evac)
 "Lo" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -35617,7 +35617,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/storage/secure/briefcase,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "jKR" = (
@@ -35921,7 +35921,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "jSw" = (
 /obj/structure/table,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/office)
@@ -38752,8 +38752,8 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 10
 	},
@@ -49337,12 +49337,12 @@
 /area/medical/medbay/central)
 "pjl" = (
 /obj/structure/table,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "pjm" = (

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -1222,7 +1222,7 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -90,7 +90,7 @@
 /obj/item/restraints/handcuffs,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "ao" = (

--- a/_maps/shuttles/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator_advanced.dmm
@@ -1091,8 +1091,8 @@
 	pixel_y = 6
 	},
 /obj/item/assembly/infra,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
+/obj/item/assembly/flash,
 /turf/open/floor/pod/dark,
 /area/shuttle/syndicate/armory)
 "cj" = (

--- a/_maps/shuttles/ruin_syndicate_dropship.dmm
+++ b/_maps/shuttles/ruin_syndicate_dropship.dmm
@@ -235,7 +235,7 @@
 "vw" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
 	dir = 1

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -1981,7 +1981,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack,
 /obj/item/storage/box/zipties,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/item/melee/classic_baton/telescopic,
 /obj/machinery/light/small/built{
 	dir = 8

--- a/_maps/shuttles/whiteship_tram.dmm
+++ b/_maps/shuttles/whiteship_tram.dmm
@@ -1324,7 +1324,7 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/zipties,
-/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash,
 /obj/item/melee/classic_baton/telescopic,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/abandoned/bridge)

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -73,7 +73,7 @@
 	name = "Strobe Shield"
 	result = /obj/item/shield/riot/flash
 	reqs = list(/obj/item/wallframe/flasher = 1,
-				/obj/item/assembly/flash/handheld = 1,
+				/obj/item/assembly/flash = 1,
 				/obj/item/shield/riot = 1)
 	time = 40
 	category = CAT_WEAPONRY

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -11,7 +11,7 @@
 	light_color = COLOR_WHITE
 	light_power = FLASH_LIGHT_POWER
 	damage_deflection = 10
-	var/obj/item/assembly/flash/handheld/bulb
+	var/obj/item/assembly/flash/bulb
 	var/id = null
 	var/range = 2 //this is roughly the size of brig cell
 	var/last_flash = 0 //Don't want it getting spammed like regular flashes
@@ -67,7 +67,7 @@
 				bulb = null
 				power_change()
 
-	else if (istype(W, /obj/item/assembly/flash/handheld))
+	else if (istype(W, /obj/item/assembly/flash))
 		if (!bulb)
 			if(!user.transferItemToLoc(W, src))
 				return

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -92,7 +92,7 @@
 				/obj/item/clothing/mask/cigarette/rollie/cannabis = 4,
 				/obj/item/toy/crayon/spraycan = 2,
 				/obj/item/crowbar = 1,
-				/obj/item/assembly/flash/handheld = 1,
+				/obj/item/assembly/flash = 1,
 				/obj/item/restraints/handcuffs/cable/zipties = 1,
 				/obj/item/restraints/handcuffs = 1,
 				/obj/item/radio/off = 1,

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -125,7 +125,7 @@
 	desc = "A shield with a built in, high intensity light capable of blinding and disorienting suspects. Takes regular handheld flashes as bulbs."
 	icon_state = "flashshield"
 	inhand_icon_state = "flashshield"
-	var/obj/item/assembly/flash/handheld/embedded_flash
+	var/obj/item/assembly/flash/embedded_flash
 
 /obj/item/shield/riot/flash/Initialize()
 	. = ..()
@@ -151,8 +151,8 @@
 
 
 /obj/item/shield/riot/flash/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/assembly/flash/handheld))
-		var/obj/item/assembly/flash/handheld/flash = W
+	if(istype(W, /obj/item/assembly/flash))
+		var/obj/item/assembly/flash/flash = W
 		if(flash.burnt_out)
 			to_chat(user, "<span class='warning'>No sense replacing it with a broken bulb!</span>")
 			return

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -230,7 +230,7 @@
 		/obj/item/grenade,
 		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/restraints/handcuffs,
-		/obj/item/assembly/flash/handheld,
+		/obj/item/assembly/flash,
 		/obj/item/clothing/glasses,
 		/obj/item/ammo_casing/shotgun,
 		/obj/item/ammo_box,
@@ -248,7 +248,7 @@
 	new /obj/item/reagent_containers/spray/pepper(src)
 	new /obj/item/restraints/handcuffs(src)
 	new /obj/item/grenade/flashbang(src)
-	new /obj/item/assembly/flash/handheld(src)
+	new /obj/item/assembly/flash(src)
 	new /obj/item/melee/baton/loaded(src)
 	update_appearance()
 

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -311,7 +311,7 @@
 
 /obj/item/storage/box/flashes/PopulateContents()
 	for(var/i in 1 to 6)
-		new /obj/item/assembly/flash/handheld(src)
+		new /obj/item/assembly/flash(src)
 
 /obj/item/storage/box/wall_flash
 	name = "wall-mounted flash kit"
@@ -329,7 +329,7 @@
 	remote.id = id
 	var/obj/item/wallframe/flasher/frame = new(src)
 	frame.id = id
-	new /obj/item/assembly/flash/handheld(src)
+	new /obj/item/assembly/flash(src)
 	new /obj/item/screwdriver(src)
 
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -18,7 +18,7 @@
 	new /obj/item/megaphone/command(src)
 	new /obj/item/areaeditor/blueprints(src)
 	new /obj/item/holosign_creator/atmos(src)
-	new /obj/item/assembly/flash/handheld(src)
+	new /obj/item/assembly/flash(src)
 	new /obj/item/clothing/glasses/meson/engine(src)
 	new /obj/item/door_remote/chief_engineer(src)
 	new /obj/item/pipe_dispenser(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -86,7 +86,7 @@
 	new /obj/item/defibrillator/compact/loaded(src)
 	new /obj/item/clothing/gloves/color/latex/nitrile(src)
 	new /obj/item/healthanalyzer/advanced(src)
-	new /obj/item/assembly/flash/handheld(src)
+	new /obj/item/assembly/flash(src)
 	new /obj/item/reagent_containers/hypospray/cmo(src)
 	new /obj/item/autosurgeon/organ/cmo(src)
 	new /obj/item/door_remote/chief_medical_officer(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/misc.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/misc.dm
@@ -9,7 +9,7 @@
 	new /obj/item/storage/firstaid/regular(src)
 	new /obj/item/storage/box/handcuffs(src)
 	new /obj/item/aicard(src)
-	new /obj/item/assembly/flash/handheld(src)
+	new /obj/item/assembly/flash(src)
 	if(prob(50))
 		new /obj/item/ammo_box/magazine/m50(src)
 		new /obj/item/ammo_box/magazine/m50(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -22,7 +22,7 @@
 	new /obj/item/megaphone/command(src)
 	new /obj/item/storage/lockbox/medal/sci(src)
 	new /obj/item/clothing/suit/armor/reactive/teleport(src)
-	new /obj/item/assembly/flash/handheld(src)
+	new /obj/item/assembly/flash(src)
 	new /obj/item/laser_pointer(src)
 	new /obj/item/door_remote/research_director(src)
 	new /obj/item/circuitboard/machine/techfab/department/science(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -52,7 +52,7 @@
 	new /obj/item/storage/box/ids(src)
 	new /obj/item/megaphone/command(src)
 	new /obj/item/clothing/suit/armor/vest/alt(src)
-	new /obj/item/assembly/flash/handheld(src)
+	new /obj/item/assembly/flash(src)
 	new /obj/item/clothing/glasses/sunglasses(src)
 	new /obj/item/gun/energy/e_gun(src)
 	new /obj/item/clothing/neck/petcollar(src)

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -510,7 +510,7 @@
 	shoes = /obj/item/clothing/shoes/jackboots
 	id = /obj/item/card/id/away/old/sec
 	r_pocket = /obj/item/restraints/handcuffs
-	l_pocket = /obj/item/assembly/flash/handheld
+	l_pocket = /obj/item/assembly/flash
 	assignedrole = "Ancient Crew"
 
 /obj/effect/mob_spawn/human/oldsec/Destroy()

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -122,7 +122,7 @@
 
 /datum/antagonist/rev/head/proc/admin_take_flash(mob/admin)
 	var/list/L = owner.current.get_contents()
-	var/obj/item/assembly/flash/handheld/flash = locate() in L
+	var/obj/item/assembly/flash/flash = locate() in L
 	if (!flash)
 		to_chat(admin, "<span class='danger'>Deleting flash failed!</span>")
 		return
@@ -143,7 +143,7 @@
 
 /datum/antagonist/rev/head/proc/admin_repair_flash(mob/admin)
 	var/list/L = owner.current.get_contents()
-	var/obj/item/assembly/flash/handheld/flash = locate() in L
+	var/obj/item/assembly/flash/flash = locate() in L
 	if (!flash)
 		to_chat(admin, "<span class='danger'>Repairing flash failed!</span>")
 	else
@@ -270,7 +270,7 @@
 		return
 
 	if(give_flash)
-		var/obj/item/assembly/flash/handheld/T = new(C)
+		var/obj/item/assembly/flash/T = new(C)
 		var/list/slots = list (
 			"backpack" = ITEM_SLOT_BACKPACK,
 			"left pocket" = ITEM_SLOT_LPOCKET,

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -363,7 +363,7 @@
 /obj/item/assembly/flash/armimplant/proc/cooldown()
 	overheat = FALSE
 
-/obj/item/assembly/flash/hypnotic
+/obj/item/assembly/flash/handheld/hypnotic
 	desc = "A modified flash device, programmed to emit a sequence of subliminal flashes that can send a vulnerable target into a hypnotic trance."
 	flashing_overlay = "flash-hypno"
 	light_color = LIGHT_COLOR_PINK

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -332,8 +332,6 @@
 	icon_state = "memorizer"
 	inhand_icon_state = "nullrod"
 
-/obj/item/assembly/flash/handheld //this is now the regular pocket flashes
-
 /obj/item/assembly/flash/armimplant
 	name = "photon projector"
 	desc = "A high-powered photon projector implant normally used for lighting purposes, but also doubles as a flashbulb weapon. Self-repair protocols fix the flashbulb if it ever burns out."
@@ -363,7 +361,7 @@
 /obj/item/assembly/flash/armimplant/proc/cooldown()
 	overheat = FALSE
 
-/obj/item/assembly/flash/handheld/hypnotic
+/obj/item/assembly/flash/hypnotic
 	desc = "A modified flash device, programmed to emit a sequence of subliminal flashes that can send a vulnerable target into a hypnotic trance."
 	flashing_overlay = "flash-hypno"
 	light_color = LIGHT_COLOR_PINK

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -29,7 +29,7 @@
 	inhand_icon_state = "bio_suit"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
-	allowed = list(/obj/item/disk, /obj/item/stamp, /obj/item/reagent_containers/food/drinks/flask, /obj/item/melee, /obj/item/storage/lockbox/medal, /obj/item/assembly/flash/handheld, /obj/item/storage/box/matches, /obj/item/lighter, /obj/item/clothing/mask/cigarette, /obj/item/storage/fancy/cigarettes, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
+	allowed = list(/obj/item/disk, /obj/item/stamp, /obj/item/reagent_containers/food/drinks/flask, /obj/item/melee, /obj/item/storage/lockbox/medal, /obj/item/assembly/flash, /obj/item/storage/box/matches, /obj/item/lighter, /obj/item/clothing/mask/cigarette, /obj/item/storage/fancy/cigarettes, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 
 //Chef
 /obj/item/clothing/suit/toggle/chef

--- a/code/modules/instruments/items.dm
+++ b/code/modules/instruments/items.dm
@@ -8,7 +8,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/instruments_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/instruments_righthand.dmi'
 	/// Our song datum.
-	var/datum/song/handheld/song
+	var/datum/song/song
 	/// Our allowed list of instrument ids. This is nulled on initialize.
 	var/list/allowed_instrument_ids
 	/// How far away our song datum can be heard.

--- a/code/modules/instruments/songs/_song.dm
+++ b/code/modules/instruments/songs/_song.dm
@@ -378,12 +378,12 @@
 				set_linear_falloff_duration(var_value)
 
 // subtype for handheld instruments, like violin
-/datum/song/handheld
+/datum/song
 
-/datum/song/handheld/updateDialog(mob/user)
+/datum/song/updateDialog(mob/user)
 	parent.ui_interact(user || usr)
 
-/datum/song/handheld/should_stop_playing(mob/user)
+/datum/song/should_stop_playing(mob/user)
 	. = ..()
 	if(.)
 		return TRUE

--- a/code/modules/instruments/songs/_song.dm
+++ b/code/modules/instruments/songs/_song.dm
@@ -378,12 +378,12 @@
 				set_linear_falloff_duration(var_value)
 
 // subtype for handheld instruments, like violin
-/datum/song
+/datum/song/handheld
 
-/datum/song/updateDialog(mob/user)
+/datum/song/handheld/updateDialog(mob/user)
 	parent.ui_interact(user || usr)
 
-/datum/song/should_stop_playing(mob/user)
+/datum/song/handheld/should_stop_playing(mob/user)
 	. = ..()
 	if(.)
 		return TRUE

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -48,7 +48,7 @@
 	head = /obj/item/clothing/head/hos/beret
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	suit_store = /obj/item/gun/energy/e_gun
-	r_pocket = /obj/item/assembly/flash/handheld
+	r_pocket = /obj/item/assembly/flash
 	l_pocket = /obj/item/restraints/handcuffs
 	backpack_contents = list(/obj/item/melee/baton/loaded=1, /obj/item/modular_computer/tablet/preset/advanced/command=1)
 

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -180,7 +180,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	suit = /obj/item/clothing/suit/armor/vest/alt
 	shoes = /obj/item/clothing/shoes/jackboots
 	l_pocket = /obj/item/restraints/handcuffs
-	r_pocket = /obj/item/assembly/flash/handheld
+	r_pocket = /obj/item/assembly/flash
 	suit_store = /obj/item/gun/energy/disabler
 	backpack_contents = list(/obj/item/melee/baton/loaded=1)
 

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -38,7 +38,7 @@
 	gloves = /obj/item/clothing/gloves/color/black
 	head = /obj/item/clothing/head/warden
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
-	r_pocket = /obj/item/assembly/flash/handheld
+	r_pocket = /obj/item/assembly/flash
 	l_pocket = /obj/item/restraints/handcuffs
 	suit_store = /obj/item/gun/energy/disabler
 	backpack_contents = list(/obj/item/melee/baton/loaded=1)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -541,7 +541,7 @@
 		new /obj/item/bodypart/head/robot(T)
 		var/b
 		for(b=0, b!=2, b++)
-			var/obj/item/assembly/flash/handheld/F = new /obj/item/assembly/flash/handheld(T)
+			var/obj/item/assembly/flash/F = new /obj/item/assembly/flash(T)
 			F.burn_out()
 	if (cell) //Sanity check.
 		cell.forceMove(T)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -849,7 +849,7 @@
 	build_type = MECHFAB
 	materials = list(/datum/material/iron = 750, /datum/material/glass = 750)
 	construction_time = 100
-	build_path = /obj/item/assembly/flash/handheld
+	build_path = /obj/item/assembly/flash
 	category = list("Misc")
 
 /datum/design/maint_drone

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -225,8 +225,8 @@
 	medium_burn_msg = ROBOTIC_MEDIUM_BURN_MSG
 	heavy_burn_msg = ROBOTIC_HEAVY_BURN_MSG
 
-	var/obj/item/assembly/flash/handheld/flash1 = null
-	var/obj/item/assembly/flash/handheld/flash2 = null
+	var/obj/item/assembly/flash/flash1 = null
+	var/obj/item/assembly/flash/flash2 = null
 
 
 /obj/item/bodypart/head/robot/handle_atom_del(atom/A)
@@ -256,8 +256,8 @@
 		. += "<span class='notice'>You can remove the seated flash[single_flash ? "":"es"] with a <b>crowbar</b>.</span>"
 
 /obj/item/bodypart/head/robot/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/assembly/flash/handheld))
-		var/obj/item/assembly/flash/handheld/F = W
+	if(istype(W, /obj/item/assembly/flash))
+		var/obj/item/assembly/flash/F = W
 		if(flash1 && flash2)
 			to_chat(user, "<span class='warning'>You have already inserted the eyes!</span>")
 			return

--- a/code/modules/vending/robotics.dm
+++ b/code/modules/vending/robotics.dm
@@ -9,7 +9,7 @@
 	products = list(/obj/item/clothing/suit/toggle/labcoat = 4,
 					/obj/item/clothing/under/rank/rnd/roboticist = 4,
 					/obj/item/stack/cable_coil = 4,
-					/obj/item/assembly/flash/handheld = 4,
+					/obj/item/assembly/flash = 4,
 					/obj/item/stock_parts/cell/high = 12,
 					/obj/item/assembly/prox_sensor = 3,
 					/obj/item/assembly/signaler = 3,

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -9,7 +9,7 @@
 	products = list(/obj/item/restraints/handcuffs = 8,
 					/obj/item/restraints/handcuffs/cable/zipties = 10,
 					/obj/item/grenade/flashbang = 4,
-					/obj/item/assembly/flash/handheld = 5,
+					/obj/item/assembly/flash = 5,
 					/obj/item/food/donut = 12,
 					/obj/item/storage/box/evidence = 6,
 					/obj/item/flashlight/seclite = 4,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #54538

### "There are no consequences of making hypnoflashes a child of handheld"

![1984](https://user-images.githubusercontent.com/40974010/115986666-2ae79780-a566-11eb-8749-119e7bc4f1c3.gif)

## Changelog
:cl:
fix: hypnoflashes are now a subtype of handheld, which lets you do a few more things with them that normal flashes can.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
