### PR TITLE
Social Anxiety rework

### DIFF
--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -425,7 +425,7 @@
 	RegisterSignal(quirk_holder, COMSIG_MOB_SAY, .proc/handle_speech)
 
 /datum/quirk/social_anxiety/remove()
-	UnregisterSignal(quirk_holder, list(COMSIG_MOB_EYECONTACT, COMSIG_MOB_EXAMINATE))
+	UnregisterSignal(quirk_holder, list(COMSIG_MOB_EYECONTACT, COMSIG_MOB_EXAMINATE, COMSIG_MOB_SAY))
 
 /datum/quirk/social_anxiety/proc/handle_speech(datum/source, list/speech_args)
 	if(HAS_TRAIT(quirk_holder, TRAIT_FEARLESS))

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -428,6 +428,8 @@
 	UnregisterSignal(quirk_holder, list(COMSIG_MOB_EYECONTACT, COMSIG_MOB_EXAMINATE, COMSIG_MOB_SAY))
 
 /datum/quirk/social_anxiety/proc/handle_speech(datum/source, list/speech_args)
+	SIGNAL_HANDLER
+
 	if(HAS_TRAIT(quirk_holder, TRAIT_FEARLESS))
 		return
 	var/datum/component/mood/mood = quirk_holder.GetComponent(/datum/component/mood)

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -444,8 +444,8 @@
 			if(prob(nearby_people+mood.sanity_level+(10-mood.mood_level)) && word != message_split[1])
 				new_message += pick("uh,","erm,","um,")
 				if(prob(max(1, (1+nearby_people)*mood.sanity_level*(10-mood.mood_level))))
-					to_chat(Q, "<span class='danger'>What a dumb thing to say! You need a moment to recover.</span>")
-					Q.silent = max(2, Q.silent)
+					to_chat(Q, "<span class='danger'>You feel self-conscious and stop talking. You need a moment to recover!</span>")
+					Q.silent = max(3, Q.silent)
 					break
 			if(prob(nearby_people+mood.sanity_level+(10-mood.mood_level)))
 				word = html_decode(word)

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -439,13 +439,13 @@
 	if(message)
 		var/list/message_split = splittext(message, " ")
 		var/list/new_message = list()
-		var/mob/living/carbon/human/Q = quirk_holder
+		var/mob/living/carbon/human/quirker = quirk_holder
 		for(var/word in message_split)
 			if(prob(nearby_people+mood.sanity_level+(10-mood.mood_level)) && word != message_split[1])
 				new_message += pick("uh,","erm,","um,")
 				if(prob(max(1, (1+nearby_people)*mood.sanity_level*(10-mood.mood_level))))
-					to_chat(Q, "<span class='danger'>You feel self-conscious and stop talking. You need a moment to recover!</span>")
-					Q.silent = max(3, Q.silent)
+					to_chat(quirker, "<span class='danger'>You feel self-conscious and stop talking. You need a moment to recover!</span>")
+					quirker.silent = max(3, quirker.silent)
 					break
 			if(prob(nearby_people+mood.sanity_level+(10-mood.mood_level)))
 				word = html_decode(word)
@@ -469,18 +469,18 @@
 			else
 				new_message += word
 		message = jointext(new_message, " ")
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/quirker = quirk_holder
 	if(prob(min(87.5, (nearby_people*(mood.sanity_level+(10-mood.mood_level))))))
 		if(dumb_thing)
-			to_chat(H, "<span class='userdanger'>You think of a dumb thing you said a long time ago and scream internally.</span>")
+			to_chat(quirker, "<span class='userdanger'>You think of a dumb thing you said a long time ago and scream internally.</span>")
 			dumb_thing = FALSE //only once per life
 			if(prob(1))
-				new/obj/item/food/spaghetti/pastatomato(get_turf(H)) //now that's what I call spaghetti code
+				new/obj/item/food/spaghetti/pastatomato(get_turf(quirker)) //now that's what I call spaghetti code
 		else
 			to_chat(quirk_holder, "<span class='warning'>You think that wouldn't add much to the conversation and decide not to say it.</span>")
 			if(mood.mood_level < 5 && prob(100-(mood.mood_level*20)))
-				to_chat(H, "<span class='danger'>You retreat into yourself. You <i>really</i> don't feel up to talking.</span>")
-				H.silent = max(5, H.silent)
+				to_chat(quirker, "<span class='danger'>You retreat into yourself. You <i>really</i> don't feel up to talking.</span>")
+				quirker.silent = max(5, quirker.silent)
 		speech_args[SPEECH_MESSAGE] = pick("Uh.","Erm.","Um.")
 	else
 		speech_args[SPEECH_MESSAGE] = message

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -456,7 +456,6 @@
 					to_chat(quirker, "<span class='danger'>You feel self-conscious and stop talking. You need a moment to recover!</span>")
 					break
 			if(prob(max(5,(nearby_people*12.5*moodmod)))) //Minimum 1/20 chance of stutter
-				new_message += pick("uh,","erm,","um,")
 				word = html_decode(word)
 				var/leng = length(word)
 				var/stuttered = ""

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -433,13 +433,12 @@
 	if(HAS_TRAIT(quirk_holder, TRAIT_FEARLESS))
 		return
 
+	var/datum/component/mood/mood = quirk_holder.GetComponent(/datum/component/mood)
 	var/moodmod
-	if(CONFIG_GET(flag/disable_human_mood))
-		moodmod = (max(50, 0.1*quirk_holder.nutrition))
+	if(mood)
+		moodmod = (1+0.02*(50-(max(50, mood.mood_level*(7-mood.sanity_level))))) //low sanity levels are better, they max at 6
 	else
-		var/datum/component/mood/mood = quirk_holder.GetComponent(/datum/component/mood)
-		moodmod = (mood.mood_level*(7-mood.sanity_level)) //low sanity levels are better, they max at 6
-
+		moodmod = (1+0.02*(50-(max(50, 0.1*quirk_holder.nutrition))))
 	var/nearby_people = 0
 	for(var/mob/living/carbon/human/H in oview(3, quirk_holder))
 		if(H.client)
@@ -450,14 +449,13 @@
 		var/list/new_message = list()
 		var/mob/living/carbon/human/quirker = quirk_holder
 		for(var/word in message_split)
-			if(prob(max(12.50,(100*(nearby_people/(nearby_people+1))*moodmod))) && word != message_split[1]) //Minimum 1/8 chance of filler, multiplicative inverse for nearby people
+			if(prob(max(5,(nearby_people*12.5*moodmod))) && word != message_split[1]) //Minimum 1/20 chance of filler
 				new_message += pick("uh,","erm,","um,")
-				if(prob(min(0.2,(0.002*((1+nearby_people)*12.5)*moodmod)))) ////Max 1 in 20 chance of cutoff after a succesful filler roll, for 50% odds in a 15 word sentence
-
+				if(prob(min(5,(0.05*(nearby_people*12.5)*moodmod)))) //Max 1 in 20 chance of cutoff after a succesful filler roll, for 50% odds in a 15 word sentence
+					quirker.silent = max(3, quirker.silent)
 					to_chat(quirker, "<span class='danger'>You feel self-conscious and stop talking. You need a moment to recover!</span>")
-					quirker.silent = max(5, quirker.silent)
 					break
-			if(prob(max(12.50,(100*(nearby_people/(nearby_people+1))*moodmod)))) //Minimum 1/8 chance of stutter, multiplicative inverse for nearby people
+			if(prob(max(5,(nearby_people*12.5*moodmod)))) //Minimum 1/20 chance of stutter
 				new_message += pick("uh,","erm,","um,")
 				word = html_decode(word)
 				var/leng = length(word)
@@ -481,7 +479,7 @@
 				new_message += word
 		message = jointext(new_message, " ")
 	var/mob/living/carbon/human/quirker = quirk_holder
-	if(prob(min(50,(0.50*((1+nearby_people)*12.5)*moodmod)))) //Max 50% chance of not talking
+	if(prob(min(50,(0.50*(nearby_people*12.5)*moodmod)))) //Max 50% chance of not talking
 		if(dumb_thing)
 			to_chat(quirker, "<span class='userdanger'>You think of a dumb thing you said a long time ago and scream internally.</span>")
 			dumb_thing = FALSE //only once per life
@@ -489,9 +487,9 @@
 				new/obj/item/food/spaghetti/pastatomato(get_turf(quirker)) //now that's what I call spaghetti code
 		else
 			to_chat(quirk_holder, "<span class='warning'>You think that wouldn't add much to the conversation and decide not to say it.</span>")
-			if(prob(min(25,(0.25*((1+nearby_people)*12.75)*moodmod)))) //Max 25% chance of silence stacks after succesful not talking roll
+			if(prob(min(25,(0.25*(nearby_people*12.75)*moodmod)))) //Max 25% chance of silence stacks after succesful not talking roll
 				to_chat(quirker, "<span class='danger'>You retreat into yourself. You <i>really</i> don't feel up to talking.</span>")
-				quirker.silent = max(7, quirker.silent)
+				quirker.silent = max(5, quirker.silent)
 		speech_args[SPEECH_MESSAGE] = pick("Uh.","Erm.","Um.")
 	else
 		speech_args[SPEECH_MESSAGE] = message


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- This PR moves `on_process` features of the social anxiety quirk over to a `handle_speech` proc.
- In the `handle_speech` proc is a modified version of stuttering that activates per word and also doesn't drop letters
- Adds mood and sanity modifiers to complement the use of oview in determining if a social anxiety event should happen
- Adds a chance for filler words like "um" to be added between words
- Chances to stop speaking mid-sentence or have your whole statement replaced with a single filler word
- Adds another chance to be silenced, reduces the length of silencing on both events.
- Retreating into yourself now requires a failed speech check *and* a mood check.

Neglecting mood and sanity will have a noticeable effect on your speaking even if you're in isolation. The mechanics reinforce using shorter sentences with fewer words to prevent getting cut off mid-sentence when social anxiety is exacerbated.

## Why It's Good For The Game
Social anxiety `on_process` is currently stammering and silence glued to each other with a fun little message that procs at the beginning of the round once (usually when you're alone) and also spaghetti meme joke.

Players currently find it unfair to get hit with 10 silence when they are alone or with one other person, additionally the 10 silence feels on the long side for how often it happens. The silence can't even be stopped by `FEARLESS` once it has been applied.

These changes will make social anxiety more dependent on mood, sanity, and actually being around other crew. With this new system, a social anxiety sufferer can actually walk away from a group of people and have their speaking improve, rather than being at the mercy of constantly running `on_process`


I'd like to add a forced whisper event but I'm not sure how I'd go about that, if anyone knows how to go about that let me know.

I'm also not firm on a lot of the balancing here... gonna need to work it over some more.

## Changelog
:cl:
qol: Social Anxiety is more immersive
balance: made social anxiety more tied to speaking, along with more affect from sanity, mood, and nearby people
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
