### PR TITLE
Resource swarmers can no longer destroy and harvest Protolathes, the ORM, the Ore silo or Circuit Imprinters

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -167,7 +167,7 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 	attack_all_objects = TRUE //attempt to nibble everything
 	lose_patience_timeout = 150
 	var/static/list/sharedWanted = typecacheof(list(/turf/closed/mineral, /turf/closed/wall)) //eat rocks and walls
-	var/static/list/sharedIgnore = list()
+	var/static/list/sharedIgnore = list(/obj/machinery/mineral/ore_redemption, /obj/machinery/rnd/production/protolathe, /obj/machinery/rnd/production/circuit_imprinter/department, /obj/machinery/ore_silo)
 
 //This handles viable things to eat/attack
 //Place specific cases of AI derpiness here

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -167,7 +167,7 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 	attack_all_objects = TRUE //attempt to nibble everything
 	lose_patience_timeout = 150
 	var/static/list/sharedWanted = typecacheof(list(/turf/closed/mineral, /turf/closed/wall)) //eat rocks and walls
-	var/static/list/sharedIgnore = list(/obj/machinery/mineral/ore_redemption, /obj/machinery/rnd/production/protolathe, /obj/machinery/rnd/production/circuit_imprinter/department, /obj/machinery/ore_silo)
+	var/static/list/sharedIgnore = list()
 
 //This handles viable things to eat/attack
 //Place specific cases of AI derpiness here

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -191,6 +191,22 @@
 	to_chat(actor, "<span class='warning'>This bluespace source will be important to us later. Aborting.</span>")
 	return FALSE
 
+/obj/machinery/rnd/protolathe/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>This mechanical lathe should be preserved, it will facilitate the creation of tools for our masters in the future. Aborting.</span>")
+	return FALSE
+
+/obj/machinery/mineral/ore_redemption/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>This industrial-degree smelter should be preserved, it will facilitate obtention of materials. Aborting.</span>")
+	return FALSE
+
+/obj/machinery/rnd/production/circuit_imprinter/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>This micro-circuit printer should be preserved, it will accelerate technological development. Aborting.</span>")
+	return FALSE
+
+/obj/machinery/ore_silo/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>This dense storage unit should be preserved, it will make distribution of resources more efficient for our masters in the future. Aborting.</span>")
+	return FALSE
+
 /turf/closed/wall/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	var/isonshuttle = istype(loc, /area/shuttle)
 	for(var/turf/turf_in_range as anything in RANGE_TURFS(1, src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Resource swarmers can no longer destroy and harvest Protolathes, the ORM, the Ore silo or Circuit Imprinters

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Swarmers become stupidly unmanageable and round ending if they break any of these. It's ridiculously overpowered and hard to avoid.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: resource swarmers can no longer destroy and harvest Protolathes, the ORM, the Ore silo or Circuit Imprinters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
