### PR TITLE
Cleans up some fallout from canister processing changes

### DIFF
--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -240,7 +240,7 @@
 			else if (istype(atmosmch, /obj/machinery/atmospherics/components/unary/portables_connector))
 				var/obj/machinery/atmospherics/components/unary/portables_connector/considered_connector = atmosmch
 				if(considered_connector.connected_device)
-					gas_mixture_list += considered_connector.connected_device.air_contents
+					gas_mixture_list += considered_connector.connected_device.return_air()
 
 	var/total_thermal_energy = 0
 	var/total_heat_capacity = 0

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -462,6 +462,12 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 
 	return TRUE
 
+/obj/machinery/portable_atmospherics/canister/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", sound_effect = TRUE, attack_dir, armour_penetration = 0)
+	. = ..()
+	if(!.)
+		return
+	SSair.start_processing_machine(src)
+
 /obj/machinery/portable_atmospherics/canister/obj_break(damage_flag)
 	. = ..()
 	if(!.)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cleans up some stuff from #58418
Namely:  
A use of air_contents in pipeline code, it's not doing anything yet, but if someone wants to change how reactions work they might break it. 
Adds proc override to catch taking damage, which fixes the canister not leaking until it's updated

## Why It's Good For The Game

When you hit a canister, it should leak. Big brained I know.

## Changelog
:cl:
fix: Fixed hitting a canister not cause it to leak until it's interacted with in some other wa
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
