### PR TITLE
Smart organ storage fix

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -166,9 +166,9 @@
 
 //organ defines
 #define STANDARD_ORGAN_THRESHOLD 100
-#define STANDARD_ORGAN_HEALING 0.00050
+#define STANDARD_ORGAN_HEALING 50 / 100000
 /// designed to fail organs when left to decay for ~15 minutes
-#define STANDARD_ORGAN_DECAY 0.00111
+#define STANDARD_ORGAN_DECAY 111 / 100000
 
 //used for the can_chromosome var on mutations
 #define CHROMOSOME_NEVER 0

--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -166,7 +166,7 @@
 
 //organ defines
 #define STANDARD_ORGAN_THRESHOLD 100
-#define STANDARD_ORGAN_HEALING 0.0005
+#define STANDARD_ORGAN_HEALING 0.00050
 /// designed to fail organs when left to decay for ~15 minutes
 #define STANDARD_ORGAN_DECAY 0.00111
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -446,7 +446,7 @@
 /obj/machinery/smartfridge/organ/RefreshParts()
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		max_n_of_items = 20 * B.rating
-		repair_rate = max(0, STANDARD_ORGAN_HEALING * (B.rating - 1) * 2)
+		repair_rate = max(0, STANDARD_ORGAN_HEALING * (B.rating - 1) * 0.5)
 
 /obj/machinery/smartfridge/organ/process(delta_time)
 	for(var/organ in contents)

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -446,14 +446,14 @@
 /obj/machinery/smartfridge/organ/RefreshParts()
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		max_n_of_items = 20 * B.rating
-		repair_rate = max(0, STANDARD_ORGAN_HEALING * (B.rating - 1) * 0.5)
+		repair_rate = max(0, STANDARD_ORGAN_HEALING * (B.rating - 1) * 2)
 
 /obj/machinery/smartfridge/organ/process(delta_time)
 	for(var/organ in contents)
 		var/obj/item/organ/O = organ
 		if(!istype(O))
-			return
-		O.applyOrganDamage(-repair_rate * delta_time)
+			continue
+		O.applyOrganDamage(-repair_rate * O.maxHealth * delta_time)
 
 /obj/machinery/smartfridge/organ/Exited(atom/movable/AM, atom/newLoc)
 	. = ..()

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -449,11 +449,8 @@
 		repair_rate = max(0, STANDARD_ORGAN_HEALING * (B.rating - 1) * 0.5)
 
 /obj/machinery/smartfridge/organ/process(delta_time)
-	for(var/organ in contents)
-		var/obj/item/organ/O = organ
-		if(!istype(O))
-			continue
-		O.applyOrganDamage(-repair_rate * O.maxHealth * delta_time)
+	for(var/obj/item/organ/organ in contents)
+		organ.applyOrganDamage(-repair_rate * organ.maxHealth * delta_time)
 
 /obj/machinery/smartfridge/organ/Exited(atom/movable/AM, atom/newLoc)
 	. = ..()


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This fixes a few goofs in smart organ storage code, namely:
- return instead of continue in a loop, which broke the organ repairing functionality
- not factored in maxHealth, which resulted in absurdly slow repair rates
- repair rate used STANDARD_ORGAN_HEALING divided by 2, while organ/proc/on_life uses STANDARD_ORGAN_HEALING multiplied by up to 4

The repair rate is still slow as fuck even when upgraded with bluespace matter bin and should probably be buffed, but thats none of my business, im just fixing shit here

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Organ repairing feature of Smart organ storage is broken, which makes upgrading it kinda pointless
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
fix: fixed buggy organ fridges repair rate
fix: fixed upgraded organ fridges not repairing organs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
