### PR TITLE
Fixes gib code creating more then one rot component per gib

### DIFF
--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -37,7 +37,7 @@
 	get_timer()
 	START_PROCESSING(SSobj, src)
 
-///This is what actually "drys" the blood. Returns true if it's all out of blood to dry, and false otherwise
+///This is what actually "dries" the blood. Returns true if it's all out of blood to dry, and false otherwise
 /obj/effect/decal/cleanable/blood/proc/dry()
 	if(bloodiness > 20)
 		bloodiness -= BLOOD_AMOUNT_PER_DECAL

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -37,16 +37,19 @@
 	get_timer()
 	START_PROCESSING(SSobj, src)
 
+///This is what actually "drys" the blood. Returns true if it's all out of blood to dry, and false otherwise
 /obj/effect/decal/cleanable/blood/proc/dry()
 	if(bloodiness > 20)
 		bloodiness -= BLOOD_AMOUNT_PER_DECAL
 		get_timer()
+		return FALSE
 	else
 		name = dryname
 		desc = drydesc
 		bloodiness = 0
 		color =  COLOR_GRAY //not all blood splatters have their own sprites... It still looks pretty nice
 		STOP_PROCESSING(SSobj, src)
+		return TRUE
 
 /obj/effect/decal/cleanable/blood/replace_decal(obj/effect/decal/cleanable/blood/C)
 	C.add_blood_DNA(return_blood_DNA())
@@ -107,6 +110,8 @@
 
 /obj/effect/decal/cleanable/blood/gibs/dry()
 	. = ..()
+	if(!.)
+		return
 	AddComponent(/datum/component/rot, 0, 5 MINUTES, 0.7)
 
 /obj/effect/decal/cleanable/blood/gibs/ex_act(severity, target)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I assumed dry() would only be called on the final pass-through, like a fool

## Why It's Good For The Game

Maybe fixes some fuckery with rot starting too early/resetting every 3 minutes, maybe fixes a problem @Kylerace is having with #58340

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
