### PR TITLE
Fixes mechs being unable to move in space

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -592,7 +592,7 @@
 
 	var/atom/backup = get_spacemove_backup()
 	if(backup && movement_dir)
-		if(isturf(backup) && movement_dir) //get_spacemove_backup() already checks if a returned turf is solid, so we can just go
+		if(isturf(backup)) //get_spacemove_backup() already checks if a returned turf is solid, so we can just go
 			return TRUE
 		if(istype(backup, /atom/movable))
 			var/atom/movable/movable_backup = backup

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -590,14 +590,17 @@
 	if(.)
 		return
 
-	var/atom/movable/backup = get_spacemove_backup()
-	if(backup)
-		if(movement_dir && !backup.anchored)
-			if(backup.newtonian_move(turn(movement_dir, 180)))
+	var/atom/backup = get_spacemove_backup()
+	if(backup && movement_dir)
+		if(isturf(backup) && movement_dir) //get_spacemove_backup() already checks if a returned turf is solid, so we can just go
+			return TRUE
+		if(istype(backup, /atom/movable))
+			var/atom/movable/movable_backup = backup
+			if((!movable_backup.anchored) && (movable_backup.newtonian_move(turn(movement_dir, 180))))
 				step_silent = TRUE
 				if(return_drivers())
-					to_chat(occupants, "[icon2html(src, occupants)]<span class='info'>The [src] push off [backup] to propel yourself.</span>")
-		return TRUE
+					to_chat(occupants, "[icon2html(src, occupants)]<span class='info'>The [src] push off [movable_backup] to propel yourself.</span>")
+			return TRUE
 
 	if(active_thrusters?.thrust(movement_dir))
 		step_silent = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The `/obj/vehicle/sealed/mecha/Process_Spacemove()` proc uses `atom/get_spacemove_backup()` to get whatever atom it should use to push off with. The mecha's `Process_Spacemove()` was assuming the returned atom was movable, like a box or locker, and checked if it was anchored (to push it if it's not). However, `get_spacemove_backup()` can return turfs, which cause a runtime since turfs don't have an `anchored` variable. This fixes that (and reorganizes the block of `if` statements).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #58241
Fixes #57769
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Mechs can move in space if near a wall again.
fix: Mech thrusters no longer incorrectly fail if the mech is near a wall.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
