### PR TITLE
Fixes a wire in tram medbay storage

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -20016,7 +20016,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/holopad,
@@ -20554,7 +20553,6 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "dFW" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/storage)
@@ -45265,6 +45263,10 @@
 /obj/item/ammo_casing/spent,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
+"nEg" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "nEr" = (
 /obj/effect/turf_decal/arrows/white{
 	dir = 4
@@ -167605,7 +167607,7 @@ bOQ
 fCO
 ofE
 mJp
-xZg
+nEg
 mhz
 ozN
 aIK


### PR DESCRIPTION
## About The Pull Request
Old: 
![image](https://user-images.githubusercontent.com/8881105/116553145-b60fb700-a8f1-11eb-9c7f-dd2c0856beb2.png)

New:
![image](https://user-images.githubusercontent.com/8881105/116552919-7ea10a80-a8f1-11eb-8575-6b04c0d8dc8b.png)

## Why It's Good For The Game

bug fix

## Changelog
:cl:
fix: Tram medbay storage is now wired to the grid at round start.
/:cl: