### PR TITLE
Update license text in changelog

### DIFF
--- a/tgui/packages/tgui/interfaces/Changelog.js
+++ b/tgui/packages/tgui/interfaces/Changelog.js
@@ -225,12 +225,53 @@ export class Changelog extends Component {
           <a href="http://forums.somethingawful.com/">SomethingAwful Goons</a>
           {' only.'}
         </p>
+        <h3>Traditional Games Space Station 13 License</h3>
         <p>
-          {'Traditional Games Space Station 13 is licensed under a '}
-          <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">
-            GNU Affero General Public 3.0 License
+          {'All code after '}
+          <a href={'https://github.com/tgstation/tgstation/commit/'
+            + '333c566b88108de218d882840e61928a9b759d8f'}>
+            commit 333c566b88108de218d882840e61928a9b759d8f on 2014/31/12
+            at 4:38 PM PST
           </a>
-          .
+          {' is licensed under '}
+          <a href="https://www.gnu.org/licenses/agpl-3.0.html">
+            GNU AGPL v3
+          </a>
+          {'. All code before that commit is licensed under '}
+          <a href="https://www.gnu.org/licenses/gpl-3.0.html">
+            GNU GPL v3
+          </a>
+          {', including tools unless their readme specifies otherwise. See '}
+          <a href="https://github.com/tgstation/tgstation/blob/master/LICENSE">
+            LICENSE
+          </a>
+          {' and '}
+          <a
+            href="https://github.com/tgstation/tgstation/blob/master/GPLv3.txt">
+            GPLv3.txt
+          </a>
+          {' for more details.'}
+        </p>
+        <p>
+          The TGS DMAPI API is licensed as a subproject under the MIT license.
+          {' See the footer of '}
+          <a href={'https://github.com/tgstation/tgstation/blob/master'
+            + '/code/__DEFINES/tgs.dm'}>
+            code/__DEFINES/tgs.dm
+          </a>
+          {' and '}
+          <a href={'https://github.com/tgstation/tgstation/blob/master'
+            + '/code/modules/tgs/LICENSE'}>
+            code/modules/tgs/LICENSE
+          </a>
+          {' for the MIT license.'}
+        </p>
+        <p>
+          {'All assets including icons and sound are under a '}
+          <a href="https://creativecommons.org/licenses/by-sa/3.0/">
+            Creative Commons 3.0 BY-SA license
+          </a>
+          {' unless otherwise indicated.'}
         </p>
       </Section>
     );


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

After reading the repository's readme I have come to the conclusion that the license text in the changelog TGUI is misleading.

Before:
![image](https://user-images.githubusercontent.com/81999976/116292076-f827e400-a79d-11eb-8ceb-c893573a0ae9.png)
After:
![image](https://user-images.githubusercontent.com/81999976/116292099-ff4ef200-a79d-11eb-89a8-32b3beee7e18.png)

## Why It's Good For The Game

The license should be clear and not misleading.

## Changelog
:cl: Celotajs
code: The license details in the TGUI changelog are now correct.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
