### PR TITLE
RPD can destroy broken disposal pipes

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -447,7 +447,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 	. = TRUE
 
-	if((mode & DESTROY_MODE) && istype(attack_target, /obj/item/pipe) || istype(attack_target, /obj/structure/disposalconstruct) || istype(attack_target, /obj/structure/c_transit_tube) || istype(attack_target, /obj/structure/c_transit_tube_pod) || istype(attack_target, /obj/item/pipe_meter))
+	if((mode & DESTROY_MODE) && istype(attack_target, /obj/item/pipe) || istype(attack_target, /obj/structure/disposalconstruct) || istype(attack_target, /obj/structure/c_transit_tube) || istype(attack_target, /obj/structure/c_transit_tube_pod) || istype(attack_target, /obj/item/pipe_meter) || istype(attack_target, /obj/structure/disposalpipe/broken))
 		to_chat(user, "<span class='notice'>You start destroying a pipe...</span>")
 		playsound(get_turf(src), 'sound/machines/click.ogg', 50, TRUE)
 		if(do_after(user, destroy_speed, target = attack_target))

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -117,8 +117,10 @@
 
 		var/turf/T = get_turf(src)
 		if(T.intact && isfloorturf(T))
-			to_chat(user, "<span class='warning'>You can only attach the [pipename] if the floor plating is removed!</span>")
-			return TRUE
+			var/obj/item/crowbar/held_crowbar = user.is_holding_item_of_type(/obj/item/crowbar)
+			if(!held_crowbar || !T.crowbar_act(user, held_crowbar))
+				to_chat(user, "<span class='warning'>You can only attach the [pipename] if the floor plating is removed!</span>")
+				return TRUE
 
 		if(!ispipe && iswallturf(T))
 			to_chat(user, "<span class='warning'>You can't build [pipename]s on walls, only disposal pipes!</span>")
@@ -131,8 +133,11 @@
 				if(istype(CP, /obj/structure/disposalpipe/broken))
 					pdir = CP.dir
 				if(pdir & dpdir)
-					to_chat(user, "<span class='warning'>There is already a disposal pipe at that location!</span>")
-					return TRUE
+					if(istype(CP, /obj/structure/disposalpipe/broken))
+						qdel(CP)
+					else
+						to_chat(user, "<span class='warning'>There is already a disposal pipe at that location!</span>")
+						return TRUE
 
 		else // Disposal or outlet
 			var/found_trunk = locate(/obj/structure/disposalpipe/trunk) in T


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Aims to speed up the replacement of broken disposal pipes by making it less demanding on the player. Hopefully this will lead to it happening more often. Does this by:

- Allowing the RPD to destroy broken disposal pipes
- Automatically destroying broken disposal pipes before trying to secure new ones of the same direction over the top of them
- Automatically crowbarring floor tiles while trying to secure disposal pipes over the top of them if a crowbar is held in the offhand

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Speeds up the rate at which broken disposal pipes can be replaced.

At the moment to replace a disposal pipe you have to weld each end of the broken pipe. It requires fuel, activation of eye protection and three seconds per end. This becomes time consuming when you have a lot of pipes to replace. It only serves to further disincentivise repair of everything but small breaches.

This PR lessens the requirement to only an RPD and half a second per end. You can also just place a pipe of the same direction over a broken pipe and the ends will be deleted for you. If you place a disposal pipe over a broken pipe that's above a floor tile while holding a crowbar, the floor tile will be removed so the RPD can secure the pipe. All that's left is welding the pipe and replacing the floor tile.

Hopefully this will lead to more people replacing disposals. There's still undesirable difficulty in finding out where pipes went and which ones were used (if you can't figure it out the only solution is making do or looking at the .dmm -- usually it just doesn't get fixed) but that's out of scope for this pull request. Replacing disposal pipes is just one of several jobs involved in repairing hull breaches that players don't want to do. Hopefully this eases the tedium of replacing obvious pipes.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
qol: RPD can destroy broken disposal pipes
qol: Securing a disposal pipe over a broken disposal pipe will delete it
balance: Securing a disposal pipe over a floor tile with a crowbar in your offhand will remove the floor tile before trying to secure it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
