### PR TITLE
beepsky smash once again heals the stamina damage of sec officers

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -801,8 +801,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.Jitter(2)
 	var/obj/item/organ/liver/liver = M.getorganslot(ORGAN_SLOT_LIVER)
-	// if you don't have a liver, or your liver isn't an officer's liver
-	if(!liver || !HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
+	// if you have a liver and that liver is an officer's liver
+	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		M.adjustStaminaLoss(-10 * REM * delta_time, 0)
 		if(DT_PROB(10, delta_time))
 			new /datum/hallucination/items_other(M)


### PR DESCRIPTION
## About The Pull Request

Beepsky smash's stamina healing and non-beepsky-related hallucinatory effects are now applied to people WITH sec-affiliated livers instead of to people WITHOUT sec-affiliated livers, restoring its previous, intended functionality.

## Why It's Good For The Game

epic copy+paste error

In case you didn't already know, this was how beepsky smash worked before the departmental liver update: Non-seccies who drank beepsky smash would risk acquiring a phobia of sec if they OD'd, get drunk (as they would if they drank any other alcoholic drink), and have a hallucinatory beepsky chase them around, while seccies who drank it would gain an impressive amount of stamina regeneration at the cost of getting drunk as hell, seeing hallucinatory items in the hands of other people, and having to dodge hallucinatory projectiles.

Currently, non-seccies get all of the above effects, and seccies get jack shit aside from the normal drunkenness caused by alcoholic drinks, which almost certainly isn't intentional.

## Changelog
:cl: ATHATH
fix: Beepsky smash's stamina healing and non-beepsky-related hallucinatory effects are now applied to people WITH sec-affiliated livers instead of to people WITHOUT sec-affiliated livers, restoring its previous, intended functionality.
/:cl: