### PR TITLE
Fix gas canisters selling for the same price regardless of gas amount

### DIFF
--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -138,4 +138,4 @@
 
 /datum/export/large/gas_canister/proc/get_gas_value(datum/gas/gasType, moles)
 	var/baseValue = initial(gasType.base_value)
-	return round((baseValue/k_elasticity) * 1 - NUM_E**(-1 * k_elasticity * moles))
+	return round((baseValue/k_elasticity) * (1 - NUM_E**(-1 * k_elasticity * moles)))


### PR DESCRIPTION
## About The Pull Request

PR #57844 accidentally omitted a pair of parenthesis in gas value calculations, making gas canisters with 0.1 moles of gas cost the same as canisters with 1000 moles
Blue line: Correct value of plasma gas pre-#57844, x axis is amount of moles in canister
Green line: Incorrect value of gas caused by the typo
![graph](https://i.imgur.com/0iMqxMz.png)

## Why It's Good For The Game

Can't have free money in spess

## Changelog
:cl:
fix: Gas canisters now sell for the correct value.
/:cl: