### PR TITLE
Refactor defib() to be a carbon level proc, adds defib to shock touch.

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -75,6 +75,8 @@
 #define HEALTH_THRESHOLD_FULLCRIT -30
 #define HEALTH_THRESHOLD_DEAD -100
 
+#define HALFWAYCRITDEATH ((HEALTH_THRESHOLD_CRIT + HEALTH_THRESHOLD_DEAD) * 0.5) //Used for defib code
+
 #define HEALTH_THRESHOLD_NEARDEATH -90 //Not used mechanically, but to determine if someone is so close to death they hear the other side
 
 //Actual combat defines

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -57,7 +57,7 @@
 
 #define HALFWAYCRITDEATH ((HEALTH_THRESHOLD_CRIT + HEALTH_THRESHOLD_DEAD) * 0.5)
 
-/obj/item/melee/touch_attack/shock/proc/defib(var/mob/living/carbon/target, var/mob/living/carbon/user)
+/obj/item/melee/touch_attack/shock/proc/defib(mob/living/carbon/target, mob/living/carbon/user)
 
 	if(target.can_defib() == DEFIB_POSSIBLE)
 		target.notify_ghost_cloning("Your heart is being defibrillated!")

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -63,7 +63,7 @@
 		target.notify_ghost_cloning("Your heart is being defibrillated!")
 		target.grab_ghost() // Shove them back in their body.
 
-	user.visible_message("<span class='warning'>[user] begins to place their hand on [target]'s chest.</span>", "<span class='warning'>You begin to place your hand on [target]'s chest...</span>")
+	user.visible_message("<span class='warning'>[user] begins to place [user.p_their()] hand on [target]'s chest.</span>", "<span class='warning'>You begin to place your hand on [target]'s chest...</span>")
 	if(do_after(user, 5 SECONDS, target))
 		for(var/obj/item/clothing/C in target.get_equipped_items())
 			if((C.body_parts_covered & CHEST) && (C.clothing_flags & THICKMATERIAL)) //check to see if something is obscuring their chest.

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -55,8 +55,6 @@
 		to_chat(user,"<span class='warning'>The electricity doesn't seem to affect [target]...</span>")
 		return ..()
 
-#define HALFWAYCRITDEATH ((HEALTH_THRESHOLD_CRIT + HEALTH_THRESHOLD_DEAD) * 0.5)
-
 /obj/item/melee/touch_attack/shock/proc/defib(mob/living/carbon/target, mob/living/carbon/user)
 
 	if(target.can_defib() == DEFIB_POSSIBLE)

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -1,5 +1,5 @@
 //backpack item
-#define HALFWAYCRITDEATH ((HEALTH_THRESHOLD_CRIT + HEALTH_THRESHOLD_DEAD) * 0.5)
+
 
 /obj/item/defibrillator
 	name = "defibrillator"
@@ -682,4 +682,4 @@
 /obj/item/shockpaddles/syndicate/cyborg
 	req_defib = FALSE
 
-#undef HALFWAYCRITDEATH
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

WIP

## Why It's Good For The Game

More utility to genetics that can help do other things than validhunt. Cool flavour. A one handed-defib, useful for rod of asclepius users. Better code.

## TODO

- [ ] Achieve world domination
- [ ] Refactor defib to be a carbon level proc
- [ ] Find inner peace

## Changelog
:cl:
add: Shock touch can now defib.
refactor: defib is now a mob level proc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
