### PR TITLE
the backfire effect of killer tomatoes no longer requires the liquid contents trait

### DIFF
--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -99,7 +99,7 @@
 
 /obj/item/food/grown/tomato/blue/bluespace/Initialize(mapload, obj/item/seeds/new_seed)
 	. = ..()
-	AddElement(/datum/element/plant_backfire, /obj/item/food/grown/tomato/blue/bluespace.proc/splat_user)
+	AddElement(/datum/element/plant_backfire, /obj/item/food/grown/tomato/blue/bluespace.proc/splat_user, extra_genes = list(/datum/plant_gene/trait/squash))
 
 /*
  * Splat our tomato on our user. Called from [/datum/element/plant_backfire]
@@ -138,7 +138,7 @@
 
 /obj/item/food/grown/tomato/killer/Initialize(mapload, obj/item/seeds/new_seed)
 	. = ..()
-	AddElement(/datum/element/plant_backfire, /obj/item/food/grown/tomato/killer.proc/early_awaken, extra_genes = list(/datum/plant_gene/trait/squash))
+	AddElement(/datum/element/plant_backfire, /obj/item/food/grown/tomato/killer.proc/early_awaken)
 
 /obj/item/food/grown/tomato/killer/attack(mob/M, mob/user, def_zone)
 	if(awakening)

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -99,7 +99,7 @@
 
 /obj/item/food/grown/tomato/blue/bluespace/Initialize(mapload, obj/item/seeds/new_seed)
 	. = ..()
-	AddElement(/datum/element/plant_backfire, /obj/item/food/grown/tomato/blue/bluespace.proc/splat_user, extra_genes = list(/datum/plant_gene/trait/squash))
+	AddElement(/datum/element/plant_backfire, /obj/item/food/grown/tomato/blue/bluespace.proc/splat_user)
 
 /*
  * Splat our tomato on our user. Called from [/datum/element/plant_backfire]


### PR DESCRIPTION
## About The Pull Request

Killer tomatoes no longer require the liquid contents trait to have a chance to self-animate when picked up without proper protection.

## Why It's Good For The Game

This was almost certainly a copy+paste error from the code for the backfire effect of bluespace tomatoes, for which a liquid contents trait requirement actually makes sense.

## Changelog
:cl: ATHATH
fix: Killer tomatoes no longer require the liquid contents trait to have a chance to self-animate when picked up without proper protection.
/:cl: