### PR TITLE
Fix Wizard Loadouts from the Wizard Spellbook crashing the server.

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -81,6 +81,22 @@ GLOBAL_LIST_INIT(heretic_start_knowledge,list(/datum/eldritch_knowledge/spell/ba
 /// because they have nothing else that supports an implant.
 #define UPLINK_IMPLANT_TELECRYSTAL_COST 4
 
+/// The Classic Wizard wizard loadout.
+#define WIZARD_LOADOUT_CLASSIC "loadout_classic"
+/// Mjolnir's Power wizard loadout.
+#define WIZARD_LOADOUT_MJOLNIR "loadout_hammer"
+/// Fantastical Army wizard loadout.
+#define WIZARD_LOADOUT_WIZARMY "loadout_army"
+/// Soul Tapper wizard loadout.
+#define WIZARD_LOADOUT_SOULTAP "loadout_tap"
+/// Convenient list of all wizard loadouts for unit testing.
+#define ALL_WIZARD_LOADOUTS list( \
+	WIZARD_LOADOUT_CLASSIC, \
+	WIZARD_LOADOUT_MJOLNIR, \
+	WIZARD_LOADOUT_WIZARMY, \
+	WIZARD_LOADOUT_SOULTAP, \
+)
+
 /// Checks if the given mob is a blood cultist
 #define IS_CULTIST(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/cult))
 

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -819,13 +819,13 @@
 			if(!(entry.name in wanted_spell_names))
 				continue
 			if(entry?.CanBuy(wizard,src))
+				wanted_spell_names -= entry.name
 				for(var/i in 1 to wanted_spell_names[entry.name])
 					entry.Buy(wizard,src)
 					if(entry.limit)
 						entry.limit--
 					uses -= entry.cost
 				entry.refundable = FALSE //once you go loading out, you never go back
-				wanted_spell_names -= entry.name
 				continue
 			if(wanted_spell_names.len)
 				failed = TRUE//we went through the entire loop without finding what we wanted, sound the alarm!

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -650,11 +650,6 @@
 
 #undef MINIMUM_THREAT_FOR_RITUALS
 
-#define LOADOUT_CLASSIC "loadout_classic"
-#define LOADOUT_MJOLNIR "loadout_hammer"
-#define LOADOUT_WIZARMY "loadout_army"
-#define LOADOUT_SOULTAP "loadout_tap"
-
 /obj/item/spellbook
 	name = "spell book"
 	desc = "An unearthly tome that glows with power."
@@ -805,31 +800,31 @@
 /obj/item/spellbook/proc/wizard_loadout(mob/living/carbon/human/wizard, loadout)
 	var/list/wanted_spell_names
 	switch(loadout)
-		if(LOADOUT_CLASSIC) //(Fireball>2, MM>2, Smite>2, Jauntx2>4) = 10
+		if(WIZARD_LOADOUT_CLASSIC) //(Fireball>2, MM>2, Smite>2, Jauntx2>4) = 10
 			wanted_spell_names = list("Fireball" = 1, "Magic Missile" = 1, "Smite" = 1, "Ethereal Jaunt" = 2)
-		if(LOADOUT_MJOLNIR) //(Mjolnir>2, Summon Itemx3>3, Mutate>2, Force Wall>1, Blink>2) = 10
+		if(WIZARD_LOADOUT_MJOLNIR) //(Mjolnir>2, Summon Itemx3>3, Mutate>2, Force Wall>1, Blink>2) = 10
 			wanted_spell_names = list("Mjolnir" = 1, "Summon Item" = 3, "Mutate" = 1, "Force Wall" = 1, "Blink" = 1)
-		if(LOADOUT_WIZARMY) //(Soulstones>2, Staff of Change>2, A Necromantic Stone>2, Teleport>2, Ethereal Jaunt>2) = 10
+		if(WIZARD_LOADOUT_WIZARMY) //(Soulstones>2, Staff of Change>2, A Necromantic Stone>2, Teleport>2, Ethereal Jaunt>2) = 10
 			wanted_spell_names = list("Soulstone Shard Kit" = 1, "Staff of Change" = 1, "A Necromantic Stone" = 1, "Teleport" = 1, "Ethereal Jaunt" = 1)
-		if(LOADOUT_SOULTAP) //(Soul Tap>1, Smite>2, Flesh to Stone>2, Mindswap>2, Knock>1, Teleport>2) = 10
+		if(WIZARD_LOADOUT_SOULTAP) //(Soul Tap>1, Smite>2, Flesh to Stone>2, Mindswap>2, Knock>1, Teleport>2) = 10
 			wanted_spell_names = list("Soul Tap" = 1, "Smite" = 1, "Flesh to Stone" = 1, "Mindswap" = 1, "Knock" = 1, "Teleport" = 1)
-	var/failed = FALSE
-	while(wanted_spell_names.len && !failed)
-		for(var/datum/spellbook_entry/entry as anything in entries)
-			if(!(entry.name in wanted_spell_names))
-				continue
-			if(entry?.CanBuy(wizard,src))
-				wanted_spell_names -= entry.name
-				for(var/i in 1 to wanted_spell_names[entry.name])
-					entry.Buy(wizard,src)
-					if(entry.limit)
-						entry.limit--
-					uses -= entry.cost
-				entry.refundable = FALSE //once you go loading out, you never go back
-				continue
-			if(wanted_spell_names.len)
-				failed = TRUE//we went through the entire loop without finding what we wanted, sound the alarm!
-	if(failed)
+
+	for(var/datum/spellbook_entry/entry as anything in entries)
+		if(!(entry.name in wanted_spell_names))
+			continue
+		if(entry.CanBuy(wizard,src))
+			var/purchase_count = wanted_spell_names[entry.name]
+			wanted_spell_names -= entry.name
+			for(var/i in 1 to purchase_count)
+				entry.Buy(wizard,src)
+				if(entry.limit)
+					entry.limit--
+				uses -= entry.cost
+			entry.refundable = FALSE //once you go loading out, you never go back
+		if(!length(wanted_spell_names))
+			break
+
+	if(length(wanted_spell_names))
 		stack_trace("Wizard Loadout \"[loadout]\" could not find valid spells to buy in the spellbook. Either you input a name that doesn't exist, or you overspent")
 	if(uses)
 		stack_trace("Wizard Loadout \"[loadout]\" does not use 10 wizard spell slots. Stop scamming players out.")

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -89,6 +89,7 @@
 #include "teleporters.dm"
 #include "timer_sanity.dm"
 #include "unit_test.dm"
+#include "wizard.dm"
 
 #ifdef REFERENCE_TRACKING //Don't try and parse this file if ref tracking isn't turned on. IE: don't parse ref tracking please mr linter
 #include "find_reference_sanity.dm"

--- a/code/modules/unit_tests/wizard.dm
+++ b/code/modules/unit_tests/wizard.dm
@@ -7,5 +7,6 @@
 	for(var/loadout in ALL_WIZARD_LOADOUTS)
 		var/obj/item/spellbook/wizard_book = allocate(/obj/item/spellbook)
 		var/mob/living/carbon/human/wizard = allocate(/mob/living/carbon/human)
+		wizard.mind_initialize()
 		wizard.put_in_active_hand(wizard_book, forced = TRUE)
 		wizard_book.wizard_loadout(wizard, loadout)

--- a/code/modules/unit_tests/wizard.dm
+++ b/code/modules/unit_tests/wizard.dm
@@ -1,0 +1,11 @@
+// Once upon a time, a Game Master decided to upgrade the wizard's spellbook to tgui.
+// In doing so, he introduced an infinite loop that crashed many servers and made many wizards sad.
+// May this never happen again.
+
+/// Test loadouts for crashes, runtimes, stack traces and infinite loops. No ASSERTs necessary.
+/datum/unit_test/wizard_loadout/Run()
+	for(var/loadout in ALL_WIZARD_LOADOUTS)
+		var/obj/item/spellbook/wizard_book = allocate(/obj/item/spellbook)
+		var/mob/living/carbon/human/wizard = allocate(/mob/living/carbon/human)
+		wizard.put_in_active_hand(wizard_book, forced = TRUE)
+		wizard_book.wizard_loadout(wizard, loadout)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![nJBCfzjjt0](https://user-images.githubusercontent.com/24975989/117513664-1b1a7b00-af8a-11eb-9b5d-956c8d417e86.gif)

There's an infinite loop in the wizard's spellbook.

It is caused by buying a loadout with multiple spell ranks, where that spell changes its name with each new rank purchased.

![image](https://user-images.githubusercontent.com/24975989/117513753-4ef5a080-af8a-11eb-9085-1de3c78cb57a.png)
![image](https://user-images.githubusercontent.com/24975989/117513792-646aca80-af8a-11eb-9af5-921cf082c031.png)

This entry is not removed from the original list, since the original list doesn't contain it. It then `continue`s through the for loop without ever setting `failed = TRUE`.

This causes an infinite loop in the while block, as failed is always FALSE and the wanted spell name is no longer in the spellbook entries (as the spellbook entry has the upgraded name) so the for loop always insta-continues on the first opportunity and returns to the while loop.

I... Have no clue why this is set up in this way.

I have completely re-written the logic. There is no more while loop. There is only a single for loop where all spells in the spellbook are iterated over one-by-one. If the spell is in the wanted_spell_names list, it is purchased. The spell name is removed from the list immediately and the number of purchases is cached.

This will no longer infinite loop under any circumstance. To prevent regressions and catch any of the stack traces that purchasing loadouts generates, there is now a simple unit test that simply purchases each loadout one by one with a new mob and new spellbook each time. It exists to stop any more potential issues with this before the PR even hits live servers.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feexes infinite loop, no more server crashing wizards, adds unit tests to prevent regressions, is good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Purchasing classic or mjolnir loadouts as the wizard will no longer crash the server.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
