### PR TITLE
SStramprocess only fires on maps with trams actually present on the map

### DIFF
--- a/code/controllers/subsystem/processing/tramprocess.dm
+++ b/code/controllers/subsystem/processing/tramprocess.dm
@@ -1,3 +1,5 @@
 PROCESSING_SUBSYSTEM_DEF(tramprocess)
 	name = "Tram Process"
 	wait = 1
+	/// only used on maps with trams, so only enabled by such.
+	can_fire = FALSE

--- a/code/game/objects/structures/industrial_lift.dm
+++ b/code/game/objects/structures/industrial_lift.dm
@@ -415,6 +415,10 @@ GLOBAL_LIST_EMPTY(lifts)
 
 /obj/structure/industrial_lift/tram/central//that's a surprise tool that can help us later
 
+/obj/structure/industrial_lift/tram/central/Initialize(mapload)
+	. = ..()
+	SStramprocess.can_fire = TRUE
+
 /obj/structure/industrial_lift/tram/LateInitialize()
 	. = ..()
 	find_our_location()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So there I was, scorned from my latest ban from #coderbus. don't they know i'm a long time contributor with many refactors, fixes, features, entire antags, THE TRAM, THE GHOST PIRATE SHIP and more under my belt?! And last I checked, I did it for passion. Not for the passion of the 1984 ingsoc society now in full control of coderbus. Their attempts to memory hole the silencing of bazelart and tralezab's friend was really uncool, quote from tralezab's friend himself. And now, as I sit here refactoring parts of simplemob code, I am once again called upon to execute favors for those who threw me out. But as a wise man once said, "nobody can put down a gun in an environment where everyone keeps commenting on them holding it" so I'll do this solid and once again increase the game's speed by having tramprocess not run whilst there is no tram

also I really don't mess with subsystems a lot, so if I should switch this from can_fire to the subsystem flag tell me.

![image](https://user-images.githubusercontent.com/40974010/117514914-d969e000-af49-11eb-9716-a1f12201c3b3.png)

## Why It's Good For The Game

Game goes faster!

## Changelog
:cl:
code: SStramprocess only fires on maps with trams actually present on the map
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
