### PR TITLE
Fixes Silverscale pirates being unable to access their own turrets

### DIFF
--- a/code/datums/id_trim/ruins.dm
+++ b/code/datums/id_trim/ruins.dm
@@ -86,12 +86,21 @@
 	assignment = "Gunner"
 	template_access = null
 
-/// Trim for silverscale pirates.
+/// Trim for pirates.
+/datum/id_trim/pirate
+	assignment = "Pirate"
+	trim_state = "trim_unknown"
+	access = list(ACCESS_SYNDICATE)
+
+/// Trim for pirates.
 /datum/id_trim/pirate/silverscale
 	assignment = "Silver Scale Member"
-	trim_state = "trim_unknown"
 
-/// Trim for silverscale pirates.
-/datum/id_trim/pirate/silverscale/captain
-	assignment = "Silver Scale VIP"
+/// Trim for the pirate captain.
+/datum/id_trim/pirate/captain
+	assignment = "Pirate Captain"
 	trim_state = "trim_captain"
+
+/// Trim for the pirate captain.
+/datum/id_trim/pirate/captain/silverscale
+	assignment = "Silver Scale VIP"

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -116,6 +116,8 @@
 /datum/outfit/pirate
 	name = "Space Pirate"
 
+	id = /obj/item/card/id/advanced
+	id_trim = /datum/id_trim/pirate
 	uniform = /obj/item/clothing/under/costume/pirate
 	suit = /obj/item/clothing/suit/pirate/armored
 	ears = /obj/item/radio/headset/syndicate
@@ -140,12 +142,12 @@
 /datum/outfit/pirate/captain
 	name = "Space Pirate Captain"
 
+	id_trim = /datum/id_trim/pirate/captain
 	head = /obj/item/clothing/head/pirate/armored
 
 /datum/outfit/pirate/space
 	name = "Space Pirate (EVA)"
 
-	id = /obj/item/card/id/advanced
 	suit = /obj/item/clothing/suit/space/pirate
 	suit_store = /obj/item/tank/internals/oxygen
 	head = /obj/item/clothing/head/helmet/space/pirate/bandana
@@ -171,7 +173,7 @@
 /datum/outfit/pirate/silverscale/captain
 	name = "Silver Scale Captain"
 
-	id_trim = /datum/id_trim/pirate/silverscale/captain
+	id_trim = /datum/id_trim/pirate/captain/silverscale
 	head = /obj/item/clothing/head/crown
 	mask = /obj/item/clothing/mask/cigarette/cigar/havana
 	l_pocket = /obj/item/lighter


### PR DESCRIPTION
## About The Pull Request

This is just a fix that actually makes the /pirate id_trim subtype exist, gives it syndicate access, and gives that trim to pirates (The pirate outfit didn't have an ID while the space one did, and it had no trim? I don't know if that was intentional, I added it just to be sure)

## Why It's Good For The Game

Something tells me -maybe- silverscale pirates should be able to access their turrets.

## Changelog
:cl:
fix: Silverscale pirates can now access their turrets.
/:cl:
