### PR TITLE
Fixes Shuttle Catastrophe only picking Disco Inferno

### DIFF
--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -37,7 +37,7 @@
 	var/list/valid_shuttle_templates = list()
 	for(var/shuttle_id in SSmapping.shuttle_templates)
 		var/datum/map_template/shuttle/template = SSmapping.shuttle_templates[shuttle_id]
-		if(isnull(template.who_can_purchase) && template.credit_cost < INFINITY) //if we could get it from the communications console, it's cool for us to get it here
+		if(!isnull(template.who_can_purchase) && template.credit_cost < INFINITY) //if we could get it from the communications console, it's cool for us to get it here
 			valid_shuttle_templates += template
 	new_shuttle = pick(valid_shuttle_templates)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Mothblocks made a slight oopsie in #58389, reversing the shuttle selection logic for the Shuttle Catastrophe event from selecting only shuttles that can normally be purchased to selecting only shuttles that normally can't be purchased. Combined with the other check that limits it to selecting shuttles with a non-infinite price, this had the hilarious consequence of only being able to select Disco Inferno every single time the event triggered.

So this PR, y'know, reverses that to restore the old intended behavior.

Fixes: #58754
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Even if Disco Inferno is the very definition of "Shuttle Catastrophe", it was disabled for a reason
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Disco's Dead, Baby- and by that I mean, the Shuttle Catastrophe random event will no longer select Disco Inferno every single time it triggers (or selecting it at all, in fact, as it was before)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
