### PR TITLE
RCD repairs grilles before adding windows to them

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -110,10 +110,8 @@
 
 	if(!unanchored_items_on_tile)
 		return TRUE
-	else if(unanchored_items_on_tile == 1)
-		to_chat(user, "<span class='notice'>You move [last_item_moved] out of the way.</span>")
-	else if(unanchored_items_on_tile > 1)
-		to_chat(user, "<span class='notice'>You move some things out of the way.</span>")
+
+	to_chat(user, "<span class='notice'>You move [unanchored_items_on_tile == 1 ? "[last_item_moved]" : "some things"] out of the way.</span>")
 
 	if(unanchored_items_on_tile - CLEAR_TILE_MOVE_LIMIT > 0)
 		to_chat(user, "<span class ='warning'>There's still too much stuff in the way!</span>")

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -1,3 +1,6 @@
+/// Max number of unanchored items that will be moved from a tile when attempting to add a window to a grille.
+#define CLEAR_TILE_MOVE_LIMIT 20
+
 /obj/structure/grille
 	desc = "A flimsy framework of iron rods."
 	name = "grille"
@@ -15,8 +18,6 @@
 	var/rods_type = /obj/item/stack/rods
 	var/rods_amount = 2
 	var/rods_broken = TRUE
-	var/grille_type = null
-	var/broken_type = /obj/structure/grille/broken
 
 /obj/structure/grille/ComponentInitialize()
 	. = ..()
@@ -77,6 +78,13 @@
 			if(!isturf(loc))
 				return FALSE
 			var/turf/T = loc
+
+			if(repair_grille())
+				to_chat(user, "<span class='notice'>You rebuild the broken grille.</span>")
+
+			if(!clear_tile(user))
+				return FALSE
+
 			if(!ispath(the_rcd.window_type, /obj/structure/window))
 				CRASH("Invalid window path type in RCD: [the_rcd.window_type]")
 			var/obj/structure/window/window_path = the_rcd.window_type
@@ -87,6 +95,31 @@
 			WD.set_anchored(TRUE)
 			return TRUE
 	return FALSE
+
+/obj/structure/grille/proc/clear_tile(mob/user)
+	var/at_users_feet = get_turf(user)
+
+	var/unanchored_items_on_tile
+	var/obj/item/last_item_moved
+	for(var/obj/item/item_to_move in loc.contents)
+		if(!item_to_move.anchored)
+			if(unanchored_items_on_tile <= CLEAR_TILE_MOVE_LIMIT)
+				item_to_move.forceMove(at_users_feet)
+				last_item_moved = item_to_move
+			unanchored_items_on_tile++
+
+	if(!unanchored_items_on_tile)
+		return TRUE
+	else if(unanchored_items_on_tile == 1)
+		to_chat(user, "<span class='notice'>You move [last_item_moved] out of the way.</span>")
+	else if(unanchored_items_on_tile > 1)
+		to_chat(user, "<span class='notice'>You move some things out of the way.</span>")
+
+	if(unanchored_items_on_tile - CLEAR_TILE_MOVE_LIMIT > 0)
+		to_chat(user, "<span class ='warning'>There's still too much stuff in the way!</span>")
+		return FALSE
+
+	return TRUE
 
 /obj/structure/grille/Bumped(atom/movable/AM)
 	if(!ismob(AM))
@@ -159,9 +192,8 @@
 		if(!shock(user, 90))
 			user.visible_message("<span class='notice'>[user] rebuilds the broken grille.</span>", \
 				"<span class='notice'>You rebuild the broken grille.</span>")
-			new grille_type(src.loc)
+			repair_grille()
 			R.use(1)
-			qdel(src)
 			return
 
 //window placing begin
@@ -178,11 +210,15 @@
 			for(var/obj/structure/window/WINDOW in loc)
 				to_chat(user, "<span class='warning'>There is already a window there!</span>")
 				return
+			if(!clear_tile(user))
+				return
 			to_chat(user, "<span class='notice'>You start placing the window...</span>")
 			if(do_after(user,20, target = src))
 				if(!src.loc || !anchored) //Grille broken or unanchored while waiting
 					return
 				for(var/obj/structure/window/WINDOW in loc) //Another window already installed on grille
+					return
+				if(!clear_tile(user))
 					return
 				var/obj/structure/window/WD
 				if(istype(W, /obj/item/stack/sheet/plasmarglass))
@@ -232,11 +268,25 @@
 
 /obj/structure/grille/obj_break()
 	if(!broken && !(flags_1 & NODECONSTRUCT_1))
-		new broken_type(src.loc)
+		icon_state = "brokengrille"
+		density = FALSE
+		obj_integrity = 20
+		broken = TRUE
+		rods_amount = 1
+		rods_broken = FALSE
 		var/obj/R = new rods_type(drop_location(), rods_broken)
 		transfer_fingerprints_to(R)
-		qdel(src)
 
+/obj/structure/grille/proc/repair_grille()
+	if(broken)
+		icon_state = "grille"
+		density = TRUE
+		obj_integrity = max_integrity
+		broken = FALSE
+		rods_amount = 2
+		rods_broken = TRUE
+		return TRUE
+	return FALSE
 
 // shock user with probability prb (if all connections & power are working)
 // returns 1 if shocked, 0 otherwise
@@ -289,5 +339,3 @@
 	broken = TRUE
 	rods_amount = 1
 	rods_broken = FALSE
-	grille_type = /obj/structure/grille
-	broken_type = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- RCD repairs grilles before adding windows to them
- Grilles need to be clear of unanchored items for a window to fit over them
- Attempting to build a window on a grille will move 20 unanchored items to your tile
- If unanchored items remain on the tile, adding the window will fail
- You can attempt to add the window again to move 20 more items
- It's unlikely the tile of a missing window will have more than a shard or rods on it
- It's still possible to secure full tile windows over piles of items
- Grilles no longer rely on a subtype to break

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
1. Makes adding windows with the RCD consistent with adding them by hand (can't use a broken grille)
2. Makes repairing a window without leaving a mess much faster
3. Grilles no longer spawn a different version of themselves when they break or get fixed
4. Adds logic to window replacement which leads to better-looking results while asking little extra of players
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
qol: RCD repairs grilles when adding windows
balance: If a grille's tile has unanchored items on it, adding a window will fail
qol: Attempting to add a window to a grille with unanchored items on the tile will move 20 of them to your tile
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
