### PR TITLE
Mutations with class MUT_OTHER can no longer be saved

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -755,6 +755,11 @@
 			// GUARD CHECK - This should not be possible. Unexpected result
 			if(!HM)
 				return
+			
+			// Checks for things that should not be copied my any means- wizard spells, holy mutations, etc
+			if(initial(HM.class) == MUT_OTHER)
+				say("ERROR: This mutation is anomalous, and cannot be made into an injector.")
+				injectorready = world.time + INJECTOR_TIMEOUT
 
 			// Create a new DNA Injector and add the appropriate mutations to it
 			var/obj/item/dnainjector/activator/I = new /obj/item/dnainjector/activator(loc)
@@ -1436,9 +1441,23 @@
 
 			// Run through each mutation in our Advanced Injector and add them to a
 			//  new injector
+			
+			var/bad_mutation_alert = FALSE
+			
+			
 			for(var/A in injector)
 				var/datum/mutation/human/HM = A
+				if(initial(HM.class) == MUT_OTHER)
+					bad_mutation_alert = TRUE
+					continue //skip this one
 				I.add_mutations += new HM.type(copymut=HM)
+
+			//if only bad mutations were tried
+			if(!I.mutations)
+				qdel(I)
+			
+			if(bad_mutation_alert)
+				say("ERROR: At least one mutation was anomalous, and had to be skipped.")
 
 			// Force apply any mutations, this is functionality similar to mutators
 			I.doitanyway = TRUE

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -755,11 +755,6 @@
 			// GUARD CHECK - This should not be possible. Unexpected result
 			if(!HM)
 				return
-			
-			// Checks for things that should not be copied my any means- wizard spells, holy mutations, etc
-			if(initial(HM.class) == MUT_OTHER)
-				say("ERROR: This mutation is anomalous, and cannot be made into an injector.")
-				injectorready = world.time + INJECTOR_TIMEOUT
 
 			// Create a new DNA Injector and add the appropriate mutations to it
 			var/obj/item/dnainjector/activator/I = new /obj/item/dnainjector/activator(loc)
@@ -818,6 +813,11 @@
 
 			// GUARD CHECK - This should not be possible. Unexpected result
 			if(!HM)
+				return
+
+			// Saving temporary or unobtainable mutations leads to gratuitous abuse
+			if(HM.class == MUT_OTHER)
+				say("ERROR: This mutation is anomalous, and cannot be saved.")
 				return
 
 			var/datum/mutation/human/A = new HM.type()
@@ -1441,23 +1441,9 @@
 
 			// Run through each mutation in our Advanced Injector and add them to a
 			//  new injector
-			
-			var/bad_mutation_alert = FALSE
-			
-			
 			for(var/A in injector)
 				var/datum/mutation/human/HM = A
-				if(initial(HM.class) == MUT_OTHER)
-					bad_mutation_alert = TRUE
-					continue //skip this one
 				I.add_mutations += new HM.type(copymut=HM)
-
-			//if only bad mutations were tried
-			if(!I.mutations)
-				qdel(I)
-			
-			if(bad_mutation_alert)
-				say("ERROR: At least one mutation was anomalous, and had to be skipped.")
 
 			// Force apply any mutations, this is functionality similar to mutators
 			I.doitanyway = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables creating injectors of abnormally added mutations

## Why It's Good For The Game

MUT_OTHER are special mutations that are not meant to be copied, removed, or modified. Letting people copy temporary mutations like wizard ones to reapply permanently is really bad, letting people copy the holy mutations is somehow worse

## Changelog
:cl:
fix: you can no longer copy honorbound, burdened, wizard mutations, other heinous shit
/:cl: