### PR TITLE
Adds a new obj_flag that prevents building on objects that shouldn't be built on.

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -14,6 +14,7 @@
 #define BLOCK_Z_OUT_UP (1<<10) // Should this object block z uprise from loc?
 #define BLOCK_Z_IN_DOWN (1<<11) // Should this object block z falling from above?
 #define BLOCK_Z_IN_UP (1<<12) // Should this object block z uprise from below?
+#define NO_BUILD (1<<13) // Can we build on this object?
 
 // If you add new ones, be sure to add them to /obj/Initialize as well for complete mapping support
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -11,6 +11,7 @@
 	icon_state = "sleeper"
 	base_icon_state = "sleeper"
 	density = FALSE
+	obj_flags = NO_BUILD
 	state_open = TRUE
 	circuit = /obj/item/circuitboard/machine/sleeper
 

--- a/code/game/machinery/dna_scanner.dm
+++ b/code/game/machinery/dna_scanner.dm
@@ -5,6 +5,7 @@
 	icon_state = "scanner"
 	base_icon_state = "scanner"
 	density = TRUE
+	obj_flags = NO_BUILD // Becomes undense when the door is open
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 50
 	active_power_usage = 300

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -14,6 +14,7 @@ The console is located at computer/gulag_teleporter.dm
 	base_icon_state = "implantchair"
 	state_open = FALSE
 	density = TRUE
+	obj_flags = NO_BUILD // Becomes undense when the door is open
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 200
 	active_power_usage = 5000

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -6,6 +6,7 @@
 	icon_state = "stasis"
 	base_icon_state = "stasis"
 	density = FALSE
+	obj_flags = NO_BUILD
 	can_buckle = TRUE
 	buckle_lying = 90
 	circuit = /obj/item/circuitboard/machine/stasis

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -8,6 +8,7 @@
 	active_power_usage = 60
 	power_channel = AREA_USAGE_EQUIP
 	density = TRUE
+	obj_flags = NO_BUILD // Becomes undense when the unit is open
 	max_integrity = 250
 
 	var/obj/item/clothing/suit/space/suit = null

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -336,8 +336,8 @@
 				var/obj/structure/window/window_structure = object
 				if(!window_structure.fulltile)
 					continue
-			if(object.density)
-				to_chat(usr, "<span class='warning'>There is \a [object.name] here. You cant make \a [recipe.title] here!</span>")
+			if(object.density || NO_BUILD & object.obj_flags)
+				to_chat(usr, "<span class='warning'>There is \a [object.name] here. You can't make \a [recipe.title] here!</span>")
 				return FALSE
 	if(recipe.placement_checks)
 		switch(recipe.placement_checks)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -337,7 +337,7 @@
 				if(!window_structure.fulltile)
 					continue
 			if(object.density || NO_BUILD & object.obj_flags)
-				to_chat(usr, "<span class='warning'>There is \a [object.name] here. You can't make \a [recipe.title] here!</span>")
+				to_chat(usr, "<span class='warning'>There is \a [object.name] here. You can\'t make \a [recipe.title] here!</span>")
 				return FALSE
 	if(recipe.placement_checks)
 		switch(recipe.placement_checks)

--- a/code/modules/research/nanites/nanite_chamber.dm
+++ b/code/modules/research/nanites/nanite_chamber.dm
@@ -9,6 +9,7 @@
 	use_power = IDLE_POWER_USE
 	anchored = TRUE
 	density = TRUE
+	obj_flags = NO_BUILD // Becomes undense when the door is open
 	idle_power_usage = 50
 	active_power_usage = 300
 

--- a/code/modules/research/nanites/public_chamber.dm
+++ b/code/modules/research/nanites/public_chamber.dm
@@ -9,6 +9,7 @@
 	use_power = IDLE_POWER_USE
 	anchored = TRUE
 	density = TRUE
+	obj_flags = NO_BUILD // Becomes undense when the door is open
 	idle_power_usage = 50
 	active_power_usage = 300
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new obj_flag that prevents building on objects that shouldn't be built on.
Adds it to the stasis bed and the sleeper, as well as some machines that become undense when the doors opens (nanite chambers, DNA scanners, suit storage unit, and gulag teleporter).

If I forgot any feel free to lmk.

Fixes https://github.com/tgstation/tgstation/issues/58528

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Some objects/machines that aren't dense (or become undense in certain states) shouldn't be able to be built upon, so this flag allows for specifying that you can't build on it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes building things on top of objects that shouldn't be built upon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
