### PR TITLE
admins can add specific fantasy affixes to items

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -97,6 +97,9 @@
 #define VV_HK_MASS_DEL_TYPE "mass_delete_type"
 #define VV_HK_ARMOR_MOD "mod_obj_armor"
 
+// /obj/item
+#define VV_HK_ADD_FANTASY_AFFIX "add_fantasy_affix"
+
 // /mob
 #define VV_HK_GIB "gib"
 #define VV_HK_GIVE_SPELL "give_spell"

--- a/code/datums/components/fantasy/_fantasy.dm
+++ b/code/datums/components/fantasy/_fantasy.dm
@@ -22,7 +22,10 @@
 
 	src.affixes = affixes
 	appliedComponents = list()
-	randomAffixes()
+	if(affixes && affixes.len)
+		setAffixes()
+	else
+		randomAffixes()
 
 /datum/component/fantasy/Destroy()
 	unmodify()
@@ -55,6 +58,7 @@
 		quality = -quality
 	return quality
 
+///proc on creation for random affixes
 /datum/component/fantasy/proc/randomAffixes(force)
 	if(!affixListing)
 		affixListing = list()
@@ -83,6 +87,15 @@
 		if(!affix.validate(src))
 			continue
 		affixes += affix
+		usedSlots |= affix.placement
+
+///proc on creation for specific affixes given to the fantasy component
+/datum/component/fantasy/proc/setAffixes(force)
+	var/usedSlots = NONE
+	for(var/datum/fantasy_affix/affix in affixes) // We want at least 1 affix applied
+		if((affix.placement & usedSlots) || (!affix.validate(src)))
+			affixes.Remove(affix) //bad affix (can't be added to this item)
+			continue
 		usedSlots |= affix.placement
 
 /datum/component/fantasy/proc/modify()

--- a/code/datums/components/fantasy/_fantasy.dm
+++ b/code/datums/components/fantasy/_fantasy.dm
@@ -12,6 +12,7 @@
 
 	var/static/list/affixListing
 
+///affixes expects an initialized list
 /datum/component/fantasy/Initialize(quality, list/affixes = list(), canFail=FALSE, announce=FALSE)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -84,7 +85,7 @@
 			continue
 		if(!(affix.alignment & alignment))
 			continue
-		if(!affix.validate(src))
+		if(!affix.validate(parent))
 			continue
 		affixes += affix
 		usedSlots |= affix.placement
@@ -93,7 +94,7 @@
 /datum/component/fantasy/proc/setAffixes(force)
 	var/usedSlots = NONE
 	for(var/datum/fantasy_affix/affix in affixes) // We want at least 1 affix applied
-		if((affix.placement & usedSlots) || (!affix.validate(src)))
+		if((affix.placement & usedSlots) || (!affix.validate(parent)))
 			affixes.Remove(affix) //bad affix (can't be added to this item)
 			continue
 		usedSlots |= affix.placement

--- a/code/datums/components/fantasy/affix.dm
+++ b/code/datums/components/fantasy/affix.dm
@@ -6,7 +6,7 @@
 	var/weight = 10
 
 // For those occasional affixes which only make sense in certain circumstances
-/datum/fantasy_affix/proc/validate(datum/component/fantasy/comp)
+/datum/fantasy_affix/proc/validate(obj/item/attached)
 	return TRUE
 
 /datum/fantasy_affix/proc/apply(datum/component/fantasy/comp, newName)

--- a/code/datums/components/fantasy/affix.dm
+++ b/code/datums/components/fantasy/affix.dm
@@ -1,4 +1,6 @@
 /datum/fantasy_affix
+	///only used for admins adding the affix, this is not what players will see.
+	var/name = "SOMEONE DIDN'T SET AN ADMIN NAME FOR THIS"
 	var/placement // A bitflag of "slots" this affix takes up, for example pre/suffix
 	var/alignment
 	var/weight = 10

--- a/code/datums/components/fantasy/prefixes.dm
+++ b/code/datums/components/fantasy/prefixes.dm
@@ -1,4 +1,5 @@
 /datum/fantasy_affix/cosmetic_prefixes
+	name = "purely cosmetic prefix"
 	placement = AFFIX_PREFIX
 	alignment = AFFIX_GOOD | AFFIX_EVIL
 
@@ -39,6 +40,7 @@
 		return "[pick(badPrefixes)] [newName]"
 
 /datum/fantasy_affix/tactical
+	name = "tactical"
 	placement = AFFIX_PREFIX
 	alignment = AFFIX_GOOD
 	weight = 1 // Very powerful, no one should have such power
@@ -49,6 +51,7 @@
 	return "tactical [newName]"
 
 /datum/fantasy_affix/pyromantic
+	name = "pyromantic"
 	placement = AFFIX_PREFIX
 	alignment = AFFIX_GOOD
 
@@ -58,6 +61,7 @@
 	return "pyromantic [newName]"
 
 /datum/fantasy_affix/vampiric
+	name = "vampiric"
 	placement = AFFIX_PREFIX
 	alignment = AFFIX_GOOD
 	weight = 5
@@ -68,6 +72,7 @@
 	return "vampiric [newName]"
 
 /datum/fantasy_affix/beautiful
+	name = "beautiful"
 	placement = AFFIX_PREFIX
 	alignment = AFFIX_GOOD
 
@@ -81,6 +86,7 @@
 	master.RemoveElement(/datum/element/beauty, max(comp.quality, 1) * 250)
 
 /datum/fantasy_affix/ugly
+	name = "ugly"
 	placement = AFFIX_PREFIX
 	alignment = AFFIX_EVIL
 

--- a/code/datums/components/fantasy/suffixes.dm
+++ b/code/datums/components/fantasy/suffixes.dm
@@ -80,7 +80,7 @@
 	return "[newName] of [initial(picked_mobtype.name)] slaying"
 
 /datum/fantasy_affix/summoning
-	name = "summoning some random mob (careful with this)"
+	name = "summoning some random mob (unbalanced and dangerous)"
 	placement = AFFIX_SUFFIX
 	alignment = AFFIX_GOOD
 	weight = 5
@@ -122,8 +122,8 @@
 	placement = AFFIX_SUFFIX
 	alignment = AFFIX_GOOD
 
-/datum/fantasy_affix/shrapnel/validate(datum/component/fantasy/comp)
-	if(isgun(comp.parent))
+/datum/fantasy_affix/shrapnel/validate(obj/item/attached)
+	if(isgun(attached))
 		return TRUE
 	return FALSE
 

--- a/code/datums/components/fantasy/suffixes.dm
+++ b/code/datums/components/fantasy/suffixes.dm
@@ -48,7 +48,7 @@
 
 //////////// Good suffixes
 /datum/fantasy_affix/bane
-	name = "bane of some random mob"
+	name = "of <mobtype> slaying (random species, carbon or simple animal)"
 	placement = AFFIX_SUFFIX
 	alignment = AFFIX_GOOD
 
@@ -80,7 +80,7 @@
 	return "[newName] of [initial(picked_mobtype.name)] slaying"
 
 /datum/fantasy_affix/summoning
-	name = "summoning some random mob (unbalanced and dangerous)"
+	name = "of <mobtype> summoning (dangerous, can pick all but megafauna tier stuff)"
 	placement = AFFIX_SUFFIX
 	alignment = AFFIX_GOOD
 	weight = 5
@@ -153,7 +153,7 @@
 	return "[newName] of [initial(picked_projectiletype.name)] shrapnel"
 
 /datum/fantasy_affix/strength
-	name = "knockback (strength in game)"
+	name = "of strength (knockback)"
 	placement = AFFIX_SUFFIX
 	alignment = AFFIX_GOOD
 
@@ -166,7 +166,7 @@
 //////////// Bad suffixes
 
 /datum/fantasy_affix/fool
-	name = "clown honks (fool in game)"
+	name = "of the fool (honking)"
 	placement = AFFIX_SUFFIX
 	alignment = AFFIX_EVIL
 

--- a/code/datums/components/fantasy/suffixes.dm
+++ b/code/datums/components/fantasy/suffixes.dm
@@ -1,4 +1,5 @@
 /datum/fantasy_affix/cosmetic_suffixes
+	name = "purely cosmetic suffix"
 	placement = AFFIX_SUFFIX
 	alignment = AFFIX_GOOD | AFFIX_EVIL
 
@@ -47,6 +48,7 @@
 
 //////////// Good suffixes
 /datum/fantasy_affix/bane
+	name = "bane of some random mob"
 	placement = AFFIX_SUFFIX
 	alignment = AFFIX_GOOD
 
@@ -78,6 +80,7 @@
 	return "[newName] of [initial(picked_mobtype.name)] slaying"
 
 /datum/fantasy_affix/summoning
+	name = "summoning some random mob (careful with this)"
 	placement = AFFIX_SUFFIX
 	alignment = AFFIX_GOOD
 	weight = 5
@@ -115,6 +118,7 @@
 	return "[newName] of [initial(picked_mobtype.name)] summoning"
 
 /datum/fantasy_affix/shrapnel
+	name = "shrapnel"
 	placement = AFFIX_SUFFIX
 	alignment = AFFIX_GOOD
 
@@ -149,6 +153,7 @@
 	return "[newName] of [initial(picked_projectiletype.name)] shrapnel"
 
 /datum/fantasy_affix/strength
+	name = "knockback (strength in game)"
 	placement = AFFIX_SUFFIX
 	alignment = AFFIX_GOOD
 
@@ -161,6 +166,7 @@
 //////////// Bad suffixes
 
 /datum/fantasy_affix/fool
+	name = "clown honks (fool in game)"
 	placement = AFFIX_SUFFIX
 	alignment = AFFIX_EVIL
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1105,6 +1105,7 @@
 /atom/movable/vv_get_dropdown()
 	. = ..()
 	VV_DROPDOWN_OPTION(VV_HK_DEADCHAT_PLAYS, "Start/Stop Deadchat Plays")
+	VV_DROPDOWN_OPTION(VV_HK_ADD_FANTASY_AFFIX, "Add Fantasy Affix")
 
 /atom/movable/vv_do_topic(list/href_list)
 	. = ..()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -408,14 +408,19 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 		else
 			fantasy_quality--
 
+		//name gets changed by the component so i want to store it for feedback later
+		var/before_name = name
+		//naming these vars that i'm putting into the fantasy component to make it more readable
+		var/canFail = FALSE
+		var/announce = FALSE
 		//Apply fantasy with affix. failing this should never happen, but if it does it should not be silent.
-		if(AddComponent(/datum/component/fantasy, fantasy_quality, list(affix), FALSE, FALSE) == COMPONENT_INCOMPATIBLE)
+		if(AddComponent(/datum/component/fantasy, fantasy_quality, list(affix), canFail, announce) == COMPONENT_INCOMPATIBLE)
 			to_chat(usr, "<span class='warning'>Fantasy component not compatible with [src].</span>")
 			CRASH("fantasy component incompatible with object of type: [type]")
 
-		to_chat(usr, "<span class='notice'>[src] now has [picked_affix_name]!</span>")
-		log_admin("[key_name(usr)] has added [picked_affix_name] fantasy affix to [src]")
-		message_admins("<span class='notice'>[key_name(usr)] has added [picked_affix_name] fantasy affix to [src]</span>")
+		to_chat(usr, "<span class='notice'>[before_name] now has [picked_affix_name]!</span>")
+		log_admin("[key_name(usr)] has added [picked_affix_name] fantasy affix to [before_name]")
+		message_admins("<span class='notice'>[key_name(usr)] has added [picked_affix_name] fantasy affix to [before_name]</span>")
 
 /obj/item/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -364,6 +364,42 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	add_fingerprint(usr)
 	return ..()
 
+/obj/item/vv_get_dropdown()
+	. = ..()
+	VV_DROPDOWN_OPTION(VV_HK_ADD_FANTASY_AFFIX, "Add Fantasy Affix")
+
+/obj/item/vv_do_topic(list/href_list)
+	. = ..()
+
+	if(!.)
+		return
+
+	if(href_list[VV_HK_ADD_FANTASY_AFFIX] && check_rights(R_FUN))
+
+		var/list/affixes = list()
+		for(var/datum/fantasy_affix/affix_choice in subtypesof(/datum/fantasy_affix))
+			affixes[initial(affix_choice.name)] = affix_choice
+
+		var/picked_affix_name = input(usr, "Choose an affix to add to [src]...", "Enchant [src]", "Allow", "Cancel")
+		if(!picked_affix_name || QDELETED(src))
+			return
+
+		var/datum/fantasy_affix/affix = affixes[picked_affix_name]
+		var/fantasy_quality = 0
+		if(initial(affix.alignment) & AFFIX_GOOD)
+			fantasy_quality++
+		else
+			fantasy_quality--
+
+		// This should never happen, but if it does it should not be silent.
+		if(AddComponent(/datum/component/fantasy, fantasy_quality, list(affix), FALSE, FALSE) == COMPONENT_INCOMPATIBLE)
+			to_chat(usr, "<span class='warning'>Fantasy component not compatible with [src].</span>")
+			CRASH("fantasy component incompatible with object of type: [type]")
+
+		to_chat(usr, "<span class='notice'>[src] now has [picked_affix_name]!</span>")
+		log_admin("[key_name(usr)] has added [picked_affix_name] fantasy affix to [src]")
+		message_admins("<span class='notice'>[key_name(usr)] has added [picked_affix_name] fantasy affix to [src]</span>")
+
 /obj/item/attack_hand(mob/user, list/modifiers)
 	. = ..()
 	if(.)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -376,22 +376,39 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 
 	if(href_list[VV_HK_ADD_FANTASY_AFFIX] && check_rights(R_FUN))
 
-		var/list/affixes = list()
-		for(var/datum/fantasy_affix/affix_choice in subtypesof(/datum/fantasy_affix))
-			affixes[initial(affix_choice.name)] = affix_choice
+		//gathering all affixes that make sense for this item
+		var/list/prefixes = list()
+		var/list/suffixes = list()
+		for(var/datum/fantasy_affix/affix_choice as anything in subtypesof(/datum/fantasy_affix))
+			affix_choice = new affix_choice()
+			if(!affix_choice.validate(src))
+				qdel(affix_choice)
+			else
+				if(affix_choice.placement & AFFIX_PREFIX)
+					prefixes[affix_choice.name] = affix_choice
+				else
+					suffixes[affix_choice.name] = affix_choice
 
-		var/picked_affix_name = input(usr, "Choose an affix to add to [src]...", "Enchant [src]", "Allow", "Cancel")
-		if(!picked_affix_name || QDELETED(src))
+		//making it more presentable here
+		var/list/affixes = list("---PREFIXES---")
+		affixes.Add(prefixes)
+		affixes.Add("---SUFFIXES---")
+		affixes.Add(suffixes)
+
+		//admin picks, cleanup the ones we didn't do and handle chosen
+		var/picked_affix_name = input(usr, "Choose an affix to add to [src]...", "Enchant [src]") as null|anything in affixes
+		if(!affixes[picked_affix_name] || QDELETED(src))
 			return
-
 		var/datum/fantasy_affix/affix = affixes[picked_affix_name]
+		affixes.Remove(affix)
+		QDEL_LIST_ASSOC(affixes) //remove the rest, we didn't use them
 		var/fantasy_quality = 0
-		if(initial(affix.alignment) & AFFIX_GOOD)
+		if(affix.alignment & AFFIX_GOOD)
 			fantasy_quality++
 		else
 			fantasy_quality--
 
-		// This should never happen, but if it does it should not be silent.
+		//Apply fantasy with affix. failing this should never happen, but if it does it should not be silent.
 		if(AddComponent(/datum/component/fantasy, fantasy_quality, list(affix), FALSE, FALSE) == COMPONENT_INCOMPATIBLE)
 			to_chat(usr, "<span class='warning'>Fantasy component not compatible with [src].</span>")
 			CRASH("fantasy component incompatible with object of type: [type]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added "Add Fantasy Affix" vv dropdown

## Why It's Good For The Game

I keep having recurring good ideas for how to make special adminbuse weapons from these really cool prefixes but I don't have the power to do so... so here you go!

This is a lot like when i added adding components to the VV dropdown and that was a historic day for new levels of buse

## Changelog
:cl:
admin: Added fantasy affixes to the VV dropdown for items!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
