### PR TITLE
Refactors pet bonuses to be an element

### DIFF
--- a/code/datums/elements/pet_bonus.dm
+++ b/code/datums/elements/pet_bonus.dm
@@ -20,7 +20,7 @@
 
 	src.emote_message = emote_message
 	src.moodlet = moodlet
-	RegisterSignal(target, COMSIG_ATOM_ATTACK_HAND , .proc/on_attack_hand)
+	RegisterSignal(target, COMSIG_ATOM_ATTACK_HAND, .proc/on_attack_hand)
 
 /datum/element/pet_bonus/Detach(datum/target)
 	. = ..()
@@ -34,5 +34,5 @@
 
 	new /obj/effect/temp_visual/heart(pet.loc)
 	if(emote_message && prob(33))
-		pet.manual_emote("[emote_message]")
+		pet.manual_emote(emote_message)
 	SEND_SIGNAL(petter, COMSIG_ADD_MOOD_EVENT, pet, moodlet, pet)

--- a/code/datums/elements/pet_bonus.dm
+++ b/code/datums/elements/pet_bonus.dm
@@ -1,0 +1,35 @@
+/**
+ * # Pet bonus element!
+ *
+ * Bespoke element that plays a fun message, sends a heart out, and gives a stronger mood bonus when you pet this animal.
+ * I may have been able to make this work for carbons, but it would have been interjecting on some help mode interactions anyways.
+ */
+/datum/element/pet_bonus
+	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	id_arg_index = 2
+
+	///optional cute message to send when you pet your pet!
+	var/emote_message
+
+/datum/element/pet_bonus/Attach(datum/target, emote_message)
+	. = ..()
+	if(!isliving(target))
+		return ELEMENT_INCOMPATIBLE
+
+	src.emote_message = emote_message
+	RegisterSignal(target, COMSIG_ATOM_ATTACK_HAND , .proc/on_attack_hand)
+
+/datum/element/pet_bonus/Detach(datum/target)
+	. = ..()
+	UnregisterSignal(target, COMSIG_ATOM_ATTACK_HAND)
+
+/datum/element/pet_bonus/proc/on_attack_hand(mob/living/pet, mob/living/petter)
+	SIGNAL_HANDLER
+
+	if(pet.stat != CONSCIOUS || petter.combat_mode)
+		return
+
+	new /obj/effect/temp_visual/heart(pet.loc)
+	if(emote_message && prob(33))
+		pet.manual_emote("[emote_message]")
+	SEND_SIGNAL(petter, COMSIG_ADD_MOOD_EVENT, pet, /datum/mood_event/pet_animal, pet)

--- a/code/datums/elements/pet_bonus.dm
+++ b/code/datums/elements/pet_bonus.dm
@@ -10,13 +10,16 @@
 
 	///optional cute message to send when you pet your pet!
 	var/emote_message
+	///actual moodlet given, defaults to the pet animal one
+	var/moodlet
 
-/datum/element/pet_bonus/Attach(datum/target, emote_message)
+/datum/element/pet_bonus/Attach(datum/target, emote_message, moodlet = /datum/mood_event/pet_animal)
 	. = ..()
 	if(!isliving(target))
 		return ELEMENT_INCOMPATIBLE
 
 	src.emote_message = emote_message
+	src.moodlet = moodlet
 	RegisterSignal(target, COMSIG_ATOM_ATTACK_HAND , .proc/on_attack_hand)
 
 /datum/element/pet_bonus/Detach(datum/target)
@@ -32,4 +35,4 @@
 	new /obj/effect/temp_visual/heart(pet.loc)
 	if(emote_message && prob(33))
 		pet.manual_emote("[emote_message]")
-	SEND_SIGNAL(petter, COMSIG_ADD_MOOD_EVENT, pet, /datum/mood_event/pet_animal, pet)
+	SEND_SIGNAL(petter, COMSIG_ADD_MOOD_EVENT, pet, moodlet, pet)

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -49,9 +49,12 @@
 	icon_prefix = "rabbit"
 	feedMessages = list("It nibbles happily.","It noms happily.")
 	layMessage = list("hides an egg.","scampers around suspiciously.","begins making a huge racket.","begins shuffling.")
-	pet_bonus = TRUE
-	pet_bonus_emote = "hops around happily!"
 	can_be_held = TRUE
+
+/mob/living/simple_animal/chicken/rabbit/Initialize()
+	. = ..()
+	AddElement(/datum/element/pet_bonus, "hops around happily!")
+
 
 /mob/living/simple_animal/chicken/rabbit/empty //top hats summon these kinds of rabbits instead of the normal kind
 	eggsleft = 0 //if you want to harvest toys and easter bunny gear from these guys, you're gonna need to feed them carrots first

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -26,8 +26,6 @@
 						"<span class='notice'>[user] [response_help_continuous] you.</span>", null, null, user)
 		to_chat(user, "<span class='notice'>You [response_help_simple] [src].</span>")
 		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
-		if(pet_bonus)
-			funpet(user)
 	else
 		if(HAS_TRAIT(user, TRAIT_PACIFISM))
 			to_chat(user, "<span class='warning'>You don't want to hurt [src]!</span>")
@@ -41,16 +39,6 @@
 		log_combat(user, src, "attacked")
 		updatehealth()
 		return TRUE
-
-/**
-*This is used to make certain mobs (pet_bonus == TRUE) emote when pet, make a heart emoji at their location, and give the petter a moodlet.
-*
-*/
-/mob/living/simple_animal/proc/funpet(mob/petter)
-	new /obj/effect/temp_visual/heart(loc)
-	if(prob(33))
-		manual_emote("[pet_bonus_emote]")
-	SEND_SIGNAL(petter, COMSIG_ADD_MOOD_EVENT, src, /datum/mood_event/pet_animal, src)
 
 /mob/living/simple_animal/attack_hulk(mob/living/carbon/human/user)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -39,8 +39,6 @@
 	collar_type = "cat"
 	can_be_held = TRUE
 	held_state = "cat2"
-	pet_bonus = TRUE
-	pet_bonus_emote = "purrs!"
 	///In the case 'melee_damage_upper' is somehow raised above 0
 	attack_verb_continuous = "claws"
 	attack_verb_simple = "claw"
@@ -51,6 +49,7 @@
 
 /mob/living/simple_animal/pet/cat/Initialize()
 	. = ..()
+	AddElement(/datum/element/pet_bonus, "purrs!")
 	add_verb(src, /mob/living/proc/toggle_resting)
 	add_cell_sample()
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -17,8 +17,6 @@
 	speak_chance = 1
 	turns_per_move = 10
 	can_be_held = TRUE
-	pet_bonus = TRUE
-	pet_bonus_emote = "woofs happily!"
 	ai_controller = /datum/ai_controller/dog
 	stop_automated_movement = TRUE
 	///In the case 'melee_damage_upper' is somehow raised above 0
@@ -31,6 +29,7 @@
 
 /mob/living/simple_animal/pet/dog/Initialize()
 	. = ..()
+	AddElement(/datum/element/pet_bonus, "woofs happily!")
 	add_cell_sample()
 
 //Corgis and pugs are now under one dog subtype

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -149,11 +149,10 @@
 	tame_chance = 25
 	bonus_tame_chance = 15
 	footstep_type = FOOTSTEP_MOB_SHOE
-	pet_bonus = TRUE
-	pet_bonus_emote = "moos happily!"
 
 /mob/living/simple_animal/cow/Initialize()
 	udder = new()
+	AddElement(/datum/element/pet_bonus, "moos happily!")
 	add_cell_sample()
 	. = ..()
 
@@ -267,13 +266,12 @@
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	mob_size = MOB_SIZE_TINY
 	gold_core_spawnable = FRIENDLY_SPAWN
-	pet_bonus = TRUE
-	pet_bonus_emote = "chirps!"
 
 	footstep_type = FOOTSTEP_MOB_CLAW
 
 /mob/living/simple_animal/chick/Initialize()
 	. = ..()
+	AddElement(/datum/element/pet_bonus, "chirps!")
 	pixel_x = base_pixel_x + rand(-6, 6)
 	pixel_y = base_pixel_y + rand(0, 10)
 	add_cell_sample()

--- a/code/modules/mob/living/simple_animal/friendly/fox.dm
+++ b/code/modules/mob/living/simple_animal/friendly/fox.dm
@@ -23,8 +23,6 @@
 	gold_core_spawnable = FRIENDLY_SPAWN
 	can_be_held = TRUE
 	held_state = "fox"
-	pet_bonus = TRUE
-	pet_bonus_emote = "pants and yaps happily!"
 	///In the case 'melee_damage_upper' is somehow raised above 0
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
@@ -32,6 +30,10 @@
 	attack_vis_effect = ATTACK_EFFECT_BITE
 
 	footstep_type = FOOTSTEP_MOB_CLAW
+
+/mob/living/simple_animal/pet/fox/Initialize()
+	. = ..()
+	AddElement(/datum/element/pet_bonus, "pants and yaps happily!")
 
 //Captain fox
 /mob/living/simple_animal/pet/fox/renault

--- a/code/modules/mob/living/simple_animal/friendly/gondola.dm
+++ b/code/modules/mob/living/simple_animal/friendly/gondola.dm
@@ -28,13 +28,12 @@
 	maxHealth = 200
 	health = 200
 	del_on_death = TRUE
-	pet_bonus = TRUE
-	pet_bonus_emote = "smiles!"
 
 	//Gondolas don't make footstep sounds
 
 /mob/living/simple_animal/pet/gondola/Initialize()
 	. = ..()
+	AddElement(/datum/element/pet_bonus, "smiles!")
 	if (!(istype(src, /mob/living/simple_animal/pet/gondola/gondolapod)))
 		CreateGondola()
 

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -26,11 +26,10 @@
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	var/static/list/edibles = typecacheof(list(/mob/living/simple_animal/butterfly, /mob/living/simple_animal/hostile/cockroach)) //list of atoms, however turfs won't affect AI, but will affect consumption.
-	pet_bonus = TRUE
-	pet_bonus_emote = "sticks its tongue out contentedly!"
 
 /mob/living/simple_animal/hostile/lizard/Initialize()
 	. = ..()
+	AddElement(/datum/element/pet_bonus, "sticks its tongue out contentedly!")
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 
 /mob/living/simple_animal/hostile/lizard/CanAttack(atom/the_target)//Can we actually attack a possible target?

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -182,11 +182,10 @@
 	response_harm_continuous = "splats"
 	response_harm_simple = "splat"
 	gold_core_spawnable = NO_SPAWN
-	pet_bonus = TRUE
-	pet_bonus_emote = "squeaks happily!"
 
 /mob/living/simple_animal/mouse/brown/tom/Initialize()
 	. = ..()
+	AddElement(/datum/element/pet_bonus, "squeaks happily!")
 	// Tom fears no cable.
 	ADD_TRAIT(src, TRAIT_SHOCKIMMUNE, SPECIES_TRAIT)
 

--- a/code/modules/mob/living/simple_animal/friendly/penguin.dm
+++ b/code/modules/mob/living/simple_animal/friendly/penguin.dm
@@ -18,13 +18,12 @@
 	turns_per_move = 10
 	icon = 'icons/mob/penguins.dmi'
 	butcher_results = list(/obj/item/organ/ears/penguin = 1, /obj/item/food/meat/slab/penguin = 3)
-	pet_bonus = TRUE
-	pet_bonus_emote = "honks happily!"
 
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 
 /mob/living/simple_animal/pet/penguin/Initialize()
 	. = ..()
+	AddElement(/datum/element/pet_bonus, "honks happily!")
 	AddElement(/datum/element/waddling)
 
 /mob/living/simple_animal/pet/penguin/emperor

--- a/code/modules/mob/living/simple_animal/friendly/sloth.dm
+++ b/code/modules/mob/living/simple_animal/friendly/sloth.dm
@@ -25,8 +25,6 @@
 	maxHealth = 50
 	speed = 10
 	held_state = "sloth"
-	pet_bonus = TRUE
-	pet_bonus_emote = "slowly smiles!"
 	///In the case 'melee_damage_upper' is somehow raised above 0
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
@@ -35,6 +33,9 @@
 
 	footstep_type = FOOTSTEP_MOB_CLAW
 
+/mob/living/simple_animal/sloth/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/pet_bonus, "slowly smiles!")
 
 //Cargo Sloth
 /mob/living/simple_animal/sloth/paperwork

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -209,8 +209,10 @@
 	food_type = list()
 	tame_chance = 0
 	bonus_tame_chance = 0
-	pet_bonus = TRUE
-	pet_bonus_emote = "bloops happily!"
+
+/mob/living/simple_animal/hostile/carp/lia/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/pet_bonus, "bloops happily!")
 
 /mob/living/simple_animal/hostile/carp/cayenne
 	name = "Cayenne"
@@ -224,8 +226,6 @@
 	food_type = list()
 	tame_chance = 0
 	bonus_tame_chance = 0
-	pet_bonus = TRUE
-	pet_bonus_emote = "bloops happily!"
 	/// Keeping track of the nuke disk for the functionality of storing it.
 	var/obj/item/disk/nuclear/disky
 	/// Location of the file storing disk overlays
@@ -235,6 +235,7 @@
 
 /mob/living/simple_animal/hostile/carp/cayenne/Initialize()
 	. = ..()
+	AddElement(/datum/element/pet_bonus, "bloops happily!")
 	colored_disk_mouth = mutable_appearance(SSgreyscale.GetColoredIconByType(/datum/greyscale_config/carp/disk_mouth, greyscale_colors))
 	ADD_TRAIT(src, TRAIT_DISK_VERIFIER, INNATE_TRAIT) //carp can verify disky
 	ADD_TRAIT(src, TRAIT_ADVANCEDTOOLUSER, INNATE_TRAIT) //carp SMART

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -64,5 +64,7 @@
 	response_help_continuous = "pets"
 	response_help_simple = "pet"
 	turns_per_move = 10
-	pet_bonus = TRUE
-	pet_bonus_emote = "chitters proudly!"
+
+/mob/living/simple_animal/hostile/retaliate/bat/sgt_araneus/Initialize()
+	. = ..()
+	AddElement(/datum/element/pet_bonus, "chitters proudly!")

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -170,11 +170,6 @@
 	///Generic flags
 	var/simple_mob_flags = NONE
 
-	/// Used for making mobs show a heart emoji and give a mood boost when pet.
-	var/pet_bonus = FALSE
-	/// A string for an emote used when pet_bonus == true for the mob being pet.
-	var/pet_bonus_emote = ""
-
 
 /mob/living/simple_animal/Initialize(mapload)
 	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -683,6 +683,7 @@
 #include "code\datums\elements\light_eater.dm"
 #include "code\datums\elements\movetype_handler.dm"
 #include "code\datums\elements\obj_regen.dm"
+#include "code\datums\elements\pet_bonus.dm"
 #include "code\datums\elements\plant_backfire.dm"
 #include "code\datums\elements\point_of_interest.dm"
 #include "code\datums\elements\rad_insulation.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pet bonuses are now an element. The incompatibility comes at a living level instead of a simple animal level, so in theory adminbuse will let you make bonus moodlet hugging... or something! 😳 

## Why It's Good For The Game

Hooking componentized functions of things is better than object oriented pathing variables toggling it on and off.

## Changelog
:cl:
refactor: pet bonuses are now an element
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
