### PR TITLE
holoparasites now inherit the time stop immunities of their owners in more cases

### DIFF
--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -30,7 +30,7 @@
 		if(locate(/obj/effect/proc_holder/spell/aoe_turf/timestop) in L.mind.spell_list) //People who can stop time are immune to its effects
 			immune[L] = TRUE
 	for(var/mob/living/simple_animal/hostile/guardian/G in GLOB.parasites)
-		if(G.summoner && locate(/obj/effect/proc_holder/spell/aoe_turf/timestop) in G.summoner.mind.spell_list) //It would only make sense that a person's stand would also be immune.
+		if(G.summoner && immune[G.summoner]) //It would only make sense that a person's stand would also be immune.
 			immune[G] = TRUE
 	if(start)
 		INVOKE_ASYNC(src, .proc/timestop)
@@ -79,6 +79,12 @@
 		if(M.anti_magic_check(check_anti_magic, check_holy))
 			immune[A] = TRUE
 			return
+		if(istype(A, /mob/living/simple_animal/hostile/guardian))
+			var/mob/living/simple_animal/hostile/guardian/starplatinum = A
+			if(starplatinum.summoner && (immune[starplatinum.summoner] || starplatinum.summoner.anti_magic_check(check_anti_magic, check_holy))) //your antimagic will also protect your stand(s)
+				immune[starplatinum] = TRUE
+				immune[starplatinum.summoner] = TRUE //so that the order in which a stand and its owner enter an antimagic field won't affect the number of antimagic charges that are expended
+				return
 	var/frozen = TRUE
 	if(isliving(A))
 		freeze_mob(A)


### PR DESCRIPTION
## About The Pull Request

Previously, holoparasites would only be immune to the effects of a time stop field if their owner knew the time stop spell. This PR makes it so that if a holoparasite's owner is immune to the effects of a time stop field for any reason (including possessing a source of antimagic), the holoparasite will be as well.

## Why It's Good For The Game

Now this reference will still work with non-spell sources of time stop fields, like the sepia extract's major luminescent power, and with stand owners who can't stop time but can still act in a field of stopped time (such as null rod wielders).

## Changelog
:cl: ATHATH
fix: If a holoparasite's owner is immune to the effects of a time stop field for any reason (including possessing a source of antimagic), the holoparasite will be as well.
/:cl:
