### PR TITLE
Gives botany plants a new formula for calculating bite size, fixes swallowing watermelons whole

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -3,6 +3,7 @@
 // Data from the seeds carry over to these grown foods
 // ***********************************************************
 
+/// A few defines for use in calculating our plant's bite size.
 /// When calculating bite size, potency is multiplied by this number.
 #define BITE_SIZE_POTENCY_MULTIPLIER 0.05
 /// When calculating bite size, max_volume is multiplied by this number.
@@ -18,7 +19,7 @@
 	var/obj/item/seeds/seed = null
 	///Name of the plant
 	var/plantname = ""
-	/// The base bite-size for plants is [max_volume / 20], multiplied by this if set
+	/// The modifier applied to the plant's bite size. If your plant has a large amount of reagents naturally, this should be increased to match.
 	var/bite_consumption_mod = 1
 	///the splat it makes when it splats lol
 	var/splat_type = /obj/effect/decal/cleanable/food/plant_smudge
@@ -54,10 +55,9 @@
 	for(var/datum/plant_gene/trait/trait in seed.genes)
 		trait.on_new_plant(src, loc)
 
-	// Set our default bite size
-	// Bite size = 1 + (potency / 20) * (volume / 100) * modifier
+	// Set our default bitesize: bite size = 1 + (potency * 0.05) * (max_volume * 0.01) * modifier
 	// A 100 potency, non-densified plant = 1 + (5 * 1 * modifier) = 6u bite size
-	// For reference, your average tomato has 14u of reagents
+	// For reference, your average 100 potency tomato has 14u of reagents - So, with no modifier it is eaten in 3 bites
 	bite_consumption = 1 + round(max((seed.potency * BITE_SIZE_POTENCY_MULTIPLIER), 1) * (max_volume * BITE_SIZE_VOLUME_MULTIPLIER) * bite_consumption_mod)
 
 	. = ..() //Only call it here because we want all the genes and shit to be applied before we add edibility. God this code is a mess.

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -3,6 +3,11 @@
 // Data from the seeds carry over to these grown foods
 // ***********************************************************
 
+/// When calculating bite size, potency is multiplied by this number.
+#define BITE_SIZE_POTENCY_MULTIPLIER 0.05
+/// When calculating bite size, max_volume is multiplied by this number.
+#define BITE_SIZE_VOLUME_MULTIPLIER 0.01
+
 // Base type. Subtypes are found in /grown dir. Lavaland-based subtypes can be found in mining/ash_flora.dm
 /obj/item/food/grown
 	icon = 'icons/obj/hydroponics/harvest.dmi'
@@ -13,8 +18,8 @@
 	var/obj/item/seeds/seed = null
 	///Name of the plant
 	var/plantname = ""
-	/// If set, bitesize = 1 + round(reagents.total_volume / bite_consumption_mod)
-	var/bite_consumption_mod = 0
+	/// The base bite-size for plants is [max_volume / 20], multiplied by this if set
+	var/bite_consumption_mod = 1
 	///the splat it makes when it splats lol
 	var/splat_type = /obj/effect/decal/cleanable/food/plant_smudge
 
@@ -49,6 +54,12 @@
 	for(var/datum/plant_gene/trait/trait in seed.genes)
 		trait.on_new_plant(src, loc)
 
+	// Set our default bite size
+	// Bite size = 1 + (potency / 20) * (volume / 100) * modifier
+	// A 100 potency, non-densified plant = 1 + (5 * 1 * modifier) = 6u bite size
+	// For reference, your average tomato has 14u of reagents
+	bite_consumption = 1 + round(max((seed.potency * BITE_SIZE_POTENCY_MULTIPLIER), 1) * (max_volume * BITE_SIZE_VOLUME_MULTIPLIER) * bite_consumption_mod)
+
 	. = ..() //Only call it here because we want all the genes and shit to be applied before we add edibility. God this code is a mess.
 
 	seed.prepare_result(src)
@@ -63,7 +74,7 @@
 				eat_time = eat_time,\
 				tastes = tastes,\
 				eatverbs = eatverbs,\
-				bite_consumption = bite_consumption_mod ? 1 + round(max_volume / bite_consumption_mod) : bite_consumption,\
+				bite_consumption = bite_consumption,\
 				microwaved_type = microwaved_type,\
 				junkiness = junkiness)
 
@@ -105,3 +116,6 @@
 			juice_results[juice_results[i]] = nutriment
 		reagents.del_reagent(/datum/reagent/consumable/nutriment)
 		reagents.del_reagent(/datum/reagent/consumable/nutriment/vitamin)
+
+#undef BITE_SIZE_POTENCY_MULTIPLIER
+#undef BITE_SIZE_VOLUME_MULTIPLIER

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -3,7 +3,7 @@
 // Data from the seeds carry over to these grown foods
 // ***********************************************************
 
-/// A few defines for use in calculating our plant's bite size.
+// A few defines for use in calculating our plant's bite size.
 /// When calculating bite size, potency is multiplied by this number.
 #define BITE_SIZE_POTENCY_MULTIPLIER 0.05
 /// When calculating bite size, max_volume is multiplied by this number.
@@ -19,7 +19,7 @@
 	var/obj/item/seeds/seed = null
 	///Name of the plant
 	var/plantname = ""
-	/// The modifier applied to the plant's bite size. If your plant has a large amount of reagents naturally, this should be increased to match.
+	/// The modifier applied to the plant's bite size. If a plant has a large amount of reagents naturally, this should be increased to match.
 	var/bite_consumption_mod = 1
 	///the splat it makes when it splats lol
 	var/splat_type = /obj/effect/decal/cleanable/food/plant_smudge

--- a/code/modules/hydroponics/grown/ambrosia.dm
+++ b/code/modules/hydroponics/grown/ambrosia.dm
@@ -5,7 +5,7 @@
 	desc = "This is a plant."
 	icon_state = "ambrosiavulgaris"
 	slot_flags = ITEM_SLOT_HEAD
-	bite_consumption_mod = 2
+	bite_consumption_mod = 3
 	foodtypes = VEGETABLES
 	tastes = list("ambrosia" = 1)
 

--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -21,7 +21,7 @@
 	name = "apple"
 	desc = "It's a little piece of Eden."
 	icon_state = "apple"
-	bite_consumption = 100 // Always eat the apple in one bite
+	bite_consumption_mod = 100 // Always eat the apple in one bite
 	foodtypes = FRUIT
 	juice_results = list(/datum/reagent/consumable/applejuice = 0)
 	tastes = list("apple" = 1)

--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -21,7 +21,7 @@
 	name = "apple"
 	desc = "It's a little piece of Eden."
 	icon_state = "apple"
-	bite_consumption_mod = 100 // Always eat the apple in one bite
+	bite_consumption_mod = 100 // Always eat apples in one bite
 	foodtypes = FRUIT
 	juice_results = list(/datum/reagent/consumable/applejuice = 0)
 	tastes = list("apple" = 1)

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -23,7 +23,7 @@
 	icon_state = "banana"
 	inhand_icon_state = "banana"
 	trash_type = /obj/item/grown/bananapeel
-	bite_consumption = 5
+	bite_consumption_mod = 3
 	foodtypes = FRUIT
 	juice_results = list(/datum/reagent/consumable/banana = 0)
 	distill_reagent = /datum/reagent/consumable/ethanol/bananahonk

--- a/code/modules/hydroponics/grown/beans.dm
+++ b/code/modules/hydroponics/grown/beans.dm
@@ -23,7 +23,6 @@
 	desc = "It's pretty bland, but oh the possibilities..."
 	gender = PLURAL
 	icon_state = "soybeans"
-	bite_consumption_mod = 2
 	foodtypes = VEGETABLES
 	grind_results = list(/datum/reagent/consumable/soymilk = 0)
 	tastes = list("soy" = 1)
@@ -47,7 +46,7 @@
 	name = "koibean"
 	desc = "Something about these seems fishy."
 	icon_state = "koibeans"
-	bite_consumption_mod = 2
+
 	foodtypes = VEGETABLES
 	tastes = list("koi" = 1)
 	wine_power = 40

--- a/code/modules/hydroponics/grown/beans.dm
+++ b/code/modules/hydroponics/grown/beans.dm
@@ -46,7 +46,6 @@
 	name = "koibean"
 	desc = "Something about these seems fishy."
 	icon_state = "koibeans"
-
 	foodtypes = VEGETABLES
 	tastes = list("koi" = 1)
 	wine_power = 40

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -85,7 +85,6 @@
 	icon_state = "seed-glowberry"
 	species = "glowberry"
 	plantname = "Glow-Berry Bush"
-	bite_consumption_mod = 3
 	product = /obj/item/food/grown/berries/glow
 	lifespan = 30
 	endurance = 25
@@ -99,6 +98,7 @@
 	seed = /obj/item/seeds/berry/glow
 	name = "bunch of glow-berries"
 	desc = "Nutritious!"
+	bite_consumption_mod = 3
 	icon_state = "glowberrypile"
 	foodtypes = FRUIT
 	tastes = list("glow-berry" = 1)
@@ -133,7 +133,7 @@
 	desc = "Great for toppings!"
 	icon_state = "cherry"
 	gender = PLURAL
-
+	bite_consumption_mod = 2
 	foodtypes = FRUIT
 	grind_results = list(/datum/reagent/consumable/cherryjelly = 0)
 	tastes = list("cherry" = 1)
@@ -156,7 +156,7 @@
 	name = "blue cherries"
 	desc = "They're cherries that are blue."
 	icon_state = "bluecherry"
-
+	bite_consumption_mod = 2
 	foodtypes = FRUIT
 	grind_results = list(/datum/reagent/consumable/bluecherryjelly = 0)
 	tastes = list("blue cherry" = 1)
@@ -181,7 +181,7 @@
 	name = "cherry bulbs"
 	desc = "They're like little Space Christmas lights!"
 	icon_state = "cherry_bulb"
-
+	bite_consumption_mod = 2
 	foodtypes = FRUIT
 	grind_results = list(/datum/reagent/consumable/cherryjelly = 0)
 	tastes = list("cherry" = 1)

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -24,7 +24,6 @@
 	desc = "Nutritious!"
 	icon_state = "berrypile"
 	gender = PLURAL
-	bite_consumption_mod = 2
 	foodtypes = FRUIT
 	juice_results = list(/datum/reagent/consumable/berryjuice = 0)
 	tastes = list("berry" = 1)
@@ -47,6 +46,7 @@
 	name = "bunch of poison-berries"
 	desc = "Taste so good, you might die!"
 	icon_state = "poisonberrypile"
+	bite_consumption_mod = 3
 	foodtypes = FRUIT | TOXIC
 	juice_results = list(/datum/reagent/consumable/poisonberryjuice = 0)
 	tastes = list("poison-berry" = 1)
@@ -72,6 +72,7 @@
 	name = "bunch of death-berries"
 	desc = "Taste so good, you will die!"
 	icon_state = "deathberrypile"
+	bite_consumption_mod = 3
 	foodtypes = FRUIT | TOXIC
 	tastes = list("death-berry" = 1)
 	distill_reagent = null
@@ -84,6 +85,7 @@
 	icon_state = "seed-glowberry"
 	species = "glowberry"
 	plantname = "Glow-Berry Bush"
+	bite_consumption_mod = 3
 	product = /obj/item/food/grown/berries/glow
 	lifespan = 30
 	endurance = 25
@@ -131,7 +133,7 @@
 	desc = "Great for toppings!"
 	icon_state = "cherry"
 	gender = PLURAL
-	bite_consumption_mod = 2
+
 	foodtypes = FRUIT
 	grind_results = list(/datum/reagent/consumable/cherryjelly = 0)
 	tastes = list("cherry" = 1)
@@ -154,7 +156,7 @@
 	name = "blue cherries"
 	desc = "They're cherries that are blue."
 	icon_state = "bluecherry"
-	bite_consumption_mod = 2
+
 	foodtypes = FRUIT
 	grind_results = list(/datum/reagent/consumable/bluecherryjelly = 0)
 	tastes = list("blue cherry" = 1)
@@ -179,7 +181,7 @@
 	name = "cherry bulbs"
 	desc = "They're like little Space Christmas lights!"
 	icon_state = "cherry_bulb"
-	bite_consumption_mod = 2
+
 	foodtypes = FRUIT
 	grind_results = list(/datum/reagent/consumable/cherryjelly = 0)
 	tastes = list("cherry" = 1)
@@ -234,5 +236,6 @@
 	seed = /obj/item/seeds/grape/green
 	name = "bunch of green grapes"
 	icon_state = "greengrapes"
+	bite_consumption_mod = 3
 	tastes = list("green grape" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/cognac

--- a/code/modules/hydroponics/grown/cannabis.dm
+++ b/code/modules/hydroponics/grown/cannabis.dm
@@ -88,7 +88,7 @@
 	name = "cannabis leaf"
 	desc = "Recently legalized in most galaxies."
 	icon_state = "cannabis"
-	bite_consumption_mod = 2
+	bite_consumption_mod = 4
 	foodtypes = VEGETABLES //i dont really know what else weed could be to be honest
 	tastes = list("cannabis" = 1)
 	wine_power = 20
@@ -119,5 +119,6 @@
 	name = "omega cannabis leaf"
 	desc = "You feel dizzy looking at it. What the fuck?"
 	icon_state = "ocannabis"
+	bite_consumption_mod = 2 // Ingesting like 40 units of drugs in 1 bite at 100 potency
 	max_volume = 420
 	wine_power = 90

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -20,7 +20,7 @@
 	desc = "Sigh... wheat... a-grain?"
 	gender = PLURAL
 	icon_state = "wheat"
-	bite_consumption_mod = 2
+	bite_consumption_mod = 0.5
 	foodtypes = GRAIN
 	grind_results = list(/datum/reagent/consumable/flour = 0)
 	tastes = list("wheat" = 1)
@@ -42,7 +42,7 @@
 	desc = "Eat oats, do squats."
 	gender = PLURAL
 	icon_state = "oat"
-	bite_consumption_mod = 2
+	bite_consumption_mod = 0.5
 	foodtypes = GRAIN
 	grind_results = list(/datum/reagent/consumable/flour = 0)
 	tastes = list("oat" = 1)
@@ -66,7 +66,7 @@
 	desc = "Rice to meet you."
 	gender = PLURAL
 	icon_state = "rice"
-	bite_consumption_mod = 2
+	bite_consumption_mod = 0.5
 	foodtypes = GRAIN
 	grind_results = list(/datum/reagent/consumable/rice = 0)
 	tastes = list("rice" = 1)
@@ -87,7 +87,7 @@
 	desc = "Some blood-drenched wheat stalks. You can crush them into what passes for meat if you squint hard enough."
 	icon_state = "meatwheat"
 	gender = PLURAL
-	bite_consumption_mod = 2
+	bite_consumption_mod = 0.5
 	seed = /obj/item/seeds/wheat/meat
 	foodtypes = MEAT | GRAIN
 	grind_results = list(/datum/reagent/consumable/flour = 0, /datum/reagent/blood = 0)

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -20,7 +20,7 @@
 	desc = "Sigh... wheat... a-grain?"
 	gender = PLURAL
 	icon_state = "wheat"
-	bite_consumption_mod = 0.5
+	bite_consumption_mod = 0.5 // Chewing on wheat grains?
 	foodtypes = GRAIN
 	grind_results = list(/datum/reagent/consumable/flour = 0)
 	tastes = list("wheat" = 1)

--- a/code/modules/hydroponics/grown/chili.dm
+++ b/code/modules/hydroponics/grown/chili.dm
@@ -50,7 +50,7 @@
 	name = "chilly pepper"
 	desc = "It's a mutant strain of chili."
 	icon_state = "icepepper"
-	bite_consumption_mod = 2
+
 	foodtypes = FRUIT
 	wine_power = 30
 
@@ -78,7 +78,7 @@
 	desc = "It seems to be vibrating gently."
 	icon_state = "ghostchilipepper"
 	var/mob/living/carbon/human/held_mob
-	bite_consumption_mod = 4
+	bite_consumption_mod = 2
 	foodtypes = FRUIT
 	wine_power = 50
 

--- a/code/modules/hydroponics/grown/chili.dm
+++ b/code/modules/hydroponics/grown/chili.dm
@@ -50,7 +50,7 @@
 	name = "chilly pepper"
 	desc = "It's a mutant strain of chili."
 	icon_state = "icepepper"
-
+	bite_consumption_mod = 5
 	foodtypes = FRUIT
 	wine_power = 30
 
@@ -77,6 +77,7 @@
 	name = "ghost chili"
 	desc = "It seems to be vibrating gently."
 	icon_state = "ghostchilipepper"
+	bite_consumption_mod = 5
 	var/mob/living/carbon/human/held_mob
 	bite_consumption_mod = 2
 	foodtypes = FRUIT

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -4,7 +4,6 @@
 	name = "citrus"
 	desc = "It's so sour, your face will twist."
 	icon_state = "lime"
-	bite_consumption_mod = 2
 	foodtypes = FRUIT
 	wine_power = 30
 
@@ -106,7 +105,7 @@
 	name = "Combustible Lemon"
 	desc = "Made for burning houses down."
 	icon_state = "firelemon"
-	bite_consumption_mod = 2
+
 	foodtypes = FRUIT
 	wine_power = 70
 
@@ -176,6 +175,7 @@
 	name = "extradimensional orange"
 	desc = "You can hardly wrap your head around this thing."
 	icon_state = "orang"
+	bite_consumption_mod = 2
 	juice_results = list(/datum/reagent/consumable/orangejuice = 0)
 	distill_reagent = /datum/reagent/toxin/mindbreaker
 	tastes = list("polygons" = 1, "bluespace" = 1, "the true nature of reality" = 1)

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -105,7 +105,6 @@
 	name = "Combustible Lemon"
 	desc = "Made for burning houses down."
 	icon_state = "firelemon"
-
 	foodtypes = FRUIT
 	wine_power = 70
 

--- a/code/modules/hydroponics/grown/cocoa_vanilla.dm
+++ b/code/modules/hydroponics/grown/cocoa_vanilla.dm
@@ -76,6 +76,7 @@
 	name = "bungo fruit"
 	desc = "A strange fruit, tough leathery skin protects its juicy flesh and large poisonous seed."
 	icon_state = "bungo"
+	bite_consumption_mod = 2
 	trash_type = /obj/item/food/grown/bungopit
 	foodtypes = FRUIT
 	juice_results = list(/datum/reagent/consumable/bungojuice = 0)
@@ -86,6 +87,7 @@
 	seed = /obj/item/seeds/cocoapod/bungotree
 	name = "bungo pit"
 	icon_state = "bungopit"
+	bite_consumption_mod = 5
 	desc = "A large seed, it is said to be potent enough to be able to stop a mans heart."
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 5

--- a/code/modules/hydroponics/grown/cocoa_vanilla.dm
+++ b/code/modules/hydroponics/grown/cocoa_vanilla.dm
@@ -46,6 +46,7 @@
 	name = "vanilla pod"
 	desc = "Fattening... Mmmmm... vanilla."
 	icon_state = "vanillapod"
+	bite_consumption_mod = 2
 	foodtypes = FRUIT
 	tastes = list("vanilla" = 1)
 	distill_reagent = /datum/reagent/consumable/vanilla //Takes longer, but you can get even more vanilla from it.

--- a/code/modules/hydroponics/grown/eggplant.dm
+++ b/code/modules/hydroponics/grown/eggplant.dm
@@ -42,6 +42,5 @@
 	desc = "There MUST be a chicken inside."
 	icon_state = "eggyplant"
 	trash_type = /obj/item/food/egg
-
 	foodtypes = MEAT
 	distill_reagent = /datum/reagent/consumable/ethanol/eggnog

--- a/code/modules/hydroponics/grown/eggplant.dm
+++ b/code/modules/hydroponics/grown/eggplant.dm
@@ -20,7 +20,6 @@
 	name = "eggplant"
 	desc = "Maybe there's a chicken inside?"
 	icon_state = "eggplant"
-	bite_consumption_mod = 2
 	foodtypes = FRUIT
 	wine_power = 20
 
@@ -43,6 +42,6 @@
 	desc = "There MUST be a chicken inside."
 	icon_state = "eggyplant"
 	trash_type = /obj/item/food/egg
-	bite_consumption_mod = 2
+
 	foodtypes = MEAT
 	distill_reagent = /datum/reagent/consumable/ethanol/eggnog

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -24,7 +24,7 @@
 	desc = "Long-used as a symbol of rest, peace, and death."
 	icon_state = "poppy"
 	slot_flags = ITEM_SLOT_HEAD
-	bite_consumption_mod = 3
+	bite_consumption_mod = 2
 	foodtypes = VEGETABLES | GROSS
 	distill_reagent = /datum/reagent/consumable/ethanol/vermouth
 
@@ -80,7 +80,7 @@
 	name = "spaceman's trumpet"
 	desc = "A vivid flower that smells faintly of freshly cut grass. Touching the flower seems to stain the skin some time after contact, yet most other surfaces seem to be unaffected by this phenomenon."
 	icon_state = "spacemanstrumpet"
-	bite_consumption_mod = 3
+	bite_consumption_mod = 2
 	foodtypes = VEGETABLES
 
 // Geranium
@@ -146,7 +146,7 @@
 	desc = "\"I'll sweeten thy sad grave: thou shalt not lack the flower that's like thy face, pale primrose, nor the azured hare-bell, like thy veins; no, nor the leaf of eglantine, whom not to slander, out-sweeten'd not thy breath.\""
 	icon_state = "harebell"
 	slot_flags = ITEM_SLOT_HEAD
-	bite_consumption_mod = 3
+	bite_consumption_mod = 2
 	distill_reagent = /datum/reagent/consumable/ethanol/vermouth
 
 // Sunflower
@@ -211,7 +211,6 @@
 	desc = "Store in a location at least 50 yards away from werewolves."
 	icon_state = "moonflower"
 	slot_flags = ITEM_SLOT_HEAD
-	bite_consumption_mod = 2
 	distill_reagent = /datum/reagent/consumable/ethanol/absinthe //It's made from flowers.
 
 // Novaflower
@@ -309,7 +308,7 @@
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
 	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK
-	bite_consumption_mod = 3
+	bite_consumption_mod = 2
 	foodtypes = VEGETABLES | GROSS
 
 /obj/item/food/grown/rose/pickup(mob/living/carbon/human/user)

--- a/code/modules/hydroponics/grown/garlic.dm
+++ b/code/modules/hydroponics/grown/garlic.dm
@@ -16,6 +16,5 @@
 	name = "garlic"
 	desc = "Delicious, but with a potentially overwhelming odor."
 	icon_state = "garlic"
-	bite_consumption_mod = 2
 	tastes = list("garlic" = 1)
 	wine_power = 10

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -24,7 +24,7 @@
 	name = "grass"
 	desc = "Green and lush."
 	icon_state = "grassclump"
-	bite_consumption_mod = 2
+	bite_consumption_mod = 0.5
 	var/stacktype = /obj/item/stack/tile/grass
 	var/tile_coefficient = 0.02 // 1/50
 	wine_power = 15

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -45,6 +45,7 @@
 	name = "pack of fairygrass seeds"
 	desc = "These seeds grow into a more mystical grass."
 	icon_state = "seed-fairygrass"
+	bite_consumption_mod = 1
 	species = "fairygrass"
 	plantname = "Fairygrass"
 	product = /obj/item/food/grown/grass/fairy

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -45,7 +45,6 @@
 	name = "pack of fairygrass seeds"
 	desc = "These seeds grow into a more mystical grass."
 	icon_state = "seed-fairygrass"
-	bite_consumption_mod = 1
 	species = "fairygrass"
 	plantname = "Fairygrass"
 	product = /obj/item/food/grown/grass/fairy
@@ -60,6 +59,7 @@
 	name = "fairygrass"
 	desc = "Blue, glowing, and smells fainly of mushrooms."
 	icon_state = "fairygrassclump"
+	bite_consumption_mod = 1
 	stacktype = /obj/item/stack/tile/fairygrass
 
 // Carpet

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -24,7 +24,7 @@
 	name = "grass"
 	desc = "Green and lush."
 	icon_state = "grassclump"
-	bite_consumption_mod = 0.5
+	bite_consumption_mod = 0.5 // Grazing on grass
 	var/stacktype = /obj/item/stack/tile/grass
 	var/tile_coefficient = 0.02 // 1/50
 	wine_power = 15

--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -102,7 +102,6 @@
 	name = "kudzu pod"
 	desc = "<I>Pueraria Virallis</I>: An invasive species with vines that rapidly creep and wrap around whatever they contact."
 	icon_state = "kudzupod"
-	bite_consumption_mod = 2
 	foodtypes = VEGETABLES | GROSS
 	tastes = list("kudzu" = 1)
 	wine_power = 20

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -28,7 +28,6 @@
 	desc = "It's full of watery goodness."
 	icon_state = "watermelon"
 	w_class = WEIGHT_CLASS_NORMAL
-	bite_consumption_mod = 3
 	foodtypes = FRUIT
 	juice_results = list(/datum/reagent/consumable/watermelonjuice = 0)
 	wine_power = 40
@@ -58,9 +57,9 @@
 	name = "holymelon"
 	desc = "The water within this melon has been blessed by some deity that's particularly fond of watermelon."
 	icon_state = "holymelon"
+	bite_consumption_mod = 2
 	wine_power = 70 //Water to wine, baby.
 	wine_flavor = "divinity"
-
 
 /obj/item/food/grown/holymelon/make_dryable()
 	return //No drying

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -27,6 +27,7 @@
 	name = "watermelon"
 	desc = "It's full of watery goodness."
 	icon_state = "watermelon"
+	bite_consumption_mod = 2
 	w_class = WEIGHT_CLASS_NORMAL
 	foodtypes = FRUIT
 	juice_results = list(/datum/reagent/consumable/watermelonjuice = 0)

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -97,7 +97,7 @@
 	name = "galaxythistle flower head"
 	desc = "This spiny cluster of florets reminds you of the highlands."
 	icon_state = "galaxythistle"
-	bite_consumption_mod = 3
+	bite_consumption_mod = 2
 	foodtypes = VEGETABLES
 	wine_power = 35
 	tastes = list("thistle" = 2, "artichoke" = 1)
@@ -128,7 +128,6 @@
 	name = "cabbage"
 	desc = "Ewwwwwwwwww. Cabbage."
 	icon_state = "cabbage"
-	bite_consumption_mod = 2
 	foodtypes = VEGETABLES
 	wine_power = 20
 
@@ -207,7 +206,7 @@
 	desc = "You think you can hear the hissing of a tiny fuse."
 	icon_state = "cherry_bomb"
 	seed = /obj/item/seeds/cherry/bomb
-	bite_consumption_mod = 2
+	bite_consumption_mod = 3
 	max_volume = 125 //Gives enough room for the gunpowder at max potency
 	max_integrity = 40
 	wine_power = 80
@@ -254,7 +253,7 @@
 	name = "aloe"
 	desc = "Cut leaves from the aloe plant."
 	icon_state = "aloe"
-	bite_consumption_mod = 5
+	bite_consumption_mod = 3
 	foodtypes = VEGETABLES
 	juice_results = list(/datum/reagent/consumable/aloejuice = 0)
 	distill_reagent = /datum/reagent/consumable/ethanol/tequila

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -1,6 +1,6 @@
 /obj/item/food/grown/mushroom
 	name = "mushroom"
-	bite_consumption_mod = 2
+	bite_consumption_mod = 3
 	foodtypes = VEGETABLES
 	wine_power = 40
 
@@ -30,7 +30,6 @@
 	name = "reishi"
 	desc = "<I>Ganoderma lucidum</I>: A special fungus known for its medicinal and stress relieving properties."
 	icon_state = "reishi"
-
 
 // Fly Amanita
 /obj/item/seeds/amanita

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -37,6 +37,7 @@
 	desc = "It's probably <B>not</B> wise to touch it with bare hands..."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "nettle"
+	bite_consumption_mod = 2
 	lefthand_file = 'icons/mob/inhands/weapons/plants_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/plants_righthand.dmi'
 	damtype = BURN
@@ -92,6 +93,7 @@
 	name = "deathnettle"
 	desc = "The <span class='danger'>glowing</span> nettle incites <span class='boldannounce'>rage</span> in you just from looking at it!"
 	icon_state = "deathnettle"
+	bite_consumption_mod = 4 // I guess if you really wanted to
 	force = 30
 	wound_bonus = CANT_WOUND
 	throwforce = 15

--- a/code/modules/hydroponics/grown/onion.dm
+++ b/code/modules/hydroponics/grown/onion.dm
@@ -22,7 +22,6 @@
 	name = "onion"
 	desc = "Nothing to cry over."
 	icon_state = "onion"
-	bite_consumption_mod = 2
 	tastes = list("onions" = 1)
 	wine_power = 30
 

--- a/code/modules/hydroponics/grown/peas.dm
+++ b/code/modules/hydroponics/grown/peas.dm
@@ -22,7 +22,6 @@
 	name = "peapod"
 	desc = "Finally... peas."
 	icon_state = "peas"
-	bite_consumption_mod = 1
 	foodtypes = VEGETABLES
 	tastes = list ("peas" = 1, "chalky saltiness" = 1)
 	wine_power = 50
@@ -54,7 +53,6 @@
 	name = "pod of laughin' peas"
 	desc = "Ridens Cicer, guaranteed to improve your mood dramatically upon consumption!"
 	icon_state = "laughpeas"
-	bite_consumption_mod = 2
 	foodtypes = VEGETABLES
 	juice_results = list (/datum/reagent/consumable/laughsyrup = 0)
 	tastes = list ("a prancing rabbit" = 1) //Vib Ribbon sends her regards.. wherever she is.
@@ -87,7 +85,7 @@
 	name = "cluster of world peas"
 	desc = "A plant discovered through extensive genetic engineering, and iterative graft work. It's rumored to bring peace to any who consume it. In the wider AgSci community, it's attained the nickname of 'Pax Mundi'." //at last... world peas. I'm not sorry.
 	icon_state = "worldpeas"
-	bite_consumption_mod = 4
+	bite_consumption_mod = 2
 	foodtypes = VEGETABLES
 	tastes = list ("numbing tranquility" = 2, "warmth" = 1)
 	wine_power = 100

--- a/code/modules/hydroponics/grown/pineapple.dm
+++ b/code/modules/hydroponics/grown/pineapple.dm
@@ -20,6 +20,7 @@
 	name = "pineapples"
 	desc = "Blorble."
 	icon_state = "pineapple"
+	bite_consumption_mod = 2
 	force = 4
 	throwforce = 8
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/hydroponics/grown/potato.dm
+++ b/code/modules/hydroponics/grown/potato.dm
@@ -24,7 +24,7 @@
 	name = "potato"
 	desc = "Boil 'em! Mash 'em! Stick 'em in a stew!"
 	icon_state = "potato"
-	bite_consumption = 100
+	bite_consumption_mod = 100
 	foodtypes = VEGETABLES
 	juice_results = list(/datum/reagent/consumable/potato_juice = 0)
 	distill_reagent = /datum/reagent/consumable/ethanol/vodka
@@ -33,7 +33,7 @@
 	name = "potato wedges"
 	desc = "Slices of neatly cut potato."
 	icon_state = "potato_wedges"
-	bite_consumption = 100
+	bite_consumption_mod = 100
 
 
 /obj/item/food/grown/potato/attackby(obj/item/W, mob/user, params)

--- a/code/modules/hydroponics/grown/pumpkin.dm
+++ b/code/modules/hydroponics/grown/pumpkin.dm
@@ -52,7 +52,7 @@
 	name = "blumpkin"
 	desc = "The pumpkin's toxic sibling."
 	icon_state = "blumpkin"
-	bite_consumption_mod = 2
+	bite_consumption_mod = 3
 	foodtypes = FRUIT
 	juice_results = list(/datum/reagent/consumable/blumpkinjuice = 0)
 	wine_power = 50

--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -27,7 +27,6 @@
 	name = "strange plant"
 	desc = "What could this even be?"
 	icon_state = "crunchy"
-	bite_consumption_mod = 2
 
 /obj/item/food/grown/random/Initialize()
 	. = ..()

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -52,7 +52,6 @@
 	name = "parsnip"
 	desc = "Closely related to carrots."
 	icon_state = "parsnip"
-
 	foodtypes = VEGETABLES
 	juice_results = list(/datum/reagent/consumable/parsnipjuice = 0)
 	wine_power = 35

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -52,7 +52,7 @@
 	name = "parsnip"
 	desc = "Closely related to carrots."
 	icon_state = "parsnip"
-	bite_consumption_mod = 2
+
 	foodtypes = VEGETABLES
 	juice_results = list(/datum/reagent/consumable/parsnipjuice = 0)
 	wine_power = 35
@@ -80,7 +80,7 @@
 	name = "white-beet"
 	desc = "You can't beat white-beet."
 	icon_state = "whitebeet"
-	bite_consumption_mod = 2
+	bite_consumption_mod = 3
 	foodtypes = VEGETABLES
 	wine_power = 40
 

--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -40,6 +40,7 @@
 	seed = /obj/item/seeds/tea/astra
 	name = "Tea Astra tips"
 	icon_state = "tea_astra_leaves"
+	bite_consumption_mod = 2
 	grind_results = list(/datum/reagent/toxin/teapowder = 0, /datum/reagent/medicine/salglu_solution = 0)
 
 
@@ -68,7 +69,6 @@
 	name = "coffee arabica beans"
 	desc = "Dry them out to make coffee."
 	icon_state = "coffee_arabica"
-	bite_consumption_mod = 2
 	dry_grind = TRUE
 	grind_results = list(/datum/reagent/toxin/coffeepowder = 0)
 	distill_reagent = /datum/reagent/consumable/ethanol/kahlua

--- a/code/modules/hydroponics/grown/tobacco.dm
+++ b/code/modules/hydroponics/grown/tobacco.dm
@@ -39,5 +39,6 @@
 	name = "space tobacco leaves"
 	desc = "Dry them out to make some space-smokes."
 	icon_state = "stobacco_leaves"
+	bite_consumption_mod = 2
 	distill_reagent = null
 	wine_power = 50

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -44,6 +44,7 @@
 	name = "blood-tomato"
 	desc = "So bloody...so...very...bloody....AHHHH!!!!"
 	icon_state = "bloodtomato"
+	bite_consumption_mod = 3
 	splat_type = /obj/effect/gibspawner/generic
 	foodtypes = FRUIT | GROSS
 	grind_results = list(/datum/reagent/consumable/ketchup = 0, /datum/reagent/blood = 0)

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -22,7 +22,6 @@
 	desc = "I say to-mah-to, you say tom-mae-to."
 	icon_state = "tomato"
 	splat_type = /obj/effect/decal/cleanable/food/tomato_smudge
-	bite_consumption_mod = 2
 	foodtypes = FRUIT
 	grind_results = list(/datum/reagent/consumable/ketchup = 0)
 	juice_results = list(/datum/reagent/consumable/tomatojuice = 0)
@@ -71,6 +70,7 @@
 	name = "blue-tomato"
 	desc = "I say blue-mah-to, you say blue-mae-to."
 	icon_state = "bluetomato"
+	bite_consumption_mod = 2
 	splat_type = /obj/effect/decal/cleanable/oil
 	distill_reagent = /datum/reagent/consumable/laughter
 
@@ -94,6 +94,7 @@
 	name = "bluespace tomato"
 	desc = "So lubricated, you might slip through space-time."
 	icon_state = "bluespacetomato"
+	bite_consumption_mod = 3
 	distill_reagent = null
 	wine_power = 80
 

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -270,7 +270,6 @@
 	desc = "A spikey, round cluster of prickly star cacti. And no, it's not called a star cactus because it's in space."
 	icon_state = "starcactus"
 	filling_color = "#1c801c"
-	bite_consumption_mod = 3
 	foodtypes = VEGETABLES
 	distill_reagent = /datum/reagent/consumable/ethanol/tequila
 


### PR DESCRIPTION
## About The Pull Request

This PR gives botany plants a new formula for getting the size of their bites.

The formula is `(potency / 20) * (max_volume / 100) * (modifier) + 1`.

This brings your average 100 potency plant to a bite size of 6 units per bite. [(5 * 1 * 1) + 1] - For reference, a Tomato has 14 units of reagents with default genes at 100 potency, so this means a tomato is eaten in 3 bites. 

This PR also goes through and audits all the plant's bite modifiers to bring them in line with the new formula. This makes the bite modifier actually a bite modifier instead of some weird constant var that lies about what it actually does.

Fixes #55527

## Why It's Good For The Game

Currently, all plants are eaten in a single bite. Including watermelons and the dank weeds. This is bad.

![image](https://user-images.githubusercontent.com/51863163/116485567-2a464e00-a851-11eb-935c-41552d2a2cbb.png)

This PR brings them all in line so you no longer swallow watermelons whole, so you stop accidentally getting fat.
I also audited all the plants so their relative bitesizes make sense with the new formula. Only apples and potatos are eaten in 1 bite. Plants with more reagents naturally should now have larger bitesizes, and plants with less reagents have smaller bitesizes. Balance is restored.

## Changelog
:cl: Melbert
fix: You no longer eat all botany plants plants in 1 bite. Apples and Potatos retain their unique 1 bite behavior.
code: Botany plants use a new formula for calculating bite size. All botany plants have had their bite modifier adjusted to match.
/:cl:

