### PR TITLE
PDAs reset the alert overlay when you read your messages

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -398,6 +398,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 							dat += "<br><a href='byond://?src=[REF(src)];choice=SkillReward;skill=[type]'>Contact the Professional [S.title] Association</a>"
 						dat += "</li></ul>"
 			if(21)
+				if(icon_alert)
+					cut_overlay(icon_alert)
+
 				dat += "<h4>[PDAIMG(mail)] SpaceMessenger V3.9.6</h4>"
 				dat += "<a href='byond://?src=[REF(src)];choice=Clear'>[PDAIMG(blank)]Clear Messages</a>"
 


### PR DESCRIPTION
## About The Pull Request

Title

## Why It's Good For The Game

Getting one message and having your PDA flash at you for the rest of the round was annoying as shit

## Changelog
:cl:
fix: PDAs will no longer flash at you over messages that you've already read
/:cl: