### PR TITLE
Fixes uplink type being unchangeable and radio uplink frequency

### DIFF
--- a/code/__HELPERS/radio.dm
+++ b/code/__HELPERS/radio.dm
@@ -19,7 +19,7 @@
 	return frequency * 10
 
 ///returns a random unused frequency between MIN_FREE_FREQ & MAX_FREE_FREQ if free = TRUE, and MIN_FREQ & MAX_FREQ if FALSE
-/proc/return_unused_frequency(free = FALSE)
+/proc/return_unused_frequency(free = TRUE)
 	var/start = free ? MIN_FREE_FREQ : 1459//MIN_FREQ
 	var/end = free ? MAX_FREE_FREQ : 1460//MAX_FREQ
 

--- a/code/__HELPERS/radio.dm
+++ b/code/__HELPERS/radio.dm
@@ -19,9 +19,9 @@
 	return frequency * 10
 
 ///returns a random unused frequency between MIN_FREE_FREQ & MAX_FREE_FREQ if free = TRUE, and MIN_FREQ & MAX_FREQ if FALSE
-/proc/return_unused_frequency(free = TRUE)
-	var/start = free ? MIN_FREE_FREQ : 1459//MIN_FREQ
-	var/end = free ? MAX_FREE_FREQ : 1460//MAX_FREQ
+/proc/return_unused_frequency(free = FALSE)
+	var/start = free ? MIN_FREE_FREQ : MIN_FREQ
+	var/end = free ? MAX_FREE_FREQ : MAX_FREQ
 
 	var/freq_to_check = 0
 	do

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1508,7 +1508,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_loc = input(user, "Choose your character's traitor uplink spawn location:", "Character Preference") as null|anything in GLOB.uplink_spawn_loc_list
 					if(new_loc)
 						// This is done to prevent affecting saves
-						uplink_spawn_loc = new_loc == UPLINK_IMPLANT_WITH_PRICE ? UPLINK_IMPLANT : uplink_spawn_loc
+						uplink_spawn_loc = new_loc == UPLINK_IMPLANT_WITH_PRICE ? UPLINK_IMPLANT : new_loc
 
 				if("playtime_reward_cloak")
 					if (user.client.get_exp_living(TRUE) >= PLAYTIME_VETERAN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Radio uplink frequencies are now random again, fixing #58897.
You can now change your uplink to something that isn't the uplink implant, as #58872 broke it.

## Why It's Good For The Game

Being able to change the uplink type is something that should probably be fixed (also radio frequency)

## Changelog
:cl:
fix: Syndicate uplink types can now be changed again
fix: Radio uplink frequencies are now random again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
