### PR TITLE
Lighter Grammar Fix

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -49,8 +49,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		inhand_icon_state = "cigon"
 		name = "lit [initial(name)]"
 		desc = "A [initial(name)]. This one is lit."
-		attack_verb_continuous = string_list(list("burns", "sings"))
-		attack_verb_simple = string_list(list("burn", "sing"))
+		attack_verb_continuous = string_list(list("burns", "singes", "scorches"))
+		attack_verb_simple = string_list(list("burn", "singe", "scorch"))
 		START_PROCESSING(SSobj, src)
 		update_appearance()
 
@@ -191,8 +191,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	lit = TRUE
 	name = "lit [name]"
-	attack_verb_continuous = string_list(list("burns", "sings"))
-	attack_verb_simple = string_list(list("burn", "sing"))
+	attack_verb_continuous = string_list(list("burns", "singes", "scorches"))
+	attack_verb_simple = string_list(list("burn", "singe", "scorch"))
 	hitsound = 'sound/items/welder.ogg'
 	damtype = BURN
 	force = 4
@@ -692,8 +692,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		force = 5
 		damtype = BURN
 		hitsound = 'sound/items/welder.ogg'
-		attack_verb_continuous = string_list(list("burns", "sings"))
-		attack_verb_simple = string_list(list("burn", "sing"))
+		attack_verb_continuous = string_list(list("burns", "singes", "scorches"))
+		attack_verb_simple = string_list(list("burn", "singe", "scorch"))
 		START_PROCESSING(SSobj, src)
 	else
 		hitsound = "swing_hit"

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -49,8 +49,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		inhand_icon_state = "cigon"
 		name = "lit [initial(name)]"
 		desc = "A [initial(name)]. This one is lit."
-		attack_verb_continuous = string_list(list("burns", "singes", "scorches"))
-		attack_verb_simple = string_list(list("burn", "singe", "scorch"))
+		attack_verb_continuous = string_list(list("burns", "singes"))
+		attack_verb_simple = string_list(list("burn", "singe"))
 		START_PROCESSING(SSobj, src)
 		update_appearance()
 
@@ -191,8 +191,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	lit = TRUE
 	name = "lit [name]"
-	attack_verb_continuous = string_list(list("burns", "singes", "scorches"))
-	attack_verb_simple = string_list(list("burn", "singe", "scorch"))
+	attack_verb_continuous = string_list(list("burns", "singes"))
+	attack_verb_simple = string_list(list("burn", "singe"))
 	hitsound = 'sound/items/welder.ogg'
 	damtype = BURN
 	force = 4
@@ -692,8 +692,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		force = 5
 		damtype = BURN
 		hitsound = 'sound/items/welder.ogg'
-		attack_verb_continuous = string_list(list("burns", "singes", "scorches"))
-		attack_verb_simple = string_list(list("burn", "singe", "scorch"))
+		attack_verb_continuous = string_list(list("burns", "singes"))
+		attack_verb_simple = string_list(list("burn", "singe"))
 		START_PROCESSING(SSobj, src)
 	else
 		hitsound = "swing_hit"

--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -217,8 +217,8 @@
 		force = 5
 		damtype = BURN
 		hitsound = 'sound/items/welder.ogg'
-		attack_verb_continuous = string_list(list("burns", "sings"))
-		attack_verb_simple = string_list(list("burn", "sing"))
+		attack_verb_continuous = string_list(list("burns", "singes"))
+		attack_verb_simple = string_list(list("burn", "singe"))
 		START_PROCESSING(SSobj, src)
 	else
 		hitsound = "swing_hit"

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -37,8 +37,8 @@ Slimecrossing Weapons
 			attack_verb_simple = string_list(list("slash", "slice", "cut"))
 		if(BURN)
 			hitsound = 'sound/weapons/sear.ogg'
-			attack_verb_continuous = string_list(list("burns", "sings", "heats"))
-			attack_verb_simple = string_list(list("burn", "sing", "heat"))
+			attack_verb_continuous = string_list(list("burns", "singes", "heats"))
+			attack_verb_simple = string_list(list("burn", "singe", "heat"))
 		if(TOX)
 			hitsound = 'sound/weapons/pierce.ogg'
 			attack_verb_continuous = string_list(list("poisons", "doses", "toxifies"))


### PR DESCRIPTION
The infernal serenade has come to an end. Lighters no longer sing when you attack with them. Now, they singe.

(Edit: Changed fix to spellcheck because I did an oopsie. Officially bad first PR)

## About The Pull Request

Simple attack verb replacement fixing an incorrect word

## Why It's Good For The Game

The total number of incorrect words in the code has decreased

## Changelog
:cl:
spellcheck: Corrects sing/sings to singe/singes
/:cl:

