### PR TITLE
[FIX] Anesthetic Tank Holder Not Rendering

### DIFF
--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -49,7 +49,7 @@
 	desc = "A tank with an N2O/O2 gas mix."
 	icon_state = "anesthetic"
 	inhand_icon_state = "an_tank"
-	tank_holder_icon_state = "holder_oxygen_anesthetic"
+	tank_holder_icon_state = "holder_anesthetic"
 	force = 10
 
 /obj/item/tank/internals/anesthetic/populate_gas()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Two code files were applying conflicting Icon states to tank holders when the tank holder was supposed to have an anesthetic tank in it. tank_types.dm contained a reference to an icon state that did not exist and was overriding the tank_holder.dm 's icon state

## Why It's Good For The Game

Players need to be able to see their equipment in order to be able to interact with it.

## Changelog
:cl:
fix: Anesthetic Tank holders will now always render when loaded with an anesthetic tank and upon round load.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
