### PR TITLE
Easy container swapping for Pandemic machine.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -138,9 +138,12 @@
 
 /obj/machinery/computer/pandemic/proc/eject_beaker()
 	if(beaker)
+		var/obj/item/reagent_containers/beaker_out = beaker
 		try_put_in_hand(beaker, usr)
-		beaker = null
-		update_appearance()
+	    beaker = null
+        update_appearance()
+		return beaker_out
+	return null
 
 /obj/machinery/computer/pandemic/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -236,18 +239,24 @@
 	if(istype(I, /obj/item/reagent_containers) && !(I.item_flags & ABSTRACT) && I.is_open_container())
 		. = TRUE //no afterattack
 		if(machine_stat & (NOPOWER|BROKEN))
-			return
-		if(beaker)
-			to_chat(user, "<span class='warning'>A container is already loaded into [src]!</span>")
-			return
-		if(!user.transferItemToLoc(I, src))
-			return
-
-		beaker = I
-		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
-		update_appearance()
+            return
+		var/obj/item/reagent_containers/beaker_out
+        if(beaker)
+            to_chat(user, "<span class='warning'>A container is already loaded into [src]!</span>")
+            return
+		    beaker_out = eject_beaker() //now with 100% more swapping
+        if(!user.transferItemToLoc(I, src))
+            return
+        if(beaker_out)
+            if(user && Adjacent(user) && user.can_hold_items())
+                user.put_in_hands(beaker_out)
+        beaker = I
+        to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
+		if(beaker_out) to_chat(user, "<span class='notice'>You remove [beaker_out] and insert [I] into [src].</span>")
+		else to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
+        update_appearance()
 	else
-		return ..()
+        return ..()
 
 /obj/machinery/computer/pandemic/on_deconstruction()
 	eject_beaker()

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -140,8 +140,8 @@
 	if(beaker)
 		var/obj/item/reagent_containers/beaker_out = beaker
 		try_put_in_hand(beaker, usr)
-	    beaker = null
-        update_appearance()
+		beaker = null
+		update_appearance()
 		return beaker_out
 	return null
 
@@ -239,24 +239,24 @@
 	if(istype(I, /obj/item/reagent_containers) && !(I.item_flags & ABSTRACT) && I.is_open_container())
 		. = TRUE //no afterattack
 		if(machine_stat & (NOPOWER|BROKEN))
-            return
+			return
 		var/obj/item/reagent_containers/beaker_out
-        if(beaker)
-            to_chat(user, "<span class='warning'>A container is already loaded into [src]!</span>")
-            return
-		    beaker_out = eject_beaker() //now with 100% more swapping
-        if(!user.transferItemToLoc(I, src))
-            return
-        if(beaker_out)
-            if(user && Adjacent(user) && user.can_hold_items())
-                user.put_in_hands(beaker_out)
-        beaker = I
-        to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
+		if(beaker)
+			to_chat(user, "<span class='warning'>A container is already loaded into [src]!</span>")
+			return
+			beaker_out = eject_beaker() //now with 100% more swapping
+		if(!user.transferItemToLoc(I, src))
+			return
+		if(beaker_out)
+			if(user && Adjacent(user) && user.can_hold_items())
+				user.put_in_hands(beaker_out)
+		beaker = I
+		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
 		if(beaker_out) to_chat(user, "<span class='notice'>You remove [beaker_out] and insert [I] into [src].</span>")
 		else to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
-        update_appearance()
+		update_appearance()
 	else
-        return ..()
+		return ..()
 
 /obj/machinery/computer/pandemic/on_deconstruction()
 	eject_beaker()

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -246,7 +246,8 @@
 		if(!user.transferItemToLoc(I, src))
 			return
 		if(beaker_out)
-			eject_beaker()
+			if(user && Adjacent(user) && user.can_hold_items())
+				user.put_in_hands(beaker_out)
 		beaker = I
 		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
 		if(beaker_out) to_chat(user, "<span class='notice'>You remove [beaker_out] and insert [I] into [src].</span>")

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -246,8 +246,7 @@
 		if(!user.transferItemToLoc(I, src))
 			return
 		if(beaker_out)
-			if(user && Adjacent(user) && user.can_hold_items())
-				user.put_in_hands(beaker_out)
+			eject_beaker()
 		beaker = I
 		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
 		if(beaker_out) to_chat(user, "<span class='notice'>You remove [beaker_out] and insert [I] into [src].</span>")

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -250,8 +250,10 @@
 				user.put_in_hands(beaker_out)
 		beaker = I
 		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
-		if(beaker_out) to_chat(user, "<span class='notice'>You remove [beaker_out] and insert [I] into [src].</span>")
-		else to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
+		if(beaker_out)
+			to_chat(user, "<span class='notice'>You remove [beaker_out] and insert [I] into [src].</span>")
+		else
+			to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
 		update_appearance()
 	else
 		return ..()

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -242,11 +242,11 @@
 		. = TRUE //no afterattack
 		if(machine_stat & (NOPOWER|BROKEN))
 			return
-		var/obj/item/reagent_containers/B = I
+		var/obj/item/reagent_containers/beaker_in = I
 		if(!user.transferItemToLoc(I, src))
 			return
-		replace_beaker(user, B)
-		to_chat(user, "<span class='notice'>You add [B] to [src].</span>")
+		replace_beaker(user, beaker_in)
+		to_chat(user, "<span class='notice'>You add [beaker_in] to [src].</span>")
 		updateUsrDialog()
 		update_appearance()
 	else

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -242,8 +242,6 @@
 			return
 		var/obj/item/reagent_containers/beaker_out
 		if(beaker)
-			to_chat(user, "<span class='warning'>A container is already loaded into [src]!</span>")
-			return
 			beaker_out = eject_beaker() //now with 100% more swapping
 		if(!user.transferItemToLoc(I, src))
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This lets you swap reagent containers for the pandemic machine, instead of having to eject a container first before inserting a new one. 

## Why It's Good For The Game

Its really just a big quality of life change that already exists on some other TG downstream code bases. Having to click all those extra times feels awful, and this puts it in line with the way that chem dispenses already function. I tested it locally, it feels nice and smooth, allowing you to just click and watch it update as you swap between samples.

## Changelog
:cl:
qol: The pandemic machine can now let you swap containers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
