### PR TITLE
Fix logging in chemical grenades

### DIFF
--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -26,6 +26,18 @@
 	if(G.stage == GRENADE_WIRED)
 		return TRUE
 
+/datum/wires/explosive/chem_grenade/on_pulse(index)
+	var/obj/item/grenade/chem_grenade/grenade = holder
+	if(grenade.stage != GRENADE_READY)
+		return
+	. = ..()
+
+/datum/wires/explosive/chem_grenade/on_cut(index, mend)
+	var/obj/item/grenade/chem_grenade/grenade = holder
+	if(grenade.stage != GRENADE_READY)
+		return
+	. = ..()
+
 /datum/wires/explosive/chem_grenade/attach_assembly(color, obj/item/assembly/S)
 	if(istype(S,/obj/item/assembly/timer))
 		var/obj/item/grenade/chem_grenade/G = holder


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds an early return in chemical grenade wires if the grenade is not in a secure, ready to detonate state. Unsecured grenades can be repeatedly pulsed, and each pulse admin logs in three seperate places.

## Why It's Good For The Game
Being able to spam the admins with unstoppable pages of text is bad enough, and you can do much worse with this.

## Changelog
:cl:
fix: spammable logging in chem grenades
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
