### PR TITLE
Allow for proper damage / blood spatters on GAGS icons

### DIFF
--- a/code/datums/elements/decals/blood.dm
+++ b/code/datums/elements/decals/blood.dm
@@ -30,10 +30,10 @@
 	pic = blood_splatter_appearances[index]
 
 	if(!pic)
-		var/icon/blood_splatter_icon = icon(I.icon, I.icon_state, , 1) //we only want to apply blood-splatters to the initial icon_state for each object
+		var/icon/blood_splatter_icon = icon(I.icon, I.icon_state, , 1)
 		blood_splatter_icon.Blend("#fff", ICON_ADD) //fills the icon_state with white (except where it's transparent)
 		blood_splatter_icon.Blend(icon(_icon, _icon_state), ICON_MULTIPLY) //adds blood and the remaining white areas become transparant
-		pic = mutable_appearance(blood_splatter_icon, initial(I.icon_state))
+		pic = mutable_appearance(blood_splatter_icon, I.icon_state)
 		blood_splatter_appearances[index] = pic
 	return TRUE
 

--- a/code/datums/elements/decals/blood.dm
+++ b/code/datums/elements/decals/blood.dm
@@ -18,8 +18,8 @@
 		_icon = 'icons/effects/blood.dmi'
 	if(!_icon_state)
 		_icon_state = "itemblood"
-	var/icon = initial(I.icon)
-	var/icon_state = initial(I.icon_state)
+	var/icon = I.icon
+	var/icon_state = I.icon_state
 	if(!icon || !icon_state)
 		// It's something which takes on the look of other items, probably
 		icon = I.icon
@@ -30,7 +30,7 @@
 	pic = blood_splatter_appearances[index]
 
 	if(!pic)
-		var/icon/blood_splatter_icon = icon(initial(I.icon), initial(I.icon_state), , 1) //we only want to apply blood-splatters to the initial icon_state for each object
+		var/icon/blood_splatter_icon = icon(I.icon, I.icon_state, , 1) //we only want to apply blood-splatters to the initial icon_state for each object
 		blood_splatter_icon.Blend("#fff", ICON_ADD) //fills the icon_state with white (except where it's transparent)
 		blood_splatter_icon.Blend(icon(_icon, _icon_state), ICON_MULTIPLY) //adds blood and the remaining white areas become transparant
 		pic = mutable_appearance(blood_splatter_icon, initial(I.icon_state))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -415,11 +415,11 @@
 	if(!damaged_clothes)
 		return
 
-	var/index = "[REF(initial(icon))]-[initial(icon_state)]"
+	var/index = "[REF(icon)]-[icon_state]"
 	var/static/list/damaged_clothes_icons = list()
 	var/icon/damaged_clothes_icon = damaged_clothes_icons[index]
 	if(!damaged_clothes_icon)
-		damaged_clothes_icon = icon(initial(icon), initial(icon_state), , 1) //we only want to apply damaged effect to the initial icon_state for each object
+		damaged_clothes_icon = icon(icon, icon_state, , 1) //we only want to apply damaged effect to the initial icon_state for each object
 		damaged_clothes_icon.Blend("#fff", ICON_ADD) //fills the icon_state with white (except where it's transparent)
 		damaged_clothes_icon.Blend(icon('icons/effects/item_damage.dmi', "itemdamaged"), ICON_MULTIPLY) //adds damage effect and the remaining white areas become transparant
 		damaged_clothes_icon = fcopy_rsc(damaged_clothes_icon)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -419,7 +419,7 @@
 	var/static/list/damaged_clothes_icons = list()
 	var/icon/damaged_clothes_icon = damaged_clothes_icons[index]
 	if(!damaged_clothes_icon)
-		damaged_clothes_icon = icon(icon, icon_state, , 1) //we only want to apply damaged effect to the initial icon_state for each object
+		damaged_clothes_icon = icon(icon, icon_state, , 1)
 		damaged_clothes_icon.Blend("#fff", ICON_ADD) //fills the icon_state with white (except where it's transparent)
 		damaged_clothes_icon.Blend(icon('icons/effects/item_damage.dmi', "itemdamaged"), ICON_MULTIPLY) //adds damage effect and the remaining white areas become transparant
 		damaged_clothes_icon = fcopy_rsc(damaged_clothes_icon)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes this
![image](https://user-images.githubusercontent.com/81999976/116119942-a6148f00-a6c7-11eb-8dcd-c9caa3354d99.png)
![image](https://user-images.githubusercontent.com/81999976/116119983-ba588c00-a6c7-11eb-80f9-ddaf9531d87a.png)


## Why It's Good For The Game

this looks better
![image](https://user-images.githubusercontent.com/81999976/116120054-d0664c80-a6c7-11eb-808a-c37e5e245c81.png)
![image](https://user-images.githubusercontent.com/81999976/116120192-f55abf80-a6c7-11eb-9952-33f2de563f14.png)

## Changelog
:cl: Celotajs
fix: GAGS-generated clothing can now have proper blood splatters and damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
