### PR TITLE
screwdrivers no longer randomize their pixel_y on initialize

### DIFF
--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -55,8 +55,6 @@
 		colored_belt_appearance = mutable_appearance(SSgreyscale.GetColoredIconByType(/datum/greyscale_config/screwdriver_belt, greyscale_colors))
 	. = ..()
 	AddElement(/datum/element/eyestab)
-	if(prob(75))
-		pixel_y = rand(0, 16)
 
 /obj/item/screwdriver/get_belt_overlay()
 	if(random_color)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


removes the 75% chance on screwdrivers initialize to have a random pixel_y between 0 and 16

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
it looks bad now that the screwdriver is centered on the tile

## Changelog
:cl:
qol: screwdrivers no longer randomize their pixel_y on initialize
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
