### PR TITLE
Adds estimations of damage values when examining items

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -318,7 +318,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 		if(resistance_flags & FIRE_PROOF)
 			. += "[src] is made of fire-retardant materials."
 
-	if(HAS_TRAIT(user, TRAIT_SECURITY_HUD) && return_damage_rundown())
+	if(return_damage_rundown())
 		. += return_damage_rundown()
 
 	. += "[gender == PLURAL ? "They are" : "It is"] a [weightclass2text(w_class)] item."
@@ -765,13 +765,13 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 /obj/item/proc/on_juice()
 	return SEND_SIGNAL(src, COMSIG_ITEM_ON_JUICE)
 
-/obj/item/proc/return_strength_string(forcenumber)
+/obj/item/proc/return_blows2crit_rating_string(forcenumber)
 	if(!forcenumber)
 		return
 	var/verb
 	switch(CEILING(MAX_LIVING_HEALTH / forcenumber, 1)) //blows to crit a human
 		if(1 to 3)
-			verb = "excellent"
+			verb = "incredible"
 		if(4 to 6)
 			verb = "great"
 		if(7 to 9)
@@ -780,13 +780,32 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 			verb = "mediocre"
 	return verb
 
+/obj/item/proc/return_percentile_rating_string(percentile)
+	if(!percentile)
+		return
+	var/verb
+	switch(percentile)
+		if(1 to 25)
+			verb = "mediocre"
+		if(26 to 50)
+			verb = "good"
+		if(51 to 75)
+			verb = "great"
+		if(76 to INFINITY)
+			verb = "incredible"
+	return verb
+
 /obj/item/proc/return_damage_rundown()
-	if(return_strength_string(throwforce))
-		damage_rundown_message += "a [return_strength_string(throwforce)] throwing weapon"
-	if(return_strength_string(force))
-		damage_rundown_message += "a [return_strength_string(force)] melee weapon"
-	if(return_strength_string(stamina_damage))
-		damage_rundown_message += "a [return_strength_string(stamina_damage)] incapacitating weapon"
+	if(return_blows2crit_rating_string(throwforce))
+		damage_rundown_message += "a [return_blows2crit_rating_string(throwforce)] throwing weapon"
+	if(return_blows2crit_rating_string(force))
+		damage_rundown_message += "a [return_blows2crit_rating_string(force)] melee weapon"
+	if(return_blows2crit_rating_string(stamina_damage))
+		damage_rundown_message += "a [return_blows2crit_rating_string(stamina_damage)] incapacitating melee weapon"
+	if(return_percentile_rating_string(block_chance))
+		damage_rundown_message += "a [return_percentile_rating_string(block_chance)] blocking weapon"
+	if(return_percentile_rating_string(armour_penetration))
+		damage_rundown_message += "a [return_percentile_rating_string(armour_penetration)] armour penetrating weapon"
 
 	if(LAZYLEN(damage_rundown_message))
 		var/start_of_message = "<span class='danger'>[gender == PLURAL ? "They" : "It"] would make "
@@ -794,8 +813,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 		var/end_of_message = "[damage_rundown_message[LAZYLEN(damage_rundown_message)]].</span>"
 		if(LAZYLEN(damage_rundown_message) > 1)
 			damage_rundown_message -= damage_rundown_message[LAZYLEN(damage_rundown_message)]
-			damage_rundown_message += "and "
-			middle_of_message = damage_rundown_message.Join(", ")
+			middle_of_message = damage_rundown_message.Join(", ") + " and "
 		LAZYCLEARLIST(damage_rundown_message)
 
 		. += "[start_of_message][middle_of_message][end_of_message]"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -765,7 +765,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 /obj/item/proc/on_juice()
 	return SEND_SIGNAL(src, COMSIG_ITEM_ON_JUICE)
 
-/obj/item/proc/return_strength_string(var/forcenumber)
+/obj/item/proc/return_strength_string(forcenumber)
 	if(!forcenumber)
 		return
 	var/verb

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -771,7 +771,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	var/verb
 	switch(CEILING(MAX_LIVING_HEALTH / forcenumber, 1)) //blows to crit a human
 		if(1 to 3)
-			verb = "superb"
+			verb = "excellent"
 		if(4 to 6)
 			verb = "great"
 		if(7 to 9)

--- a/code/game/objects/items/grenades/atmos_grenades.dm
+++ b/code/game/objects/items/grenades/atmos_grenades.dm
@@ -27,7 +27,7 @@
 	desc = "A crystal made from the Healium gas, it's cold to the touch."
 	icon_state = "healium_crystal"
 	///Amount of stamina damage mobs will take if in range
-	var/stamina_damage = 30
+	stamina_damage = 30
 	///Range of the grenade that will cool down and affect mobs
 	var/freeze_range = 4
 	///Amount of gas released if the state is optimal

--- a/code/game/objects/items/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/grenades/syndieminibomb.dm
@@ -52,7 +52,7 @@
 	inhand_icon_state = "flashbang"
 	var/freeze_range = 4
 	var/rad_damage = 350
-	var/stamina_damage = 30
+	stamina_damage = 30
 
 /obj/item/grenade/gluon/detonate(mob/living/lanced_by)
 	. = ..()

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -189,7 +189,7 @@
 	var/cooldown = 40 // Default wait time until can stun again.
 	var/knockdown_time_carbon = (1.5 SECONDS) // Knockdown length for carbons.
 	var/stun_time_silicon = (5 SECONDS) // If enabled, how long do we stun silicons.
-	var/stamina_damage = 55 // Do we deal stamina damage.
+	stamina_damage = 55 // Do we deal stamina damage.
 	var/affect_silicon = FALSE // Does it stun silicons.
 	var/on_sound // "On" sound, played when switching between able to stun or not.
 	var/on_stun_sound = 'sound/effects/woodhit.ogg' // Default path to sound for when we stun.

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -38,23 +38,6 @@
 	. = ..()
 	if(tile_reskin_types || tile_rotate_dirs)
 		. += "<span class='notice'>Use while in your hand to change what type of [src] you want.</span>"
-	if(throwforce && !is_cyborg) //do not want to divide by zero or show the message to borgs who can't throw
-		var/verb
-		switch(CEILING(MAX_LIVING_HEALTH / throwforce, 1)) //throws to crit a human
-			if(1 to 3)
-				verb = "superb"
-			if(4 to 6)
-				verb = "great"
-			if(7 to 9)
-				verb = "good"
-			if(10 to 12)
-				verb = "fairly decent"
-			if(13 to 15)
-				verb = "mediocre"
-		if(!verb)
-			return
-		. += "<span class='notice'>Those could work as a [verb] throwing weapon.</span>"
-
 
 /obj/item/stack/tile/proc/place_tile(turf/open/T)
 	if(!turf_type || !use(1))

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -32,7 +32,7 @@
 	var/stun_sound = 'sound/weapons/egloves.ogg'
 
 	var/confusion_amt = 10
-	var/stamina_loss_amt = 60
+	stamina_damage = 60
 	var/apply_stun_delay = 2 SECONDS
 	var/stun_time = 5 SECONDS
 
@@ -233,7 +233,7 @@
 	L.Jitter(20)
 	L.set_confusion(max(confusion_amt, L.get_confusion()))
 	L.stuttering = max(8, L.stuttering)
-	L.apply_damage(stamina_loss_amt, STAMINA, BODY_ZONE_CHEST)
+	L.apply_damage(stamina_damage, STAMINA, BODY_ZONE_CHEST)
 
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 	addtimer(CALLBACK(src, .proc/apply_stun_effect_end, L), apply_stun_delay)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -8,6 +8,9 @@
 	var/damtype = BRUTE
 	var/force = 0
 
+	/// Used when an object applies stamina damage.
+	var/stamina_damage
+
 	/// How good a given object is at causing wounds on carbons. Higher values equal better shots at creating serious wounds.
 	var/wound_bonus = 0
 	/// If this attacks a human with no wound armor on the affected body part, add this to the wound mod. Some attacks may be significantly worse at wounding if there's even a slight layer of armor to absorb some of it vs bare flesh

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -452,7 +452,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 
 	attack_cooldown = 0 SECONDS
 	confusion_amt = 0
-	stamina_loss_amt = 0
+	stamina_damage = 0
 	apply_stun_delay = 0 SECONDS
 	stun_time = 14 SECONDS
 

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -64,20 +64,19 @@
 
 /obj/item/ammo_casing/return_damage_rundown()
 	if(loaded_projectile)
-		if(return_strength_string(loaded_projectile.stamina*pellets))
-			damage_rundown_message += "[return_strength_string(loaded_projectile.stamina*pellets)] stamina damage"
-		if(return_strength_string(loaded_projectile.damage*pellets))
-			damage_rundown_message += "[return_strength_string(loaded_projectile.damage*pellets)] [loaded_projectile.damage_type] damage"
+		if(return_blows2crit_rating_string(loaded_projectile.stamina*pellets))
+			damage_rundown_message += "[return_blows2crit_rating_string(loaded_projectile.stamina*pellets)] stamina damage"
+		if(return_blows2crit_rating_string(loaded_projectile.damage*pellets))
+			damage_rundown_message += "[return_blows2crit_rating_string(loaded_projectile.damage*pellets)] [loaded_projectile.damage_type] damage"
 
 		if(LAZYLEN(damage_rundown_message))
-			var/start_of_message = "<span class='danger'>If fired, it would do "
+			var/start_of_message = "<span class='danger'>Firing it would do "
 			var/middle_of_message
 			var/end_of_message = "[damage_rundown_message[LAZYLEN(damage_rundown_message)]].</span>"
 
 			if(LAZYLEN(damage_rundown_message) > 1)
 				damage_rundown_message -= damage_rundown_message[LAZYLEN(damage_rundown_message)]
-				damage_rundown_message += "and "
-				middle_of_message = damage_rundown_message.Join(", ")
+				middle_of_message = damage_rundown_message.Join(", ") + " and "
 
 			LAZYCLEARLIST(damage_rundown_message)
 

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -62,6 +62,28 @@
 	desc = "[initial(desc)][loaded_projectile ? null : " This one is spent."]"
 	return ..()
 
+/obj/item/ammo_casing/return_damage_rundown()
+	if(loaded_projectile)
+		if(return_strength_string(loaded_projectile.stamina*pellets))
+			damage_rundown_message += "[return_strength_string(loaded_projectile.stamina*pellets)] stamina damage"
+		if(return_strength_string(loaded_projectile.damage*pellets))
+			damage_rundown_message += "[return_strength_string(loaded_projectile.damage*pellets)] [loaded_projectile.damage_type] damage"
+
+		if(LAZYLEN(damage_rundown_message))
+			var/start_of_message = "<span class='danger'>If fired, it would do "
+			var/middle_of_message
+			var/end_of_message = "[damage_rundown_message[LAZYLEN(damage_rundown_message)]].</span>"
+
+			if(LAZYLEN(damage_rundown_message) > 1)
+				damage_rundown_message -= damage_rundown_message[LAZYLEN(damage_rundown_message)]
+				damage_rundown_message += "and "
+				middle_of_message = damage_rundown_message.Join(", ")
+
+			LAZYCLEARLIST(damage_rundown_message)
+
+			. += "[start_of_message][middle_of_message][end_of_message] "
+	. += ..()
+
 /*
  * On accidental consumption, 'spend' the ammo, and add in some gunpowder
  */

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -70,7 +70,7 @@
 			damage_rundown_message += "[return_blows2crit_rating_string(loaded_projectile.damage*pellets)] [loaded_projectile.damage_type] damage"
 
 		if(LAZYLEN(damage_rundown_message))
-			var/start_of_message = "<span class='danger'>Firing it would do "
+			var/start_of_message = "<span class='danger'>Firing it[pellets > 1 ? "s [pellets] pellets" : ""] would do "
 			var/middle_of_message
 			var/end_of_message = "[damage_rundown_message[LAZYLEN(damage_rundown_message)]].</span>"
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -720,5 +720,9 @@
 		azoom = new()
 		azoom.gun = src
 
+/obj/item/gun/return_damage_rundown()
+	. += chambered?.return_damage_rundown()
+	. += ..()
+
 #undef FIRING_PIN_REMOVAL_DELAY
 #undef DUALWIELD_PENALTY_EXTRA_MULTIPLIER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<details>
  <summary>SCREENSHOTS (click to expand)</summary>
  
![](https://i.imgur.com/6TCIhld.png)
![](https://i.imgur.com/PdNHxdc.png)
![](https://i.imgur.com/21eFsTn.png)
![](https://i.imgur.com/B67b89F.png)
![](https://i.imgur.com/7vvPUwn.png)
![](https://i.imgur.com/aMNpcxT.png)
![](https://i.imgur.com/ndmjf5O.png)
![](https://i.imgur.com/HehZF8z.png)
</details>

Initially started as wanting to do #58845 a bit differently but after that got killed it evolved into doing it in a way that might actually get merged.

This gives you an estimation of the damage an item will do when examining it. These estimations are based on the system currently used by floor tiles to describe their throwforce.

It gives you force, throwforce, stamina damage, block chance and armour piercing amount for items. It shows damage, damage type and stamina damage for the chambered projectile in guns and projectiles themselves. These only show up if the damage is noteworthy, though.

Leaves out pellet amount and caliber for projectiles and damage type for items from the original PR. I think these are obvious or unnecessary. Doesn't show all attack types for energy weapons either, only the currently selected one.

I think everything else is consistent with the original PR. I wanted to do this myself a long time ago but lacked the knowledge.

Assuming this doesn't get closed there's room for this to be fleshed out with more items stats that affect combat in future. Hopefully this will shed light on mechanics that have never been explained in-game.

Also makes objects that cause stamina damage use the same var and makes it an object proc like force.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This makes notable combat items obvious to everybody. It stops codediving or testing weapons with a health analyser from being necessary to equip yourself properly for combat. It also stops you grabbing something that doesn't do much or any damage because it looks like it should.

Adds armour penetration and block chance values to items. These are obscure stats you currently have no way of seeing on items in-game. Maybe they'll be added to more things if there's a way to see them without looking at the code.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
balance: You can examine items to see estimations of their damage values if they're notable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
