### PR TITLE
Fixes  swarmer making hull breaches in shuttle

### DIFF
--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -129,6 +129,68 @@
 	actor.dis_integrate(src)
 	return TRUE
 
+	/obj/structure/shuttle/engine/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+    /obj/structure/shuttle/engine/heater/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+	/obj/structure/shuttle/engine/propulsion/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+	/obj/structure/shuttle/engine/propulsion/right/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+	/obj/structure/shuttle/engine/propulsion/left/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+	/obj/structure/shuttle/engine/propulsion/burst/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+	/obj/structure/shuttle/engine/propulsion/burst/right/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+	/obj/structure/shuttle/engine/propulsion/burst/left/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+	/obj/structure/shuttle/engine/propulsion/burst/cargo/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+	/obj/structure/shuttle/engine/router/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+	/obj/structure/shuttle/engine/platform/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+	/obj/structure/shuttle/engine/large/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+	/obj/structure/shuttle/engine/huge/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+	/obj/structure/shuttle/engine/heater/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+
+
+
+
+
+
 /obj/machinery/camera/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	actor.dis_integrate(src)
 	if(!QDELETED(actor)) //If it got blown up no need to turn it off.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

 Stops swarmers from creating hullbreaches in evac shuttle by not allowing them to EAT the shuttle engines 

## Why It's Good For The Game

swarmers cant kill people in the shuttle

## Changelog
:cl:
THIS SUPPOSEDLY STOPS THE 1 SWARMER IN SPACE FROM KILLING THE ENTIRE EVAC SHUTTLE BY EATING THROUGH THE SHUTTLE ENGINES AND CREATING HULL BREACHES
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
