### PR TITLE
Fixes felinid disliked foods

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -11,7 +11,7 @@
 	mutant_organs = list(/obj/item/organ/tail/cat)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/felinid
-	disliked_food = CLOTH
+	disliked_food = GROSS | RAW | CLOTH
 	var/original_felinid = TRUE //set to false for felinids created by mass-purrbation
 	payday_modifier = 0.75
 	ass_image = 'icons/ass/asscat.png'

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -22,7 +22,7 @@
 	no_equip = list(ITEM_SLOT_EARS, ITEM_SLOT_EYES, ITEM_SLOT_OCLOTHING, ITEM_SLOT_GLOVES, ITEM_SLOT_FEET, ITEM_SLOT_ICLOTHING, ITEM_SLOT_SUITSTORE)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | ERT_SPAWN | SLIME_EXTRACT
 	liked_food = MEAT | FRUIT
-	disliked_food = CLOTH
+	disliked_food = GROSS | RAW | CLOTH
 	limbs_id = "monkey"
 	damage_overlay_type = "monkey"
 	sexes = FALSE

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -22,7 +22,7 @@
 	no_equip = list(ITEM_SLOT_EARS, ITEM_SLOT_EYES, ITEM_SLOT_OCLOTHING, ITEM_SLOT_GLOVES, ITEM_SLOT_FEET, ITEM_SLOT_ICLOTHING, ITEM_SLOT_SUITSTORE)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | ERT_SPAWN | SLIME_EXTRACT
 	liked_food = MEAT | FRUIT
-	disliked_food = GROSS | RAW | CLOTH
+	disliked_food = CLOTH
 	limbs_id = "monkey"
 	damage_overlay_type = "monkey"
 	sexes = FALSE


### PR DESCRIPTION
## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/58887
I forgot to give felinids the gross and raw food types for their disliked foods when adding cloth, which made them able to eat dead mice happily when previously they couldn't.

## Why It's Good For The Game
A pr that adds a muffin that people don't like shouldn't be making people like to eat dead mice.
This maintains previous behavior which was unintentionally modified.

## Changelog
:cl:
fix: Felinids are disgusted by raw and gross foods again.
/:cl:
