### PR TITLE
Corrects a define regarding the amount of mail arriving on station + QOL changes.

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -56,7 +56,7 @@ SUBSYSTEM_DEF(economy)
 
 /datum/controller/subsystem/economy/fire(resumed = 0)
 	var/temporary_total = 0
-	var/delta_time = wait * 0.2
+	var/delta_time = wait / (5 MINUTES)
 	departmental_payouts()
 	station_total = 0
 	station_target_buffer += STATION_TARGET_BUFFER

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -53,7 +53,7 @@
 /obj/item/mail/Initialize()
 	. = ..()
 	RegisterSignal(src, COMSIG_MOVABLE_DISPOSING, .proc/disposal_handling)
-	AddElement(/datum/element/item_scaling, 0.5, 1)
+	AddElement(/datum/element/item_scaling, 0.75, 1)
 	if(isnull(department_colors))
 		department_colors = list(
 			ACCOUNT_CIV = COLOR_WHITE,
@@ -121,6 +121,16 @@
 		user.put_in_hands(contents[1])
 	playsound(loc, 'sound/items/poster_ripped.ogg', 50, TRUE)
 	qdel(src)
+
+/obj/item/mail/examine_more(mob/user)
+	. = ..()
+	var/list/msg = list("<span class='notice'><i>You notice the postmarking on the front of the mail...</i></span>")
+	if(recipient)
+		msg += "\t<span class='info'>Certified NT mail for [recipient].</span>"
+	else
+		msg += "\t<span class='info'>Certified mail for any 13th class space station.</span>"
+	msg += "\t<span class='info'>Distribute by hand or via destination tagger using the certified NT disposal system.</span>"
+	return msg
 
 /// Accepts a mob to initialize goodies for a piece of mail.
 /obj/item/mail/proc/initialize_for_recipient(mob/new_recipient)

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -128,7 +128,7 @@
 	if(recipient)
 		msg += "\t<span class='info'>Certified NT mail for [recipient].</span>"
 	else
-		msg += "\t<span class='info'>Certified mail for any 13th class space station.</span>"
+		msg += "\t<span class='info'>Certified mail for [GLOB.station_name].</span>"
 	msg += "\t<span class='info'>Distribute by hand or via destination tagger using the certified NT disposal system.</span>"
 	return msg
 


### PR DESCRIPTION
## About The Pull Request

There was a math error in mail's implementation in the economy SS when I switched it over to delta_time, so that basically the time-based define MAX_MAIL_PER_MINUTE was being multiplied by delta_time. Just one problem, delta_time was being considered in deciseconds as usual, but my chimp brain failed to recognize that, meaning that the maximum amount of mail arriving on station was around 100x more than expected.

This corrects the delta_time variable to think in terms of MINUTE time defines, not just a static decimal multipliers.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/41715314/116031589-f9390400-a62b-11eb-9056-8d0b96e6fa9e.png)

^This is NOT good for the game. ~~Despite being peak comedy.~~
Junk mail is funny and good, but you'll never read any of these if you get 200+ letters every shift just like it.

Additionally, adds some fluff text to the examine_more of letters, to let players know that you can use destination taggers to sne and distribute letters once they arrive.

QOL tweak is just to make cargo players and in-game purists lives easier.

## Changelog
:cl:
fix: Due to a stabilization in mail uncertainty, crew should see SIGNIFIGANTLY less mail per minute arriving in cargo.
qol: Close Examine text has been added to letters to inform players they can be used with destination taggers.
/:cl:

