### PR TITLE
Stops bodybags from locking you inside of a morgue tray

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -68,7 +68,9 @@
 /obj/structure/closet/body_bag/container_resist_act(mob/living/user)
 	if (istype(src.loc, /obj/structure/bodycontainer))
 		var/obj/structure/bodycontainer/tray = src.loc
-		tray.open()
+		to_chat(user, "<span class='notice'>You attempt to breakout of the [src.loc]... (This will take around 30 seconds.)</span>")
+		if(do_after(user, 30 SECONDS))
+			tray.open()
 
 /obj/structure/closet/body_bag/MouseDrop(over_object, src_location, over_location)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -65,6 +65,11 @@
 		density = FALSE
 		mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 
+/obj/structure/closet/body_bag/container_resist_act(mob/living/user)
+	if (istype(src.loc, /obj/structure/bodycontainer))
+		var/obj/structure/bodycontainer/tray = src.loc
+		tray.open()
+
 /obj/structure/closet/body_bag/MouseDrop(over_object, src_location, over_location)
 	. = ..()
 	if(over_object == usr && Adjacent(usr) && (in_range(src, usr) || usr.contents.Find(src)))

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -68,7 +68,7 @@
 /obj/structure/closet/body_bag/container_resist_act(mob/living/user)
 	if (istype(src.loc, /obj/structure/bodycontainer))
 		var/obj/structure/bodycontainer/tray = src.loc
-		to_chat(user, "<span class='notice'>You attempt to breakout of the [src.loc]... (This will take around 30 seconds.)</span>")
+		to_chat(user, "<span class='notice'>You attempt to breakout of the [tray]... (This will take around 30 seconds.)</span>")
 		if(do_after(user, 30 SECONDS))
 			tray?.open()
 

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -70,7 +70,7 @@
 		var/obj/structure/bodycontainer/tray = src.loc
 		to_chat(user, "<span class='notice'>You attempt to breakout of the [src.loc]... (This will take around 30 seconds.)</span>")
 		if(do_after(user, 30 SECONDS))
-			tray.open()
+			tray?.open()
 
 /obj/structure/closet/body_bag/MouseDrop(over_object, src_location, over_location)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Same as title. (Adds a 30 second do after)

Fixes https://github.com/tgstation/tgstation/issues/31656

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Removing the ability to GBJ people with little to no effort is a good thing.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: A bodybag will no longer permanently lock you inside of a morgue tray.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
