### PR TITLE
Heavily nerfs corazargh to a 1u/cycle metabolization rate

### DIFF
--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -648,7 +648,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	self_consuming = TRUE
 	ph = 13.5
 	addiction_types = list(/datum/addiction/medicine = 2.5)
-	metabolization_rate = 0.01 * REM
+	metabolization_rate = REM
 	chemical_flags = REAGENT_DEAD_PROCESS
 	tox_damage = 0
 	///The old heart we're swapping for


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Multiplies corazargh's metabolization rate by 100, moving it from a 0.01u/cycle rate to a 1u.
extremely simple change, so I'm just doing this by webedit - from what I understand one-liners are OK'd for webedit but if that's not the case just let me know.

## Why It's Good For The Game

Currently, corazargh's the best-in-class weapon for chemical syringes. 0.01u metabolization rate, kills in 6 seconds, easily manufactured. Getting hit with it sets your heart to a cursed one, so not pumping = VERY rapid death.

4u of it with any chem really designed to knock out or stun an enemy leads to them dying of extreme bloodloss. It's hilariously overtuned, and while thalpy/fermi/bramble works on a more permanent solution, this thing's definitely worth pushing out a temporary fix to.

![Conversation with thalpy about making this temp change before his unique solution](https://cdn.discordapp.com/attachments/625471067900608512/836730021090557973/unknown.png)

Obviously, a 4u deathmix that only requires a bit of fuckery on pH values while making ephedrine seems way out of place in current syringe gun deathmix world, so although this won't nuke its incredible killing potential, it'll at the very least make it so that people have to put more than just 4 units into a syringe to turn someone into a juice pouch stomped on by a first-grader.

## Changelog
:cl:
balance: Multiplies corazargh's metabolization by 100x so it's no longer hilariously overpowered and only slightly overpowered now. No more 4u deathmixes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
