### PR TITLE
Supermatter sliver goes above the crystal

### DIFF
--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -123,6 +123,7 @@
 	icon_state = "supermatter_sliver"
 	inhand_icon_state = "supermattersliver"
 	pulseicon = "supermatter_sliver_pulse"
+	layer = ABOVE_MOB_LAYER
 
 
 /obj/item/nuke_core/supermatter_sliver/attack_tk(mob/user) // no TK dusting memes


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Moves the supermatter sliver (the antag objective) to the sprite layer above the supermatter crystal.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
![CE observes honey crystal](https://user-images.githubusercontent.com/25239573/116345460-c3238d80-a7ad-11eb-83b0-26ce8ab22f15.png)
The new SM sprite is on a higher layer than the sliver, this means the only way to pick the sliver up is to alt-click and open up the tile contents menu. Not good in a situation where every second you take irradiates you more and one misclick dusts you.
## Changelog
:cl:
qol: The supermatter sliver sprite shows up above the supermatter crystal sprite again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
