### PR TITLE
Fixes connect_loc related hard dels

### DIFF
--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -43,6 +43,8 @@
 
 /// Finds the singleton for the element type given and attaches it to src
 /datum/proc/_AddElement(list/arguments)
+	if(QDELING(src))
+		CRASH("We just tried to add an element to a qdeleted datum, something is fucked")
 	var/datum/element/ele = SSdcs.GetElement(arguments)
 	arguments[1] = src
 	if(ele.Attach(arglist(arguments)) == ELEMENT_INCOMPATIBLE)

--- a/code/datums/elements/caltrop.dm
+++ b/code/datums/elements/caltrop.dm
@@ -4,7 +4,7 @@
  * Used for broken glass, cactuses and four sided dice.
  */
 /datum/element/caltrop
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
 	id_arg_index = 2
 
 	///Minimum damage done when crossed

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -34,7 +34,7 @@
 		unregister_all(listener)
 	else if(targets[tracked.loc]) // Detach can happen multiple times due to qdel
 		unregister_signals(listener, tracked, tracked.loc)
-		UnregisterSignal(tracked, COMSIG_MOVABLE_MOVED)
+		UnregisterSignal(tracked, COMSIG_MOVABLE_LOCATION_CHANGE)
 
 /datum/element/connect_loc/proc/update_signals(datum/listener, atom/movable/tracked)
 	var/existing = length(targets[tracked.loc])
@@ -62,7 +62,7 @@
 				unregister_signals(listener, tracked, location)
 			else
 				continue
-			UnregisterSignal(tracked, COMSIG_MOVABLE_MOVED)
+			UnregisterSignal(tracked, COMSIG_MOVABLE_LOCATION_CHANGE)
 
 /datum/element/connect_loc/proc/unregister_signals(datum/listener, atom/movable/tracked, atom/old_loc)
 	if (length(targets[old_loc]) <= 1)

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -56,15 +56,19 @@
 	for(var/atom/location as anything in targets)
 		var/list/loc_targets = targets[location]
 		for(var/atom/movable/tracked as anything in loc_targets)
-			if(loc_targets[tracked] != listener)
-				continue
-			unregister_signals(listener, tracked, location)
+			if(tracked == listener)
+				unregister_signals(loc_targets[tracked], tracked, location)
+			else if(loc_targets[tracked] == listener)
+				unregister_signals(listener, tracked, location)
+			else
+				return
 			UnregisterSignal(tracked, COMSIG_MOVABLE_MOVED)
 
 /datum/element/connect_loc/proc/unregister_signals(datum/listener, atom/movable/tracked, atom/old_loc)
-	targets[old_loc] -= tracked
-	if (length(targets[old_loc]) == 0)
+	if (length(targets[old_loc]) <= 1)
 		targets -= old_loc
+	else
+		targets[old_loc] -= tracked
 
 	// Yes this is after the above because we use null as a key when objects are in nullspace
 	if(isnull(old_loc))

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -24,7 +24,7 @@
 
 	src.connections = connections
 
-	RegisterSignal(tracked, COMSIG_MOVABLE_LOCATION_CHANGE, .proc/on_moved)
+	RegisterSignal(tracked, COMSIG_MOVABLE_LOCATION_CHANGE, .proc/on_moved, override=TRUE)
 	update_signals(listener, tracked)
 
 /datum/element/connect_loc/Detach(datum/listener, atom/movable/tracked, list/connections)

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -61,7 +61,7 @@
 			else if(loc_targets[tracked] == listener)
 				unregister_signals(listener, tracked, location)
 			else
-				return
+				continue
 			UnregisterSignal(tracked, COMSIG_MOVABLE_MOVED)
 
 /datum/element/connect_loc/proc/unregister_signals(datum/listener, atom/movable/tracked, atom/old_loc)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -63,6 +63,9 @@
 		for(var/obj/item/stack/S in loc)
 			if(can_merge(S))
 				INVOKE_ASYNC(src, .proc/merge, S)
+				//Merge can call qdel on us, so let's be safe yeah?
+				if(QDELETED(src))
+					return
 	var/list/temp_recipes = get_main_recipes()
 	recipes = temp_recipes.Copy()
 	if(material_type)


### PR DESCRIPTION
Probably nothing visible to players but some hard dels were happening in regards to connect_loc when their attached object was being qdeleted and not manually removing the element.

Not 100% sure this fixes them all but the dels that existed with edibles and airlocks were cleared up by these changes.
