### PR TITLE
moves sdql spell to vv dropdown

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -110,6 +110,7 @@
 #define VV_HK_DIRECT_CONTROL "direct_control"
 #define VV_HK_GIVE_DIRECT_CONTROL "give_direct_control"
 #define VV_HK_OFFER_GHOSTS "offer_ghosts"
+#define VV_HK_SDQL_SPELL "sdql_spell"
 
 // /mob/living/carbon
 #define VV_HK_MAKE_AI "aiify"

--- a/code/modules/admin/verbs/SDQL2/SDQL_spells_and_items.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_spells_and_items.dm
@@ -207,8 +207,8 @@
 #undef RAW_ADDRESS
 
 /client/proc/cmd_give_sdql_spell(mob/target in GLOB.mob_list)
-	set category = "Debug.Admin"
 	set name = "Give SDQL spell"
+	set hidden = TRUE
 	if(CONFIG_GET(flag/sdql_spells))
 		var/datum/give_sdql_spell/ui = new(usr, target)
 		ui.ui_interact(usr)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1176,6 +1176,7 @@
 	VV_DROPDOWN_OPTION(VV_HK_DIRECT_CONTROL, "Assume Direct Control")
 	VV_DROPDOWN_OPTION(VV_HK_GIVE_DIRECT_CONTROL, "Give Direct Control")
 	VV_DROPDOWN_OPTION(VV_HK_OFFER_GHOSTS, "Offer Control to Ghosts")
+	VV_DROPDOWN_OPTION(VV_HK_SDQL_SPELL, "Give SDQL Spell")
 
 /mob/vv_do_topic(list/href_list)
 	. = ..()
@@ -1227,7 +1228,10 @@
 		if(!check_rights(NONE))
 			return
 		offer_control(src)
-
+	if(href_list[VV_HK_SDQL_SPELL])
+		if(!check_rights(R_DEBUG))
+			return
+		usr.client.cmd_give_sdql_spell(src)
 /**
  * extra var handling for the logging var
  */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
moves sdql spell from an admin tab in debug tab to vv dropdown
i got permission from timber to make this

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
we shouldnt be adding a whole new section for one proc
also its annoying as f*ck that if you type sdql in the bottom bar it shows 2 things instead of instantly showing you the thing youre gonna use 99% of the time

## Changelog
:cl:
admin: moves sdql spell from debug tab to vv dropdown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
