### PR TITLE
removes an unused sticky tape variable

### DIFF
--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -17,7 +17,6 @@
 	splint_factor = 0.8
 	merge_type = /obj/item/stack/sticky_tape
 	var/list/conferred_embed = EMBED_HARMLESS
-	var/overwrite_existing = FALSE
 
 /obj/item/stack/sticky_tape/afterattack(obj/item/I, mob/living/user, proximity)
 	if(!proximity)


### PR DESCRIPTION
## About The Pull Request

This PR removes the definition of the "overwrite_existing" variable from sticky tape, which is never checked for anywhere, is never modified anywhere, and is never set anywhere other than in this one line.

## Why It's Good For The Game

it's free gbp

## Changelog
:cl: ATHATH
refactor: An unused variable in the code for sticky tape has been removed.
/:cl:
