### PR TITLE
Changeling legs now swap to digitigrade if the target has digitigrade during transform

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -57,6 +57,7 @@
 	new_dna.blood_type = blood_type
 	new_dna.features = features.Copy()
 	new_dna.species = new species.type
+	new_dna.species.species_traits = species.species_traits
 	new_dna.real_name = real_name
 	new_dna.mutations = mutations.Copy()
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -516,6 +516,7 @@
 	user.socks = chosen_prof.socks
 
 	chosen_dna.transfer_identity(user, 1)
+	user.Digitigrade_Leg_Swap((DIGITIGRADE in chosen_dna.species.species_traits))
 	user.updateappearance(mutcolor_update=1)
 	user.update_body()
 	user.domutcheck()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -516,7 +516,7 @@
 	user.socks = chosen_prof.socks
 
 	chosen_dna.transfer_identity(user, 1)
-	user.Digitigrade_Leg_Swap((DIGITIGRADE in chosen_dna.species.species_traits))
+	user.Digitigrade_Leg_Swap(!(DIGITIGRADE in chosen_dna.species.species_traits))
 	user.updateappearance(mutcolor_update=1)
 	user.update_body()
 	user.domutcheck()


### PR DESCRIPTION
## About The Pull Request

Changeling legs now swap to digitigrade if the target has digitigrade during transform

## Why It's Good For The Game

Because consistency is good. Also bug fixes, yes.

## Changelog
:cl:
fix: changeling legs now swap to digitigrade if the target has digitigrade during transform
/:cl: