### PR TITLE
Swarmers can't make breaches in shuttle anymore

### DIFF
--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -195,58 +195,6 @@
 	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 	return FALSE
 
-/obj/structure/shuttle/engine/heater/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
-	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
-	return FALSE
-
-/obj/structure/shuttle/engine/propulsion/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
-    to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
-    return FALSE
-
-/obj/structure/shuttle/engine/propulsion/right/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
-	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
-	return FALSE
-
-/obj/structure/shuttle/engine/propulsion/left/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
-	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
-	return FALSE
-
-/obj/structure/shuttle/engine/propulsion/burst/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
-	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
-	return FALSE
-
-/obj/structure/shuttle/engine/propulsion/burst/right/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
-	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
-	return FALSE
-
-/obj/structure/shuttle/engine/propulsion/burst/left/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
-	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
-	return FALSE
-
-/obj/structure/shuttle/engine/propulsion/burst/cargo/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
-	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
-	return FALSE
-
-/obj/structure/shuttle/engine/router/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
-	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
-	return FALSE
-
-/obj/structure/shuttle/engine/platform/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
-	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
-	return FALSE
-
-/obj/structure/shuttle/engine/large/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
-	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
-	return FALSE
-
-/obj/structure/shuttle/engine/huge/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
-	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
-	return FALSE
-
-/obj/structure/shuttle/engine/heater/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
-	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
-	return FALSE
-
 /turf/closed/wall/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	var/isonshuttle = istype(loc, /area/shuttle)
 	for(var/turf/turf_in_range as anything in RANGE_TURFS(1, src))

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -191,6 +191,62 @@
 	to_chat(actor, "<span class='warning'>This bluespace source will be important to us later. Aborting.</span>")
 	return FALSE
 
+/obj/structure/shuttle/engine/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+/obj/structure/shuttle/engine/heater/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+/obj/structure/shuttle/engine/propulsion/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+    to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+    return FALSE
+
+/obj/structure/shuttle/engine/propulsion/right/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+/obj/structure/shuttle/engine/propulsion/left/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+/obj/structure/shuttle/engine/propulsion/burst/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+/obj/structure/shuttle/engine/propulsion/burst/right/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+/obj/structure/shuttle/engine/propulsion/burst/left/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+/obj/structure/shuttle/engine/propulsion/burst/cargo/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+/obj/structure/shuttle/engine/router/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+/obj/structure/shuttle/engine/platform/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+/obj/structure/shuttle/engine/large/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+/obj/structure/shuttle/engine/huge/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
+/obj/structure/shuttle/engine/heater/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	to_chat(actor, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+	return FALSE
+
 /turf/closed/wall/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	var/isonshuttle = istype(loc, /area/shuttle)
 	for(var/turf/turf_in_range as anything in RANGE_TURFS(1, src))


### PR DESCRIPTION
## About The Pull Request

adds all components of engines to the blacklist of what swarmers are able to dismantle

## Why It's Good For The Game

A single swarmer can no longer kill the entire shuttle

## Changelog
:cl:
balance: Swarmers are no longer able to eat the shuttle engines and make hull breaches in their place.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
