### PR TITLE
Cyborg multitool can read wires and Engborgs don't have blueprints anymore.

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -117,6 +117,7 @@
 #define ui_borg_camera "CENTER+3:21,SOUTH:5"
 #define ui_borg_alerts "CENTER+4:21,SOUTH:5"
 #define ui_borg_language_menu "CENTER+4:19,SOUTH+1:6"
+#define ui_borg_create_area "CENTER+3:19,SOUTH+1:6"
 
 //Aliens
 #define ui_alien_health "EAST,CENTER-1:15"

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -81,6 +81,12 @@
 	using.screen_loc = ui_borg_language_menu
 	static_inventory += using
 
+//Area Creator
+	using = new /atom/movable/screen/area_creator
+	using.screen_loc = ui_borg_create_area
+	using.hud = src
+	static_inventory += using
+
 //Radio
 	using = new /atom/movable/screen/robot/radio()
 	using.screen_loc = ui_borg_radio

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -241,8 +241,9 @@
 	if(isAdminGhostAI(user))
 		return TRUE
 
-	// Same for anyone with an abductor multitool.
-	if(user.is_holding_item_of_type(/obj/item/multitool/abductor))
+	// Same for anyone with an abductor/cyborg multitool.
+	if(user.is_holding_item_of_type(/obj/item/multitool/abductor) || user.is_holding_item_of_type(/obj/item/multitool/cyborg))
+
 		return TRUE
 
 	// Station blueprints do that too, but only if the wires are not randomized.

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -202,15 +202,6 @@
 	interact()
 	return TRUE
 
-//Blueprint Subtypes
-
-/obj/item/areaeditor/blueprints/cyborg
-	name = "station schematics"
-	desc = "A digital copy of the station blueprints stored in your memory."
-	icon = 'icons/obj/items_and_weapons.dmi'
-	icon_state = "blueprints"
-	fluffnotice = "Intellectual Property of Nanotrasen. For use in engineering cyborgs only. Wipe from memory upon departure from the station."
-
 /proc/rename_area(a, new_name)
 	var/area/A = get_area(a)
 	var/prevname = "[A.name]"

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -163,14 +163,14 @@
 
 /obj/item/multitool/abductor
 	name = "alien multitool"
-	desc = "An omni-technological interface."
+	desc = "An omni-technological interface. It can read machinery wires and their functions."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "multitool"
 	toolspeed = 0.1
 
 /obj/item/multitool/cyborg
 	name = "electronic multitool"
-	desc = "Optimised version of a regular multitool. Streamlines processes handled by its internal microchip."
+	desc = "Optimised version of a regular multitool. It can read machinery wires and their functions."
 	icon = 'icons/obj/items_cyborg.dmi'
 	icon_state = "multitool_cyborg"
 	toolspeed = 0.5

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -245,7 +245,6 @@
 		/obj/item/analyzer,
 		/obj/item/geiger_counter/cyborg,
 		/obj/item/assembly/signaler/cyborg,
-		/obj/item/areaeditor/blueprints/cyborg,
 		/obj/item/electroadaptive_pseudocircuit,
 		/obj/item/stack/sheet/iron,
 		/obj/item/stack/sheet/glass,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Make repairs for borgs smoother since you don't need to hold both a multitool and the blueprints, better description for both the cyborg and abductor multitool to help new players.
This was meant to be only a QoL for engborgs by removing 1 item from their big inventory with 3 rolls of items but I found some balance implications and wanted them fixed too:

First, the augmented toolset arm uses the cyborg multitool, so it is a direct buff to it, still you need someone to do surgery for you and grabbing a blueprints from Xeno or a skill chip is easier IMO.

Second, removing the blueprints also removes their option of renaming areas to dumb names and this little "exploit" you could do with engborgs to make their Malf AIs rounds a breeze by stacking multiple APCs in a small room in their satellite by splitting rooms into 1x1 boxes, removing all risks and fun of hacking APCs for power. 

<img src="https://i.gyazo.com/14a1f2c8d567cd3b5912fd640a887aa1.png"/>

Engborgs already are the most valuable to any Malf AI, let's not give them free, safe and basically impossible for the crew to find Malf points.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Smoother multitool use for the Engborgs, better descriptions for advanced multitools.
Removes a very boring, risk free way to play Malf AI.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Guillaume Prata
qol: Engborgs can read wires using their multitool instead of the blueprints which was removed from their bloated inventory.
balance: Augmented toolset arms already had the cyborg multitool and can also read wires now.
balance: Engborgs can't build multiple APCs in one room to make their Malf AI round a breeze.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
