### PR TITLE
Removes some boiler plate from working with atmos code

### DIFF
--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -91,7 +91,7 @@
 		return
 
 	var/datum/gas_mixture/env = L.return_air() //get air from the turf
-	var/datum/gas_mixture/removed = env.remove(0.1 * env.total_moles())
+	var/datum/gas_mixture/removed = env.remove_ratio(0.1)
 
 	if(!removed)
 		return

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -224,7 +224,6 @@
 	//Burn it based on transfered gas
 	target.hotspot_expose((tank_mix.temperature*2) + 380,500)
 	//location.hotspot_expose(1000,500,1)
-	SSair.add_to_active(target)
 
 /obj/item/flamethrower/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -82,7 +82,6 @@
 	if(!T)
 		return
 	T.assume_air(gasused)
-	T.air_update_turf(FALSE, FALSE)
 	if(!gasused)
 		to_chat(user, "<span class='warning'>\The [src]'s tank is empty!</span>")
 		target.apply_damage((force / 5), BRUTE)

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -131,7 +131,6 @@
 	var/atom/location = loc
 	if(location)
 		location.assume_air(air_contents)
-		location.air_update_turf(FALSE, FALSE)
 		playsound(location, 'sound/effects/spray.ogg', 10, TRUE, -3)
 	return ..()
 
@@ -267,7 +266,6 @@
 		return
 	var/datum/gas_mixture/leaked_gas = air_contents.remove_ratio(0.25)
 	location.assume_air(leaked_gas)
-	location.air_update_turf(FALSE, FALSE)
 
 /**
  * Handles the minimum and maximum pressure tolerances of the tank.

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -200,8 +200,6 @@
 		ground_zero.assume_air(bomb_mixture)
 		ground_zero.hotspot_expose(1000, 125)
 
-	ground_zero.air_update_turf(FALSE, FALSE)
-
 /obj/item/tank/proc/release() //This happens when the bomb is not welded. Tank contents are just spat out.
 	var/datum/gas_mixture/our_mix = return_air()
 	var/datum/gas_mixture/removed = remove_air(our_mix.total_moles())
@@ -209,7 +207,6 @@
 	if(!T)
 		return
 	T.assume_air(removed)
-	air_update_turf(FALSE, FALSE)
 
 /obj/item/onetankbomb/return_analyzable_air()
 	if(bombtank)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -63,12 +63,14 @@
 		return FALSE
 	air.merge(giver)
 	update_visuals()
+	air_update_turf(FALSE, FALSE)
 	return TRUE
 
 /turf/open/remove_air(amount)
 	var/datum/gas_mixture/ours = return_air()
 	var/datum/gas_mixture/removed = ours.remove(amount)
 	update_visuals()
+	air_update_turf(FALSE, FALSE)
 	return removed
 
 /turf/open/proc/copy_air_with_tile(turf/open/T)

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -82,7 +82,6 @@
 			return
 
 		loc.assume_air(removed)
-		air_update_turf(FALSE, FALSE)
 
 		var/datum/pipeline/parent1 = parents[1]
 		parent1.update = TRUE
@@ -107,7 +106,6 @@
 			return
 
 		air2.merge(removed)
-		air_update_turf(FALSE, FALSE)
 
 		var/datum/pipeline/parent2 = parents[2]
 		parent2.update = TRUE

--- a/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
@@ -383,7 +383,6 @@
 		loc.assume_air(main_port.remove_ratio(1))
 	if(thermal_exchange_port)
 		loc.assume_air(thermal_exchange_port.remove_ratio(1))
-	air_update_turf(FALSE, FALSE)
 	qdel(src)
 
 /obj/machinery/atmospherics/components/binary/thermomachine/ui_status(mob/user)

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -83,7 +83,6 @@
 		if(istype(T))
 			var/datum/gas_mixture/leaked = removed.remove_ratio(VOLUME_PUMP_LEAK_AMOUNT)
 			T.assume_air(leaked)
-			T.air_update_turf(FALSE, FALSE)
 
 	air2.merge(removed)
 

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -184,7 +184,6 @@
 			continue
 		to_release.merge(air.remove(shared_loss))
 	T.assume_air(to_release)
-	air_update_turf(FALSE, FALSE)
 
 // Helpers
 

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -325,7 +325,6 @@
 			remove = remove_fusion.remove_ratio(0.1)
 			var/turf/local = pick(around_turfs)
 			local.assume_air(remove)
-			local.air_update_turf(FALSE, FALSE)
 		loc.assume_air(internal_fusion)
 	var/datum/gas_mixture/remove_moderator
 	if(moderator_internal.total_moles() > 0)
@@ -335,7 +334,5 @@
 			remove = remove_moderator.remove_ratio(0.1)
 			var/turf/local = pick(around_turfs)
 			local.assume_air(remove)
-			local.air_update_turf(FALSE, FALSE)
 		loc.assume_air(moderator_internal)
-	air_update_turf(FALSE, FALSE)
 	qdel(src)

--- a/code/modules/atmospherics/machinery/components/unary_devices/bluespace_sender.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/bluespace_sender.dm
@@ -40,7 +40,6 @@
 	if(bluespace_network.total_moles())
 		var/turf/local_turf = get_turf(src)
 		local_turf.assume_air(bluespace_network)
-		local_turf.air_update_turf(FALSE, FALSE)
 	return ..()
 
 /obj/machinery/atmospherics/components/unary/bluespace_sender/update_icon_state()

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -153,12 +153,9 @@
 	///Take the turf the cryotube is on
 	var/turf/T = get_turf(src)
 	if(T)
-		///Take the air composition of the turf
-		var/datum/gas_mixture/env = T.return_air()
 		///Take the air composition inside the cryotube
 		var/datum/gas_mixture/air1 = airs[1]
-		env.merge(air1)
-		T.air_update_turf(FALSE, FALSE)
+		T.assume_air(air1)
 
 	return ..()
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -76,7 +76,6 @@
 		var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
 
 		location.assume_air(removed)
-		air_update_turf(FALSE, FALSE)
 
 		update_parents()
 
@@ -89,7 +88,7 @@
 
 	injecting = 1
 	flick("inje_inject", src)
-	
+
 	if(air_contents.temperature > 0)
 		var/transfer_moles = (air_contents.return_pressure() * volume_rate) / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -118,7 +118,6 @@
 					return
 
 				loc.assume_air(removed)
-				air_update_turf(FALSE, FALSE)
 				update_parents()
 
 	else // external -> internal
@@ -137,7 +136,6 @@
 				return
 
 			air_contents.merge(removed)
-			air_update_turf(FALSE, FALSE)
 			update_parents()
 
 //Radio remote control

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -190,7 +190,6 @@
 			//Remix the resulting gases
 			air_contents.merge(filtered_out)
 			tile.assume_air(removed)
-			tile.air_update_turf(FALSE, FALSE)
 			update_parents()
 
 	else //Just siphoning all air
@@ -200,7 +199,6 @@
 		var/datum/gas_mixture/removed = tile.remove_air(transfer_moles)
 
 		air_contents.merge(removed)
-		tile.air_update_turf(FALSE, FALSE)
 		update_parents()
 
 	return TRUE

--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -138,7 +138,6 @@
 	merger.gases[spawn_id][MOLES] = spawn_mol * delta_time
 	merger.temperature = spawn_temp
 	O.assume_air(merger)
-	O.air_update_turf(FALSE, FALSE)
 
 /obj/machinery/atmospherics/miner/attack_ai(mob/living/silicon/user)
 	if(broken)

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -45,7 +45,6 @@
 	if(air_temporary)
 		var/turf/T = loc
 		T.assume_air(air_temporary)
-		air_update_turf(FALSE, FALSE)
 
 /obj/machinery/atmospherics/pipe/return_air()
 	if(air_temporary)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -477,7 +477,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 	var/expelled_pressure = expelled_gas?.return_pressure()
 	var/turf/T = get_turf(src)
 	T.assume_air(expelled_gas)
-	air_update_turf(FALSE, FALSE)
+
 	obj_break()
 
 	if(expelled_pressure > pressure_limit)

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -40,7 +40,6 @@
 		//This explosion will destroy the can, release its air.
 		var/turf/T = get_turf(src)
 		T.assume_air(air_contents)
-		T.air_update_turf(FALSE, FALSE)
 
 	return ..()
 

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -30,7 +30,6 @@
 /obj/machinery/portable_atmospherics/pump/Destroy()
 	var/turf/T = get_turf(src)
 	T.assume_air(air_contents)
-	air_update_turf(FALSE, FALSE)
 	return ..()
 
 /obj/machinery/portable_atmospherics/pump/update_icon_state()

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -38,7 +38,6 @@
 /obj/machinery/portable_atmospherics/scrubber/Destroy()
 	var/turf/T = get_turf(src)
 	T.assume_air(air_contents)
-	air_update_turf(FALSE, FALSE)
 	return ..()
 
 /obj/machinery/portable_atmospherics/scrubber/update_icon_state()

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -63,7 +63,6 @@
 	stank.gases[/datum/gas/miasma][MOLES] = (yield + 6)*3.5*MIASMA_CORPSE_MOLES*delta_time // this process is only being called about 2/7 as much as corpses so this is 12-32 times a corpses
 	stank.temperature = T20C // without this the room would eventually freeze and miasma mining would be easier
 	T.assume_air(stank)
-	T.air_update_turf(FALSE, FALSE)
 
 //Galaxy Thistle
 /obj/item/seeds/galaxythistle

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -125,7 +125,6 @@
 
 	if(breath)
 		loc.assume_air(breath)
-		air_update_turf(FALSE, FALSE)
 
 /mob/living/carbon/proc/has_smoke_protection()
 	if(HAS_TRAIT(src, TRAIT_NOBREATH))

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -132,7 +132,6 @@
 // called to vent all gas in holder to a location
 /obj/structure/disposalholder/proc/vent_gas(turf/T)
 	T.assume_air(gas)
-	T.air_update_turf(FALSE, FALSE)
 
 /obj/structure/disposalholder/AllowDrop()
 	return TRUE

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -244,7 +244,6 @@
 
 /obj/vehicle/sealed/mecha/obj_destruction()
 	loc.assume_air(cabin_air)
-	air_update_turf(FALSE, FALSE)
 	for(var/mob/living/occupant as anything in occupants)
 		if(isAI(occupant))
 			occupant.gib() //No wreck, no AI to recover
@@ -401,7 +400,6 @@
 				var/datum/gas_mixture/leaked_gas = int_tank_air.remove_ratio(DT_PROB_RATE(0.05, delta_time))
 				if(loc)
 					loc.assume_air(leaked_gas)
-					air_update_turf(FALSE, FALSE)
 				else
 					qdel(leaked_gas)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes jetpack gas visuals trails being left in space
Fixes balloons not updating their turf

Removes all uses of air_update_turf in conjunction with turf.assume_air and turf.remove_air
Adds `air_update_turf(FALSE, FALSE)` to the two procs

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Everything that called turf.assume_air and turf.remove_air was already updating turfs, and all that not tying the two together did was add more boiler plate, and break things when people forgot about it.

This shouldn't add any overhead outside of hotspots, but I think that's trivial
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: h2o jetpacks will no longer leave trails of water in space
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
