### PR TITLE
Resolve roulette styling issues

### DIFF
--- a/tgui/packages/tgui/interfaces/Roulette.js
+++ b/tgui/packages/tgui/interfaces/Roulette.js
@@ -1,231 +1,156 @@
 import { classes } from 'common/react';
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, Grid, NumberInput } from '../components';
+import { Box, Button, Grid, NumberInput, Table } from '../components';
 import { Window } from '../layouts';
 
 const getNumberColor = number => {
-  if (number === 0) {
-    return 'green';
+  const inRedOddRange = (
+    (number >= 1 && number <= 10)
+    || (number >= 19 && number <= 28)
+  );
+
+  if (number % 2 === 1) {
+    return inRedOddRange ? 'red' : 'black';
   }
-
-  const evenRedRanges = [
-    [1, 10],
-    [19, 28],
-  ];
-  let oddRed = true;
-
-  for (let i = 0; i < evenRedRanges.length; i++) {
-    let range = evenRedRanges[i];
-    if (number >= range[0] && number <= range[1]) {
-      oddRed = false;
-      break;
-    }
-  }
-
-  const isOdd = (number % 2 === 0);
-
-  return (oddRed ? isOdd : !isOdd) ? 'red' : 'black';
+  return inRedOddRange ? 'black' : 'red';
 };
 
-export const RouletteNumberButton = (props, context) => {
-  const { number } = props;
+export const RouletteNumberCell = (props, context) => {
+  const {
+    buttonClass = null,
+    cellClass = null,
+    color,
+    colspan = "1",
+    rowspan = "1",
+    text,
+    value,
+  } = props;
   const { act } = useBackend(context);
 
   return (
-    <Button
-      bold
-      content={number}
-      color={getNumberColor(number)}
-      width="40px"
-      height="28px"
-      fontSize="20px"
-      textAlign="center"
-      mb={0}
-      className="Roulette__board-extrabutton"
-      onClick={() => act('ChangeBetType', { type: number.toString() })}
-    />
+    <Table.Cell
+      className={classes([
+        "Roulette__board-cell",
+        "Roulette__board-cell-number",
+        cellClass,
+      ])}
+      colspan={colspan}
+      rowspan={rowspan}>
+      <Button
+        color={color}
+        className={classes([
+          "Roulette__board-button",
+          buttonClass,
+        ])}
+        onClick={() => act('ChangeBetType', { type: value })}
+      >
+        <span className="Roulette__board-button-text">{text}</span>
+      </Button>
+    </Table.Cell>
   );
 };
 
-export const RouletteBoard = (props, context) => {
-  const { act } = useBackend(context);
-
+export const RouletteBoard = () => {
   const firstRow = [3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36];
   const secondRow = [2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 32, 35];
   const thirdRow = [1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31, 34];
+  const fourthRow = {
+    "s1-12": "1st 12",
+    "s13-24": "2nd 12",
+    "s25-36": "3rd 12",
+  };
+  const fifthRow = [
+    { color: "transparent", text: "1-18", value: "s1-18" },
+    { color: "transparent", text: "Even", value: "even" },
+    { color: "black", text: "Black", value: "black" },
+    { color: "red", text: "Red", value: "red" },
+    { color: "transparent", text: "Odd", value: "odd" },
+    { color: "transparent", text: "19-36", value: "s19-36" },
+  ];
 
   return (
-    <table
-      className="Table"
-      style={{
-        // Setting it to 1 px makes sure it always takes up minimum width
-        'width': '1px',
-      }}>
-      <tr className="Roulette__board-row">
-        <td
-          rowSpan="3"
-          className="Roulette__board-cell">
-          <Button
-            content="0"
+    <Box className="Roulette__container">
+      <Table collapsing ml="auto" mr="auto">
+        <Table.Row>
+          <RouletteNumberCell
+            buttonClass="Roulette__board-button--rowspan-3"
             color="transparent"
-            height="88px"
-            className="Roulette__board-extrabutton"
-            onClick={() => act('ChangeBetType', { type: "0" })}
+            rowspan="3"
+            text="0"
+            value="0"
           />
-        </td>
-        {firstRow.map(number => (
-          <td
-            key={number}
-            className="Roulette__board-cell Table__cell-collapsing">
-            <RouletteNumberButton number={number} />
-          </td>
-        ))}
-        <td className="Roulette__board-cell">
-          <Button
-            fluid
-            bold
-            content="2 to 1"
+          {firstRow.map(number => (
+            <RouletteNumberCell
+              color={getNumberColor(number)}
+              key={number}
+              text={number.toString()}
+              value={number.toString()}
+            />
+          ))}
+          <RouletteNumberCell
             color="transparent"
-            className="Roulette__board-extrabutton"
-            onClick={() => act('ChangeBetType', { type: "s3rd col" })}
+            text="2 to 1"
+            value="s3rd col"
           />
-        </td>
-      </tr>
-      <tr>
-        {secondRow.map(number => (
-          <td
-            key={number}
-            className="Roulette__board-cell Table__cell-collapsing">
-            <RouletteNumberButton number={number} />
-          </td>
-        ))}
-        <td className="Roulette__board-cell">
-          <Button
-            fluid
-            bold
-            content="2 to 1"
+        </Table.Row>
+        <Table.Row>
+          {secondRow.map(number => (
+            <RouletteNumberCell
+              color={getNumberColor(number)}
+              key={number}
+              text={number.toString()}
+              value={number.toString()}
+            />
+          ))}
+          <RouletteNumberCell
             color="transparent"
-            className="Roulette__board-extrabutton"
-            onClick={() => act('ChangeBetType', { type: "s2nd col" })}
+            text="2 to 1"
+            value="s2nd col"
           />
-        </td>
-      </tr>
-      <tr>
-        {thirdRow.map(number => (
-          <td
-            key={number}
-            className="Roulette__board-cell Table__cell-collapsing">
-            <RouletteNumberButton number={number} />
-          </td>
-        ))}
-        <td className="Roulette__board-cell">
-          <Button
-            fluid
-            bold
-            content="2 to 1"
+        </Table.Row>
+        <Table.Row>
+          {thirdRow.map(number => (
+            <RouletteNumberCell
+              color={getNumberColor(number)}
+              key={number}
+              text={number.toString()}
+              value={number.toString()}
+            />
+          ))}
+          <RouletteNumberCell
             color="transparent"
-            className="Roulette__board-extrabutton"
-            onClick={() => act('ChangeBetType', { type: "s1st col" })}
+            text="2 to 1"
+            value="s1st col"
           />
-        </td>
-      </tr>
-      <tr>
-        <td />
-        <td colSpan="4" className="Roulette__board-cell">
-          <Button
-            fluid
-            bold
-            content="1st 12"
-            color="transparent"
-            className="Roulette__board-extrabutton"
-            onClick={() => act('ChangeBetType', { type: "s1-12" })}
-          />
-        </td>
-        <td colSpan="4" className="Roulette__board-cell">
-          <Button
-            fluid
-            bold
-            content="2nd 12"
-            color="transparent"
-            className="Roulette__board-extrabutton"
-            onClick={() => act('ChangeBetType', { type: "s13-24" })}
-          />
-        </td>
-        <td colSpan="4" className="Roulette__board-cell">
-          <Button
-            fluid
-            bold
-            content="3rd 12"
-            color="transparent"
-            className="Roulette__board-extrabutton"
-            onClick={() => act('ChangeBetType', { type: "s25-36" })}
-          />
-        </td>
-      </tr>
-      <tr>
-        <td />
-        <td colSpan="2" className="Roulette__board-cell">
-          <Button
-            fluid
-            bold
-            content="1-18"
-            color="transparent"
-            className="Roulette__board-extrabutton"
-            onClick={() => act('ChangeBetType', { type: "s1-18" })}
-          />
-        </td>
-        <td colSpan="2" className="Roulette__board-cell">
-          <Button
-            fluid
-            bold
-            content="Even"
-            color="transparent"
-            className="Roulette__board-extrabutton"
-            onClick={() => act('ChangeBetType', { type: "even" })}
-          />
-        </td>
-        <td colSpan="2" className="Roulette__board-cell">
-          <Button
-            fluid
-            bold
-            content="Black"
-            color="black"
-            className="Roulette__board-extrabutton"
-            onClick={() => act('ChangeBetType', { type: "black" })}
-          />
-        </td>
-        <td colSpan="2" className="Roulette__board-cell">
-          <Button
-            fluid
-            bold
-            content="Red"
-            color="red"
-            className="Roulette__board-extrabutton"
-            onClick={() => act('ChangeBetType', { type: "red" })}
-          />
-        </td>
-        <td colSpan="2" className="Roulette__board-cell">
-          <Button
-            fluid
-            bold
-            content="Odd"
-            color="transparent"
-            className="Roulette__board-extrabutton"
-            onClick={() => act('ChangeBetType', { type: "odd" })}
-          />
-        </td>
-        <td colSpan="2" className="Roulette__board-cell">
-          <Button
-            fluid
-            bold
-            content="19-36"
-            color="transparent"
-            className="Roulette__board-extrabutton"
-            onClick={() => act('ChangeBetType', { type: "s19-36" })}
-          />
-        </td>
-      </tr>
-    </table>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell />
+          {Object.entries(fourthRow).map(([value, text]) => (
+            <RouletteNumberCell
+              cellClass="Roulette__board-cell-number--colspan-4"
+              color="transparent"
+              colspan="4"
+              key={value}
+              text={text}
+              value={value}
+            />
+          ))}
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell />
+          {fifthRow.map(cell => (
+            <RouletteNumberCell
+              cellClass="Roulette__board-cell-number--colspan-2"
+              color={cell.color}
+              colspan="2"
+              key={cell.value}
+              text={cell.text}
+              value={cell.value}
+            />
+          ))}
+        </Table.Row>
+      </Table>
+    </Box>
   );
 };
 
@@ -246,35 +171,35 @@ export const RouletteBetTable = (props, context) => {
   }
 
   return (
-    <table className="Roulette__lowertable">
-      <tr>
-        <th
+    <Table className="Roulette__lowertable" collapsing>
+      <Table.Row>
+        <Table.Cell
           className={classes([
             'Roulette',
             'Roulette__lowertable--cell',
             'Roulette__lowertable--header',
           ])}>
-          Last Spun:
-        </th>
-        <th
+          Last Spin:
+        </Table.Cell>
+        <Table.Cell
           className={classes([
             'Roulette',
             'Roulette__lowertable--cell',
             'Roulette__lowertable--header',
           ])}>
           Current Bet:
-        </th>
-      </tr>
-      <tr>
-        <td className={classes([
+        </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell className={classes([
           'Roulette',
           'Roulette__lowertable--cell',
           'Roulette__lowertable--spinresult',
           'Roulette__lowertable--spinresult-' + getNumberColor(data.LastSpin),
         ])}>
           {data.LastSpin}
-        </td>
-        <td className={classes([
+        </Table.Cell>
+        <Table.Cell className={classes([
           'Roulette',
           'Roulette__lowertable--cell',
           'Roulette__lowertable--betscell',
@@ -283,7 +208,7 @@ export const RouletteBetTable = (props, context) => {
             bold
             mt={1}
             mb={1}
-            fontSize="25px"
+            fontSize="20px"
             textAlign="center">
             {data.BetAmount} cr on {BetType}
           </Box>
@@ -339,10 +264,10 @@ export const RouletteBetTable = (props, context) => {
               </Grid.Column>
             </Grid>
           </Box>
-        </td>
-      </tr>
-      <tr>
-        <td colSpan="2">
+        </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell colSpan="2">
           <Box
             bold
             m={1}
@@ -350,18 +275,18 @@ export const RouletteBetTable = (props, context) => {
             textAlign="center">
             Swipe an ID card with a connected account to spin!
           </Box>
-        </td>
-      </tr>
-      <tr>
-        <td className="Roulette__lowertable--cell">
+        </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell className="Roulette__lowertable--cell">
           <Box inline bold mr={1}>
             House Balance:
           </Box>
           <Box inline>
             {data.HouseBalance ? data.HouseBalance + ' cr': "None"}
           </Box>
-        </td>
-        <td className="Roulette__lowertable--cell">
+        </Table.Cell>
+        <Table.Cell className="Roulette__lowertable--cell">
           <Button
             fluid
             content={data.IsAnchored ? "Bolted" : "Unbolted"}
@@ -370,17 +295,17 @@ export const RouletteBetTable = (props, context) => {
             textAlign="center"
             onClick={() => act('anchor')}
           />
-        </td>
-      </tr>
-    </table>
+        </Table.Cell>
+      </Table.Row>
+    </Table>
   );
 };
 
 export const Roulette = (props, context) => {
   return (
     <Window
-      width={603}
-      height={475}
+      width={570}
+      height={520}
       theme="cardtable">
       <Window.Content>
         <RouletteBoard />

--- a/tgui/packages/tgui/styles/interfaces/Roulette.scss
+++ b/tgui/packages/tgui/styles/interfaces/Roulette.scss
@@ -25,7 +25,7 @@
   width: 143px;
 }
 
-.Roulette__board-cell-button {
+.Roulette__board-button {
   display: table-cell !important;
   border: none !important;
   width: inherit;
@@ -37,11 +37,11 @@
   color: colors.$white !important;
 }
 
-.Roulette__board-cell-button--rowspan-3 {
+.Roulette__board-button--rowspan-3 {
   height: 122px;
 }
 
-.Roulette__board-cell-button-text {
+.Roulette__board-button-text {
   text-align: center;
   font-size: 16px;
   font-weight: bold;

--- a/tgui/packages/tgui/styles/interfaces/Roulette.scss
+++ b/tgui/packages/tgui/styles/interfaces/Roulette.scss
@@ -2,99 +2,103 @@
 @use '../colors.scss';
 
 .Roulette {
-  font-family: Palatino;
-}
-
-.Roulette__board {
-  display: table;
-  width: 100%;
-  border-collapse: collapse;
-  border: 2px solid white;
-  margin: 0;
-}
-
-.Roulette__board-row {
-  padding: 0;
-  margin: 0;
-}
-
-.Roulette__board-cell {
-  display: table-cell;
-  padding: 0;
-  margin: 0;
-  border: 2px solid white;
-  font-family: Palatino;
-
-  &:first-child {
-    padding-left: 0;
+  &__container {
+    display: flex;
   }
 
-  &:last-child {
-    padding-right: 0;
+  &__board {
+    &-cell {
+      display: table-cell;
+      padding: 0;
+      margin: 0;
+      border: 1px solid colors.$white;
+      vertical-align: bottom;
+
+      &-number {
+        width: 35px;
+
+        &--colspan-2 {
+          width: 71px;
+        }
+
+        &--colspan-4 {
+          width: 143px;
+        }
+      }
+    }
+
+    &-button {
+      display: table-cell !important;
+      border: none !important;
+      width: inherit;
+      height: 40px;
+      padding: 0;
+      margin: 0;
+      text-align: center;
+      vertical-align: middle;
+      color: colors.$white !important;
+
+      &--rowspan-3 {
+        height: 122px;
+      }
+
+      &-text {
+        text-align: center;
+        font-size: 16px;
+        font-weight: bold;
+      }
+    }
   }
-}
 
-.Roulette__board-extrabutton {
-  text-align: center;
-  font-size: 20px;
-  font-weight: bold;
-  height: 28px;
-  border: none !important;
-  margin: 0 !important;
-  padding-top: 4px !important;
-  color: #FFFFFF !important;
-}
+  &__lowertable {
+    margin-top: 8px;
+    border-collapse: collapse;
+    border: 1px solid colors.$white;
+    border-spacing: 0;
 
-.Roulette__lowertable {
-  margin-top: 8px;
-  margin-left: 80px;
-  margin-right: 80px;
-  border-collapse: collapse;
-  border: 2px solid white;
-  border-spacing: 0;
-}
+    &--cell {
+      border: 2px solid colors.$white;
+      padding: 0px;
+      margin: 0px;
+    }
 
-.Roulette__lowertable--cell {
-  border: 2px solid white;
-  padding: 0px;
-  margin: 0px;
-}
+    &--betscell {
+      vertical-align: top;
+    }
 
-.Roulette__lowertable--betscell {
-  vertical-align: top;
-}
+    &--spinresult {
+      text-align: center;
+      font-size: 100px;
+      font-weight: bold;
+      vertical-align: middle;
 
-.Roulette__lowertable--spinresult {
-  text-align: center;
-  font-size: 100px;
-  font-weight: bold;
-  vertical-align: middle;
-}
+      &-black {
+        background-color: colors.$black;
+      }
 
-.Roulette__lowertable--spinresult-black {
-  background-color: colors.$black;
-}
+      &-red {
+        background-color: colors.$red;
+      }
 
-.Roulette__lowertable--spinresult-red {
-  background-color: colors.$red;
-}
+      &-green {
+        background-color: colors.$green;
+      }
+    }
 
-.Roulette__lowertable--spinresult-green {
-  background-color: colors.$green;
-}
+    &--spinbutton {
+      margin: 0 !important;
+      border: none !important;
+      font-size: 50px;
+      line-height: 60px !important;
+      text-align: center;
+      font-weight: bold;
+    }
 
-.Roulette__lowertable--spinbutton {
-  margin: 0 !important;
-  border: none !important;
-  font-size: 50px;
-  line-height: 60px !important;
-  text-align: center;
-  font-weight: bold;
-}
-
-.Roulette__lowertable--header {
-  width: 1%;
-  text-align: center;
-  font-size: 20px;
-  font-weight: bold;
+    &--header {
+      width: 1%;
+      text-align: center;
+      font-size: 16px;
+      font-weight: bold;
+    }
+  }
 }

--- a/tgui/packages/tgui/styles/interfaces/Roulette.scss
+++ b/tgui/packages/tgui/styles/interfaces/Roulette.scss
@@ -1,104 +1,100 @@
 @use '../base.scss';
 @use '../colors.scss';
 
-.Roulette {
-  &__container {
-    display: flex;
-  }
+.Roulette__container {
+  display: flex;
+}
 
-  &__board {
-    &-cell {
-      display: table-cell;
-      padding: 0;
-      margin: 0;
-      border: 1px solid colors.$white;
-      vertical-align: bottom;
+.Roulette__board-cell {
+  display: table-cell;
+  padding: 0;
+  margin: 0;
+  border: 1px solid colors.$white;
+  vertical-align: bottom;
+}
 
-      &-number {
-        width: 35px;
+.Roulette__board-cell-number {
+  width: 35px;
+}
 
-        &--colspan-2 {
-          width: 71px;
-        }
+.Roulette__board-cell-number--colspan-2 {
+  width: 71px;
+}
 
-        &--colspan-4 {
-          width: 143px;
-        }
-      }
-    }
+.Roulette__board-cell-number--colspan-4 {
+  width: 143px;
+}
 
-    &-button {
-      display: table-cell !important;
-      border: none !important;
-      width: inherit;
-      height: 40px;
-      padding: 0;
-      margin: 0;
-      text-align: center;
-      vertical-align: middle;
-      color: colors.$white !important;
+.Roulette__board-cell-button {
+  display: table-cell !important;
+  border: none !important;
+  width: inherit;
+  height: 40px;
+  padding: 0;
+  margin: 0;
+  text-align: center;
+  vertical-align: middle;
+  color: colors.$white !important;
+}
 
-      &--rowspan-3 {
-        height: 122px;
-      }
+.Roulette__board-cell-button--rowspan-3 {
+  height: 122px;
+}
 
-      &-text {
-        text-align: center;
-        font-size: 16px;
-        font-weight: bold;
-      }
-    }
-  }
+.Roulette__board-cell-button-text {
+  text-align: center;
+  font-size: 16px;
+  font-weight: bold;
+}
 
-  &__lowertable {
-    margin-top: 8px;
-    border-collapse: collapse;
-    border: 1px solid colors.$white;
-    border-spacing: 0;
+.Roulette__lowertable {
+  margin-top: 8px;
+  border-collapse: collapse;
+  border: 1px solid colors.$white;
+  border-spacing: 0;
+}
 
-    &--cell {
-      border: 2px solid colors.$white;
-      padding: 0px;
-      margin: 0px;
-    }
+.Roulette__lowertable--cell {
+  border: 2px solid colors.$white;
+  padding: 0px;
+  margin: 0px;
+}
 
-    &--betscell {
-      vertical-align: top;
-    }
+.Roulette__lowertable--betscell {
+  vertical-align: top;
+}
 
-    &--spinresult {
-      text-align: center;
-      font-size: 100px;
-      font-weight: bold;
-      vertical-align: middle;
+.Roulette__lowertable--spinresult {
+  text-align: center;
+  font-size: 100px;
+  font-weight: bold;
+  vertical-align: middle;
+}
 
-      &-black {
-        background-color: colors.$black;
-      }
+.Roulette__lowertable--spinresult-black {
+  background-color: colors.$black;
+}
 
-      &-red {
-        background-color: colors.$red;
-      }
+.Roulette__lowertable--spinresult-red {
+  background-color: colors.$red;
+}
 
-      &-green {
-        background-color: colors.$green;
-      }
-    }
+.Roulette__lowertable--spinresult-green {
+  background-color: colors.$green;
+}
 
-    &--spinbutton {
-      margin: 0 !important;
-      border: none !important;
-      font-size: 50px;
-      line-height: 60px !important;
-      text-align: center;
-      font-weight: bold;
-    }
+.Roulette__lowertable--spinbutton {
+  margin: 0 !important;
+  border: none !important;
+  font-size: 50px;
+  line-height: 60px !important;
+  text-align: center;
+  font-weight: bold;
+}
 
-    &--header {
-      width: 1%;
-      text-align: center;
-      font-size: 16px;
-      font-weight: bold;
-    }
-  }
+.Roulette__lowertable--header {
+  width: 1%;
+  text-align: center;
+  font-size: 16px;
+  font-weight: bold;
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The roulette appeared broken:
![image](https://user-images.githubusercontent.com/81999976/116601856-a1eca980-a933-11eb-8fed-f6bcdb12a118.png)
Now it looks like this:
![image](https://user-images.githubusercontent.com/81999976/116602375-4cfd6300-a934-11eb-9258-f7f33f2bd402.png)

I didn't really bother improving the code much for the bottom part, my aim was merely to make the styling appear better in the top part.

## Why It's Good For The Game

The roulette TGUI does not appear broken

## Changelog
:cl: Celotajs
qol: The roulette TGUI now looks a bit better
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
