### PR TITLE
Allows canister repairs and adds right click tool acts

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -193,8 +193,12 @@
 #define COMSIG_ATOM_CANREACH "atom_can_reach"
 	#define COMPONENT_ALLOW_REACH (1<<0)
 ///for any tool behaviors: (mob/living/user, obj/item/I, list/recipes)
-#define COMSIG_ATOM_TOOL_ACT(tooltype) "tool_recipe_discovery_[tooltype]"
+#define COMSIG_ATOM_TOOL_ACT(tooltype) "tool_act_[tooltype]"
 	#define COMPONENT_BLOCK_TOOL_ATTACK (1<<0)
+///for any rightclick tool behaviors: (mob/living/user, obj/item/I)
+#define COMSIG_ATOM_SECONDARY_TOOL_ACT(tooltype) "tool_secondary_act_[tooltype]"
+	// We have the same returns here as COMSIG_ATOM_TOOL_ACT
+	// #define COMPONENT_BLOCK_TOOL_ATTACK (1<<0)
 ///for when an atom has been created through processing (atom/original_atom, list/chosen_processing_option)
 #define COMSIG_ATOM_CREATEDBY_PROCESSING "atom_createdby_processing"
 ///when an atom is processed (mob/living/user, obj/item/I, list/atom/results)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -11,7 +11,7 @@
 
 	var/is_right_clicking = LAZYACCESS(params2list(params), RIGHT_CLICK)
 
-	if(tool_behaviour && target.tool_act(user, src, tool_behaviour))
+	if(tool_behaviour && target.tool_act(user, src, tool_behaviour, is_right_clicking))
 		return TRUE
 
 	var/pre_attack_result

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1352,28 +1352,47 @@
  *
  * Must return  parent proc ..() in the end if overridden
  */
-/atom/proc/tool_act(mob/living/user, obj/item/I, tool_type)
-	var/list/processing_recipes = list() //List of recipes that can be mutated by sending the signal
-	var/signal_result = SEND_SIGNAL(src, COMSIG_ATOM_TOOL_ACT(tool_type), user, I, processing_recipes)
-	if(processing_recipes.len)
-		process_recipes(user, I, processing_recipes)
-	if(QDELETED(I))
-		return TRUE
-	switch(tool_type)
-		if(TOOL_CROWBAR)
-			. = crowbar_act(user, I)
-		if(TOOL_MULTITOOL)
-			. = multitool_act(user, I)
-		if(TOOL_SCREWDRIVER)
-			. = screwdriver_act(user, I)
-		if(TOOL_WRENCH)
-			. = wrench_act(user, I)
-		if(TOOL_WIRECUTTER)
-			. = wirecutter_act(user, I)
-		if(TOOL_WELDER)
-			. = welder_act(user, I)
-		if(TOOL_ANALYZER)
-			. = analyzer_act(user, I)
+/atom/proc/tool_act(mob/living/user, obj/item/I, tool_type, is_right_clicking)
+	var/signal_result
+	if(!is_right_clicking) // Left click first for sensibility
+		var/list/processing_recipes = list() //List of recipes that can be mutated by sending the signal
+		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_TOOL_ACT(tool_type), user, I, processing_recipes)
+		if(processing_recipes.len)
+			process_recipes(user, I, processing_recipes)
+		if(QDELETED(I))
+			return TRUE
+		switch(tool_type)
+			if(TOOL_CROWBAR)
+				. = crowbar_act(user, I,)
+			if(TOOL_MULTITOOL)
+				. = multitool_act(user, I)
+			if(TOOL_SCREWDRIVER)
+				. = screwdriver_act(user, I)
+			if(TOOL_WRENCH)
+				. = wrench_act(user, I)
+			if(TOOL_WIRECUTTER)
+				. = wirecutter_act(user, I)
+			if(TOOL_WELDER)
+				. = welder_act(user, I)
+			if(TOOL_ANALYZER)
+				. = analyzer_act(user, I)
+	else
+		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_SECONDARY_TOOL_ACT(tool_type), user, I)
+		switch(tool_type)
+			if(TOOL_CROWBAR)
+				. = secondary_crowbar_act(user, I,)
+			if(TOOL_MULTITOOL)
+				. = secondary_multitool_act(user, I)
+			if(TOOL_SCREWDRIVER)
+				. = secondary_screwdriver_act(user, I)
+			if(TOOL_WRENCH)
+				. = secondary_wrench_act(user, I)
+			if(TOOL_WIRECUTTER)
+				. = secondary_wirecutter_act(user, I)
+			if(TOOL_WELDER)
+				. = secondary_welder_act(user, I)
+			if(TOOL_ANALYZER)
+				. = secondary_analyzer_act(user, I)
 	if(. || signal_result & COMPONENT_BLOCK_TOOL_ATTACK) //Either the proc or the signal handled the tool's events in some way.
 		return TRUE
 
@@ -1430,12 +1449,20 @@
 //! Tool-specific behavior procs.
 ///
 
-///Crowbar act
-/atom/proc/crowbar_act(mob/living/user, obj/item/I)
+/// Called on an object when a tool with crowbar capabilities is used to left click an object
+/atom/proc/crowbar_act(mob/living/user, obj/item/tool)
 	return
 
-///Multitool act
-/atom/proc/multitool_act(mob/living/user, obj/item/I)
+/// Called on an object when a tool with crowbar capabilities is used to right click an object
+/atom/proc/secondary_crowbar_act(mob/living/user, obj/item/tool)
+	return
+
+/// Called on an object when a tool with multitool capabilities is used to left click an object
+/atom/proc/multitool_act(mob/living/user, obj/item/tool)
+	return
+
+/// Called on an object when a tool with multitool capabilities is used to right click an object
+/atom/proc/secondary_multitool_act(mob/living/user, obj/item/tool)
 	return
 
 ///Check if the multitool has an item in it's data buffer
@@ -1446,24 +1473,44 @@
 		return FALSE
 	return TRUE
 
-///Screwdriver act
-/atom/proc/screwdriver_act(mob/living/user, obj/item/I)
+/// Called on an object when a tool with screwdriver capabilities is used to left click an object
+/atom/proc/screwdriver_act(mob/living/user, obj/item/tool)
 	return
 
-///Wrench act
-/atom/proc/wrench_act(mob/living/user, obj/item/I)
+/// Called on an object when a tool with screwdriver capabilities is used to right click an object
+/atom/proc/secondary_screwdriver_act(mob/living/user, obj/item/tool)
 	return
 
-///Wirecutter act
-/atom/proc/wirecutter_act(mob/living/user, obj/item/I)
+/// Called on an object when a tool with wrench capabilities is used to left click an object
+/atom/proc/wrench_act(mob/living/user, obj/item/tool)
 	return
 
-///Welder act
-/atom/proc/welder_act(mob/living/user, obj/item/I)
+/// Called on an object when a tool with wrench capabilities is used to right click an object
+/atom/proc/secondary_wrench_act(mob/living/user, obj/item/tool)
 	return
 
-///Analyzer act
-/atom/proc/analyzer_act(mob/living/user, obj/item/I)
+/// Called on an object when a tool with wirecutter capabilities is used to left click an object
+/atom/proc/wirecutter_act(mob/living/user, obj/item/tool)
+	return
+
+/// Called on an object when a tool with wirecutter capabilities is used to right click an object
+/atom/proc/secondary_wirecutter_act(mob/living/user, obj/item/tool)
+	return
+
+/// Called on an object when a tool with welder capabilities is used to left click an object
+/atom/proc/welder_act(mob/living/user, obj/item/tool)
+	return
+
+/// Called on an object when a tool with welder capabilities is used to right click an object
+/atom/proc/secondary_welder_act(mob/living/user, obj/item/tool)
+	return
+
+/// Called on an object when a tool with analyzer capabilities is used to left click an object
+/atom/proc/analyzer_act(mob/living/user, obj/item/tool)
+	return
+
+/// Called on an object when a tool with analyzer capabilities is used to right click an object
+/atom/proc/secondary_analyzer_act(mob/living/user, obj/item/tool)
 	return
 
 ///Generate a tag for this atom

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1380,19 +1380,19 @@
 		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_SECONDARY_TOOL_ACT(tool_type), user, I)
 		switch(tool_type)
 			if(TOOL_CROWBAR)
-				. = secondary_crowbar_act(user, I,)
+				. = crowbar_act_secondary(user, I,)
 			if(TOOL_MULTITOOL)
-				. = secondary_multitool_act(user, I)
+				. = multitool_act_secondary(user, I)
 			if(TOOL_SCREWDRIVER)
-				. = secondary_screwdriver_act(user, I)
+				. = screwdriver_act_secondary(user, I)
 			if(TOOL_WRENCH)
-				. = secondary_wrench_act(user, I)
+				. = wrench_act_secondary(user, I)
 			if(TOOL_WIRECUTTER)
-				. = secondary_wirecutter_act(user, I)
+				. = wirecutter_act_secondary(user, I)
 			if(TOOL_WELDER)
-				. = secondary_welder_act(user, I)
+				. = welder_act_secondary(user, I)
 			if(TOOL_ANALYZER)
-				. = secondary_analyzer_act(user, I)
+				. = analyzer_act_secondary(user, I)
 	if(. || signal_result & COMPONENT_BLOCK_TOOL_ATTACK) //Either the proc or the signal handled the tool's events in some way.
 		return TRUE
 
@@ -1454,7 +1454,7 @@
 	return
 
 /// Called on an object when a tool with crowbar capabilities is used to right click an object
-/atom/proc/secondary_crowbar_act(mob/living/user, obj/item/tool)
+/atom/proc/crowbar_act_secondary(mob/living/user, obj/item/tool)
 	return
 
 /// Called on an object when a tool with multitool capabilities is used to left click an object
@@ -1462,7 +1462,7 @@
 	return
 
 /// Called on an object when a tool with multitool capabilities is used to right click an object
-/atom/proc/secondary_multitool_act(mob/living/user, obj/item/tool)
+/atom/proc/multitool_act_secondary(mob/living/user, obj/item/tool)
 	return
 
 ///Check if the multitool has an item in it's data buffer
@@ -1478,7 +1478,7 @@
 	return
 
 /// Called on an object when a tool with screwdriver capabilities is used to right click an object
-/atom/proc/secondary_screwdriver_act(mob/living/user, obj/item/tool)
+/atom/proc/screwdriver_act_secondary(mob/living/user, obj/item/tool)
 	return
 
 /// Called on an object when a tool with wrench capabilities is used to left click an object
@@ -1486,7 +1486,7 @@
 	return
 
 /// Called on an object when a tool with wrench capabilities is used to right click an object
-/atom/proc/secondary_wrench_act(mob/living/user, obj/item/tool)
+/atom/proc/wrench_act_secondary(mob/living/user, obj/item/tool)
 	return
 
 /// Called on an object when a tool with wirecutter capabilities is used to left click an object
@@ -1494,7 +1494,7 @@
 	return
 
 /// Called on an object when a tool with wirecutter capabilities is used to right click an object
-/atom/proc/secondary_wirecutter_act(mob/living/user, obj/item/tool)
+/atom/proc/wirecutter_act_secondary(mob/living/user, obj/item/tool)
 	return
 
 /// Called on an object when a tool with welder capabilities is used to left click an object
@@ -1502,7 +1502,7 @@
 	return
 
 /// Called on an object when a tool with welder capabilities is used to right click an object
-/atom/proc/secondary_welder_act(mob/living/user, obj/item/tool)
+/atom/proc/welder_act_secondary(mob/living/user, obj/item/tool)
 	return
 
 /// Called on an object when a tool with analyzer capabilities is used to left click an object
@@ -1510,7 +1510,7 @@
 	return
 
 /// Called on an object when a tool with analyzer capabilities is used to right click an object
-/atom/proc/secondary_analyzer_act(mob/living/user, obj/item/tool)
+/atom/proc/analyzer_act_secondary(mob/living/user, obj/item/tool)
 	return
 
 ///Generate a tag for this atom

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -326,7 +326,6 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 	greyscale_colors = "#ffffff#a50021#ffffff"
 	mode = NONE
 
-
 /obj/machinery/portable_atmospherics/canister/proto/default
 	name = "prototype canister"
 	desc = "The best way to fix an atmospheric emergency... or the best way to introduce one."
@@ -336,7 +335,6 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 	can_max_release_pressure = (ONE_ATMOSPHERE * 30)
 	can_min_release_pressure = (ONE_ATMOSPHERE / 30)
 	prototype = TRUE
-
 
 /obj/machinery/portable_atmospherics/canister/proto/default/oxygen
 	name = "prototype canister"
@@ -443,11 +441,8 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 			new /obj/item/stack/sheet/bluespace_crystal (drop_location(), 1)
 	qdel(src)
 
-/obj/machinery/portable_atmospherics/canister/welder_act(mob/living/user, obj/item/I)
+/obj/machinery/portable_atmospherics/canister/secondary_welder_act(mob/living/user, obj/item/I)
 	. = ..()
-	if(user.combat_mode)
-		return FALSE
-
 	if(!I.tool_start_check(user, amount=0))
 		return TRUE
 	var/pressure = air_contents.return_pressure()
@@ -459,7 +454,25 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 	if(I.use_tool(src, user, 3 SECONDS, volume=50))
 		to_chat(user, "<span class='notice'>You cut \the [src] apart.</span>")
 		deconstruct(TRUE)
+	return TRUE
 
+/obj/machinery/portable_atmospherics/canister/welder_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if(user.combat_mode)
+		return FALSE
+	if(obj_integrity >= max_integrity)
+		return TRUE
+	if(machine_stat & BROKEN)
+		return TRUE
+	if(!tool.tool_start_check(user, amount=0))
+		return TRUE
+	to_chat(user, "<span class='notice'>You begin repairing cracks in \the [src]...</span>")
+	while(tool.use_tool(src, user, 2.5 SECONDS, volume=40))
+		obj_integrity = min(obj_integrity + 25, max_integrity)
+		if(obj_integrity >= max_integrity)
+			to_chat(user, "<span class='notice'>You've finished repairing '\the [src].</span>")
+			return TRUE
+		to_chat(user, "<span class='notice'>You repair some of the cracks in \the [src]...</span>")
 	return TRUE
 
 /obj/machinery/portable_atmospherics/canister/obj_break(damage_flag)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -441,18 +441,18 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 			new /obj/item/stack/sheet/bluespace_crystal (drop_location(), 1)
 	qdel(src)
 
-/obj/machinery/portable_atmospherics/canister/secondary_welder_act(mob/living/user, obj/item/I)
+/obj/machinery/portable_atmospherics/canister/welder_act_secondary(mob/living/user, obj/item/I)
 	. = ..()
 	if(!I.tool_start_check(user, amount=0))
 		return TRUE
 	var/pressure = air_contents.return_pressure()
 	if(pressure > 300)
-		to_chat(user, "<span class='alert'>The pressure gauge on \the [src] indicates a high pressure inside... maybe you want to reconsider?</span>")
+		to_chat(user, "<span class='alert'>The pressure gauge on [src] indicates a high pressure inside... maybe you want to reconsider?</span>")
 		message_admins("[src] deconstructed by [ADMIN_LOOKUPFLW(user)]")
 		log_game("[src] deconstructed by [key_name(user)]")
-	to_chat(user, "<span class='notice'>You begin cutting \the [src] apart...</span>")
+	to_chat(user, "<span class='notice'>You begin cutting [src] apart...</span>")
 	if(I.use_tool(src, user, 3 SECONDS, volume=50))
-		to_chat(user, "<span class='notice'>You cut \the [src] apart.</span>")
+		to_chat(user, "<span class='notice'>You cut [src] apart.</span>")
 		deconstruct(TRUE)
 	return TRUE
 
@@ -466,13 +466,13 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 		return TRUE
 	if(!tool.tool_start_check(user, amount=0))
 		return TRUE
-	to_chat(user, "<span class='notice'>You begin repairing cracks in \the [src]...</span>")
+	to_chat(user, "<span class='notice'>You begin repairing cracks in [src]...</span>")
 	while(tool.use_tool(src, user, 2.5 SECONDS, volume=40))
 		obj_integrity = min(obj_integrity + 25, max_integrity)
 		if(obj_integrity >= max_integrity)
-			to_chat(user, "<span class='notice'>You've finished repairing '\the [src].</span>")
+			to_chat(user, "<span class='notice'>You've finished repairing [src].</span>")
 			return TRUE
-		to_chat(user, "<span class='notice'>You repair some of the cracks in \the [src]...</span>")
+		to_chat(user, "<span class='notice'>You repair some of the cracks in [src]...</span>")
 	return TRUE
 
 /obj/machinery/portable_atmospherics/canister/obj_break(damage_flag)


### PR DESCRIPTION
## About The Pull Request

With damaged canisters leaking gas now, repairing a canister quickly and without having to move out the gas first is needed. This moves canister deconstruction from welder left click to welder right click, and repair takes its place in welder left click. To make this cleaner, left and right click versions of the tool acts have been added.

## Changelog
:cl:
qol: You can repair canisters now by left clicking with an active welder. Deconstruction, which previously took this slot, has been moved to right click instead.
/:cl:
