### PR TITLE
WHY WON'T THE MAIL BURN ALREADY

### DIFF
--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -12,6 +12,7 @@
 	drop_sound = 'sound/items/handling/paper_drop.ogg'
 	pickup_sound =  'sound/items/handling/paper_pickup.ogg'
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
+	resistance_flags = FLAMMABLE
 	/// Destination tagging for the mail sorter.
 	var/sort_tag = 0
 	/// Who this mail is for and who can open it.


### PR DESCRIPTION
## About The Pull Request

Adds the flammable tag to mail. Putting this under QoL because now cargo can burn their excess mail instead instead of furiously trying to dump bits and pieces into disposals or otherwise.

Also, yes, this is a one line change, but, oh well I suppose? I don't have any other improvements for mail that I can think of to go in this.

## Why It's Good For The Game

Because mail, is mail. It's paper. It should burn. Also, the mail bag burns, but the mail itself doesn't. What.

## Changelog
:cl:
qol: cargo can now burn their excess mail
/:cl: