### PR TITLE
Lowers chem gun capacity to 90 units

### DIFF
--- a/code/modules/projectiles/guns/misc/chem_gun.dm
+++ b/code/modules/projectiles/guns/misc/chem_gun.dm
@@ -21,7 +21,7 @@
 	. = ..()
 	chambered = new /obj/item/ammo_casing/chemgun(src)
 	START_PROCESSING(SSobj, src)
-	create_reagents(100, OPENCONTAINER)
+	create_reagents(90, OPENCONTAINER)
 
 /obj/item/gun/chem/Destroy()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Reduces the capacity of the Reagent Dartgun from 100 to 90.

From Minor Suggestion: https://tgstation13.org/phpBB/viewtopic.php?p=598719#p598719

## Why It's Good For The Game

100 is not divisible by 15, which is how many reagents each dart uses. This means when you fire all through the gun, you have 10 reagents left over, which isn't enough to fill another dart.

Maybe that's okay, please discuss.

## Changelog
:cl: JJRcop
balance: The reagent gun, aka the Reagent Dartgun, has has its capacity reduced to 90, or exactly 6 shots. Down from 100, or 6.6 shots.
/:cl:
