### PR TITLE
Buff the hallucination symptom's stats.

### DIFF
--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -18,9 +18,9 @@ Bonus
 /datum/symptom/hallucigen
 	name = "Hallucigen"
 	desc = "The virus stimulates the brain, causing occasional hallucinations."
-	stealth = -1
-	resistance = -3
-	stage_speed = -3
+	stealth = 1
+	resistance = -4
+	stage_speed = 1
 	transmittable = -1
 	level = 5
 	severity = 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Old stats: Stealth(-1), Resistance (-3), Stage speed(-3), transmission (-1)

New stats: Stealth(1), Resistance (-4), Stage speed(1), transmission (-1)

## Why It's Good For The Game
I'll keep this concise.

- Hallucination is completely unviable because it has poor stats and an effect that is interesting but underwhelming for the cost.
-  Its large cost in stage speed and resistance makes it unviable as a hindering supplemental symptom. 
- Its most interesting trait is its ability to mimic positive virus symptoms in order to make a stealthy virus. With its current -1 to stealth, you would have to take many undesirable symptoms leaving little room for buffing your payload symptom (see point 2).

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: itseasytosee
balance: The hallucination virus symptom has had its stats buffed, check the wiki if you are interested.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
