### PR TITLE
Adds using a door remote on a door's tile

### DIFF
--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -53,6 +53,12 @@
 	. = ..()
 	var/datum/component/ntnet_interface/target_interface = A.GetComponent(/datum/component/ntnet_interface)
 
+	// Try to find an airlock in the clicked turf
+	if(!target_interface)
+		var/obj/machinery/door/airlock/door = locate() in get_turf(A)
+		if(door)
+			target_interface = door.GetComponent(/datum/component/ntnet_interface)
+
 	if(!target_interface)
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Made door remote work by clicking on the floor under an airlock too. Similar to #58124

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bolting doors open with remote required annoying pixelhunting

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: made door remote work by clicking on the floor under an airlock too
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
