### PR TITLE
The Captain can now open and reuse their display case.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -102312,10 +102312,7 @@
 /turf/open/floor/iron,
 /area/medical/virology)
 "uYQ" = (
-/obj/structure/displaycase/captain{
-	req_access = null;
-	req_access_txt = "20"
-	},
+/obj/structure/displaycase/captain,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain)
 "uZi" = (

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -267,7 +267,7 @@
 //The lab cage and captain's display case do not spawn with electronics, which is why req_access is needed.
 /obj/structure/displaycase/captain
 	start_showpiece_type = /obj/item/gun/energy/laser/captain
-	req_access = list(ACCESS_CENT_SPECOPS) //this was intentional, presumably to make it slightly harder for caps to grab their gun roundstart
+	req_access = list(ACCESS_CAPTAIN)
 
 /obj/structure/displaycase/labcage
 	name = "lab cage"


### PR DESCRIPTION
## About The Pull Request

![1](https://user-images.githubusercontent.com/51800976/116760926-ec296580-a9db-11eb-8942-eac25960055c.png)

![2](https://user-images.githubusercontent.com/51800976/116760932-ef245600-a9db-11eb-8e67-e2bcf9370eee.png)

![3](https://user-images.githubusercontent.com/51800976/116760935-f186b000-a9db-11eb-97aa-d0edeae01f0e.png)

![4](https://user-images.githubusercontent.com/51800976/116760938-f3e90a00-a9db-11eb-949d-664dcb5b86fa.png)

![5](https://user-images.githubusercontent.com/51800976/116760942-f6e3fa80-a9db-11eb-9f23-ca97f3efb397.png)*
*(Disclaimer: Nanotrasen does not advise leaving the nuclear authentication disk in the display case)


As per the title, the captain can now open their display case without breaking it, take their gun, and even put other stuff inside.
Show off that prized decapitated head of the tider who broke in roundstart.

Also removed a now redundant snowflake varedit from Deltastation's Captain's display case.

## Why It's Good For The Game

Presently it has some sort of centcom access for ??? reasons, elaborated on in a comment, "this was intentional, presumably to make it slightly harder for caps to grab their gun roundstart".
Slightly indeed, it's a few seconds of hitting the case with your sword to break it, then hitting the firealarm and unbolting the doors with your remote. I don't see how this discourages Captains from lugging the gun around at round start (never stopped me) nor others from yoinking it, it's just an inconsistent annoyance.

## Changelog
:cl:
qol: The Captain can now open their own display case, and also put other things inside.
/:cl:
