### PR TITLE
Removes the Gamer Cube in Delta Cargo

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -52447,7 +52447,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/cargo/miningoffice)
 "ibr" = (
 /obj/structure/cable,
@@ -75877,6 +75877,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	desc = "Cooks and boils stuff, somehow.";
+	pixel_y = 5
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ocW" = (
@@ -95336,9 +95341,14 @@
 /turf/open/floor/wood,
 /area/command/meeting_room/council)
 "sYS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/iron,
-/area/cargo/miningoffice)
+/area/cargo/storage)
 "sYU" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/green{
@@ -159133,8 +159143,8 @@ ncY
 snR
 fQy
 oQN
-wzW
 sYS
+mFE
 eID
 vZl
 kfD

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -7579,25 +7579,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice)
-"bdh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/box/donkpockets,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "bdo" = (
 /mob/living/simple_animal/hostile/cockroach,
 /turf/open/floor/plating,
@@ -58973,7 +58954,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/cargo_technician,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jQa" = (
@@ -68509,14 +68489,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/cargo,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "mnC" = (
@@ -71670,11 +71644,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/window{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = -7;
+	pixel_y = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/chips,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ndg" = (
@@ -87123,14 +87097,18 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/computer/cargo,
-/obj/structure/window{
-	dir = 4
+/obj/item/paper_bin{
+	pixel_x = 4;
+	pixel_y = 6
 	},
-/obj/structure/window{
-	dir = 1
+/obj/item/stamp/denied{
+	pixel_x = -7;
+	pixel_y = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/item/stamp{
+	pixel_x = -7;
+	pixel_y = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qUc" = (
@@ -89012,26 +88990,6 @@
 	heat_capacity = 1e+006
 	},
 /area/engineering/storage_shared)
-"rtZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/window/southleft{
-	req_access_txt = "31"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "rum" = (
 /obj/machinery/door/airlock/external{
 	name = "External Solar Access";
@@ -90401,16 +90359,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/closet/crate/bin,
-/obj/structure/window,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/item/trash/cheesie,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/can{
-	pixel_x = -8
-	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "rMx" = (
@@ -91124,10 +91072,6 @@
 	dir = 4
 	},
 /obj/machinery/modular_computer/console/preset/cargochat/cargo,
-/obj/structure/window{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "rWm" = (
@@ -92396,16 +92340,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/structure/window,
-/obj/structure/window{
-	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -158625,7 +158559,7 @@ jpQ
 iuR
 uld
 mny
-bdh
+jpQ
 rMo
 tII
 ffH
@@ -158883,7 +158817,7 @@ jpQ
 hXn
 rWl
 jPM
-rtZ
+hJN
 sMk
 vma
 eHP


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
EDIT: I've altered this since the initial text came off as far more hostile than I wanted.
Changes up Delta cargo to remove the gamer cube, since it stands out too much from the surroundings. (Also, directional glass is something we should really be aiming to get rid of in most cases, especially when it's free standing panes such as it is here)
Old:
![cube](https://user-images.githubusercontent.com/58124831/117230373-3d42ba80-ae1d-11eb-87fa-e048ab2085af.png)
New:
![nocube](https://user-images.githubusercontent.com/58124831/117230378-403dab00-ae1d-11eb-95a8-b33f4a3495be.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Keeps Delta cargo sensible- while gimmicky stuff isn't bad, it's preferable that it fits into its environment.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Inept
fix: Removed the gamer cube in Delta cargo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
