### PR TITLE
Keybind to skip confirm prompt for dragging ghosts onto mobs

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -14,6 +14,7 @@
 #define COMSIG_KB_ADMIN_INVISIMINTOGGLE_DOWN "keybinding_admin_invisimintoggle_down"
 #define COMSIG_KB_ADMIN_DEADMIN_DOWN "keybinding_admin_deadmin_down"
 #define COMSIG_KB_ADMIN_READMIN_DOWN "keybinding_admin_readmin_down"
+#define COMSIG_KB_ADMIN_CONF_OVERRIDE_DOWN "keybinding_admin_conf_override_down"
 
 //Carbon
 #define COMSIG_KB_CARBON_HOLDRUNMOVEINTENT_DOWN "keybinding_carbon_holdrunmoveintent_down"

--- a/code/datums/keybinding/admin.dm
+++ b/code/datums/keybinding/admin.dm
@@ -130,3 +130,18 @@
 		return
 	user.readmin()
 	return TRUE
+
+/datum/keybinding/admin/confirm_override
+	name = "confirm_override"
+	full_name = "Confirmation Override Mode"
+	description = "Override confirmation prompts for admin actions (Hold)"
+	keybind_signal = COMSIG_KB_ADMIN_CONF_OVERRIDE_DOWN
+
+/datum/keybinding/admin/confirm_override/down(client/user)
+	. = ..()
+	if(.)
+		return
+	user.confirmation_override = TRUE
+
+/datum/keybinding/admin/confirm_override/up(client/user)
+	user.confirmation_override = FALSE

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -917,7 +917,7 @@
 
 //returns TRUE to let the dragdrop code know we are trapping this event
 //returns FALSE if we don't plan to trap the event
-/datum/admins/proc/cmd_ghost_drag(mob/dead/observer/frommob, mob/tomob)
+/datum/admins/proc/cmd_ghost_drag(mob/dead/observer/frommob, mob/tomob, params)
 
 	//this is the exact two check rights checks required to edit a ckey with vv.
 	if (!check_rights(R_VAREDIT,0) || !check_rights(R_SPAWN|R_DEBUG,0))
@@ -926,14 +926,16 @@
 	if (!frommob.ckey)
 		return FALSE
 
-	var/question = ""
-	if (tomob.ckey)
-		question = "This mob already has a user ([tomob.key]) in control of it! "
-	question += "Are you sure you want to place [frommob.name]([frommob.key]) in control of [tomob.name]?"
+	var/modifiers = params2list(params)
+	if(!LAZYACCESS(modifiers, SHIFT_CLICK))
+		var/question = ""
+		if (tomob.ckey)
+			question = "This mob already has a user ([tomob.key]) in control of it! "
+		question += "Are you sure you want to place [frommob.name]([frommob.key]) in control of [tomob.name]?"
 
-	var/ask = alert(question, "Place ghost in control of mob?", "Yes", "No")
-	if (ask != "Yes")
-		return TRUE
+		var/ask = alert(question, "Place ghost in control of mob?", "Yes", "No")
+		if (ask != "Yes")
+			return TRUE
 
 	if (!frommob || !tomob) //make sure the mobs don't go away while we waited for a response
 		return TRUE

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -926,8 +926,7 @@
 	if (!frommob.ckey)
 		return FALSE
 
-	var/modifiers = params2list(params)
-	if(!LAZYACCESS(modifiers, SHIFT_CLICK))
+	if(!owner.confirmation_override)
 		var/question = ""
 		if (tomob.ckey)
 			question = "This mob already has a user ([tomob.key]) in control of it! "

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -209,3 +209,6 @@
 
 	/// If the client is currently under the restrictions of the interview system
 	var/interviewee = FALSE
+
+	/// For admins: override confirmation prompts
+	var/confirmation_override = FALSE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -933,6 +933,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			return FALSE
 		if (NAMEOF(src, key))
 			return FALSE
+		if(NAMEOF(src, confirmation_override))
+			return FALSE
 		if(NAMEOF(src, view))
 			view_size.setDefault(var_value)
 			return TRUE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -682,11 +682,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	GLOB.crew_manifest_tgui.ui_interact(src)
 
 //this is called when a ghost is drag clicked to something.
-/mob/dead/observer/MouseDrop(atom/over)
+/mob/dead/observer/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
 	if(!usr || !over)
 		return
 	if (isobserver(usr) && usr.client.holder && (isliving(over) || iscameramob(over)) )
-		if (usr.client.holder.cmd_ghost_drag(src,over))
+		if (usr.client.holder.cmd_ghost_drag(src, over, params))
 			return
 
 	return ..()


### PR DESCRIPTION
## About The Pull Request

The "Are you sure you want to place `yourself` in control of `mobyoujustspawned`?" prompt is annoying when testing. Now there is a bindable key, unbound by default, which automatically skips this prompt.

## Why It's Good For The Game

Helps speed up testing.

## Changelog
:cl: JJRcop
admin: New keybind which lets you skip the confirmation prompt of dragging a ghost onto a mob.
/:cl:
