### PR TITLE
Fixes cooks being able to open/close hop shutters on metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -25086,14 +25086,14 @@
 	name = "Queue Shutters Control";
 	pixel_x = 25;
 	pixel_y = -36;
-	req_access_txt = "28"
+	req_access = list(57)
 	},
 /obj/machinery/button/door{
 	id = "hop";
 	name = "Privacy Shutters Control";
 	pixel_x = 25;
 	pixel_y = -26;
-	req_access_txt = "28"
+	req_access = list(57)
 	},
 /obj/machinery/button/flasher{
 	id = "hopflash";
@@ -58321,7 +58321,7 @@
 	name = "Privacy Shutters Control";
 	pixel_x = -24;
 	pixel_y = -6;
-	req_access_txt = "28"
+	req_access = list(57)
 	},
 /obj/machinery/light_switch{
 	pixel_x = -25;

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -25086,14 +25086,16 @@
 	name = "Queue Shutters Control";
 	pixel_x = 25;
 	pixel_y = -36;
-	req_access = list(57)
+	req_access = null;
+	req_access_txt = "57"
 	},
 /obj/machinery/button/door{
 	id = "hop";
 	name = "Privacy Shutters Control";
 	pixel_x = 25;
 	pixel_y = -26;
-	req_access = list(57)
+	req_access = null;
+	req_access_txt = "57"
 	},
 /obj/machinery/button/flasher{
 	id = "hopflash";
@@ -58321,7 +58323,8 @@
 	name = "Privacy Shutters Control";
 	pixel_x = -24;
 	pixel_y = -6;
-	req_access = list(57)
+	req_access = null;
+	req_access_txt = "57"
 	},
 /obj/machinery/light_switch{
 	pixel_x = -25;


### PR DESCRIPTION
## About The Pull Request
For some reason cooks/kitchen acess can open/close the hop shutters on metastation
fixes: a part of #58294
## Why It's Good For The Game
the food man shouldnt be controlling the id mans shutters
## Changelog
:cl:
fix: Cooks can no longer influence the hop shutters on metastation.
/:cl: